### PR TITLE
Add gray overlay on editor when it is hovered.

### DIFF
--- a/core/templates/dev/head/components/outcome_editor_directive.html
+++ b/core/templates/dev/head/components/outcome_editor_directive.html
@@ -30,6 +30,8 @@
           </span>
         </div>
       </div>
+      <!-- This is a dummy div created to mask the contents when hovored above outcome editor contents -->
+      <div class="oppia-rule-preview-section-mask"></div>
     </div>
   </div>
 

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1189,34 +1189,12 @@ pre.oppia-pre-wrapped-text {
   position: relative;
 }
 
-/* this class below is used to graymask
- * outcome section when one hovers
- * over the editable section
+/* this classes below are used to graymask
+ * outcome section when one hovers and
+ * editable section when one hovers over them
  */
 
-.oppia-editable-section .oppia-rule-preview-section-mask {
-  background-color: #eee;
-  bottom: 0;
-  height: 100%;
-  opacity: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-  z-index: 10;
-}
-
-.oppia-editable-section:hover .oppia-rule-preview-section-mask {
-  border-radius: 4px;
-  opacity: 0.4;
-  transition: all 200ms;
-  -webkit-transition: all 200ms;
-}
-
-/* this class below is used to graymask
- * editable section when one hovers
- * over the editable section
- */
-
+.oppia-editable-section .oppia-rule-preview-section-mask,
 .oppia-editable-section .oppia-editable-section-mask {
   background-color: #eee;
   bottom: 0;
@@ -1228,6 +1206,7 @@ pre.oppia-pre-wrapped-text {
   z-index: 10;
 }
 
+.oppia-editable-section:hover .oppia-rule-preview-section-mask,
 .oppia-editable-section:hover .oppia-editable-section-mask {
   border-radius: 4px;
   opacity: 0.4;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1189,11 +1189,28 @@ pre.oppia-pre-wrapped-text {
   position: relative;
 }
 
-.oppia-editable-section:hover .oppia-rule-preview {
-  background: #eee;
-  border-radius: 4px;
+/* this class below is used to graymask
+ * outcome section when one hovers
+ * over the editable section
+ */
+
+.oppia-editable-section .oppia-rule-preview-section-mask {
+  background-color: #eee;
+  bottom: 0;
+  height: 100%;
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 10;
 }
 
+.oppia-editable-section:hover .oppia-rule-preview-section-mask {
+  border-radius: 4px;
+  opacity: 0.4;
+  transition: all 200ms;
+  -webkit-transition: all 200ms;
+}
 
 /* this class below is used to graymask
  * editable section when one hovers

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1189,10 +1189,27 @@ pre.oppia-pre-wrapped-text {
   position: relative;
 }
 
-.oppia-editable-section:hover .oppia-state-content-display,
-.oppia-editable-section:hover .oppia-rule-preview {
-  background: #eee;
+/* this class below is used to graymask
+ * editable section when one hovers
+ * over the editable section
+ */
+
+.oppia-editable-section .oppia-editable-section-mask {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  background-color: #eee;
+  z-index: 10;
+  opacity: 0;
+}
+
+.oppia-editable-section:hover .oppia-editable-section-mask {
+  opacity: 0.4;
   border-radius: 4px;
+  -webkit-transition: all 200ms;
+  transition: all 200ms;
 }
 
 .oppia-editable-section:hover .oppia-interaction-preview {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1189,27 +1189,33 @@ pre.oppia-pre-wrapped-text {
   position: relative;
 }
 
+.oppia-editable-section:hover .oppia-rule-preview {
+  background: #eee;
+  border-radius: 4px;
+}
+
+
 /* this class below is used to graymask
  * editable section when one hovers
  * over the editable section
  */
 
 .oppia-editable-section .oppia-editable-section-mask {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  top: 0;
-  bottom: 0;
   background-color: #eee;
-  z-index: 10;
+  bottom: 0;
+  height: 100%;
   opacity: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 10;
 }
 
 .oppia-editable-section:hover .oppia-editable-section-mask {
-  opacity: 0.4;
   border-radius: 4px;
-  -webkit-transition: all 200ms;
+  opacity: 0.4;
   transition: all 200ms;
+  -webkit-transition: all 200ms;
 }
 
 .oppia-editable-section:hover .oppia-interaction-preview {

--- a/core/templates/dev/head/editor/state_editor_content.html
+++ b/core/templates/dev/head/editor/state_editor_content.html
@@ -13,6 +13,8 @@
       </span>
       <span angular-html-bind="content[0].value" class="protractor-test-state-content-display"></span>
     </div>
+    <!-- This is a dummy divison created to mask the contents when hovoverd over above division -->
+    <div class="oppia-editable-section-mask"></div>
   </div>
 </div>
 

--- a/core/templates/dev/head/editor/state_editor_content.html
+++ b/core/templates/dev/head/editor/state_editor_content.html
@@ -13,7 +13,7 @@
       </span>
       <span angular-html-bind="content[0].value" class="protractor-test-state-content-display"></span>
     </div>
-    <!-- This is a dummy divison created to mask the contents when hovoverd over above division -->
+    <!-- This is a dummy div created to mask the contents when hovored above user contents-->
     <div class="oppia-editable-section-mask"></div>
   </div>
 </div>

--- a/core/templates/dev/head/services/explorationContextService.js
+++ b/core/templates/dev/head/services/explorationContextService.js
@@ -98,12 +98,8 @@ oppia.factory('explorationContextService', [
       // Following variable helps to know whether exploration editor is
       // in main editing mode or preview mode.
       isInExplorationEditorMode: function() {
-        if (this.getPageContext() === PAGE_CONTEXT.EDITOR &&
-            this.getEditorTabContext() === EDITOR_TAB_CONTEXT.EDITOR) {
-          return true;
-        } else {
-          return false;
-        }
+        return (this.getPageContext() === PAGE_CONTEXT.EDITOR &&
+            this.getEditorTabContext() === EDITOR_TAB_CONTEXT.EDITOR);
       }
     };
   }

--- a/core/templates/dev/head/services/explorationContextService.js
+++ b/core/templates/dev/head/services/explorationContextService.js
@@ -93,6 +93,17 @@ oppia.factory('explorationContextService', [
             'ERROR: explorationContextService should not be used outside the ' +
             'context of an exploration.');
         }
+      },
+
+      // Following variable helps to know whether exploration editor is
+      // in main editing mode or preview mode.
+      isInExplorationEditorMode: function() {
+        if (this.getPageContext() === PAGE_CONTEXT.EDITOR &&
+            this.getEditorTabContext() === EDITOR_TAB_CONTEXT.EDITOR) {
+          return true;
+        } else {
+          return false;
+        }
       }
     };
   }

--- a/extensions/rich_text_components/Image/Image.html
+++ b/extensions/rich_text_components/Image/Image.html
@@ -1,11 +1,3 @@
-<style>
-.oppia-editable-section:hover oppia-noninteractive-image img {
-    opacity: 0.7;
-    -webkit-transition : all 200ms;
-    transition: all 200ms;
-}
-</style>
-
 <script type="text/ng-template" id="richTextComponent/Image">
   <img ng-src="<[imageUrl]>" alt="<[imageAltText]>"
        style="display: block; margin-left: auto; margin-right: auto;">

--- a/extensions/rich_text_components/Link/Link.html
+++ b/extensions/rich_text_components/Link/Link.html
@@ -3,6 +3,6 @@
   being added before and after the link. See http://stackoverflow.com/q/5078239
 -->
 <script type="text/ng-template" id="richTextComponent/Link"><!--
-  --><a ng-if="showUrlInTooltip" href="<[url]>" target="<[target]>" tooltip="<[url]>"><[text]></a><!--
-  --><a ng-if="!showUrlInTooltip" href="<[url]>" target="<[target]>"><[url]></a><!--
+  --><a ng-if="showUrlInTooltip" href="<[url]>" target="<[target]>" tooltip="<[url]>" tabindex="<[tabIndexVal]>"><[text]></a><!--
+  --><a ng-if="!showUrlInTooltip" href="<[url]>" target="<[target]>" tabindex="<[tabIndexVal]>"><[url]></a><!--
 --></script>

--- a/extensions/rich_text_components/Link/Link.js
+++ b/extensions/rich_text_components/Link/Link.js
@@ -25,38 +25,46 @@ oppia.directive('oppiaNoninteractiveLink', [
       restrict: 'E',
       scope: {},
       templateUrl: 'richTextComponent/Link',
-      controller: ['$scope', '$attrs', function($scope, $attrs) {
-        if (!$attrs.openLinkInSameWindowWithValue) {
-          // This is done for backward-compatibility.
-          $scope.target = '_blank';
-        } else {
-          $scope.target = (
-            oppiaHtmlEscaper.escapedJsonToObj(
-              $attrs.openLinkInSameWindowWithValue) ? '_top' : '_blank');
-        }
-
-        var untrustedUrl = oppiaHtmlEscaper.escapedJsonToObj(
-          $attrs.urlWithValue);
-        if (untrustedUrl.indexOf('http://') !== 0 &&
-            untrustedUrl.indexOf('https://') !== 0) {
-          return;
-        }
-        $scope.url = untrustedUrl;
-
-        $scope.showUrlInTooltip = false;
-        $scope.text = $scope.url;
-        if ($attrs.textWithValue) {
-          // This is done for backward-compatibility; some old explorations
-          // have content parts that don't include a 'text' attribute on
-          // their links.
-          $scope.text = oppiaHtmlEscaper.escapedJsonToObj($attrs.textWithValue);
-          // Note that this second 'if' condition is needed because a link may
-          // have an empty 'text' value.
-          if ($scope.text) {
-            $scope.showUrlInTooltip = true;
+      controller: ['$scope', '$attrs', 'explorationContextService',
+        function($scope, $attrs, explorationContextService) {
+          if (!$attrs.openLinkInSameWindowWithValue) {
+            // This is done for backward-compatibility.
+            $scope.target = '_blank';
+          } else {
+            $scope.target = (
+              oppiaHtmlEscaper.escapedJsonToObj(
+                $attrs.openLinkInSameWindowWithValue) ? '_top' : '_blank');
           }
-        }
-      }]
+
+          var untrustedUrl = oppiaHtmlEscaper.escapedJsonToObj(
+            $attrs.urlWithValue);
+          if (untrustedUrl.indexOf('http://') !== 0 &&
+              untrustedUrl.indexOf('https://') !== 0) {
+            return;
+          }
+          $scope.url = untrustedUrl;
+
+          $scope.showUrlInTooltip = false;
+          $scope.text = $scope.url;
+          if ($attrs.textWithValue) {
+            // This is done for backward-compatibility; some old explorations
+            // have content parts that don't include a 'text' attribute on
+            // their links.
+            $scope.text =
+              oppiaHtmlEscaper.escapedJsonToObj($attrs.textWithValue);
+            // Note that this second 'if' condition is needed because a link may
+            // have an empty 'text' value.
+            if ($scope.text) {
+              $scope.showUrlInTooltip = true;
+            }
+          }
+
+          // This following check disbales the link in Editor being caught
+          // by tabbing while in Exploration Editor mode.
+          if (explorationContextService.isInExplorationEditorMode()) {
+            $scope.tabIndexVal = -1;
+          }
+        }]
     };
   }
 ]);

--- a/extensions/rich_text_components/Video/Video.html
+++ b/extensions/rich_text_components/Video/Video.html
@@ -1,7 +1,7 @@
 <script type="text/ng-template" id="richTextComponent/Video">
   <center>
     <iframe width="500" height="280"
-            ng-src="<[videoUrl]>" frameborder="0" allowfullscreen>
+            ng-src="<[videoUrl]>" frameborder="0" allowfullscreen tabindex="<[tabIndexVal]>">
     </iframe>
   </center>
 </script>

--- a/extensions/rich_text_components/Video/Video.js
+++ b/extensions/rich_text_components/Video/Video.js
@@ -25,19 +25,26 @@ oppia.directive('oppiaNoninteractiveVideo', [
       restrict: 'E',
       scope: {},
       templateUrl: 'richTextComponent/Video',
-      controller: ['$scope', '$attrs', function($scope, $attrs) {
-        var start = oppiaHtmlEscaper.escapedJsonToObj($attrs.startWithValue);
-        var end = oppiaHtmlEscaper.escapedJsonToObj($attrs.endWithValue);
+      controller: ['$scope', '$attrs', 'explorationContextService',
+        function($scope, $attrs, explorationContextService) {
+          var start = oppiaHtmlEscaper.escapedJsonToObj($attrs.startWithValue);
+          var end = oppiaHtmlEscaper.escapedJsonToObj($attrs.endWithValue);
 
-        $scope.autoplaySuffix = (oppiaHtmlEscaper.escapedJsonToObj(
-          $attrs.autoplayWithValue) ? '&autoplay=1' : '&autoplay=0');
-        $scope.videoId = oppiaHtmlEscaper.escapedJsonToObj(
-          $attrs.videoIdWithValue);
-        $scope.timingParams = '&start=' + start + '&end=' + end;
-        $scope.videoUrl = $sce.trustAsResourceUrl(
-          'https://www.youtube.com/embed/' + $scope.videoId + '?rel=0' +
-          $scope.timingParams + $scope.autoplaySuffix);
-      }]
+          $scope.autoplaySuffix = (oppiaHtmlEscaper.escapedJsonToObj(
+            $attrs.autoplayWithValue) ? '&autoplay=1' : '&autoplay=0');
+          $scope.videoId = oppiaHtmlEscaper.escapedJsonToObj(
+            $attrs.videoIdWithValue);
+          $scope.timingParams = '&start=' + start + '&end=' + end;
+          $scope.videoUrl = $sce.trustAsResourceUrl(
+            'https://www.youtube.com/embed/' + $scope.videoId + '?rel=0' +
+            $scope.timingParams + $scope.autoplaySuffix);
+
+          // This following check disbales the video in Editor being caught
+          // by tabbing while in Exploration Editor mode.
+          if (explorationContextService.isInExplorationEditorMode()) {
+            $scope.tabIndexVal = -1;
+          }
+        }]
     };
   }
 ]);


### PR DESCRIPTION
This patch fixes following,
1. It uses a sibling div to editor div for overlaying it with a gray mask. Thus no need for individual elemental gray masking when editor is being hovered in editor mode. In turn it also prevents opening of links and playing of videos in editor when it is clicked.
2. It prevents focus on links and videos while tabbing on editor screen. But focus via tabbing will be available while in preview mode  or learner mode.