### PR TITLE
Fix link anchor in about page

### DIFF
--- a/core/templates/dev/head/pages/about.html
+++ b/core/templates/dev/head/pages/about.html
@@ -98,7 +98,7 @@
         <a href="https://www.apache.org/licenses/">Apache 2.0</a> license.
       </p>
 
-      <a class="oppia-about-foundation" name="foundation"></a>
+      <a class="oppia-about-anchor" name="foundation"></a>
       <h3>The Oppia Foundation</h3>
       <p>
         The Oppia website and source code are supported by the Oppia


### PR DESCRIPTION
This commit fixes the anchor which was not anchoring at the right location
earlier on the about page.

Fixes #1633 