### PR TITLE
Caching files for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,3 +62,5 @@ cache:
     - ../oppia_tools/
     - third_party/
     - core/templates/prod/
+
+before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ after_success:
 cache:
   # Cache codecov and its dependencies.
   pip: true
+  # Cache Oppia's dependencies.
   directories:
     - ../node_modules/
     - ../oppia_tools/

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,5 +64,5 @@ cache:
     - core/templates/prod/
 
 before_cache:
-  # Delete python bytecode and pip debug log to prevent cache rebuild.
+  # Delete python bytecode to prevent cache rebuild.
   - find third_party -name "*.pyc" -print -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,7 @@ after_success:
 - if [ $RUN_FRONTEND_TESTS == 'true' ]; then codecov --file ../karma_coverage_reports/coverage-final.json; fi
 
 cache:
-  # Cache codecov and Oppia's dependencies.
-  pip: true
+  # Cache Oppia's dependencies.
   directories:
     - ../node_modules/
     - ../oppia_tools/
@@ -67,4 +66,3 @@ cache:
 before_cache:
   # Delete python bytecode and pip debug log to prevent cache rebuild.
   - find third_party -name "*.pyc" -print -delete
-  - rm $HOME/.cache/pip/log/debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,8 @@ after_success:
 - if [ $RUN_FRONTEND_TESTS == 'true' ]; then codecov --file ../karma_coverage_reports/coverage-final.json; fi
 
 cache:
-  # Cache codecov and its dependencies.
+  # Cache codecov and Oppia's dependencies.
   pip: true
-  # Cache Oppia's dependencies.
   directories:
     - ../node_modules/
     - ../oppia_tools/
@@ -66,7 +65,6 @@ cache:
     - core/templates/prod/
 
 before_cache:
-  # Delete python bytecode to prevent cache rebuild.
+  # Delete python bytecode and pip debug log to prevent cache rebuild.
   - find third_party -name "*.pyc" -print -delete
-  # Delete the pip debug log to prevent cache rebuild.
-  - rm -f $HOME/.cache/pip/log/debug.log
+  - rm $HOME/.cache/pip/log/debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ matrix:
   - env: RUN_BACKEND_TESTS=true RUN_FRONTEND_TESTS=false RUN_LINT=false REPORT_BACKEND_COVERAGE=true
   fast_finish: true
 
-notifications:
-  email:
-    recipients:
-    - sean@seanlip.org
-    - henning.benmax@gmail.com
-    - wxy.xinyu@gmail.com
-    on_success: change
-    on_failure: change
+#notifications:
+#  email:
+#    recipients:
+#    - sean@seanlip.org
+#    - henning.benmax@gmail.com
+#    - wxy.xinyu@gmail.com
+#    on_success: change
+#    on_failure: change
 
 before_install:
 - pip install codecov
@@ -56,8 +56,9 @@ after_success:
 - if [ $RUN_FRONTEND_TESTS == 'true' ]; then codecov --file ../karma_coverage_reports/coverage-final.json; fi
 
 cache:
+  # Cache codecov its dependencies.
+  pip: true
   directories:
-    # Runs once before being cached by Travis
     - ../node_modules/
     - ../oppia_tools/
     - third_party/
@@ -65,5 +66,5 @@ cache:
 
 before_cache:
   # Deleting python bytecode before files are cached,
-  # to prevent recaching.
+  # to prevent Travis from making a new cache every time.
   - find third_party -name ["*.pyc"] -print -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,3 +64,6 @@ cache:
     - core/templates/prod/
 
 before_cache:
+  # Deleting python bytecode before files are cached,
+  # to prevent recaching.
+  - find third_party -name ["*.pyc"] -print -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ after_success:
 - if [ $RUN_FRONTEND_TESTS == 'true' ]; then codecov --file ../karma_coverage_reports/coverage-final.json; fi
 
 cache:
