### PR TITLE
Show output and error messages for coderepl interaction.

### DIFF
--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -354,7 +354,7 @@
       padding: 12px;
       position: absolute;
       right: 12px;
-      bottom: 12px;
+      bottom: -50px;
       text-align: left;
       transition: all 350ms;
       z-index: 500;

--- a/extensions/interactions/CodeRepl/CodeRepl.html
+++ b/extensions/interactions/CodeRepl/CodeRepl.html
@@ -4,7 +4,18 @@
   }
   .code-repl-language {
     float: right;
+    font-size: 0.8em;
     margin-top: 8px;
+  }
+  .code-repl-terminal {
+    background-color: #222;
+    color: white;
+    font-weight: bold;
+  }
+  .code-repl-terminal-error {
+    background-color: #222;
+    color: red;
+    font-weight: bold;
   }
 </style>
 
@@ -20,6 +31,16 @@
         <em>Language: <[language]></em>
       </span>
     </form>
+  </div>
+
+  <hr>
+
+  <div ng-if="fullError">
+    <pre class="code-repl-terminal-error"><[fullError]></pre>
+  </div>
+  <div ng-if="!fullError">
+    <pre ng-if="output" class="code-repl-terminal"><[output]></pre>
+    <pre ng-if="!output" class="code-repl-terminal">[No terminal output]</pre>
   </div>
 </script>
 
@@ -44,7 +65,7 @@
 </script>
 
 <script type="text/ng-template" id="shortResponse/CodeRepl">
-  <span><pre><[answer.code | truncateAtFirstLine]></pre></span>
+  <span><pre><[answer.code]></pre></span>
 
   <span ng-if="answer.output">
     <h5>Output</h5>

--- a/extensions/interactions/CodeRepl/CodeRepl.js
+++ b/extensions/interactions/CodeRepl/CodeRepl.js
@@ -64,6 +64,14 @@ oppia.directive('oppiaInteractiveCodeRepl', [
             $scope.code = editor.getValue();
           });
 
+          // Without this, the editor does not show up correctly on small
+          // screens when the user switches to the supplemental interaction.
+          $scope.$on('showInteraction', function() {
+            setTimeout(function() {
+              editor.refresh();
+            }, 200);
+          });
+
           $scope.hasLoaded = true;
         };
 

--- a/extensions/interactions/CodeRepl/CodeRepl.js
+++ b/extensions/interactions/CodeRepl/CodeRepl.js
@@ -49,11 +49,17 @@ oppia.directive('oppiaInteractiveCodeRepl', [
           // Options for the ui-codemirror display.
           editor.setOption('lineNumbers', true);
           editor.setOption('indentWithTabs', true);
-
-          // Note that only 'coffeescript', 'javascript', 'python', and 'ruby'
-          // have CodeMirror-supported syntax highlighting. For other
-          // languages, syntax highlighting will not happen.
-          editor.setOption('mode', $scope.language);
+          editor.setOption('indentUnit', 4);
+          editor.setOption('mode', 'python');
+          editor.setOption('extraKeys', {
+            Tab: function(cm) {
+              var spaces = Array(cm.getOption('indentUnit') + 1).join(' ');
+              cm.replaceSelection(spaces);
+              // Move the cursor to the end of the selection.
+              var endSelectionPos = cm.getDoc().getCursor('head');
+              cm.getDoc().setCursor(endSelectionPos);
+            }
+          });
 
           // NOTE: this is necessary to avoid the textarea being greyed-out.
           setTimeout(function() {

--- a/extensions/interactions/CodeRepl/CodeRepl.js
+++ b/extensions/interactions/CodeRepl/CodeRepl.js
@@ -116,8 +116,19 @@ oppia.directive('oppiaInteractiveCodeRepl', [
 
         var fixLineNumbers = function(err) {
           var preCodeNumLines = $scope.preCode.split('\n').length;
+          var userCodeNumLines = $scope.code.split('\n').length;
           return err.replace(/on line ([0-9]+)/g, function(match, p1) {
-            return '(on line ' + String(Number(p1) - preCodeNumLines) + ')';
+            var originalLineNumber = Number(p1);
+
+            return (
+              originalLineNumber <= preCodeNumLines ?
+              '(on line ' + String(originalLineNumber) +
+                ' of exploration creator\'s prepended code)' :
+              originalLineNumber <= preCodeNumLines + userCodeNumLines ?
+              '(on line ' + String(originalLineNumber - preCodeNumLines) + ')' :
+              '(on line ' + String(
+                  originalLineNumber - preCodeNumLines - userCodeNumLines) +
+                ' of exploration creator\'s appended code)');
           });
         };
 

--- a/extensions/interactions/CodeRepl/CodeRepl.js
+++ b/extensions/interactions/CodeRepl/CodeRepl.js
@@ -100,16 +100,23 @@ oppia.directive('oppiaInteractiveCodeRepl', [
           });
         };
 
+        var fixLineNumbers = function(err) {
+          var preCodeNumLines = $scope.preCode.split('\n').length;
+          return err.replace(/on line ([0-9]+)/g, function(match, p1) {
+            return '(on line ' + String(Number(p1) - preCodeNumLines) + ')';
+          });
+        };
+
         $scope.sendResponse = function(evaluation, err) {
           $scope.evaluation = (evaluation || '');
-          $scope.err = (err || '');
+          $scope.fullError = err ? fixLineNumbers(err) : '';
           $scope.$parent.submitAnswer({
             // Replace tabs with 2 spaces.
             // TODO(sll): Change the default Python indentation to 4 spaces.
             code: $scope.code.replace(/\t/g, '  ') || '',
             output: $scope.output,
             evaluation: $scope.evaluation,
-            error: $scope.err
+            error: (err || '')
           }, codeReplRulesService);
         };
       }]


### PR DESCRIPTION
Initial stab at #1308 and #1309. This will probably need to be redesigned (or added to) later, but not being able to see the output/error is a critical issue, so I'd like to push a fix for it.

/cc @amitdeutsch , @cjerry 