### PR TITLE
Fix CSS bug: align tick marks in gallery dropdowns with the corresponding rows

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -557,7 +557,12 @@ textarea {
   border-radius: 0;
   margin-top: 10px;
 }
-
+/* In Bootstrap,white-space for dropdown list is no-wrap.Use this instead to allign ticks and 
+   dropdown options 
+*/
+.oppia-navbar-button-container >.dropdown-menu > li > a {
+  white-space: normal;
+}
 .btn.oppia-navbar-add-exploration-button {
   background-color: rgba(5, 190, 178, 0.9);
   color: rgba(255,255,255,0.9);

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -560,7 +560,7 @@ textarea {
 /* In Bootstrap,white-space for dropdown list is no-wrap.Use this instead to allign ticks and 
    dropdown options 
 */
-.oppia-navbar-button-container >.dropdown-menu > li > a {
+.oppia-navbar-button-container > .dropdown-menu > li > a {
   white-space: normal;
 }
 .btn.oppia-navbar-add-exploration-button {


### PR DESCRIPTION
![bug2](https://cloud.githubusercontent.com/assets/6409210/9295620/507d48d8-447c-11e5-9908-94625d116d14.png)

after fix.
![fixed](https://cloud.githubusercontent.com/assets/6409210/9295626/603bf652-447c-11e5-9a6b-eb785355e546.png)

