### PR TITLE
Fixes map interaction displaying previous marker

### DIFF
--- a/extensions/interactions/InteractiveMap/InteractiveMap.html
+++ b/extensions/interactions/InteractiveMap/InteractiveMap.html
@@ -11,9 +11,12 @@
 
   <div>
     <div id="map_canvas" ui-map="map" ui-options="mapOptions"
-         style="width: 100%; height: 400px; max-width: 600px; max-height: 400px; margin: auto"
-         ui-event="{'map-click': 'registerClick($event, $params)'}">
+         style="width: 100%; height: 400px; max-width: 600px; max-height: 400px; margin: auto">
     </div>
+    <md-button class="md-raised" style="margin-top: 10px; margin-bottom: 10px;"
+               aria-label="Submit" ng-click="submitAnswer()" >
+          Submit
+    </md-button>
   </div>
 </script>
 

--- a/extensions/interactions/InteractiveMap/InteractiveMap.js
+++ b/extensions/interactions/InteractiveMap/InteractiveMap.js
@@ -37,32 +37,30 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
           refreshMap();
         });
 
-        $scope.mapMarkers = [];
-
         // This is required in order to avoid the following bug:
         //   http://stackoverflow.com/questions/18769287
         var refreshMap = function() {
           $timeout(function() {
             google.maps.event.trigger($scope.map, 'resize');
             $scope.map.setCenter({lat: coords[0], lng: coords[1]});
+            $scope.marker = new google.maps.Marker({
+              map: $scope.map,
+              draggable: true,
+              position: $scope.map.getCenter()
+            });
           }, 100);
         };
 
         var coords = $scope.coords || [0, 0];
-        var zoom_level = parseInt($scope.zoom, 10) || 0;
+        var zoomLevel = parseInt($scope.zoom, 10) || 0;
         $scope.mapOptions = {
           center: new google.maps.LatLng(coords[0], coords[1]),
-          zoom: zoom_level,
+          zoom: zoomLevel,
           mapTypeId: google.maps.MapTypeId.ROADMAP
         };
 
-        $scope.registerClick = function($event, $params) {
-          var ll = $params[0].latLng;
-          $scope.mapMarkers.push(new google.maps.Marker({
-            map: $scope.map,
-            position: ll
-          }));
-
+        $scope.submitAnswer = function() {
+          var ll = $scope.marker.getPosition();
           $scope.$parent.submitAnswer(
             [ll.lat(), ll.lng()], interactiveMapRulesService);
         };


### PR DESCRIPTION
Fixes this problem:
When interacting with map, if you click to the map so that "try again" will
appear, old marker didn't disappear and if you click to the map several times,
you got more than one markers.