### PR TITLE
Fix #1813: Fix jerky animation when card expanded to show previous answers

### DIFF
--- a/core/templates/dev/head/player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/player/ConversationSkinDirective.js
@@ -25,11 +25,19 @@ var TIME_NUM_CARDS_CHANGE_MSEC = 500;
 
 oppia.animation('.conversation-skin-responses-animate-slide', function() {
   return {
-    enter: function(element) {
-      element.hide().slideDown();
+    removeClass: function(element, className, done) {
+      if (className !== 'ng-hide') {
+        done();
+        return;
+      }
+      element.hide().slideDown(400, done);
     },
-    leave: function(element) {
-      element.slideUp();
+    addClass: function(element, className, done) {
+      if (className !== 'ng-hide') {
+        done();
+        return;
+      }
+      element.slideUp(400, done);
     }
   };
 });

--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -57,7 +57,7 @@
             </h4>
           </div>
 
-          <div ng-if="arePreviousResponsesShown"
+          <div ng-show="arePreviousResponsesShown"
                class="conversation-skin-tutor-card-middle-section conversation-skin-responses-animate-slide">
             <div ng-repeat="responsePair in activeCard.answerFeedbackPairs track by $index">
               <div ng-if="!$last || !exploration.isInteractionInline(activeCard.stateName)">
@@ -102,7 +102,7 @@
                   </div>
                 </div>
                 <div ng-if="!exploration.isInteractionInline(activeCard.stateName)" style="opacity: 0.8;">
-                  <div ng-if="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()" style="padding: 6px 12px;"> 
+                  <div ng-if="isCurrentSupplementalCardNonempty() && !isScreenNarrowAndShowingTutorCard()" style="padding: 6px 12px;">
                     <[exploration.getInteractionInstructions(activeCard.stateName)]>
                     <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
                   </div>


### PR DESCRIPTION
Fix #1813.
The reason was when ng-if element injected into animation it doesn't know sub dom elements.