### PR TITLE
Added title of states bak which display on hover Fix #1167

### DIFF
--- a/core/templates/dev/head/components/visualizations.html
+++ b/core/templates/dev/head/components/visualizations.html
@@ -87,6 +87,7 @@
                       ng-attr-style="<[node.style]>"
                       ng-click="onClickFunction(node.id)">
                 </rect>
+                <title><[getNodeTitle(node)]></title>
                 <text text-anchor="middle" ng-attr-x="<[node.xLabel]>" ng-attr-y="<[node.yLabel]>" class="protractor-test-node-label">
                   <tspan alignment-baseline="central"><[getTruncatedLabel(node.label)]></tspan>
                   <tspan ng-attr-x="<[node.xLabel]>" dy="1em" style="fill:gray"><[getTruncatedLabel(node.secondaryLabel)]></tspan>

--- a/core/templates/dev/head/editor/exploration_editor.html
+++ b/core/templates/dev/head/editor/exploration_editor.html
@@ -116,7 +116,7 @@
     </li>
 
     <li ng-class="{'active': getTabStatuses().active === 'feedback'}">
-      <a href="#" tooltip="Feedback" tooltip-placement="bottom" tooltip-append-to-body="true" ng-click="selectFeedbackTab()">
+      <a href="#" tooltip="Feedback" tooltip-placement="bottom" ng-click="selectFeedbackTab()">
         <span class="glyphicon glyphicon-comment"></span>
       </a>
     </li>


### PR DESCRIPTION
prevent window juddering on hover over navbar feedback link. @seanlip  can you also produce this? hover over navbar feedback icon, then juddering occurs before tooltip is displayed.