### PR TITLE
Hide feedback editor for continue interaction

### DIFF
--- a/core/templates/dev/head/components/AnswerGroupEditorDirective.js
+++ b/core/templates/dev/head/components/AnswerGroupEditorDirective.js
@@ -23,6 +23,7 @@ oppia.directive('answerGroupEditor', [function() {
     restrict: 'E',
     scope: {
       isEditable: '=',
+      displayFeedback: '=',
       getOnSaveAnswerGroupDestFn: '&onSaveAnswerGroupDest',
       getOnSaveAnswerGroupFeedbackFn: '&onSaveAnswerGroupFeedback',
       getOnSaveAnswerGroupRulesFn: '&onSaveAnswerGroupRules',

--- a/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
@@ -22,6 +22,7 @@ oppia.directive('outcomeDestinationEditor', [function() {
   return {
     restrict: 'E',
     scope: {
+      outcomeHasFeedback: '=',
       outcome: '='
     },
     templateUrl: 'rules/outcomeDestinationEditor',

--- a/core/templates/dev/head/components/OutcomeEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeEditorDirective.js
@@ -23,6 +23,7 @@ oppia.directive('outcomeEditor', [function() {
     restrict: 'E',
     scope: {
       isEditable: '&isEditable',
+      displayFeedback: '=',
       getOnSaveDestFn: '&onSaveDest',
       getOnSaveFeedbackFn: '&onSaveFeedback',
       outcome: '=outcome'

--- a/core/templates/dev/head/components/answer_group_editor_directive.html
+++ b/core/templates/dev/head/components/answer_group_editor_directive.html
@@ -43,6 +43,7 @@
     <br ng-if="rules">
 
     <outcome-editor is-editable="isEditable"
+		    display-feedback="displayFeedback"
                     on-save-dest="getOnSaveAnswerGroupDestFn()"
                     on-save-feedback="getOnSaveAnswerGroupFeedbackFn()"
                     outcome="outcome">

--- a/core/templates/dev/head/components/outcome_destination_editor_directive.html
+++ b/core/templates/dev/head/components/outcome_destination_editor_directive.html
@@ -1,7 +1,8 @@
 <script type="text/ng-template" id="rules/outcomeDestinationEditor">
   <div class="form-inline protractor-test-dest-bubble" style="margin-bottom: 10px;">
     <div class="oppia-rule-details-header">
-      <strong>And afterwards, directs the learner to...</strong>
+      <strong ng-if="outcomeHasFeedback">And afterwards, directs the learner to...</strong>
+      <strong ng-if="!outcomeHasFeedback">Oppia directs the learner to...</strong>
     </div>
     <div class="form-group" style="font-size: 1.1em;">
       <span>

--- a/core/templates/dev/head/components/outcome_editor_directive.html
+++ b/core/templates/dev/head/components/outcome_editor_directive.html
@@ -1,5 +1,5 @@
 <script type="text/ng-template" id="components/outcomeEditor">
-  <div ng-if="!feedbackEditorIsOpen"
+  <div ng-if="!feedbackEditorIsOpen && displayFeedback"
        title="<[isEditable() ? 'Edit feedback' : '']>"
        style="height: 100%;">
     <div class="oppia-readonly-rule-tile protractor-test-edit-outcome-feedback-button"
@@ -62,7 +62,7 @@
     </div>
   </div>
 
-  <br>
+  <br ng-if="displayFeedback">
 
   <div ng-if="!destinationEditorIsOpen"
        style="height: 100%;"
@@ -75,7 +75,9 @@
         </div>
 
         <div ng-if="outcome.dest !== getActiveStateName()">
-          <strong>And afterwards, directs the learner to...</strong>
+          <strong ng-if="displayFeedback">And afterwards, directs the learner
+          to...</strong>
+          <strong ng-if="!displayFeedback">Oppia directs the learner to...</strong>
           <span ng-if="!isSelfLoop(outcome)" style="position: relative;">
             <[outcome.dest]>
           </span>
@@ -96,7 +98,7 @@
           class="form-inline protractor-test-edit-outcome-dest"
           name="editOutcomeForm.editDestForm"
           ng-submit="saveThisDestination()">
-      <outcome-destination-editor outcome="outcome">
+      <outcome-destination-editor outcome="outcome" outcome-has-feedback="displayFeedback">
       </outcome-destination-editor>
     </form>
 

--- a/core/templates/dev/head/editor/StateResponses.js
+++ b/core/templates/dev/head/editor/StateResponses.js
@@ -362,9 +362,10 @@ oppia.controller('StateResponses', [
     $scope.getOutcomeTooltip = function(outcome) {
       // Outcome tooltip depends on whether feedback is displayed
       if ($scope.isLinearWithNoFeedback(outcome)) {
-        return "Please direct the learner to a different card.";
+        return 'Please direct the learner to a different card.';
       } else {
-        return "Please give Oppia something useful to say, or direct the learner to a different card.";
+        return 'Please give Oppia something useful to say,' +
+               ' or direct the learner to a different card.';
       }
     };
 

--- a/core/templates/dev/head/editor/StateResponses.js
+++ b/core/templates/dev/head/editor/StateResponses.js
@@ -348,6 +348,26 @@ oppia.controller('StateResponses', [
       return interactionId && INTERACTION_SPECS[interactionId].is_linear;
     };
 
+    $scope.isLinearWithNoFeedback = function(outcome) {
+      // Returns false if current interaction is linear and has no feedback
+      if (!outcome) {
+        return false;
+      }
+      var hasFeedback = outcome.feedback.some(function(feedbackItem) {
+        return Boolean(feedbackItem);
+      });
+      return $scope.isCurrentInteractionLinear() && !hasFeedback;
+    };
+
+    $scope.getOutcomeTooltip = function(outcome) {
+      // Outcome tooltip depends on whether feedback is displayed
+      if ($scope.isLinearWithNoFeedback(outcome)) {
+        return "Please direct the learner to a different card.";
+      } else {
+        return "Please give Oppia something useful to say, or direct the learner to a different card.";
+      }
+    };
+
     $scope.$on('initializeAnswerGroups', function(evt, data) {
       responsesService.init(data);
       $scope.answerGroups = responsesService.getAnswerGroups();

--- a/core/templates/dev/head/editor/state_editor_responses.html
+++ b/core/templates/dev/head/editor/state_editor_responses.html
@@ -17,7 +17,7 @@
               <img ng-if="editabilityService.isEditable()" src="/images/general/drag_dots.png" width="10">
             </span>
             <div class="oppia-rule-header-warning-placement" ng-if="isSelfLoopWithNoFeedback(answerGroup.outcome)" ng-click="changeActiveAnswerGroupIndex($index)"
-                 tooltip="Please give Oppia something useful to say or direct the learner to a different card." tooltip-placement="bottom">
+                 tooltip="<[getOutcomeTooltip(answerGroup.outcome)]>" tooltip-placement="bottom">
               <div class="oppia-rule-header-warning-style" >
                 ⚠
               </div>
@@ -41,6 +41,7 @@
                                        on-save-answer-group-dest="saveActiveAnswerGroupDest"
                                        on-save-answer-group-rules="saveActiveAnswerGroupRules"
                                        is-editable="editabilityService.isEditable()"
+                                       display-feedback="!isLinearWithNoFeedback(answerGroup.outcome)"
                                        class="protractor-test-response-body">
                   </answer-group-editor>
                 </div>
@@ -54,7 +55,7 @@
         <ul class="nav nav-stacked nav-pills" role="tablist">
           <li ng-class="{'active': activeAnswerGroupIndex === answerGroups.length}" class="oppia-rule-block">
             <div class="oppia-rule-header-warning-placement" ng-if="isSelfLoopWithNoFeedback(defaultOutcome)" ng-click="changeActiveAnswerGroupIndex(answerGroups.length)"
-                 tooltip="Please give Oppia something useful to say or direct the learner to a different card." tooltip-placement="bottom">
+                 tooltip="<[getOutcomeTooltip(defaultOutcome)]>" tooltip-placement="bottom">
               <div class="oppia-rule-header-warning-style" >
                 ⚠
               </div>
@@ -76,6 +77,7 @@
                                        on-save-answer-group-feedback="saveDefaultOutcomeFeedback"
                                        on-save-answer-group-dest="saveDefaultOutcomeDest"
                                        is-editable="editabilityService.isEditable()"
+                                       display-feedback="!isLinearWithNoFeedback(defaultOutcome)"
                                        class="protractor-test-response-body">
                   </answer-group-editor>
                 </div>
@@ -183,7 +185,7 @@
 
       <br>
 
-      <div ng-if="!feedbackEditorIsOpen"
+      <div ng-if="!feedbackEditorIsOpen && !isLinearWithNoFeedback(tmpOutcome)"
            title="Edit feedback"
            style="height: 100%; margin-right: 22px;">
         <div class="oppia-rule-details-header oppia-editable-section">
@@ -209,7 +211,7 @@
       </div>
       <br>
 
-      <outcome-destination-editor outcome="tmpOutcome">
+      <outcome-destination-editor outcome="tmpOutcome" outcome-has-feedback="!isLinearWithNoFeedback(tmpOutcome)">
       </outcome-destination-editor>
     </form>
   </div>


### PR DESCRIPTION
Hides feedback editor if interaction is linear (Continue) and has no existing feedback.  Modifies information text and tooltip warnings when feedback is not shown.