### PR TITLE
Music widget waits for page to load before displaying.

### DIFF
--- a/extensions/interactions/MusicNotesInput/MusicNotesInput.js
+++ b/extensions/interactions/MusicNotesInput/MusicNotesInput.js
@@ -150,48 +150,22 @@ oppia.directive('oppiaInteractiveMusicNotesInput', [
         var noteChoicesElt = $element.find('.oppia-music-input-note-choices');
         var staffContainerElt = $element.find('.oppia-music-input-staff');
 
-        // Sets grid positions, displays the staff and note,
-        // and then initializes the view after staff has loaded.
-        $(document).ready(function() {
-          setTimeout(function() {
-            // Display valid note area only after page has fully loaded.
-            $('.oppia-music-input-valid-note-area').css('visibility', 'visible');
-            $scope.init();
-          }, 20);
-        });
-
         // Staff has to be reinitialized every time that the staff is resized or
         // displayed. The staffContainerElt and all subsequent measurements
         // must be recalculated in order for the grid to work properly.
         $scope.reinitStaff = function() {
           // Prevent staff from reinitializing unneccesarily.
-          if (!$('.img-circle').data('fired')) {
-            $('.oppia-music-input-valid-note-area').css('visibility', 'hidden');
-            var that = $('.img-circle');
-            setTimeout(function() {
-              $(that).data('fired', true);
-              $('.oppia-music-input-valid-note-area').css('visibility', 'visible');
-              $scope.init();
-            }, 200);
-          }
+          $('.oppia-music-input-valid-note-area').css('visibility', 'hidden');
+          setTimeout(function() {
+            $('.oppia-music-input-valid-note-area').css('visibility', 'visible');
+            $scope.init();
+          }, 20);
         };
 
-        // TODO(wagnerdmike): This would be better if it listened for a
-        // card switch event instead of the button click. Reinit needs to be
-        // triggered when page is in the smaller one card format or else
-        // dimensions for the staff will be incorrectly calculated.
-        $('.img-circle').on("click", function(e) {
-          // Reinit staff on click of conversation card switcher button.
-          $('.img-circle').data('fired', false);
-          $scope.reinitStaff();
-        });
-
-        // When page is resized, all notes are removed from sequence and staff
-        // and then repainted in their new corresponding positions.
-        $(window).resize(function() {
-          // Hide the valid note area while the page resizes and
-          // recalculate staff dimensions.
-          $('.img-circle').data('fired', false);
+        // When page is in the smaller one card format, reinitialize staff after
+        // the user navigates to the Interaction Panel. Otherwise the dimensions
+        // for the staff will be incorrectly calculated.
+        $scope.$on('showInteraction', function(event) {
           $scope.reinitStaff();
         });
 
@@ -228,6 +202,12 @@ oppia.directive('oppiaInteractiveMusicNotesInput', [
         initializeNoteSequence($scope.initialSequence);
         $scope.init();
 
+        // Sets grid positions, displays the staff and note,
+        // and then initializes the view after staff has loaded.
+        $(document).ready(function() {
+          $scope.reinitStaff();
+        });
+        
         // Initial notes are are placed on the staff at the
         // start of the exploration and can be removed by the learner.
         function initializeNoteSequence(initialNotesToAdd) {

--- a/extensions/interactions/MusicNotesInput/MusicNotesInput.js
+++ b/extensions/interactions/MusicNotesInput/MusicNotesInput.js
@@ -154,7 +154,6 @@ oppia.directive('oppiaInteractiveMusicNotesInput', [
         // displayed. The staffContainerElt and all subsequent measurements
         // must be recalculated in order for the grid to work properly.
         $scope.reinitStaff = function() {
-          // Prevent staff from reinitializing unneccesarily.
           $('.oppia-music-input-valid-note-area').css('visibility', 'hidden');
           setTimeout(function() {
             $('.oppia-music-input-valid-note-area').css('visibility', 'visible');
@@ -207,7 +206,7 @@ oppia.directive('oppiaInteractiveMusicNotesInput', [
         $(document).ready(function() {
           $scope.reinitStaff();
         });
-        
+
         // Initial notes are are placed on the staff at the
         // start of the exploration and can be removed by the learner.
         function initializeNoteSequence(initialNotesToAdd) {

--- a/extensions/interactions/MusicNotesInput/MusicNotesInput.js
+++ b/extensions/interactions/MusicNotesInput/MusicNotesInput.js
@@ -150,15 +150,49 @@ oppia.directive('oppiaInteractiveMusicNotesInput', [
         var noteChoicesElt = $element.find('.oppia-music-input-note-choices');
         var staffContainerElt = $element.find('.oppia-music-input-staff');
 
-        // Sets grid positions and initializes the view after staff has loaded.
-        setTimeout(function() {
-          $scope.init();
-        }, 1000);
+        // Sets grid positions, displays the staff and note,
+        // and then initializes the view after staff has loaded.
+        $(document).ready(function() {
+          setTimeout(function() {
+            // Display valid note area only after page has fully loaded.
+            $('.oppia-music-input-valid-note-area').css('visibility', 'visible');
+            $scope.init();
+          }, 20);
+        });
+
+        // Staff has to be reinitialized every time that the staff is resized or
+        // displayed. The staffContainerElt and all subsequent measurements
+        // must be recalculated in order for the grid to work properly.
+        $scope.reinitStaff = function() {
+          // Prevent staff from reinitializing unneccesarily.
+          if (!$('.img-circle').data('fired')) {
+            $('.oppia-music-input-valid-note-area').css('visibility', 'hidden');
+            var that = $('.img-circle');
+            setTimeout(function() {
+              $(that).data('fired', true);
+              $('.oppia-music-input-valid-note-area').css('visibility', 'visible');
+              $scope.init();
+            }, 200);
+          }
+        };
+
+        // TODO(wagnerdmike): This would be better if it listened for a
+        // card switch event instead of the button click. Reinit needs to be
+        // triggered when page is in the smaller one card format or else
+        // dimensions for the staff will be incorrectly calculated.
+        $('.img-circle').on("click", function(e) {
+          // Reinit staff on click of conversation card switcher button.
+          $('.img-circle').data('fired', false);
+          $scope.reinitStaff();
+        });
 
         // When page is resized, all notes are removed from sequence and staff
         // and then repainted in their new corresponding positions.
         $(window).resize(function() {
-          $scope.init();
+          // Hide the valid note area while the page resizes and
+          // recalculate staff dimensions.
+          $('.img-circle').data('fired', false);
+          $scope.reinitStaff();
         });
 
         // Creates draggable notes and droppable staff.

--- a/extensions/interactions/MusicNotesInput/MusicNotesInputSpec.js
+++ b/extensions/interactions/MusicNotesInput/MusicNotesInputSpec.js
@@ -67,32 +67,37 @@ describe('MusicNotesInput interaction', function() {
       ctrlScope._addNoteToNoteSequence({
         baseNoteMidiNumber: 71,
         offset: 0,
-        noteId: 'note_id_0'
+        noteId: 'note_id_0',
+        noteStart: {'num': 1, 'den': 1}
       });
       expect(ctrlScope.noteSequence).toEqual([{
         note: {
           baseNoteMidiNumber: 71,
           offset: 0,
-          noteId: 'note_id_0'
+          noteId: 'note_id_0',
+          noteStart: {'num': 1, 'den': 1}
         }
       }]);
 
       ctrlScope._addNoteToNoteSequence({
         baseNoteMidiNumber: 72,
         offset: 0,
-        noteId: 'note_id_1'
+        noteId: 'note_id_1',
+        noteStart: {'num': 1, 'den': 1}
       });
       expect(ctrlScope.noteSequence).toEqual([{
         note: {
           baseNoteMidiNumber: 71,
           offset: 0,
-          noteId: 'note_id_0'
+          noteId: 'note_id_0',
+          noteStart: {'num': 1, 'den': 1}
         }
       }, {
         note: {
           baseNoteMidiNumber: 72,
           offset: 0,
-          noteId: 'note_id_1'
+          noteId: 'note_id_1',
+          noteStart: {'num': 1, 'den': 1}
         }
       }]);
     });
@@ -128,14 +133,16 @@ describe('MusicNotesInput interaction', function() {
       ctrlScope._addNoteToNoteSequence({
         baseNoteMidiNumber: 81,
         offset: 0,
-        noteId: 'note_id_1'
+        noteId: 'note_id_1',
+        noteStart: {'num': 1, 'den': 1}
       });
       ctrlScope._removeNotesFromNoteSequenceWithId('note_id_0');
       expect(ctrlScope.noteSequence).toEqual([{
         note: {
           baseNoteMidiNumber: 81,
           offset: 0,
-          noteId: 'note_id_1'
+          noteId: 'note_id_1',
+          noteStart: {'num': 1, 'den': 1}
         }
       }]);
     });
@@ -147,14 +154,16 @@ describe('MusicNotesInput interaction', function() {
       ctrlScope._addNoteToNoteSequence({
         baseNoteMidiNumber: 64,
         offset: 0,
-        noteId: 'note_id_0'
+        noteId: 'note_id_0',
+        noteStart: {'num': 1, 'den': 1}
       });
       ctrlScope._removeNotesFromNoteSequenceWithId('note_id_1');
       expect(ctrlScope.noteSequence).toEqual([{
         note: {
           baseNoteMidiNumber: 64,
           offset: 0,
-          noteId: 'note_id_0'
+          noteId: 'note_id_0',
+          noteStart: {'num': 1, 'den': 1}
         }
       }]);
     });

--- a/extensions/interactions/MusicNotesInput/static/css/musicNotesInput.css
+++ b/extensions/interactions/MusicNotesInput/static/css/musicNotesInput.css
@@ -8,6 +8,7 @@
   margin: 0 0 0 11.0784%;
   width: 87.34525%;
   height: 43%;
+  /* Hide valid note area until page loads */
   visibility: hidden;
 }
 

--- a/extensions/interactions/MusicNotesInput/static/css/musicNotesInput.css
+++ b/extensions/interactions/MusicNotesInput/static/css/musicNotesInput.css
@@ -8,7 +8,6 @@
   margin: 0 0 0 11.0784%;
   width: 87.34525%;
   height: 43%;
-  /*display: none; /* Hide valid note area until page loads */
   visibility: hidden;
 }
 

--- a/extensions/interactions/MusicNotesInput/static/css/musicNotesInput.css
+++ b/extensions/interactions/MusicNotesInput/static/css/musicNotesInput.css
@@ -8,6 +8,8 @@
   margin: 0 0 0 11.0784%;
   width: 87.34525%;
   height: 43%;
+  /*display: none; /* Hide valid note area until page loads */
+  visibility: hidden;
 }
 
 /* The box around staff */
@@ -77,12 +79,11 @@
   background-size: 8.5% 89%;
 }
 
-
 /* Individual notes */
 
 .oppia-music-input-note-choices div {
   width: 7.8%;
-  height: 8.2%;
+  height: 9.2%;
   position: relative;
   background: transparent;
 }


### PR DESCRIPTION
fixes #987 and #989. 

Music widget doesn't load squished now. Waits for page to load before getting the dimensions of the parent div (card). Now the widget will always display properly for the size of the page it has been initially loaded for. 

There is still an issue that needs to be tackled seperately. Two cases: 
1. When the page is first loaded in the full two card style, the widget will look fine and all the sizes will be consistent. From there if the user resizes the page down to the one card style, the widget is still hidden and thus its height is incorrect when recalculating after the reisze event (I used the visibility property hidden instead of display:none and that seems to help, but there are still some problems with drastic resizing).
2. When the page is first loaded in the smaller one card style, the widget works well when sizing around within the one card window range. When some notes are added and the page is sized up to the full two card style and back down again a few times it will very intermittantly get squished. Still looking into why this is. 

I think having access to an event like isPanelVisible(PANEL_SUPPLEMENTAL) would be helpful so that we don't have to attach a listener to something as specific as a button click to know when the card is switched and the dimensions are ready to be calculated. 