### PR TITLE
Replaced the JSRepl dependency with Skulpt.

### DIFF
--- a/core/domain/dependency_registry_test.py
+++ b/core/domain/dependency_registry_test.py
@@ -30,8 +30,8 @@ class DependencyRegistryTests(test_utils.GenericTestBase):
 
     def test_get_dependency_html(self):
         self.assertIn(
-            'jsrepl',
-            dependency_registry.Registry.get_dependency_html('jsrepl'))
+            'skulpt',
+            dependency_registry.Registry.get_dependency_html('skulpt'))
 
         with self.assertRaises(IOError):
             dependency_registry.Registry.get_dependency_html('a')
@@ -43,11 +43,11 @@ class DependencyControllerTests(test_utils.GenericTestBase):
     def test_no_dependencies_in_non_exploration_pages(self):
         response = self.testapp.get(feconf.GALLERY_URL)
         self.assertEqual(response.status_int, 200)
-        response.mustcontain(no=['jsrepl'])
+        response.mustcontain(no=['skulpt'])
 
         response = self.testapp.get('/about')
         self.assertEqual(response.status_int, 200)
-        response.mustcontain(no=['jsrepl'])
+        response.mustcontain(no=['skulpt'])
 
     def test_dependencies_loaded_in_exploration_editor(self):
         exp_services.load_demo('0')
@@ -56,20 +56,20 @@ class DependencyControllerTests(test_utils.GenericTestBase):
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
         self.login(self.EDITOR_EMAIL)
 
-        # Verify that the exploration does not have a jsrepl dependency.
+        # Verify that the exploration does not have a Skulpt dependency.
         exploration = exp_services.get_exploration_by_id('0')
         interaction_ids = exploration.get_interaction_ids()
         all_dependency_ids = (
             interaction_registry.Registry.get_deduplicated_dependency_ids(
                 interaction_ids))
 
-        self.assertNotIn('jsrepl', all_dependency_ids)
+        self.assertNotIn('skulpt', all_dependency_ids)
 
-        # However, jsrepl is loaded in the exploration editor anyway, since
+        # However, Skulpt is loaded in the exploration editor anyway, since
         # all dependencies are loaded in the exploration editor.
         response = self.testapp.get('/create/0')
         self.assertEqual(response.status_int, 200)
-        response.mustcontain('jsrepl')
+        response.mustcontain('skulpt')
 
         self.logout()
 
@@ -78,33 +78,33 @@ class DependencyControllerTests(test_utils.GenericTestBase):
 
         exp_services.load_demo(EXP_ID)
 
-        # Verify that exploration 0 does not have a jsrepl dependency.
+        # Verify that exploration 0 does not have a Skulpt dependency.
         exploration = exp_services.get_exploration_by_id(EXP_ID)
         interaction_ids = exploration.get_interaction_ids()
         all_dependency_ids = (
             interaction_registry.Registry.get_deduplicated_dependency_ids(
                 interaction_ids))
-        self.assertNotIn('jsrepl', all_dependency_ids)
+        self.assertNotIn('skulpt', all_dependency_ids)
 
-        # Thus, jsrepl is not loaded in the exploration reader.
+        # Thus, Skulpt is not loaded in the exploration reader.
         response = self.testapp.get('/explore/%s' % EXP_ID)
         self.assertEqual(response.status_int, 200)
-        response.mustcontain(no=['jsrepl'])
+        response.mustcontain(no=['skulpt'])
 
     def test_dependency_loads_in_exploration_containing_it(self):
         EXP_ID = '1'
 
         exp_services.load_demo(EXP_ID)
 
-        # Verify that exploration 1 has a jsrepl dependency.
+        # Verify that exploration 1 has a Skulpt dependency.
         exploration = exp_services.get_exploration_by_id(EXP_ID)
         interaction_ids = exploration.get_interaction_ids()
         all_dependency_ids = (
             interaction_registry.Registry.get_deduplicated_dependency_ids(
                 interaction_ids))
