### PR TITLE
Switch to using new impact metric

### DIFF
--- a/core/domain/user_jobs_continuous.py
+++ b/core/domain/user_jobs_continuous.py
@@ -16,12 +16,10 @@
 
 import ast
 import logging
-import math
 
 from core import jobs
 from core.domain import exp_services
 from core.domain import feedback_services
-from core.domain import rating_services
 from core.domain import stats_jobs_continuous
 from core.platform import models
 import feconf
@@ -293,100 +291,72 @@ class UserImpactAggregator(jobs.BaseContinuousComputationManager):
 
 class UserImpactMRJobManager(
         jobs.BaseMapReduceJobManagerForContinuousComputations):
-    """Manager for a MapReduce job that computes the impact score for every
-    user, where impact score is defined as follows:
-    Sum of (
-    ln(playthroughs) * (ratings_scaler) * (average(ratings) - 2.5))
-    *(multiplier),
-    where multiplier = 10, and ratings_scaler is .1 * (number of ratings)
-    if there are < 10 ratings for that exploration.
-
-    The impact score is 0 for an exploration with 0 playthroughs or with an
-    average rating of less than 2.5.
-
-    Impact scores are calculated over explorations for which a user
-    is listed as a contributor.
-    """
+    # Impact of user is defined as S^(2/3) where S is the sum
+    # over all explorations this user has contributed to of
+    #  value (per_user) * reach * fractional contribution
+    # Value per user: average rating - 2
+    # Reach: sum over all cards of count of answers given ^ (2/3)
+    # Fractional contribution: percent of commits by this user
+    # The final number will be rounded.
     @classmethod
     def _get_continuous_computation_class(cls):
         return UserImpactAggregator
 
-    MULTIPLIER = 10
-    MIN_AVERAGE_RATING = 2.5
-    NUM_RATINGS_SCALER_CUTOFF = 10
-    NUM_RATINGS_SCALER = .1
-
     @classmethod
     def entity_classes_to_map_over(cls):
-        return [exp_models.ExplorationModel]
-
-    @classmethod
-    def _get_exp_impact_score(cls, exploration_id):
-        # Get ratings and compute average rating score.
-        rating_frequencies = (
-            rating_services.get_overall_ratings_for_exploration(
-                exploration_id))
-        total_num_ratings = 0
-        total_rating = 0.0
-        for rating, num_ratings in rating_frequencies.iteritems():
-            total_rating += (int(rating) * num_ratings)
-            total_num_ratings += num_ratings
-        # Only divide by a non-zero number.
-        if total_num_ratings == 0:
-            return 0
-        average_rating = total_rating / total_num_ratings
-
-        # Get rating term to use in impact calculation.
-        rating_term = average_rating - cls.MIN_AVERAGE_RATING
-        # Only explorations with an average rating greater than the minimum
-        # have an impact.
-        if rating_term <= 0:
-            return 0
-
-        # Get num_ratings_scaler.
-        if total_num_ratings < cls.NUM_RATINGS_SCALER_CUTOFF:
-            num_ratings_scaler = cls.NUM_RATINGS_SCALER * total_num_ratings
-        else:
-            num_ratings_scaler = 1.0
-
-        # Get number of completions/playthroughs.
-        num_completions = (
-            stats_jobs_continuous.StatisticsAggregator.get_statistics(
-                exploration_id, stats_jobs_continuous.VERSION_ALL)[
-                    'complete_exploration_count'])
-        # Only take the log of a non-zero number.
-        if num_completions <= 0:
-            return 0
-        num_completions_term = math.log(num_completions)
-
-        exploration_impact_score = (
-            rating_term *
-            num_completions_term *
-            num_ratings_scaler *
-            cls.MULTIPLIER
-        )
-
-        return exploration_impact_score
+        return [exp_models.ExpSummaryModel]
 
     @staticmethod
     def map(item):
         if item.deleted:
             return
 
