### PR TITLE
Fix #1697: upgrade collection schema version to 2 by introducing language codes to collections (where the default is 'en').

### DIFF
--- a/core/controllers/home.py
+++ b/core/controllers/home.py
@@ -260,7 +260,7 @@ class NewCollection(base.BaseHandler):
         title = self.payload.get('title')
         category = self.payload.get('category')
         objective = self.payload.get('objective')
-        # TODO(bhenning): Implement support for language codes in collections.
+        language_code = self.payload.get('language_code')
 
         if not title:
             raise self.InvalidInputException('No title supplied.')
@@ -269,7 +269,8 @@ class NewCollection(base.BaseHandler):
 
         new_collection_id = collection_services.get_new_collection_id()
         collection = collection_domain.Collection.create_default_collection(
-            new_collection_id, title, category, objective=objective)
+            new_collection_id, title, category, objective=objective,
+            language_code=language_code)
         collection_services.save_new_collection(self.user_id, collection)
 
         self.render_json({

--- a/core/domain/collection_domain.py
+++ b/core/domain/collection_domain.py
@@ -350,7 +350,6 @@ class Collection(object):
                 % e)
 
         collection_schema_version = collection_dict.get('schema_version')
-        initial_schema_version = collection_schema_version
         if collection_schema_version is None:
             raise Exception('Invalid YAML file: no schema version specified.')
         if not (1 <= collection_schema_version

--- a/core/domain/collection_domain.py
+++ b/core/domain/collection_domain.py
@@ -32,6 +32,7 @@ import utils
 COLLECTION_PROPERTY_TITLE = 'title'
 COLLECTION_PROPERTY_CATEGORY = 'category'
 COLLECTION_PROPERTY_OBJECTIVE = 'objective'
+COLLECTION_PROPERTY_LANGUAGE_CODE = 'language_code'
 COLLECTION_NODE_PROPERTY_PREREQUISITE_SKILLS = 'prerequisite_skills'
 COLLECTION_NODE_PROPERTY_ACQUIRED_SKILLS = 'acquired_skills'
 
@@ -64,7 +65,7 @@ class CollectionChange(object):
 
     COLLECTION_PROPERTIES = (
         COLLECTION_PROPERTY_TITLE, COLLECTION_PROPERTY_CATEGORY,
-        COLLECTION_PROPERTY_OBJECTIVE)
+        COLLECTION_PROPERTY_OBJECTIVE, COLLECTION_PROPERTY_LANGUAGE_CODE)
 
     def __init__(self, change_dict):
         """Initializes an CollectionChange object from a dict.
@@ -256,7 +257,7 @@ class Collection(object):
     """Domain object for an Oppia collection."""
 
     def __init__(self, collection_id, title, category, objective,
-                 schema_version, nodes, version, created_on=None,
+                 language_code, schema_version, nodes, version, created_on=None,
                  last_updated=None):
         """Constructs a new collection given all the information necessary to
         represent a collection.
@@ -277,6 +278,7 @@ class Collection(object):
         self.title = title
         self.category = category
         self.objective = objective
+        self.language_code = language_code
         self.schema_version = schema_version
         self.nodes = nodes
         self.version = version
@@ -288,6 +290,7 @@ class Collection(object):
             'id': self.id,
             'title': self.title,
             'category': self.category,
+            'language_code': self.language_code,
             'objective': self.objective,
             'schema_version': self.schema_version,
             'nodes': [
@@ -297,9 +300,10 @@ class Collection(object):
 
     @classmethod
     def create_default_collection(
-            cls, collection_id, title, category, objective):
+            cls, collection_id, title, category, objective,
+            language_code=feconf.DEFAULT_LANGUAGE_CODE):
         return cls(
-            collection_id, title, category, objective,
+            collection_id, title, category, objective, language_code,
             feconf.CURRENT_COLLECTION_SCHEMA_VERSION, [], 0)
 
     @classmethod
@@ -309,8 +313,9 @@ class Collection(object):
         collection = cls(
             collection_dict['id'], collection_dict['title'],
             collection_dict['category'], collection_dict['objective'],
-            collection_dict['schema_version'], [], collection_version,
-            collection_created_on, collection_last_updated)
+            collection_dict['language_code'], collection_dict['schema_version'],
+            [], collection_version, collection_created_on,
+            collection_last_updated)
 
         for node_dict in collection_dict['nodes']:
             collection.nodes.append(
@@ -328,7 +333,14 @@ class Collection(object):
         return utils.yaml_from_dict(collection_dict)
 
     @classmethod
-    def from_yaml(cls, collection_id, yaml_content):
+    def _convert_v1_dict_to_v2_dict(cls, collection_dict):
+        """Converts a v1 collection dict into a v2 collection dict."""
+        collection_dict['schema_version'] = 2
+        collection_dict['language_code'] = feconf.DEFAULT_LANGUAGE_CODE
+        return collection_dict
+
+    @classmethod
+    def _migrate_to_latest_yaml_version(cls, yaml_content):
         try:
             collection_dict = utils.dict_from_yaml(yaml_content)
         except Exception as e:
@@ -336,6 +348,26 @@ class Collection(object):
                 'Please ensure that you are uploading a YAML text file, not '
                 'a zip file. The YAML parser returned the following error: %s'
                 % e)
