### PR TITLE
Fix #1766 - initialize zero selection for multiple select interaction

### DIFF
--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.js
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.js
@@ -52,7 +52,7 @@ oppia.directive('oppiaInteractiveItemSelectionInput', [
 
         // The following indicates that the number of answers is less than
         // minAllowableSelectionCount.
-        $scope.notEnoughSelections = true;
+        $scope.notEnoughSelections = ($scope.minAllowableSelectionCount > 0);
 
         $scope.onToggleCheckbox = function() {
           $scope.newQuestion = false;


### PR DESCRIPTION
Added a simple check for case when zero items are selected in multiple select interaction.