-        exploration_impact_score = (
-            UserImpactMRJobManager._get_exp_impact_score(item.id))
+        exponent = 2/float(3)
 
-        if exploration_impact_score > 0:
-            # Get exploration summary and contributor ids,
-            # yield for each contributor.
+        # Get average rating and value per user
+        total_rating = 0
+        for ratings_value in item.ratings:
+            total_rating += item.ratings[ratings_value] * int(ratings_value)
+        if sum(item.ratings.itervalues()):
+            average_rating = total_rating / sum(item.ratings.itervalues())
+            value_per_user = average_rating - 2
+        else:
+            value_per_user = 0
+
+        statistics = (
+            stats_jobs_continuous.StatisticsAggregator.get_statistics(item.id,
+                                                                      'all'))
+        answer_count = 0
+        # Find number of users per state (card), and subtract no answer
+        # This will not count people who have been back to a state twice
+        # but did not give an answer the second time, but is probably the
+        # closest we can get with current statistics to "number of users
+        # who gave an answer" since it is "number of users who always gave
+        # an answer".
+        for state_name in statistics['state_hit_counts']:
+            state = statistics['state_hit_counts'][state_name]
+            first_entry_count = state['first_entry_count']
+            no_answer_count = state['no_answer_count']
+            answer_count += first_entry_count - no_answer_count
+        # Turn answer count into reach
+        reach = answer_count**exponent
+
+        if value_per_user > 0:
             exploration_summary = exp_services.get_exploration_summary_by_id(
                 item.id)
-            contributor_ids = exploration_summary.contributor_ids
-            for contributor_id in contributor_ids:
-                yield (contributor_id, exploration_impact_score)
+            contributors = exploration_summary.contributors_summary
+            total_commits = sum(contributors.itervalues())
+            for contrib_id in contributors:
+                # Find fractional contribution for each contributor
+                contribution = contributors[contrib_id] / float(total_commits)
+                # Find score for this specific exploration
+                exploration_impact_score = value_per_user * reach * contribution
+                yield (contrib_id, exploration_impact_score)
 
     @staticmethod
     def reduce(key, stringified_values):
         values = [ast.literal_eval(v) for v in stringified_values]
-        user_impact_score = int(round(sum(values)))
+        exponent = 2/float(3)
+        # Find the final score and round to a whole number
+        user_impact_score = int(round(sum(values) ** exponent))
         user_models.UserStatsModel(id=key, impact_score=user_impact_score).put()

--- a/core/domain/user_jobs_continuous_test.py
+++ b/core/domain/user_jobs_continuous_test.py
@@ -16,7 +16,6 @@
 
 """Tests for user dashboard computations."""
 
-import math
 from collections import defaultdict
 
 from core import jobs_registry
@@ -34,8 +33,8 @@ from core.platform import models
 from core.tests import test_utils
 import feconf
 
-(exp_models, user_models,) = models.Registry.import_models([
-    models.NAMES.exploration, models.NAMES.user])
+(exp_models, stats_models, user_models,) = models.Registry.import_models([
+    models.NAMES.exploration, models.NAMES.statistics, models.NAMES.user])
 taskqueue_services = models.Registry.import_taskqueue_services()
 
 COLLECTION_ID = 'cid'
@@ -584,20 +583,12 @@ class UserImpactAggregatorTest(test_utils.GenericTestBase):
 
     EXP_ID_1 = 'exp_id_1'
     EXP_ID_2 = 'exp_id_2'
+    EXP_ID_3 = 'exp_id_3'
     USER_A_EMAIL = 'a@example.com'
+    USER_B_EMAIL = 'b@example.com'
     USER_A_USERNAME = 'a'
