### PR TITLE
Added flags to the frontend test runner script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
 - if [ $RUN_LINT == 'true' ]; then bash scripts/install_third_party.sh; python scripts/pre_commit_linter.py --path=.; fi
 # Travis aborts test run if nothing is printed back to STDOUT for some time.
 # -x is used to avoid that.
-- if [ $RUN_FRONTEND_TESTS == 'true' ]; then bash -x scripts/run_frontend_tests.sh; fi
+- if [ $RUN_FRONTEND_TESTS == 'true' ]; then bash -x scripts/run_frontend_tests.sh --run-minified-tests=true; fi
 
 after_success:
 - if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'true' ]; then codecov; fi

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -22,6 +22,7 @@
 #   bash scripts/run_e2e_tests.sh
 #
 # Optional arguments:
+#   --skip-install=true/false Possibly skips installing dependencies. The default value is false.
 #   --sharding=true/false Disables/Enables parallelization of protractor tests.
 #   --sharding-instances=# Sets the number of parallel browsers to open while sharding.
 # Sharding must be disabled (either by passing in false to --sharding or 1 to
@@ -69,20 +70,9 @@ set -e
 source $(dirname $0)/setup.sh || exit 1
 source $(dirname $0)/setup_gae.sh || exit 1
 
-# Install third party dependencies
-bash scripts/install_third_party.sh
-
-install_node_module karma 0.12.16
-install_node_module karma-jasmine 0.1.0
-install_node_module karma-ng-html2js-preprocessor 0.1.0
-install_node_module protractor 2.5.0
-install_node_module protractor-screenshot-reporter 0.0.5
-install_node_module jasmine-spec-reporter 2.2.2
-
-$NODE_MODULE_DIR/.bin/webdriver-manager update
-
-#build so as to have minified js and css
-$NODE_PATH/bin/node $NODE_MODULE_DIR/gulp/bin/gulp.js build
+export DEFAULT_SKIP_INSTALLING_THIRD_PARTY_LIBS=false
+export DEFAULT_RUN_MINIFIED_TESTS=false
+maybeInstallDependencies "$@"
 
 if ( nc -vz localhost 8181 ); then
   echo ""

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -22,9 +22,11 @@
 #   bash scripts/run_e2e_tests.sh
 #
 # Optional arguments:
-#   --skip-install=true/false Possibly skips installing dependencies. The default value is false.
+#   --skip-install=true/false If true, skips installing dependencies. The
+#         default value is false.
 #   --sharding=true/false Disables/Enables parallelization of protractor tests.
-#   --sharding-instances=# Sets the number of parallel browsers to open while sharding.
+#   --sharding-instances=# Sets the number of parallel browsers to open while
+#         sharding.
 # Sharding must be disabled (either by passing in false to --sharding or 1 to
 # --sharding-instances) if running any tests in isolation (iit or ddescribe).
 #
@@ -130,7 +132,7 @@ for i in "$@"; do
     ;;
 
     *)
-    echo Error: Unknown command line option: $i
+    echo "Error: Unknown command line option: $i"
     ;;
   esac
 done

--- a/scripts/run_frontend_tests.sh
+++ b/scripts/run_frontend_tests.sh
@@ -22,7 +22,7 @@
 #   bash scripts/run_frontend_tests.sh
 #
 # Optional arguments:
-#   --skip-install=true/false Possibly skips installing dependencies. The
+#   --skip-install=true/false If true, skips installing dependencies. The
 #         default value is false.
 #   --run-minified-tests=true/false Whether to run frontend karma tests on both
 #         minified and non-minified code. The default value is false.

--- a/scripts/run_frontend_tests.sh
+++ b/scripts/run_frontend_tests.sh
@@ -20,6 +20,13 @@
 #
 # Run this script from the oppia root folder:
 #   bash scripts/run_frontend_tests.sh
+#
+# Optional arguments:
+#   --skip-install=true/false Possibly skips installing dependencies. The
+#         default value is false.
+#   --run-minified-tests=true/false Whether to run frontend karma tests on both
+#         minified and non-minified code. The default value is false.
+#
 # The root folder MUST be named 'oppia'.
 # It runs unit tests for frontend JavaScript code (using Karma).
 
@@ -37,60 +44,9 @@ set -e
 source $(dirname $0)/setup.sh || exit 1
 source $(dirname $0)/setup_gae.sh || exit 1
 
-# Parse additional command line arguments.
-# Credit: http://stackoverflow.com/questions/192249
-SKIP_INSTALL=false
-RUN_MINIFIED_TESTS=false
-for i in "$@"; do
-  # Match each space-separated argument passed to the shell file to a separate
-  # case label, based on a pattern. E.g. Match to --skip-install=*, where the
-  # asterisk refers to any characters following the equals sign, other than
-  # whitespace.
-  case $i in
-    --skip-install=*)
-    # Extract the value right of the equal sign by substringing the $i variable
-    # at the equal sign.
-    # http://tldp.org/LDP/abs/html/string-manipulation.html
-    SKIP_INSTALL="${i#*=}"
-    # Shifts the argument parameters over by one. E.g. $2 becomes $1, etc.
-    shift
-    ;;
-
-    --run-minified-tests=*)
-    RUN_MINIFIED_TESTS="${i#*=}"
-    shift
-    ;;
-
-    *)
-    echo Error: Unknown command line option: $i
-    ;;
-  esac
-done
-
-if [ "$SKIP_INSTALL" = "false" ]; then
-  # Install third party dependencies
-  # TODO(sll): Make this work with fewer third-party dependencies.
-  bash scripts/install_third_party.sh
-
-  # Ensure that generated JS and CSS files are in place before running the tests.
-  echo ""
-  echo "  Running build task with concatenation only "
-  echo ""
-
-  $NODE_PATH/bin/node $NODE_MODULE_DIR/gulp/bin/gulp.js build
-
-  echo ""
-  echo "  Running build task with concatenation and minification"
-  echo ""
-
-  $NODE_PATH/bin/node $NODE_MODULE_DIR/gulp/bin/gulp.js build --minify=True
-
-  install_node_module karma 0.12.16
-  install_node_module karma-jasmine 0.1.0
-  install_node_module karma-coverage 0.5.2
-  install_node_module karma-ng-html2js-preprocessor 0.1.0
-  install_node_module karma-chrome-launcher 0.1.4
-fi
+export DEFAULT_SKIP_INSTALLING_THIRD_PARTY_LIBS=false
+export DEFAULT_RUN_MINIFIED_TESTS=false
+maybeInstallDependencies "$@"
 
 echo ""
 echo "  View interactive frontend test coverage reports by navigating to"

