### PR TITLE
Fix #1848 as per suggesstion by @bbriggs for setting up the proxy if the user is on Vagrant

### DIFF
--- a/scripts/install_third_party.py
+++ b/scripts/install_third_party.py
@@ -31,7 +31,7 @@ import common
 #their is no error like the one at pastebin http://pastebin.com/z34hsmi9
 if 'VAGRANT' in os.environ:
     os.environ['http_proxy'] = ''
-    
+
 TOOLS_DIR = os.path.join('..', 'oppia_tools')
 THIRD_PARTY_DIR = os.path.join('.', 'third_party')
 THIRD_PARTY_STATIC_DIR = os.path.join(THIRD_PARTY_DIR, 'static')

--- a/scripts/install_third_party.py
+++ b/scripts/install_third_party.py
@@ -27,7 +27,7 @@ import zipfile
 
 import common
 
-#These two lines prevent a "IOError: [Errno socket error] 
+#These two lines prevent a "IOError: [Errno socket error]
 #[Errno -2] Name or service not known" error
 # in urllib.urlretrieve, if the user is behind a proxy.
 if 'VAGRANT' in os.environ:

--- a/scripts/install_third_party.py
+++ b/scripts/install_third_party.py
@@ -27,8 +27,8 @@ import zipfile
 
 import common
 
-#set the proxy to empty sting if the installation is through Vagrant so that
-#their is no error like the one at pastebin http://pastebin.com/z34hsmi9
+# These two lines prevent a "IOError: [Errno socket error] [Errno -2] Name or service not known" error
+# in urllib.urlretrieve, if the user is behind a proxy.
 if 'VAGRANT' in os.environ:
     os.environ['http_proxy'] = ''
 

--- a/scripts/install_third_party.py
+++ b/scripts/install_third_party.py
@@ -27,7 +27,8 @@ import zipfile
 
 import common
 
-# These two lines prevent a "IOError: [Errno socket error] [Errno -2] Name or service not known" error
+#These two lines prevent a "IOError: [Errno socket error] 
+#[Errno -2] Name or service not known" error
 # in urllib.urlretrieve, if the user is behind a proxy.
 if 'VAGRANT' in os.environ:
     os.environ['http_proxy'] = ''

--- a/scripts/install_third_party.py
+++ b/scripts/install_third_party.py
@@ -27,6 +27,11 @@ import zipfile
 
 import common
 
+#set the proxy to empty sting if the installation is through Vagrant so that
+#their is no error like the one at pastebin http://pastebin.com/z34hsmi9
+if 'VAGRANT' in os.environ:
+    os.environ['http_proxy'] = ''
+    
 TOOLS_DIR = os.path.join('..', 'oppia_tools')
 THIRD_PARTY_DIR = os.path.join('.', 'third_party')
 THIRD_PARTY_STATIC_DIR = os.path.join(THIRD_PARTY_DIR, 'static')


### PR DESCRIPTION
Fix #1848 
If the user is behind a proxy and is installing Oppia on Vagrant there is error generated like the one here at this pastebin --> http://pastebin.com/z34hsmi9
So this PR solves this problem and sets proxy to empty string if the user is on Vagrant 