### PR TITLE
Run a build task when running intergration test Fix #1272

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,9 +29,7 @@ var argv = yargs
         .usage('Usage: $0 build [--minify]')
         .option('minify', {
           describe: 'Whether to minify third-party dependencies'
-        })
-        .demand(['minify'])
-        .argv;
+        }).argv;
     })
   .command('start_devserver', 'start GAE development server',
     function(yargs) {

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -81,6 +81,9 @@ install_node_module jasmine-spec-reporter 2.2.2
 
 $NODE_MODULE_DIR/.bin/webdriver-manager update
 
+#build so as to have minified js and css
+$NODE_PATH/bin/node $NODE_MODULE_DIR/gulp/bin/gulp.js build
+
 if ( nc -vz localhost 8181 ); then
   echo ""
   echo "  There is already a server running on localhost:8181."


### PR DESCRIPTION
I had to run a gulp build task in the ```scripts/run_e2e_test.sh``` so as if you did not run ```bash scripts/start.sh``` at first you wont face the issue of missing minified css and js.