### PR TITLE
Fix for italicized links on the sidebar #1631

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -494,6 +494,7 @@ textarea {
 }
 .oppia-sidebar-menu a {
   color: #333;
+  font-style: normal; /* Fix for italicized links on the sidebar #1631 */
   display: block;
   padding: 1em 0 1em 18px;
   text-decoration: none;

--- a/core/templates/dev/head/pages/privacy.html
+++ b/core/templates/dev/head/pages/privacy.html
@@ -318,7 +318,7 @@
         provide feedback, please send an e-mail to admin@oppia.org.
       </p>
 
-      <em>Last updated: 7 December 2015</h3>
+      <em>Last updated: 7 December 2015</h3></em>
     </md-card>
   </div>
 

--- a/core/templates/dev/head/pages/privacy.html
+++ b/core/templates/dev/head/pages/privacy.html
@@ -318,7 +318,7 @@
         provide feedback, please send an e-mail to admin@oppia.org.
       </p>
 
-      <em>Last updated: 7 December 2015</h3></em>
+      <em>Last updated: 7 December 2015</em>
     </md-card>
   </div>
 


### PR DESCRIPTION
Added universal font style on .oppia-sidebar-menu a to remove italicization on the sidebar links.