### PR TITLE
Fix #1815: Place tutor avatar above the supplemental card

### DIFF
--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -636,7 +636,7 @@
     @media screen and (max-width: 959px) {
       .conversation-skin-cards-container {
         display: block;
-        padding: 40px 0px;
+        padding: 65px 0px;
         position: relative;
         width: 100%;
       }
@@ -695,12 +695,12 @@
         border-radius: 50%;
         box-shadow: 0 3px 3px grey, 0 5px 3px grey;
         display: block;
-        height: 45px;
+        height: 40px;
         left: 100%;
         position: absolute;
         position: absolute;
-        transform: translateX(-100%);
-        width: 45px;
+        transform: translate(-100%, -100%);
+        width: 40px;
         z-index: 16;
       }
       .conversation-skin-oppia-avatar.show-tutor-card:hover {


### PR DESCRIPTION
This is first try on #1815.
