### PR TITLE
Displaying warning markers in the exploration graph  Fixes #696

### DIFF
--- a/core/templates/dev/head/components/visualizations.html
+++ b/core/templates/dev/head/components/visualizations.html
@@ -91,14 +91,11 @@
                   <tspan alignment-baseline="central"><[getTruncatedLabel(node.label)]></tspan>
                   <tspan ng-attr-x="<[node.xLabel]>" dy="1em" style="fill:gray"><[getTruncatedLabel(node.secondaryLabel)]></tspan>
                 </text>
-                <g ng-if="getNodeErrorMessage(node.label)">
+                <g ng-if="getNodeErrorMessage(node.label) && showWarningSign">
                   <rect ng-click="onClickFunction(node.id)" class="clickable"
                         style="fill: yellow;" width="22" height="22"
                         ng-attr-x="<[node.x0]>" ng-attr-y="<[node.y0]>"
-                        ng-attr-transform="<[getHighlightTransform(node.x0, node.y0)]>"
-                        tooltip="<[getNodeErrorMessage(node.label)]>"
-                        tooltip-placement="bottom" tooltip-append-to-body="true"
-                        tooltip-animation="false">
+                        ng-attr-transform="<[getHighlightTransform(node.x0, node.y0)]>">
                   </rect>
                   <text fill="firebrick" text-anchor="middle" ng-attr-x="<[node.x0 + 11]>"
                       ng-attr-y="<[node.y0 + 17]>"
@@ -106,6 +103,7 @@
                       ng-attr-transform="<[getHighlightTextTransform(node.x0, node.y0)]>">
                     ⚠
                   </text>
+                  <title><[getNodeErrorMessage(node.label)]></title>
                 </g>
                 <g ng-if="isEditable && onDeleteFunction && node.canDelete" class="protractor-test-delete-node">
                   <rect height="15" width="15" opacity="0" stroke-width="0"

--- a/core/templates/dev/head/components/visualizations.html
+++ b/core/templates/dev/head/components/visualizations.html
@@ -94,11 +94,11 @@
                 <g ng-if="getNodeErrorMessage(node.label) && showWarningSign">
                   <rect ng-click="onClickFunction(node.id)" class="clickable"
                         style="fill: yellow;" width="22" height="22"
-                        ng-attr-x="<[node.x0]>" ng-attr-y="<[node.y0]>"
+                        ng-attr-x="<[node.x0]>" ng-attr-y="<[node.y0 - 8]>"
                         ng-attr-transform="<[getHighlightTransform(node.x0, node.y0)]>">
                   </rect>
                   <text fill="firebrick" text-anchor="middle" ng-attr-x="<[node.x0 + 11]>"
-                      ng-attr-y="<[node.y0 + 17]>"
+                      ng-attr-y="<[node.y0 + 9]>"
                       style="font-size: 22px; font-weight: bold;"
                       ng-attr-transform="<[getHighlightTextTransform(node.x0, node.y0)]>">
                     ⚠

--- a/core/templates/dev/head/components/visualizations.html
+++ b/core/templates/dev/head/components/visualizations.html
@@ -11,24 +11,20 @@
       fill-opacity: 0;
       pointer-events: all;
     }
-
     .oppia-graph-viz path.link {
       fill: none;
       stroke: rgb(179, 179, 179);
       stroke-width: 3px;
     }
-
     .oppia-graph-viz text {
       font: 12px sans-serif;
       pointer-events: none;
     }
-
     .oppia-graph-viz text.shadow {
       stroke: #fff;
       stroke-width: 3px;
       stroke-opacity: .8;
     }
