### PR TITLE
Made progress dots scroll horizontally underneath left and right arrows when they are too many

### DIFF
--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -605,7 +605,10 @@ oppia.directive('progressDots', [function() {
     templateUrl: 'components/progressDots',
     controller: ['$scope', function($scope) {
 
+      $scope.MAX_DOTS = 4;
       $scope.dots = [];
+      $scope.currentDotIndex = null;
+
       var initialDotCount = $scope.getNumDots();
       for (var i = 0; i < initialDotCount; i++) {
         $scope.dots.push({});
@@ -643,44 +646,25 @@ oppia.directive('progressDots', [function() {
           $scope.changeActiveDot($scope.currentDotIndex + 1);
         }
       };
+
+      /* This is need to watch any change for both number of dots and currentDot. */
+      $scope.$watchGroup(['dots', 'currentDotIndex'], function(oldValue, newValue) {
+        if(newValue !== oldValue) {
+          if($scope.dots.length > $scope.MAX_DOTS) {
+            if($scope.currentDotIndex < $scope.dots.length - $scope.MAX_DOTS) {
+              $scope.leftmostVisibleDotIndex = $scope.currentDotIndex;
+              $scope.rightmostVisibleDotIndex = $scope.leftmostVisibleDotIndex + $scope.MAX_DOTS;
+            } else {
+              $scope.leftmostVisibleDotIndex = $scope.dots.length - $scope.MAX_DOTS;
+              $scope.rightmostVisibleDotIndex = $scope.dots.length;
+            }
+          } else{
+            $scope.leftmostVisibleDotIndex = 0;
+            $scope.rightmostVisibleDotIndex = $scope.MAX_DOTS;
+          }
+        }
+      });
+
     }]
   };
 }]);
-oppia.filter('sliceDots', function() {
-
-  return function(input, currentDotIndex) {
-    var _maximumNumberOfDotsShown = 18;
-    var _numberOfDots = input.length;
-    angular.forEach(input,function(value,key) {
-      value.isVisible = false;
-      value.hidingDotsStartingPosition = null;
-    });
-
-   if(_numberOfDots > _maximumNumberOfDotsShown) {
-
-    if(currentDotIndex < _numberOfDots - _maximumNumberOfDotsShown) {
-        var last = currentDotIndex+ _maximumNumberOfDotsShown;
-        for(var i = currentDotIndex; i<last; i++) {
-          input[i].isVisible = true;
-        }
-        input[last-1].hidingDotsStartingPosition = 'right';
-      } else {
-
-        var _start = _numberOfDots - _maximumNumberOfDotsShown
-        for(var i=_start; i<_numberOfDots;  i++) {
-          input[i].isVisible = true;
-        }
-        if(_start !== currentDotIndex ) {
-          input[_start].hidingDotsStartingPosition = 'left';
-        }
-      }
-      return input;
-    } else {
-
-      angular.forEach(input,function(value,key) {
-        value.isVisible = true;
-      });
-      return input;
-    }
-  };
-});

--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -646,3 +646,41 @@ oppia.directive('progressDots', [function() {
     }]
   };
 }]);
+oppia.filter('sliceDots', function() {
+
+  return function(input, currentDotIndex) {
+    var _maximumNumberOfDotsShown = 18;
+    var _numberOfDots = input.length;
+    angular.forEach(input,function(value,key) {
+      value.isVisible = false;
+      value.hiddindDotsPosition = null;
+    });
+
+   if(_numberOfDots > _maximumNumberOfDotsShown) {
+
+    if(currentDotIndex < _numberOfDots - _maximumNumberOfDotsShown) {
+        var last = currentDotIndex+ _maximumNumberOfDotsShown;
+        for(var i = currentDotIndex; i<last; i++) {
+          input[i].isVisible = true;
+        }
+        input[last-1].hiddindDotsPosition = 'right';
+      } else {
+
+        var _start = _numberOfDots - _maximumNumberOfDotsShown
+        for(var i=_start; i<_numberOfDots;  i++) {
+          input[i].isVisible = true;
+        }
+        if(_start !== currentDotIndex ) {
+          input[_start].hiddindDotsPosition = 'left';
+        }
+      }
+      return input;
+    } else {
+
+      angular.forEach(input,function(value,key) {
+        value.isVisible = true;
+      });
+      return input;
+    }
+  };
+});

