### PR TITLE
Updated deprecated $http requests

### DIFF
--- a/core/templates/dev/head/admin/Admin.js
+++ b/core/templates/dev/head/admin/Admin.js
@@ -25,12 +25,16 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
   $scope.adminTopicsCsvDownloadHandlerUrl = '/admintopicscsvdownloadhandler';
   $scope.configProperties = {};
 
+  $scope.reportError = function(errorResponse) {
+    $scope.message = 'Server error: ' + errorResponse.error;
+  };
+
   $scope.showJobOutput = false;
   $scope.getJobOutput = function(jobId) {
     var adminJobOutputUrl = ADMIN_JOB_OUTPUT_URL_PREFIX + '?job_id=' + jobId;
-    $http.get(adminJobOutputUrl).success(function(data) {
+    $http.get(adminJobOutputUrl).then(function(response) {
       $scope.showJobOutput = true;
-      $scope.jobOutput = data.output;
+      $scope.jobOutput = response.data.output;
     });
   };
 
@@ -43,9 +47,9 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
   };
 
   $scope.reloadConfigProperties = function() {
-    $http.get($scope.adminHandlerUrl).success(function(data) {
-      $scope.configProperties = data.config_properties;
-      $scope.computedProperties = data.computed_properties;
+    $http.get($scope.adminHandlerUrl).then(function(response) {
+      $scope.configProperties = response.data.config_properties;
+      $scope.computedProperties = response.data.computed_properties;
     });
   };
 
@@ -59,11 +63,11 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
     $http.post($scope.adminHandlerUrl, {
       action: 'revert_config_property',
       config_property_id: configPropertyId
-    }).success(function() {
+    }).then(function() {
       $scope.message = 'Config property reverted successfully.';
       $scope.reloadConfigProperties();
-    }).error(function(errorResponse) {
-      $scope.message = 'Server error: ' + errorResponse.error;
+    }).catch(function(errorResponse) {
+      $scope.reportError(errorResponse);
     });
   };
 
@@ -73,12 +77,12 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
 
     $http.post($scope.adminHandlerUrl, {
       action: 'migrate_feedback'
-    }).success(function() {
+    }).then(function() {
       $scope.message = 'Feedback migrated successfully.';
       $scope.migrationInProcess = false;
       window.reload();
-    }).error(function(errorResponse) {
-      $scope.message = 'Server error: ' + errorResponse.error;
+    }).catch(function(errorResponse) {
+      $scope.reportError(errorResponse);
       $scope.migrationInProcess = false;
     });
   };
@@ -87,10 +91,10 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
     $http.post($scope.adminHandlerUrl, {
       action: 'refresh_computed_property',
       computed_property_name: computedPropertyId
-    }).success(function() {
+    }).then(function() {
       $scope.message = 'Computed property reloaded successfully.';
-    }).error(function(errorResponse) {
-      $scope.message = 'Server error: ' + errorResponse.error;
+    }).catch(function(errorResponse) {
+      $scope.reportError(errorResponse);
     });
   };
 
@@ -114,10 +118,10 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
     $http.post($scope.adminHandlerUrl, {
       action: 'save_config_properties',
       new_config_property_values: newConfigPropertyValues
-    }).success(function() {
+    }).then(function() {
       $scope.message = 'Data saved successfully.';
-    }).error(function(errorResponse) {
-      $scope.message = 'Server error: ' + errorResponse.error;
+    }).catch(function(errorResponse) {
+      $scope.reportError(errorResponse);
     });
   };
 
@@ -134,10 +138,10 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
 
     $http.post($scope.adminHandlerUrl, {
       action: 'clear_search_index'
-    }).success(function() {
+    }).then(function() {
       $scope.message = 'Index successfully cleared.';
-    }).error(function(errorResponse) {
-      $scope.message = 'Server error: ' + errorResponse.error;
+    }).catch(function(errorResponse) {
+      $scope.reportError(errorResponse);
     });
   };
 
@@ -155,10 +159,10 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
     $http.post($scope.adminHandlerUrl, {
       action: 'reload_exploration',
       exploration_id: String(explorationId)
-    }).success(function() {
+    }).then(function() {
       $scope.message = 'Data reloaded successfully.';
-    }).error(function(errorResponse) {
-      $scope.message = 'Server error: ' + errorResponse.error;
+    }).catch(function(errorResponse) {
+      $scope.reportError(errorResponse);
     });
   };
 
