### PR TITLE
Overwritten bootstrap default tooltip width. Fixes #1279

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2513,6 +2513,7 @@ md-card.preview-conversation-skin-supplemental-card {
   color: blue;
 }
 
+/* This is necessary so that long usernames don't overflow the tooltip. */
 .oppia-info-card-content .tooltip-inner {
   max-width: none;
 }

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2513,6 +2513,10 @@ md-card.preview-conversation-skin-supplemental-card {
   color: blue;
 }
 
+.oppia-info-card-content .tooltip-inner {
+  max-width: none;
+}
+
 .oppia-info-card-tag-icon {
   padding-top: 6px;
   width: 28px;
@@ -2667,4 +2671,3 @@ md-card.preview-conversation-skin-supplemental-card {
 .oppia-visible-gadgets-container {
   position: relative;
 }
-


### PR DESCRIPTION
This little CSS tweak fixes #1279 by overwriting bootstrap's default tooltip max-width to none.

![screenshot](http://i.imgur.com/doiXwoo.jpg)