-        self.assertIn('jsrepl', all_dependency_ids)
+        self.assertIn('skulpt', all_dependency_ids)
 
-        # Thus, jsrepl is loaded in the exploration reader.
+        # Thus, Skulpt is loaded in the exploration reader.
         response = self.testapp.get('/explore/%s' % EXP_ID)
         self.assertEqual(response.status_int, 200)
-        response.mustcontain('jsrepl')
+        response.mustcontain('skulpt')

--- a/core/domain/interaction_registry_test.py
+++ b/core/domain/interaction_registry_test.py
@@ -30,17 +30,17 @@ class InteractionDependencyTests(test_utils.GenericTestBase):
         self.assertItemsEqual(
             interaction_registry.Registry.get_deduplicated_dependency_ids(
                 ['CodeRepl']),
-            ['jsrepl', 'codemirror'])
+            ['skulpt', 'codemirror'])
 
         self.assertItemsEqual(
             interaction_registry.Registry.get_deduplicated_dependency_ids(
                 ['CodeRepl', 'CodeRepl', 'CodeRepl']),
-            ['jsrepl', 'codemirror'])
+            ['skulpt', 'codemirror'])
 
         self.assertItemsEqual(
             interaction_registry.Registry.get_deduplicated_dependency_ids(
                 ['CodeRepl', 'LogicProof']),
-            ['jsrepl', 'codemirror', 'logic_proof'])
+            ['skulpt', 'codemirror', 'logic_proof'])
 
 
 class InteractionRegistryUnitTests(test_utils.GenericTestBase):

--- a/extensions/dependencies/dependencies_config.py
+++ b/extensions/dependencies/dependencies_config.py
@@ -24,7 +24,7 @@ __author__ = 'Sean Lip'
 DEPENDENCIES_TO_ANGULAR_MODULES_DICT = {
     'codemirror': ['ui.codemirror'],
     'google_maps': ['ui.map'],
-    'jsrepl': [],
     'logic_proof': [],
     'midijs': [],
+    'skulp': [],
 }

--- a/extensions/dependencies/dependencies_config.py
+++ b/extensions/dependencies/dependencies_config.py
@@ -26,5 +26,5 @@ DEPENDENCIES_TO_ANGULAR_MODULES_DICT = {
     'google_maps': ['ui.map'],
     'logic_proof': [],
     'midijs': [],
-    'skulp': [],
+    'skulpt': [],
 }

--- a/extensions/dependencies/jsrepl.html
+++ b/extensions/dependencies/jsrepl.html
@@ -1,2 +1,0 @@
-<script src="/third_party/static/jsrepl/jsrepl.js" id="jsrepl-script">
-</script>

--- a/extensions/dependencies/skulpt.html
+++ b/extensions/dependencies/skulpt.html
@@ -1,0 +1,4 @@
+<script src="/third_party/static/skulpt/skulpt.min.js">
+</script>
+<script src="/third_party/static/skulpt/skulpt-stdlib.js">
+</script>