@@ -193,11 +197,11 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
       $http.post($scope.adminHandlerUrl, {
         action: 'reload_exploration',
         exploration_id: explorationId
-      }).success(function() {
+      }).then(function() {
         ++numSucceeded;
         ++numTried;
         printResult();
-      }).error(function() {
+      }).catch(function() {
         ++numFailed;
         ++numTried;
         printResult();
@@ -219,10 +223,10 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
     $http.post($scope.adminHandlerUrl, {
       action: 'reload_collection',
       collection_id: String(collectionId)
-    }).success(function() {
+    }).then(function() {
       $scope.message = 'Data reloaded successfully.';
-    }).error(function(errorResponse) {
-      $scope.message = 'Server error: ' + errorResponse.error;
+    }).catch(function(errorResponse) {
+      $scope.reportError(errorResponse);
     });
   };
 
@@ -232,11 +236,11 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
     $http.post($scope.adminHandlerUrl, {
       action: 'start_new_job',
       job_type: jobType
-    }).success(function() {
+    }).then(function() {
       $scope.message = 'Job started successfully.';
       window.location.reload();
-    }).error(function(errorResponse) {
-      $scope.message = 'Server error: ' + errorResponse.error;
+    }).catch(function(errorResponse) {
+      $scope.reportError(errorResponse);
     });
   };
 
@@ -247,11 +251,11 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
       action: 'cancel_job',
       job_id: jobId,
       job_type: jobType
-    }).success(function() {
+    }).then(function() {
       $scope.message = 'Abort signal sent to job.';
       window.location.reload();
-    }).error(function(errorResponse) {
-      $scope.message = 'Server error: ' + errorResponse.error;
+    }).catch(function(errorResponse) {
+      $scope.reportError(errorResponse);
     });
   };
 
@@ -261,11 +265,11 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
     $http.post($scope.adminHandlerUrl, {
       action: 'start_computation',
       computation_type: computationType
-    }).success(function() {
+    }).then(function() {
       $scope.message = 'Computation started successfully.';
       window.location.reload();
-    }).error(function(errorResponse) {
-      $scope.message = 'Server error: ' + errorResponse.error;
+    }).catch(function(errorResponse) {
+      $scope.reportError(errorResponse);
     });
   };
 
@@ -275,11 +279,11 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
     $http.post($scope.adminHandlerUrl, {
       action: 'stop_computation',
       computation_type: computationType
-    }).success(function() {
+    }).then(function() {
       $scope.message = 'Abort signal sent to computation.';
       window.location.reload();
-    }).error(function(errorResponse) {
-      $scope.message = 'Server error: ' + errorResponse.error;
+    }).catch(function(errorResponse) {
+      $scope.reportError(errorResponse);
     });
   };
 
@@ -291,10 +295,10 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
       $http.post($scope.adminHandlerUrl, {
         action: 'upload_topic_similarities',
         data: data
-      }).success(function() {
+      }).then(function() {
         $scope.message = 'Topic similarities uploaded successfully.';
-      }).error(function(errorResponse) {
-        $scope.message = 'Server error: ' + errorResponse.error;
+      }).catch(function(errorResponse) {
+        $scope.reportError(errorResponse);
       });
     };
     reader.readAsText(file);

