### PR TITLE
Minor tidying up of first-published job code.

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -57,6 +57,7 @@ class ExpSummariesCreationOneOffJob(jobs.BaseMapReduceJobManager):
     def reduce(exp_id, list_of_exps):
         pass
 
+
 class ExplorationFirstPublishedOneOffJob(jobs.BaseMapReduceJobManager):
     """One-off job that finds first published datetime for all explorations."""
 
@@ -78,7 +79,7 @@ class ExplorationFirstPublishedOneOffJob(jobs.BaseMapReduceJobManager):
             ast.literal_eval(commit_time_string) for
             commit_time_string in stringified_commit_times_msecs]
         first_published_msec = min(commit_times_msecs)
-        rights_manager.update_activity_first_published_msec_if_necessary(
+        rights_manager.update_activity_first_published_msec(
             rights_manager.ACTIVITY_TYPE_EXPLORATION, exp_id,
             first_published_msec)
 

--- a/core/domain/rights_manager.py
+++ b/core/domain/rights_manager.py
@@ -204,18 +204,21 @@ def _update_activity_summary(activity_type, activity_rights):
         _update_collection_summary(activity_rights)
 
 
-def update_activity_first_published_msec_if_necessary(
-    activity_type, activity_id, first_published_msec):
+def update_activity_first_published_msec(
+        activity_type, activity_id, first_published_msec):
+    """Updates the first_published_msec field for an activity. Callers are
+    responsible for ensuring that this value is not already set before updating
+    it.
+    """
     activity_rights = _get_activity_rights(activity_type, activity_id)
-    if activity_rights.first_published_msec is None:
-        activity_rights.first_published_msec = first_published_msec
-        commit_cmds = [{
-            'cmd': CMD_UPDATE_FIRST_PUBLISHED_MSEC,
-            'first_published': first_published_msec
-        }]
-        _save_activity_rights(
-            feconf.SYSTEM_COMMITTER_ID, activity_rights, activity_type,
-            'set first published time in msec', commit_cmds)
+    activity_rights.first_published_msec = first_published_msec
+    commit_cmds = [{
+        'cmd': CMD_UPDATE_FIRST_PUBLISHED_MSEC,
+        'first_published_msec': first_published_msec
+    }]
+    _save_activity_rights(
+        feconf.SYSTEM_COMMITTER_ID, activity_rights, activity_type,
+        'Set first_published_msec time', commit_cmds)
 
 
 def create_new_exploration_rights(exploration_id, committer_id):
@@ -231,7 +234,7 @@ def create_new_exploration_rights(exploration_id, committer_id):
         community_owned=exploration_rights.community_owned,
         status=exploration_rights.status,
         viewable_if_private=exploration_rights.viewable_if_private,
-        first_published_msec=exploration_rights.first_published_msec
+        first_published_msec=exploration_rights.first_published_msec,
     ).commit(committer_id, 'Created new exploration', commit_cmds)
 
     subscription_services.subscribe_to_exploration(

--- a/core/storage/collection/gae_models.py
+++ b/core/storage/collection/gae_models.py
@@ -140,7 +140,7 @@ class CollectionRightsModel(base_models.VersionedModel):
     # by anyone who has the URL. If the collection is not private, this
     # setting is ignored.
     viewable_if_private = ndb.BooleanProperty(indexed=True, default=False)
-    #Time when the collection was first published
+    # Time, in milliseconds, when the collection was first published.
     first_published_msec = ndb.FloatProperty(indexed=True, default=None)
 
     # The publication status of this collection.

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -176,7 +176,7 @@ class ExplorationRightsModel(base_models.VersionedModel):
     # by anyone who has the URL. If the exploration is not private, this
     # setting is ignored.
     viewable_if_private = ndb.BooleanProperty(indexed=True, default=False)
-    # Time in milliseconds when the collection was first published.
+    # Time, in milliseconds, when the exploration was first published.
     first_published_msec = ndb.FloatProperty(indexed=True, default=None)
 
     # The publication status of this exploration.


### PR DESCRIPTION
@kerryxwang -- would you mind taking a look at this? I did a bit of standardizing on the first_published_msec time and some stuff related to whitespace.

Also, I made one change: I asked callers to check that first_published_msec is not set before setting it. This is because the job really should just overwrite the time, without checking anything, because it's computing it from scratch. However, the incremental update does need to do the check, so it seems to me that it's better to have a standalone method that just replaces the msec value and leave validation to the caller. What do you think?