--- a/scripts/run_presubmit_checks.sh
+++ b/scripts/run_presubmit_checks.sh
@@ -49,7 +49,7 @@ echo ''
 
 # Run frontend unit tests.
 echo 'Running frontend unit tests'
-source $(dirname $0)/run_frontend_tests.sh --run_minified_tests=true || exit 1
+source $(dirname $0)/run_frontend_tests.sh --run-minified-tests=true || exit 1
 echo 'Frontend tests passed.'
 echo ''
 

--- a/scripts/run_presubmit_checks.sh
+++ b/scripts/run_presubmit_checks.sh
@@ -49,7 +49,7 @@ echo ''
 
 # Run frontend unit tests.
 echo 'Running frontend unit tests'
-source $(dirname $0)/run_frontend_tests.sh || exit 1
+source $(dirname $0)/run_frontend_tests.sh --run_minified_tests=true || exit 1
 echo 'Frontend tests passed.'
 echo ''
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,6 +18,71 @@
 # Bash execution environent set up for all scripts.
 
 
+function maybeInstallDependencies {
+  # Parse additional command line arguments.
+  # Credit: http://stackoverflow.com/questions/192249
+  export SKIP_INSTALLING_THIRD_PARTY_LIBS=$DEFAULT_SKIP_INSTALLING_THIRD_PARTY_LIBS
+  export RUN_MINIFIED_TESTS=$DEFAULT_RUN_MINIFIED_TESTS
+  for i in "$@"; do
+    # Match each space-separated argument passed to the shell file to a separate
+    # case label, based on a pattern. E.g. Match to --skip-install=*, where the
+    # asterisk refers to any characters following the equals sign, other than
+    # whitespace.
+    case $i in
+      --skip-install=*)
+      # Extract the value right of the equal sign by substringing the $i
+      # variable at the equal sign.
+      # http://tldp.org/LDP/abs/html/string-manipulation.html
+      SKIP_INSTALLING_THIRD_PARTY_LIBS="${i#*=}"
+      # Shifts the argument parameters over by one. E.g. $2 becomes $1, etc.
+      shift
+      ;;
+
+      --run-minified-tests=*)
+      RUN_MINIFIED_TESTS="${i#*=}"
+      shift
+      ;;
+
+      *)
+      echo Error: Unknown command line option: $i
+      ;;
+    esac
+  done
+
+  if [ "$SKIP_INSTALLING_THIRD_PARTY_LIBS" = "false" ]; then
+    # Install third party dependencies
+    # TODO(sll): Make this work with fewer third-party dependencies.
+    bash scripts/install_third_party.sh
+
+    # Ensure that generated JS and CSS files are in place before running the
+    # tests.
+    echo ""
+    echo "  Running build task with concatenation only "
+    echo ""
+
+    $NODE_PATH/bin/node $NODE_MODULE_DIR/gulp/bin/gulp.js build
+
+    install_node_module karma 0.12.16
+    install_node_module karma-jasmine 0.1.0
+    install_node_module karma-coverage 0.5.2
+    install_node_module karma-ng-html2js-preprocessor 0.1.0
+    install_node_module karma-chrome-launcher 0.1.4
+    install_node_module protractor 2.5.0
+    install_node_module protractor-screenshot-reporter 0.0.5
+    install_node_module jasmine-spec-reporter 2.2.2
+
+    $NODE_MODULE_DIR/.bin/webdriver-manager update
+  fi
+
+  if [ "$RUN_MINIFIED_TESTS" = "true" ]; then
+    echo ""
+    echo "  Running build task with concatenation and minification"
+    echo ""
+
+    $NODE_PATH/bin/node $NODE_MODULE_DIR/gulp/bin/gulp.js build --minify=True
+  fi
+}
+
 if [ "$SETUP_DONE" ]; then
   echo 'Environment setup completed.'
   return 0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -44,7 +44,7 @@ function maybeInstallDependencies {
       ;;
 
       *)
-      echo Error: Unknown command line option: $i
+      echo "Error: Unknown command line option: $i"
       ;;
     esac
   done


### PR DESCRIPTION
Updated the frontend test script to not run the second pass of tests by default. It still runs for the presubmit check, but not by default. Also, added an optional flag to skip the installation process. This is useful for when third party dependencies have already been installed. These two flags together significantly speed up running the frontend tests. We may want to consider setting the install dependencies flag on by default and having the frontend checks error-out if third party dependencies haven't been installed yet.