-    # Constants imported from the impact job manager.
-    impact_mr_job_manager = ModifiedUserImpactMRJobManager
-    NUM_RATINGS_SCALER_CUTOFF = impact_mr_job_manager.NUM_RATINGS_SCALER_CUTOFF
-    NUM_RATINGS_SCALER = impact_mr_job_manager.NUM_RATINGS_SCALER
-    MIN_AVERAGE_RATING = impact_mr_job_manager.MIN_AVERAGE_RATING
-    MULTIPLIER = impact_mr_job_manager.MULTIPLIER
-    # The impact score takes the ln of the number of completions as a factor,
-    # so the minimum number of completions to get a nonzero impact score
-    # is 2.
+    USER_B_USERNAME = 'b'
     MIN_NUM_COMPLETIONS = 2
-    BELOW_MIN_RATING = int(math.ceil(MIN_AVERAGE_RATING - 1))
-    ABOVE_MIN_RATING = int(math.floor(MIN_AVERAGE_RATING + 1))
 
     def setUp(self):
         super(UserImpactAggregatorTest, self).setUp()
@@ -607,12 +598,27 @@ class UserImpactAggregatorTest(test_utils.GenericTestBase):
         current_completions = {
             self.EXP_ID_1: {
                 'complete_exploration_count':
-                self.num_completions[self.EXP_ID_1]
+                self.num_completions[self.EXP_ID_1],
+                'state_hit_counts': {
+                    'state1': {'first_entry_count': 3,
+                               'no_answer_count': 1},
+                    'state2': {'first_entry_count': 7,
+                               'no_answer_count': 1},
+                }
             },
             self.EXP_ID_2: {
                 'complete_exploration_count':
-                self.num_completions[self.EXP_ID_2]
+                self.num_completions[self.EXP_ID_2],
+                'state_hit_counts': {
+                    'state1': {'first_entry_count': 3,
+                               'no_answer_count': 1},
+                    'state2': {'first_entry_count': 7,
+                               'no_answer_count': 1},
+                }
             },
+            self.EXP_ID_3: {
+                'state_hit_counts': {}
+            }
         }
         return current_completions[exp_id]
 
@@ -637,14 +643,6 @@ class UserImpactAggregatorTest(test_utils.GenericTestBase):
             ModifiedUserImpactAggregator.start_computation()
             self.process_and_flush_pending_tasks()
 
-    def _run_exp_impact_calculation_and_assert_equals(
-            self, exploration_id, expected_impact):
-        with self.swap(stats_jobs_continuous.StatisticsAggregator,
-                       'get_statistics', self._mock_get_statistics):
-            self.assertEqual(
-                expected_impact,
-                self.impact_mr_job_manager._get_exp_impact_score(  # pylint: disable=protected-access
-                    exploration_id))
 
     def _sign_up_user(self, user_email, username):
         # Sign up a user, have them create an exploration.
@@ -697,31 +695,19 @@ class UserImpactAggregatorTest(test_utils.GenericTestBase):
         self.assertIsNone(user_stats_model)
 
     def test_standard_user_impact_calculation_one_exploration(self):
-        """Test that a user who is a contributor on one exploration that:
-        - has a number of ratings for that exploration above the treshold
-        for the scaler for number of ratings
-        - has an average rating above the minimum average rating
-        - has a number of playthroughs > 1
-        is assigned the correct impact score by the
-        UserImpactMRJobManager.
-        """
         # Sign up a user and have them create an exploration.
         user_a_id = self._sign_up_user(
             self.USER_A_EMAIL, self.USER_A_USERNAME)
         exploration = self._create_exploration(self.EXP_ID_1, user_a_id)
-        # Give this exploration as many ratings as necessary to avoid
-        # the scaler for number of ratings.
-        self._rate_exploration(
-            exploration.id, self.NUM_RATINGS_SCALER_CUTOFF,
-            self.ABOVE_MIN_RATING)
-        # Give this exploration more than one playthrough (so
-        # ln(num_completions) != 0.
-        self._complete_exploration(exploration, self.MIN_NUM_COMPLETIONS)
+        # Give this exploration an average rating of 4
+        avg_rating = 4
+        self._rate_exploration(exploration.id, 5, avg_rating)
 
