### PR TITLE
Fix #1842: Adjust <ul> min-width to fit in mobile navbar

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2166,7 +2166,7 @@ div#ng-curtain {
 }
 
 .oppia-navbar-tabs-narrow {
-  min-width: 210px;
+  width: 100px;
 }
 .oppia-navbar-tabs {
   min-width: 500px;


### PR DESCRIPTION
The gravatar is nested under a `<ul class="oppia-navbar-tabs-narrow">` element that had a CSS property min-width set as 210px. This width was causing it to be squished down out of the navbar  but seemed unnecessary. I adjusted the width to an arbitrary 100px and the issue is resolved.