### PR TITLE
Removed unnecessary two way binding

### DIFF
--- a/core/templates/dev/head/components/RuleTypeSelectorDirective.js
+++ b/core/templates/dev/head/components/RuleTypeSelectorDirective.js
@@ -22,7 +22,7 @@ oppia.directive('ruleTypeSelector', [function() {
   return {
     restrict: 'E',
     scope: {
-      localValue: '=',
+      localValue: '@',
       onSelectionChange: '&'
     },
     template: '<input type="hidden">',
@@ -62,12 +62,6 @@ oppia.directive('ruleTypeSelector', [function() {
           }
         });
 
-        // Select the first choice by default.
-        if (!$scope.localValue) {
-          $scope.localValue = choices[0].id;
-          $scope.onSelectionChange()($scope.localValue);
-        }
-
         var select2Node = $element[0].firstChild;
         $(select2Node).select2({
           allowClear: false,
@@ -80,15 +74,16 @@ oppia.directive('ruleTypeSelector', [function() {
           }
         });
 
+        // Select the first choice by default.
+        if (!$scope.localValue) {
+          $scope.localValue = choices[0].id;
+          $scope.onSelectionChange()($scope.localValue);
+        }
+
         // Initialize the dropdown.
         $(select2Node).select2('val', $scope.localValue);
 
-        // Update $scope.localValue when the selection changes.
         $(select2Node).on('change', function(e) {
-          $scope.localValue = e.val;
-          // This is needed to actually update the localValue in the containing
-          // scope.
-          $scope.$apply();
           $scope.onSelectionChange()(e.val);
           // This is needed to propagate the change and display input fields for
           // parameterizing the rule.

--- a/core/templates/dev/head/components/RuleTypeSelectorDirective.js
+++ b/core/templates/dev/head/components/RuleTypeSelectorDirective.js
@@ -85,9 +85,6 @@ oppia.directive('ruleTypeSelector', [function() {
 
         $(select2Node).on('change', function(e) {
           $scope.onSelectionChange()(e.val);
-          // This is needed to propagate the change and display input fields for
-          // parameterizing the rule.
-          $scope.$apply();
         });
       }
     ]

--- a/core/templates/dev/head/components/rule_editor_directive.html
+++ b/core/templates/dev/head/components/rule_editor_directive.html
@@ -2,7 +2,7 @@
   <div style="position: relative;">
     <form class="form-inline protractor-test-rule-details" role="form" name="ruleEditForm.form">
       <div ng-if="rule.rule_type != 'FuzzyMatches'">
-        <rule-type-selector class="protractor-test-answer-description" local-value="rule.rule_type" on-selection-change="onSelectNewRuleType">
+        <rule-type-selector class="protractor-test-answer-description" local-value="<[rule.rule_type]>" on-selection-change="onSelectNewRuleType">
         </rule-type-selector>
 
         <span ng-repeat="item in ruleDescriptionFragments track by $index" class="form-group protractor-test-answer-description-fragment" style="margin-right: 5px; width: 100%;">


### PR DESCRIPTION
Before, when you select a "rule type", $scope.rule.type in the parent scope changes and invokes "onSelectNewRuleType(newRuleType)". 
I think, one of these is unnecessary and was confusing me. However, I might have wrong argument. 
 