### PR TITLE
Centered the gallery tiles container

### DIFF
--- a/core/templates/dev/head/components/exploration_summary_tile.html
+++ b/core/templates/dev/head/components/exploration_summary_tile.html
@@ -4,13 +4,15 @@
     cursor: pointer;
     display: inline-block;
     height: 240px;
-    margin: 12px 12px 12px 0px;
+    margin: 12px 4px;
     padding: 0;
     position: relative;
     text-align: left;
     vertical-align: top;
     width: 200px;
   }
+
+
 
   .oppia-exploration-summary-tile a,
   .oppia-exploration-summary-tile a:hover,

--- a/core/templates/dev/head/components/exploration_summary_tile.html
+++ b/core/templates/dev/head/components/exploration_summary_tile.html
@@ -12,8 +12,6 @@
     width: 200px;
   }
 
-
-
   .oppia-exploration-summary-tile a,
   .oppia-exploration-summary-tile a:hover,
   .oppia-exploration-summary-tile a:active,

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -772,11 +772,30 @@ textarea {
   height: 100%;
   margin-left: auto;
   margin-right: auto;
-  max-width: 900px;
+  width: 844px;
   min-height: 500px;
   padding-bottom: 25px;
   padding-top: 56px;
-  text-align:center;
+}
+
+/* Ensure that the gallery tiles remain centered. Note that these values would
+   need to be updated if the gallery tiles are changed. */
+@media (max-width: 844px) {
+  .oppia-gallery-tiles-container {
+    width: 632px;
+  }
+}
+
+@media (max-width: 632px) {
+  .oppia-gallery-tiles-container {
+    width: 420px;
+  }
+}
+
+@media (max-width: 420px) {
+  .oppia-gallery-tiles-container {
+    width: 208px;
+  }
 }
 
 md-card.oppia-gallery-tile {
@@ -878,8 +897,6 @@ md-card.oppia-gallery-tile {
 .oppia-create-exploration-label {
   margin-top: 5px;
 }
-
-
 
 .carousel-indicators {
   margin-bottom: 120px;


### PR DESCRIPTION
@seanlip this solution feels a bit specific to the current size of the gallery tiles, but I couldn't figure out a more general solution. At least this removes the text-align: center issue. Fixes #1217.