### PR TITLE
Changed supplement width to be dynamic.

### DIFF
--- a/extensions/skins/conversation_v1/player.html
+++ b/extensions/skins/conversation_v1/player.html
@@ -137,8 +137,7 @@
            class="conversation-skin-supplemental-card-container"
            ng-class="{'conversation-skin-right-card-container': isCurrentSupplementalCardNonempty() && isPanelVisible(PANEL_TUTOR) && isPanelVisible(PANEL_SUPPLEMENTAL)}">
         <div ng-show="isPanelVisible(PANEL_SUPPLEMENTAL)"
-             class="conversation-skin-supplemental-card"
-             style="height: 550px;">
+             class="conversation-skin-supplemental-card">
 
           <div class="conversation-skin-help-card" ng-if="helpCardHtml">
             <img class="conversation-skin-oppia-avatar"

--- a/extensions/skins/conversation_v1/static/conversation.css
+++ b/extensions/skins/conversation_v1/static/conversation.css
@@ -127,6 +127,9 @@ html, body {
      card, plus a 12px margin between them.
   */
   max-width: 1420px;
+  padding-left: 6px;
+  padding-right: 6px;
+  position: relative;
 }
 
 .conversation-skin-help-card {
@@ -362,8 +365,8 @@ html, body {
 }
 
 .conversation-skin-right-card-container {
-  margin-left: 12px;
-  width: 1040px;
+  margin-left: 6px;
+  width: calc(100% - 380px);
 }
 
 div.conversation-skin-supplemental-card {
@@ -375,7 +378,6 @@ div.conversation-skin-supplemental-card {
   padding: 8px;
   position: relative;
   right: 0;
-  width: 1040px;
 }
 
 .conversation-skin-right-card-container div.conversation-skin-supplemental-card-fixed {


### PR DESCRIPTION
@seanlip would you mind taking a look at this? This makes the supplement card width be dynamic based on the screen width. Note that this affects all supplements, though I believe the only other one we use is Image Region select; this would cause the image size to change dynamically, which may or may not be a problem. Thanks!