### PR TITLE
Fix #1814 - Added css rules for wide window buttons

### DIFF
--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -103,13 +103,16 @@
                 </div>
                 <div ng-if="!exploration.isInteractionInline(activeCard.stateName)"
                      style="opacity: 0.8;">
-		     <md-button ng-class="{'instructions-button' : (!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard()), 
-			     'instructions-no-button' : (isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard())}"
-		     ng-click="showSupplementalCardIfScreenIsNarrow()">
-		     
-			  <[exploration.getInteractionInstructions(activeCard.stateName)]>
-                    <i ng-if="(!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard())" class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
-                  </md-button>
+		     <div style="text-transform: uppercase;padding: 6px 12px;" ng-if ="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()">
+				  <[exploration.getInteractionInstructions(activeCard.stateName)]>
+		     </div>
+		   <div ng-if="(!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard())">
+			<md-button class="instructions-button"
+			     ng-click="showSupplementalCardIfScreenIsNarrow()">
+				  <[exploration.getInteractionInstructions(activeCard.stateName)]>
+			          <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
+			</md-button>
+		  </div>
                 </div>
               </div>
             </div>
@@ -624,12 +627,6 @@
     .conversation-skin-main-tutor-card .instructions-button {
         background: inherit;
         border: none;
-    }
-
-    .conversation-skin-main-tutor-card .instructions-no-button:hover,
-    .conversation-skin-main-tutor-card .instructions-no-button:active {
-    	background-color: transparent !important;
-        cursor: default !important;
     }
 
     @media screen and (max-width: 959px) {

--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -102,14 +102,13 @@
                   </div>
                 </div>
                 <div ng-if="!exploration.isInteractionInline(activeCard.stateName)" style="opacity: 0.8;">
-                  <div ng-if="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()" style="text-transform: uppercase; padding: 6px 12px;"> 
+                  <div ng-if="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()" style="padding: 6px 12px;"> 
                     <[exploration.getInteractionInstructions(activeCard.stateName)]>
                     <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
                   </div>
-                  <div ng-if="(!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard())">
+                  <div ng-if="!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard()">
                     <md-button class="instructions-button" ng-click="showSupplementalCardIfScreenIsNarrow()">
                       <[exploration.getInteractionInstructions(activeCard.stateName)]>
-                      <i ng-if="!isScreenNarrowAndShowingTutorCard()" class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
                     </md-button>
                   </div>
                 </div>

--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -101,20 +101,18 @@
                        angular-html-bind="activeCard.interactionHtml">
                   </div>
                 </div>
-                <div ng-if="!exploration.isInteractionInline(activeCard.stateName)"
-                     style="opacity: 0.8;">
+                <div ng-if="!exploration.isInteractionInline(activeCard.stateName)" style="opacity: 0.8;">
                   <div ng-if="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()" 
                        style="text-transform: uppercase; padding: 6px 12px;"> 
-		     <[exploration.getInteractionInstructions(activeCard.stateName)]>
-                     <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
+                    <[exploration.getInteractionInstructions(activeCard.stateName)]>
+                    <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
                   </div>
-		  <div ng-if="(!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard())">
-                    <md-button class="instructions-button"
-                               ng-click="showSupplementalCardIfScreenIsNarrow()">
+                  <div ng-if="(!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard())">
+                    <md-button class="instructions-button" ng-click="showSupplementalCardIfScreenIsNarrow()">
                       <[exploration.getInteractionInstructions(activeCard.stateName)]>
-		      <i ng-if="!isScreenNarrowAndShowingTutorCard()" class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
+                      <i ng-if="!isScreenNarrowAndShowingTutorCard()" class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
                     </md-button>
-		  </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -103,11 +103,12 @@
                 </div>
                 <div ng-if="!exploration.isInteractionInline(activeCard.stateName)"
                      style="opacity: 0.8;">
-		     <md-button ng-class="{'instructions-button' : (!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard), 
+		     <md-button ng-class="{'instructions-button' : (!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard()), 
 			     'instructions-no-button' : (isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard())}"
-                          ng-click="showSupplementalCardIfScreenIsNarrow()">
+		     ng-click="showSupplementalCardIfScreenIsNarrow()">
+		     
 			  <[exploration.getInteractionInstructions(activeCard.stateName)]>
-                    <i ng-if="(isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard())" class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
+                    <i ng-if="(!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard())" class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
                   </md-button>
                 </div>
               </div>

