### PR TITLE
Fix #1236: extract YouTube ID from URL

### DIFF
--- a/extensions/rich_text_components/Video/Video.js
+++ b/extensions/rich_text_components/Video/Video.js
@@ -34,6 +34,8 @@ oppia.directive('oppiaNoninteractiveVideo', [
 
           $scope.videoId = oppiaHtmlEscaper.escapedJsonToObj(
             $attrs.videoIdWithValue);
+          $scope.videoId = $scope.videoId.match(
+            /([A-z]|[0-9]){11}/g);
           $scope.timingParams = '&start=' + start + '&end=' + end;
           $scope.autoplaySuffix = '&autoplay=0';
 


### PR DESCRIPTION
Using regex, the first 11 alphanumeric characters in a row of $scope.vidoId are extracted.  Obviously this doesn't change anything in the case that the user supplies the ID, but when the user supplies an entire URL only the ID will be stored.  Fixes issue #1236 
