### PR TITLE
UI fix in intro tutorial #1286

### DIFF
--- a/core/templates/dev/head/editor/ExplorationEditor.js
+++ b/core/templates/dev/head/editor/ExplorationEditor.js
@@ -209,7 +209,7 @@ oppia.controller('ExplorationEditor', [
         'learner that is divided into several \'cards\'.<br><br>' +
         'The first part of a card is the <b>content</b>. Here, you can set ' +
         'the scene and ask the learner a question.'),
-      placement: 'right'
+      placement: 'bottom'
     }, {
       type: 'function',
       fn: function(isGoingForward) {


### PR DESCRIPTION
Changed placement of a popover for intro tutorial. 
![2016-01-07-143617_1366x744_scrot](https://cloud.githubusercontent.com/assets/13562152/12181024/c974e3b2-b54d-11e5-9439-9c4336f7569c.png)
