### PR TITLE
Update JSCS to v3.0.3

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -17,7 +17,6 @@
     "fileExtensions": [".js"],
     "extract": ["*.html"],
     "maxErrors": null,
-    "verbose": true,
 
     "disallowEmptyBlocks": true,
     "disallowFunctionDeclarations": true,

--- a/core/templates/dev/head/exploration_editor/EditorServices.js
+++ b/core/templates/dev/head/exploration_editor/EditorServices.js
@@ -1774,14 +1774,14 @@ oppia.factory('explorationWarningsService', [
             _getReversedLinks(_graphData.links), false);
           if (deadEndStates.length) {
             angular.forEach(deadEndStates, function(deadEndState) {
-             if (stateWarnings.hasOwnProperty(deadEndState)) {
-               stateWarnings[deadEndState].push(
-                 STATE_ERROR_MESSAGES.UNABLE_TO_END_EXPLORATION);
-             } else {
-               stateWarnings[deadEndState] = [
-                 STATE_ERROR_MESSAGES.UNABLE_TO_END_EXPLORATION];
-             }
-           });
+              if (stateWarnings.hasOwnProperty(deadEndState)) {
+                stateWarnings[deadEndState].push(
+                  STATE_ERROR_MESSAGES.UNABLE_TO_END_EXPLORATION);
+              } else {
+                stateWarnings[deadEndState] = [
+                  STATE_ERROR_MESSAGES.UNABLE_TO_END_EXPLORATION];
+              }
+            });
           }
         }
 

--- a/core/templates/dev/head/expressions/typeParser.js
+++ b/core/templates/dev/head/expressions/typeParser.js
@@ -1,16 +1,16 @@
- // Copyright 2014 The Oppia Authors. All Rights Reserved.
- //
- // Licensed under the Apache License, Version 2.0 (the "License");
- // you may not use this file except in compliance with the License.
- // You may obtain a copy of the License at
- //
- //      http://www.apache.org/licenses/LICENSE-2.0
- //
- // Unless required by applicable law or agreed to in writing, software
- // distributed under the License is distributed on an "AS-IS" BASIS,
- // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- // See the License for the specific language governing permissions and
- // limitations under the License.
+// Copyright 2014 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 oppia.factory('expressionTypeParserService', [
   '$log', 'expressionParserService', 'expressionSyntaxTreeService',

--- a/core/templates/dev/head/expressions/typeParserSpec.js
+++ b/core/templates/dev/head/expressions/typeParserSpec.js
@@ -1,16 +1,16 @@
- // Copyright 2014 The Oppia Authors. All Rights Reserved.
- //
- // Licensed under the Apache License, Version 2.0 (the "License");
- // you may not use this file except in compliance with the License.
- // You may obtain a copy of the License at
- //
- //      http://www.apache.org/licenses/LICENSE-2.0
- //
- // Unless required by applicable law or agreed to in writing, software
- // distributed under the License is distributed on an "AS-IS" BASIS,
- // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- // See the License for the specific language governing permissions and
- // limitations under the License.
+// Copyright 2014 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 describe('Expression type parser service', function() {
   beforeEach(module('oppia'));

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -212,8 +212,8 @@ oppia.filter('parameterizeRuleDescription', [
             }
           }
         }
-      // TODO(sll): Generalize this to use the inline string representation of
-      // an object type.
+        // TODO(sll): Generalize this to use the inline string representation of
+        // an object type.
       } else if (varType === 'MusicPhrase') {
         replacementText = '[';
         for (var i = 0; i < inputs[varName].length; i++) {

--- a/scripts/install_third_party.sh
+++ b/scripts/install_third_party.sh
@@ -28,7 +28,7 @@ install_node_module yargs 3.29.0
 install_node_module gulp-concat 2.6.0
 install_node_module gulp-clean-css 2.0.2
 install_node_module gulp-util 3.0.7
-install_node_module jscs 2.3.0
+install_node_module jscs 3.0.3
 install_node_module gulp-sourcemaps 1.6.0
 install_node_module gulp-minify 0.0.5
 


### PR DESCRIPTION
Updates JSCS to v3.0.3 and fix corresponding the linter errors. 