### PR TITLE
Fix failing e2e test by correcting url

### DIFF
--- a/core/tests/protractor/privileges.js
+++ b/core/tests/protractor/privileges.js
@@ -49,7 +49,7 @@ describe('Permissions for private explorations', function() {
       users.login('eve@example.com');
       general.openEditor(explorationId);
       // Eve is redirected to the homepage.
-      expect(browser.getCurrentUrl()).toEqual(general.SERVER_URL_PREFIX + '/');
+      expect(browser.getCurrentUrl()).toEqual(general.SERVER_URL_PREFIX + '/my_explorations');
       users.logout();
     });
   });


### PR DESCRIPTION
After fixing issue #1533 , one of the e2e tests failed. Simply changing the url from `/` to `/my_explorations` fixes this.

Thanks for pointing this out, @seanlip . Please review