### PR TITLE
Issue #1247 Change "statistics" to "Impact"

### DIFF
--- a/core/templates/dev/head/profile/profile.html
+++ b/core/templates/dev/head/profile/profile.html
@@ -71,7 +71,7 @@
     <md-card ng-cloak class="oppia-profile-tabs">
       <md-content>
         <md-tabs md-dynamic-height md-border-bottom>
-          <md-tab label="Statistics">
+          <md-tab label="Impact">
             <md-content class="oppia-profile-tabs-content">
               <div class="oppia-stat-big-container big-top-container">
                 <div ng-repeat="stat in userDisplayedStatistics" class="oppia-stat-container-top">


### PR DESCRIPTION
This issue is committed to the user-profile branch.
This changes the "Statistics" tab text to "Impact".

![stat-to-impact](https://cloud.githubusercontent.com/assets/11045720/12012703/1884b382-ad02-11e5-9a55-b7cbcce80ad1.png)
