### PR TITLE
Fix for feedback status position. #1628

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1818,7 +1818,7 @@ oppia-parameter {
   height: 85px;
   margin-left: 10px;
   padding-left: 20px;
-  padding-right: 30px;
+  padding-right: 20px;
 }
 
 md-card.oppia-dashboard-tile {


### PR DESCRIPTION
Modified padding for .oppia-dashboard-tile-metadata to improve feedback status visibility within the exploration card.