### PR TITLE
Fix #1911: Fix carousel scroll overlay height

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1055,7 +1055,7 @@ textarea {
   background: linear-gradient(to right, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0) 100%);
   /*The display is set in Library.js*/
   display: none;
-  height: 259px;
+  height: 258px;
   left: 0;
   margin-top: 12px;
   position: absolute;
@@ -1071,7 +1071,7 @@ textarea {
   background: linear-gradient(to right, rgba(0,0,0,0) 0%, rgba(0,0,0,0.65) 100%);
   /*The display is set in Library.js*/
   display: none;
-  height: 259px;
+  height: 258px;
   right: 0;
   margin-top: 12px;
   position: absolute;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -110,7 +110,7 @@ body {
   width: 100%;
 }
 
-/* According to the Angular documentation - https://docs.angularjs.org/api/ng/directive/ngCloak - 
+/* According to the Angular documentation - https://docs.angularjs.org/api/ng/directive/ngCloak -
    the following rule needs to be added to the css file in order for ng-cloak to work.  */
 [ng\:cloak], [ng-cloak], .ng-cloak {
   display: none !important;
@@ -1055,7 +1055,7 @@ textarea {
   background: linear-gradient(to right, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0) 100%);
   /*The display is set in Library.js*/
   display: none;
-  height: 240px;
+  height: 259px;
   left: 0;
   margin-top: 12px;
   position: absolute;
@@ -1071,7 +1071,7 @@ textarea {
   background: linear-gradient(to right, rgba(0,0,0,0) 0%, rgba(0,0,0,0.65) 100%);
   /*The display is set in Library.js*/
   display: none;
-  height: 240px;
+  height: 259px;
   right: 0;
   margin-top: 12px;
   position: absolute;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1048,15 +1048,11 @@ textarea {
   position: relative;
 }
 
-.oppia-library-carousel-overlay-left {
-  background: #b5bdc8;
-  background: -moz-linear-gradient(left, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0) 100%);
-  background: -webkit-linear-gradient(left, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0) 100%);
-  background: linear-gradient(to right, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0) 100%);
+.oppia-library-carousel-overlay-left,
+.oppia-library-carousel-overlay-right {
   /*The display is set in Library.js*/
   display: none;
   height: 258px;
-  left: 0;
   margin-top: 12px;
   position: absolute;
   top: 0;
@@ -1064,20 +1060,20 @@ textarea {
   z-index: 99;
 }
 
+.oppia-library-carousel-overlay-left {
+  background: #b5bdc8;
+  background: -moz-linear-gradient(left, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0) 100%);
+  background: -webkit-linear-gradient(left, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0) 100%);
+  background: linear-gradient(to right, rgba(0,0,0,0.65) 0%, rgba(0,0,0,0) 100%);
+  left: 0;
+}
+
 .oppia-library-carousel-overlay-right {
   background: #b5bdc8;
   background: -moz-linear-gradient(left, rgba(0,0,0,0) 0%, rgba(0,0,0,0.65) 100%);
   background: -webkit-linear-gradient(left, rgba(0,0,0,0) 0%, rgba(0,0,0,0.65) 100%);
   background: linear-gradient(to right, rgba(0,0,0,0) 0%, rgba(0,0,0,0.65) 100%);
-  /*The display is set in Library.js*/
-  display: none;
-  height: 258px;
   right: 0;
-  margin-top: 12px;
-  position: absolute;
-  top: 0;
-  width: 20px;
-  z-index: 99;
 }
 
 /* Rules for the tiles in the "My Explorations" page. */


### PR DESCRIPTION
This fixes #1911 with which the overlay shadow did not have the proper height. 