### PR TITLE
Fix frontend tests in Vagrant VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure(2) do |config|
     v.memory = 1024
   end
   # General-purpose env var to let scripts know we are in Vagrant.
-  config.vm.provision "shell", inline: 'echo "export VAGRANT=true" >> ~/.profile'
+  config.vm.provision "shell", inline: 'echo "export VAGRANT=true" >> /etc/profile'
   # Tell apt to default to "yes" when installing packages. Necessary for unattended installs.
   config.vm.provision "shell", inline: 'echo \'APT::Get::Assume-Yes "true";\' > /etc/apt/apt.conf.d/90yes'
   config.vm.network "forwarded_port", guest: 8000, host: 8000

--- a/scripts/run_frontend_tests.sh
+++ b/scripts/run_frontend_tests.sh
@@ -60,14 +60,14 @@ echo ""
 echo "  Running test in development environment"
 echo ""
 
-$NODE_MODULE_DIR/karma/bin/karma start core/tests/karma.conf.js
+$XVFB_PREFIX $NODE_MODULE_DIR/karma/bin/karma start core/tests/karma.conf.js
 
 if [ "$RUN_MINIFIED_TESTS" = "true" ]; then
   echo ""
   echo "  Running test in production environment"
   echo ""
 
-  $NODE_MODULE_DIR/karma/bin/karma start core/tests/karma.conf.js --minify=True
+  $XVFB_PREFIX $NODE_MODULE_DIR/karma/bin/karma start core/tests/karma.conf.js --minify=True
 fi
 
 echo Done!

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -199,7 +199,7 @@ elif [ "$VAGRANT" = true ]; then
     # Used in frontend and e2e tests. Only gets set if using Vagrant VM.
     export XVFB_PREFIX="/usr/bin/xvfb-run"
     # Enforce proper ownership on Oppia and oppia_tools or else NPM installs will fail.
-    sudo chown -R vagrant.vagrant /home/vagrant/oppia*
+    sudo chown -R vagrant.vagrant /home/vagrant/oppia /home/vagrant/oppia_tools
 elif [ -f "/usr/bin/google-chrome" ]; then
   # Unix.
   export CHROME_BIN="/usr/bin/google-chrome"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -190,9 +190,9 @@ if [ ! -d "$NODE_PATH" ]; then
 fi
 
 # Adjust path to support the default Chrome locations for Unix, Windows and Mac OS.
-if [ $TRAVIS = 'true' ]; then
+if [ $TRAVIS = true ]; then
   export CHROME_BIN="chromium-browser"
-elif [ $VAGRANT = 'true' ]; then
+elif [ $VAGRANT = true ]; then
     # Required for headless testing in Vagrant
     sudo apt-get install xvfb chromium-browser
     export CHROME_BIN="chromium-browser"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -190,12 +190,16 @@ if [ ! -d "$NODE_PATH" ]; then
 fi
 
 # Adjust path to support the default Chrome locations for Unix, Windows and Mac OS.
-if [ $VAGRANT = 'true' ] || [ $TRAVIS = 'true' ] ; then
+if [ $VAGRANT = 'true' ]; then
   export CHROME_BIN="chromium-browser"
-  # Used in frontend and e2e tests. Only gets set if using Vagrant VM.
-  export XVFB_PREFIX="/usr/bin/xvfb-run"
-  # Enforce proper ownership on Oppia and oppia_tools or else NPM installs will fail.
-  sudo chown -R vagrant.vagrant /home/vagrant/oppia*
+elif [ $TRAVIS = 'true' ]; then
+    # Required for headless testing in Vagrant
+    sudo apt-get install xvfb chromium-browser
+    export CHROME_BIN="chromium-browser"
+    # Used in frontend and e2e tests. Only gets set if using Vagrant VM.
+    export XVFB_PREFIX="/usr/bin/xvfb-run"
+    # Enforce proper ownership on Oppia and oppia_tools or else NPM installs will fail.
+    sudo chown -R vagrant.vagrant /home/vagrant/oppia*
 elif [ -f "/usr/bin/google-chrome" ]; then
   # Unix.
   export CHROME_BIN="/usr/bin/google-chrome"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -190,9 +190,9 @@ if [ ! -d "$NODE_PATH" ]; then
 fi
 
 # Adjust path to support the default Chrome locations for Unix, Windows and Mac OS.
