### PR TITLE
Fix #914: removes RTE icon resize handlebars in Firefox.

### DIFF
--- a/core/templates/dev/head/forms/formBuilder.js
+++ b/core/templates/dev/head/forms/formBuilder.js
@@ -1163,7 +1163,10 @@ oppia.directive('schemaBasedEditor', [function() {
       onInputFocus: '='
     },
     templateUrl: 'schemaBasedEditor/master',
-    restrict: 'E'
+    restrict: 'E',
+    controller: function() {
+      document.execCommand('enableObjectResizing', false, false);
+    }
   };
 }]);
 

--- a/core/templates/dev/head/forms/formBuilder.js
+++ b/core/templates/dev/head/forms/formBuilder.js
@@ -723,6 +723,7 @@ oppia.config(['$provide', function($provide) {
       var _openCustomizationModal = function(
           customizationArgSpecs, attrsCustomizationArgsDict, onSubmitCallback,
           onDismissCallback, refocusFn) {
+        document.execCommand('enableObjectResizing', false, false);
         var modalDialog = $modal.open({
           templateUrl: 'modals/customizeRteComponent',
           backdrop: 'static',
@@ -1163,10 +1164,7 @@ oppia.directive('schemaBasedEditor', [function() {
       onInputFocus: '='
     },
     templateUrl: 'schemaBasedEditor/master',
-    restrict: 'E',
-    controller: function() {
-      document.execCommand('enableObjectResizing', false, false);
-    }
+    restrict: 'E'
   };
 }]);
 

--- a/core/templates/dev/head/forms/formBuilder.js
+++ b/core/templates/dev/head/forms/formBuilder.js
@@ -701,13 +701,13 @@ oppia.factory('rteHelperService', [
 // Add RTE extensions to textAngular toolbar options.
 oppia.config(['$provide', function($provide) {
   $provide.decorator('taOptions', [
-    '$delegate', '$modal', '$timeout', 'focusService', 'taRegisterTool',
-    'rteHelperService', 'alertsService', 'explorationContextService',
-    'PAGE_CONTEXT',
+    '$delegate', '$document', '$modal', '$timeout', 'focusService',
+    'taRegisterTool', 'rteHelperService', 'alertsService',
+    'explorationContextService', 'PAGE_CONTEXT',
     function(
-        taOptions, $modal, $timeout, focusService, taRegisterTool,
-        rteHelperService, alertsService, explorationContextService,
-        PAGE_CONTEXT) {
+        taOptions, $document, $modal, $timeout, focusService,
+        taRegisterTool, rteHelperService, alertsService,
+        explorationContextService, PAGE_CONTEXT) {
       taOptions.disableSanitizer = true;
       taOptions.forceTextAngularSanitize = false;
       taOptions.classes.textEditor = 'form-control oppia-rte-content';
@@ -723,7 +723,7 @@ oppia.config(['$provide', function($provide) {
       var _openCustomizationModal = function(
           customizationArgSpecs, attrsCustomizationArgsDict, onSubmitCallback,
           onDismissCallback, refocusFn) {
-        document.execCommand('enableObjectResizing', false, false);
+        $document[0].execCommand('enableObjectResizing', false, false);
         var modalDialog = $modal.open({
           templateUrl: 'modals/customizeRteComponent',
           backdrop: 'static',


### PR DESCRIPTION
Not sure if this is the best place but it seems to fix the issue in my testing.

