### PR TITLE
Fix #1829 Reduce space between username and exploration revision

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -109,6 +109,9 @@ body {
   padding: 0;
   width: 100%;
 }
+.reduce-space{
+  margin-right: -40px;
+}
 
 .oppia-dashboard-container {
   margin: 60px auto 30px auto;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -109,9 +109,6 @@ body {
   padding: 0;
   width: 100%;
 }
-.reduce-space{
-  margin-right: -40px;
-}
 
 .oppia-dashboard-container {
   margin: 60px auto 30px auto;

--- a/core/templates/dev/head/editor/exploration_history.html
+++ b/core/templates/dev/head/editor/exploration_history.html
@@ -25,9 +25,6 @@
         [<[versionCheckbox.vnum]>]
         <strong><profile-link-text username="explorationVersionMetadata[versionCheckbox.vnum].committerId"></profile-link-text></strong>
       </div>
-    <!--  <div class="col-sm-2 col-md-3 col-lg-3">
-
-    </div>-->
       <div class="col-sm-4 col-md-4 col-lg-4">
         <[explorationVersionMetadata[versionCheckbox.vnum].commitMessage]>
       </div>

--- a/core/templates/dev/head/editor/exploration_history.html
+++ b/core/templates/dev/head/editor/exploration_history.html
@@ -20,11 +20,11 @@
   <md-card class="oppia-editor-card">
     <h3>List of Changes</h3>
     <div ng-repeat="versionCheckbox in versionCheckboxArray " class="row">
-      <div class="col-sm-2 col-md-2 col-lg-2">
+      <div class="col-sm-2 col-md-1 col-lg-1 reduce-space">
         <input type="checkbox" name="compareVer" ng-model="versionCheckbox.selected" ng-init="init()" ng-click="changeSelectedVersions($event, versionCheckbox.vnum)" ng-disabled="isCheckboxDisabled(versionCheckbox.vnum)" ng-hide="comparisonsAreDisabled" class='protractor-test-history-checkbox-selector'>
         [<[versionCheckbox.vnum]>]
       </div>
-      <div class="col-sm-2 col-md-2 col-lg-2">
+      <div class="col-sm-2 col-md-3 col-lg-3">
         <strong><profile-link-text username="explorationVersionMetadata[versionCheckbox.vnum].committerId"></profile-link-text></strong>
       </div>
       <div class="col-sm-4 col-md-4 col-lg-4">

--- a/core/templates/dev/head/editor/exploration_history.html
+++ b/core/templates/dev/head/editor/exploration_history.html
@@ -22,8 +22,8 @@
     <div ng-repeat="versionCheckbox in versionCheckboxArray " class="row">
       <div class="col-sm-2 col-md-4 col-lg-4">
         <input type="checkbox" name="compareVer" ng-model="versionCheckbox.selected" ng-init="init()" ng-click="changeSelectedVersions($event, versionCheckbox.vnum)" ng-disabled="isCheckboxDisabled(versionCheckbox.vnum)" ng-hide="comparisonsAreDisabled" class='protractor-test-history-checkbox-selector'>
-        [<[versionCheckbox.vnum]>]
-        <strong><profile-link-text username="explorationVersionMetadata[versionCheckbox.vnum].committerId"></profile-link-text></strong>
+         [<[versionCheckbox.vnum]>]
+         <strong><profile-link-text username="explorationVersionMetadata[versionCheckbox.vnum].committerId"></profile-link-text></strong>
       </div>
       <div class="col-sm-4 col-md-4 col-lg-4">
         <[explorationVersionMetadata[versionCheckbox.vnum].commitMessage]>

--- a/core/templates/dev/head/editor/exploration_history.html
+++ b/core/templates/dev/head/editor/exploration_history.html
@@ -20,10 +20,10 @@
   <md-card class="oppia-editor-card">
     <h3>List of Changes</h3>
     <div ng-repeat="versionCheckbox in versionCheckboxArray " class="row">
-      <div class="col-sm-2 col-md-4 col-lg-4">
+      <div class="col-sm-4 col-md-4 col-lg-4">
         <input type="checkbox" name="compareVer" ng-model="versionCheckbox.selected" ng-init="init()" ng-click="changeSelectedVersions($event, versionCheckbox.vnum)" ng-disabled="isCheckboxDisabled(versionCheckbox.vnum)" ng-hide="comparisonsAreDisabled" class='protractor-test-history-checkbox-selector'>
-         [<[versionCheckbox.vnum]>]
-         <strong><profile-link-text username="explorationVersionMetadata[versionCheckbox.vnum].committerId"></profile-link-text></strong>
+        [<[versionCheckbox.vnum]>]
+        <strong><profile-link-text username="explorationVersionMetadata[versionCheckbox.vnum].committerId"></profile-link-text></strong>
       </div>
       <div class="col-sm-4 col-md-4 col-lg-4">
         <[explorationVersionMetadata[versionCheckbox.vnum].commitMessage]>

--- a/core/templates/dev/head/editor/exploration_history.html
+++ b/core/templates/dev/head/editor/exploration_history.html
@@ -20,13 +20,14 @@
   <md-card class="oppia-editor-card">
     <h3>List of Changes</h3>
     <div ng-repeat="versionCheckbox in versionCheckboxArray " class="row">
-      <div class="col-sm-2 col-md-1 col-lg-1 reduce-space">
+      <div class="col-sm-2 col-md-4 col-lg-4">
         <input type="checkbox" name="compareVer" ng-model="versionCheckbox.selected" ng-init="init()" ng-click="changeSelectedVersions($event, versionCheckbox.vnum)" ng-disabled="isCheckboxDisabled(versionCheckbox.vnum)" ng-hide="comparisonsAreDisabled" class='protractor-test-history-checkbox-selector'>
         [<[versionCheckbox.vnum]>]
-      </div>
-      <div class="col-sm-2 col-md-3 col-lg-3">
         <strong><profile-link-text username="explorationVersionMetadata[versionCheckbox.vnum].committerId"></profile-link-text></strong>
       </div>
+    <!--  <div class="col-sm-2 col-md-3 col-lg-3">
+
+    </div>-->
       <div class="col-sm-4 col-md-4 col-lg-4">
         <[explorationVersionMetadata[versionCheckbox.vnum].commitMessage]>
       </div>


### PR DESCRIPTION
Fix #1829 
A commit with just two files was made that were changed.
Extra white space between username and exploration revision was reduced

