### PR TITLE
Update textAngular to V 1.5.0

### DIFF
--- a/core/templates/dev/head/forms/formBuilder.js
+++ b/core/templates/dev/head/forms/formBuilder.js
@@ -681,6 +681,7 @@ oppia.config(['$provide', function($provide) {
         rteHelperService, alertsService, explorationContextService,
         PAGE_CONTEXT) {
       taOptions.disableSanitizer = true;
+      taOptions.forceTextAngularSanitize = false;
       taOptions.classes.textEditor = 'form-control oppia-rte-content';
       taOptions.setup.textEditorSetup = function($element) {
         $timeout(function() {

--- a/core/templates/dev/head/services/explorationContextService.js
+++ b/core/templates/dev/head/services/explorationContextService.js
@@ -19,7 +19,8 @@
 
 oppia.constant('PAGE_CONTEXT', {
   EDITOR: 'editor',
-  LEARNER: 'learner'
+  LEARNER: 'learner',
+  OTHER: 'other'
 });
 
 oppia.constant('EDITOR_TAB_CONTEXT', {
@@ -49,7 +50,8 @@ oppia.factory('explorationContextService', [
       },
       // Returns a string representing the context of the current page.
       // This is either PAGE_CONTEXT.EDITOR or PAGE_CONTEXT.LEARNER.
-      // If the current page is not one of these, an error is raised.
+      // If the current page is not one in either EDITOR or LEARNER then
+      // return PAGE_CONTEXT.OTHER
       getPageContext: function() {
         if (_pageContext) {
           return _pageContext;
@@ -65,9 +67,7 @@ oppia.factory('explorationContextService', [
             }
           }
 
-          throw Error(
-            'ERROR: explorationContextService should not be used outside the ' +
-            'context of an exploration.');
+          return PAGE_CONTEXT.OTHER;
         }
       },
       // Returns a string representing the explorationId (obtained from the

--- a/core/templates/dev/head/services/explorationContextServiceSpec.js
+++ b/core/templates/dev/head/services/explorationContextServiceSpec.js
@@ -94,9 +94,9 @@ describe('Exploration context service', function() {
       expect(ecs.getExplorationId).toThrow();
     });
 
-    it('should throw an error when trying to retrieve the page context',
+    it('should retrieve other as page context',
         function() {
-      expect(ecs.getPageContext).toThrow();
+      expect(ecs.getPageContext()).toBe('other');
     });
   });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -257,6 +257,16 @@
           "js": ["ng-infinite-scroll.min.js"]
         }
       },
+      "rangy": {
+        "version": "1.3.0",
+        "downloadFormat": "zip",
+        "url": "https://github.com/timdown/rangy/archive/1.3.0.zip",
+        "rootDirPrefix": "rangy-",
+        "targetDirPrefix": "rangy-",
+        "bundle": {
+          "js": ["lib/rangy-core.js", "lib/rangy-selectionsaverestore.js"]
+        }
+      },
       "select2": {
         "version": "3.5.1",
         "downloadFormat": "zip",
@@ -271,16 +281,14 @@
         }
       },
       "textAngular": {
-        "version": "1.3.7",
+        "version": "1.5.0",
         "downloadFormat": "zip",
-        "url": "https://github.com/fraywing/textAngular/archive/v1.3.7.zip",
+        "url": "https://github.com/fraywing/textAngular/archive/v1.5.0.zip",
         "rootDirPrefix": "textAngular-",
         "targetDirPrefix": "textAngular-",
         "bundle": {
-          "css": ["src/textAngular.css"],
-          "js": [
-            "src/textAngular.js", "src/textAngularSetup.js",
-            "dist/textAngular-rangy.min.js"]
+          "css": ["dist/textAngular.css"],
+          "js": ["dist/textAngular.js", "dist/textAngularSetup.js"]
         }
       },
       "uiBootstrap": {


### PR DESCRIPTION
This commit are intended to update textAngular to 1.5.0
Rangy is also added in dependencies to solve issues with new version of textAngular, since minified version of rangy provided in textAngular package broke some frontend tests.
Inclusion of rangy as independent dependency solves this issues and everything works as it is expected to.