### PR TITLE
Add support for import of builtin python module in skulpt (fix-#1383)

### DIFF
--- a/extensions/interactions/CodeRepl/CodeRepl.js
+++ b/extensions/interactions/CodeRepl/CodeRepl.js
@@ -104,6 +104,15 @@ oppia.directive('oppiaInteractiveCodeRepl', [
             // runtime of the script.
             $scope.output += out;
           },
+          read: function(name) {
+            // This function is called when a builtin module is imported
+            if (Sk.builtinFiles.files[name] === undefined) {
+              // If corresponding module is not present then,
+              // removal of this block also results in failure of import.
+              throw 'module ' + name + ' not found';
+            }
+            return Sk.builtinFiles.files[name];
+          },
           timeoutMsg: function() {
             $scope.sendResponse('', 'timeout');
           },


### PR DESCRIPTION
This is to fix issue with importing builtin python modules, which are supported by skultp.