### PR TITLE
Made changes to bottom of learner view…

### DIFF
--- a/core/templates/dev/head/attribution_guide.html
+++ b/core/templates/dev/head/attribution_guide.html
@@ -1,6 +1,6 @@
-<span class="oppia-cc-icon">
+<div class="oppia-cc-icon oppia-transition-200">
   <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">
     <img alt="Creative Commons Licence" style="border-width: 0; height: 24px;" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" />
   </a><br />
-  <a href="/about#license" target="_blank" style="font-size: 9px;">Attribution Guide</a>
-</span>
+  <a href="/about#license" target="_blank" style="color: white; font-size: 9px;">Attribution Guide</a>
+</div>

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -222,12 +222,12 @@ textarea {
 */
 .oppia-dev-mode {
   background-color: DarkSlateGray;
-  border-top-left-radius: 0.5em;
+  border-top-right-radius: 0.5em;
   bottom: 0;
   color: white;
-  padding: 5px;
+  padding: 4px 8px;
   position: fixed;
-  right: 0;
+  left: 0;
 }
 
 /*
@@ -834,8 +834,13 @@ md-card.oppia-gallery-tile {
 
 .oppia-cc-icon {
   bottom: 0;
+  opacity: 0.4;
   position: fixed;
   right: 25px;
+}
+
+.oppia-cc-icon:hover {
+  opacity: 0.7;
 }
 
 .oppia-wide-panel {

--- a/extensions/skins/conversation_v1/static/conversation.css
+++ b/extensions/skins/conversation_v1/static/conversation.css
@@ -129,13 +129,14 @@ html, body {
 md-card.conversation-skin-tutor-card {
   background: rgb(255, 255, 255);
   left: 0;
-  margin: 44px auto 24px auto;
+  margin: 44px auto 60px auto;
   max-width: 472px;
   padding: 0;
   position: relative;
   right: 0;
   text-align: left;
   width: 472px;
+  z-index: 1;
 }
 
 .conversation-skin-tutor-card-top-section {
@@ -258,10 +259,11 @@ md-card.conversation-skin-tutor-card {
 md-card.conversation-skin-supplemental-card {
   background-color: #f6f6f6;
   left: 0;
-  margin: 44px auto;
+  margin: 44px auto 60px auto;
   position: absolute;
   right: 0;
   width: 600px;
+  z-index: 1;
 }
 
 .conversation-skin-right-card-container md-card.conversation-skin-supplemental-card-fixed {
@@ -298,6 +300,7 @@ md-card.conversation-skin-supplemental-card {
   height: 50px;
   position: fixed;
   width: 100%;
+  z-index: 2;
 }
 .conversation-skin-card-switcher-thumbnails-container {
   height: 100%;


### PR DESCRIPTION
…to prevent elements from overlapping on mobile screens. Added opacity and hover to CC icon, and moved 'Development Mode' label to left side of screen to prevent it from overlapping with CC icon.