### PR TITLE
Add preference for membership notifications in UserEmailPreferencesModel and relevant changes

### DIFF
--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -156,7 +156,8 @@ class PreferencesHandler(base.BaseHandler):
         elif update_type == 'profile_picture_data_url':
             user_services.update_profile_picture_data_url(self.user_id, data)
         elif update_type == 'can_receive_email_updates':
-            user_services.update_email_preferences(self.user_id, data)
+            user_services.update_email_preferences(
+                self.user_id, data, feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
         else:
             raise self.InvalidInputException(
                 'Invalid update type: %s' % update_type)
@@ -266,7 +267,8 @@ class SignupHandler(base.BaseHandler):
 
         if can_receive_email_updates is not None:
             user_services.update_email_preferences(
-                self.user_id, can_receive_email_updates)
+                self.user_id, can_receive_email_updates,
+                feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
 
         # Note that an email is only sent when the user registers for the first
         # time.

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -170,11 +170,17 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', True):
             self.assertEqual(
                 user_services.get_email_preferences(editor_id),
-                {'can_receive_email_updates': True})
+                {
+                    'can_receive_email_updates': True,
+                    'can_receive_membership_email': True
+                })
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
             self.assertEqual(
                 user_services.get_email_preferences(editor_id),
-                {'can_receive_email_updates': False})
+                {
+                    'can_receive_email_updates': False,
+                    'can_receive_membership_email': True
+                })
 
     def test_user_allowing_emails_on_signup(self):
         self.login(self.EDITOR_EMAIL)
@@ -191,11 +197,17 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', True):
             self.assertEqual(
                 user_services.get_email_preferences(editor_id),
-                {'can_receive_email_updates': True})
+                {
+                    'can_receive_email_updates': True,
+                    'can_receive_membership_email': True
+                })
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
             self.assertEqual(
                 user_services.get_email_preferences(editor_id),
-                {'can_receive_email_updates': True})
+                {
+                    'can_receive_email_updates': True,
+                    'can_receive_membership_email': True
+                })
 
     def test_user_disallowing_emails_on_signup(self):
         self.login(self.EDITOR_EMAIL)
