### PR TITLE
After a user logs in via the top right button, take them to the 'logged in' home page, which is the 'my explorations' page.

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -449,8 +449,11 @@ class BaseHandler(webapp2.RequestHandler):
                 current_user_services.create_logout_url(
                     redirect_url_on_logout))
         else:
+            target_url = (
+                '/' if self.request.uri.endswith(feconf.SPLASH_URL)
+                else self.request.uri)
             values['login_url'] = (
-                current_user_services.create_login_url('/'))
+                current_user_services.create_login_url(target_url))
 
         # Create a new csrf token for inclusion in HTML responses. This assumes
         # that tokens generated in one handler will be sent back to a handler

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -450,7 +450,7 @@ class BaseHandler(webapp2.RequestHandler):
                     redirect_url_on_logout))
         else:
             values['login_url'] = (
-                current_user_services.create_login_url(self.request.uri))
+                current_user_services.create_login_url('/'))
 
         # Create a new csrf token for inclusion in HTML responses. This assumes
         # that tokens generated in one handler will be sent back to a handler


### PR DESCRIPTION
I noticed (while working on the dev server) that if I log in as a new user by clicking the top right button in the splash page, I get taken through the registration flow and end up ... back at the splash page. This seems a bit silly.

So I changed the redirection-on-signup to point to "/" instead (which would redirect to the logged-in homepage) in all cases. Any objections?

@kevinlee12 @BenHenning @jacobdavis11 