### PR TITLE
stateName client-side validation  Fixes #950

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -212,7 +212,7 @@ oppia.factory('validatorsService', [
           if (showWarnings) {
             warningsData.addWarning(
              'Invalid input. Please use a non-empty description consisting ' +
-             'of alphanumeric characters, underscores, spaces and/or hyphens.'
+             'of alphanumeric characters, spaces and/or hyphens.'
             );
           }
           return false;

--- a/core/templates/dev/head/components/answerGroupEditor.js
+++ b/core/templates/dev/head/components/answerGroupEditor.js
@@ -404,6 +404,7 @@ oppia.directive('outcomeDestinationEditor', [function() {
           return outcome.dest == PLACEHOLDER_OUTCOME_DEST;
         };
 
+        $scope.newStateNamePattern = /^[a-zA-Z0-9.\s-]+$/;
         $scope.destChoices = [];
         $scope.$watch(explorationStatesService.getStates, function(newValue) {
           var _currentStateName = editorContextService.getActiveStateName();

--- a/core/templates/dev/head/components/answer_group_editor.html
+++ b/core/templates/dev/head/components/answer_group_editor.html
@@ -79,7 +79,7 @@
     <div class="oppia-rule-save-cancel-buttons">
       <div class="pull-right">
         <button type="button" class="btn btn-default" ng-click="cancelThisFeedbackEdit()">Cancel</button>
-        <button type="button" class="btn btn-success protractor-test-save-outcome-feedback" ng-click="saveThisFeedback()">Save Feedback</button>
+        <button type="button" class="btn btn-success protractor-test-save-outcome-feedback" ng-disabled="editAnswerGroupForm.editFeedbackForm.$invalid" ng-click="saveThisFeedback()">Save Feedback</button>
       </div>
 
       <div style="clear: both;"></div>
@@ -112,7 +112,6 @@
     <form role="form" class="form-inline protractor-test-edit-outcome-dest" name="editAnswerGroupForm.editDestForm" ng-submit="saveThisDestination()">
       <outcome-destination-editor outcome="outcome">
       </outcome-destination-editor>
-      <p ng-show="editAnswerGroupForm.editDestForm.$invalid && editAnswerGroupForm.editDestForm.newStateName.$dirty" class="help-block oppia-form-error" style="font-size: 0.85em;">Please pick a card name consisting of alphanumeric characters, spaces and/or hyphens only.</p>
     </form>
 
     <div class="oppia-rule-save-cancel-buttons">
@@ -151,8 +150,11 @@
         </select>
       </span>
     </div>
+    <ng-form name="newStateNameForm">
     <span ng-if="isCreatingNewState(outcome)">
       <input type="text" focus-on="newStateNameInputField" name="newStateName" ng-model="outcome.newStateName" class="form-control ng-pristine ng-valid ng-scope ng-touched protractor-test-add-state-input" tabindex="0" aria-invalid="false" ng-pattern="newStateNamePattern" required>
     </span>
+    <p ng-show="newStateNameForm.newStateName.$error.pattern" class="help-block oppia-form-error" style="font-size: 0.85em;">Please pick a card name consisting of alphanumeric characters, spaces and/or hyphens only.</p>
+    <ng-form>
   </div>
 </script>

--- a/core/templates/dev/head/components/answer_group_editor.html
+++ b/core/templates/dev/head/components/answer_group_editor.html
@@ -151,10 +151,10 @@
       </span>
     </div>
     <ng-form name="newStateNameForm">
-    <span ng-if="isCreatingNewState(outcome)">
-      <input type="text" focus-on="newStateNameInputField" name="newStateName" ng-model="outcome.newStateName" class="form-control ng-pristine ng-valid ng-scope ng-touched protractor-test-add-state-input" tabindex="0" aria-invalid="false" ng-pattern="newStateNamePattern" required>
-    </span>
-    <p ng-show="newStateNameForm.newStateName.$error.pattern" class="help-block oppia-form-error" style="font-size: 0.85em;">Please pick a card name consisting of alphanumeric characters, spaces and/or hyphens only.</p>
-    <ng-form>
+      <span ng-if="isCreatingNewState(outcome)">
+        <input type="text" focus-on="newStateNameInputField" name="newStateName" ng-model="outcome.newStateName" class="form-control ng-pristine ng-valid ng-scope ng-touched protractor-test-add-state-input" tabindex="0" aria-invalid="false" ng-pattern="newStateNamePattern" required>
+      </span>
+      <p ng-show="newStateNameForm.newStateName.$error.pattern" class="help-block oppia-form-error" style="font-size: 0.85em;">Please pick a card name consisting of alphanumeric characters, spaces and/or hyphens.</p>
+    </ng-form>
   </div>
 </script>

--- a/core/templates/dev/head/components/answer_group_editor.html
+++ b/core/templates/dev/head/components/answer_group_editor.html
@@ -77,10 +77,9 @@
     </form>
 
     <div class="oppia-rule-save-cancel-buttons">
-    <p ng-show="editAnswerGroupForm.editFeedbackForm.$invalid && editAnswerGroupForm.editFeedbackForm.newStateName.$dirty" class="help-block oppia-form-error">Please use a non-empty description consisting of alphanumeric characters, spaces and/or hyphens.</p>
       <div class="pull-right">
         <button type="button" class="btn btn-default" ng-click="cancelThisFeedbackEdit()">Cancel</button>
-        <button type="button" class="btn btn-success protractor-test-save-outcome-feedback" ng-disabled="editAnswerGroupForm.editFeedbackForm.$invalid" ng-click="saveThisFeedback()">Save Feedback</button>
+        <button type="button" class="btn btn-success protractor-test-save-outcome-feedback" ng-click="saveThisFeedback()">Save Feedback</button>
       </div>
 
       <div style="clear: both;"></div>
@@ -113,10 +112,10 @@
     <form role="form" class="form-inline protractor-test-edit-outcome-dest" name="editAnswerGroupForm.editDestForm" ng-submit="saveThisDestination()">
       <outcome-destination-editor outcome="outcome">
       </outcome-destination-editor>
+      <p ng-show="editAnswerGroupForm.editDestForm.$invalid && editAnswerGroupForm.editDestForm.newStateName.$dirty" class="help-block oppia-form-error" style="font-size: 0.85em;">Please pick a card name consisting of alphanumeric characters, spaces and/or hyphens only.</p>
     </form>
 
     <div class="oppia-rule-save-cancel-buttons">
-      <p ng-show="editAnswerGroupForm.editDestForm.$invalid && editAnswerGroupForm.editDestForm.newStateName.$dirty" class="help-block oppia-form-error">Please use a non-empty description consisting of alphanumeric characters, spaces and/or hyphens.</p>
       <div class="pull-right">
         <button type="button" class="btn btn-default protractor-test-cancel-outcome-dest" ng-click="cancelThisDestinationEdit()">Cancel</button>
         <button type="button" class="btn btn-success protractor-test-save-outcome-dest" ng-disabled="editAnswerGroupForm.editDestForm.$invalid" ng-click="saveThisDestination()">Save Destination</button>
@@ -153,7 +152,7 @@
       </span>
     </div>
     <span ng-if="isCreatingNewState(outcome)">
-      <input type="text" focus-on="newStateNameInputField" name="newStateName" ng-model="outcome.newStateName" class="form-control ng-pristine ng-valid ng-scope ng-touched protractor-test-add-state-input" tabindex="0" aria-invalid="false" ng-pattern = newStateNamePattern required>
+      <input type="text" focus-on="newStateNameInputField" name="newStateName" ng-model="outcome.newStateName" class="form-control ng-pristine ng-valid ng-scope ng-touched protractor-test-add-state-input" tabindex="0" aria-invalid="false" ng-pattern="newStateNamePattern" required>
     </span>
   </div>
 </script>

--- a/core/templates/dev/head/components/answer_group_editor.html
+++ b/core/templates/dev/head/components/answer_group_editor.html
@@ -77,6 +77,7 @@
     </form>
 
     <div class="oppia-rule-save-cancel-buttons">
+    <p ng-show="editAnswerGroupForm.editFeedbackForm.$invalid && editAnswerGroupForm.editFeedbackForm.newStateName.$dirty" class="help-block oppia-form-error">Please use a non-empty description consisting of alphanumeric characters, spaces and/or hyphens.</p>
       <div class="pull-right">
         <button type="button" class="btn btn-default" ng-click="cancelThisFeedbackEdit()">Cancel</button>
         <button type="button" class="btn btn-success protractor-test-save-outcome-feedback" ng-disabled="editAnswerGroupForm.editFeedbackForm.$invalid" ng-click="saveThisFeedback()">Save Feedback</button>
@@ -115,6 +116,7 @@
     </form>
 
     <div class="oppia-rule-save-cancel-buttons">
+      <p ng-show="editAnswerGroupForm.editDestForm.$invalid && editAnswerGroupForm.editDestForm.newStateName.$dirty" class="help-block oppia-form-error">Please use a non-empty description consisting of alphanumeric characters, spaces and/or hyphens.</p>
       <div class="pull-right">
         <button type="button" class="btn btn-default protractor-test-cancel-outcome-dest" ng-click="cancelThisDestinationEdit()">Cancel</button>
         <button type="button" class="btn btn-success protractor-test-save-outcome-dest" ng-disabled="editAnswerGroupForm.editDestForm.$invalid" ng-click="saveThisDestination()">Save Destination</button>
@@ -151,7 +153,7 @@
       </span>
     </div>
     <span ng-if="isCreatingNewState(outcome)">
-      <input type="text" focus-on="newStateNameInputField" ng-model="outcome.newStateName" class="form-control ng-pristine ng-valid ng-scope ng-touched protractor-test-add-state-input" tabindex="0" aria-invalid="false" required>
+      <input type="text" focus-on="newStateNameInputField" name="newStateName" ng-model="outcome.newStateName" class="form-control ng-pristine ng-valid ng-scope ng-touched protractor-test-add-state-input" tabindex="0" aria-invalid="false" ng-pattern = newStateNamePattern required>
     </span>
   </div>
 </script>

--- a/core/templates/dev/head/components/answer_group_editor.html
+++ b/core/templates/dev/head/components/answer_group_editor.html
@@ -152,7 +152,7 @@
     </div>
     <ng-form name="newStateNameForm">
       <span ng-if="isCreatingNewState(outcome)">
-        <input type="text" focus-on="newStateNameInputField" name="newStateName" ng-model="outcome.newStateName" class="form-control ng-pristine ng-valid ng-scope ng-touched protractor-test-add-state-input" tabindex="0" aria-invalid="false" ng-pattern="newStateNamePattern" required>
+        <input type="text" focus-on="newStateNameInputField" name="newStateName" ng-model="outcome.newStateName" class="form-control protractor-test-add-state-input" tabindex="0" aria-invalid="false" ng-pattern="newStateNamePattern" required>
       </span>
       <p ng-show="newStateNameForm.newStateName.$error.pattern" class="help-block oppia-form-error" style="font-size: 0.85em;">Please pick a card name consisting of alphanumeric characters, spaces and/or hyphens.</p>
     </ng-form>

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -120,7 +120,7 @@ a:focus {
   outline-style: none;
 }
 
-/* Change the all borders of an input to red when there is validation errors. */
+/* Change all the borders of an input to red when there is validation errors. */
 input.ng-dirty.ng-invalid, md-input-group.md-default-theme input.ng-dirty.ng-invalid {
   border-color: #F44336;
 }

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -120,8 +120,9 @@ a:focus {
   outline-style: none;
 }
 
+/* Change the all borders of an input to red when there is validation errors. */
 input.ng-dirty.ng-invalid, md-input-group.md-default-theme input.ng-dirty.ng-invalid {
-  border-bottom-color: #F44336;
+  border-color: #F44336;
 }
 
 /* Change the color of odd-numbered lines in a table. */


### PR DESCRIPTION
+ Made sure the input name consists of alphanumeric characters, spaces and/or hyphens ONLY
+ disable submit button when the form has error
+ display help message/error message instantly when you include invalid character
+ change border of input from blue (on focus) to red to show error in the input