### PR TITLE
Jump to particular state in preview mode

### DIFF
--- a/core/templates/dev/head/editor/ExplorationEditor.js
+++ b/core/templates/dev/head/editor/ExplorationEditor.js
@@ -134,7 +134,7 @@ oppia.controller('ExplorationEditor', [
 
         if (!routerService.isLocationSetToNonStateEditorTab() &&
             !data.states.hasOwnProperty(
-              routerService.getCurrentStateFromLocationPath())) {
+              routerService.getCurrentStateFromLocationPath('gui'))) {
           routerService.navigateToMainTab();
         }
 

--- a/core/templates/dev/head/editor/ExplorationPreview.js
+++ b/core/templates/dev/head/editor/ExplorationPreview.js
@@ -18,13 +18,15 @@
  */
 
 oppia.controller('ExplorationPreview', [
-  '$scope', '$timeout', 'LearnerParamsService', 'explorationData',
+  '$scope', '$timeout', 'LearnerParamsService',
+  'explorationData', 'editorContextService',
   'explorationStatesService', 'explorationInitStateNameService',
   'explorationParamSpecsService', 'explorationTitleService',
   'explorationCategoryService', 'explorationParamChangesService',
   'explorationGadgetsService', 'oppiaPlayerService',
   function(
-      $scope, $timeout, LearnerParamsService, explorationData,
+      $scope, $timeout, LearnerParamsService,
+      explorationData, editorContextService,
       explorationStatesService, explorationInitStateNameService,
       explorationParamSpecsService, explorationTitleService,
       explorationCategoryService, explorationParamChangesService,
@@ -59,5 +61,31 @@ oppia.controller('ExplorationPreview', [
     $scope.$on('playerStateChange', function() {
       $scope.allParams = LearnerParamsService.getAllParams();
     });
+
+    explorationData.getData().then($scope._refreshPreviewTab = function() {
+      var newStateName = explorationInitStateNameService;
+
+      if (angular.equals({}, explorationParamSpecsService.savedMemento)) {
+        newStateName.init(editorContextService.getActiveStateName());
+      }
+      // TODO(oparry): This conditional is a temporary fix meant to prevent
+      // starting a preview from the middle of an exploration if the exploration
+      // makes use of parameters. Once manual entry of parameter values is
+      // supported, remove the if (but not newStateName.init...)
+
+      oppiaPlayerService.populateExploration({
+        category: explorationCategoryService.savedMemento,
+        init_state_name: newStateName.savedMemento,
+        param_changes: explorationParamChangesService.savedMemento,
+        param_specs: explorationParamSpecsService.savedMemento,
+        states: explorationStatesService.getStates(),
+        title: explorationTitleService.savedMemento,
+        skin_customizations: {
+          panels_contents: explorationGadgetsService.getPanelsContents()
+        }
+      });
+    });
+
+    $scope.$on('refreshPreviewTab', $scope._refreshPreviewTab);
   }
 ]);

--- a/core/templates/dev/head/player/PlayerServices.js
+++ b/core/templates/dev/head/player/PlayerServices.js
@@ -30,12 +30,14 @@ oppia.constant('INTERACTION_SPECS', GLOBALS.INTERACTION_SPECS);
 // and audit it to ensure it behaves differently for learner mode and editor
 // mode. Add tests to ensure this.
 oppia.factory('oppiaPlayerService', [
+  '$http', '$location', '$rootScope', '$q', 'LearnerParamsService',
   '$http', '$rootScope', '$q', 'LearnerParamsService',
   'alertsService', 'answerClassificationService', 'explorationContextService',
   'PAGE_CONTEXT', 'oppiaExplorationHtmlFormatterService',
   'playerTranscriptService', 'ExplorationObjectFactory',
   'expressionInterpolationService', 'StatsReportingService',
   function(
+      $http, $location, $rootScope, $q, LearnerParamsService,
       $http, $rootScope, $q, LearnerParamsService,
       alertsService, answerClassificationService, explorationContextService,
       PAGE_CONTEXT, oppiaExplorationHtmlFormatterService,
@@ -315,6 +317,7 @@ oppia.factory('oppiaPlayerService', [
             }
           }
 
+          $location.path('/preview/' + newStateName);
           $rootScope.$broadcast('playerStateChange');
           successCallback(
             newStateName, refreshInteraction, feedbackHtml, questionHtml,


### PR DESCRIPTION
Stay on the same state of an exploration when switching between edit and preview modes. (Milestone 1 of #921).

1. When switching to preview, the URL is constructed using the current state name.
2. The URL is reconstructed when moving to the next state in preview mode (correct answer submitted).
3. When a preview URL is detected, the state name is extracted and the preview tab is refreshed accordingly.

Explorations with parameters are not properly handled yet, so 3. always begins the preview in the initial state.  N.B. - the URL is still constructed using the active state, so it is wrong until returning to edit mode or moving on to the next state.
