### PR TITLE
Add frontend rules for multiple choice input

### DIFF
--- a/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.js
+++ b/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.js
@@ -21,7 +21,8 @@
  * followed by the name of the arg.
  */
 oppia.directive('oppiaInteractiveMultipleChoiceInput', [
-  'oppiaHtmlEscaper', function(oppiaHtmlEscaper) {
+  'oppiaHtmlEscaper', 'multipleChoiceInputRulesService',
+  function(oppiaHtmlEscaper, multipleChoiceInputRulesService) {
     return {
       restrict: 'E',
       scope: {},
@@ -33,7 +34,7 @@ oppia.directive('oppiaInteractiveMultipleChoiceInput', [
 
         $scope.submitAnswer = function(answer) {
           answer = parseInt(answer, 10);
-          $scope.$parent.$parent.submitAnswer(answer);
+          $scope.$parent.submitAnswer(answer, multipleChoiceInputRulesService);
         };
       }]
     };
@@ -71,3 +72,11 @@ oppia.directive('oppiaShortResponseMultipleChoiceInput', [
     };
   }
 ]);
+
+oppia.factory('multipleChoiceInputRulesService', [function() {
+  return {
+    Equals: function(answer, inputs) {
+      return answer === inputs.x;
+    }
+  };
+}]);

--- a/extensions/interactions/MultipleChoiceInput/MultipleChoiceInputRulesServiceSpec.js
+++ b/extensions/interactions/MultipleChoiceInput/MultipleChoiceInputRulesServiceSpec.js
@@ -26,7 +26,7 @@ describe('Multiple choice input rules service', function() {
     mcirs = $injector.get('multipleChoiceInputRulesService');
   }));
 
-  it('should have a correct equivalence rule', function() {
+  it('should have a correct \'equals\' rule', function() {
     expect(mcirs.Equals(3, {x: 3})).toBe(true);
     expect(mcirs.Equals(3, {x: 4})).toBe(false);
   });

--- a/extensions/interactions/MultipleChoiceInput/MultipleChoiceInputRulesSpec.js
+++ b/extensions/interactions/MultipleChoiceInput/MultipleChoiceInputRulesSpec.js
@@ -1,0 +1,33 @@
+// Copyright 2015 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for multiple choice input rules.
+ *
+ * @author wxyxinyu@gmail.com (Xinyu Wu)
+ */
+
+describe('Multiple choice input rules service', function() {
+  beforeEach(module('oppia'));
+
+  var mcirs = null;
+  beforeEach(inject(function($injector) {
+    mcirs = $injector.get('multipleChoiceInputRulesService');
+  }));
+
+  it('should have a correct equivalence rule', function() {
+    expect(mcirs.Equals(3, {x: 3})).toBe(true);
+    expect(mcirs.Equals(3, {x: 4})).toBe(false);
+  });
+});


### PR DESCRIPTION
I've left the backend rules for now, since they are used by some backend tests. They will be deprecated when we remove the backend tests' dependence on rules.