-        expected_user_impact_score = round(
-            math.log(self.MIN_NUM_COMPLETIONS) *
-            (self.ABOVE_MIN_RATING - self.MIN_AVERAGE_RATING) *
-            self.MULTIPLIER)
+        rating = avg_rating - 2
+        exp = 2/float(3)
+        answer_count = 8 # see state counts above
+        reach = answer_count**exp
+        expected_user_impact_score = round((rating * reach) ** exp)
 
         # Verify that the impact score matches the expected.
         self._run_computation()
@@ -729,39 +715,50 @@ class UserImpactAggregatorTest(test_utils.GenericTestBase):
         self.assertEqual(
             user_stats_model.impact_score, expected_user_impact_score)
 
+    def test_exploration_multiple_contributors(self):
+        # Sign up a user and have them create an exploration.
+        user_a_id = self._sign_up_user(
+            self.USER_A_EMAIL, self.USER_A_USERNAME)
+        user_b_id = self._sign_up_user(
+            self.USER_B_EMAIL, self.USER_B_USERNAME)
+        exploration = self._create_exploration(self.EXP_ID_1, user_a_id)
+        # Give this exploration an average rating of 4
+        avg_rating = 4
+        self._rate_exploration(exploration.id, 5, avg_rating)
+        exp_services.update_exploration(user_b_id, self.EXP_ID_1, [], '')
+
+        rating = avg_rating - 2
+        exp = 2/float(3)
+        answer_count = 8 # see state counts above
+        reach = answer_count**exp
+        contrib = 0.5
+        expected_user_impact_score = round((rating * reach * contrib) ** exp)
+
+        # Verify that the impact score matches the expected.
+        self._run_computation()
+        user_stats_model = user_models.UserStatsModel.get(user_a_id)
+        self.assertEqual(
+            user_stats_model.impact_score, expected_user_impact_score)
+        user_stats_model = user_models.UserStatsModel.get(user_b_id)
+        self.assertEqual(
+            user_stats_model.impact_score, expected_user_impact_score)
+
     def test_standard_user_impact_calculation_multiple_explorations(self):
-        """Test that a user who is a contributor on two explorations that:
-        - have a number of ratings for that exploration above the treshold
-        for the scaler for number of ratings
-        - have an average rating above the minimum average rating
-        - have a number of playthroughs > 1
-        is assigned the correct impact score by the
-        UserImpactMRJobManager.
-        """
         # Sign up a user and have them create two explorations.
         user_a_id = self._sign_up_user(
             self.USER_A_EMAIL, self.USER_A_USERNAME)
         exploration_1 = self._create_exploration(self.EXP_ID_1, user_a_id)
         exploration_2 = self._create_exploration(self.EXP_ID_2, user_a_id)
-        # Give these explorations as many ratings as necessary to avoid
-        # the scaler for number of ratings.
-        self._rate_exploration(
-            exploration_1.id, self.NUM_RATINGS_SCALER_CUTOFF,
-            self.ABOVE_MIN_RATING)
-        self._rate_exploration(
-            exploration_2.id, self.NUM_RATINGS_SCALER_CUTOFF,
-            self.ABOVE_MIN_RATING)
-        # Give these explorations more than one playthrough (so
-        # ln(num_completions) != 0.
-        self._complete_exploration(exploration_1, self.MIN_NUM_COMPLETIONS)
-        self._complete_exploration(exploration_2, self.MIN_NUM_COMPLETIONS)
+        avg_rating = 4
+        self._rate_exploration(exploration_1.id, 2, avg_rating)
+        self._rate_exploration(exploration_2.id, 2, avg_rating)
 
-        # The user impact score should be the rounded sum of these two impacts
-        # (2 * the same impact).
-        expected_user_impact_score = round(
-            2 * math.log(self.MIN_NUM_COMPLETIONS) *
-            (self.ABOVE_MIN_RATING - self.MIN_AVERAGE_RATING) *
-            self.MULTIPLIER)
+        rating = avg_rating - 2
+        exp = 2/float(3)
+        answer_count = 8 # see state counts above
+        reach = answer_count**exp
+        impact_per_exp = (rating * reach) # * 1 for contribution
+        expected_user_impact_score = round((impact_per_exp * 2) ** exp)
 
         # Verify that the impact score matches the expected.
         self._run_computation()
