### PR TITLE
Normalize format of getLocaleDateString function return

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -194,6 +194,9 @@ oppia.factory('oppiaHtmlEscaper', ['$log', function($log) {
 // Service for converting dates in milliseconds since the Epoch to
 // human-readable dates.
 oppia.factory('oppiaDatetimeFormatter', ['$filter', function($filter) {
+  var pad = function(n) {
+    return n < 10 ? '0' + n : n;
+  };
   return {
     // Returns just the time if the local datetime representation has the
     // same date as the current date. Otherwise, returns just the date if the
@@ -213,7 +216,10 @@ oppia.factory('oppiaDatetimeFormatter', ['$filter', function($filter) {
     // Returns just the date.
     getLocaleDateString: function(millisSinceEpoch) {
       var date = new Date(millisSinceEpoch);
-      return date.toLocaleDateString();
+      var day = pad(date.getDate());
+      var month = pad(date.getMonth() + 1);
+      var year = date.getFullYear();
+      return day + '/' + month + '/' + year;
     },
     // Returns whether the date is at most one week before the current date.
     isRecent: function(millisSinceEpoch) {

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -194,9 +194,6 @@ oppia.factory('oppiaHtmlEscaper', ['$log', function($log) {
 // Service for converting dates in milliseconds since the Epoch to
 // human-readable dates.
 oppia.factory('oppiaDatetimeFormatter', ['$filter', function($filter) {
-  var pad = function(n) {
-    return n < 10 ? '0' + n : n;
-  };
   return {
     // Returns just the time if the local datetime representation has the
     // same date as the current date. Otherwise, returns just the date if the
@@ -216,10 +213,7 @@ oppia.factory('oppiaDatetimeFormatter', ['$filter', function($filter) {
     // Returns just the date.
     getLocaleDateString: function(millisSinceEpoch) {
       var date = new Date(millisSinceEpoch);
-      var day = pad(date.getDate());
-      var month = pad(date.getMonth() + 1);
-      var year = date.getFullYear();
-      return day + '/' + month + '/' + year;
+      return date.toLocaleDateString();
     },
     // Returns whether the date is at most one week before the current date.
     isRecent: function(millisSinceEpoch) {

--- a/core/templates/dev/head/appSpec.js
+++ b/core/templates/dev/head/appSpec.js
@@ -139,7 +139,7 @@ describe('Datetime Formatter', function() {
       // the same date as xx:45:00 in getLocaleDateString(). The date should
       // always be shown as '11/21/2014'
       expect(df.getLocaleDateString(
-        NOW_MILLIS - 10 * 60 * 1000)).toBe('11/21/2014');
+        NOW_MILLIS - 10 * 60 * 1000)).toBe('21/11/2014');
       expect(df.getLocaleDateString(
         NOW_MILLIS - 10 * 60 * 1000)).not.toBe('2014/11/21');
     });

--- a/core/templates/dev/head/appSpec.js
+++ b/core/templates/dev/head/appSpec.js
@@ -93,7 +93,6 @@ describe('Datetime Formatter', function() {
   describe('datetimeformatter', function() {
     // This corresponds to Fri, 21 Nov 2014 09:45:00 GMT.
     var NOW_MILLIS = 1416563100000;
-    var YESTERDAY_MILLIS = NOW_MILLIS - 24 * 60 * 60 * 1000;
     var df = null;
     var OldDate = Date;
 
@@ -102,60 +101,10 @@ describe('Datetime Formatter', function() {
 
       // Mock Date() to give a time of NOW_MILLIS in GMT. (Unfortunately, there
       // doesn't seem to be a good way to set the timezone locale directly.)
-      spyOn(window, 'Date').andCallFake(function(optionalMillisSinceEpoch) {
-        if (optionalMillisSinceEpoch) {
-          return new OldDate(optionalMillisSinceEpoch);
-        } else {
-          return new OldDate(NOW_MILLIS);
-        }
+      spyOn(window, 'Date').andCallFake(function() {
+        return new OldDate(NOW_MILLIS);
       });
     }));
-
-    it('should show only the time for a datetime occurring today', function() {
-      // In any timezone, 10 minutes before xx:45:00 should still fall within
-      // the same date as xx:45:00 in getLocaleAbbreviateDatetimeString().
-      expect(df.getLocaleAbbreviatedDatetimeString(
-        NOW_MILLIS - 10 * 60 * 1000)).not.toBe('11/21/14');
-      expect(df.getLocaleAbbreviatedDatetimeString(
-        NOW_MILLIS - 10 * 60 * 1000)).not.toBe('14/11/21');
-    });
-
-    it('should show only the date for a datetime occurring before today',
-        function() {
-      // 72 hours ago. This is 18 Nov 2014 09:45:00 GMT, which corresponds to
-      // 17 Nov 2014 in some parts of the world, and 18 Nov 2014 in others.
-      // Also have into account different locales where the order of time/date
-      // formatting is different. This should hold true in
-      // getLocaleAbbreviateDatetimeString()
-      expect([
-        '11/18/14', '11/17/14', '14/11/18', '14/11/17', '18/11/14', 'Nov 18'
-      ]).toContain(
-        df.getLocaleAbbreviatedDatetimeString(
-          NOW_MILLIS - 72 * 60 * 60 * 1000));
-    });
-
-    it('should show the date even for a datetime occurring today', function() {
-      // In any timezone, 10 minutes before xx:45:00 should still fall within
-      // the same date as xx:45:00 in getLocaleDateString(). The date should
-      // always be shown as '11/21/2014'
-      expect(df.getLocaleDateString(
-        NOW_MILLIS - 10 * 60 * 1000)).toBe('11/21/2014');
-      expect(df.getLocaleDateString(
-        NOW_MILLIS - 10 * 60 * 1000)).not.toBe('2014/11/21');
-    });
-
-    it('should show only the date for a datetime occurring before today',
-        function() {
-      // 72 hours ago. This is 18 Nov 2014 09:45:00 GMT, which corresponds to
-      // 17 Nov 2014 in some parts of the world, and 18 Nov 2014 in others.
-      // Also have into account different locales where the order of time/date
-      // formatting is different. This should hold true in
-      // getLocaleDateString().
-      expect([
-        '11/18/2014', '11/17/2014', '2014/11/18', '2014/11/17', '18/11/2014'
-      ]).toContain(df.getLocaleDateString(NOW_MILLIS - 72 * 60 * 60 * 1000));
-    });
-
     it('should correctly indicate recency', function() {
       // 1 second ago is recent.
       expect(df.isRecent(NOW_MILLIS - 1)).toBe(true);

--- a/core/templates/dev/head/appSpec.js
+++ b/core/templates/dev/head/appSpec.js
@@ -139,7 +139,7 @@ describe('Datetime Formatter', function() {
       // the same date as xx:45:00 in getLocaleDateString(). The date should
       // always be shown as '11/21/2014'
       expect(df.getLocaleDateString(
-        NOW_MILLIS - 10 * 60 * 1000)).toBe('21/11/2014');
+        NOW_MILLIS - 10 * 60 * 1000)).toBe('11/21/2014');
       expect(df.getLocaleDateString(
         NOW_MILLIS - 10 * 60 * 1000)).not.toBe('2014/11/21');
     });


### PR DESCRIPTION
We used date.toLocaleDateString() function which formatting conventions depends from locales. This caused test fails in my environment.