### PR TITLE
Fix #1793: Set hyperlink to /preferences on profile image contingent on whether the profile page was the current user's or not.

### DIFF
--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -65,9 +65,9 @@ class ProfilePage(base.BaseHandler):
 
 class ProfileHandler(base.BaseHandler):
     """Provides data for the profile page."""
-    
+
     PAGE_NAME_FOR_CSRF = 'profile'
-    
+
     def get(self, username):
         """Handles GET requests."""
         if not username:

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -65,6 +65,7 @@ class ProfilePage(base.BaseHandler):
 
 class ProfileHandler(base.BaseHandler):
     """Provides data for the profile page."""
+    
     PAGE_NAME_FOR_CSRF = 'profile'
     def get(self, username):
         """Handles GET requests."""
@@ -89,9 +90,8 @@ class ProfileHandler(base.BaseHandler):
                     user_contributions.edited_exploration_ids))
         profile_is_of_current_user = (self.username == username)
 
-
         self.values.update({
-            'profileIsOfCurrentUser': profile_is_of_current_user,
+            'profile_is_of_current_user': profile_is_of_current_user,
             'profile_username': user_settings.username,
             'user_bio': user_settings.user_bio,
             'subject_interests': user_settings.subject_interests,

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -65,11 +65,11 @@ class ProfilePage(base.BaseHandler):
 
 class ProfileHandler(base.BaseHandler):
     """Provides data for the profile page."""
-
     PAGE_NAME_FOR_CSRF = 'profile'
-
     def get(self, username):
         """Handles GET requests."""
+        print 'LOOK AT ME %s' % self.username
+        print (self.values)
         if not username:
             raise self.PageNotFoundException
 
@@ -89,8 +89,15 @@ class ProfileHandler(base.BaseHandler):
             edited_exp_summary_dicts = (
                 summary_services.get_displayable_exp_summary_dicts_matching_ids(
                     user_contributions.edited_exploration_ids))
+            ### function to determine whether current user is same as user on page ###
+            if (self.username == username):
+                profile_is_of_current_user = True
+            if (self.username != username):
+                profile_is_of_current_user = False
+
 
         self.values.update({
+            'profileIsOfCurrentUser': profile_is_of_current_user,
             'profile_username': user_settings.username,
             'user_bio': user_settings.user_bio,
             'subject_interests': user_settings.subject_interests,

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -67,6 +67,7 @@ class ProfileHandler(base.BaseHandler):
     """Provides data for the profile page."""
     
     PAGE_NAME_FOR_CSRF = 'profile'
+    
     def get(self, username):
         """Handles GET requests."""
         if not username:

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -87,11 +87,7 @@ class ProfileHandler(base.BaseHandler):
             edited_exp_summary_dicts = (
                 summary_services.get_displayable_exp_summary_dicts_matching_ids(
                     user_contributions.edited_exploration_ids))
-            ### function to determine whether current user is same as user on page ###
-            if (self.username == username):
-                profile_is_of_current_user = True
-            if (self.username != username):
-                profile_is_of_current_user = False
+        profile_is_of_current_user = (self.username == username)
 
 
         self.values.update({

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -68,8 +68,6 @@ class ProfileHandler(base.BaseHandler):
     PAGE_NAME_FOR_CSRF = 'profile'
     def get(self, username):
         """Handles GET requests."""
-        print 'LOOK AT ME %s' % self.username
-        print (self.values)
         if not username:
             raise self.PageNotFoundException
 

--- a/core/templates/dev/head/profile/Profile.js
+++ b/core/templates/dev/head/profile/Profile.js
@@ -75,11 +75,12 @@ oppia.controller('Profile', [
       $scope.Math = window.Math;
 
       $scope.profileIsOfCurrentUser = function() {
-        if GLOBALS.PROFILE_USERNAME == data.profile_username
-          $scope.profileIsOfCurrentUser = True
-        else
-          $scope.profileIsOfCurrentUser = False
-      }
+        if (GLOBALS.PROFILE_USERNAME == data.profile_username) {
+          ($scope.profileIsOfCurrentUser = True);
+        } else {
+          ($scope.profileIsOfCurrentUser = False);
+        }
+      };
 
       $scope.goToPreviousPage = function() {
         if ($scope.currentPageNumber === 0) {

--- a/core/templates/dev/head/profile/Profile.js
+++ b/core/templates/dev/head/profile/Profile.js
@@ -73,14 +73,11 @@ oppia.controller('Profile', [
       $scope.startingExplorationNumber = 1;
       $scope.endingExplorationNumber = 6;
       $scope.Math = window.Math;
-
-      $scope.profileIsOfCurrentUser = False
-        if (GLOBALS.PROFILE_USERNAME == data.profile_username) {
-          $scope.profileIsOfCurrentUser = True;
-        } 
-        else {
-          $scope.profileIsOfCurrentUser = False;
-        }      
+      $scope.profileIsOfCurrentUser = (
+        GLOBALS.PROFILE_USERNAME == data.profile_username);
+          console.log($scope.profileIsOfCurrentUser);
+          console.log(data.profile_username);
+          console.log(GLOBALS.PROFILE_USERNAME);
 
       $scope.goToPreviousPage = function() {
         if ($scope.currentPageNumber === 0) {

--- a/core/templates/dev/head/profile/Profile.js
+++ b/core/templates/dev/head/profile/Profile.js
@@ -73,7 +73,7 @@ oppia.controller('Profile', [
       $scope.startingExplorationNumber = 1;
       $scope.endingExplorationNumber = 6;
       $scope.Math = window.Math;
-      $scope.profileIsOfCurrentUser = data.profileIsOfCurrentUser;
+      $scope.profileIsOfCurrentUser = data.profile_is_of_current_user;
 
       $scope.goToPreviousPage = function() {
         if ($scope.currentPageNumber === 0) {

--- a/core/templates/dev/head/profile/Profile.js
+++ b/core/templates/dev/head/profile/Profile.js
@@ -74,6 +74,13 @@ oppia.controller('Profile', [
       $scope.endingExplorationNumber = 6;
       $scope.Math = window.Math;
 
+      $scope.profileIsOfCurrentUser = function() {
+        if GLOBALS.PROFILE_USERNAME == data.profile_username
+          $scope.profileIsOfCurrentUser = True
+        else
+          $scope.profileIsOfCurrentUser = False
+      }
+
       $scope.goToPreviousPage = function() {
         if ($scope.currentPageNumber === 0) {
           console.log('Error: cannot decrement page');
@@ -116,6 +123,7 @@ oppia.controller('Profile', [
       $scope.profilePictureDataUrl = (
         data.profile_picture_data_url || DEFAULT_PROFILE_PICTURE_URL);
       $rootScope.loadingMessage = '';
+
     });
   }
 ]);

--- a/core/templates/dev/head/profile/Profile.js
+++ b/core/templates/dev/head/profile/Profile.js
@@ -73,11 +73,7 @@ oppia.controller('Profile', [
       $scope.startingExplorationNumber = 1;
       $scope.endingExplorationNumber = 6;
       $scope.Math = window.Math;
-      $scope.profileIsOfCurrentUser = (
-        GLOBALS.PROFILE_USERNAME == data.profile_username);
-          console.log($scope.profileIsOfCurrentUser);
-          console.log(data.profile_username);
-          console.log(GLOBALS.PROFILE_USERNAME);
+      $scope.profileIsOfCurrentUser = data.profileIsOfCurrentUser;
 
       $scope.goToPreviousPage = function() {
         if ($scope.currentPageNumber === 0) {

--- a/core/templates/dev/head/profile/Profile.js
+++ b/core/templates/dev/head/profile/Profile.js
@@ -74,13 +74,13 @@ oppia.controller('Profile', [
       $scope.endingExplorationNumber = 6;
       $scope.Math = window.Math;
 
-      $scope.profileIsOfCurrentUser = function() {
+      $scope.profileIsOfCurrentUser = False
         if (GLOBALS.PROFILE_USERNAME == data.profile_username) {
-          ($scope.profileIsOfCurrentUser = True);
-        } else {
-          ($scope.profileIsOfCurrentUser = False);
-        }
-      };
+          $scope.profileIsOfCurrentUser = True;
+        } 
+        else {
+          $scope.profileIsOfCurrentUser = False;
+        }      
 
       $scope.goToPreviousPage = function() {
         if ($scope.currentPageNumber === 0) {
@@ -124,7 +124,6 @@ oppia.controller('Profile', [
       $scope.profilePictureDataUrl = (
         data.profile_picture_data_url || DEFAULT_PROFILE_PICTURE_URL);
       $rootScope.loadingMessage = '';
-
     });
   }
 ]);

--- a/core/templates/dev/head/profile/profile.html
+++ b/core/templates/dev/head/profile/profile.html
@@ -33,15 +33,17 @@
   <div class="oppia-profile-container" ng-controller="Profile">
     <md-card class="oppia-profile-user-card">
 
-    <div ng-if=" '{{username}}' == '{{PROFILE_USERNAME}}' ">
-      <a HREF="/preferences"> <img ng-src="<[profilePictureDataUrl]>"
-           class="oppia-profile-picture-fullsize"> </a>
-    </div>
+      <div ng-if=" '{{username}}' == '{{PROFILE_USERNAME}}' ">
+        <a href="/preferences"> 
+          <img ng-src="<[profilePictureDataUrl]>"
+             class="oppia-profile-picture-fullsize"> 
+        </a>
+      </div>
 
-    <div ng-if=" '{{username}}' != '{{PROFILE_USERNAME}}' ">
-      <img ng-src="<[profilePictureDataUrl]>"
-           class="oppia-profile-picture-fullsize">
-    </div>
+      <div ng-if=" 'username' != 'PROFILE_USERNAME' ">
+        <img ng-src="<[profilePictureDataUrl]>"
+             class="oppia-profile-picture-fullsize">
+      </div>
 
       <h2 class="oppia-profile-username-large-screen">
         <span popover-placement="right" ng-attr-popover="<[usernameIsLong ? username.helpText : undefined]>"

--- a/core/templates/dev/head/profile/profile.html
+++ b/core/templates/dev/head/profile/profile.html
@@ -33,8 +33,15 @@
   <div class="oppia-profile-container" ng-controller="Profile">
     <md-card class="oppia-profile-user-card">
 
+    <div ng-if=" '{{username}}' == '{{PROFILE_USERNAME}}' ">
+      <a HREF="/preferences"> <img ng-src="<[profilePictureDataUrl]>"
+           class="oppia-profile-picture-fullsize"> </a>
+    </div>
+
+    <div ng-if=" '{{username}}' != '{{PROFILE_USERNAME}}' ">
       <img ng-src="<[profilePictureDataUrl]>"
            class="oppia-profile-picture-fullsize">
+    </div>
 
       <h2 class="oppia-profile-username-large-screen">
         <span popover-placement="right" ng-attr-popover="<[usernameIsLong ? username.helpText : undefined]>"

--- a/core/templates/dev/head/profile/profile.html
+++ b/core/templates/dev/head/profile/profile.html
@@ -33,15 +33,14 @@
   <div class="oppia-profile-container" ng-controller="Profile">
     <md-card class="oppia-profile-user-card">
 
-      <div ng-if="!profileIsOfCurrentUser">
+      <div ng-if="profileIsOfCurrentUser">
         <a href="/preferences"> 
           <img ng-src="<[profilePictureDataUrl]>" class="oppia-profile-picture-fullsize"> 
         </a>
       </div>
 
       <div ng-if="!profileIsOfCurrentUser">
-        <img ng-src="<[profilePictureDataUrl]>"
-             class="oppia-profile-picture-fullsize">
+        <img ng-src="<[profilePictureDataUrl]>" class="oppia-profile-picture-fullsize">
       </div>
 
       <h2 class="oppia-profile-username-large-screen">

--- a/core/templates/dev/head/profile/profile.html
+++ b/core/templates/dev/head/profile/profile.html
@@ -33,14 +33,13 @@
   <div class="oppia-profile-container" ng-controller="Profile">
     <md-card class="oppia-profile-user-card">
 
-      <div ng-if=" '{{username}}' == '{{PROFILE_USERNAME}}' ">
+      <div ng-if="profileIsOfCurrentUser">
         <a href="/preferences"> 
-          <img ng-src="<[profilePictureDataUrl]>"
-             class="oppia-profile-picture-fullsize"> 
+          <img ng-src="<[profilePictureDataUrl]>" class="oppia-profile-picture-fullsize"> 
         </a>
       </div>
 
-      <div ng-if=" 'username' != 'PROFILE_USERNAME' ">
+      <div ng-if="profileIsOfCurrentUser">
         <img ng-src="<[profilePictureDataUrl]>"
              class="oppia-profile-picture-fullsize">
       </div>

--- a/core/templates/dev/head/profile/profile.html
+++ b/core/templates/dev/head/profile/profile.html
@@ -33,13 +33,13 @@
   <div class="oppia-profile-container" ng-controller="Profile">
     <md-card class="oppia-profile-user-card">
 
-      <div ng-if="profileIsOfCurrentUser">
+      <div ng-if="!profileIsOfCurrentUser">
         <a href="/preferences"> 
           <img ng-src="<[profilePictureDataUrl]>" class="oppia-profile-picture-fullsize"> 
         </a>
       </div>
 
-      <div ng-if="profileIsOfCurrentUser">
+      <div ng-if="!profileIsOfCurrentUser">
         <img ng-src="<[profilePictureDataUrl]>"
              class="oppia-profile-picture-fullsize">
       </div>


### PR DESCRIPTION
Added a set of `ng-if` statements to determine whether the profile page belonged to the current user or not; if it did, the profile image hyperlinks to `/preferences`, however if it does not, the profile picture contains no hyperlink.