### PR TITLE
Fix #1840: Fix oval contributor icons in exploration summary tile 

### DIFF
--- a/core/templates/dev/head/components/exploration_summary_tile_directive.html
+++ b/core/templates/dev/head/components/exploration_summary_tile_directive.html
@@ -23,9 +23,9 @@
           </div>
 
           <div class="all-avatars" style="display: none;">
-            <div class="circular-image-container">
-              <circular-image ng-repeat="avatar in avatarsList | limitTo:MAX_AVATARS_TO_DISPLAY-1:1"
-                              src="avatar.image"
+            <div class="circular-image-container"
+                 ng-repeat="avatar in avatarsList | limitTo:MAX_AVATARS_TO_DISPLAY-1:1">
+              <circular-image src="avatar.image"
                               link="avatar.link"
                               tooltip="<[avatar.tooltipText | truncate:14]>"
                               tooltip-placement="right">


### PR DESCRIPTION
Fix #1840;