### PR TITLE
Bugfix for mp4 video playback

### DIFF
--- a/core/templates/dev/head/base.js
+++ b/core/templates/dev/head/base.js
@@ -64,6 +64,8 @@ oppia.constant('DEFAULT_FUZZY_RULE', {
   }
 });
 
+oppia.constant('EVENT_HTML_CHANGED', 'htmlChanged');
+
 oppia.constant('PARAMETER_TYPES', {
   REAL: 'Real',
   UNICODE_STRING: 'UnicodeString'

--- a/core/templates/dev/head/directives.js
+++ b/core/templates/dev/head/directives.js
@@ -21,13 +21,19 @@
 
 // HTML bind directive that trusts the value it is given and also evaluates
 // custom directive tags in the provided value.
-oppia.directive('angularHtmlBind', ['$compile', function($compile) {
+oppia.directive('angularHtmlBind', ['$compile', '$timeout',
+  'EVENT_HTML_CHANGED', function($compile, $timeout, EVENT_HTML_CHANGED) {
   return {
     restrict: 'A',
     link: function(scope, elm, attrs) {
       scope.$watch(attrs.angularHtmlBind, function(newValue) {
-        elm.html(newValue);
-        $compile(elm.contents())(scope);
+        // Inform child components that the value of the HTML string has changed, so
+        // that they can perform any necessary cleanup.
+        scope.$broadcast(EVENT_HTML_CHANGED);
+        $timeout(function() {
+          elm.html(newValue);
+          $compile(elm.contents())(scope);
+        }, 10);
       });
     }
   };

--- a/core/templates/dev/head/directives.js
+++ b/core/templates/dev/head/directives.js
@@ -27,8 +27,8 @@ oppia.directive('angularHtmlBind', ['$compile', '$timeout',
     restrict: 'A',
     link: function(scope, elm, attrs) {
       scope.$watch(attrs.angularHtmlBind, function(newValue) {
-        // Inform child components that the value of the HTML string has changed, so
-        // that they can perform any necessary cleanup.
+        // Inform child components that the value of the HTML string has
+        // changed, so that they can perform any necessary cleanup.
         scope.$broadcast(EVENT_HTML_CHANGED);
         $timeout(function() {
           elm.html(newValue);

--- a/extensions/rich_text_components/VideoMp4/VideoMp4.js
+++ b/extensions/rich_text_components/VideoMp4/VideoMp4.js
@@ -20,19 +20,26 @@
  * followed by the name of the arg.
  */
 oppia.directive('oppiaNoninteractiveVideoMp4', [
-  '$sce', 'oppiaHtmlEscaper', function($sce, oppiaHtmlEscaper) {
+  '$sce', 'oppiaHtmlEscaper', 'EVENT_HTML_CHANGED',
+  function($sce, oppiaHtmlEscaper, EVENT_HTML_CHANGED) {
     return {
       restrict: 'E',
       scope: {},
       templateUrl: 'richTextComponent/VideoMp4',
       controller: ['$scope', '$attrs', function($scope, $attrs) {
-        // Chrome has a bug where HTML5 videos sometimes stay pending for a
-        // long time. The randomParameter used here applies the fix in
-        // http://stackoverflow.com/a/18858057.
-        var randomParameter = new Date().getMilliseconds();
         $scope.videoUrl = $sce.trustAsResourceUrl(
-          oppiaHtmlEscaper.escapedJsonToObj($attrs.videoUrlWithValue) +
-          '?t=' + randomParameter);
+          oppiaHtmlEscaper.escapedJsonToObj($attrs.videoUrlWithValue));
+
+        // Clearing the video URL src after a card leaves the user's view
+        // helps browsers clear memory and release resources. Without this,
+        // a bug was observed where resources would freeze for learning
+        // experiences that rely heavily on video.
+        //
+        // See W3C spec 4.7.10.18
+        // Ref: https://www.w3.org/TR/html5/embedded-content-0.html
+        $scope.$on(EVENT_HTML_CHANGED, function() {
+          $scope.videoUrl = '';
+        });
       }]
     };
   }


### PR DESCRIPTION
We now clear the src= tag after a video leaves the user's view to release memory and browser resources.

Originally escalated this as a bug in Chrome. Upon review learned it's each site's responsibility to embed video resources according to W3C spec 4.7.10.18.  Ref: https://www.w3.org/TR/html5/embedded-content-0.html

I confirmed this fix appears to function as expected locally (wasn't able to reproduce the prior bug), but wasn't sure how to manually re-execute the video element's load() method after clearing the src= tag as suggested in the W3C spec above. The Chrome team suggested clearing src='' may be sufficient, but if anyone in review is familiar with how best to re-execute the element's load() method it would bring us fully in alignment with the spec.