### PR TITLE
RTE components should be covered by gray, when hovered over in editor…

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1195,9 +1195,32 @@ pre.oppia-pre-wrapped-text {
   border-radius: 4px;
 }
 
+.oppia-editable-section:hover pre {
+	background-color: inherit;
+}
+
+.oppia-editable-section:hover oppia-noninteractive-link,
+.oppia-editable-section:hover oppia-noninteractive-video,
+.oppia-editable-section:hover oppia-noninteractive-tabs {
+	pointer-events: none;
+	cursor: pointer;
+}
+
+.oppia-editable-section:hover oppia-noninteractive-tabs li.active a {
+	background-color: inherit;
+	-webkit-transition : all 200ms;
+	transition: all 200ms;
+}
+
 .oppia-editable-section:hover .oppia-interaction-preview {
   background: rgba(5, 140, 166, 0.5);
   border-radius: 4px;
+}
+
+.oppia-editable-section:hover oppia-noninteractive-image img {
+    opacity: 0.7;
+    -webkit-transition : all 200ms;
+    transition: all 200ms;
 }
 
 .oppia-interaction-preview {

--- a/extensions/rich_text_components/Image/Image.html
+++ b/extensions/rich_text_components/Image/Image.html
@@ -1,11 +1,3 @@
-<style>
-.oppia-editable-section:hover oppia-noninteractive-image img {
-    opacity: 0.7;
-    -webkit-transition : all 200ms;
-    transition: all 200ms;
-}
-</style>
-
 <script type="text/ng-template" id="richTextComponent/Image">
   <img ng-src="<[imageUrl]>" alt="<[imageAltText]>"
        style="display: block; margin-left: auto; margin-right: auto;">

--- a/extensions/rich_text_components/Link/Link.html
+++ b/extensions/rich_text_components/Link/Link.html
@@ -3,6 +3,6 @@
   being added before and after the link. See http://stackoverflow.com/q/5078239
 -->
 <script type="text/ng-template" id="richTextComponent/Link"><!--
-  --><a ng-if="showUrlInTooltip" href="<[url]>" target="<[target]>" tooltip="<[url]>"><[text]></a><!--
-  --><a ng-if="!showUrlInTooltip" href="<[url]>" target="<[target]>"><[url]></a><!--
+  --><a ng-if="showUrlInTooltip" href="<[url]>" target="<[target]>" tooltip="<[url]>" tabIndex="<[tabIndexVal]>"><[text]></a><!--
+  --><a ng-if="!showUrlInTooltip" href="<[url]>" target="<[target]>" tabIndex="<[tabIndexVal]>"><[url]></a><!--
 --></script>

--- a/extensions/rich_text_components/Link/Link.js
+++ b/extensions/rich_text_components/Link/Link.js
@@ -25,38 +25,52 @@ oppia.directive('oppiaNoninteractiveLink', [
       restrict: 'E',
       scope: {},
       templateUrl: 'richTextComponent/Link',
-      controller: ['$scope', '$attrs', function($scope, $attrs) {
-        if (!$attrs.openLinkInSameWindowWithValue) {
-          // This is done for backward-compatibility.
-          $scope.target = '_blank';
-        } else {
-          $scope.target = (
-            oppiaHtmlEscaper.escapedJsonToObj(
-              $attrs.openLinkInSameWindowWithValue) ? '_top' : '_blank');
-        }
-
-        var untrustedUrl = oppiaHtmlEscaper.escapedJsonToObj(
-          $attrs.urlWithValue);
-        if (untrustedUrl.indexOf('http://') !== 0 &&
-            untrustedUrl.indexOf('https://') !== 0) {
-          return;
-        }
-        $scope.url = untrustedUrl;
-
-        $scope.showUrlInTooltip = false;
-        $scope.text = $scope.url;
-        if ($attrs.textWithValue) {
-          // This is done for backward-compatibility; some old explorations
-          // have content parts that don't include a 'text' attribute on
-          // their links.
-          $scope.text = oppiaHtmlEscaper.escapedJsonToObj($attrs.textWithValue);
-          // Note that this second 'if' condition is needed because a link may
-          // have an empty 'text' value.
-          if ($scope.text) {
-            $scope.showUrlInTooltip = true;
+      controller: [
+        '$scope', '$attrs', 'explorationContextService', 'PAGE_CONTEXT',
+        'EDITOR_TAB_CONTEXT',
+        function(
+            $scope, $attrs, explorationContextService,
+            PAGE_CONTEXT, EDITOR_TAB_CONTEXT) {
+          if (!$attrs.openLinkInSameWindowWithValue) {
+            // This is done for backward-compatibility.
+            $scope.target = '_blank';
+          } else {
+            $scope.target = (
+              oppiaHtmlEscaper.escapedJsonToObj(
+                $attrs.openLinkInSameWindowWithValue) ? '_top' : '_blank');
           }
-        }
-      }]
+
+          var untrustedUrl = oppiaHtmlEscaper.escapedJsonToObj(
+            $attrs.urlWithValue);
+          if (untrustedUrl.indexOf('http://') !== 0 &&
+              untrustedUrl.indexOf('https://') !== 0) {
+            return;
+          }
+          $scope.url = untrustedUrl;
+
+          $scope.showUrlInTooltip = false;
+          $scope.text = $scope.url;
+          if ($attrs.textWithValue) {
+            // This is done for backward-compatibility; some old explorations
+            // have content parts that don't include a 'text' attribute on
+            // their links.
+            $scope.text =
+              oppiaHtmlEscaper.escapedJsonToObj($attrs.textWithValue);
+            // Note that this second 'if' condition is needed because a link may
+            // have an empty 'text' value.
+            if ($scope.text) {
+              $scope.showUrlInTooltip = true;
+            }
+            // This code prevents tabbing while in editor mode.
+          }
+          if (
+            explorationContextService.getPageContext() ===
+              PAGE_CONTEXT.EDITOR &&
+            explorationContextService.getEditorTabContext() ===
+              EDITOR_TAB_CONTEXT.EDITOR) {
+            $scope.tabIndexVal = '-1';
+          }
+        }]
     };
   }
 ]);