@@ -769,60 +766,32 @@ class UserImpactAggregatorTest(test_utils.GenericTestBase):
         self.assertEqual(
             user_stats_model.impact_score, expected_user_impact_score)
 
-    def test_only_yield_when_impact_greater_than_zero(self):
+    def test_only_yield_when_rating_greater_than_two(self):
         """Tests that map only yields an impact score for an
         exploration when the impact score is greater than 0."""
         # Sign up a user and have them create an exploration.
         user_a_id = self._sign_up_user(
             self.USER_A_EMAIL, self.USER_A_USERNAME)
         self._create_exploration(self.EXP_ID_1, user_a_id)
-        exp_model = exp_models.ExplorationModel.get(self.EXP_ID_1)
+        self._rate_exploration(self.EXP_ID_1, 2, 1)
 
-        # Use mock impact scores to verify that map only yields when
-        # the impact score > 0.
-        # Should not yield when impact score < 0.
-        with self.swap(
-            user_jobs_continuous.UserImpactMRJobManager,
-            '_get_exp_impact_score', self._mock_get_zero_impact_score
-            ):
-            results = self.impact_mr_job_manager.map(exp_model)
-            with self.assertRaises(StopIteration):
-                next(results)
-        with self.swap(
-            user_jobs_continuous.UserImpactMRJobManager,
-            '_get_exp_impact_score', self._mock_get_below_zero_impact_score
-            ):
-            results = self.impact_mr_job_manager.map(exp_model)
-            with self.assertRaises(StopIteration):
-                next(results)
-        # Should yield one result when impact score > 0.
-        with self.swap(
-            user_jobs_continuous.UserImpactMRJobManager,
-            '_get_exp_impact_score', self._mock_get_positive_impact_score
-            ):
-            results = self.impact_mr_job_manager.map(exp_model)
-            next(results)
-            with self.assertRaises(StopIteration):
-                next(results)
+        self._run_computation()
+        user_stats_model = user_models.UserStatsModel.get(user_a_id,
+                                                          strict=False)
+        self.assertEqual(user_stats_model, None)
 
-    def test_impact_for_exp_with_one_completion(self):
-        """Test that when an exploration has only one completion,
-        the impact returned from the impact function is 0.
+    def test_impact_for_exp_with_no_answers(self):
+        """Test that when an exploration has no answers and thus has
+         no reach.
         """
         # Sign up a user and have them create an exploration.
         user_a_id = self._sign_up_user(
             self.USER_A_EMAIL, self.USER_A_USERNAME)
-        exploration = self._create_exploration(self.EXP_ID_1, user_a_id)
-        # Give this exploration as many ratings as necessary to avoid
-        # the scaler for number of ratings.
-        self._rate_exploration(
-            exploration.id, self.NUM_RATINGS_SCALER_CUTOFF,
-            self.ABOVE_MIN_RATING)
-        # Complete the exploration once.
-        self._complete_exploration(exploration, 1)
-        # Verify that the impact calculated is 0.
-        self._run_exp_impact_calculation_and_assert_equals(
-            exploration.id, 0)
+        exploration = self._create_exploration(self.EXP_ID_3, user_a_id)
+        self._rate_exploration(exploration.id, 5, 3)
+        self._run_computation()
+        user_stats_model = user_models.UserStatsModel.get(user_a_id)
+        self.assertEqual(user_stats_model.impact_score, 0)
 
     def test_impact_for_exp_with_no_ratings(self):
         """Test that when an exploration has no ratings, the impact returned
