### PR TITLE
Minor bugfix on ScoreBar text label display when parameter value exc...

### DIFF
--- a/extensions/gadgets/ScoreBar/ScoreBar.js
+++ b/extensions/gadgets/ScoreBar/ScoreBar.js
@@ -21,21 +21,30 @@
  */
 
 oppia.directive('oppiaGadgetScoreBar', [
-  'oppiaHtmlEscaper', 'learnerParamsService', function(oppiaHtmlEscaper, learnerParamsService) {
-
+  'oppiaHtmlEscaper', 'learnerParamsService',
+  function(oppiaHtmlEscaper, learnerParamsService) {
     return {
       restrict: 'E',
       templateUrl: 'gadget/ScoreBar',
-      controller: ['$scope', '$attrs', function ($scope, $attrs) {
-
-        $scope.scoreBarLabel = oppiaHtmlEscaper.escapedJsonToObj($attrs.gadgetName);
-        $scope.maxValue = oppiaHtmlEscaper.escapedJsonToObj($attrs.maxValueWithValue);
-        $scope.scoreBarParamName = oppiaHtmlEscaper.escapedJsonToObj($attrs.paramNameWithValue);
+      controller: ['$scope', '$attrs', function($scope, $attrs) {
+        $scope.scoreBarLabel = oppiaHtmlEscaper.escapedJsonToObj(
+          $attrs.gadgetName);
+        $scope.maxValue = oppiaHtmlEscaper.escapedJsonToObj(
+          $attrs.maxValueWithValue);
+        $scope.scoreBarParamName = oppiaHtmlEscaper.escapedJsonToObj(
+          $attrs.paramNameWithValue);
 
         $scope.getScoreValue = function() {
-          return learnerParamsService.getValue($scope.scoreBarParamName);
+          // If a parameter's value exceeds the ScoreBar's maxValue, return
+          // maxValue to keep the label text visible.
+          if (learnerParamsService.getValue(
+              $scope.scoreBarParamName) > $scope.maxValue) {
+            return $scope.maxValue;
+          } else {
+            return learnerParamsService.getValue($scope.scoreBarParamName);
+          }
         };
-      }],
-    }
+      }]
+    };
   }
 ]);

--- a/extensions/gadgets/ScoreBar/ScoreBar.js
+++ b/extensions/gadgets/ScoreBar/ScoreBar.js
@@ -34,20 +34,21 @@ oppia.directive('oppiaGadgetScoreBar', [
         $scope.scoreBarParamName = oppiaHtmlEscaper.escapedJsonToObj(
           $attrs.paramNameWithValue);
 
+        // Returns the closest number to `value` in the range [bound1, bound2]
+        var clamp = function(value, bound1, bound2) {
+          var minValue = Math.min(bound1, bound2);
+          var maxValue = Math.max(bound1, bound2);
+          return Math.min(Math.max(value, minValue), maxValue);
+        };
+
+        // If a parameter's value exceeds the ScoreBar's maxValue, return
+        // maxValue to keep the label text visible.
         $scope.getScoreValue = function() {
-          // If a parameter's value exceeds the ScoreBar's maxValue, return
-          // maxValue to keep the label text visible.
-          if (learnerParamsService.getValue(
-              $scope.scoreBarParamName) > $scope.maxValue) {
-            return $scope.maxValue;
-          } else if (learnerParamsService.getValue(
-              $scope.scoreBarParamName) < 0) {
-            // Defense-in-depth: although underflows don't break the current
-            // UI, return a sensible minimum.
-            return 0;
-          } else {
-            return learnerParamsService.getValue($scope.scoreBarParamName);
-          }
+          return clamp(
+            learnerParamsService.getValue($scope.scoreBarParamName),
+            0,
+            $scope.maxValue
+          );
         };
       }]
     };

--- a/extensions/gadgets/ScoreBar/ScoreBar.js
+++ b/extensions/gadgets/ScoreBar/ScoreBar.js
@@ -40,6 +40,11 @@ oppia.directive('oppiaGadgetScoreBar', [
           if (learnerParamsService.getValue(
               $scope.scoreBarParamName) > $scope.maxValue) {
             return $scope.maxValue;
+          } else if (learnerParamsService.getValue(
+              $scope.scoreBarParamName) < 0) {
+            // Defense-in-depth: although underflows don't break the current
+            // UI, return a sensible minimum.
+            return 0;
           } else {
             return learnerParamsService.getValue($scope.scoreBarParamName);
           }


### PR DESCRIPTION
…eeds a ScoreBar's maxValue (lines 38-50). Additionally correcting JS style with the new linter. (lines 24-35)

Additional background:
- Discovered that when a parameter's value is allowed to exceed a ScoreBar's maxValue, the text label in Angular UI Bootstrap's progressbar gradually disappears out of bounds.  This fix keeps the label visible at the progressbar's upper limit.
- Authors using a ScoreBar will ideally create content in such a way that the value doesn't overflow. In cases where it does this fix keeps the UI intuitive to the learner.
- Tested for the case of parameter underflow and verified the label remains visible fine. Added a second commit to return a 0 minimum for defense in depth.
- Considered trying to detect & warn authors for this case automatically, but there's not a ready way to aggregate all parameter changes in an exploration to detect the max (especially considering learners can theoretically follow infinite loops between states where each step's increment causes a parameter to approach infinity).  This fix should be sufficient to address the edge cases where a parameter value exceeds a ScoreBar's maxValue.

A possible feature improvement in the future might give authors the option to limit a parameter's actual value to not exceed a ScoreBar's maxValue  (or to assign the limit on the parameter itself), but that feature is probably too complicated for most users at this time.