### PR TITLE
Fix for content width inconsistency between editor and learner view. #1739

### DIFF
--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -418,9 +418,9 @@
     .conversation-skin-main-tutor-card.conversation-skin-left-card,
     .conversation-skin-future-tutor-card.conversation-skin-left-card {
       float: left;
-      margin-left: 0;
+      margin-left: -60px;
       margin-right: 0;
-      width: 472px;
+      width: 600px;
     }
 
     .conversation-skin-main-tutor-card.animate-card-width {


### PR DESCRIPTION
Modified conversation-skin-future-tutor-card.conversation-skin-left-card width approximately to adjust with content editor view.