### PR TITLE
Protractor bugfix: Scroll to the top of the page before clicking on the state graph.

### DIFF
--- a/core/tests/protractor_utils/editor.js
+++ b/core/tests/protractor_utils/editor.js
@@ -900,6 +900,7 @@ var addFallback = function(
 
 // NOTE: if the state is not visible in the state graph this function will fail
 var moveToState = function(targetName) {
+  general.scrollToTop();
   element.all(by.css('.protractor-test-node')).map(function(stateElement) {
     return stateElement.element(by.css('.protractor-test-node-label')).
       getText();

--- a/core/tests/protractor_utils/general.js
+++ b/core/tests/protractor_utils/general.js
@@ -33,6 +33,10 @@ var waitForSystem = function() {
   browser.sleep(waitTime);
 };
 
+var scrollToTop = function() {
+  browser.executeScript('window.scrollTo(0,0);');
+};
+
 // We will report all console logs of level greater than this.
 var CONSOLE_LOG_THRESHOLD = 900;
 var CONSOLE_ERRORS_TO_IGNORE = [
@@ -127,6 +131,7 @@ var expect404Error = function() {
 };
 
 exports.waitForSystem = waitForSystem;
+exports.scrollToTop = scrollToTop;
 exports.checkForConsoleErrors = checkForConsoleErrors;
 
 exports.SERVER_URL_PREFIX = SERVER_URL_PREFIX;


### PR DESCRIPTION
Without this I and Arun get errors that the state graph cannot be clicked on, though Travis doesn't seem to care.