@@ -831,200 +800,7 @@ class UserImpactAggregatorTest(test_utils.GenericTestBase):
         # Sign up a user and have them create an exploration.
         user_a_id = self._sign_up_user(
             self.USER_A_EMAIL, self.USER_A_USERNAME)
-        exploration = self._create_exploration(self.EXP_ID_1, user_a_id)
-        # Give this exploration more than one playthrough (so
-        # ln(num_completions) != 0.
-        self._complete_exploration(exploration, self.MIN_NUM_COMPLETIONS)
-        # Verify that the impact calculated is 0.
-        self._run_exp_impact_calculation_and_assert_equals(
-            exploration.id, 0)
-
-    def test_impact_for_exp_with_avg_rating_not_greater_than_min(self):
-        """Test that an exploration has an average rating less than the
-        minimum average rating, the impact returned from the impact function
-        is 0.
-        """
-        # Sign up a user and have them create an exploration.
-        user_a_id = self._sign_up_user(
-            self.USER_A_EMAIL, self.USER_A_USERNAME)
-        exploration = self._create_exploration(self.EXP_ID_1, user_a_id)
-        # Give this exploration more than one playthrough (so
-        # ln(num_completions) != 0.
-        self._complete_exploration(exploration, self.MIN_NUM_COMPLETIONS)
-
-        # Rate this exploration once, with exactly the minimum average
-        # rating.
-        self._rate_exploration(exploration.id, 1, self.BELOW_MIN_RATING)
-        # Verify that the impact calculated is 0.
-        self._run_exp_impact_calculation_and_assert_equals(
-            exploration.id, 0)
-
-        # Rate this exploration again, dropping the average below the minimum.
-        self._rate_exploration(exploration.id, 1, self.BELOW_MIN_RATING)
-        # Verify that the impact calculated is still 0.
-        self._run_exp_impact_calculation_and_assert_equals(
-            exploration.id, 0)
-
-    def test_impact_with_ratings_scaler(self):
-        """Test that the ratings scaler is being properly applied in the
-        impact calculation.
-        """
-        # Sign up a user and have them create an exploration.
-        user_a_id = self._sign_up_user(
-            self.USER_A_EMAIL, self.USER_A_USERNAME)
-        exploration = self._create_exploration(self.EXP_ID_1, user_a_id)
-        # Give this exploration more than one playthrough (so
-        # ln(num_completions) != 0.
-        self._complete_exploration(exploration, self.MIN_NUM_COMPLETIONS)
-        # Rate this exploration only twice, but give rating above minimum
-        # average rating.
-        self._rate_exploration(
-            exploration.id, 2, self.ABOVE_MIN_RATING)
-
-        expected_exp_impact_score = (
-            math.log(self.MIN_NUM_COMPLETIONS) *
-            (self.ABOVE_MIN_RATING - self.MIN_AVERAGE_RATING) *
-            (self.NUM_RATINGS_SCALER * 2) *
-            self.MULTIPLIER)
-        self._run_exp_impact_calculation_and_assert_equals(
-            exploration.id, expected_exp_impact_score)
-
-    def test_scaler_multiplier_independence(self):
-        """Test that when one exploration has less than 10 ratings,
-        the other exploration's impact score is not impacted.
-        """
-        # Sign up a user and have them create two explorations.
-        user_a_id = self._sign_up_user(
-            self.USER_A_EMAIL, self.USER_A_USERNAME)
-        exploration_1 = self._create_exploration(self.EXP_ID_1, user_a_id)
-        exploration_2 = self._create_exploration(self.EXP_ID_2, user_a_id)
-        # Give one explorations as many ratings as necessary to avoid
-        # the scaler for number of ratings. Give the other only 1.
-        self._rate_exploration(
-            exploration_1.id, self.NUM_RATINGS_SCALER_CUTOFF,
-            self.ABOVE_MIN_RATING)
-        self._rate_exploration(
-            exploration_2.id, 1, self.ABOVE_MIN_RATING)
-        # Give these explorations more than one playthrough (so
-        # ln(num_completions) != 0.
-        self._complete_exploration(exploration_1, self.MIN_NUM_COMPLETIONS)
-        self._complete_exploration(exploration_2, self.MIN_NUM_COMPLETIONS)
-
-        # Calculate the expected impact for each exploration.
-        exp_1_impact = (
-            math.log(self.MIN_NUM_COMPLETIONS) *
-            (self.ABOVE_MIN_RATING - self.MIN_AVERAGE_RATING) *
-            self.MULTIPLIER)
-        exp_2_impact = (
-            math.log(self.MIN_NUM_COMPLETIONS) *
-            (self.ABOVE_MIN_RATING - self.MIN_AVERAGE_RATING) *
-            self.NUM_RATINGS_SCALER *
-            self.MULTIPLIER)
-        # The user impact score should be the rounded sum of these two impacts.
-        expected_user_impact_score = round(exp_1_impact + exp_2_impact)
-
-        # Verify that the impact score matches the expected.
-        self._run_computation()
-        user_stats_model = user_models.UserStatsModel.get(user_a_id)
-        self.assertEqual(
-            user_stats_model.impact_score, expected_user_impact_score)
-
-    def test_no_ratings_independence(self):
-        """Test that when one exploration has no ratings, the other
-        exploration's impact score is not impacted.
-        """
-        # Sign up a user and have them create two explorations.
-        user_a_id = self._sign_up_user(
-            self.USER_A_EMAIL, self.USER_A_USERNAME)
-        exploration_1 = self._create_exploration(self.EXP_ID_1, user_a_id)
-        exploration_2 = self._create_exploration(self.EXP_ID_2, user_a_id)
-        # Give one exploration as many ratings as necessary to avoid
-        # the scaler for number of ratings. Don't give the other any ratings.
-        self._rate_exploration(
-            exploration_1.id, self.NUM_RATINGS_SCALER_CUTOFF,
-            self.ABOVE_MIN_RATING)
-        # Give these explorations more than one playthrough (so
-        # ln(num_completions) != 0.
-        self._complete_exploration(exploration_1, self.MIN_NUM_COMPLETIONS)
-        self._complete_exploration(exploration_2, self.MIN_NUM_COMPLETIONS)
-        # We expect the second exploration to yield 0 (since it has no
-        # ratings), so the expected impact score is just the impact score for
-        # exploration 1.
-        expected_user_impact_score = round(
-            math.log(self.MIN_NUM_COMPLETIONS) *
-            (self.ABOVE_MIN_RATING - self.MIN_AVERAGE_RATING) *
-            self.MULTIPLIER)
-        # Verify that the impact score matches the expected.
-        self._run_computation()
-        user_stats_model = user_models.UserStatsModel.get(user_a_id)
-        self.assertEqual(
-            user_stats_model.impact_score, expected_user_impact_score)
-
-    def test_min_avg_rating_independence(self):
-        """Test that when one exploration has less than the minimum average
-        rating, the other exploration's impact score is not impacted.
-        """
-        # Sign up a user and have them create two explorations.
-        user_a_id = self._sign_up_user(
-            self.USER_A_EMAIL, self.USER_A_USERNAME)
-        exploration_1 = self._create_exploration(self.EXP_ID_1, user_a_id)
-        exploration_2 = self._create_exploration(self.EXP_ID_2, user_a_id)
-        # Give these explorations as many ratings as necessary to avoid
-        # the scaler for number of ratings. Rate one above the minimum,
-        # rate the other below.
-        self._rate_exploration(
-            exploration_1.id, self.NUM_RATINGS_SCALER_CUTOFF,
-            self.ABOVE_MIN_RATING)
-        self._rate_exploration(
-            exploration_2.id, self.NUM_RATINGS_SCALER_CUTOFF,
-            self.BELOW_MIN_RATING)
-        # Give these explorations more than one playthrough (so
-        # ln(num_completions) != 0.
-        self._complete_exploration(exploration_1, self.MIN_NUM_COMPLETIONS)
-        self._complete_exploration(exploration_2, self.MIN_NUM_COMPLETIONS)
-        # We expect the second exploration to yield 0 (since its average rating
-        # is below the minimum), so the expected impact score is just the
-        # impact score for exploration 1.
-        expected_user_impact_score = round(
-            math.log(self.MIN_NUM_COMPLETIONS) *
-            (self.ABOVE_MIN_RATING - self.MIN_AVERAGE_RATING) *
-            self.MULTIPLIER)
-        # Verify that the impact score matches the expected.
-        self._run_computation()
-        user_stats_model = user_models.UserStatsModel.get(user_a_id)
-        self.assertEqual(
-            user_stats_model.impact_score, expected_user_impact_score)
-
-    def test_num_completions_independence(self):
-        """Test that when one exploration has less than the minimum number
-        of completions, the other exploration's impact score is not impacted.
-        """
-        # Sign up a user and have them create two explorations.
-        user_a_id = self._sign_up_user(
-            self.USER_A_EMAIL, self.USER_A_USERNAME)
-        exploration_1 = self._create_exploration(self.EXP_ID_1, user_a_id)
-        exploration_2 = self._create_exploration(self.EXP_ID_2, user_a_id)
-        # Give these explorations as many ratings as necessary to avoid
-        # the scaler for number of ratings.
-        self._rate_exploration(
-            exploration_1.id, self.NUM_RATINGS_SCALER_CUTOFF,
-            self.ABOVE_MIN_RATING)
-        self._rate_exploration(
-            exploration_2.id, self.NUM_RATINGS_SCALER_CUTOFF,
-            self.ABOVE_MIN_RATING)
-        # Give one exploration the minimum number of completions. Give the other
-        # only one.
-        self._complete_exploration(exploration_1, self.MIN_NUM_COMPLETIONS)
-        self._complete_exploration(exploration_2, 1)
-        # We expect the second exploration to yield 0 (since its average rating
-        # is below the minimum), so the expected impact score is just the
-        # impact score for exploration 1.
-        expected_user_impact_score = round(
-            math.log(self.MIN_NUM_COMPLETIONS) *
-            (self.ABOVE_MIN_RATING - self.MIN_AVERAGE_RATING) *
-            self.MULTIPLIER)
-        # Verify that the impact score matches the expected.
-        self._run_computation()
-        user_stats_model = user_models.UserStatsModel.get(user_a_id)
-        self.assertEqual(
-            user_stats_model.impact_score, expected_user_impact_score)
+        self._create_exploration(self.EXP_ID_1, user_a_id)
+        user_stats_model = user_models.UserStatsModel.get(user_a_id,
+                                                          strict=False)
+        self.assertEqual(user_stats_model, None)


### PR DESCRIPTION
This is based off of issue #1288 and the design attached there. 

The only piece of this that was tricky to actually fully make work as I would have wanted is definition of reach. As it is defined in the design doc, it uses "the number of users that have given an answer per card", which is really hard to define given what information we have.
The information we have is:
* Number of sessions to hit this state (so multiple playthroughs by the same person would count separately)
* Number of times this state was hit (so multiple times to the same state in the same playthrough would count separately)
* Number of times this state was hit but no answer was given (which is a max of one time per session)

So what I have right now is `first_entry (per session) - no answer given`, which in theory is the number of playthroughs that gave an answer to this card, but will undercount slightly people who hit the state more than once and didn't give an answer the 2nd, 3rd, etc time, and somewhat overcount for multiple sessions per user. 

I'd be OK with changing it to `number of state hits - no answer given` which would give the total number of answers given to that state, and it should be exact because we are just trying to count answers instead of users. I opted against this due to the specific choice of the word "user" in the design doc, but if we'd rather an exact number of answers rather than an approximate number of users I can easily make that change.

As it stands, I've documented what I feel the shortcomings of the current design are in the code so that if we choose to leave it, people will at least understand the issue in the future. 