-  # Cache codecov its dependencies.
+  # Cache codecov and its dependencies.
   pip: true
   directories:
     - ../node_modules/
@@ -67,4 +67,4 @@ cache:
 before_cache:
   # Deleting python bytecode before files are cached,
   # to prevent Travis from making a new cache every time.
-  - find third_party -name ["*.pyc"] -print -delete
+  - find third_party -name "*.pyc" -print -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,12 +42,6 @@ install:
 - pushd $TRAVIS_BUILD_DIR
 - source scripts/setup.sh || exit 1
 - source scripts/setup_gae.sh || exit 1
-# Google Appengine ends up being cached already; commented out to let Travis build finish.
-#- mkdir -p $GOOGLE_APP_ENGINE_HOME
-#- curl --silent https://storage.googleapis.com/appengine-sdks/deprecated/1919/google_appengine_1.9.19.zip
-#  -o gae-download.zip
-#- unzip -qq gae-download.zip -d $TOOLS_DIR/google_appengine_1.9.19/
-#- rm gae-download.zip
 
 script:
 - if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'true' ]; then bash scripts/run_backend_tests.sh --generate_coverage_report; fi
@@ -63,7 +57,7 @@ after_success:
 
 cache:
   directories:
-    # Needed to be run once before files are cached.
+    # Runs once before being cached by Travis
     - ../node_modules/
     - ../oppia_tools/
     - third_party/

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,12 @@ install:
 - pushd $TRAVIS_BUILD_DIR
 - source scripts/setup.sh || exit 1
 - source scripts/setup_gae.sh || exit 1
-- mkdir -p $GOOGLE_APP_ENGINE_HOME
-- curl --silent https://storage.googleapis.com/appengine-sdks/deprecated/1919/google_appengine_1.9.19.zip
-  -o gae-download.zip
-- unzip -qq gae-download.zip -d $TOOLS_DIR/google_appengine_1.9.19/
-- rm gae-download.zip
+# Google Appengine ends up being cached already; commented out to let Travis build finish.
+#- mkdir -p $GOOGLE_APP_ENGINE_HOME
+#- curl --silent https://storage.googleapis.com/appengine-sdks/deprecated/1919/google_appengine_1.9.19.zip
+#  -o gae-download.zip
+#- unzip -qq gae-download.zip -d $TOOLS_DIR/google_appengine_1.9.19/
+#- rm gae-download.zip
 
 script:
 - if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'true' ]; then bash scripts/run_backend_tests.sh --generate_coverage_report; fi
@@ -59,3 +60,11 @@ script:
 after_success:
 - if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'true' ]; then codecov; fi
 - if [ $RUN_FRONTEND_TESTS == 'true' ]; then codecov --file ../karma_coverage_reports/coverage-final.json; fi
+
+cache:
+  directories:
+    # Needed to be run once before files are cached.
+    - ../node_modules/
+    - ../oppia_tools/
+    - third_party/
+    - core/templates/prod/

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ cache:
     - core/templates/prod/
 
 before_cache:
-  # Deleting python bytecode before files are cached,
-  # to prevent Travis from making a new cache every time.
+  # Delete python bytecode to prevent cache rebuild.
   - find third_party -name "*.pyc" -print -delete
+  # Delete the pip debug log to prevent cache rebuild.
+  - rm -f $HOME/.cache/pip/log/debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ matrix:
   - env: RUN_BACKEND_TESTS=true RUN_FRONTEND_TESTS=false RUN_LINT=false REPORT_BACKEND_COVERAGE=true
   fast_finish: true
 
-#notifications:
-#  email:
-#    recipients:
-#    - sean@seanlip.org
-#    - henning.benmax@gmail.com
-#    - wxy.xinyu@gmail.com
-#    on_success: change
-#    on_failure: change
+notifications:
+  email:
+    recipients:
+    - sean@seanlip.org
+    - henning.benmax@gmail.com
+    - wxy.xinyu@gmail.com
+    on_success: change
+    on_failure: change
 
 before_install:
 - pip install codecov

