### PR TITLE
Don't animate for the first card

### DIFF
--- a/extensions/skins/conversation_v1/Conversation.js
+++ b/extensions/skins/conversation_v1/Conversation.js
@@ -382,14 +382,13 @@ oppia.directive('conversationSkin', [function() {
         var nextSupplementalCardIsNonempty = isSupplementalCardNonempty(
           playerTranscriptService.getLastCard());
 
-        if ($scope.canWindowFitTwoCards() && !previousSupplementalCardIsNonempty &&
-            nextSupplementalCardIsNonempty) {
+        if (totalNumCards > 1 && $scope.canWindowFitTwoCards() && 
+          !previousSupplementalCardIsNonempty && nextSupplementalCardIsNonempty) {
           animateToTwoCards(function() {
             $scope.currentProgressDotIndex = $scope.numProgressDots - 1;
           });
-        } else if (
-            $scope.canWindowFitTwoCards() && previousSupplementalCardIsNonempty &&
-            !nextSupplementalCardIsNonempty) {
+        } else if (totalNumCards > 1 && $scope.canWindowFitTwoCards() && 
+          previousSupplementalCardIsNonempty && !nextSupplementalCardIsNonempty) {
           animateToOneCard(function() {
             $scope.currentProgressDotIndex = $scope.numProgressDots - 1;
           });


### PR DESCRIPTION
By animating for the first card, front-end error occurs for a Supplemental Interactive.