### PR TITLE
Improve Vagrantfile for development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ venv/
 .DS_Store
 .idea
 static/images/splash/*
+.vagrant/*

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,6 @@ Vagrant.configure(2) do |config|
     end
   config.vm.provision "shell", inline: 'echo "export VAGRANT=true" >> ~/.profile'
   config.vm.network "forwarded_port", guest: 8000, host: 8000
-  config.vm.network "forwarded_port", guest: 42559, host: 42559
   config.vm.network "forwarded_port", guest: 8181, host: 8181
   config.vm.box = "ubuntu/trusty64"
   config.vm.synced_folder ".", "/home/vagrant/oppia"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,70 +8,9 @@
 
 
 Vagrant.configure(2) do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
-  
-  config.vm.provider "virtualbox" do |v|
-    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
-    end
-
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "hashicorp/precise32"
-
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.provision "shell", inline: 'echo "export VAGRANT=true" >> ~/.profile'
+  config.vm.provision "shell", inline: 'apt-get install -y unzip python-pip build-essential gfortran libatlas-base-dev python-dev && pip install -U pip'
   config.vm.network "forwarded_port", guest: 8181, host: 8181
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   sudo apt-get update
-  #   sudo apt-get install -y apache2
-  # SHELL
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.synced_folder ".", "/home/vagrant/oppia"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,8 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 
+# The recommended method for short, multi-line shell scripts in Vagrant.
+# Usage: http://stackoverflow.com/questions/2500436/how-does-cat-eof-work-in-bash
 $script = <<SCRIPT
 cd /home/vagrant/oppia
 bash ./scripts/install_prerequisites.sh
@@ -17,9 +19,9 @@ Vagrant.configure(2) do |config|
     v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     v.memory = 1024
   end
-  # General-purpose env var to let scripts know we are in Vagrant.  
+  # General-purpose env var to let scripts know we are in Vagrant.
   config.vm.provision "shell", inline: 'echo "export VAGRANT=true" >> ~/.profile'
-  # Tell apt to default to "yes" when installing pacakges. Necessary for unattended installs.
+  # Tell apt to default to "yes" when installing packages. Necessary for unattended installs.
   config.vm.provision "shell", inline: 'echo \'APT::Get::Assume-Yes "true";\' > /etc/apt/apt.conf.d/90yes'
   config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.network "forwarded_port", guest: 8181, host: 8181

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,9 @@
 
 
 Vagrant.configure(2) do |config|
+    config.vm.provider "virtualbox" do |v|
+      v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+    end
   config.vm.provision "shell", inline: 'echo "export VAGRANT=true" >> ~/.profile'
   config.vm.provision "shell", inline: 'apt-get install -y unzip python-pip build-essential gfortran libatlas-base-dev python-dev && pip install -U pip'
   config.vm.network "forwarded_port", guest: 8181, host: 8181

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
       v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     end
   config.vm.provision "shell", inline: 'echo "export VAGRANT=true" >> ~/.profile'
-  config.vm.provision "shell", inline: 'apt-get install -y unzip python-pip build-essential gfortran libatlas-base-dev python-dev && pip install -U pip'
+  config.vm.provision "shell", inline: 'apt-get install -y unzip python-pip build-essential git gfortran libatlas-base-dev python-dev && pip install -U pip'
   config.vm.network "forwarded_port", guest: 8181, host: 8181
   config.vm.box = "ubuntu/trusty64"
   config.vm.synced_folder ".", "/home/vagrant/oppia"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,9 +8,8 @@
 
 $script = <<SCRIPT
 cd /home/vagrant/oppia
-apt-get update && apt-get install -y python-pip python-dev unzip
-bash ./scripts/setup.sh
-bash ./scripts/install_third_party.sh
+bash ./scripts/install_prerequisites.sh
+bash ./scripts/start.sh
 SCRIPT
 
 Vagrant.configure(2) do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,11 +13,14 @@ bash ./scripts/start.sh
 SCRIPT
 
 Vagrant.configure(2) do |config|
-    config.vm.provider "virtualbox" do |v|
-      v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
-      v.memory = 1024
-    end
+  config.vm.provider "virtualbox" do |v|
+    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+    v.memory = 1024
+  end
+  # General-purpose env var to let scripts know we are in Vagrant.  
   config.vm.provision "shell", inline: 'echo "export VAGRANT=true" >> ~/.profile'
+  # Tell apt to default to "yes" when installing pacakges. Necessary for unattended installs.
+  config.vm.provision "shell", inline: 'echo \'APT::Get::Assume-Yes "true";\' > /etc/apt/apt.conf.d/90yes'
   config.vm.network "forwarded_port", guest: 8000, host: 8000
   config.vm.network "forwarded_port", guest: 8181, host: 8181
   config.vm.box = "ubuntu/trusty64"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,14 +6,23 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 
+$script = <<SCRIPT
+cd /home/vagrant/oppia
+apt-get update && apt-get install -y python-pip python-dev unzip
+bash ./scripts/setup.sh
+bash ./scripts/install_third_party.sh
+SCRIPT
 
 Vagrant.configure(2) do |config|
     config.vm.provider "virtualbox" do |v|
       v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
+      v.memory = 1024
     end
   config.vm.provision "shell", inline: 'echo "export VAGRANT=true" >> ~/.profile'
-  config.vm.provision "shell", inline: 'apt-get install -y unzip python-pip build-essential git gfortran libatlas-base-dev python-dev && pip install -U pip'
+  config.vm.network "forwarded_port", guest: 8000, host: 8000
+  config.vm.network "forwarded_port", guest: 42559, host: 42559
   config.vm.network "forwarded_port", guest: 8181, host: 8181
   config.vm.box = "ubuntu/trusty64"
   config.vm.synced_folder ".", "/home/vagrant/oppia"
+  config.vm.provision "shell", inline: $script
 end

--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -26,22 +26,11 @@
 # Note that the root folder MUST be named 'oppia'.
 
 sudo apt-get update
-if [[ $VAGRANT ]]; then 
-    sudo apt-get install -y curl
-    sudo apt-get install -y git
-    sudo apt-get install -y openjdk-7-jre
-    sudo apt-get install -y python-setuptools
-    sudo apt-get install -y python-dev
-    sudo apt-get install -y python-pip
-    sudo apt-get install -y unzip
-    sudo pip install --upgrade pip
-else
-    sudo apt-get install curl
-    sudo apt-get install git
-    sudo apt-get install openjdk-7-jre
-    sudo apt-get install python-setuptools
-    sudo apt-get install python-dev
-    sudo apt-get install python-pip
-    sudo apt-get install unzip
-    sudo pip install --upgrade pip
-fi
+sudo apt-get install curl
+sudo apt-get install git
+sudo apt-get install openjdk-7-jre
+sudo apt-get install python-setuptools
+sudo apt-get install python-dev
+sudo apt-get install python-pip
+sudo apt-get install unzip
+sudo pip install --upgrade pip

--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -26,12 +26,22 @@
 # Note that the root folder MUST be named 'oppia'.
 
 sudo apt-get update
-sudo apt-get install curl
-sudo apt-get install git
-sudo apt-get install openjdk-7-jre
-sudo apt-get install python-setuptools
-sudo apt-get install python-dev
-sudo apt-get install python-pip
-sudo apt-get install unzip
-
-sudo pip install --upgrade pip
+if [[ $VAGRANT ]]; then 
+    sudo apt-get install -y curl
+    sudo apt-get install -y git
+    sudo apt-get install -y openjdk-7-jre
+    sudo apt-get install -y python-setuptools
+    sudo apt-get install -y python-dev
+    sudo apt-get install -y python-pip
+    sudo apt-get install -y unzip
+    sudo pip install --upgrade pip
+else
+    sudo apt-get install curl
+    sudo apt-get install git
+    sudo apt-get install openjdk-7-jre
+    sudo apt-get install python-setuptools
+    sudo apt-get install python-dev
+    sudo apt-get install python-pip
+    sudo apt-get install unzip
+    sudo pip install --upgrade pip
+fi


### PR DESCRIPTION
Builds a Vagrant machine with all dependencies so that it can build and run Oppia. Useful for users on Windows, users who want to test against a clean environment, to ensure a clean environment without polluting the host machine, or for people who are otherwise having issues building Oppia on their host (like yours truly). 

Also adds a VAGRANT env variable set to `true` for use by any scripts that may need to behave differently if inside a vagrant machine. 

Finally, Vagrant creates a `.vagrant` directory with information about the VM state, so I have added that directory to `.gitignore`. 