### PR TITLE
Ignoring external console error. Adding latin american date format.

### DIFF
--- a/core/templates/dev/head/appSpec.js
+++ b/core/templates/dev/head/appSpec.js
@@ -137,9 +137,9 @@ describe('Datetime Formatter', function() {
     it('should show the date even for a datetime occurring today', function() {
       // In any timezone, 10 minutes before xx:45:00 should still fall within
       // the same date as xx:45:00 in getLocaleDateString(). The date should
-      // always be shown as '11/21/2014'
-      expect(df.getLocaleDateString(
-        NOW_MILLIS - 10 * 60 * 1000)).toBe('11/21/2014');
+      // always be shown as '11/21/2014' or '21/11/2014'
+      expect(['11/21/2014', '21/11/2014']).toContain(
+        df.getLocaleDateString(NOW_MILLIS - 10 * 60 * 1000));
       expect(df.getLocaleDateString(
         NOW_MILLIS - 10 * 60 * 1000)).not.toBe('2014/11/21');
     });

--- a/core/tests/protractor/richTextComponents.js
+++ b/core/tests/protractor/richTextComponents.js
@@ -96,6 +96,8 @@ describe('rich-text components', function() {
       'chrome-extension://eojlgccfgnjlphjnlopmadngcgmmdgpk/' +
         'cast_sender.js 0:0 Failed to load resource: net::ERR_FAILED',
       'chrome-extension://fjhoaacokmgbjemoflkofnenfaiekifl/' +
+        'cast_sender.js 0:0 Failed to load resource: net::ERR_FAILED',
+      'chrome-extension://pkedcjkdefgpdelpbcmbmeomcjbeemfm/' +
         'cast_sender.js 0:0 Failed to load resource: net::ERR_FAILED'
     ]);
   });


### PR DESCRIPTION
Two test were failing:
*  core/tests/protractor/richTextComponents.js has a list of console logs to be ignored. These are external logs from google-cast-sdk. I just added a new error that was not listed before.
* core/templates/dev/head/appSpec.js was missing a date format used in Latin America, dd/mm/YY.