--- a/extensions/interactions/CodeRepl/CodeRepl.js
+++ b/extensions/interactions/CodeRepl/CodeRepl.js
@@ -62,49 +62,41 @@ oppia.directive('oppiaInteractiveCodeRepl', [
           editor.on('change', function(instance, change) {
             $scope.code = editor.getValue();
           });
+
+          $scope.hasLoaded = true;
         };
 
-
-        // Set up the jsrepl instance with callbacks set.
-        var jsrepl = new JSREPL({
+        // Configure Skulpt.
+        Sk.configure({
           output: function(out) {
-            // For successful evaluation, this is called before 'result', so
-            // just keep the output string here.
-            $scope.output = out;
+            // This output function is called continuously throughout the
+            // runtime of the script.
+            $scope.output += out;
           },
-          result: function(res) {
-            $scope.sendResponse(res, '');
+          timeoutMsg: function() {
+            $scope.sendResponse('', 'timeout');
           },
-          error: function(err) {
-            if ($scope.output) {
-              // Part of the error message can be in the output string.
-              err += $scope.output;
-              $scope.output = '';
-            }
-            $scope.sendResponse('', err);
-          },
-          timeout: {
-            time: 10000,
-            callback: function() {
-              $scope.sendResponse('', 'timeout');
-            },
-          },
-        });
-
-        jsrepl.loadLanguage($scope.language, function() {
-          $scope.hasLoaded = true;
-          $scope.$apply();
+          execLimit: 10000,
         });
 
         $scope.runCode = function(codeInput) {
           $scope.code = codeInput;
           $scope.output = '';
 
-          // Running the code. This triggers one of the callbacks set to jsrepl
-          // which then calls sendResponse with the result.
           var fullCode = (
             $scope.preCode + '\n' + codeInput + '\n' + $scope.postCode);
-          jsrepl.eval(fullCode);
+
+          // Evaluate the program asynchronously using Skulpt.
+          Sk.misceval.asyncToPromise(function() {
+            Sk.importMainWithBody('<stdin>', false, fullCode, true);
+          }).then(function(res) {
+            // Finished evaluating.
+            $scope.sendResponse('', '');
+          }, function(err) {
+            if (!(err instanceof Sk.builtin.TimeLimitError)) {
+              $scope.sendResponse('', String(err));
+            }
+          });
         };
 
         $scope.sendResponse = function(evaluation, err) {

--- a/extensions/interactions/CodeRepl/CodeRepl.py
+++ b/extensions/interactions/CodeRepl/CodeRepl.py
@@ -24,20 +24,20 @@ class CodeRepl(base.BaseInteraction):
     description = 'Allows learners to enter code and get it evaluated.'
     display_mode = base.DISPLAY_MODE_SUPPLEMENTAL
     is_trainable = True
-    _dependency_ids = ['jsrepl', 'codemirror']
+    _dependency_ids = ['skulpt', 'codemirror']
     answer_type = 'CodeEvaluation'
     instructions = 'Type code in the editor'
     needs_summary = True
 
-    # Language options 'lua' and 'scheme' have been removed for possible
-    # later re-release.
+    # Language options 'lua', 'scheme', 'coffeescript', 'javascript', and
+    # 'ruby' have been removed for possible later re-release.
     _customization_arg_specs = [{
         'name': 'language',
         'description': 'Programming language',
         'schema': {
             'type': 'unicode',
             'choices': [
-                'coffeescript', 'javascript', 'python', 'ruby',
+                'python',
             ]
         },
         'default_value': 'python'

--- a/scripts/install_third_party.sh
+++ b/scripts/install_third_party.sh
@@ -67,28 +67,13 @@ fi
 $NPM_CMD config set ca ""
 
 # Download and install Skulpt. Skulpt is built using a Python script included
-# within the Skulpt repository (skulpt.py). This script requires GitPython to
-# run, among other various tools. GitPython is installed temporarily and these
-# other tools are ignored when building Skulpt (see the sed statements below).
-# The Python script is used to avoid having to manually recreate the Skulpt
-# dist build process in install_third_party.py.
-
-# GitPython is needed by Skulpt's dist build function. Download a local copy to
-# avoid the user needing to install it.
-echo Checking whether GitPython is installed in third_party
-if [ ! -d "$TOOLS_DIR/gitpython" ]; then
-  echo Downloading GitPython
-  cd $TOOLS_DIR
-  rm -rf gitpython
-  git clone https://github.com/gitpython-developers/GitPython ./gitpython/
-  cd gitpython
-
-  # Use a specific GitPython release.
-  git checkout 0.3.6
-  git submodule update --init --recursive
-fi
-
-export PYTHONPATH="$PYTHONPATH:$TOOLS_DIR/gitpython"
+# within the Skulpt repository (skulpt.py). This script normally requires
+# GitPython, however the patches to it below (with the sed operations) lead to
+# it no longer being required. The Python script is used to avoid having to
+# manually recreate the Skulpt dist build process in install_third_party.py.
+# Note that skulpt.py will issue a warning saying its dist command will not
+# work properly without GitPython, but it does actually work due to the
+# patches.
 
 echo Checking whether Skulpt is installed in third_party
 if [ ! "$NO_SKULPT" -a ! -d "$THIRD_PARTY_DIR/static/skulpt" ]; then
@@ -101,7 +86,6 @@ if [ ! "$NO_SKULPT" -a ! -d "$THIRD_PARTY_DIR/static/skulpt" ]; then
 
     # Use a specific Skulpt release.
     git checkout 0.10.0
-    git submodule update --init --recursive
 
     # Add a temporary backup file so that this script works on both Linux and
     # Mac.

--- a/scripts/install_third_party.sh
+++ b/scripts/install_third_party.sh
@@ -62,11 +62,16 @@ fi
 
 # Prevent SELF_SIGNED_CERT_IN_CHAIN error as per
 #
-#   http://blog.npmjs.org/post/78085451721/npms-self-signed-certificate-is-no-more
+#   http://blog.npmjs.org/post/78085451721
 #
 $NPM_CMD config set ca ""
 
-# Download and install Skulpt.
+# Download and install Skulpt. Skulpt is built using a Python script included
+# within the Skulpt repository (skulpt.py). This script requires GitPython to
+# run, among other various tools. GitPython is installed temporarily and these
+# other tools are ignored when building Skulpt (see the sed statements below).
+# The Python script is used to avoid having to manually recreate the Skulpt
+# dist build process in install_third_party.py.
 
 # GitPython is needed by Skulpt's dist build function. Download a local copy to
 # avoid the user needing to install it.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -53,6 +53,10 @@ if [ ${PWD##*/} != $EXPECTED_PWD ]; then
 fi
 
 export OPPIA_DIR=`pwd`
+# Set COMMON_DIR to the absolute path of the directory above OPPIA_DIR. This
+# is necessary becaue COMMON_DIR (or subsequent variables which refer to it)
+# may use it in a situation where relative paths won't work as expected (such
+# as $PYTHONPATH).
 export COMMON_DIR=$(cd $OPPIA_DIR/..; pwd)
 export TOOLS_DIR=$COMMON_DIR/oppia_tools
 export THIRD_PARTY_DIR=$OPPIA_DIR/third_party

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -34,16 +34,16 @@ then
   return 1
 fi
 
-# TODO: Consider using getopts command.
+# TODO(sll): Consider using getopts command.
 declare -a remaining_params
 for arg in "$@"; do
-  if [ "$arg" == "--nojsrepl" ]; then
-    NO_JSREPL=true
+  if [ "$arg" == "--nojsrepl" ] || [ "$arg" == "--noskulpt" ]; then
+    NO_SKULPT=true
   else
     remaining_params+=($arg)
   fi
 done
-export NO_JSREPL
+export NO_SKULPT
 export remaining_params
 
 EXPECTED_PWD='oppia'
@@ -53,7 +53,7 @@ if [ ${PWD##*/} != $EXPECTED_PWD ]; then
 fi
 
 export OPPIA_DIR=`pwd`
-export COMMON_DIR=$OPPIA_DIR/..
+export COMMON_DIR=$(cd $OPPIA_DIR/..; pwd)
 export TOOLS_DIR=$COMMON_DIR/oppia_tools
 export THIRD_PARTY_DIR=$OPPIA_DIR/third_party
 export NODE_MODULE_DIR=$COMMON_DIR/node_modules


### PR DESCRIPTION
Fixes #986.

Replaced the JSRepl dependency with Skulp, updating the CodeRepl interaction in the process. This commit removes the functionality to evaluate JavaScript, CoffeeScript, and Ruby in the CodeRepl interaction. It now only supports Python 2.7 (though there is experimental support in Skulpt for Python 3.x).