### PR TITLE
replaced deprecated gulp-minify-css in favour of gulp-cssnano

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,7 +53,7 @@ var gulp = require('gulp');
 var gulpStartGae = require('./scripts/gulp-start-gae-devserver');
 var gulpUtil = require('gulp-util');
 var manifest = require('./manifest.json');
-var minifyCss = require('gulp-minify-css');
+var cssnano = require('gulp-cssnano');
 var path = require('path');
 var sourcemaps = require('gulp-sourcemaps');
 var minify = require('gulp-minify');
@@ -145,7 +145,7 @@ gulp.task('collectDependencyFilepaths', function() {
 gulp.task('generateCss', function() {
   requireFilesExist(cssFilePaths);
   gulp.src(cssFilePaths)
-    .pipe(isMinificationNeeded ? minifyCss() : gulpUtil.noop())
+    .pipe(isMinificationNeeded ? cssnano() : gulpUtil.noop())
     .pipe(concat('third_party.css'))
     .pipe(gulp.dest(generatedCssTargetDir));
 });

--- a/scripts/install_third_party.sh
+++ b/scripts/install_third_party.sh
@@ -26,7 +26,7 @@ install_node_module gulp 3.9.0
 install_node_module through2 2.0.0
 install_node_module yargs 3.29.0
 install_node_module gulp-concat 2.6.0
-install_node_module gulp-minify-css 1.2.1
+install_node_module gulp-cssnano 2.1.0
 install_node_module gulp-util 3.0.7
 install_node_module jscs 2.3.0
 install_node_module gulp-sourcemaps 1.6.0


### PR DESCRIPTION
As gulp-minify-css is [deprecated](https://www.npmjs.com/package/gulp-minify-css#deprecation-warning)  , Is changed in favour of gulp-cssnano