+
+        collection_schema_version = collection_dict.get('schema_version')
+        initial_schema_version = collection_schema_version
+        if collection_schema_version is None:
+            raise Exception('Invalid YAML file: no schema version specified.')
+        if not (1 <= collection_schema_version
+                <= feconf.CURRENT_COLLECTION_SCHEMA_VERSION):
+            raise Exception(
+                'Sorry, we can only process v1 to v%s collection YAML files at '
+                'present.' % feconf.CURRENT_COLLECTION_SCHEMA_VERSION)
+
+        if collection_schema_version == 1:
+            collection_dict = cls._convert_v1_dict_to_v2_dict(collection_dict)
+            collection_schema_version = 2
+
+        return collection_dict
+
+    @classmethod
+    def from_yaml(cls, collection_id, yaml_content):
+        collection_dict = cls._migrate_to_latest_yaml_version(yaml_content)
 
         collection_dict['id'] = collection_id
         return Collection.from_dict(collection_dict)
@@ -356,8 +388,7 @@ class Collection(object):
         """Returns a list of all the exploration IDs that are part of this
         collection.
         """
-        return [
-            node.exploration_id for node in self.nodes]
+        return [node.exploration_id for node in self.nodes]
 
     @property
     def init_exploration_ids(self):
@@ -415,6 +446,9 @@ class Collection(object):
     def update_objective(self, objective):
         self.objective = objective
 
+    def update_language_code(self, language_code):
+        self.language_code = language_code
+
     def _find_node(self, exploration_id):
         for ind, node in enumerate(self.nodes):
             if node.exploration_id == exploration_id:
@@ -470,6 +504,20 @@ class Collection(object):
         if not self.objective:
             raise utils.ValidationError(
                 'An objective must be specified (in the \'Settings\' tab).')
