### PR TITLE
Fix #1516: fix outcome editor so the continue button works

### DIFF
--- a/core/templates/dev/head/components/OutcomeEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeEditorDirective.js
@@ -92,6 +92,7 @@ oppia.directive('outcomeEditor', [function() {
           return $scope.isSelfLoopWithNoFeedback(tmpOutcome);
         };
         $scope.openFeedbackEditor = function() {
+          $scope.savedOutcome = angular.copy($scope.outcome);
           if ($scope.isEditable()) {
             $scope.feedbackEditorIsOpen = true;
             if ($scope.outcome.feedback.length === 0) {
@@ -101,6 +102,7 @@ oppia.directive('outcomeEditor', [function() {
         };
 
         $scope.openDestinationEditor = function() {
+          $scope.savedOutcome = angular.copy($scope.outcome);
           if ($scope.isEditable()) {
             $scope.destinationEditorIsOpen = true;
           }


### PR DESCRIPTION
The problem appears to be that the continue button is very small and loads too quickly, before the outcome editor gets a copy of the outcome.

I added a line that copies the old outcome whenever the feedback/destination editor is opened. I'm not entirely sure this is the right fix, though.