### PR TITLE
Adds speech synthesis functionality to exploration

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -93,6 +93,14 @@ oppia.config(['$provide', function($provide) {
   }]);
 }]);
 
+oppia.factory('browserInfoService', ['$window', function($window) {
+  return {
+    isSpeechSynthesisEnabled: function() {
+      return 'speechSynthesis' in $window;
+    }
+  };
+}]);
+
 //Returns true if the user is on a mobile device.
 //See here: http://stackoverflow.com/a/14301832/5020618
 oppia.factory('deviceInfoService', ['$window', function($window) {

--- a/core/templates/dev/head/player/PlayerServices.js
+++ b/core/templates/dev/head/player/PlayerServices.js
@@ -634,6 +634,21 @@ oppia.factory('ratingService', [
   };
 }]);
 
+oppia.factory('speechService', ['oppiaHtmlEscaper', function(oppiaHtmlEscaper) {
+  return {
+    getSpokenText: function(component) {
+      var componentId = component.nodeName;
+      if (componentId == "#text") {
+        return component.nodeValue;
+      }
+      if (componentId == "OPPIA-NONINTERACTIVE-LINK") {
+        var linkPreface = "Clickable Link. "
+        return linkPreface + oppiaHtmlEscaper.escapedStrToUnescapedStr(component.attributes.item(1).nodeValue);
+      }
+      return "";
+    }
+  };
+}]);
 
 oppia.controller('LearnerLocalNav', [
     '$scope', '$http', '$modal', 'oppiaHtmlEscaper',

--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -162,13 +162,13 @@ oppia.directive('conversationSkin', [function() {
     scope: {},
     templateUrl: 'skins/Conversation',
     controller: [
-        '$scope', '$timeout', '$rootScope', '$window', 'messengerService',
-        'oppiaPlayerService', 'urlService', 'focusService', 'ratingService',
-        'windowDimensionsService',
+        '$scope', '$timeout', '$rootScope', '$window', 'browserInfoService',  
+        'messengerService', 'oppiaHtmlEscaper', 'oppiaPlayerService', 'urlService', 
+        'focusService', 'ratingService', 'speechService', 'windowDimensionsService',
         function(
-          $scope, $timeout, $rootScope, $window, messengerService,
-          oppiaPlayerService, urlService, focusService, ratingService,
-          windowDimensionsService) {
+          $scope, $timeout, $rootScope, $window, browserInfoService,  
+          messengerService, oppiaHtmlEscaper, oppiaPlayerService, urlService, 
+          focusService, ratingService, speechService, windowDimensionsService) {
 
       // The minimum width, in pixels, needed to be able to show two cards
       // side-by-side.
@@ -186,6 +186,7 @@ oppia.directive('conversationSkin', [function() {
 
       $scope.isInPreviewMode = oppiaPlayerService.isInPreviewMode();
       $scope.isIframed = urlService.isIframed();
+      $scope.isSpeechSynthesisEnabled = browserInfoService.isSpeechSynthesisEnabled();
       $rootScope.loadingMessage = 'Loading';
       $scope.explorationCompleted = false;
       $scope.hasFullyLoaded = false;
@@ -283,6 +284,28 @@ oppia.directive('conversationSkin', [function() {
         if (panelName === $scope.PANEL_SUPPLEMENTAL) {
           $scope.$broadcast('showInteraction');
         }
+      };
+
+      $scope.readSelectedTextAloud = function() {
+        var content = $scope.activeCard.contentHtml;
+        var contentElement = document.createElement('div');
+        contentElement.innerHTML = content;
+        var contentNodes = contentElement.childNodes[0].childNodes;
+        var stringToRead = "";
+        
+        for (var i = 0; i < contentNodes.length; i ++) {
+          var component = contentNodes[i];
+          stringToRead += speechService.getSpokenText(component);
+        };
+        var defaultMessage = stringToRead;
+        var selectedText =  $window.getSelection();
+        if (selectedText == '') {
+          var readText = new SpeechSynthesisUtterance(defaultMessage);
+        } else {
+          var readText = new SpeechSynthesisUtterance(selectedText);
+        };
+        readText.lang = 'en-US';
+        $window.speechSynthesis.speak(readText);
       };
 
       $scope.resetVisiblePanel = function() {

--- a/extensions/skins/conversation_v1/player.html
+++ b/extensions/skins/conversation_v1/player.html
@@ -38,6 +38,13 @@
       -->
       <md-card class="conversation-skin-tutor-card conversation-skin-tutor-card-active"
                ng-class="{'conversation-skin-left-card': isCurrentSupplementalCardNonempty() && canWindowFitTwoCards(), 'conversation-skin-has-subsidiary-cards': isCurrentSupplementalCardNonempty() && !canWindowFitTwoCards()}" ng-show="isPanelVisible(PANEL_TUTOR)">
+        <div class="conversation-skin-tutor-card-read-text-aloud-container" ng-if="activeCard.stateName && !isInPreviewMode && isSpeechSynthesisEnabled">
+          <button class="conversation-skin-tutor-card-read-text-aloud"
+                  tooltip="Click to read highlighted text aloud" tooltip-placement="bottom" 
+                  state-name="<[activeCard.stateName]>" ng-click="readSelectedTextAloud()">
+            <span class="glyphicon glyphicon-volume-up" aria-hidden="true"></span>
+          </button>
+        </div> 
         <div class="conversation-skin-tutor-card-feedback-toggle-container" ng-if="activeCard.stateName && !isInPreviewMode">
           <button class="conversation-skin-tutor-card-feedback-toggle"
                   popover-placement="<[getFeedbackPopoverPlacement()]>"

--- a/extensions/skins/conversation_v1/static/conversation.css
+++ b/extensions/skins/conversation_v1/static/conversation.css
@@ -194,6 +194,26 @@ md-card.conversation-skin-tutor-card {
   opacity: 0.8;
 }
 
+.conversation-skin-tutor-card-read-text-aloud-container {
+  position: absolute;
+  right: 38px;
+  top: 8px;
+  width: 20px;
+}
+.conversation-skin-tutor-card-read-text-aloud {
+  background: none;
+  border: 0;
+  color: #000;
+  cursor: pointer;
+  font-size: 20px;
+  height: 20px;
+  margin-left: -5px;
+  opacity: 0.4;
+}
+.conversation-skin-tutor-card-read-text-aloud:hover {
+  opacity: 0.8;
+}
+
 .conversation-skin-inline-interaction {
   background: rgba(0, 0, 0, 0.04);
   padding: 16px 36px 24px 36px;


### PR DESCRIPTION
This PR has functionality for the hyperlink RTE element but currently nothing else.  I'm open to suggestions for each of the following RTE elements:
* Collapsables - Should it just say something like "Collapsable text here" or actually read the collapsable text within?
* Images - Would the alt image text be alright? It was created for screen readers so it would make sense to do that.
* Math - This is tricky. I'm a little low on ideas for this one.
* Tabs - Not sure on this one either.  These elements are used as hints in the default example so I would  imagine automatically reading the content wouldn't work.
* Video - "Video link here"?
* Link - This one is working in the PR. Currently it reads "Clickable link." before reading the placeholder text. I'm open to suggestions on this as well.

 Any ideas?