### PR TITLE
fixes overflow of image in exploration on firefox (issue #1525)

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -348,6 +348,7 @@ p {
 */
 img, video, canvas {
   max-width: 100%;
+  width: 100%;
 }
 
 textarea {


### PR DESCRIPTION
fixes the firefox issue where the images overflowed from the container. (#1525)