### PR TITLE
Check for non-existent exploration within a collection 

### DIFF
--- a/core/domain/collection_services.py
+++ b/core/domain/collection_services.py
@@ -282,10 +282,10 @@ def get_learner_collection_dict_by_id(
     for collection_node in collection_dict['nodes']:
         summary = exp_summaries_dict.get(collection_node['exploration_id'])
         if not summary:
-            raise Exception(
-                'Unexpected error: access to a collection node that refernces'
-                'a non-existent exploration with exploration id: %s' % (
-                    collection_node['exploration_id']))
+            raise utils.ValidationError(
+                'Expected collection to only reference valid explorations, but '
+                'found an exploration with ID: %s (was the exploration '
+                'deleted?)' % collection_node['exploration_id'])
 
         collection_node['exploration'] = {
             'id': collection_node['exploration_id'],
@@ -534,10 +534,10 @@ def _save_collection(committer_id, collection, commit_message, change_list):
     for collection_node in collection.nodes:
         if not exp_services.get_exploration_by_id(
             collection_node.exploration_id, strict=False):
-            raise Exception(
-                'Unexpected error: Access to a collection node that references '
-                'a non-existent exploration with id: %s when trying to save a'
-                'collection' % (collection_node.exploration_id))
+            raise utils.ValidationError (
+                'Expected collection to only reference valid explorations, '
+                'but found an exploration with ID: %s' %
+                collection_node.exploration_id)
 
     collection_model = collection_models.CollectionModel.get(
         collection.id, strict=False)

--- a/core/domain/collection_services_test.py
+++ b/core/domain/collection_services_test.py
@@ -626,8 +626,6 @@ class CollectionCreateAndDeleteUnitTests(CollectionServicesUnitTests):
         with self.assertRaisesRegexp(Exception, 'between 1 and 50 characters'):
             collection_services.save_new_collection(self.OWNER_ID, collection)
 
-        collection = self.save_new_valid_collection
-
     def test_save_and_retrieve_collection(self):
         collection = self.save_new_valid_collection(
             self.COLLECTION_ID, self.OWNER_ID)
@@ -745,7 +743,9 @@ class UpdateCollectionNodeTests(CollectionServicesUnitTests):
         _INVALID_EXP_ID = 'invalid_exploration_id'
         collection = collection_services.get_collection_by_id(
             self.COLLECTION_ID)
-        with self.assertRaises(Exception):
+        with self.assertRaisesRegexp(
+            utils.ValidationError, 'Expected collection to only reference '
+                'valid explorations'):
             collection_services.update_collection(
                 self.OWNER_ID, self.COLLECTION_ID, [{
                     'cmd': collection_domain.CMD_ADD_COLLECTION_NODE,

--- a/core/domain/collection_services_test.py
+++ b/core/domain/collection_services_test.py
@@ -626,6 +626,8 @@ class CollectionCreateAndDeleteUnitTests(CollectionServicesUnitTests):
         with self.assertRaisesRegexp(Exception, 'between 1 and 50 characters'):
             collection_services.save_new_collection(self.OWNER_ID, collection)
 
+        collection = self.save_new_valid_collection
+
     def test_save_and_retrieve_collection(self):
         collection = self.save_new_valid_collection(
             self.COLLECTION_ID, self.OWNER_ID)
@@ -738,6 +740,17 @@ class UpdateCollectionNodeTests(CollectionServicesUnitTests):
             self.COLLECTION_ID)
         self.assertEqual(
             collection.exploration_ids, [self.EXPLORATION_ID, _NEW_EXP_ID])
+
+    def test_add_node_with_invalid_exploration(self):
+        _INVALID_EXP_ID = 'invalid_exploration_id'
+        collection = collection_services.get_collection_by_id(
+            self.COLLECTION_ID)
+        with self.assertRaises(Exception):
+            collection_services.update_collection(
+                self.OWNER_ID, self.COLLECTION_ID, [{
+                    'cmd': collection_domain.CMD_ADD_COLLECTION_NODE,
+                    'exploration_id': _INVALID_EXP_ID
+                }], 'Added invalid exploration')
 
     def test_delete_node(self):
         # Verify the initial collection only has 1 exploration in it.


### PR DESCRIPTION
This PR provides a check against the addition of non-existent exploration into a collection. 