### PR TITLE
Added code for extracting youtube video id from youtube url, for the case where URL is input instead of ID

### DIFF
--- a/extensions/rich_text_components/Video/Video.js
+++ b/extensions/rich_text_components/Video/Video.js
@@ -32,8 +32,14 @@ oppia.directive('oppiaNoninteractiveVideo', [
           var start = oppiaHtmlEscaper.escapedJsonToObj($attrs.startWithValue);
           var end = oppiaHtmlEscaper.escapedJsonToObj($attrs.endWithValue);
 
-          $scope.videoId = oppiaHtmlEscaper.escapedJsonToObj(
+          var idUrl = oppiaHtmlEscaper.escapedJsonToObj(
             $attrs.videoIdWithValue);
+          if (idUrl.match('^(http|https)://(www.)?youtube|youtu\.be')) {
+            $scope.videoId = idUrl.split(/v\/|v=|youtu\.be\//)[1].split(/[?&]/)
+              [0];
+          } else if (idUrl.length == 11) {
+            $scope.videoId = idUrl;
+          }
           $scope.timingParams = '&start=' + start + '&end=' + end;
           $scope.autoplaySuffix = '&autoplay=0';
 


### PR DESCRIPTION
Solves [#1236](https://github.com/oppia/oppia/issues/1236)

Youtube Video ID is extracted from the url using regex and also the id is checked to ascertain it is 11 characters long.