### PR TITLE
Add checkbox for editor role emails receiving agreement on preferences page

### DIFF
--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -131,13 +131,17 @@ class PreferencesHandler(base.BaseHandler):
     def get(self):
         """Handles GET requests."""
         user_settings = user_services.get_user_settings(self.user_id)
+        user_email_preferences = user_services.get_email_preferences(
+            self.user_id)
         self.values.update({
             'preferred_language_codes': user_settings.preferred_language_codes,
             'profile_picture_data_url': user_settings.profile_picture_data_url,
             'user_bio': user_settings.user_bio,
             'subject_interests': user_settings.subject_interests,
-            'can_receive_email_updates': user_services.get_email_preferences(
-                self.user_id)['can_receive_email_updates'],
+            'can_receive_email_updates': (
+                user_email_preferences['can_receive_email_updates']),
+            'can_receive_editor_role_email': (
+                user_email_preferences['can_receive_editor_role_email'])
         })
         self.render_json(self.values)
 
@@ -155,9 +159,10 @@ class PreferencesHandler(base.BaseHandler):
             user_services.update_preferred_language_codes(self.user_id, data)
         elif update_type == 'profile_picture_data_url':
             user_services.update_profile_picture_data_url(self.user_id, data)
-        elif update_type == 'can_receive_email_updates':
+        elif update_type == 'update_email_preferences':
             user_services.update_email_preferences(
-                self.user_id, data, feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
+                self.user_id, data['can_receive_email_updates'],
+                data['can_receive_editor_role_email'])
         else:
             raise self.InvalidInputException(
                 'Invalid update type: %s' % update_type)

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -159,7 +159,7 @@ class PreferencesHandler(base.BaseHandler):
             user_services.update_preferred_language_codes(self.user_id, data)
         elif update_type == 'profile_picture_data_url':
             user_services.update_profile_picture_data_url(self.user_id, data)
-        elif update_type == 'update_email_preferences':
+        elif update_type == 'email_preferences':
             user_services.update_email_preferences(
                 self.user_id, data['can_receive_email_updates'],
                 data['can_receive_editor_role_email'])

--- a/core/templates/dev/head/profile/Preferences.js
+++ b/core/templates/dev/head/profile/Preferences.js
@@ -73,8 +73,13 @@ oppia.controller('Preferences', [
     }
   };
 
-  $scope.saveCanReceiveEmailUpdates = function(canReceiveEmailUpdates) {
-    _saveDataItem('can_receive_email_updates', canReceiveEmailUpdates);
+  $scope.saveEmailPreferences = function(
+    canReceiveEmailUpdates, canReceiveEditorRoleEmail) {
+    var data = {
+      can_receive_email_updates: canReceiveEmailUpdates,
+      can_receive_editor_role_email: canReceiveEditorRoleEmail
+    };
+    _saveDataItem('update_email_preferences', data);
   };
 
   $scope.savePreferredLanguageCodes = function(preferredLanguageCodes) {
@@ -159,6 +164,7 @@ oppia.controller('Preferences', [
     $scope.preferredLanguageCodes = data.preferred_language_codes;
     $scope.profilePictureDataUrl = data.profile_picture_data_url;
     $scope.canReceiveEmailUpdates = data.can_receive_email_updates;
+    $scope.canReceiveEditorRoleEmail = data.can_receive_editor_role_email;
     $scope.hasPageLoaded = true;
   });
 }]);

