### PR TITLE
Video should autoplay when it first appears to the learner, #1380

### DIFF
--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -7,6 +7,11 @@
        ng-class="{'conversation-skin-left-card': isCurrentSupplementalCardNonempty() && canWindowFitTwoCards(), 'conversation-skin-has-subsidiary-cards': isCurrentSupplementalCardNonempty() && !canWindowFitTwoCards()}">
     <div class="conversation-skin-tutor-card-content">
       <div class="conversation-skin-tutor-card-top-section">
+        <!--
+          This following div code is used to determine whether card is hidden or not
+          in extension/rich_text_components/Video/Video.js, any changes in this code
+          will be required to be done there too
+        -->
         <div class="conversation-skin-tutor-card-top-content"
              angular-html-bind="upcomingContentHtml">
         </div>

--- a/core/templates/dev/head/services/explorationContextService.js
+++ b/core/templates/dev/head/services/explorationContextService.js
@@ -34,7 +34,7 @@ oppia.factory('explorationContextService', [
   function($window, PAGE_CONTEXT, EDITOR_TAB_CONTEXT) {
     var _pageContext = null;
     var _explorationId = null;
-
+    var isVideoPlayedList = {};
     return {
       // Returns a string representing the current tab of the editor (either
       // 'editor' or 'preview'), or null if the current tab is neither of these,
@@ -100,6 +100,21 @@ oppia.factory('explorationContextService', [
       isInExplorationEditorMode: function() {
         return (this.getPageContext() === PAGE_CONTEXT.EDITOR &&
             this.getEditorTabContext() === EDITOR_TAB_CONTEXT.EDITOR);
+      },
+
+      // Following functions help in remembering whether video is already
+      // autoplayed or not. Consider the case when same video is to be shown
+      // in exploration twice, then 2nd time video will not autoplay. To
+      // solve that problem, unique id to each element can be assigned and
+      // that id can be used to store whether video is autoplayed or not.
+      addToPlayedList: function(
+          videoId) {
+        isVideoPlayedList[videoId] = true;
+      },
+
+      getFromPlayedList: function(
+          videoId) {
+        return isVideoPlayedList.videoId;
       }
     };
   }

--- a/extensions/rich_text_components/Video/Video.js
+++ b/extensions/rich_text_components/Video/Video.js
@@ -25,16 +25,44 @@ oppia.directive('oppiaNoninteractiveVideo', [
       restrict: 'E',
       scope: {},
       templateUrl: 'richTextComponent/Video',
-      controller: ['$scope', '$attrs', 'explorationContextService',
-        function($scope, $attrs, explorationContextService) {
+      controller: ['$scope', '$attrs', 'explorationContextService', '$element',
+        'PAGE_CONTEXT',
+        function($scope, $attrs, explorationContextService, $element) {
           var start = oppiaHtmlEscaper.escapedJsonToObj($attrs.startWithValue);
           var end = oppiaHtmlEscaper.escapedJsonToObj($attrs.endWithValue);
 
-          $scope.autoplaySuffix = (oppiaHtmlEscaper.escapedJsonToObj(
-            $attrs.autoplayWithValue) ? '&autoplay=1' : '&autoplay=0');
           $scope.videoId = oppiaHtmlEscaper.escapedJsonToObj(
             $attrs.videoIdWithValue);
           $scope.timingParams = '&start=' + start + '&end=' + end;
+
+          // This code helps in checking whether video is for upcoming content.
+          // This is totally dependent of parent div of video container
+          // If in future that parent div changes then this code will be
+          // required to change accordingly.
+          var isVisible = true;
+          var videoVisibilty = angular.element($element).prop('offsetParent');
+          if(videoVisibilty) {
+            var isVisible = (videoVisibilty.getAttribute('angular-html-bind')
+                              !== 'upcomingContentHtml' ? true : false);
+          }
+
+          // If user in learner context then only autoplay videos.
+          if (explorationContextService.getPageContext() === PAGE_CONTEXT.LEARNER) {
+            // If video has been already played or if it is not visible for now
+            // then dont autoplay it.
+            if (explorationContextService.getFromPlayedList($scope.videoId) || !(isVisible)) {
+                $scope.autoplaySuffix = '&autoplay=0';
+            }
+            else {
+              $scope.autoplaySuffix = '&autoplay=1';
+            }
+          }
+          else {
+            // If not in learner context then use default value,
+            $scope.autoplaySuffix = (oppiaHtmlEscaper.escapedJsonToObj(
+            $attrs.autoplayWithValue) ? '&autoplay=1' : '&autoplay=0');
+          }
+
           $scope.videoUrl = $sce.trustAsResourceUrl(
             'https://www.youtube.com/embed/' + $scope.videoId + '?rel=0' +
             $scope.timingParams + $scope.autoplaySuffix);


### PR DESCRIPTION
This fixes the autoplay issue that is stated in #1380.
As seen this code requires use of parent div of oppia-non-interactivevideo to distinguish between hidden and visible content. Therefore, I added a little note in that specific html file about where that code is being utilized, so that if it is changed in future then corresponding required changes can be done in Video.js file too.