### PR TITLE
Update MathJax to v2.6.0. Fixes #1421.

### DIFF
--- a/core/templates/dev/head/header_js_libs.html
+++ b/core/templates/dev/head/header_js_libs.html
@@ -22,4 +22,4 @@ bundled js at the header will block rendering.-->
   });
   MathJax.Hub.Configured();
 </script>
-<script src="/third_party/static/MathJax-2.4-latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script src="/third_party/static/MathJax-2.6.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -200,9 +200,9 @@
         "targetDir": "math-expressions-762ffd"
       },
       "mathJax": {
-        "version": "2.4-latest",
+        "version": "2.6.0",
         "downloadFormat": "zip",
-        "url": "https://github.com/mathjax/MathJax/archive/v2.4-latest.zip",
+        "url": "https://github.com/mathjax/MathJax/archive/2.6.0.zip",
         "rootDirPrefix": "MathJax-",
         "targetDirPrefix": "MathJax-"
       },

--- a/scripts/install_third_party.py
+++ b/scripts/install_third_party.py
@@ -304,7 +304,7 @@ def download_manifest_files(filepath):
                     dependency_tar_root_name, dependency_target_root_name)
 
 
-MATHJAX_REV = '2.4-latest'
+MATHJAX_REV = '2.6.0'
 MATHJAX_ROOT_NAME = 'MathJax-%s' % MATHJAX_REV
 MATHJAX_TARGET_ROOT_NAME = MATHJAX_ROOT_NAME
 MATHJAX_DIR_PREFIX = os.path.join(


### PR DESCRIPTION
MathJax version updated to 2.6.0.
Fixes #1421 - verified that black bar no longer appears on card or in preview with Chrome 48.0.2564.97 and Firefox 43.0.4 .