### PR TITLE
Fix #1864: Fix carousel scrolling when user clicks on button quickly 5-7 times

### DIFF
--- a/core/templates/dev/head/library/Library.js
+++ b/core/templates/dev/head/library/Library.js
@@ -92,10 +92,10 @@ oppia.controller('Library', [
       }
     };
 
-    var isCarouselScrolling = false;
+    var isAnyCarouselCurrentlyScrolling = false;
 
     $scope.scroll = function(ind, isLeftScroll) {
-      if (isCarouselScrolling) {
+      if (isAnyCarouselCurrentlyScrolling) {
         return;
       }
       var carouselJQuerySelector = (
@@ -136,10 +136,10 @@ oppia.controller('Library', [
         duration: 800,
         queue: false,
         start: function() {
-          isCarouselScrolling = true;
+          isAnyCarouselCurrentlyScrolling = true;
         },
         complete: function() {
-          isCarouselScrolling = false;
+          isAnyCarouselCurrentlyScrolling = false;
         }
       });
 

--- a/core/templates/dev/head/library/Library.js
+++ b/core/templates/dev/head/library/Library.js
@@ -92,7 +92,12 @@ oppia.controller('Library', [
       }
     };
 
+    var isCarouselScrolling = false;
+
     $scope.scroll = function(ind, isLeftScroll) {
+      if (isCarouselScrolling) {
+        return;
+      }
       var carouselJQuerySelector = (
         '.oppia-library-carousel-tiles:eq(n)'.replace('n', ind));
       var leftOverlaySelector =
@@ -129,7 +134,13 @@ oppia.controller('Library', [
         scrollLeft: newScrollPositionPx
       }, {
         duration: 800,
-        queue: false
+        queue: false,
+        start: function() {
+          isCarouselScrolling = true;
+        },
+        complete: function() {
+          isCarouselScrolling = false;
+        }
       });
 
       $(leftOverlaySelector).css({


### PR DESCRIPTION
This fixes #1864 by adding in checkers and jQuery methods to ensure that JS will wait until the current iteration of scroll is completed before allowing the user to click it again. There was a deliberate choice not to queue the action as there would be a perceived lag by the user. Employing start and complete methods in jQuery would guarantee that the action has truly started and completed. 