### PR TITLE
fix select dropdown image overlap (#1536)

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -996,7 +996,7 @@ md-card.oppia-gallery-tile {
   top: 0;
 }
 
-.oppia-html-select .oppia-html-select-selection {  
+.oppia-html-select .oppia-html-select-selection {
   padding-right: 20px;
   position: relative;
   text-decoration: none;
@@ -1013,8 +1013,8 @@ md-card.oppia-gallery-tile {
 }
 
 .oppia-html-select .oppia-html-select-option oppia-noninteractive-image {
-  display: block;
-  margin-bottom: -22px;
+  display: inline-block;
+  margin-bottom: 0;
 }
 
 .oppia-create-exploration-label {


### PR DESCRIPTION
Fixes the overlap of images in the Html-select dropdown that occurs in the rule editor when creating an exploration.