### PR TITLE
Remove whitespace around links in RTEs.

### DIFF
--- a/extensions/rich_text_components/Link/Link.html
+++ b/extensions/rich_text_components/Link/Link.html
@@ -1,8 +1,8 @@
-<script type="text/ng-template" id="richTextComponent/Link">
-  <span ng-if="showUrlInTooltip">
-    <a href="<[url]>" target="<[target]>" tooltip="<[url]>"><[text]></a>
-  </span>
-  <span ng-if="!showUrlInTooltip">
-    <a href="<[url]>" target="<[target]>"><[url]></a>
-  </span>
-</script>
+<!--
+  The extra comments in this file are needed to prevent extra whitespace from
+  being added before and after the link. See http://stackoverflow.com/q/5078239
+-->
+<script type="text/ng-template" id="richTextComponent/Link"><!--
+  --><a ng-if="showUrlInTooltip" href="<[url]>" target="<[target]>" tooltip="<[url]>"><[text]></a><!--
+  --><a ng-if="!showUrlInTooltip" href="<[url]>" target="<[target]>"><[url]></a><!--
+--></script>


### PR DESCRIPTION
/cc @brokenairplane 

Note: this turned out to be surprisingly tricky. The whitespace was due to whitespace in the HTML. I'm not sure if this is the best solution; @amitdeutsch WDYT?