### PR TITLE
Updated the Travis CI configuration to send email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,14 @@ env:
   - BACKEND_TEST=true JS_TEST=false
   - BACKEND_TEST=false JS_TEST=true
 
+notifications:
+  email:
+    recipients:
+    - sean@seanlip.org
+    - henning.benmax@gmail.com
+    on_success: change
+    on_failure: change
+
 before_install:
 - pip install codecov
 - export CHROME_BIN=chromium-browser


### PR DESCRIPTION
Updated the Travis CI configuration to send email notifications to Sean and Ben when a build succeeds or breaks after a commit. In particular, email notifications will only be sent when a build changes (goes from succeeding to failing or vice versa). Also, this overrides the default behavior of notifications wherein the committer will no longer receive an email if their commit breaks (though I'm not sure they did before, either). See for more information:

http://docs.travis-ci.com/user/notifications/#Email-notifications