### PR TITLE
Install numpy using pip.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -99,5 +99,7 @@ handlers:
 libraries:
 - name: jinja2
   version: '2.6'
+- name: numpy
+  version: '1.6.1'
 - name: webapp2
   version: '2.5.2'

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -77,6 +77,8 @@ THIRD_PARTY_LIBS = [
     os.path.join(ROOT_PATH, 'third_party', 'gae-pipeline-1.9.17.0'),
     os.path.join(ROOT_PATH, 'third_party', 'graphy-1.0.0'),
     os.path.join(ROOT_PATH, 'third_party', 'simplejson-3.7.1'),
+    os.path.abspath(os.path.join(
+        ROOT_PATH, '..', 'oppia_tools', 'numpy-1.6.1')),
 ]
 
 for lib_path in THIRD_PARTY_LIBS:

--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -40,17 +40,18 @@ THIRD_PARTY_DIR = os.path.join(CURR_DIR, 'third_party')
 DIRS_TO_ADD_TO_SYS_PATH = [
     os.path.join(
         OPPIA_TOOLS_DIR, 'google_appengine_1.9.19', 'google_appengine'),
-    CURR_DIR,
+    os.path.join(OPPIA_TOOLS_DIR, 'numpy-1.6.1'),
     os.path.join(OPPIA_TOOLS_DIR, 'webtest-1.4.2'),
     os.path.join(
         OPPIA_TOOLS_DIR, 'google_appengine_1.9.19', 'google_appengine',
         'lib', 'webob_0_9'),
-    os.path.join(CURR_DIR, 'third_party', 'bleach-1.2.2'),
-    os.path.join(THIRD_PARTY_DIR, 'html5lib-python-0.95'),
-    os.path.join(THIRD_PARTY_DIR, 'gae-mapreduce-1.9.17.0'),
+    CURR_DIR,
+    os.path.join(THIRD_PARTY_DIR, 'bleach-1.2.2'),
     os.path.join(THIRD_PARTY_DIR, 'gae-cloud-storage-1.9.15.0'),
+    os.path.join(THIRD_PARTY_DIR, 'gae-mapreduce-1.9.17.0'),
     os.path.join(THIRD_PARTY_DIR, 'gae-pipeline-1.9.17.0'),
     os.path.join(THIRD_PARTY_DIR, 'graphy-1.0.0'),
+    os.path.join(THIRD_PARTY_DIR, 'html5lib-python-0.95'),
     os.path.join(THIRD_PARTY_DIR, 'simplejson-3.7.1'),
 ]
 

--- a/scripts/install_third_party.py
+++ b/scripts/install_third_party.py
@@ -14,6 +14,7 @@
 
 """Installation script for Oppia third-party libraries."""
 
+import contextlib
 import itertools
 import os
 import shutil
@@ -130,7 +131,7 @@ def download_and_untar_files(
         common.ensure_directory_exists(target_parent_dir)
 
         urllib.urlretrieve(source_url, TMP_UNZIP_PATH)
-        with tarfile.open(TMP_UNZIP_PATH, 'r:gz') as t:
+        with contextlib.closing(tarfile.open(TMP_UNZIP_PATH, 'r:gz')) as t:
             t.extractall(target_parent_dir)
         os.remove(TMP_UNZIP_PATH)
 

--- a/scripts/install_third_party.sh
+++ b/scripts/install_third_party.sh
@@ -116,3 +116,12 @@ if [ ! -d "$NODE_MODULE_DIR/jscs" ]; then
   echo installing node-jscs
   $NPM_INSTALL jscs@2.3.0
 fi
+
+# Note that numpy needs to be built after downloading. If you are having
+# trouble, please ensure that you have pip installed (see "Installing Oppia"
+# on the Oppia developers' wiki page).
+echo Checking if numpy is installed in $TOOLS_DIR/pip_packages
+if [ ! -d "$TOOLS_DIR/numpy-1.6.1" ]; then
+  echo Installing numpy
+  pip install numpy==1.6.1 --target="$TOOLS_DIR/numpy-1.6.1"
+fi

--- a/scripts/run_backend_tests.sh
+++ b/scripts/run_backend_tests.sh
@@ -67,6 +67,9 @@ set -e
 source $(dirname $0)/setup.sh || exit 1
 source $(dirname $0)/setup_gae.sh || exit 1
 
+# Install third party dependencies
+bash scripts/install_third_party.sh
+
 # Install webtest.
 echo Checking if webtest is installed in third_party
 if [ ! -d "$TOOLS_DIR/webtest-1.4.2" ]; then


### PR DESCRIPTION
I think I finally got this working!

@isaac-friedman, @michaelWagner, @jacobdavis11, @BenHenning, @stephenchiang -- can you please check this on your machines and see if it works? Basically:

1. Follow the instructions in the 'Prerequisites' section in the installation instructions for your local machine ([Linux](https://github.com/oppia/oppia/wiki/Installing-Oppia-%28Linux%29#prerequisites), [Mac OS](https://github.com/oppia/oppia/wiki/Installing-Oppia-%28Mac-OS%29#prerequisites)).

2. Run

```
    bash scripts/run_backend_tests.sh --test_target=core.domain.classifier_services_test.py
```

If all tests pass -- it works! If not, I'd be grateful if you could send me any console errors you run into.