-if [ $VAGRANT = 'true' ]; then
+if [ $TRAVIS = 'true' ]; then
   export CHROME_BIN="chromium-browser"
-elif [ $TRAVIS = 'true' ]; then
+elif [ $VAGRANT = 'true' ]; then
     # Required for headless testing in Vagrant
     sudo apt-get install xvfb chromium-browser
     export CHROME_BIN="chromium-browser"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -190,12 +190,12 @@ if [ ! -d "$NODE_PATH" ]; then
 fi
 
 # Adjust path to support the default Chrome locations for Unix, Windows and Mac OS.
-if [ $TRAVIS = true ]; then
-  export CHROME_BIN="chromium-browser"
-elif [ $VAGRANT = true ]; then
-    # Required for headless testing in Vagrant
+if [ "$TRAVIS" = true ]; then
+  export CHROME_BIN="/usr/bin/chromium-browser"
+elif [ "$VAGRANT" = true ]; then
+    # XVFB is required for headless testing in Vagrant
     sudo apt-get install xvfb chromium-browser
-    export CHROME_BIN="chromium-browser"
+    export CHROME_BIN="/usr/bin/chromium-browser"
     # Used in frontend and e2e tests. Only gets set if using Vagrant VM.
     export XVFB_PREFIX="/usr/bin/xvfb-run"
     # Enforce proper ownership on Oppia and oppia_tools or else NPM installs will fail.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -190,7 +190,7 @@ if [ ! -d "$NODE_PATH" ]; then
 fi
 
 # Adjust path to support the default Chrome locations for Unix, Windows and Mac OS.
-if [ $VAGRANT = 'true' ]; then
+if [ $VAGRANT = 'true' ] || [ $TRAVIS = 'true' ] ; then
   export CHROME_BIN="chromium-browser"
   # Used in frontend and e2e tests. Only gets set if using Vagrant VM.
   export XVFB_PREFIX="/usr/bin/xvfb-run"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -190,8 +190,12 @@ if [ ! -d "$NODE_PATH" ]; then
 fi
 
 # Adjust path to support the default Chrome locations for Unix, Windows and Mac OS.
-if [[ $TRAVIS == 'true' ]]; then
+if [ $VAGRANT = 'true' ]; then
   export CHROME_BIN="chromium-browser"
+  # Used in frontend and e2e tests. Only gets set if using Vagrant VM.
+  export XVFB_PREFIX="/usr/bin/xvfb-run"
+  # Enforce proper ownership on Oppia and oppia_tools or else NPM installs will fail.
+  sudo chown -R vagrant.vagrant /home/vagrant/oppia*
 elif [ -f "/usr/bin/google-chrome" ]; then
   # Unix.
   export CHROME_BIN="/usr/bin/google-chrome"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -193,13 +193,13 @@ fi
 if [ "$TRAVIS" = true ]; then
   export CHROME_BIN="/usr/bin/chromium-browser"
 elif [ "$VAGRANT" = true ]; then
-    # XVFB is required for headless testing in Vagrant
-    sudo apt-get install xvfb chromium-browser
-    export CHROME_BIN="/usr/bin/chromium-browser"
-    # Used in frontend and e2e tests. Only gets set if using Vagrant VM.
-    export XVFB_PREFIX="/usr/bin/xvfb-run"
-    # Enforce proper ownership on Oppia and oppia_tools or else NPM installs will fail.
-    sudo chown -R vagrant.vagrant /home/vagrant/oppia /home/vagrant/oppia_tools
+  # XVFB is required for headless testing in Vagrant
+  sudo apt-get install xvfb chromium-browser
+  export CHROME_BIN="/usr/bin/chromium-browser"
+  # Used in frontend and e2e tests. Only gets set if using Vagrant VM.
+  export XVFB_PREFIX="/usr/bin/xvfb-run"
+  # Enforce proper ownership on Oppia and oppia_tools or else NPM installs will fail.
+  sudo chown -R vagrant.vagrant /home/vagrant/oppia /home/vagrant/oppia_tools
 elif [ -f "/usr/bin/google-chrome" ]; then
   # Unix.
   export CHROME_BIN="/usr/bin/google-chrome"


### PR DESCRIPTION
Install XVFB and adjust setup.sh to prepend `xvfb-run` to frontend test commands if using Vagrant. 