--- a/extensions/rich_text_components/Video/Video.html
+++ b/extensions/rich_text_components/Video/Video.html
@@ -1,7 +1,7 @@
 <script type="text/ng-template" id="richTextComponent/Video">
   <center>
     <iframe width="500" height="280"
-            ng-src="<[videoUrl]>" frameborder="0" allowfullscreen>
+            ng-src="<[videoUrl]>" frameborder="0" allowfullscreen tabIndex="<[tabIndexVal]>">
     </iframe>
   </center>
 </script>

--- a/extensions/rich_text_components/Video/Video.js
+++ b/extensions/rich_text_components/Video/Video.js
@@ -25,19 +25,30 @@ oppia.directive('oppiaNoninteractiveVideo', [
       restrict: 'E',
       scope: {},
       templateUrl: 'richTextComponent/Video',
-      controller: ['$scope', '$attrs', function($scope, $attrs) {
-        var start = oppiaHtmlEscaper.escapedJsonToObj($attrs.startWithValue);
-        var end = oppiaHtmlEscaper.escapedJsonToObj($attrs.endWithValue);
+      controller: [
+        '$scope', '$attrs', 'explorationContextService', 'PAGE_CONTEXT',
+        'EDITOR_TAB_CONTEXT',
+        function(
+          $scope, $attrs, explorationContextService,
+          PAGE_CONTEXT, EDITOR_TAB_CONTEXT) {
+          var start = oppiaHtmlEscaper.escapedJsonToObj($attrs.startWithValue);
+          var end = oppiaHtmlEscaper.escapedJsonToObj($attrs.endWithValue);
 
-        $scope.autoplaySuffix = (oppiaHtmlEscaper.escapedJsonToObj(
-          $attrs.autoplayWithValue) ? '&autoplay=1' : '&autoplay=0');
-        $scope.videoId = oppiaHtmlEscaper.escapedJsonToObj(
-          $attrs.videoIdWithValue);
-        $scope.timingParams = '&start=' + start + '&end=' + end;
-        $scope.videoUrl = $sce.trustAsResourceUrl(
-          'https://www.youtube.com/embed/' + $scope.videoId + '?rel=0' +
-          $scope.timingParams + $scope.autoplaySuffix);
-      }]
+          $scope.autoplaySuffix = (oppiaHtmlEscaper.escapedJsonToObj(
+            $attrs.autoplayWithValue) ? '&autoplay=1' : '&autoplay=0');
+          $scope.videoId = oppiaHtmlEscaper.escapedJsonToObj(
+            $attrs.videoIdWithValue);
+          $scope.timingParams = '&start=' + start + '&end=' + end;
+          $scope.videoUrl = $sce.trustAsResourceUrl(
+            'https://www.youtube.com/embed/' + $scope.videoId + '?rel=0' +
+            $scope.timingParams + $scope.autoplaySuffix);
+          if (explorationContextService.getPageContext() ===
+              PAGE_CONTEXT.EDITOR &&
+              explorationContextService.getEditorTabContext() ===
+              EDITOR_TAB_CONTEXT.EDITOR) {
+            $scope.tabIndexVal = '-1';
+          }
+        }]
     };
   }
 ]);


### PR DESCRIPTION
… mode. (#1409)

My apologies for lot of add/delete of lines in js files. After new added code it was showing lint errors and upon solving them it resulted in a lot of changes.