+
+        if not isinstance(self.language_code, basestring):
+            raise utils.ValidationError(
+                'Expected language code to be a string, received %s' %
+                self.language_code)
+
+        if not self.language_code:
+            raise utils.ValidationError(
+                'A language must be specified (in the \'Settings\' tab).')
+
+        if not any([self.language_code == lc['code']
+                    for lc in feconf.ALL_LANGUAGE_CODES]):
+            raise utils.ValidationError(
+                'Invalid language code: %s' % self.language_code)
 
         if not isinstance(self.schema_version, int):
             raise utils.ValidationError(
@@ -532,7 +580,7 @@ class Collection(object):
 class CollectionSummary(object):
     """Domain object for an Oppia collection summary."""
 
-    def __init__(self, collection_id, title, category, objective,
+    def __init__(self, collection_id, title, category, objective, language_code,
                  status, community_owned, owner_ids, editor_ids,
                  viewer_ids, contributor_ids, contributors_summary, version,
                  collection_model_created_on, collection_model_last_updated):
@@ -540,6 +588,7 @@ class CollectionSummary(object):
         self.title = title
         self.category = category
         self.objective = objective
+        self.language_code = language_code
         self.status = status
         self.community_owned = community_owned
         self.owner_ids = owner_ids
@@ -557,6 +606,7 @@ class CollectionSummary(object):
             'title': self.title,
             'category': self.category,
             'objective': self.objective,
+            'language_code': self.language_code,
             'status': self.status,
             'community_owned': self.community_owned,
             'owner_ids': self.owner_ids,

--- a/core/domain/collection_domain_test.py
+++ b/core/domain/collection_domain_test.py
@@ -30,6 +30,7 @@ import utils
 # utils.dict_from_yaml can isolate differences quickly.
 
 SAMPLE_YAML_CONTENT = ("""category: A category
+language_code: en
 nodes:
 - acquired_skills:
   - Skill0a
@@ -81,6 +82,16 @@ class CollectionDomainUnitTests(test_utils.GenericTestBase):
 
         self.collection.objective = 0
         self._assert_validation_error('Expected objective to be a string')
+
+    def test_language_code_validation(self):
+        self.collection.language_code = ''
+        self._assert_validation_error('language must be specified')
+
+        self.collection.language_code = 0
+        self._assert_validation_error('Expected language code to be a string')
+
+        self.collection.language_code = 'xz'
+        self._assert_validation_error('Invalid language code')
 
     def test_schema_version_validation(self):
         self.collection.schema_version = 'some_schema_version'
@@ -456,8 +467,21 @@ objective: ''
 schema_version: 1
 title: A title
 """)
+    YAML_CONTENT_V2 = ("""category: A category
+language_code: en
+nodes:
+- acquired_skills:
+  - Skill1
+  - Skill2
+  exploration_id: Exp1
+  prerequisite_skills: []
+objective: ''
+schema_version: 2
+title: A title
+""")
 
     _LATEST_YAML_CONTENT = YAML_CONTENT_V1
+    _LATEST_YAML_CONTENT = YAML_CONTENT_V2
 
     def test_load_from_v1(self):
         """Test direct loading from a v1 yaml file."""
@@ -465,4 +489,12 @@ title: A title
             'Exp1', 'user@example.com', end_state_name='End')
         collection = collection_domain.Collection.from_yaml(
             'cid', self.YAML_CONTENT_V1)
+        self.assertEqual(collection.to_yaml(), self._LATEST_YAML_CONTENT)
+
+    def test_load_from_v2(self):
+        """Test direct loading from a v2 yaml file."""
+        self.save_new_valid_exploration(
+            'Exp1', 'user@example.com', end_state_name='End')
+        collection = collection_domain.Collection.from_yaml(
+            'cid', self.YAML_CONTENT_V2)
         self.assertEqual(collection.to_yaml(), self._LATEST_YAML_CONTENT)

--- a/core/domain/collection_services.py
+++ b/core/domain/collection_services.py
@@ -125,6 +125,7 @@ def get_collection_from_model(collection_model, run_conversion=True):
     return collection_domain.Collection(
         collection_model.id, collection_model.title,
         collection_model.category, collection_model.objective,
+        collection_model.language_code,
         versioned_collection['schema_version'], [
             collection_domain.CollectionNode.from_dict(collection_node_dict)
             for collection_node_dict in versioned_collection['nodes']
@@ -137,7 +138,7 @@ def get_collection_summary_from_model(collection_summary_model):
     return collection_domain.CollectionSummary(
         collection_summary_model.id, collection_summary_model.title,
         collection_summary_model.category, collection_summary_model.objective,
-        collection_summary_model.status,
+        collection_summary_model.language_code, collection_summary_model.status,
         collection_summary_model.community_owned,
         collection_summary_model.owner_ids,
         collection_summary_model.editor_ids,
@@ -533,6 +534,9 @@ def apply_change_list(collection_id, change_list):
                 elif (change.property_name ==
                       collection_domain.COLLECTION_PROPERTY_OBJECTIVE):
                     collection.update_objective(change.new_value)
+                elif (change.property_name ==
+                      collection_domain.COLLECTION_PROPERTY_LANGUAGE_CODE):
+                    collection.update_language_code(change.new_value)
             elif (
                     change.cmd ==
                     collection_domain.CMD_MIGRATE_SCHEMA_TO_LATEST_VERSION):
@@ -618,6 +622,7 @@ def _save_collection(committer_id, collection, commit_message, change_list):
     collection_model.category = collection.category
     collection_model.title = collection.title
     collection_model.objective = collection.objective
+    collection_model.language_code = collection.language_code
     collection_model.schema_version = collection.schema_version
     collection_model.nodes = [
         collection_node.to_dict() for collection_node in collection.nodes
@@ -645,6 +650,7 @@ def _create_collection(committer_id, collection, commit_message, commit_cmds):
         category=collection.category,
         title=collection.title,
         objective=collection.objective,
+        language_code=collection.language_code,
         schema_version=collection.schema_version,
         nodes=[
             collection_node.to_dict() for collection_node in collection.nodes
@@ -820,10 +826,10 @@ def compute_summary_of_collection(collection, contributor_id_to_add):
 
     collection_summary = collection_domain.CollectionSummary(
         collection.id, collection.title, collection.category,
-        collection.objective, collection_rights.status,
-        collection_rights.community_owned, collection_rights.owner_ids,
-        collection_rights.editor_ids, collection_rights.viewer_ids,
-        contributor_ids, contributors_summary,
+        collection.objective, collection.language_code,
+        collection_rights.status, collection_rights.community_owned,
+        collection_rights.owner_ids, collection_rights.editor_ids,
+        collection_rights.viewer_ids, contributor_ids, contributors_summary,
         collection.version, collection_model_created_on,
         collection_model_last_updated
     )
@@ -866,6 +872,7 @@ def save_collection_summary(collection_summary):
         title=collection_summary.title,
         category=collection_summary.category,
         objective=collection_summary.objective,
+        language_code=collection_summary.language_code,
         status=collection_summary.status,
         community_owned=collection_summary.community_owned,
         owner_ids=collection_summary.owner_ids,
@@ -1045,6 +1052,7 @@ def _collection_to_search_dict(collection):
         'title': collection.title,
         'category': collection.category,
         'objective': collection.objective,
+        'language_code': collection.language_code,
         'rank': _get_search_rank(collection.id),
     }
     doc.update(_collection_rights_to_search_dict(rights))

--- a/core/domain/collection_services_test.py
+++ b/core/domain/collection_services_test.py
@@ -863,6 +863,25 @@ class UpdateCollectionNodeTests(CollectionServicesUnitTests):
             self.COLLECTION_ID)
         self.assertEqual(collection.objective, 'Some new objective')
 
+    def test_update_collection_language_code(self):
+        # Verify initial language code.
+        collection = collection_services.get_collection_by_id(
+            self.COLLECTION_ID)
+        self.assertEqual(collection.language_code, 'en')
+
+        # Update the language code.
+        collection_services.update_collection(
+            self.owner_id, self.COLLECTION_ID, [{
+                'cmd': collection_domain.CMD_EDIT_COLLECTION_PROPERTY,
+                'property_name': 'language_code',
+                'new_value': 'fi'
+            }], 'Changed the language to Finnish')
+
+        # Verify the language is different.
+        collection = collection_services.get_collection_by_id(
+            self.COLLECTION_ID)
+        self.assertEqual(collection.language_code, 'fi')
+
     def test_update_collection_node_prerequisite_skills(self):
         # Verify initial prerequisite skills are empty.
         collection = collection_services.get_collection_by_id(

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -2413,8 +2413,8 @@ class Exploration(object):
         if not (1 <= exploration_schema_version
                 <= cls.CURRENT_EXP_SCHEMA_VERSION):
             raise Exception(
-                'Sorry, we can only process v1 to v%s YAML files at '
-                'present.' % cls.CURRENT_EXP_SCHEMA_VERSION)
+                'Sorry, we can only process v1 to v%s exploration YAML files '
+                'at present.' % cls.CURRENT_EXP_SCHEMA_VERSION)
         if exploration_schema_version == 1:
             exploration_dict = cls._convert_v1_dict_to_v2_dict(
                 exploration_dict)

--- a/core/storage/collection/gae_models.py
+++ b/core/storage/collection/gae_models.py
@@ -51,6 +51,9 @@ class CollectionModel(base_models.VersionedModel):
     category = ndb.StringProperty(required=True, indexed=True)
     # The objective of this collection.
     objective = ndb.TextProperty(default='', indexed=False)
+    # The language code of this collection.
+    language_code = ndb.StringProperty(
+        default=feconf.DEFAULT_LANGUAGE_CODE, indexed=True)
 
     # The version of all property blob schemas.
     schema_version = ndb.IntegerProperty(
@@ -278,6 +281,8 @@ class CollectionSummaryModel(base_models.BaseModel):
     category = ndb.StringProperty(required=True, indexed=True)
     # The objective of this collection.
     objective = ndb.TextProperty(required=True, indexed=False)
+    # The ISO 639-1 code for the language this collection is written in.
+    language_code = ndb.StringProperty(required=True, indexed=True)
 
     # Aggregate user-assigned ratings of the collection
     ratings = ndb.JsonProperty(default=None, indexed=False)

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -310,8 +310,7 @@ class ExpSummaryModel(base_models.BaseModel):
     # The objective of this exploration.
     objective = ndb.TextProperty(required=True, indexed=False)
     # The ISO 639-1 code for the language this exploration is written in.
-    language_code = ndb.StringProperty(
-        required=True, indexed=True)
+    language_code = ndb.StringProperty(required=True, indexed=True)
     # Tags associated with this exploration.
     tags = ndb.StringProperty(repeated=True, indexed=True)
 

--- a/core/templates/dev/head/domain/collection/CollectionObjectFactory.js
+++ b/core/templates/dev/head/domain/collection/CollectionObjectFactory.js
@@ -24,6 +24,7 @@ oppia.factory('CollectionObjectFactory', [
       this._id = collectionBackendObject.id;
       this._title = collectionBackendObject.title;
       this._objective = collectionBackendObject.objective;
+      this._languageCode = collectionBackendObject.language_code;
       this._category = collectionBackendObject.category;
       this._version = collectionBackendObject.version;
       this._nodes = [];
@@ -59,6 +60,14 @@ oppia.factory('CollectionObjectFactory', [
 
     Collection.prototype.setObjective = function(objective) {
       this._objective = objective;
+    };
+
+    Collection.prototype.getLanguageCode = function() {
+      return this._languageCode;
+    };
+
+    Collection.prototype.setLanguageCode = function(languageCode) {
+      this._languageCode = languageCode;
     };
 
     Collection.prototype.getCategory = function() {

--- a/core/templates/dev/head/domain/collection/CollectionUpdateService.js
+++ b/core/templates/dev/head/domain/collection/CollectionUpdateService.js
@@ -30,6 +30,7 @@ oppia.constant(
 oppia.constant('COLLECTION_PROPERTY_TITLE', 'title');
 oppia.constant('COLLECTION_PROPERTY_CATEGORY', 'category');
 oppia.constant('COLLECTION_PROPERTY_OBJECTIVE', 'objective');
+oppia.constant('COLLECTION_PROPERTY_LANGUAGE_CODE', 'language_code');
 oppia.constant(
   'COLLECTION_NODE_PROPERTY_PREREQUISITE_SKILLS', 'prerequisite_skills');
 oppia.constant('COLLECTION_NODE_PROPERTY_ACQUIRED_SKILLS', 'acquired_skills');
@@ -40,6 +41,7 @@ oppia.factory('CollectionUpdateService', [
     'CMD_EDIT_COLLECTION_PROPERTY', 'CMD_EDIT_COLLECTION_NODE_PROPERTY',
     'COLLECTION_PROPERTY_TITLE', 'COLLECTION_PROPERTY_CATEGORY',
     'COLLECTION_PROPERTY_OBJECTIVE',
+    'COLLECTION_PROPERTY_LANGUAGE_CODE',
     'COLLECTION_NODE_PROPERTY_PREREQUISITE_SKILLS',
     'COLLECTION_NODE_PROPERTY_ACQUIRED_SKILLS', function(
       CollectionNodeObjectFactory, ChangeObjectFactory, UndoRedoService,
@@ -47,6 +49,7 @@ oppia.factory('CollectionUpdateService', [
       CMD_EDIT_COLLECTION_PROPERTY, CMD_EDIT_COLLECTION_NODE_PROPERTY,
       COLLECTION_PROPERTY_TITLE, COLLECTION_PROPERTY_CATEGORY,
       COLLECTION_PROPERTY_OBJECTIVE,
+      COLLECTION_PROPERTY_LANGUAGE_CODE,
       COLLECTION_NODE_PROPERTY_PREREQUISITE_SKILLS,
       COLLECTION_NODE_PROPERTY_ACQUIRED_SKILLS) {
       // Creates a change using an apply function, reverse function, a change
@@ -198,7 +201,7 @@ oppia.factory('CollectionUpdateService', [
         },
 
         /**
-         * Changes the title of a category and records the change in the
+         * Changes the category of a collection and records the change in the
          * undo/redo service.
          */
         setCollectionCategory: function(collection, category) {
@@ -216,7 +219,7 @@ oppia.factory('CollectionUpdateService', [
         },
 
         /**
-         * Changes the title of an objective and records the change in the
+         * Changes the objective of a collection and records the change in the
          * undo/redo service.
          */
         setCollectionObjective: function(collection, objective) {
@@ -230,6 +233,25 @@ oppia.factory('CollectionUpdateService', [
             }, function(changeDict, collection) {
               // Undo.
               collection.setObjective(oldObjective);
+            });
+        },
+
+        /**
+         * Changes the language code of a collection and records the change in
+         * the undo/redo service.
+         */
+        setCollectionLanguageCode: function(collection, languageCode) {
+          var oldLanguageCode = angular.copy(collection.getLanguageCode());
+          _applyPropertyChange(
+            collection, COLLECTION_PROPERTY_LANGUAGE_CODE, languageCode,
+            oldLanguageCode,
+            function(changeDict, collection) {
+              // Apply.
+              var languageCode = _getNewPropertyValueFromChangeDict(changeDict);
+              collection.setLanguageCode(languageCode);
+            }, function(changeDict, collection) {
+              // Undo.
+              collection.setLanguageCode(oldLanguageCode);
             });
         },
 

--- a/core/templates/dev/head/domain/collection/CollectionUpdateServiceSpec.js
+++ b/core/templates/dev/head/domain/collection/CollectionUpdateServiceSpec.js
@@ -39,6 +39,7 @@ describe('Collection update service', function() {
       id: 'collection_id',
       title: 'a title',
       objective: 'an objective',
+      language_code: 'en',
       category: 'a category',
       version: '1',
       nodes: [{
@@ -158,6 +159,26 @@ describe('Collection update service', function() {
       property_name: 'objective',
       new_value: 'new objective',
       old_value: 'an objective'
+    }]);
+  });
+
+  it('should set/unset changes to a collection\'s language code', function() {
+    expect(_sampleCollection.getLanguageCode()).toEqual('en');
+    CollectionUpdateService.setCollectionLanguageCode(_sampleCollection, 'fi');
+    expect(_sampleCollection.getLanguageCode()).toEqual('fi');
+
+    UndoRedoService.undoChange(_sampleCollection);
+    expect(_sampleCollection.getLanguageCode()).toEqual('en');
+  });
+
+  it('should create a proper backend change dict for changing language codes',
+      function() {
+    CollectionUpdateService.setCollectionLanguageCode(_sampleCollection, 'fi');
+    expect(UndoRedoService.getCommittableChangeList()).toEqual([{
+      cmd: 'edit_collection_property',
+      property_name: 'language_code',
+      new_value: 'fi',
+      old_value: 'en'
     }]);
   });
 

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -415,23 +415,27 @@ class TestBase(unittest.TestCase):
 
     def save_new_default_collection(
             self, collection_id, owner_id, title='A title',
-            category='A category', objective='An objective'):
+            category='A category', objective='An objective',
+            language_code=feconf.DEFAULT_LANGUAGE_CODE):
         """Saves a new default collection written by owner_id.
 
         Returns the collection domain object.
         """
         collection = collection_domain.Collection.create_default_collection(
-            collection_id, title, category, objective)
+            collection_id, title, category, objective,
+            language_code=language_code)
         collection_services.save_new_collection(owner_id, collection)
         return collection
 
     def save_new_valid_collection(
             self, collection_id, owner_id, title='A title',
             category='A category', objective='An objective',
+            language_code=feconf.DEFAULT_LANGUAGE_CODE,
             exploration_id='an_exploration_id',
             end_state_name=DEFAULT_END_STATE_NAME):
         collection = collection_domain.Collection.create_default_collection(
-            collection_id, title, category, objective=objective)
+            collection_id, title, category, objective,
+            language_code=language_code)
         collection.add_node(
             self.save_new_valid_exploration(
                 exploration_id, owner_id, title, category, objective,

--- a/data/collections/welcome_to_collections.yaml
+++ b/data/collections/welcome_to_collections.yaml
@@ -1,4 +1,5 @@
 category: Welcome
+language_code: en
 nodes:
 - acquired_skills:
   - Introduced to Oppia
@@ -22,5 +23,5 @@ nodes:
   prerequisite_skills:
   - Learned Oppia
 objective: To introduce collections using demo explorations.
-schema_version: 1
+schema_version: 2
 title: Introduction to Collections in Oppia

--- a/feconf.py
+++ b/feconf.py
@@ -64,7 +64,7 @@ CURRENT_EXPLORATION_STATES_SCHEMA_VERSION = 7
 # structure within the Collection domain object). If any backward-incompatible
 # changes are made to any of the blob schemas in the data store, this version
 # number must be changed.
-CURRENT_COLLECTION_SCHEMA_VERSION = 1
+CURRENT_COLLECTION_SCHEMA_VERSION = 2
 
 # The default number of exploration tiles to load at a time in the search
 # results page.


### PR DESCRIPTION
Introduced a language_code to the collection data structure and updated its schema version to 2, where new collection have a default language code of 'en'. The support for this language code has been implemented end-to-end for collections, including in the collection creation dialog and for search queries (though this commit does not implement collection searching).