--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -103,16 +103,17 @@
                 </div>
                 <div ng-if="!exploration.isInteractionInline(activeCard.stateName)"
                      style="opacity: 0.8;">
-		     <div ng-if ="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()" 
-			     style="text-transform: uppercase;padding: 6px 12px;"> 
-				  <[exploration.getInteractionInstructions(activeCard.stateName)]>
-		     </div>
-		   <div ng-if="(!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard())">
-			<md-button class="instructions-button"
-			     ng-click="showSupplementalCardIfScreenIsNarrow()">
-				  <[exploration.getInteractionInstructions(activeCard.stateName)]>
-			          <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
-			</md-button>
+                  <div ng-if="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()" 
+                       style="text-transform: uppercase; padding: 6px 12px;"> 
+		     <[exploration.getInteractionInstructions(activeCard.stateName)]>
+                     <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
+                  </div>
+		  <div ng-if="(!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard())">
+                    <md-button class="instructions-button"
+                               ng-click="showSupplementalCardIfScreenIsNarrow()">
+                      <[exploration.getInteractionInstructions(activeCard.stateName)]>
+		      <i ng-if="!isScreenNarrowAndShowingTutorCard()" class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
+                    </md-button>
 		  </div>
                 </div>
               </div>

--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -103,10 +103,11 @@
                 </div>
                 <div ng-if="!exploration.isInteractionInline(activeCard.stateName)"
                      style="opacity: 0.8;">
-                  <md-button class="instructions-button"
+		     <md-button ng-class="{'instructions-button' : (!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard), 
+			     'instructions-no-button' : (isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard())}"
                           ng-click="showSupplementalCardIfScreenIsNarrow()">
-                    <[exploration.getInteractionInstructions(activeCard.stateName)]>
-                    <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
+			  <[exploration.getInteractionInstructions(activeCard.stateName)]>
+                    <i ng-if="(isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard())" class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
                   </md-button>
                 </div>
               </div>
@@ -622,6 +623,12 @@
     .conversation-skin-main-tutor-card .instructions-button {
         background: inherit;
         border: none;
+    }
+
+    .conversation-skin-main-tutor-card .instructions-no-button:hover,
+    .conversation-skin-main-tutor-card .instructions-no-button:active {
+    	background-color: transparent !important;
+        cursor: default !important;
     }
 
     @media screen and (max-width: 959px) {

--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -102,8 +102,7 @@
                   </div>
                 </div>
                 <div ng-if="!exploration.isInteractionInline(activeCard.stateName)" style="opacity: 0.8;">
-                  <div ng-if="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()" 
-                       style="text-transform: uppercase; padding: 6px 12px;"> 
+                  <div ng-if="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()" style="text-transform: uppercase; padding: 6px 12px;"> 
                     <[exploration.getInteractionInstructions(activeCard.stateName)]>
                     <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
                   </div>

--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -103,7 +103,8 @@
                 </div>
                 <div ng-if="!exploration.isInteractionInline(activeCard.stateName)"
                      style="opacity: 0.8;">
-		     <div style="text-transform: uppercase;padding: 6px 12px;" ng-if ="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()">
+		     <div ng-if ="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()" 
+			     style="text-transform: uppercase;padding: 6px 12px;"> 
 				  <[exploration.getInteractionInstructions(activeCard.stateName)]>
 		     </div>
 		   <div ng-if="(!isCurrentSupplementalCardNonempty() || isScreenNarrowAndShowingTutorCard())">

--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.js
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.js
@@ -52,7 +52,7 @@ oppia.directive('oppiaInteractiveItemSelectionInput', [
 
         // The following indicates that the number of answers is less than
         // minAllowableSelectionCount.
-        $scope.notEnoughSelections = true;
+        $scope.notEnoughSelections = ($scope.minAllowableSelectionCount > 0);
 
         $scope.onToggleCheckbox = function() {
           $scope.newQuestion = false;

--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.js
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.js
@@ -52,7 +52,7 @@ oppia.directive('oppiaInteractiveItemSelectionInput', [
 
         // The following indicates that the number of answers is less than
         // minAllowableSelectionCount.
-        $scope.notEnoughSelections = ($scope.minAllowableSelectionCount > 0);
+        $scope.notEnoughSelections = true;
 
         $scope.onToggleCheckbox = function() {
           $scope.newQuestion = false;


### PR DESCRIPTION
When two cards are shown side-by-side in the learner view, the fix changes the css class to the style .instructions-no-button. I added an !important rule to both hover and active. Not sure if this is the "proper" way to handle this case, would love to know if this is the best way to handle this or another css method is preferable.