--- a/scripts/setup_gae.sh
+++ b/scripts/setup_gae.sh
@@ -31,6 +31,7 @@ export PYTHONPATH=.:$COVERAGE_HOME:$GOOGLE_APP_ENGINE_HOME:$GOOGLE_APP_ENGINE_HO
 # Delete old *.pyc files
 find . -iname "*.pyc" -exec rm -f {} \;
 
+# Moved from install .travis.yml.
 echo Exported paths for Google App Engine, checking if it needs to be installed.
 if [ ! -d "$GOOGLE_APP_ENGINE_HOME" ]; then
 	mkdir -p $GOOGLE_APP_ENGINE_HOME
@@ -38,7 +39,7 @@ if [ ! -d "$GOOGLE_APP_ENGINE_HOME" ]; then
 	unzip -qq gae-download.zip -d $TOOLS_DIR/google_appengine_1.9.19/
 	rm gae-download.zip
 else
-	echo Google App Engine folder detected.
+	echo Google App Engine folder detected, no download commencing.
 fi
 
 export SETUP_GAE_DONE=true

--- a/scripts/setup_gae.sh
+++ b/scripts/setup_gae.sh
@@ -43,7 +43,8 @@ if [ ! -d "$GOOGLE_APP_ENGINE_HOME" ]; then
     echo "Download complete. Installing Google App Engine..."
   else
     echo "Error downloading Google App Engine. Exiting."
-    exit 1	
+    exit 1
+  fi
   unzip -q gae-download.zip -d $TOOLS_DIR/google_appengine_1.9.19/
   rm gae-download.zip
 fi

--- a/scripts/setup_gae.sh
+++ b/scripts/setup_gae.sh
@@ -32,12 +32,20 @@ export PYTHONPATH=.:$COVERAGE_HOME:$GOOGLE_APP_ENGINE_HOME:$GOOGLE_APP_ENGINE_HO
 find . -iname "*.pyc" -exec rm -f {} \;
 
 # Moved from install .travis.yml.
-echo Checking if Google App Engine is installed in $GOOGLE_APP_ENGINE_HOME
+echo Checking whether Google App Engine is installed in $GOOGLE_APP_ENGINE_HOME
 if [ ! -d "$GOOGLE_APP_ENGINE_HOME" ]; then
-	mkdir -p $GOOGLE_APP_ENGINE_HOME
-	curl --silent https://storage.googleapis.com/appengine-sdks/deprecated/1919/google_appengine_1.9.19.zip -o gae-download.zip
-	unzip -qq gae-download.zip -d $TOOLS_DIR/google_appengine_1.9.19/
-	rm gae-download.zip
+  echo "Downloading Google App Engine (this may take a little while)..."
+  mkdir -p $GOOGLE_APP_ENGINE_HOME
+  curl --silent https://storage.googleapis.com/appengine-sdks/deprecated/1919/google_appengine_1.9.19.zip -o gae-download.zip
+  # $? contains the (exit) status code of previous command.
+  # If curl was successful, $? will be 0 else non-zero.
+  if [ 0 -eq $? ]; then
+    echo "Download complete. Installing Google App Engine..."
+  else
+    echo "Error downloading Google App Engine. Exiting."
+    exit 1	
+  unzip -q gae-download.zip -d $TOOLS_DIR/google_appengine_1.9.19/
+  rm gae-download.zip
 fi
 
 export SETUP_GAE_DONE=true

--- a/scripts/setup_gae.sh
+++ b/scripts/setup_gae.sh
@@ -32,14 +32,12 @@ export PYTHONPATH=.:$COVERAGE_HOME:$GOOGLE_APP_ENGINE_HOME:$GOOGLE_APP_ENGINE_HO
 find . -iname "*.pyc" -exec rm -f {} \;
 
 # Moved from install .travis.yml.
