### PR TITLE
Wording and UI improvements, per Tricia's suggestions.

### DIFF
--- a/core/templates/dev/head/components/exploration_creation_button.html
+++ b/core/templates/dev/head/components/exploration_creation_button.html
@@ -35,7 +35,7 @@
               Goal
             </label>
             <div class="col-lg-10 col-md-10 col-sm-10">
-              <input id="newExplorationObjective" type="text" class="form-control" ng-model="newExplorationObjective" placeholder="What will this exploration help people to do?" name="newExplorationObjective">
+              <input id="newExplorationObjective" type="text" class="form-control" ng-model="newExplorationObjective" placeholder="What will people learn from this exploration?" name="newExplorationObjective">
             </div>
           </div>
         </div>

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1011,7 +1011,7 @@ pre.oppia-pre-wrapped-text {
 .oppia-state-graph-container {
   border-radius: 4px;
   border: 1px solid #ccc;
-  height: 300px;
+  height: 400px;
   overflow-y: hidden;
   position: relative;
 }
@@ -1773,11 +1773,12 @@ div#ng-curtain {
 }
 
 .oppia-editor-sidebar {
+  max-width: 500px;
   padding: 7px 5px 0 5px;
   position: absolute;
   right: 15px;
   top: 28px;
-  width: 300px;
+  width: 100%;
 }
 .oppia-editor-sidebar accordion .panel {
   border-radius: 0;

--- a/core/templates/dev/head/editor/ExplorationEditor.js
+++ b/core/templates/dev/head/editor/ExplorationEditor.js
@@ -186,10 +186,10 @@ oppia.controller('ExplorationEditor', [
     selector: _ID_TUTORIAL_STATE_CONTENT,
     heading: 'Content',
     text: (
-      'An Oppia exploration is a one-on-one conversation that is divided ' +
-      'into several \'cards\'. A card consists of Oppia asking a question, and the ' +
-      'learner responding.<br><br>' +
-      'This is where you can tell Oppia what to say to the learner at the beginning.'),
+      'An Oppia exploration is a conversation between a tutor and a ' +
+      'learner that is divided into several \'cards\'.<br><br>' +
+      'The first part of a card is the <b>content</b>. Here, you can set ' +
+      'the scene and ask the learner a question.'),
     placement: 'right'
   }, {
     type: 'function',

--- a/core/templates/dev/head/editor/exploration_editor.html
+++ b/core/templates/dev/head/editor/exploration_editor.html
@@ -162,7 +162,7 @@
                    class="visible-sm visible-xs oppia-save-publish-button-icon" alt="Publish Changes">
               <span class="hidden-sm hidden-xs">Publish Changes</span>
             </span>
-            <span class="hidden-sm hidden-xs" ng-if="getChangeListLength()">(<[getChangeListLength()]>)</span>
+            <span class="hidden-sm hidden-xs" ng-if="getChangeListLength()" style="opacity: 0.5">(<[getChangeListLength()]>)</span>
           </span>
           <span ng-if="isSaveInProgress">
             <span ng-if="isPrivate()">Saving...</span>

--- a/core/templates/dev/head/editor/state_editor_content.html
+++ b/core/templates/dev/head/editor/state_editor_content.html
@@ -1,14 +1,12 @@
 <div class="oppia-pre-avatar-oppia">
-  <div ng-if="!contentMemento" class="protractor-test-edit-content"
+  <div ng-if="contentMemento === null" class="protractor-test-edit-content"
        ng-click="openStateContentEditor()"
        ng-class="{'oppia-editable-section': editabilityService.isEditable()}">
     <span ng-if="editabilityService.isEditable()" class="glyphicon glyphicon-pencil oppia-editor-edit-icon" title="Edit Card Content">
     </span>
     <div class="oppia-state-content-display protractor-test-state-edit-content oppia-transition-200" ng-class="{'oppia-prevent-selection': editabilityService.isEditable()}" title="Card Content">
       <span ng-show="content[0].value == ''" class="oppia-placeholder">
-        This is where you give initial context to the learner or ask a question.
-        In the space below, give the learner something to do and teach Oppia how
-        to respond.
+        This is the first card of your exploration. Use this space to introduce your topic and engage the learner, then ask them a question.
       </span>
       <span angular-html-bind="content[0].value" class="protractor-test-state-content-display"></span>
     </div>
@@ -16,7 +14,7 @@
 </div>
 
 <!-- The margin-bottom here preserves parity with the 'well' in the readonly mode. -->
-<div ng-if="!!contentMemento" class="oppia-state-item-editor-div protractor-test-state-content-editor">
+<div ng-if="contentMemento !== null" class="oppia-state-item-editor-div protractor-test-state-content-editor">
   <schema-based-editor schema="STATE_CONTENT_SCHEMA" local-value="content[0].value">
   </schema-based-editor>
   <div style="margin-top: 2px;">


### PR DESCRIPTION
Implementing improvements (mostly suggested by @tngoon):

* Change placeholder for 'goal' in the exploration creation modal
* Make editor sidebar a bit wider (and taller)
* Change placeholder text for initial card
* Change tutorial text for content section
* Make the number of changes next to "save changes" less prominent.