### PR TITLE
Allow editing of exploration responses via edit icons

### DIFF
--- a/core/templates/dev/head/components/outcome_editor_directive.html
+++ b/core/templates/dev/head/components/outcome_editor_directive.html
@@ -12,6 +12,7 @@
         <strong>Oppia tells the learner...</strong>
         <div style="position: relative;">
           <span ng-if="isEditable()"
+                ng-click="openFeedbackEditor()"
                 class="glyphicon glyphicon-pencil oppia-editor-edit-icon pull-right"
                 title="Edit Feedback">
           </span>
@@ -85,6 +86,7 @@
             (try again)
           </span>
           <span ng-if="isEditable()"
+                ng-click="openDestinationEditor()"
                 class="glyphicon glyphicon-pencil oppia-editor-edit-icon pull-right"
                 title="Edit Destination">
           </span>

--- a/core/templates/dev/head/components/outcome_editor_directive.html
+++ b/core/templates/dev/head/components/outcome_editor_directive.html
@@ -7,15 +7,14 @@
       <div class="oppia-rule-preview oppia-transition-200">
         <div class="oppia-click-to-start-editing protractor-test-open-outcome-feedback-editor"
              ng-if="isEditable()" ng-click="openFeedbackEditor()">
+          <span ng-if="isEditable()"
+                class="glyphicon glyphicon-pencil oppia-editor-edit-icon pull-right"
+                title="Edit Feedback">
+          </span>
         </div>
 
         <strong>Oppia tells the learner...</strong>
         <div style="position: relative;">
-          <span ng-if="isEditable()"
-                ng-click="openFeedbackEditor()"
-                class="glyphicon glyphicon-pencil oppia-editor-edit-icon pull-right"
-                title="Edit Feedback">
-          </span>
           <span ng-if="isSelfLoopWithNoFeedback(outcome) && !suppressWarnings()">
             <span class="oppia-confusing-outcome-warning-text">
               <span class="glyphicon glyphicon-warning-sign"></span>
@@ -73,6 +72,10 @@
       <div class="oppia-rule-preview oppia-transition-200">
         <div class="oppia-click-to-start-editing protractor-test-open-outcome-dest-editor"
              ng-if="isEditable()" ng-click="openDestinationEditor()">
+          <span ng-if="isEditable()"
+                class="glyphicon glyphicon-pencil oppia-editor-edit-icon pull-right"
+                title="Edit Destination">
+          </span>
         </div>
 
         <div ng-if="outcome.dest !== getActiveStateName()">
@@ -84,11 +87,6 @@
           </span>
           <span ng-if="isSelfLoop(outcome)" style="position: relative;">
             (try again)
-          </span>
-          <span ng-if="isEditable()"
-                ng-click="openDestinationEditor()"
-                class="glyphicon glyphicon-pencil oppia-editor-edit-icon pull-right"
-                title="Edit Destination">
           </span>
         </div>
       </div>

--- a/core/templates/dev/head/editor/state_editor_responses.html
+++ b/core/templates/dev/head/editor/state_editor_responses.html
@@ -196,6 +196,7 @@
             <strong>Oppia tells the learner...</strong>
             <div style="position: relative;">
               <span class="glyphicon glyphicon-pencil oppia-editor-edit-icon pull-right"
+                    ng-click="openFeedbackEditor()"
                     title="Edit Feedback">
               </span>
               <span style="color: #888">

--- a/core/templates/dev/head/editor/state_editor_responses.html
+++ b/core/templates/dev/head/editor/state_editor_responses.html
@@ -192,13 +192,12 @@
         <div class="oppia-rule-details-header oppia-editable-section">
           <div class="oppia-rule-preview oppia-transition-200">
             <div class="oppia-click-to-start-editing protractor-test-open-feedback-editor" ng-click="openFeedbackEditor()">
+              <span class="glyphicon glyphicon-pencil oppia-editor-edit-icon pull-right"
+                    title="Edit Feedback">
+              </span>
             </div>
             <strong>Oppia tells the learner...</strong>
             <div style="position: relative;">
-              <span class="glyphicon glyphicon-pencil oppia-editor-edit-icon pull-right"
-                    ng-click="openFeedbackEditor()"
-                    title="Edit Feedback">
-              </span>
               <span style="color: #888">
                 <em>Nothing</em>
               </span>


### PR DESCRIPTION
I'm not sure if this is an issue, but clicking the edit icons doesn't open up the editor for the exploration responses.
Screenshot for the edit icon - 
![screenshot](https://cloud.githubusercontent.com/assets/6831827/13532714/fca6360a-e252-11e5-8714-8ea2f898be9e.png)

So here's the fix :)