### PR TITLE
Make the RTE components have better (noneditable) previews

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2350,6 +2350,16 @@ div#ng-curtain {
   min-height: 80px;
 }
 
+/* Hacky fix to force display of the cursor when the editor is empty */
+.form-control.oppia-rte-content > div:last-child {
+  display: inline-block;
+  width: 100%;
+}
+
+.form-control.oppia-rte-content > div:last-child p{
+  min-width: 2px;
+}
+
 /* Styles for the editor training interfaces. */
 
 .preview-conversation-skin-card-row-container {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1537,29 +1537,29 @@ pre.oppia-pre-wrapped-text {
 }
 
 .oppia-rule-header-warning-placement {
-  left: -0.5em; 
-  position: absolute; 
+  left: -0.5em;
+  position: absolute;
   top: 6px;
-  z-index: 2; 
+  z-index: 2;
 }
 
 .oppia-rule-header-warning-style {
-    
-  -ms-transform: rotate(-10deg); 
+
+  -ms-transform: rotate(-10deg);
   -webkit-transform: rotate(-10deg);
-  
-  background-color: yellow; 
-  border:1px solid black; 
+
+  background-color: yellow;
+  border:1px solid black;
   color: firebrick;
   cursor: pointer;
-  font-size: 20px; 
+  font-size: 20px;
   font-weight: bold;
-  height:22px; 
-  line-height: 22px; 
+  height:22px;
+  line-height: 22px;
   text-align: center;
-  transform: rotate(-10deg); 
-  width:22px; 
-}    
+  transform: rotate(-10deg);
+  width:22px;
+}
 
 .oppia-param-change-sort-handle {
   cursor: move;
@@ -2312,6 +2312,20 @@ div#ng-curtain {
   padding: 4px;
   resize: none;
   width: 245px;
+}
+
+.oppia-rte-overlay {
+  display: inline-block;
+  opacity: 1;
+  top: 0;
+  left: 0;
+  z-index: 5000;
+}
+
+.oppia-noninteractive-collapsible.oppia-rte-overlay,
+.oppia-noninteractive-video.oppia-rte-overlay,
+.oppia-noninteractive-image.oppia-rte-overlay{
+  width: 100%;
 }
 
 .oppia-rte-toolbar-image {

--- a/core/templates/dev/head/forms/formBuilder.js
+++ b/core/templates/dev/head/forms/formBuilder.js
@@ -278,7 +278,7 @@ oppia.directive('unicodeWithParametersEditor', ['$modal', function($modal) {
       // current caret.
       $scope.openEditParameterModal = function(currentParamName, eltToReplace) {
         return $modal.open({
-          templateUrl: 'modals/editParamName',
+          templateUrl: 'modatmls/editParamName',
           backdrop: true,
           resolve: {
             allowedParameterNames: function() {
@@ -522,7 +522,6 @@ oppia.factory('schemaUndefinedLastElementService', [function() {
 
 oppia.filter('sanitizeHtmlForRte', ['$sanitize', function($sanitize) {
   var _EXTENSION_SELECTOR = '[class^=oppia-noninteractive-]';
-
   return function(html) {
     var wrapper = document.createElement('div');
     wrapper.innerHTML = html;
@@ -550,8 +549,10 @@ oppia.filter('sanitizeHtmlForRte', ['$sanitize', function($sanitize) {
 }]);
 
 oppia.factory('rteHelperService', [
-  '$filter', '$log', 'RTE_COMPONENT_SPECS', 'oppiaHtmlEscaper',
-  function($filter, $log, RTE_COMPONENT_SPECS, oppiaHtmlEscaper) {
+  '$filter', '$log', '$compile', '$rootScope',
+  '$timeout', 'RTE_COMPONENT_SPECS', 'oppiaHtmlEscaper',
+  function($filter, $log, $compile, $rootScope,
+    $timeout, RTE_COMPONENT_SPECS, oppiaHtmlEscaper) {
     var _RICH_TEXT_COMPONENTS = [];
 
     Object.keys(RTE_COMPONENT_SPECS).sort().forEach(function(componentId) {
@@ -571,7 +572,10 @@ oppia.factory('rteHelperService', [
       for (var i = 0; i < attrs.length; i++) {
         var attr = attrs[i];
         if (attr.name == 'class' || attr.name == 'src' ||
-            attr.name == '_moz_resizing') {
+            attr.name == 'ng-scope' || attr.name == 'contenteditable' ||
+            attr.name == '_moz_resizing' || attr.name == 'style' ||
+            attr.name == 'oppia-rte-overlay'
+          ) {
           continue;
         }
         var separatorLocation = attr.name.indexOf('-with-value');
@@ -587,6 +591,50 @@ oppia.factory('rteHelperService', [
     };
 
     return {
+      bindClickEvent: function(
+        textAngularEditor, _openCustomizationModal,
+        componentDefn, customizationArgsDict, element) {
+        var that = this;
+        var clickEvent = function(event) {
+          $element = $(this);
+          event.preventDefault();
+          // Move the cursor to be immediately after the clicked widget.
+          // This prevents users from overwriting the widget.
+          var elRange = rangy.createRange();
+          elRange.setStartAfter($element.get(0));
+          elRange.setEndAfter($element.get(0));
+          var elSelection = rangy.getSelection();
+          elSelection.removeAllRanges();
+          elSelection.addRange(elRange);
+          var savedSelection = rangy.saveSelection();
+
+          // Temporarily pauses sanitizer so rangy markers save position
+          textAngularEditor.$parent.isCustomizationModalOpen = true;
+          _openCustomizationModal(
+            componentDefn.customizationArgSpecs,
+            customizationArgsDict,
+            function(customizationArgsDict) {
+              $element.unbind('click');
+              var el = that.compileRteElement(
+                that.createRteElement(
+                  componentDefn, customizationArgsDict));
+
+              $element[0].parentNode.replaceChild(el, $element[0]);
+              textAngularEditor.updateTaBindtaTextElement();
+              $(el).click(clickEvent);
+            },
+            function() {},
+            function() {
+              // Re-enables the sanitizer now that the modal is closed.
+              textAngularEditor.$parent.isCustomizationModalOpen = false;
+              textAngularEditor.displayElements.text[0].focus();
+              rangy.restoreSelection(savedSelection);
+            });
+
+          return false;
+        };
+        $(element).click(clickEvent);
+      },
       createCustomizationArgDictFromAttrs: function(attrs) {
         return _createCustomizationArgDictFromAttrs(attrs);
       },
@@ -596,44 +644,74 @@ oppia.factory('rteHelperService', [
         el.addClass('oppia-rte-toolbar-image');
         return el.get(0);
       },
-      // Returns a DOM node.
+      stripRteElementContent: function(html) {
+        _RICH_TEXT_COMPONENTS.forEach(function(componentDefn) {
+          var regex = new RegExp(
+              '(<oppia-noninteractive-' + componentDefn.name +
+              '\\s.*?>)([\\s\\S]*?)(</oppia-noninteractive-' +
+              componentDefn.name + '>)', 'g');
+          html = html.replace(regex, '$1$3');
+        });
+        return html;
+      },
+      compileRteElement: function(el) {
+        compiledElt = $($compile(el)($rootScope)[0]);
+        return compiledElt.get(0);
+      },
       createRteElement: function(componentDefn, customizationArgsDict) {
-        var el = $('<img/>');
-        el.attr('src', componentDefn.iconDataUrl);
+        var el = $('<span/>');
         el.addClass('oppia-noninteractive-' + componentDefn.name);
-
+        el.addClass('oppia-rte-overlay');
+        el.attr('contenteditable', false);
         for (var attrName in customizationArgsDict) {
           el.attr(
             $filter('camelCaseToHyphens')(attrName) + '-with-value',
-            oppiaHtmlEscaper.objToEscapedJson(customizationArgsDict[attrName]));
+            oppiaHtmlEscaper.objToEscapedJson(
+              customizationArgsDict[attrName]));
         }
-
+        var compiledElt = $(
+          '<oppia-noninteractive-' + componentDefn.name + '/>');
+        compiledElt.css('pointer-events', 'none');
+        compiledElt.attr('contenteditable', false);
+        for (var attrName in customizationArgsDict) {
+          compiledElt.attr(
+            $filter('camelCaseToHyphens')(attrName) + '-with-value',
+             oppiaHtmlEscaper.objToEscapedJson(
+               customizationArgsDict[attrName]));
+        };
+        var spaceElt = $('<span>&#8203;</span>');
+        spaceElt.css('display', 'none');
+        spaceElt.attr('contenteditable', false);
+        el.append(spaceElt);
+        el.append(compiledElt.prop('outerHTML'));
         return el.get(0);
       },
       // Replace <oppia-noninteractive> tags with <img> tags.
-      convertHtmlToRte: function(html) {
+      convertHtmlToRte: function(html, callback) {
         // If an undefined or empty html value is passed in, then the same type
         // of value should be returned. Without this check,
         // convertHtmlToRte(undefined) would return 'undefined', which is not
         // ideal.
         if (!html) {
-          return html;
+          callback(html);
+          return;
         }
-
         var elt = $('<div>' + html + '</div>');
         var that = this;
-
         _RICH_TEXT_COMPONENTS.forEach(function(componentDefn) {
           elt.find('oppia-noninteractive-' + componentDefn.name).replaceWith(
             function() {
-              return that.createRteElement(
-                componentDefn,
-                _createCustomizationArgDictFromAttrs(this.attributes));
+              return that.compileRteElement(
+                that.createRteElement(
+                  componentDefn,
+                  _createCustomizationArgDictFromAttrs(this.attributes)));
             }
           );
         });
-
-        return elt.html();
+        $timeout(function() {
+          callback(elt.html());
+        });
+        return;
       },
       // Replace <img> tags with <oppia-noninteractive> tags.
       convertRteToHtml: function(rte) {
@@ -644,12 +722,11 @@ oppia.factory('rteHelperService', [
         if (!rte) {
           return rte;
         }
-
         var elt = $('<div>' + rte + '</div>');
-
+        var that = this;
         _RICH_TEXT_COMPONENTS.forEach(function(componentDefn) {
           elt.find(
-            'img.oppia-noninteractive-' + componentDefn.name
+            'span.oppia-noninteractive-' + componentDefn.name
           ).replaceWith(function() {
             var jQueryElt = $('<' + this.className + '/>');
             for (var i = 0; i < this.attributes.length; i++) {
@@ -674,15 +751,55 @@ oppia.factory('rteHelperService', [
 // Add RTE extensions to textAngular toolbar options.
 oppia.config(['$provide', function($provide) {
   $provide.decorator('taOptions', [
-    '$delegate', '$modal', '$timeout', 'focusService', 'taRegisterTool',
-    'rteHelperService',
+    '$delegate', '$modal', '$timeout',
+    'focusService', 'taRegisterTool',
+    'rteHelperService', 'RTE_COMPONENT_SPECS',
+    'rteHelperService', 'textAngularManager',
     function(
-        taOptions, $modal, $timeout, focusService, taRegisterTool,
-        rteHelperService) {
+        taOptions, $modal, $timeout,
+        focusService, taRegisterTool,
+        rteHelperService, RTE_COMPONENT_SPECS,
+        rteHelperService, textAngularManager) {
+      var _RICH_TEXT_COMPONENTS = [];
+
+      Object.keys(RTE_COMPONENT_SPECS).sort().forEach(function(componentId) {
+        _RICH_TEXT_COMPONENTS.push({
+          backendName: RTE_COMPONENT_SPECS[componentId].backend_name,
+          customizationArgSpecs: angular.copy(
+            RTE_COMPONENT_SPECS[componentId].customization_arg_specs),
+          name: RTE_COMPONENT_SPECS[componentId].frontend_name,
+          iconDataUrl: RTE_COMPONENT_SPECS[componentId].icon_data_url,
+          isComplex: RTE_COMPONENT_SPECS[componentId].is_complex,
+          tooltip: RTE_COMPONENT_SPECS[componentId].tooltip
+        });
+      });
+
       taOptions.disableSanitizer = true;
       taOptions.classes.textEditor = 'form-control oppia-rte-content';
       taOptions.setup.textEditorSetup = function($element) {
         $timeout(function() {
+          var id = 'textAngularEditor' + $element.get(0).id.replace(/\D/g, '');
+          var textAngularEditor = textAngularManager.retrieveEditor(id);
+          if (textAngularEditor) {
+            var textAngularEditorScope = textAngularEditor.scope;
+            _RICH_TEXT_COMPONENTS.forEach(function(componentDefn) {
+              $element.find(
+                'oppia-noninteractive-' + componentDefn.name).replaceWith(
+                function() {
+                  var customizationArgsDict =
+                    rteHelperService.createCustomizationArgDictFromAttrs(
+                      this.attributes);
+                  var el = rteHelperService.compileRteElement(
+                    rteHelperService.createRteElement(
+                      componentDefn, customizationArgsDict));
+                  rteHelperService.bindClickEvent(
+                    textAngularEditorScope, _openCustomizationModal,
+                    componentDefn, customizationArgsDict, el);
+                  return el;
+                }
+              );
+            }, 1000);
+          }
           $element.trigger('focus');
         });
       };
@@ -756,49 +873,6 @@ oppia.config(['$provide', function($provide) {
         taRegisterTool(componentDefn.name, {
           display: buttonDisplay.outerHTML,
           tooltiptext: componentDefn.tooltip,
-          onElementSelect: {
-            element: 'img',
-            filter: function(elt) {
-              return elt.hasClass('oppia-noninteractive-' + componentDefn.name);
-            },
-            action: function(event, $element) {
-              event.preventDefault();
-              var textAngular = this;
-
-              // Move the cursor to be immediately after the clicked widget.
-              // This prevents users from overwriting the widget.
-              var elRange = rangy.createRange();
-              elRange.setStartAfter($element.get(0));
-              elRange.setEndAfter($element.get(0));
-              var elSelection = rangy.getSelection();
-              elSelection.removeAllRanges();
-              elSelection.addRange(elRange);
-              var savedSelection = rangy.saveSelection();
-
-              // Temporarily pauses sanitizer so rangy markers save position
-              textAngular.$editor().$parent.isCustomizationModalOpen = true;
-              _openCustomizationModal(
-                componentDefn.customizationArgSpecs,
-                rteHelperService.createCustomizationArgDictFromAttrs(
-                  $element[0].attributes),
-                function(customizationArgsDict) {
-                  var el = rteHelperService.createRteElement(
-                    componentDefn, customizationArgsDict);
-                  $element[0].parentNode.replaceChild(el, $element[0]);
-                  textAngular.$editor().updateTaBindtaTextElement();
-                },
-                function() {},
-                function() {
-                  // Re-enables the sanitizer now that the modal is closed.
-                  textAngular.$editor(
-                    ).$parent.isCustomizationModalOpen = false;
-                  textAngular.$editor().displayElements.text[0].focus();
-                  rangy.restoreSelection(savedSelection);
-                });
-
-              return false;
-            }
-          },
           action: function() {
             var textAngular = this;
             var savedSelection = rangy.saveSelection();
@@ -811,14 +885,18 @@ oppia.config(['$provide', function($provide) {
               componentDefn.customizationArgSpecs,
               {},
               function(customizationArgsDict) {
-                var el = rteHelperService.createRteElement(
-                  componentDefn, customizationArgsDict);
+                var el = rteHelperService.compileRteElement(
+                  rteHelperService.createRteElement(
+                    componentDefn, customizationArgsDict));
+                rteHelperService.bindClickEvent(
+                  textAngular.$editor(), _openCustomizationModal,
+                  componentDefn, customizationArgsDict, el);
+
                 var insertionPoint = (
                   textAngular.$editor().displayElements.text[0].querySelector(
                     '.insertionPoint'));
                 var parent = insertionPoint.parentNode;
                 parent.replaceChild(el, insertionPoint);
-                textAngular.$editor().updateTaBindtaTextElement();
               },
               function() {
                 // Clean up the insertion point if no widget was inserted.
@@ -858,7 +936,7 @@ oppia.directive('textAngularRte', [
       '<div text-angular="" ta-toolbar="<[toolbarOptionsJson]>" ' +
       '     ta-paste="stripFormatting($html)" ng-model="tempContent">' +
       '</div>'),
-    controller: ['$scope', function($scope) {
+    controller: ['$scope', '$element', function($scope) {
       $scope.isCustomizationModalOpen = false;
       var toolbarOptions = [
         ['bold', 'italics', 'underline'],
@@ -874,8 +952,8 @@ oppia.directive('textAngularRte', [
       });
       $scope.toolbarOptionsJson = JSON.stringify(toolbarOptions);
 
-      var _convertHtmlToRte = function(html) {
-        return rteHelperService.convertHtmlToRte(html);
+      var _convertHtmlToRte = function(html, callback) {
+        return rteHelperService.convertHtmlToRte(html, callback);
       };
 
       $scope.stripFormatting = function(html) {
@@ -883,27 +961,30 @@ oppia.directive('textAngularRte', [
       };
 
       $scope.init = function() {
-        $scope.tempContent = _convertHtmlToRte($scope.htmlContent);
+        $scope.tempContent = $scope.htmlContent;
       };
 
       $scope.init();
 
       $scope.$watch('tempContent', function(newVal) {
-        // Sanitizing while a modal is open would delete the markers that
-        // save and restore the cursor's position in the RTE.
         var displayedContent = $scope.isCustomizationModalOpen ? newVal :
-          $filter('sanitizeHtmlForRte')(newVal);
+          $filter('sanitizeHtmlForRte')(
+            rteHelperService.stripRteElementContent(newVal));
         $scope.htmlContent = rteHelperService.convertRteToHtml(
           displayedContent);
       });
 
+      /*
       // It is possible for the content of the RTE to be changed externally,
       // e.g. if there are several RTEs in a list, and one is deleted.
       $scope.$watch('htmlContent', function(newVal, oldVal) {
         if (newVal !== oldVal) {
-          $scope.tempContent = _convertHtmlToRte(newVal);
+          _convertHtmlToRte(newVal, function(html) {
+              $scope.tempContent = html;
+          });
         }
       });
+      */
     }]
   };
 }]);

--- a/core/templates/dev/head/forms/formBuilder.js
+++ b/core/templates/dev/head/forms/formBuilder.js
@@ -278,7 +278,7 @@ oppia.directive('unicodeWithParametersEditor', ['$modal', function($modal) {
       // current caret.
       $scope.openEditParameterModal = function(currentParamName, eltToReplace) {
         return $modal.open({
-          templateUrl: 'modatmls/editParamName',
+          templateUrl: 'modals/editParamName',
           backdrop: true,
           resolve: {
             allowedParameterNames: function() {
@@ -936,7 +936,7 @@ oppia.directive('textAngularRte', [
       '<div text-angular="" ta-toolbar="<[toolbarOptionsJson]>" ' +
       '     ta-paste="stripFormatting($html)" ng-model="tempContent">' +
       '</div>'),
-    controller: ['$scope', '$element', function($scope) {
+    controller: ['$scope', function($scope) {
       $scope.isCustomizationModalOpen = false;
       var toolbarOptions = [
         ['bold', 'italics', 'underline'],

--- a/core/templates/dev/head/forms/formBuilderSpec.js
+++ b/core/templates/dev/head/forms/formBuilderSpec.js
@@ -202,19 +202,17 @@ describe('RTE helper service', function() {
       '<div>abc<span>def</span></div><b>ghi</b>'
     ], [
       '<oppia-noninteractive-image></oppia-noninteractive-image>',
-      '<img src="' + _DATA_URI + '" class="oppia-noninteractive-image">'
+      '<oppia-noninteractive-image></oppia-noninteractive-image>'
     ], [
       '<oppia-noninteractive-image ' +
         'image_id-with-value="&amp;quot;T&amp;quot;">' +
       '</oppia-noninteractive-image>',
-      '<img src="' + _DATA_URI + '" ' +
-           'class="oppia-noninteractive-image" ' +
-           'image_id-with-value="&amp;quot;T&amp;quot;">'
+      '<oppia-noninteractive-image ' +
+        'image_id-with-value="&amp;quot;T&amp;quot;">' +
+      '</oppia-noninteractive-image>'
     ]];
 
     for (var i = 0; i < testData.length; i++) {
-      expect(rhs.convertHtmlToRte(testData[i][0]))
-        .toEqual(testData[i][1]);
       expect(rhs.convertRteToHtml(testData[i][1]))
         .toEqual(testData[i][0]);
     }

--- a/core/templates/dev/head/forms/formBuilderSpec.js
+++ b/core/templates/dev/head/forms/formBuilderSpec.js
@@ -172,7 +172,8 @@ describe('Normalizer tests', function() {
 describe('RTE helper service', function() {
   var _DATA_URI = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///';
   var rhs;
-
+  var $rootScope;
+  var $timeout;
   beforeEach(module('oppia'));
 
   beforeEach(function() {
@@ -186,11 +187,13 @@ describe('RTE helper service', function() {
     });
   });
 
-  beforeEach(inject(function($injector) {
+  beforeEach(inject(function($injector, _$rootScope_, _$timeout_) {
     rhs = $injector.get('rteHelperService');
+    $rootScope = _$rootScope_;
+    $timeout = _$timeout_;
   }));
 
-  it('should convert correctly between HTML and RTE', function() {
+  it('should convert correctly between HTML and RTE', function(done) {
     var testData = [[
       '<div></div>', '<div></div>'
     ], [
@@ -201,21 +204,43 @@ describe('RTE helper service', function() {
       '<div>abc<span>def</span></div><b>ghi</b>',
       '<div>abc<span>def</span></div><b>ghi</b>'
     ], [
-      '<oppia-noninteractive-image></oppia-noninteractive-image>',
-      '<oppia-noninteractive-image></oppia-noninteractive-image>'
+      '<oppia-noninteractive-image oppia-rte-overlay="" ng-scope="" ' +
+        'contenteditable="false">' +
+      '</oppia-noninteractive-image>',
+      '<span class="oppia-noninteractive-image oppia-rte-overlay ng-scope" ' +
+        'contenteditable="false">' +
+        '<span contenteditable="false" style="display: none;"></span>' +
+        '<oppia-noninteractive-image contenteditable="false" ' +
+          'style="pointer-events: none;">' +
+        '</oppia-noninteractive-image>' +
+      '</span>'
     ], [
-      '<oppia-noninteractive-image ' +
+      '<oppia-noninteractive-image oppia-rte-overlay="" ng-scope="" ' +
+        'contenteditable="false" ' +
         'image_id-with-value="&amp;quot;T&amp;quot;">' +
       '</oppia-noninteractive-image>',
-      '<oppia-noninteractive-image ' +
-        'image_id-with-value="&amp;quot;T&amp;quot;">' +
-      '</oppia-noninteractive-image>'
+      '<span class="oppia-noninteractive-image oppia-rte-overlay ng-scope" ' +
+        'contenteditable="false" image_id-with-value="&amp;quot;T&amp;quot;">' +
+        '<span contenteditable="false" style="display: none;"></span>' +
+        '<oppia-noninteractive-image contenteditable="false" ' +
+          'image_id-with-value="&amp;quot;T&amp;quot;" ' +
+          'style="pointer-events: none;">' +
+        '</oppia-noninteractive-image>' +
+      '</span>'
     ]];
 
     for (var i = 0; i < testData.length; i++) {
       expect(rhs.convertRteToHtml(testData[i][1]))
         .toEqual(testData[i][0]);
+      (function(htmlContent, rteContent) {
+        rhs.convertHtmlToRte(htmlContent, function(content) {
+          //Fix for a bug where a special empty string character is inserted
+          content = content.replace(String.fromCharCode(8203), "");
+          expect(content).toEqual(rteContent);
+        });
+      })(testData[i][0], testData[i][1]);
     }
+    $timeout.flush();
   });
 
   it('should correctly sanitize HTML for the RTE', inject(function($filter) {


### PR DESCRIPTION
This is a WIP attempt to render RTE components within the rich text editor. There are still some issues that needs fixing:

1. There is a bug in Chrome where on occasions, the caret will jump to the far right after the insertion of an RTE component. This seems to be well-documented here (http://stackoverflow.com/questions/27786048/why-is-my-contenteditable-cursor-jumping-to-the-end-in-chrome), but it seems like no desirable fix exists at the moment.
<img width="676" alt="screenshot 2016-01-24 10 42 32" src="https://cloud.githubusercontent.com/assets/4048170/12537312/d913ac06-c289-11e5-9bf6-38766bd0eed6.png">

2. The $scope.watch("htmlcontent") and $scope.watch("tempcontent") creates a feedback loop which can cripple the browser. Removing $scope.watch("htmlcontent") makes the RTE much faster, but now deleting the RTE from a list of RTEs does not update the htmlcontent. It's weird because the tempcontent is updated correctly upon deletion, but htmlcontent does not update correspondingly. Perhaps manually triggering the updating of htmlcontent from tempcontent upon deletion of an RTE, instead of updating the tempcontent non-discriminately whenever the htmlcontent changes might be a solution, though I'm still trying to figure out how to do that.

3.  Converting HTML to RTE content in the Jasmine test framework returns undefined, because $rootScope seems to be not injected when convertHtmlToRte runs. (Fixed, WIP)

4.  The backspace key does not delete the RTE components in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=685445)