### PR TITLE
Part 1 of #798 Ensure that users can tell which state has no interaction

### DIFF
--- a/core/templates/dev/head/player/PlayerServices.js
+++ b/core/templates/dev/head/player/PlayerServices.js
@@ -131,7 +131,7 @@ oppia.factory('oppiaPlayerService', [
       PAGE_CONTEXT) {
   var _INTERACTION_DISPLAY_MODE_INLINE = 'inline';
   var _NULL_INTERACTION_HTML = (
-    '<span style="color: red;"><strong>Error</strong>: No interaction specified.</span>');
+    '<span style="color: red;"><strong>Error</strong>: No interaction specified for </span>');
 
   var _explorationId = explorationContextService.getExplorationId();
   var _editorPreviewMode = (explorationContextService.getPageContext() === PAGE_CONTEXT.EDITOR);
@@ -161,7 +161,7 @@ oppia.factory('oppiaPlayerService', [
   // a common standalone service.
   var _getInteractionHtml = function(interactionId, interactionCustomizationArgSpecs, labelForFocusTarget) {
     if (!interactionId) {
-      return _NULL_INTERACTION_HTML;
+      return _NULL_INTERACTION_HTML + '<span style="color: red;">' + _currentStateName + '</span>';
     }
 
     var el = $(


### PR DESCRIPTION
Added a small line to show the name of the state in the error shown when a user has not included an interaction.