### PR TITLE
Fix #1631: text in sidebar of privacy page is italicized

### DIFF
--- a/core/templates/dev/head/pages/privacy.html
+++ b/core/templates/dev/head/pages/privacy.html
@@ -318,7 +318,7 @@
         provide feedback, please send an e-mail to admin@oppia.org.
       </p>
 
-      <em>Last updated: 7 December 2015</h3>
+      <em>Last updated: 7 December 2015</em>
     </md-card>
   </div>
 


### PR DESCRIPTION
This PR to fix a minor bug mentioned in issue [#1613](https://github.com/oppia/oppia/issues/1631)
Just not properly closed `<em>` tag.