### PR TITLE
Fix frontend error in admin page

### DIFF
--- a/core/templates/dev/head/admin/admin.html
+++ b/core/templates/dev/head/admin/admin.html
@@ -248,6 +248,7 @@
 
     <script>
       {{ include_js_file('app.js') }}
+      {{ include_js_file('base.js') }}
       {{ include_js_file('admin/Admin.js') }}
       {{ include_js_file('directives.js') }}
       {{ include_js_file('services/warningsData.js') }}


### PR DESCRIPTION
Admin page couldn't inject some constants, i.e PARAMETER_TYPES