### PR TITLE
In the logged-out version of the editor view, the feedback tab overlaps the sign-in menu. #1679

### DIFF
--- a/core/templates/dev/head/editor/exploration_editor.html
+++ b/core/templates/dev/head/editor/exploration_editor.html
@@ -65,7 +65,7 @@
 {% endblock navbar_breadcrumb %}
 
 {% block local_top_nav_options %}
-  <ul class="nav navbar-nav oppia-navbar-nav navbar-right ng-cloak" ng-controller="EditorNavigation" style="margin-left: 20px;">
+  <ul class="nav navbar-nav oppia-navbar-nav pull-right ng-cloak" ng-controller="EditorNavigation" style="margin-left: 20px;">
     <li ng-class="{'active': getTabStatuses().active === 'main', 'dropdown': countWarnings()}">
       <a href="#" tooltip="Editor" tooltip-placement="<[countWarnings() ? 'left' : 'bottom']>" ng-click="selectMainTab()" class="protractor-test-main-tab">
         <i class="material-icons">&#xE254;</i>


### PR DESCRIPTION
Fixes #1679