--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -647,7 +647,7 @@ oppia.directive('progressDots', [function() {
         }
       };
 
-      /* This is need to watch any change for both number of dots and currentDot. */
+      /* This is needed to watch any change for both number of dots and currentDotIndex. */
       $scope.$watchGroup(['dots', 'currentDotIndex'], function(oldValue, newValue) {
         if(newValue !== oldValue) {
           if($scope.dots.length > $scope.MAX_DOTS) {

--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -653,7 +653,7 @@ oppia.filter('sliceDots', function() {
     var _numberOfDots = input.length;
     angular.forEach(input,function(value,key) {
       value.isVisible = false;
-      value.hiddindDotsPosition = null;
+      value.hidingDotsStartingPosition = null;
     });
 
    if(_numberOfDots > _maximumNumberOfDotsShown) {
@@ -663,7 +663,7 @@ oppia.filter('sliceDots', function() {
         for(var i = currentDotIndex; i<last; i++) {
           input[i].isVisible = true;
         }
-        input[last-1].hiddindDotsPosition = 'right';
+        input[last-1].hidingDotsStartingPosition = 'right';
       } else {
 
         var _start = _numberOfDots - _maximumNumberOfDotsShown
@@ -671,7 +671,7 @@ oppia.filter('sliceDots', function() {
           input[i].isVisible = true;
         }
         if(_start !== currentDotIndex ) {
-          input[_start].hiddindDotsPosition = 'left';
+          input[_start].hidingDotsStartingPosition = 'left';
         }
       }
       return input;

--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -624,11 +624,10 @@ oppia.directive('progressDots', [function() {
           $scope.currentDotIndex = $scope.dots.length - 1;
           $scope.rightmostVisibleDotIndex = $scope.dots.length - 1;
           if ($scope.dots.length > $scope.MAX_DOTS) {
-            $scope.leftmostVisibleDotIndex = $scope.rightmostVisibleDotIndex - $scope.MAX_DOTS;
+            $scope.leftmostVisibleDotIndex = $scope.rightmostVisibleDotIndex - $scope.MAX_DOTS - 1;
           } else {
             $scope.leftmostVisibleDotIndex = 0;
           }
-
         } else {
           throw Error(
             'Unexpected change to number of dots from ' + oldValue + ' to ' +

--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -607,8 +607,6 @@ oppia.directive('progressDots', [function() {
 
       $scope.MAX_DOTS = 18;
       $scope.dots = [];
-      $scope.currentDotIndex = null;
-
       var initialDotCount = $scope.getNumDots();
       for (var i = 0; i < initialDotCount; i++) {
         $scope.dots.push({});
@@ -624,6 +622,12 @@ oppia.directive('progressDots', [function() {
         } else if (newValue === oldValue + 1) {
           $scope.dots.push({});
           $scope.currentDotIndex = $scope.dots.length - 1;
+          $scope.rightmostVisibleDotIndex = $scope.dots.length - 1;
+          if ($scope.dots.length > $scope.MAX_DOTS) {
+            $scope.leftmostVisibleDotIndex = $scope.rightmostVisibleDotIndex - $scope.MAX_DOTS;
+          } else {
+            $scope.leftmostVisibleDotIndex = 0;
+          }
         } else {
           throw Error(
             'Unexpected change to number of dots from ' + oldValue + ' to ' +
@@ -637,46 +641,23 @@ oppia.directive('progressDots', [function() {
 
       $scope.decrementCurrentDotIndex = function() {
         if ($scope.currentDotIndex > 0) {
+          if ($scope.currentDotIndex === $scope.leftmostVisibleDotIndex) {
+            $scope.leftmostVisibleDotIndex = $scope.leftmostVisibleDotIndex - 1;
+            $scope.rightmostVisibleDotIndex = $scope.rightmostVisibleDotIndex - 1;
+          }
           $scope.changeActiveDot($scope.currentDotIndex - 1);
         }
       };
 
       $scope.incrementCurrentDotIndex = function() {
         if ($scope.currentDotIndex < $scope.dots.length - 1) {
+          if($scope.currentDotIndex === $scope.rightmostVisibleDotIndex){
+            $scope.rightmostVisibleDotIndex = $scope.rightmostVisibleDotIndex + 1;
+            $scope.leftmostVisibleDotIndex = $scope.leftmostVisibleDotIndex + 1;
+          }
           $scope.changeActiveDot($scope.currentDotIndex + 1);
         }
       };
-
-      /* This is needed to watch any change for both number of dots and currentDotIndex. */
-      $scope.$watchGroup(['dots', 'currentDotIndex'], function(oldValue, newValue) {
-
-        var HALF_DOTS_RANGE = Math.ceil($scope.MAX_DOTS/2);
-        var getDotsShown = function(i, currentDotIndex, maximumDotsShown, totalDots) {
-          if (maximumDotsShown < totalDots) {
-            if (totalDots - HALF_DOTS_RANGE < currentDotIndex) {
-                    return totalDots - maximumDotsShown + i;
-                  } else if (HALF_DOTS_RANGE < currentDotIndex) {
-                    return currentDotIndex - HALF_DOTS_RANGE + i;
-                  } else {
-                    return i;
-                  }
-            } else {
-              return i;
-            }
-          };
-
-        if (newValue !== oldValue) {
-          var i = 0;
-          var dotsVisible = [];
-          while (i < $scope.MAX_DOTS && i < $scope.dots.length) {
-                var visibleDotIndex = getDotsShown(i, $scope.currentDotIndex, $scope.MAX_DOTS,$scope.dots.length);
-                dotsVisible.push(visibleDotIndex);
-                i ++;
-            }
-            $scope.leftmostVisibleDotIndex = dotsVisible[0];
-            $scope.rightmostVisibleDotIndex = dotsVisible[dotsVisible.length -1];
-          }
-      });
 
     }]
   };

--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -624,7 +624,7 @@ oppia.directive('progressDots', [function() {
           $scope.currentDotIndex = $scope.dots.length - 1;
           $scope.rightmostVisibleDotIndex = $scope.dots.length - 1;
           if ($scope.dots.length > $scope.MAX_DOTS) {
-            $scope.leftmostVisibleDotIndex = $scope.rightmostVisibleDotIndex - $scope.MAX_DOTS - 1;
+            $scope.leftmostVisibleDotIndex = $scope.rightmostVisibleDotIndex - $scope.MAX_DOTS + 1;
           } else {
             $scope.leftmostVisibleDotIndex = 0;
           }

--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -628,6 +628,7 @@ oppia.directive('progressDots', [function() {
           } else {
             $scope.leftmostVisibleDotIndex = 0;
           }
+
         } else {
           throw Error(
             'Unexpected change to number of dots from ' + oldValue + ' to ' +
@@ -651,7 +652,7 @@ oppia.directive('progressDots', [function() {
 
       $scope.incrementCurrentDotIndex = function() {
         if ($scope.currentDotIndex < $scope.dots.length - 1) {
-          if($scope.currentDotIndex === $scope.rightmostVisibleDotIndex){
+          if ($scope.currentDotIndex === $scope.rightmostVisibleDotIndex) {
             $scope.rightmostVisibleDotIndex = $scope.rightmostVisibleDotIndex + 1;
             $scope.leftmostVisibleDotIndex = $scope.leftmostVisibleDotIndex + 1;
           }

--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -605,7 +605,7 @@ oppia.directive('progressDots', [function() {
     templateUrl: 'components/progressDots',
     controller: ['$scope', function($scope) {
 
-      $scope.MAX_DOTS = 4;
+      $scope.MAX_DOTS = 18;
       $scope.dots = [];
       $scope.currentDotIndex = null;
 

--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -649,20 +649,33 @@ oppia.directive('progressDots', [function() {
 
       /* This is needed to watch any change for both number of dots and currentDotIndex. */
       $scope.$watchGroup(['dots', 'currentDotIndex'], function(oldValue, newValue) {
-        if(newValue !== oldValue) {
-          if($scope.dots.length > $scope.MAX_DOTS) {
-            if($scope.currentDotIndex < $scope.dots.length - $scope.MAX_DOTS) {
-              $scope.leftmostVisibleDotIndex = $scope.currentDotIndex;
-              $scope.rightmostVisibleDotIndex = $scope.leftmostVisibleDotIndex + $scope.MAX_DOTS;
+
+        var HALF_DOTS_RANGE = Math.ceil($scope.MAX_DOTS/2);
+        var getDotsShown = function(i, currentDotIndex, maximumDotsShown, totalDots) {
+          if (maximumDotsShown < totalDots) {
+            if (totalDots - HALF_DOTS_RANGE < currentDotIndex) {
+                    return totalDots - maximumDotsShown + i;
+                  } else if (HALF_DOTS_RANGE < currentDotIndex) {
+                    return currentDotIndex - HALF_DOTS_RANGE + i;
+                  } else {
+                    return i;
+                  }
             } else {
-              $scope.leftmostVisibleDotIndex = $scope.dots.length - $scope.MAX_DOTS;
-              $scope.rightmostVisibleDotIndex = $scope.dots.length;
+              return i;
             }
-          } else{
-            $scope.leftmostVisibleDotIndex = 0;
-            $scope.rightmostVisibleDotIndex = $scope.MAX_DOTS;
+          };
+
+        if (newValue !== oldValue) {
+          var i = 0;
+          var dotsVisible = [];
+          while (i < $scope.MAX_DOTS && i < $scope.dots.length) {
+                var visibleDotIndex = getDotsShown(i, $scope.currentDotIndex, $scope.MAX_DOTS,$scope.dots.length);
+                dotsVisible.push(visibleDotIndex);
+                i ++;
+            }
+            $scope.leftmostVisibleDotIndex = dotsVisible[0];
+            $scope.rightmostVisibleDotIndex = dotsVisible[dotsVisible.length -1];
           }
-        }
       });
 
     }]

--- a/extensions/skins/conversation_v1/player.html
+++ b/extensions/skins/conversation_v1/player.html
@@ -245,7 +245,7 @@
       background-color: #ccc;
       cursor: pointer;
     }
-    .oppia-progress-dot-gradient-left{
+    .oppia-progress-dot-gradient-right{
       background: -webkit-linear-gradient(left,#ccc,rgba(255,255,255,0));
       background: -o-linear-gradient(left,#ccc, rgba(255,255,255,0));
       background: -moz-linear-gradient(left,#ccc, rgba(255,255,255,0));
@@ -255,7 +255,7 @@
       -webkit-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Safari and Chrome */
       -o-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Opera */
     }
-    .oppia-progress-dot-gradient-right{
+    .oppia-progress-dot-gradient-left{
       background: -webkit-linear-gradient(right,#ccc,rgba(255,255,255,0));
       background: -o-linear-gradient(right,#ccc, rgba(255,255,255,0));
       background: -moz-linear-gradient(right,#ccc, rgba(255,255,255,0));

--- a/extensions/skins/conversation_v1/player.html
+++ b/extensions/skins/conversation_v1/player.html
@@ -246,20 +246,20 @@
       cursor: pointer;
     }
     .oppia-progress-dot-gradient-left{
-      background: -webkit-linear-gradient(left,#fff,#ccc);
-      background: -o-linear-gradient(left,#fff, #ccc);
-      background: -moz-linear-gradient(left,#fff, #ccc);
-      background: linear-gradient(left,#fff, #ccc);
+      background: -webkit-linear-gradient(left,#ccc,rgba(255,255,255,0));
+      background: -o-linear-gradient(left,#ccc, rgba(255,255,255,0));
+      background: -moz-linear-gradient(left,#ccc, rgba(255,255,255,0));
+      background: linear-gradient(left,#ccc, rgba(255,255,255,0));
       animation:oppia-animate-bounce-dot 1s linear 0s infinite ;
       -moz-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Firefox */
       -webkit-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Safari and Chrome */
       -o-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Opera */
     }
     .oppia-progress-dot-gradient-right{
-      background: -webkit-linear-gradient(right,#fff,#ccc);
-      background: -o-linear-gradient(right,#fff, #ccc);
-      background: -moz-linear-gradient(right,#fff, #ccc);
-      background: linear-gradient(right,#fff, #ccc);
+      background: -webkit-linear-gradient(right,#ccc,rgba(255,255,255,0));
+      background: -o-linear-gradient(right,#ccc, rgba(255,255,255,0));
+      background: -moz-linear-gradient(right,#ccc, rgba(255,255,255,0));
+      background: linear-gradient(right,#ccc, rgba(255,255,255,0));
       -moz-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Firefox */
       -webkit-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Safari and Chrome */
       -o-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Opera */

--- a/extensions/skins/conversation_v1/player.html
+++ b/extensions/skins/conversation_v1/player.html
@@ -202,6 +202,21 @@
         margin-left: 0;
       }
     }
+    @-webkit-keyframes oppia-animate-bounce-dot  {
+      0% { -webkit-transform: scale(1); }
+      50% { -webkit-transform: scale(0.9); }
+      0% { -webkit-transform: scale(1); }
+    }
+    @-moz-keyframes oppia-animate-bounce-dot  {
+      0% { -webkit-transform: scale(1); }
+      50% { -webkit-transform: scale(0.9); }
+      0% { -webkit-transform: scale(1); }
+    }
+    @-o-keyframes oppia-animate-bounce-dot  {
+      0% { -webkit-transform: scale(1); }
+      50% { -webkit-transform: scale(0.9); }
+      0% { -webkit-transform: scale(1); }
+    }
 
     .oppia-progress-arrow {
       color: #ccc;
@@ -230,6 +245,26 @@
       background-color: #ccc;
       cursor: pointer;
     }
+    .oppia-progress-dot-gradient-left{
+      background: -webkit-linear-gradient(left,#fff,#ccc);
+      background: -o-linear-gradient(left,#fff, #ccc);
+      background: -moz-linear-gradient(left,#fff, #ccc);
+      background: linear-gradient(left,#fff, #ccc);
+      animation:oppia-animate-bounce-dot 1s linear 0s infinite ;
+      -moz-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Firefox */
+      -webkit-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Safari and Chrome */
+      -o-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Opera */
+    }
+    .oppia-progress-dot-gradient-right{
+      background: -webkit-linear-gradient(right,#fff,#ccc);
+      background: -o-linear-gradient(right,#fff, #ccc);
+      background: -moz-linear-gradient(right,#fff, #ccc);
+      background: linear-gradient(right,#fff, #ccc);
+      -moz-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Firefox */
+      -webkit-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Safari and Chrome */
+      -o-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Opera */
+    }
+
 
     .oppia-progress-dot-list {
       list-style-type: none;
@@ -241,6 +276,10 @@
 
     .oppia-animate-progress-dot {
       display: inline-block;
+      vertical-align: middle;
+    }
+    .oppia-animate-progress-dot-hidden {
+      display: none;
       vertical-align: middle;
     }
     .oppia-animate-progress-dot.ng-enter {
@@ -258,11 +297,13 @@
       <span class=" glyphicon glyphicon-arrow-left">
       </span>
     </li>
-    <li ng-repeat="dot in dots track by $index" class="oppia-animate-progress-dot">
+    <li ng-repeat="dot in dots | sliceDots:currentDotIndex  track by $index"
+        ng-class="dot.isVisible ? 'oppia-animate-progress-dot': 'oppia-animate-progress-dot-hidden'">
       <span class="oppia-progress-dot oppia-progress-dot-active"
             ng-if="$index === currentDotIndex" ng-show="dots.length > 1">
       </span>
       <span class="oppia-progress-dot oppia-progress-dot-inactive"
+            ng-class="'oppia-progress-dot-gradient-'+ dot.hiddindDotsPosition"
             ng-if="$index !== currentDotIndex"
             ng-click="changeActiveDot($index)">
       </span>

--- a/extensions/skins/conversation_v1/player.html
+++ b/extensions/skins/conversation_v1/player.html
@@ -303,7 +303,7 @@
             ng-if="$index === currentDotIndex" ng-show="dots.length > 1">
       </span>
       <span class="oppia-progress-dot oppia-progress-dot-inactive"
-            ng-class="'oppia-progress-dot-gradient-'+ dot.hiddindDotsPosition"
+            ng-class="'oppia-progress-dot-gradient-'+ dot.hidingDotsStartingPosition"
             ng-if="$index !== currentDotIndex"
             ng-click="changeActiveDot($index)">
       </span>

--- a/extensions/skins/conversation_v1/player.html
+++ b/extensions/skins/conversation_v1/player.html
@@ -207,17 +207,16 @@
       50% { -webkit-transform: scale(0.9); }
       0% { -webkit-transform: scale(1); }
     }
-    @-moz-keyframes oppia-animate-bounce-dot  {
-      0% { -webkit-transform: scale(1); }
-      50% { -webkit-transform: scale(0.9); }
-      0% { -webkit-transform: scale(1); }
+    .oppia-animate-progress-dot {
+      display: inline-block;
+      vertical-align: middle;
     }
-    @-o-keyframes oppia-animate-bounce-dot  {
-      0% { -webkit-transform: scale(1); }
-      50% { -webkit-transform: scale(0.9); }
-      0% { -webkit-transform: scale(1); }
+    .oppia-animate-progress-dot.ng-enter {
+      -webkit-animation: 400ms oppia-animate-enter-progress-dot;
+      animation: 400ms oppia-animate-enter-progress-dot;
+      -webkit-animation-timing-function: linear;
+      animation-timing-function: linear;
     }
-
     .oppia-progress-arrow {
       color: #ccc;
       display: inline-block;
@@ -245,48 +244,28 @@
       background-color: #ccc;
       cursor: pointer;
     }
-    .oppia-progress-dot-gradient-right{
-      background: -webkit-linear-gradient(left,#ccc,rgba(255,255,255,0));
-      background: -o-linear-gradient(left,#ccc, rgba(255,255,255,0));
-      background: -moz-linear-gradient(left,#ccc, rgba(255,255,255,0));
-      background: linear-gradient(left,#ccc, rgba(255,255,255,0));
-      animation:oppia-animate-bounce-dot 1s linear 0s infinite ;
-      -moz-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Firefox */
-      -webkit-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Safari and Chrome */
-      -o-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Opera */
-    }
-    .oppia-progress-dot-gradient-left{
+    .oppia-progress-dot-gradient-left {
+      -webkit-animation: oppia-animate-bounce-dot 1s linear 0s infinite;
+      animation: oppia-animate-bounce-dot 1s linear 0s infinite ;
       background: -webkit-linear-gradient(right,#ccc,rgba(255,255,255,0));
       background: -o-linear-gradient(right,#ccc, rgba(255,255,255,0));
       background: -moz-linear-gradient(right,#ccc, rgba(255,255,255,0));
       background: linear-gradient(right,#ccc, rgba(255,255,255,0));
-      -moz-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Firefox */
-      -webkit-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Safari and Chrome */
-      -o-animation: oppia-animate-bounce-dot 1s linear 0s infinite ; /* Opera */
     }
-
-
+    .oppia-progress-dot-gradient-right {
+      -webkit-animation: oppia-animate-bounce-dot 1s linear 0s infinite ;
+      animation: oppia-animate-bounce-dot 1s linear 0s infinite ;
+      background: -webkit-linear-gradient(left,#ccc,rgba(255,255,255,0));
+      background: -o-linear-gradient(left,#ccc, rgba(255,255,255,0));
+      background: -moz-linear-gradient(left,#ccc, rgba(255,255,255,0));
+      background: linear-gradient(left,#ccc, rgba(255,255,255,0));
+    }
     .oppia-progress-dot-list {
       list-style-type: none;
       margin: 10px auto;
       padding-left: 0;
       position: relative;
       text-align: center;
-    }
-
-    .oppia-animate-progress-dot {
-      display: inline-block;
-      vertical-align: middle;
-    }
-    .oppia-animate-progress-dot-hidden {
-      display: none;
-      vertical-align: middle;
-    }
-    .oppia-animate-progress-dot.ng-enter {
-      -webkit-animation: 400ms oppia-animate-enter-progress-dot;
-      animation: 400ms oppia-animate-enter-progress-dot;
-      -webkit-animation-timing-function: linear;
-      animation-timing-function: linear;
     }
   </style>
 
@@ -297,13 +276,16 @@
       <span class=" glyphicon glyphicon-arrow-left">
       </span>
     </li>
-    <li ng-repeat="dot in dots | sliceDots:currentDotIndex  track by $index"
-        ng-class="dot.isVisible ? 'oppia-animate-progress-dot': 'oppia-animate-progress-dot-hidden'">
+    <li ng-repeat="dot in dots track by $index"
+        class="oppia-animate-progress-dot"
+        ng-show="($index >= leftmostVisibleDotIndex && $index < rightmostVisibleDotIndex)" >
       <span class="oppia-progress-dot oppia-progress-dot-active"
             ng-if="$index === currentDotIndex" ng-show="dots.length > 1">
       </span>
       <span class="oppia-progress-dot oppia-progress-dot-inactive"
-            ng-class="'oppia-progress-dot-gradient-'+ dot.hidingDotsStartingPosition"
+            ng-class="($index === leftmostVisibleDotIndex && $index !== 0) ? 'oppia-progress-dot-gradient-left':
+                      ($index === rightmostVisibleDotIndex-1 && $index !== MAX_DOTS-1) ?
+                       'oppia-progress-dot-gradient-right' : null "
             ng-if="$index !== currentDotIndex"
             ng-click="changeActiveDot($index)">
       </span>

--- a/extensions/skins/conversation_v1/player.html
+++ b/extensions/skins/conversation_v1/player.html
@@ -282,6 +282,7 @@
       <span class="oppia-progress-dot oppia-progress-dot-active"
             ng-if="$index === currentDotIndex" ng-show="dots.length > 1">
       </span>
+      <md-tooltip>Card #<[$index+1]></md-tooltip>
       <span class="oppia-progress-dot oppia-progress-dot-inactive"
             ng-class="$index === leftmostVisibleDotIndex && $index !== 0 ? 'oppia-progress-dot-gradient-left':
                       $index === rightmostVisibleDotIndex && $index !== dots.length-1 ?

--- a/extensions/skins/conversation_v1/player.html
+++ b/extensions/skins/conversation_v1/player.html
@@ -285,7 +285,7 @@
       <md-tooltip>Card #<[$index+1]></md-tooltip>
       <span class="oppia-progress-dot oppia-progress-dot-inactive"
             ng-class="$index === leftmostVisibleDotIndex && $index !== 0 ? 'oppia-progress-dot-gradient-left':
-                      $index === rightmostVisibleDotIndex && $index !== dots.length-1 ?
+                      $index === rightmostVisibleDotIndex && $index !== dots.length - 1 ?
                        'oppia-progress-dot-gradient-right' :''"
             ng-if="$index !== currentDotIndex"
             ng-click="changeActiveDot($index)">

--- a/extensions/skins/conversation_v1/player.html
+++ b/extensions/skins/conversation_v1/player.html
@@ -278,14 +278,14 @@
     </li>
     <li ng-repeat="dot in dots track by $index"
         class="oppia-animate-progress-dot"
-        ng-show="($index >= leftmostVisibleDotIndex && $index < rightmostVisibleDotIndex)" >
+        ng-show="$index >= leftmostVisibleDotIndex && $index <= rightmostVisibleDotIndex" >
       <span class="oppia-progress-dot oppia-progress-dot-active"
             ng-if="$index === currentDotIndex" ng-show="dots.length > 1">
       </span>
       <span class="oppia-progress-dot oppia-progress-dot-inactive"
-            ng-class="($index === leftmostVisibleDotIndex && $index !== 0) ? 'oppia-progress-dot-gradient-left':
-                      ($index === rightmostVisibleDotIndex-1 && $index !== MAX_DOTS-1) ?
-                       'oppia-progress-dot-gradient-right' : null "
+            ng-class="$index === leftmostVisibleDotIndex && $index !== 0 ? 'oppia-progress-dot-gradient-left':
+                      $index === rightmostVisibleDotIndex && $index !== dots.length-1 ?
+                       'oppia-progress-dot-gradient-right' :''"
             ng-if="$index !== currentDotIndex"
             ng-click="changeActiveDot($index)">
       </span>

--- a/extensions/skins/conversation_v1/static/conversation.css
+++ b/extensions/skins/conversation_v1/static/conversation.css
@@ -131,9 +131,9 @@ md-card.conversation-skin-tutor-card {
 .conversation-skin-tutor-card-middle-section .conversation-skin-user-avatar,
 .conversation-skin-tutor-card-middle-section .conversation-skin-oppia-avatar {
   left: -56px;
-  top: -7px;
-  /* This is needed to prevent overlapping of avatars*/
+  /* This is needed to prevent overlapping of avatars. */
   margin-top: 10px;
+  top: -7px;
 }
 
 .conversation-skin-interaction-clickable-instructions {
@@ -143,9 +143,9 @@ md-card.conversation-skin-tutor-card {
 .conversation-skin-learner-answer-container,
 .conversation-skin-oppia-feedback-container {
   margin-bottom: 30px;
-  position: relative;
-  /* This is needed to align content in-line with avatars*/
+  /* This is needed to align content in-line with avatars. */
   padding-top: 10px;
+  position: relative;
 }
 
 .conversation-skin-tutor-card-feedback-toggle-container {

--- a/extensions/skins/conversation_v1/static/conversation.css
+++ b/extensions/skins/conversation_v1/static/conversation.css
@@ -132,6 +132,8 @@ md-card.conversation-skin-tutor-card {
 .conversation-skin-tutor-card-middle-section .conversation-skin-oppia-avatar {
   left: -56px;
   top: -7px;
+  /* This is needed to prevent overlapping of avatars*/
+  margin-top: 10px;
 }
 
 .conversation-skin-interaction-clickable-instructions {
@@ -142,6 +144,8 @@ md-card.conversation-skin-tutor-card {
 .conversation-skin-oppia-feedback-container {
   margin-bottom: 30px;
   position: relative;
+  /* This is needed to align content in-line with avatars*/
+  padding-top: 10px;
 }
 
 .conversation-skin-tutor-card-feedback-toggle-container {


### PR DESCRIPTION
When progress dots are too many then I had to slice the array and show only certain range but the range keeps updating based on where  the current dot is. 
I changed from using ```$index``` to ```id```  because when using  ```$index```  its hard to keep track of sliced dots Eg. if sliced portion is from 6-10 but 6 will be at index zero and current page will be 0 instead of 6.
But i have made ```id``` start from zero too like ```$index``` so that it does not break any thing. 
I have chosen 25 to be maximum number of Dots  shown before they start to scroll horizontally underneath arrows @seanlip what do you think?. 