### PR TITLE
#937 fix

### DIFF
--- a/core/templates/dev/head/editor/ExplorationFeedback.js
+++ b/core/templates/dev/head/editor/ExplorationFeedback.js
@@ -146,14 +146,9 @@ oppia.controller('ExplorationFeedback', [
     });
   };
 
-  $scope.isSendDisabled = function(updatedStatus) {
-    if ($scope.messageSendingInProgress == true) {
-      return true;
-    }
-    else {
-      return !$scope.newMessageText &&
-        $scope.currentThreadData.status == updatedStatus;
-    };
+  $scope.isSendButtonDisabled = function(newMessageText, updatedStatus) {
+    return $scope.messageSendingInProgress || (
+      !$scope.newMessageText && $scope.currentThreadData.status == updatedStatus);
   };
 
   // We do not permit 'Duplicate' as a valid status for now, since it should

--- a/core/templates/dev/head/editor/ExplorationFeedback.js
+++ b/core/templates/dev/head/editor/ExplorationFeedback.js
@@ -146,6 +146,16 @@ oppia.controller('ExplorationFeedback', [
     });
   };
 
+  $scope.isSendDisabled = function(updatedStatus) {
+    if ($scope.messageSendingInProgress == true) {
+      return true;
+    }
+    else {
+      return !$scope.newMessageText &&
+        $scope.currentThreadData.status == updatedStatus;
+    };
+  };
+
   // We do not permit 'Duplicate' as a valid status for now, since it should
   // require the id of the duplicated thread to be specified.
   $scope.STATUS_CHOICES = [

--- a/core/templates/dev/head/editor/exploration_feedback.html
+++ b/core/templates/dev/head/editor/exploration_feedback.html
@@ -139,7 +139,7 @@
                 <select ng-model="updatedStatus" ng-options="choice.id as choice.text for choice in STATUS_CHOICES"></select>
               </span>
               <br>
-              <button style="margin-top: 10px;" class="btn btn-success" ng-click="addMessage(currentThreadId, $parent.$parent.newMessageText, updatedStatus)" ng-disabled="isSendDisabled(updatedStatus)">
+              <button style="margin-top: 10px;" class="btn btn-success" ng-click="addMessage(currentThreadId, $parent.$parent.newMessageText, updatedStatus)" ng-disabled="isSendButtonDisabled($parent.$parent.newMessageText, updatedStatus)">
                 <span ng-if="messageSendingInProgress">Sending...</span>
                 <span ng-if="!messageSendingInProgress">Send</span>
               </button>

--- a/core/templates/dev/head/editor/exploration_feedback.html
+++ b/core/templates/dev/head/editor/exploration_feedback.html
@@ -139,7 +139,7 @@
                 <select ng-model="updatedStatus" ng-options="choice.id as choice.text for choice in STATUS_CHOICES"></select>
               </span>
               <br>
-              <button style="margin-top: 10px;" class="btn btn-success" ng-click="addMessage(currentThreadId, $parent.$parent.newMessageText, updatedStatus)" ng-disabled="messageSendingInProgress || !$parent.$parent.newMessageText">
+              <button style="margin-top: 10px;" class="btn btn-success" ng-click="addMessage(currentThreadId, $parent.$parent.newMessageText, updatedStatus)" ng-disabled="isSendDisabled(updatedStatus)">
                 <span ng-if="messageSendingInProgress">Sending...</span>
                 <span ng-if="!messageSendingInProgress">Send</span>
               </button>


### PR DESCRIPTION
Allows a user to change the status of a feedback thread without adding a message as well.