--- a/core/templates/dev/head/profile/Preferences.js
+++ b/core/templates/dev/head/profile/Preferences.js
@@ -79,7 +79,7 @@ oppia.controller('Preferences', [
       can_receive_email_updates: canReceiveEmailUpdates,
       can_receive_editor_role_email: canReceiveEditorRoleEmail
     };
-    _saveDataItem('update_email_preferences', data);
+    _saveDataItem('email_preferences', data);
   };
 
   $scope.savePreferredLanguageCodes = function(preferredLanguageCodes) {

--- a/core/templates/dev/head/profile/PreferencesSpec.js
+++ b/core/templates/dev/head/profile/PreferencesSpec.js
@@ -14,19 +14,23 @@
 
 describe('Preferences Controller', function() {
   describe('PreferencesCtrl', function() {
-    var scope, ctrl, $Http;
+    var scope, ctrl, $httpBackend, default_editor_role_email, op;
 
     beforeEach(function() {
       module('oppia');
     });
 
-    beforeEach(inject(function(_$httpBackend_, $http, $rootScope, $controller) {
-      _$httpBackend_.expectGET('/signuphandler/data').respond({
-        username: 'myUsername',
-        has_agreed_to_latest_terms: true
+    beforeEach(inject(function(_$httpBackend_, $http, $rootScope, $controller, oppiaHtmlEscaper) {
+      $httpBackend = _$httpBackend_;
+      default_editor_role_email = true;
+      $httpBackend.expectGET('/preferenceshandler/data').respond({
+          can_receive_email_updates: false,
+          can_receive_editor_role_email: default_editor_role_email
       });
-
-      $Http = $http;
+      op = oppiaHtmlEscaper;
+      //$httpBackendPut.expectPUT('/preferenceshandler/data', function(data) {
+        //default_editor_role_email = data.data.can_receive_editor_role_email;
+      //}).respond({});
 
       mockAlertsService = {};
 
@@ -42,17 +46,8 @@ describe('Preferences Controller', function() {
 
     it('should show that editor role notifications checkbox is true by default',
       function() {
-        $Http.get(scope._PREFERENCES_DATA_URL).then(function(response) {
-          expect(response.data.can_receive_editor_role_email).toBe(true);
-        });
-      });
-
-    it('should set editor role checkbox to false and get correct updated value',
-      function() {
-        scope.saveEmailPreferences(true, false);
-        $Http.get(scope._PREFERENCES_DATA_URL).then(function(response) {
-          expect(response.data.can_receive_editor_role_email).toBe(false);
-        });
+        $httpBackend.flush();
+        expect(scope.canReceiveEditorRoleEmail).toBe(default_editor_role_email);
       });
   });
 });

--- a/core/templates/dev/head/profile/PreferencesSpec.js
+++ b/core/templates/dev/head/profile/PreferencesSpec.js
@@ -14,23 +14,18 @@
 
 describe('Preferences Controller', function() {
   describe('PreferencesCtrl', function() {
-    var scope, ctrl, $httpBackend, default_editor_role_email, op;
+    var scope, ctrl, $httpBackend, mockAlertsService;
 
     beforeEach(function() {
       module('oppia');
     });
 
-    beforeEach(inject(function(_$httpBackend_, $http, $rootScope, $controller, oppiaHtmlEscaper) {
+    beforeEach(inject(function(_$httpBackend_, $http, $rootScope, $controller) {
       $httpBackend = _$httpBackend_;
-      default_editor_role_email = true;
       $httpBackend.expectGET('/preferenceshandler/data').respond({
-          can_receive_email_updates: false,
-          can_receive_editor_role_email: default_editor_role_email
+        can_receive_email_updates: false,
+        can_receive_editor_role_email: true
       });
-      op = oppiaHtmlEscaper;
-      //$httpBackendPut.expectPUT('/preferenceshandler/data', function(data) {
-        //default_editor_role_email = data.data.can_receive_editor_role_email;
-      //}).respond({});
 
       mockAlertsService = {};
 
@@ -47,7 +42,7 @@ describe('Preferences Controller', function() {
     it('should show that editor role notifications checkbox is true by default',
       function() {
         $httpBackend.flush();
-        expect(scope.canReceiveEditorRoleEmail).toBe(default_editor_role_email);
+        expect(scope.canReceiveEditorRoleEmail).toBe(true);
       });
   });
 });

--- a/core/templates/dev/head/profile/PreferencesSpec.js
+++ b/core/templates/dev/head/profile/PreferencesSpec.js
@@ -14,15 +14,14 @@
 
 describe('Preferences Controller', function() {
   describe('PreferencesCtrl', function() {
-    var scope, $httpbackend, ctrl, rootScope, $Http;
+    var scope, ctrl, $Http;
 
     beforeEach(function() {
       module('oppia');
     });
 
     beforeEach(inject(function(_$httpBackend_, $http, $rootScope, $controller) {
-      $httpbackend = _$httpBackend_;
-      $httpbackend.expectGET('/signuphandler/data').respond({
+      _$httpBackend_.expectGET('/signuphandler/data').respond({
         username: 'myUsername',
         has_agreed_to_latest_terms: true
       });

--- a/core/templates/dev/head/profile/PreferencesSpec.js
+++ b/core/templates/dev/head/profile/PreferencesSpec.js
@@ -1,0 +1,59 @@
+// Copyright 2014 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+describe('Preferences Controller', function() {
+  describe('PreferencesCtrl', function() {
+    var scope, $httpbackend, ctrl, rootScope, $Http;
+
+    beforeEach(function() {
+      module('oppia');
+    });
+
+    beforeEach(inject(function(_$httpBackend_, $http, $rootScope, $controller) {
+      $httpbackend = _$httpBackend_;
+      $httpbackend.expectGET('/signuphandler/data').respond({
+        username: 'myUsername',
+        has_agreed_to_latest_terms: true
+      });
+
+      $Http = $http;
+
+      mockAlertsService = {};
+
+      scope = $rootScope.$new();
+
+      ctrl = $controller('Preferences', {
+        $scope: scope,
+        $http: $http,
+        $rootScope: $rootScope,
+        alertsService: mockAlertsService
+      });
+    }));
+
+    it('should show that editor role notifications checkbox is true by default',
+      function() {
+        $Http.get(scope._PREFERENCES_DATA_URL).then(function(response) {
+          expect(response.data.can_receive_editor_role_email).toBe(true);
+        });
+      });
+
+    it('should set editor role checkbox to false and get correct updated value',
+      function() {
+        scope.saveEmailPreferences(true, false);
+        $Http.get(scope._PREFERENCES_DATA_URL).then(function(response) {
+          expect(response.data.can_receive_editor_role_email).toBe(false);
+        });
+      });
+  });
+});

--- a/core/templates/dev/head/profile/preferences.html
+++ b/core/templates/dev/head/profile/preferences.html
@@ -147,8 +147,14 @@
             <div class="col-lg-10 col-md-10 col-sm-10">
               <div class="checkbox">
                 <label>
-                  <input type="checkbox" ng-model="canReceiveEmailUpdates" ng-change="saveCanReceiveEmailUpdates(canReceiveEmailUpdates)">
+                  <input type="checkbox" ng-model="canReceiveEmailUpdates" ng-change="saveEmailPreferences(canReceiveEmailUpdates, canReceiveEditorRoleEmail)">
                   Receive news and updates about the site
+                </label>
+              </div>
+              <div class="checkbox">
+                <label>
+                  <input type="checkbox" ng-model="canReceiveEditorRoleEmail" ng-change="saveEmailPreferences(canReceiveEmailUpdates, canReceiveEditorRoleEmail)">
+                  Receive emails when someone gives you edit rights to an exploration
                 </label>
               </div>
             </div>

--- a/core/tests/protractor/preferences.js
+++ b/core/tests/protractor/preferences.js
@@ -22,8 +22,8 @@ var workflow = require('../protractor_utils/workflow.js');
 
 describe('Preferences', function() {
   it('should change editor role email checkbox value', function() {
-    users.createUser('alice@pereferences.com', 'alicePreferences');
-    users.login('alice@pereferences.com');
+    users.createUser('alice@preferences.com', 'alicePreferences');
+    users.login('alice@preferences.com');
     browser.get('/preferences');
     var checkbox = element(by.model('canReceiveEditorRoleEmail'));
     expect(checkbox.getAttribute('aria-checked')).toBe('true');

--- a/core/tests/protractor/preferences.js
+++ b/core/tests/protractor/preferences.js
@@ -1,0 +1,39 @@
+// Copyright 2014 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview End-to-end tests for user preferences.
+ */
+
+var general = require('../protractor_utils/general.js');
+var users = require('../protractor_utils/users.js');
+var workflow = require('../protractor_utils/workflow.js');
+
+describe('Preferences', function() {
+  it('should change editor role email checkbox value', function() {
+    users.createUser('alice@pereferences.com', 'alicePreferences');
+    users.login('alice@pereferences.com');
+    browser.get('/preferences');
+    var checkbox = element(by.model('canReceiveEditorRoleEmail'));
+    expect(checkbox.getAttribute('aria-checked')).toBe('true');
+    checkbox.click();
+    expect(checkbox.getAttribute('aria-checked')).toBe('false');
+    browser.refresh();
+    expect(checkbox.getAttribute('aria-checked')).toBe('false');
+  });
+
+  afterEach(function() {
+    general.checkForConsoleErrors([]);
+  });
+});


### PR DESCRIPTION
Milestone 2 of #1357 

- Modified preferences.html to add a new checkbox property for editor role email
- Modified Preferences.js to synchronize this new added property with backend
- Modified profile.PreferencesHandler to take new values from frontend and update UserEmailPreferencesModel
- Added a new PreferencesSpec.js test file for frontend tests.