-echo Exported paths for Google App Engine, checking if it needs to be installed.
+echo Checking if Google App Engine is installed in $GOOGLE_APP_ENGINE_HOME
 if [ ! -d "$GOOGLE_APP_ENGINE_HOME" ]; then
 	mkdir -p $GOOGLE_APP_ENGINE_HOME
 	curl --silent https://storage.googleapis.com/appengine-sdks/deprecated/1919/google_appengine_1.9.19.zip -o gae-download.zip
 	unzip -qq gae-download.zip -d $TOOLS_DIR/google_appengine_1.9.19/
 	rm gae-download.zip
-else
-	echo Google App Engine folder detected, no download commencing.
 fi
 
 export SETUP_GAE_DONE=true

--- a/scripts/setup_gae.sh
+++ b/scripts/setup_gae.sh
@@ -31,4 +31,14 @@ export PYTHONPATH=.:$COVERAGE_HOME:$GOOGLE_APP_ENGINE_HOME:$GOOGLE_APP_ENGINE_HO
 # Delete old *.pyc files
 find . -iname "*.pyc" -exec rm -f {} \;
 
+echo Exported paths for Google App Engine, checking if it needs to be installed.
+if [ ! -d "$GOOGLE_APP_ENGINE_HOME" ]; then
+	mkdir -p $GOOGLE_APP_ENGINE_HOME
+	curl --silent https://storage.googleapis.com/appengine-sdks/deprecated/1919/google_appengine_1.9.19.zip -o gae-download.zip
+	unzip -qq gae-download.zip -d $TOOLS_DIR/google_appengine_1.9.19/
+	rm gae-download.zip
+else
+	echo Google App Engine folder detected.
+fi
+
 export SETUP_GAE_DONE=true

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -43,23 +43,6 @@ source $(dirname $0)/setup.sh || exit 1
 source $(dirname $0)/setup_gae.sh || exit 1
 set -- "${remaining_params[@]}"
 
-echo Checking whether GAE is installed in $GOOGLE_APP_ENGINE_HOME
-if [ ! -f "$GOOGLE_APP_ENGINE_HOME/appcfg.py" ]; then
-  echo "Downloading Google App Engine (this may take a little while)..."
-  mkdir -p $GOOGLE_APP_ENGINE_HOME
-  curl --silent https://storage.googleapis.com/appengine-sdks/deprecated/1919/google_appengine_1.9.19.zip -o gae-download.zip
-  # $? contains the (exit) status code of previous command.
-  # If curl was successful, $? will be 0 else non-zero.
-  if [ 0 -eq $? ]; then
-    echo "Download complete. Installing Google App Engine..."
-  else
-    echo "Error downloading Google App Engine. Exiting."
-    exit 1
-  fi
-  unzip -q gae-download.zip -d $TOOLS_DIR/google_appengine_1.9.19/
-  rm gae-download.zip
-fi
-
 # Install third party dependencies.
 bash scripts/install_third_party.sh
 


### PR DESCRIPTION
Cached a few folders as per #1636, ran them through Travis to see how long build time takes now.

Times go (in minutes): only linting, only front-end testing, only back-end testing, back-end testing and coverage.
- [Build without caching](https://travis-ci.org/mcab/oppia/builds/117892359): 10, 7, 19, 115.
- [Caching ../node_modules](https://travis-ci.org/mcab/oppia/builds/117894736): 9, 6, 14, 120.
- [Caching all four folders](https://travis-ci.org/mcab/oppia/builds/117896812): 8, 3, 12, 115.

Had to resolve Google App Engine already existing in the cache, leading to [Travis not knowing what to do](https://travis-ci.org/mcab/oppia/builds/117896270). Moved making the directory, downloading, and extracting GAE to the proper folder into scripts/setup_gae.sh instead of having installation instructions in both .travis.yml and scripts/start.sh. This allows for one place to update the engine if ever need be.