### PR TITLE
Adds service to check if the user is on mobile device. Fixes #1006

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -93,6 +93,10 @@ oppia.config(['$provide', function($provide) {
   }]);
 }]);
 
+oppia.factory('checkIfMobileDevice', [function() {
+  return typeof window.orientation !== 'undefined';
+}]);
+
 // Overwrite the built-in exceptionHandler service to log errors to the backend
 // (so that they can be fixed).
 oppia.factory('$exceptionHandler', ['$log', function($log) {

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -95,7 +95,7 @@ oppia.config(['$provide', function($provide) {
 
 //Returns true if the user is on a mobile device.
 //See here: http://stackoverflow.com/a/14301832/5020618
-oppia.factory('deviceInfoService', [$window, function($window) {
+oppia.factory('deviceInfoService', ['$window', function($window) {
   return typeof $window.orientation !== 'undefined';
 }]);
 
@@ -259,10 +259,13 @@ oppia.factory('validatorsService', [
 
 // Service for setting focus. This broadcasts a 'focusOn' event which sets
 // focus to the element in the page with the corresponding focusOn attribute.
-oppia.factory('focusService', ['$rootScope', '$timeout', function($rootScope, $timeout) {
+oppia.factory('focusService', ['deviceInfoService', '$rootScope', '$timeout', function(deviceInfoService, $rootScope, $timeout) {
   var _nextLabelToFocusOn = null;
   return {
     setFocus: function(name) {
+      if (deviceInfoService) {
+        return null;
+      }
       if (_nextLabelToFocusOn) {
         return;
       }

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -93,8 +93,10 @@ oppia.config(['$provide', function($provide) {
   }]);
 }]);
 
-oppia.factory('checkIfMobileDevice', [function() {
-  return typeof window.orientation !== 'undefined';
+//Returns true if the user is on a mobile device.
+//See here: http://stackoverflow.com/a/14301832/5020618
+oppia.factory('deviceInfoService', [$window, function($window) {
+  return typeof $window.orientation !== 'undefined';
 }]);
 
 // Overwrite the built-in exceptionHandler service to log errors to the backend

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -96,7 +96,11 @@ oppia.config(['$provide', function($provide) {
 //Returns true if the user is on a mobile device.
 //See here: http://stackoverflow.com/a/14301832/5020618
 oppia.factory('deviceInfoService', ['$window', function($window) {
-  return typeof $window.orientation !== 'undefined';
+  return {
+    isMobileDevice: function() {
+      return typeof $window.orientation !== 'undefined';
+    }
+  }
 }]);
 
 // Overwrite the built-in exceptionHandler service to log errors to the backend
@@ -275,10 +279,8 @@ oppia.factory('focusService', ['$rootScope', '$timeout', 'deviceInfoService',
       });
     },
     setFocusIfOnDesktop: function(newFocusLabel) {
-      if (deviceInfoService) {
-        return null;
-      } else {
-        return this.setFocus(newFocusLabel);
+      if (!deviceInfoService.isMobileDevice()) {
+        this.setFocus(newFocusLabel);
       }
     },
     // Generates a random string (to be used as a focus label).

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -100,7 +100,7 @@ oppia.factory('deviceInfoService', ['$window', function($window) {
     isMobileDevice: function() {
       return typeof $window.orientation !== 'undefined';
     }
-  }
+  };
 }]);
 
 // Overwrite the built-in exceptionHandler service to log errors to the backend

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -259,13 +259,11 @@ oppia.factory('validatorsService', [
 
 // Service for setting focus. This broadcasts a 'focusOn' event which sets
 // focus to the element in the page with the corresponding focusOn attribute.
-oppia.factory('focusService', ['deviceInfoService', '$rootScope', '$timeout', function(deviceInfoService, $rootScope, $timeout) {
+oppia.factory('focusService', ['$rootScope', '$timeout', 'deviceInfoService', 
+  function($rootScope, $timeout, deviceInfoService) {
   var _nextLabelToFocusOn = null;
   return {
     setFocus: function(name) {
-      if (deviceInfoService) {
-        return null;
-      }
       if (_nextLabelToFocusOn) {
         return;
       }
@@ -275,6 +273,13 @@ oppia.factory('focusService', ['deviceInfoService', '$rootScope', '$timeout', fu
         $rootScope.$broadcast('focusOn', _nextLabelToFocusOn);
         _nextLabelToFocusOn = null;
       });
+    },
+    setFocusIfOnDesktop: function(newFocusLabel) {
+      if (deviceInfoService) {
+        return null;
+      } else {
+        return this.setFocus(newFocusLabel);
+      }
     },
     // Generates a random string (to be used as a focus label).
     generateFocusLabel: function() {

--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -295,9 +295,9 @@ oppia.directive('conversationSkin', [function() {
 
         _recomputeAndResetPanels();
         if (_nextFocusLabel && index === $scope.transcript.length - 1) {
-          focusService.setFocus(_nextFocusLabel);
+          focusService.setFocusIfOnDesktop(_nextFocusLabel);
         } else {
-          focusService.setFocus($scope.activeCard.contentHtmlFocusLabel);
+          focusService.setFocusIfOnDesktop($scope.activeCard.contentHtmlFocusLabel);
         }
       };
 
@@ -372,7 +372,7 @@ oppia.directive('conversationSkin', [function() {
 
           $scope.adjustPageHeight(false, null);
           $window.scrollTo(0, 0);
-          focusService.setFocus(_nextFocusLabel);
+          focusService.setFocusIfOnDesktop(_nextFocusLabel);
 
           $scope.explorationCompleted = oppiaPlayerService.isStateTerminal(
             stateName);
@@ -420,7 +420,7 @@ oppia.directive('conversationSkin', [function() {
                 oppiaPlayerService.getInteractionHtml(newStateName, _nextFocusLabel) +
                 oppiaPlayerService.getRandomSuffix());
             }
-            focusService.setFocus(_nextFocusLabel);
+            focusService.setFocusIfOnDesktop(_nextFocusLabel);
             scrollToBottom();
           } else {
             // There is a new card. Disable the current interaction -- then, if
@@ -447,7 +447,7 @@ oppia.directive('conversationSkin', [function() {
               lastAnswerFeedbackPair.oppiaFeedback = feedbackHtml;
               $scope.waitingForContinueButtonClick = true;
               _nextFocusLabel = $scope.CONTINUE_BUTTON_FOCUS_LABEL;
-              focusService.setFocus(_nextFocusLabel);
+              focusService.setFocusIfOnDesktop(_nextFocusLabel);
               scrollToBottom();
             } else {
               // Note that feedbackHtml is an empty string if no feedback has
@@ -487,7 +487,7 @@ oppia.directive('conversationSkin', [function() {
         }, TIME_FADEOUT_MSEC + 0.1 * TIME_HEIGHT_CHANGE_MSEC);
 
         $timeout(function() {
-          focusService.setFocus(_nextFocusLabel);
+          focusService.setFocusIfOnDesktop(_nextFocusLabel);
           scrollToTop();
         }, TIME_FADEOUT_MSEC + TIME_HEIGHT_CHANGE_MSEC + 0.5 * TIME_FADEIN_MSEC);
 


### PR DESCRIPTION
I've tested this on both IOS 8 and Android 5.1.1.  Another option would be to check the device against a long list of known mobile devices though that approach may be more trouble to maintain.

Are there any particular places besides text input that the mobile autofocus should be reworked?