### PR TITLE
Fixes #1662: Music notes add response dialog does not work

### DIFF
--- a/core/templates/dev/head/components/RuleTypeSelectorDirective.js
+++ b/core/templates/dev/head/components/RuleTypeSelectorDirective.js
@@ -83,6 +83,10 @@ oppia.directive('ruleTypeSelector', [function() {
 
         $(select2Node).on('change', function(e) {
           $scope.onSelectionChange()(e.val);
+          // This is needed to propagate the change and display input fields
+          // for parameterizing the rule. Otherwise, the input fields do not
+          // get updated when the rule type is changed.
+          $scope.$apply();
         });
       }
     ]


### PR DESCRIPTION
This PR to fix a major bug mentioned in issue #1662
It was due to removing the data binding in a previous commit 0f400f21c6cc70d44d98f2628929c33ded07b1e6