-
     .oppia-graph-viz .node rect {
       fill: #fff;
       pointer-events: all;
@@ -51,11 +47,9 @@
     .oppia-graph-viz .node rect.normal-node:hover {
       fill: #C8C4C4;
     }
-
     .oppia-graph-viz .clickable {
       cursor: pointer;
     }
-
     .oppia-graph-viz .legend-bar {
       fill: url('#nodegradient');
       stroke: black;
@@ -93,11 +87,26 @@
                       ng-attr-style="<[node.style]>"
                       ng-click="onClickFunction(node.id)">
                 </rect>
-                <title><[getNodeTitle(node)]></title>
                 <text text-anchor="middle" ng-attr-x="<[node.xLabel]>" ng-attr-y="<[node.yLabel]>" class="protractor-test-node-label">
                   <tspan alignment-baseline="central"><[getTruncatedLabel(node.label)]></tspan>
                   <tspan ng-attr-x="<[node.xLabel]>" dy="1em" style="fill:gray"><[getTruncatedLabel(node.secondaryLabel)]></tspan>
                 </text>
+                <g ng-if="getNodeErrorMessage(node.label)">
+                  <rect ng-click="onClickFunction(node.id)" class="clickable"
+                        style="fill: yellow;" width="22" height="22"
+                        ng-attr-x="<[node.x0]>" ng-attr-y="<[node.y0]>"
+                        ng-attr-transform="<[getHighlightTransform(node.x0, node.y0)]>"
+                        tooltip="<[getNodeErrorMessage(node.label)]>"
+                        tooltip-placement="bottom" tooltip-append-to-body="true"
+                        tooltip-animation="false">
+                  </rect>
+                  <text fill="firebrick" text-anchor="middle" ng-attr-x="<[node.x0 + 11]>"
+                      ng-attr-y="<[node.y0 + 17]>"
+                      style="font-size: 22px; font-weight: bold;"
+                      ng-attr-transform="<[getHighlightTextTransform(node.x0, node.y0)]>">
+                    ⚠
+                  </text>
+                </g>
                 <g ng-if="isEditable && onDeleteFunction && node.canDelete" class="protractor-test-delete-node">
                   <rect height="15" width="15" opacity="0" stroke-width="0"
                         ng-attr-x="<[node.x0 + node.width]>" ng-attr-y="<[node.y0]>"

--- a/core/templates/dev/head/components/visualizations.js
+++ b/core/templates/dev/head/components/visualizations.js
@@ -530,7 +530,8 @@ oppia.directive('stateGraphViz', [function() {
       onMaximizeFunction: '=',
       // Object whose keys are ids of nodes, and whose values are the
       // corresponding node opacities.
-      opacityMap: '='
+      opacityMap: '=',
+      showWarningSign: '@'
     },
     templateUrl: 'visualizations/stateGraphViz',
     controller: [

--- a/core/templates/dev/head/components/visualizations.js
+++ b/core/templates/dev/head/components/visualizations.js
@@ -535,10 +535,12 @@ oppia.directive('stateGraphViz', [function() {
     templateUrl: 'visualizations/stateGraphViz',
     controller: [
       '$scope', '$element', '$timeout', '$filter', 'stateGraphArranger',
-      'MAX_NODES_PER_ROW', 'MAX_NODE_LABEL_LENGTH',
+      'explorationWarningsService', 'MAX_NODES_PER_ROW',
+      'MAX_NODE_LABEL_LENGTH',
       function(
           $scope, $element, $timeout, $filter, stateGraphArranger,
-          MAX_NODES_PER_ROW, MAX_NODE_LABEL_LENGTH) {
+          explorationWarningsService, MAX_NODES_PER_ROW,
+          MAX_NODE_LABEL_LENGTH) {
         var redrawGraph = function() {
           if ($scope.graphData()) {
             $scope.graphLoaded = false;
@@ -831,6 +833,14 @@ oppia.directive('stateGraphViz', [function() {
             nodeData[nodeId].canDelete = (nodeId != initStateId);
             $scope.nodeList.push(nodeData[nodeId]);
           }
+
+          $scope.getNodeErrorMessage = function(nodeLabel) {
+            var warnings =
+              explorationWarningsService.getAllStateRelatedWarnings();
+            if (warnings.hasOwnProperty(nodeLabel)) {
+              return warnings[nodeLabel][0].toString();
+            }
+          };
 
           // The translation applied when the graph is first loaded.
           var origTranslations = [0, 0];

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -102,6 +102,7 @@ body {
   font-size: 1.6em;
   height: 100%;
   margin: 0 auto;
+  overflow-x: hidden;
   padding: 0;
   width: 100%;
 }

--- a/core/templates/dev/head/editor/EditorServices.js
+++ b/core/templates/dev/head/editor/EditorServices.js
@@ -1493,7 +1493,7 @@ oppia.constant('WARNING_TYPES', {
 oppia.constant('STATE_ERROR_MESSAGES', {
   ADD_INTERACTION: 'Please add an interaction to this card.',
   STATE_UNREACHABLE: 'This card is unreachable',
-  INCOMPLETE_EXPOLRATION: 'Please make sure there\'s a way to complete ' +
+  UNABLE_TO_END_EXPLORATION: 'Please make sure there\'s a way to complete ' +
               'the exploration starting from this card'
 });
 
@@ -1865,10 +1865,10 @@ oppia.factory('explorationWarningsService', [
             angular.forEach(deadEndStates, function(deadEndState) {
              if (stateWarnings.hasOwnProperty(deadEndState)) {
                stateWarnings[deadEndState].push(
-                 STATE_ERROR_MESSAGES.INCOMPLETE_EXPOLRATION);
+                 STATE_ERROR_MESSAGES.UNABLE_TO_END_EXPLORATION);
              } else {
                stateWarnings[deadEndState] = [
-                 STATE_ERROR_MESSAGES.INCOMPLETE_EXPOLRATION];
+                 STATE_ERROR_MESSAGES.UNABLE_TO_END_EXPLORATION];
              }
            });
           }

--- a/core/templates/dev/head/editor/EditorServices.js
+++ b/core/templates/dev/head/editor/EditorServices.js
@@ -1908,11 +1908,11 @@ oppia.factory('explorationWarningsService', [
 
       if (Object.keys(stateWarnings).length) {
         _warningsList.push({
-            type: WARNING_TYPES.ERROR,
-            message: (
-              'The following states have errors: ' +
-              Object.keys(stateWarnings).join(', ') + '.')
-          });
+          type: WARNING_TYPES.ERROR,
+          message: (
+            'The following states have errors: ' +
+            Object.keys(stateWarnings).join(', ') + '.')
+        });
       };
 
       var statesWithAnswerGroupsWithEmptyFuzzyRules = (

--- a/core/templates/dev/head/editor/EditorServices.js
+++ b/core/templates/dev/head/editor/EditorServices.js
@@ -1490,18 +1490,26 @@ oppia.constant('WARNING_TYPES', {
   ERROR: 'error'
 });
 
+oppia.constant('STATE_ERROR_MESSAGES', {
+  ADD_INTERACTION: 'Please add an interaction to this card.',
+  STATE_UNREACHABLE: 'This card is unreachable',
+  INCOMPLETE_EXPOLRATION: 'Please make sure there\'s a way to complete ' +
+              'the exploration starting from this card'
+});
+
 // Service for the list of exploration warnings.
 oppia.factory('explorationWarningsService', [
   '$filter', 'graphDataService', 'explorationStatesService',
   'expressionInterpolationService', 'explorationParamChangesService',
   'explorationObjectiveService', 'INTERACTION_SPECS', 'WARNING_TYPES',
-  'FUZZY_RULE_TYPE',
+  'STATE_ERROR_MESSAGES', 'FUZZY_RULE_TYPE',
   function(
       $filter, graphDataService, explorationStatesService,
       expressionInterpolationService, explorationParamChangesService,
       explorationObjectiveService, INTERACTION_SPECS, WARNING_TYPES,
-      FUZZY_RULE_TYPE) {
+      STATE_ERROR_MESSAGES, FUZZY_RULE_TYPE) {
     var _warningsList = [];
+    var stateWarnings = {};
 
     var _getStatesWithoutInteractionIds = function() {
       var statesWithoutInteractionIds = [];
@@ -1822,25 +1830,31 @@ oppia.factory('explorationWarningsService', [
       var _graphData = graphDataService.getGraphData();
 
       var statesWithoutInteractionIds = _getStatesWithoutInteractionIds();
-      if (statesWithoutInteractionIds.length) {
-        _warningsList.push({
-          type: WARNING_TYPES.ERROR,
-          message: (
-            'Please add interactions for these cards: ' +
-            statesWithoutInteractionIds.join(', ') + '.')
-        });
-      }
+      angular.forEach(statesWithoutInteractionIds, function(
+        stateWithoutInteractionIds) {
+        if (stateWarnings.hasOwnProperty(stateWithoutInteractionIds)) {
+          stateWarnings[stateWithoutInteractionIds].push(
+              STATE_ERROR_MESSAGES.ADD_INTERACTION);
+        } else {
+          stateWarnings[stateWithoutInteractionIds] = [
+            STATE_ERROR_MESSAGES.ADD_INTERACTION];
+        }
+      });
 
       if (_graphData) {
         var unreachableStateNames = _getUnreachableNodeNames(
           [_graphData.initStateId], _graphData.nodes, _graphData.links);
 
         if (unreachableStateNames.length) {
-          _warningsList.push({
-            type: WARNING_TYPES.ERROR,
-            message: (
-              'The following card(s) are unreachable: ' +
-              unreachableStateNames.join(', ') + '.')
+          angular.forEach(unreachableStateNames, function(
+            unreachableStateName) {
+            if (stateWarnings.hasOwnProperty(unreachableStateName)) {
+              stateWarnings[unreachableStateName].push(
+                STATE_ERROR_MESSAGES.STATE_UNREACHABLE);
+            } else {
+              stateWarnings[unreachableStateName] =
+                [STATE_ERROR_MESSAGES.STATE_UNREACHABLE];
+            }
           });
         } else {
           // Only perform this check if all states are reachable.
@@ -1848,20 +1862,15 @@ oppia.factory('explorationWarningsService', [
             _graphData.finalStateIds, _graphData.nodes,
             _getReversedLinks(_graphData.links));
           if (deadEndStates.length) {
-            var deadEndStatesString = null;
-            if (deadEndStates.length === 1) {
-              deadEndStatesString = 'the following card: ' + deadEndStates[0];
-            } else {
-              deadEndStatesString = 'each of: ' + deadEndStates.join(', ');
-            }
-
-            _warningsList.push({
-              type: WARNING_TYPES.ERROR,
-              message: (
-                'Please make sure there\'s a way to complete ' +
-                'the exploration starting from ' +
-                deadEndStatesString + '.')
-            });
+            angular.forEach(deadEndStates, function(deadEndState) {
+             if (stateWarnings.hasOwnProperty(deadEndState)) {
+               stateWarnings[deadEndState].push(
+                 STATE_ERROR_MESSAGES.INCOMPLETE_EXPOLRATION);
+             } else {
+               stateWarnings[deadEndState] = [
+                 STATE_ERROR_MESSAGES.INCOMPLETE_EXPOLRATION];
+             }
+           });
           }
         }
 
@@ -1881,11 +1890,11 @@ oppia.factory('explorationWarningsService', [
             interaction.answer_groups, interaction.default_outcome);
 
           for (var j = 0; j < interactionWarnings.length; j++) {
-            _warningsList.push({
-              type: interactionWarnings[j].type,
-              message: (
-                'In \'' + stateName + '\', ' + interactionWarnings[j].message)
-            });
+            if (stateWarnings.hasOwnProperty(stateName)) {
+              stateWarnings[stateName].push(interactionWarnings[j].message);
+            } else {
+              stateWarnings[stateName] = [interactionWarnings[j].message];
+            }
           }
         }
       }
@@ -1896,6 +1905,15 @@ oppia.factory('explorationWarningsService', [
           message: 'Please specify an objective (in the Settings tab).'
         });
       }
+
+      if (Object.keys(stateWarnings).length) {
+        _warningsList.push({
+            type: WARNING_TYPES.ERROR,
+            message: (
+              'The following states have errors: ' +
+              Object.keys(stateWarnings).join(', ') + '.')
+          });
+      };
 
       var statesWithAnswerGroupsWithEmptyFuzzyRules = (
         _getStatesAndAnswerGroupsWithEmptyFuzzyRules());
@@ -1920,6 +1938,9 @@ oppia.factory('explorationWarningsService', [
     return {
       countWarnings: function() {
         return _warningsList.length;
+      },
+      getAllStateRelatedWarnings: function() {
+        return stateWarnings;
       },
       getWarnings: function() {
         return _warningsList;

--- a/core/templates/dev/head/editor/exploration_graph.html
+++ b/core/templates/dev/head/editor/exploration_graph.html
@@ -5,7 +5,7 @@
 
   <md-card style="background-color: white; margin: 20px 0px; padding: 8px;">
     <div class="oppia-state-graph-container protractor-test-exploration-graph">
-      <div state-graph-viz graph-data="getGraphData()" current-state-id="getActiveStateName()" on-click-function="onClickStateInMinimap" on-delete-function="deleteState" on-maximize-function="openStateGraphModal" allow-panning="true" center-at-current-state="true" style="height: 100%;" is-editable="isEditable()">
+      <div state-graph-viz graph-data="getGraphData()" current-state-id="getActiveStateName()" on-click-function="onClickStateInMinimap" on-delete-function="deleteState" on-maximize-function="openStateGraphModal" allow-panning="true" center-at-current-state="true" style="height: 100%;" is-editable="isEditable()" show-warning-sign="true">
       </div>
     </div>
   </md-card>

--- a/extensions/interactions/Continue/validator.js
+++ b/extensions/interactions/Continue/validator.js
@@ -44,7 +44,7 @@ oppia.filter('oppiaInteractiveContinueValidator', [
     if (!defaultOutcome || $filter('isOutcomeConfusing')(defaultOutcome, stateName)) {
       warningsList.push({
         type: WARNING_TYPES.ERROR,
-        message: 'please specify what Oppia should do after the button is clicked.'
+        message: 'Please specify what Oppia should do after the button is clicked.'
       });
     }
 

--- a/extensions/interactions/baseValidator.js
+++ b/extensions/interactions/baseValidator.js
@@ -49,7 +49,7 @@ oppia.factory('baseInteractionValidationService', [
           partialWarningsList.push({
             type: WARNING_TYPES.ERROR,
             message: (
-              'please specify what Oppia should do in answer group ' +
+              'Please specify what Oppia should do in answer group ' +
               String(i + 1) + '.')
           });
         }
@@ -63,7 +63,7 @@ oppia.factory('baseInteractionValidationService', [
         partialWarningsList.push({
           type: WARNING_TYPES.ERROR,
           message: (
-            'please add feedback for the user if they are to return to the ' +
+            'Please add feedback for the user if they are to return to the ' +
             'same state again.')
         });
       }

--- a/extensions/interactions/baseValidatorSpec.js
+++ b/extensions/interactions/baseValidatorSpec.js
@@ -79,7 +79,7 @@ describe('Interaction validator', function() {
       var warnings = bivs.getAnswerGroupWarnings(answerGroups, currentState);
       expect(warnings).toEqual([{
         'type': WARNING_TYPES.ERROR,
-        'message': 'please specify what Oppia should do in answer group 2.'
+        'message': 'Please specify what Oppia should do in answer group 2.'
       }]);
     });
 
@@ -98,7 +98,7 @@ describe('Interaction validator', function() {
       var warnings = bivs.getDefaultOutcomeWarnings(badOutcome, currentState);
       expect(warnings).toEqual([{
         'type': WARNING_TYPES.ERROR,
-        'message': 'please add feedback for the user if they are to return ' +
+        'message': 'Please add feedback for the user if they are to return ' +
           'to the same state again.'
       }]);
     });
@@ -120,13 +120,13 @@ describe('Interaction validator', function() {
         badAnswerGroups, badOutcome, currentState);
       expect(warnings).toEqual([{
           'type': WARNING_TYPES.ERROR,
-          'message': 'please specify what Oppia should do in answer group 2.'
+          'message': 'Please specify what Oppia should do in answer group 2.'
         }, {
           'type': WARNING_TYPES.ERROR,
-          'message': 'please specify what Oppia should do in answer group 3.'
+          'message': 'Please specify what Oppia should do in answer group 3.'
         }, {
           'type': WARNING_TYPES.ERROR,
-          'message': 'please add feedback for the user if they are to return ' +
+          'message': 'Please add feedback for the user if they are to return ' +
             'to the same state again.'
         }
       ]);
@@ -216,7 +216,7 @@ describe('Interaction validator', function() {
       var warnings = validator(currentState, customizationArguments, [], null);
       expect(warnings).toEqual([{
         'type': WARNING_TYPES.ERROR,
-        'message': 'please specify what Oppia should do after the button is' +
+        'message': 'Please specify what Oppia should do after the button is' +
           ' clicked.'
       }]);
     });


### PR DESCRIPTION
I had two options to show marker either inside the  or outside the node *(see pictures below)*
![dangeroutside](https://cloud.githubusercontent.com/assets/6409210/10511882/11496a32-7345-11e5-9a32-d683247c9809.png)
![dangerinside](https://cloud.githubusercontent.com/assets/6409210/10511884/11ad27a2-7345-11e5-80cb-ce494cdbf3b5.png)

I guess @amitdeutsch  will have a suggestion on which is the best way to show.
And Also @amitdeutsch should we use tooltip or just title to show list of errors?
![tooltipdanger](https://cloud.githubusercontent.com/assets/6409210/10511920/5c0b0e22-7345-11e5-984c-4911c296e6a4.png)
![title](https://cloud.githubusercontent.com/assets/6409210/10511922/5c63cda0-7345-11e5-8948-f8b6bd9f1f85.png)

Any suggestions?!
Thanks