@@ -212,11 +224,17 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', True):
             self.assertEqual(
                 user_services.get_email_preferences(editor_id),
-                {'can_receive_email_updates': False})
+                {
+                    'can_receive_email_updates': False,
+                    'can_receive_membership_email': True
+                })
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
             self.assertEqual(
                 user_services.get_email_preferences(editor_id),
-                {'can_receive_email_updates': False})
+                {
+                    'can_receive_email_updates': False,
+                    'can_receive_membership_email': True
+                })
 
 
 class ProfileLinkTests(test_utils.GenericTestBase):

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -172,14 +172,16 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
                 user_services.get_email_preferences(editor_id),
                 {
                     'can_receive_email_updates': True,
-                    'can_receive_membership_email': True
+                    'can_receive_editor_role_email': (
+                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
                 })
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
             self.assertEqual(
                 user_services.get_email_preferences(editor_id),
                 {
                     'can_receive_email_updates': False,
-                    'can_receive_membership_email': True
+                    'can_receive_editor_role_email': (
+                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
                 })
 
     def test_user_allowing_emails_on_signup(self):
@@ -199,14 +201,16 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
                 user_services.get_email_preferences(editor_id),
                 {
                     'can_receive_email_updates': True,
-                    'can_receive_membership_email': True
+                    'can_receive_editor_role_email': (
+                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
                 })
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
             self.assertEqual(
                 user_services.get_email_preferences(editor_id),
                 {
                     'can_receive_email_updates': True,
-                    'can_receive_membership_email': True
+                    'can_receive_editor_role_email': (
+                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
                 })
 
     def test_user_disallowing_emails_on_signup(self):
@@ -226,14 +230,16 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
                 user_services.get_email_preferences(editor_id),
                 {
                     'can_receive_email_updates': False,
-                    'can_receive_membership_email': True
+                    'can_receive_editor_role_email': (
+                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
                 })
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
             self.assertEqual(
                 user_services.get_email_preferences(editor_id),
                 {
                     'can_receive_email_updates': False,
-                    'can_receive_membership_email': True
+                    'can_receive_editor_role_email': (
+                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
                 })
 
 

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -406,7 +406,10 @@ def record_user_started_state_editor_tutorial(user_id):
     _save_user_settings(user_settings)
 
 
-def update_email_preferences(user_id, can_receive_email_updates):
+def update_email_preferences(
+        user_id, can_receive_email_updates,
+        can_receive_membership_email=(
+            feconf.DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE)):
     """Updates whether the user has chosen to receive email updates.
 
     If no UserEmailPreferencesModel exists for this user, a new one will
@@ -419,6 +422,8 @@ def update_email_preferences(user_id, can_receive_email_updates):
             id=user_id)
 
     email_preferences_model.site_updates = can_receive_email_updates
+    email_preferences_model.membership_notifications = (
+        can_receive_membership_email)
     email_preferences_model.put()
 
 
@@ -432,7 +437,11 @@ def get_email_preferences(user_id):
         'can_receive_email_updates': (
             feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE
             if email_preferences_model is None
-            else email_preferences_model.site_updates)
+            else email_preferences_model.site_updates),
+        'can_receive_membership_email': (
+            feconf.DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE
+            if email_preferences_model is None
+            else email_preferences_model.membership_notifications)
     }
 
 

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -407,9 +407,7 @@ def record_user_started_state_editor_tutorial(user_id):
 
 
 def update_email_preferences(
-        user_id, can_receive_email_updates,
-        can_receive_membership_email=(
-            feconf.DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE)):
+        user_id, can_receive_email_updates, can_receive_editor_role_email):
     """Updates whether the user has chosen to receive email updates.
 
     If no UserEmailPreferencesModel exists for this user, a new one will
@@ -422,8 +420,8 @@ def update_email_preferences(
             id=user_id)
 
     email_preferences_model.site_updates = can_receive_email_updates
-    email_preferences_model.membership_notifications = (
-        can_receive_membership_email)
+    email_preferences_model.editor_role_notifications = (
+        can_receive_editor_role_email)
     email_preferences_model.put()
 
 
@@ -438,10 +436,10 @@ def get_email_preferences(user_id):
             feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE
             if email_preferences_model is None
             else email_preferences_model.site_updates),
-        'can_receive_membership_email': (
-            feconf.DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE
+        'can_receive_editor_role_email': (
+            feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE
             if email_preferences_model is None
-            else email_preferences_model.membership_notifications)
+            else email_preferences_model.editor_role_notifications)
     }
 
 

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -147,8 +147,8 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             email_preferences['can_receive_editor_role_email'],
             feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
 
-        # When UserEmailPreferencesModel is created for user,
-        # value returned stored in UserEmailPreferencesModel should be Default.
+        # The user retrieves their email preferences. This initializes,
+        # a UserEmailPreferencesModel instance with the default values
         user_services.update_email_preferences(
             user_id, feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE,
             feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -148,7 +148,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
 
         # The user retrieves their email preferences. This initializes,
-        # a UserEmailPreferencesModel instance with the default values
+        # a UserEmailPreferencesModel instance with the default values.
         user_services.update_email_preferences(
             user_id, feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE,
             feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -132,6 +132,40 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         self.assertIsNone(
             user_services.get_user_id_from_username('fakeUsername'))
 
+    def test_set_and_get_user_email_preferences(self):
+        user_id = 'someUser'
+        username = 'username'
+        user_email = 'user@example.com'
+
+        user_services.get_or_create_user(user_id, user_email)
+        user_services.set_username(user_id, username)
+
+        # When UserEmailPreferencesModel is yet to be created value of
+        # membership email preference should be True by default
+        email_preferences = user_services.get_email_preferences(user_id)
+        self.assertEquals(
+            email_preferences['can_receive_membership_email'],
+            feconf.DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE)
+
+        user_services.update_email_preferences(
+            user_id, feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE)
+
+        # When nothing is specified for membership email notifications
+        # it should be True by default
+        email_preferences = user_services.get_email_preferences(user_id)
+        self.assertEquals(
+            email_preferences['can_receive_membership_email'],
+            feconf.DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE)
+
+        # Change preference for receiving membership emails to False
+        user_services.update_email_preferences(
+            user_id, feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE, False)
+
+        email_preferences = user_services.get_email_preferences(user_id)
+        self.assertEquals(
+            email_preferences['can_receive_membership_email'],
+            False)
+
 
 class UpdateContributionMsecTests(test_utils.GenericTestBase):
     """Test whether contribution date changes with publication of

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -147,7 +147,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             email_preferences['can_receive_editor_role_email'],
             feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
 
-        # The user retrieves their email preferences. This initializes,
+        # The user retrieves their email preferences. This initializes
         # a UserEmailPreferencesModel instance with the default values.
         user_services.update_email_preferences(
             user_id, feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE,

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -140,30 +140,31 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         user_services.get_or_create_user(user_id, user_email)
         user_services.set_username(user_id, username)
 
-        # When UserEmailPreferencesModel is yet to be created value of
-        # membership email preference should be True by default
+        # When UserEmailPreferencesModel is yet to be created,
+        # the value returned by get_email_preferences() should be True.
         email_preferences = user_services.get_email_preferences(user_id)
         self.assertEquals(
-            email_preferences['can_receive_membership_email'],
-            feconf.DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE)
+            email_preferences['can_receive_editor_role_email'],
+            feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
 
+        # When UserEmailPreferencesModel is created for user,
+        # value returned stored in UserEmailPreferencesModel should be Default.
         user_services.update_email_preferences(
-            user_id, feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE)
+            user_id, feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE,
+            feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
 
-        # When nothing is specified for membership email notifications
-        # it should be True by default
         email_preferences = user_services.get_email_preferences(user_id)
         self.assertEquals(
-            email_preferences['can_receive_membership_email'],
-            feconf.DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE)
+            email_preferences['can_receive_editor_role_email'],
+            feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
 
-        # Change preference for receiving membership emails to False
+        # The user sets their membership email preference to False.
         user_services.update_email_preferences(
             user_id, feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE, False)
 
         email_preferences = user_services.get_email_preferences(user_id)
         self.assertEquals(
-            email_preferences['can_receive_membership_email'],
+            email_preferences['can_receive_editor_role_email'],
             False)
 
 

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -99,7 +99,7 @@ class UserEmailPreferencesModel(base_models.BaseModel):
     # The user's preference for receiving email when user is added as a member
     # in exploration. This is set to True when user has never set a preference.
     editor_role_notifications = ndb.BooleanProperty(
-        indexed=False, default=feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
+        indexed=True, default=feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
 
 
 class UserSubscriptionsModel(base_models.BaseModel):

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -96,6 +96,11 @@ class UserEmailPreferencesModel(base_models.BaseModel):
     # None if the user has never set a preference.
     site_updates = ndb.BooleanProperty(indexed=True)
 
+    # The user's preference for receiving email when user is added as a member
+    # in exploration. This is set to True when user has never set a preference.
+    membership_notifications = ndb.BooleanProperty(
+        indexed=False, default=feconf.DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE)
+
 
 class UserSubscriptionsModel(base_models.BaseModel):
     """A list of things that a user subscribes to.

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -98,8 +98,8 @@ class UserEmailPreferencesModel(base_models.BaseModel):
 
     # The user's preference for receiving email when user is added as a member
     # in exploration. This is set to True when user has never set a preference.
-    membership_notifications = ndb.BooleanProperty(
-        indexed=False, default=feconf.DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE)
+    editor_role_notifications = ndb.BooleanProperty(
+        indexed=False, default=feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
 
 
 class UserSubscriptionsModel(base_models.BaseModel):

--- a/feconf.py
+++ b/feconf.py
@@ -155,6 +155,8 @@ CAN_SEND_EMAILS_TO_ADMIN = False
 CAN_SEND_EMAILS_TO_USERS = False
 # Whether to send email updates to a user who has not specified a preference.
 DEFAULT_EMAIL_UPDATES_PREFERENCE = False
+# Whther to send membership email when user who has not specified a preference.
+DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE = True
 # Whether to require an email to be sent, following a moderator action.
 REQUIRE_EMAIL_ON_MODERATOR_ACTION = False
 # Whether to allow custom event reporting to Google Analytics.

--- a/feconf.py
+++ b/feconf.py
@@ -155,7 +155,8 @@ CAN_SEND_EMAILS_TO_ADMIN = False
 CAN_SEND_EMAILS_TO_USERS = False
 # Whether to send email updates to a user who has not specified a preference.
 DEFAULT_EMAIL_UPDATES_PREFERENCE = False
-# Whther to send membership email when user who has not specified a preference.
+# Whether to send an invitation email when the user is granted
+# new role permissions in an exploration.
 DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE = True
 # Whether to require an email to be sent, following a moderator action.
 REQUIRE_EMAIL_ON_MODERATOR_ACTION = False

--- a/feconf.py
+++ b/feconf.py
@@ -156,7 +156,7 @@ CAN_SEND_EMAILS_TO_USERS = False
 # Whether to send email updates to a user who has not specified a preference.
 DEFAULT_EMAIL_UPDATES_PREFERENCE = False
 # Whther to send membership email when user who has not specified a preference.
-DEFAULT_MEMBERSHIP_EMAIL_PREFERENCE = True
+DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE = True
 # Whether to require an email to be sent, following a moderator action.
 REQUIRE_EMAIL_ON_MODERATOR_ACTION = False
 # Whether to allow custom event reporting to Google Analytics.


### PR DESCRIPTION
First milestone of #1357 
Changes:
  - Modifies UserEmailPreferencesModel
  - Modifies user_services.update_email_preferences()
  - Modifies user_services.get_email_preferences()
  - Add Default value for membership notifications in feconf
  - A backend test is also added in user_services_test.py