### PR TITLE
[#1723] Fixed Misnamed function in core.domain.exp_services

### DIFF
--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -292,7 +292,7 @@ def get_exploration_titles_and_categories(exp_ids):
     return result
 
 
-def _get_exploration_summary_dicts_from_models(exp_summary_models):
+def _get_exploration_summaries_from_models(exp_summary_models):
     """Given an iterable of ExpSummaryModel instances, create a dict containing
     corresponding exploration summary domain objects, keyed by id.
     """
@@ -363,7 +363,7 @@ def get_non_private_exploration_summaries():
     """Returns a dict with all non-private exploration summary domain objects,
     keyed by their id.
     """
-    return _get_exploration_summary_dicts_from_models(
+    return _get_exploration_summaries_from_models(
         exp_models.ExpSummaryModel.get_non_private())
 
 
@@ -371,7 +371,7 @@ def get_all_exploration_summaries():
     """Returns a dict with all exploration summary domain objects,
     keyed by their id.
     """
-    return _get_exploration_summary_dicts_from_models(
+    return _get_exploration_summaries_from_models(
         exp_models.ExpSummaryModel.get_all())
 
 

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -50,7 +50,7 @@ TEST_GADGETS = {
 }
 
 def _count_at_least_editable_exploration_summaries(user_id):
-    return len(exp_services._get_exploration_summary_dicts_from_models(  # pylint: disable=protected-access
+    return len(exp_services._get_exploration_summaries_from_models(  # pylint: disable=protected-access
         exp_models.ExpSummaryModel.get_at_least_editable(
             user_id=user_id)))
 


### PR DESCRIPTION
FIxes #1723 .
Changed misnamed _get_exploration_summary_dicts_from_models to _get_exploration_summaries_from_models in exp_services