--- a/core/templates/dev/head/base.js
+++ b/core/templates/dev/head/base.js
@@ -98,9 +98,10 @@ oppia.controller('Base', [
     if (GLOBALS.userIsLoggedIn) {
       // Show the number of unseen notifications in the navbar and page title,
       // unless the user is already on the dashboard page.
-      $http.get('/notificationshandler').success(function(data) {
+      $http.get('/notificationshandler').then(function(response) {
         if ($window.location.pathname !== '/') {
-          $scope.numUnseenNotifications = data.num_unseen_notifications;
+          $scope.numUnseenNotifications =
+            response.data.num_unseen_notifications;
           if ($scope.numUnseenNotifications > 0) {
             $window.document.title = (
               '(' + $scope.numUnseenNotifications + ') ' +

--- a/core/templates/dev/head/components/ExplorationCreationButtonService.js
+++ b/core/templates/dev/head/components/ExplorationCreationButtonService.js
@@ -148,9 +148,9 @@ oppia.factory('ExplorationCreationButtonService', [
             language_code: result.languageCode,
             objective: $filter('normalizeWhitespace')(result.objective),
             title: result.title
-          }).success(function(data) {
-            window.location = '/create/' + data.explorationId;
-          }).error(function() {
+          }).then(function(response) {
+            window.location = '/create/' + response.data.explorationId;
+          }).catch(function() {
             $rootScope.loadingMessage = '';
           });
         });

--- a/core/templates/dev/head/components/ProfileLinkImageDirective.js
+++ b/core/templates/dev/head/components/ProfileLinkImageDirective.js
@@ -39,9 +39,9 @@ oppia.directive('profileLinkImage', [function() {
       // Returns a promise for the user profile picture, or the default image if
       // user is not logged in or has not uploaded a profile picture, or the
       // player is in preview mode.
-      $http.get($scope.profileImageUrl).success(function(data) {
+      $http.get($scope.profileImageUrl).then(function(response) {
         $scope.profilePicture = (
-          data.profile_picture_data_url_for_username ||
+          response.data.profile_picture_data_url_for_username ||
           DEFAULT_PROFILE_IMAGE_PATH);
       });
     }]

--- a/core/templates/dev/head/dashboard/MyExplorations.js
+++ b/core/templates/dev/head/dashboard/MyExplorations.js
@@ -34,8 +34,8 @@ oppia.controller('MyExplorations', [
     };
 
     $rootScope.loadingMessage = 'Loading';
-    $http.get('/myexplorationshandler/data').success(function(data) {
-      $scope.explorationsList = data.explorations_list;
+    $http.get('/myexplorationshandler/data').then(function(response) {
+      $scope.explorationsList = response.data.explorations_list;
       $rootScope.loadingMessage = '';
     });
   }

--- a/core/templates/dev/head/dashboard/NotificationsDashboard.js
+++ b/core/templates/dev/head/dashboard/NotificationsDashboard.js
@@ -32,11 +32,11 @@ oppia.controller('DashboardNotifications', [
   };
 
   $rootScope.loadingMessage = 'Loading';
-  $http.get('/notificationsdashboardhandler/data').success(function(data) {
-    $scope.recentNotifications = data.recent_notifications;
-    $scope.jobQueuedMsec = data.job_queued_msec;
-    $scope.lastSeenMsec = data.last_seen_msec || 0.0;
-    $scope.currentUsername = data.username;
+  $http.get('/notificationsdashboardhandler/data').then(function(response) {
+    $scope.recentNotifications = response.data.recent_notifications;
+    $scope.jobQueuedMsec = response.data.job_queued_msec;
+    $scope.lastSeenMsec = response.data.last_seen_msec || 0.0;
+    $scope.currentUsername = response.data.username;
     $rootScope.loadingMessage = '';
   });
 }]);

--- a/core/templates/dev/head/domain/collection/CollectionDataService.js
+++ b/core/templates/dev/head/domain/collection/CollectionDataService.js
@@ -36,14 +36,14 @@ oppia.factory('CollectionDataService', [
         collection_id: collectionId
       });
 
-    $http.get(collectionDataUrl).success(function(data) {
-      var collection = angular.copy(data.collection);
+    $http.get(collectionDataUrl).then(function(response) {
+      var collection = angular.copy(response.data.collection);
       if (successCallback) {
         successCallback(collection);
       }
-    }).error(function(error) {
+    }).catch(function(error) {
       if (errorCallback) {
-        errorCallback(error);
+        errorCallback(error.data);
       }
     });
   };

--- a/core/templates/dev/head/editor/EditorServices.js
+++ b/core/templates/dev/head/editor/EditorServices.js
@@ -89,14 +89,14 @@ oppia.factory('explorationData', [
           change_list: changeList,
           commit_message: commitMessage,
           version: explorationData.data.version
-        }).success(function(data) {
+        }).then(function(response) {
           warningsData.clear();
           $log.info('Changes to this exploration were saved successfully.');
-          explorationData.data = data;
+          explorationData.data = response.data;
           if (successCallback) {
             successCallback();
           }
-        }).error(function() {
+        }).catch(function() {
           if (errorCallback) {
             errorCallback();
           }
@@ -439,8 +439,9 @@ oppia.factory('explorationRightsService', [
       requestParams.version = explorationData.data.version;
       var explorationRightsUrl = (
         '/createhandler/rights/' + explorationData.explorationId);
-      $http.put(explorationRightsUrl, requestParams).success(function(data) {
+      $http.put(explorationRightsUrl, requestParams).then(function(response) {
         warningsData.clear();
+        var data = response.data;
         that.init(
           data.rights.owner_names, data.rights.editor_names,
           data.rights.viewer_names, data.rights.status,
@@ -457,7 +458,8 @@ oppia.factory('explorationRightsService', [
         action: action,
         email_body: emailBody,
         version: explorationData.data.version
-      }).success(function(data) {
+      }).then(function(response) {
+        var data = response.data;
         warningsData.clear();
         that.init(
           data.rights.owner_names, data.rights.editor_names,
@@ -1521,7 +1523,7 @@ oppia.factory('stateEditorTutorialFirstTimeService', [
 
         if (_currentlyInFirstVisit) {
           $rootScope.$broadcast('openEditorTutorial');
-          $http.post(STARTED_TUTORIAL_EVENT_URL).error(function() {
+          $http.post(STARTED_TUTORIAL_EVENT_URL).catch(function() {
             console.error('Warning: could not record tutorial start event.');
           });
         }

--- a/core/templates/dev/head/editor/ExplorationEditor.js
+++ b/core/templates/dev/head/editor/ExplorationEditor.js
@@ -503,9 +503,9 @@ oppia.controller('ExplorationSaveAndPublishButtons', [
       $http.post($scope.changeListSummaryUrl, {
         change_list: changeListService.getChangeList(),
         version: explorationData.data.version
-      }).success(function(data) {
-        if (data.error) {
-          warningsData.addWarning(data.error);
+      }).then(function(response) {
+        if (response.data.error) {
+          warningsData.addWarning(response.data.error);
           return;
         }
 

--- a/core/templates/dev/head/editor/ExplorationFeedback.js
+++ b/core/templates/dev/head/editor/ExplorationFeedback.js
@@ -43,8 +43,8 @@ oppia.controller('ExplorationFeedback', [
     };
 
     $scope._getThreadList = function(successCallback) {
-      $http.get(THREAD_LIST_HANDLER_URL).success(function(data) {
-        $scope.threads = data.threads;
+      $http.get(THREAD_LIST_HANDLER_URL).then(function(response) {
+        $scope.threads = response.data.threads;
         if (successCallback) {
           successCallback();
         }
@@ -56,7 +56,7 @@ oppia.controller('ExplorationFeedback', [
         state_name: null,
         subject: newThreadSubject,
         text: newThreadText
-      }).success(function() {
+      }).then(function() {
         $scope._getThreadList();
         $scope.setCurrentThread(null);
       });
@@ -71,10 +71,10 @@ oppia.controller('ExplorationFeedback', [
         return;
       }
 
-      $http.get(THREAD_HANDLER_PREFIX + threadId).success(function(data) {
+      $http.get(THREAD_HANDLER_PREFIX + threadId).then(function(response) {
         $scope.currentThreadId = threadId;
         $scope.currentThreadData = $scope._getThreadById(threadId);
-        $scope.currentThreadMessages = data.messages;
+        $scope.currentThreadMessages = response.data.messages;
         $scope.updatedStatus = $scope.currentThreadData.status;
       });
     };
@@ -141,12 +141,12 @@ oppia.controller('ExplorationFeedback', [
           updatedStatus : null),
         updated_subject: null,
         text: newMessageText
-      }).success(function() {
+      }).then(function() {
         $scope.currentThreadData.status = updatedStatus;
         $scope.setCurrentThread(threadId);
         $scope.messageSendingInProgress = false;
         $scope.newMessageText = '';
-      }).error(function() {
+      }).catch(function() {
         $scope.messageSendingInProgress = false;
       });
     };

--- a/core/templates/dev/head/editor/ExplorationHistory.js
+++ b/core/templates/dev/head/editor/ExplorationHistory.js
@@ -491,7 +491,7 @@ oppia.controller('ExplorationHistory', [
         $http.post($scope.revertExplorationUrl, {
           current_version: explorationData.data.version,
           revert_to_version: version
-        }).success(function() {
+        }).then(function() {
           location.reload();
         });
       });

--- a/core/templates/dev/head/editor/ExplorationSettings.js
+++ b/core/templates/dev/head/editor/ExplorationSettings.js
@@ -256,7 +256,7 @@ oppia.controller('ExplorationSettings', [
         if (role) {
           deleteUrl += ('?role=' + role);
         }
-        $http['delete'](deleteUrl).success(function() {
+        $http['delete'](deleteUrl).then(function() {
           $window.location = MY_EXPLORATIONS_PAGE_URL;
         });
       });

--- a/core/templates/dev/head/editor/StateEditor.js
+++ b/core/templates/dev/head/editor/StateEditor.js
@@ -295,8 +295,8 @@ oppia.factory('trainingDataService', [
       initializeTrainingData: function(explorationId, stateName) {
         var trainingDataUrl = '/createhandler/training_data/' + explorationId +
           '/' + encodeURIComponent(stateName);
-        $http.get(trainingDataUrl).success(function(result) {
-          var unhandledAnswers = result.unhandled_answers;
+        $http.get(trainingDataUrl).then(function(response) {
+          var unhandledAnswers = response.data.unhandled_answers;
           _trainingDataAnswers = [];
           _trainingDataCounts = [];
           for (var i = 0; i < unhandledAnswers.length; i++) {

--- a/core/templates/dev/head/galleries/Gallery.js
+++ b/core/templates/dev/head/galleries/Gallery.js
@@ -94,13 +94,13 @@ oppia.factory('searchService', [
         _getSuffixForQuery(selectedCategories, selectedLanguageCodes));
 
       _isCurrentlyFetchingResults = true;
-      $http.get(queryUrl).success(function(data) {
+      $http.get(queryUrl).then(function(response) {
         _lastQuery = searchQuery;
         _lastSelectedCategories = angular.copy(selectedCategories);
         _lastSelectedLanguageCodes = angular.copy(selectedLanguageCodes);
-        _searchCursor = data.search_cursor;
+        _searchCursor = response.data.search_cursor;
         $rootScope.$broadcast(
-          'refreshGalleryData', data, hasPageFinishedLoading());
+          'refreshGalleryData', response.data, hasPageFinishedLoading());
         _isCurrentlyFetchingResults = false;
       });
 
@@ -123,8 +123,8 @@ oppia.factory('searchService', [
       }
 
       _isCurrentlyFetchingResults = true;
-      $http.get(queryUrl).success(function(data) {
-        _searchCursor = data.search_cursor;
+      $http.get(queryUrl).then(function(response) {
+        _searchCursor = response.data.search_cursor;
         _isCurrentlyFetchingResults = false;
         if (successCallback) {
           successCallback(data, hasPageFinishedLoading());
@@ -230,14 +230,14 @@ oppia.controller('Gallery', [
     );
 
     // Retrieves gallery data from the server.
-    $http.get(GALLERY_DATA_URL).success(function(data) {
-      $scope.currentUserIsModerator = Boolean(data.is_moderator);
+    $http.get(GALLERY_DATA_URL).then(function(response) {
+      $scope.currentUserIsModerator = Boolean(response.data.is_moderator);
 
       // Note that this will cause an initial search query to be sent.
       $rootScope.$broadcast(
-        'preferredLanguageCodesLoaded', data.preferred_language_codes);
+        'preferredLanguageCodesLoaded', response.data.preferred_language_codes);
 
-      if (data.username) {
+      if (response.data.username) {
         if (urlService.getUrlParams().mode === 'create') {
           $scope.showCreateExplorationModal(CATEGORY_LIST);
         }

--- a/core/templates/dev/head/moderator/Moderator.js
+++ b/core/templates/dev/head/moderator/Moderator.js
@@ -50,10 +50,10 @@ oppia.controller('Moderator', [
       recentCommitsUrl += ('?cursor=' + $scope.recentCommitsCursor);
     }
 
-    $http.get(recentCommitsUrl).success(function(data) {
+    $http.get(recentCommitsUrl).then(function(response) {
       // Update the explorationData object with information about newly-
       // discovered explorations.
-      var explorationIdsToExplorationData = data.exp_ids_to_exp_data;
+      var explorationIdsToExplorationData = response.data.exp_ids_to_exp_data;
       for (var expId in explorationIdsToExplorationData) {
         if (!$scope.explorationData.hasOwnProperty(expId)) {
           $scope.explorationData[expId] = (
@@ -61,11 +61,11 @@ oppia.controller('Moderator', [
         }
       }
 
-      for (var i = 0; i < data.results.length; i++) {
-        $scope.allCommits.push(data.results[i]);
+      for (var i = 0; i < response.data.results.length; i++) {
+        $scope.allCommits.push(response.data.results[i]);
       }
-      $scope.recentCommitsCursor = data.cursor;
-      if (!data.more) {
+      $scope.recentCommitsCursor = response.data.cursor;
+      if (!response.data.more) {
         $scope.reachedEndOfCommits = true;
       }
     });
@@ -87,12 +87,12 @@ oppia.controller('Moderator', [
         '?cursor=' + $scope.recentFeedbackMessagesCursor);
     }
 
-    $http.get(recentFeedbackMessagesUrl).success(function(data) {
-      for (var i = 0; i < data.results.length; i++) {
-        $scope.allFeedbackMessages.push(data.results[i]);
+    $http.get(recentFeedbackMessagesUrl).then(function(response) {
+      for (var i = 0; i < response.data.results.length; i++) {
+        $scope.allFeedbackMessages.push(response.data.results[i]);
       }
-      $scope.recentFeedbackMessagesCursor = data.cursor;
-      if (!data.more) {
+      $scope.recentFeedbackMessagesCursor = response.data.cursor;
+      if (!response.data.more) {
         $scope.reachedEndOfFeedbackMessages = true;
       }
     });

--- a/core/templates/dev/head/player/AnswerClassificationService.js
+++ b/core/templates/dev/head/player/AnswerClassificationService.js
@@ -116,11 +116,11 @@ oppia.factory('answerClassificationService', [
             old_state: oldState.toBackendDict(),
             params: params,
             answer: answer
-          }).success(function(result) {
+          }).then(function(response) {
             deferred.resolve({
-              outcome: result.outcome,
-              ruleSpecIndex: result.rule_spec_index,
-              answerGroupIndex: result.answer_group_index
+              outcome: response.data.outcome,
+              ruleSpecIndex: response.data.rule_spec_index,
+              answerGroupIndex: response.data.answer_group_index
             });
           });
         }

--- a/core/templates/dev/head/player/ExplorationRecommendationsService.js
+++ b/core/templates/dev/head/player/ExplorationRecommendationsService.js
@@ -49,8 +49,8 @@ oppia.factory('explorationRecommendationsService', [
 
         $http.get('/explorehandler/recommendations/' + explorationId, {
           params: recommendationsUrlParams
-        }).success(function(data) {
-          successCallback(data.summaries);
+        }).then(function(response) {
+          successCallback(response.data.summaries);
         });
       }
     };

--- a/core/templates/dev/head/player/LearnerViewBreadcrumb.js
+++ b/core/templates/dev/head/player/LearnerViewBreadcrumb.js
@@ -33,10 +33,10 @@ oppia.controller('LearnerViewBreadcrumb', [
           params: {
             stringified_exp_ids: JSON.stringify([explorationId])
           }
-        }).success(function(data) {
-          expInfo = data.summaries[0];
+        }).then(function(response) {
+          expInfo = response.data.summaries[0];
           openInformationCardModal();
-        }).error(function() {
+        }).catch(function() {
           $log.error(
             'Information card failed to load for exploration ' + explorationId);
         });

--- a/core/templates/dev/head/player/LearnerViewRatingService.js
+++ b/core/templates/dev/head/player/LearnerViewRatingService.js
@@ -26,9 +26,9 @@ oppia.factory('LearnerViewRatingService', [
     var userRating;
     return {
       init: function(successCallback) {
-        $http.get(ratingsUrl).success(function(data) {
-          successCallback(data.user_rating);
-          userRating = data.user_rating;
+        $http.get(ratingsUrl).then(function(response) {
+          successCallback(response.data.user_rating);
+          userRating = response.data.user_rating;
           $rootScope.$broadcast('ratingServiceInitialized');
         });
       },

--- a/core/templates/dev/head/player/PlayerServices.js
+++ b/core/templates/dev/head/player/PlayerServices.js
@@ -173,12 +173,13 @@ oppia.factory('oppiaPlayerService', [
           var explorationDataUrl = (
             '/explorehandler/init/' + _explorationId +
             (version ? '?v=' + version : ''));
-          $http.get(explorationDataUrl).success(function(data) {
-            exploration = ExplorationObjectFactory.create(data.exploration);
-            version = data.version;
+          $http.get(explorationDataUrl).then(function(response) {
+            exploration = ExplorationObjectFactory.
+              create(response.data.exploration);
+            version = response.data.version;
 
             StatsReportingService.initSession(
-              _explorationId, data.version, data.session_id,
+              _explorationId, response.data.version, response.data.session_id,
               GLOBALS.collectionId);
 
             _loadInitialState(successCallback);
@@ -329,8 +330,8 @@ oppia.factory('oppiaPlayerService', [
         if (_isLoggedIn && !_editorPreviewMode) {
           $http.get(
             '/preferenceshandler/profile_picture'
-          ).success(function(data) {
-            var profilePictureDataUrl = data.profile_picture_data_url;
+          ).then(function(response) {
+            var profilePictureDataUrl = response.data.profile_picture_data_url;
             if (profilePictureDataUrl) {
               deferred.resolve(profilePictureDataUrl);
             } else {

--- a/core/templates/dev/head/profile/Preferences.js
+++ b/core/templates/dev/head/profile/Preferences.js
@@ -135,7 +135,7 @@ oppia.controller('Preferences', [
       $http.put(_PREFERENCES_DATA_URL, {
         update_type: 'profile_picture_data_url',
         data: newProfilePictureDataUrl
-      }).success(function() {
+      }).then(function() {
         // The reload is needed in order to update the profile picture in the
         // top-right corner.
         location.reload();
@@ -153,13 +153,13 @@ oppia.controller('Preferences', [
   );
 
   $scope.hasPageLoaded = false;
-  $http.get(_PREFERENCES_DATA_URL).success(function(data) {
+  $http.get(_PREFERENCES_DATA_URL).then(function(response) {
     $rootScope.loadingMessage = '';
-    $scope.userBio = data.user_bio;
-    $scope.subjectInterests = data.subject_interests;
-    $scope.preferredLanguageCodes = data.preferred_language_codes;
-    $scope.profilePictureDataUrl = data.profile_picture_data_url;
-    $scope.canReceiveEmailUpdates = data.can_receive_email_updates;
+    $scope.userBio = response.data.user_bio;
+    $scope.subjectInterests = response.data.subject_interests;
+    $scope.preferredLanguageCodes = response.data.preferred_language_codes;
+    $scope.profilePictureDataUrl = response.data.profile_picture_data_url;
+    $scope.canReceiveEmailUpdates = response.data.can_receive_email_updates;
     $scope.hasPageLoaded = true;
   });
 }]);

--- a/core/templates/dev/head/profile/Profile.js
+++ b/core/templates/dev/head/profile/Profile.js
@@ -29,28 +29,28 @@ oppia.controller('Profile', [
     };
 
     $rootScope.loadingMessage = 'Loading';
-    $http.get(profileDataUrl).success(function(data) {
+    $http.get(profileDataUrl).then(function(response) {
       $rootScope.loadingMessage = '';
-      $scope.userBio = data.user_bio;
+      $scope.userBio = response.data.user_bio;
       $scope.userDisplayedStatistics = [{
         title: 'User Impact Score',
-        value: data.user_impact_score,
+        value: response.data.user_impact_score,
         helpText: (
           'A rough measure of the impact of explorations created by this ' +
           'user. Better ratings and more playthroughs improve this score.')
       }, {
         title: 'Created Explorations',
-        value: data.created_exp_summary_dicts.length
+        value: response.data.created_exp_summary_dicts.length
       }, {
         title: 'Edited Explorations',
-        value: data.edited_exp_summary_dicts.length
+        value: response.data.edited_exp_summary_dicts.length
       }];
-      $scope.userCreatedExplorations = data.created_exp_summary_dicts;
-      $scope.userEditedExplorations = data.edited_exp_summary_dicts;
-      $scope.subjectInterests = data.subject_interests;
-      $scope.firstContributionMsec = data.first_contribution_msec;
+      $scope.userCreatedExplorations = response.data.created_exp_summary_dicts;
+      $scope.userEditedExplorations = response.data.edited_exp_summary_dicts;
+      $scope.subjectInterests = response.data.subject_interests;
+      $scope.firstContributionMsec = response.data.first_contribution_msec;
       $scope.profilePictureDataUrl = (
-        data.profile_picture_data_url || DEFAULT_PROFILE_PICTURE_URL);
+        response.data.profile_picture_data_url || DEFAULT_PROFILE_PICTURE_URL);
       $rootScope.loadingMessage = '';
     });
   }

--- a/core/templates/dev/head/profile/Signup.js
+++ b/core/templates/dev/head/profile/Signup.js
@@ -30,11 +30,11 @@ oppia.controller('Signup', [
     $scope.showEmailPreferencesForm = GLOBALS.CAN_SEND_EMAILS_TO_USERS;
     $scope.submissionInProcess = false;
 
-    $http.get(_SIGNUP_DATA_URL).success(function(data) {
+    $http.get(_SIGNUP_DATA_URL).then(function(response) {
       $rootScope.loadingMessage = '';
-      $scope.username = data.username;
-      $scope.hasEverRegistered = data.has_ever_registered;
-      $scope.hasAgreedToLatestTerms = data.has_agreed_to_latest_terms;
+      $scope.username = response.data.username;
+      $scope.hasEverRegistered = response.data.has_ever_registered;
+      $scope.hasAgreedToLatestTerms = response.data.has_agreed_to_latest_terms;
       $scope.hasUsername = Boolean($scope.username);
       focusService.setFocus('usernameInputField');
     });
@@ -74,8 +74,8 @@ oppia.controller('Signup', [
       if (!$scope.warningText) {
         $http.post('usernamehandler/data', {
           username: $scope.username
-        }).success(function(data) {
-          if (data.username_is_taken) {
+        }).then(function(response) {
+          if (response.data.username_is_taken) {
             $scope.warningText = 'Sorry, this username is already taken.';
           }
         });
@@ -148,7 +148,7 @@ oppia.controller('Signup', [
       }
 
       $scope.submissionInProcess = true;
-      $http.post(_SIGNUP_DATA_URL, requestParams).success(function() {
+      $http.post(_SIGNUP_DATA_URL, requestParams).then(function() {
         window.location = window.decodeURIComponent(
           urlService.getUrlParams().return_url);
       }).error(function() {

--- a/extensions/interactions/EndExploration/EndExploration.js
+++ b/extensions/interactions/EndExploration/EndExploration.js
@@ -60,9 +60,9 @@ oppia.directive('oppiaInteractiveEndExploration', [function() {
               stringified_exp_ids: JSON.stringify(
                 authorRecommendedExplorationIds)
             }
-          }).success(function(data) {
+          }).then(function(response) {
             var foundExpIds = [];
-            data.summaries.map(function(expSummary) {
+            response.data.summaries.map(function(expSummary) {
               foundExpIds.push(expSummary.id);
             });
 

--- a/extensions/objects/templates/FilepathEditor.js
+++ b/extensions/objects/templates/FilepathEditor.js
@@ -157,8 +157,8 @@ oppia.directive('filepathEditor', [
         $scope.filepathsLoaded = false;
         $http.get(
           '/createhandler/resource_list/' + $scope.explorationId
-        ).success(function(data) {
-          $scope.filepaths = data.filepaths;
+        ).then(function(response) {
+          $scope.filepaths = response.data.filepaths;
           $scope.filepathsLoaded = true;
         });
       }


### PR DESCRIPTION
#1434 Extracted reportError method in the $scope in Admin.js and updated the deprecated $http requests(.success and .error) to (.then and .catch blocks).Passed all local tests, but touched quite a bit of code, careful review would be greatly appreciated. Thanks!