### PR TITLE
Fix for #1894 dropdown list creates empty item at the bottom of the list.

### DIFF
--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -194,9 +194,10 @@ class CategoryConfigTest(test_utils.GenericTestBase):
 
         # Test that an icon exists for each default category.
         for category in all_categories:
-            utils.get_file_contents(os.path.join(
-                'static', 'images', 'subjects',
-                '%s.svg' % category.replace(' ', '')))
+            if category:
+                utils.get_file_contents(os.path.join(
+                    'static', 'images', 'subjects',
+                    '%s.svg' % category.replace(' ', '')))
 
         # Test that the default icon exists.
         utils.get_file_contents(os.path.join(

--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -194,10 +194,9 @@ class CategoryConfigTest(test_utils.GenericTestBase):
 
         # Test that an icon exists for each default category.
         for category in all_categories:
-            if category:
-                utils.get_file_contents(os.path.join(
-                    'static', 'images', 'subjects',
-                    '%s.svg' % category.replace(' ', '')))
+            utils.get_file_contents(os.path.join(
+                'static', 'images', 'subjects',
+                '%s.svg' % category.replace(' ', '')))
 
         # Test that the default icon exists.
         utils.get_file_contents(os.path.join(

--- a/core/templates/dev/head/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/exploration_editor/ExplorationEditor.js
@@ -686,6 +686,7 @@ oppia.controller('ExplorationSaveAndPublishButtons', [
               $scope.TAG_REGEX = GLOBALS.TAG_REGEX;
 
               $scope.CATEGORY_LIST_FOR_SELECT2 = [];
+              $scope.CATEGORY_LIST_FOR_SELECT2.push({id:'', text:''});
 
               for (var i = 0; i < CATEGORY_LIST.length; i++) {
                 $scope.CATEGORY_LIST_FOR_SELECT2.push({

--- a/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
@@ -40,6 +40,7 @@ oppia.controller('SettingsTab', [
       EXPLORATION_TITLE_INPUT_FOCUS_LABEL);
 
     $scope.CATEGORY_LIST_FOR_SELECT2 = [];
+    $scope.CATEGORY_LIST_FOR_SELECT2.push({id: '', text: ''});
     for (var i = 0; i < CATEGORY_LIST.length; i++) {
       $scope.CATEGORY_LIST_FOR_SELECT2.push({
         id: CATEGORY_LIST[i],

--- a/feconf.py
+++ b/feconf.py
@@ -446,8 +446,9 @@ DEFAULT_THUMBNAIL_ICON = 'Lightbulb'
 # List of supported default categories. For now, each category has
 # a specific color associated with it. Each category also has a thumbnail icon
 # whose filename is "{{CategoryName}}.svg".
+# The blank category was added to address #1894.
 CATEGORIES_TO_COLORS = {
-    'Mathematics': '#cd672b',
+    '': '',
     'Algebra': '#cd672b',
     'Arithmetic': '#d68453',
     'Calculus': '#b86330',

--- a/feconf.py
+++ b/feconf.py
@@ -448,7 +448,6 @@ DEFAULT_THUMBNAIL_ICON = 'Lightbulb'
 # whose filename is "{{CategoryName}}.svg".
 # The blank category was added to address #1894.
 CATEGORIES_TO_COLORS = {
-    '': '',
     'Algebra': '#cd672b',
     'Arithmetic': '#d68453',
     'Calculus': '#b86330',


### PR DESCRIPTION
Fix #1894: default value in select2 dropdown creates a blank item at the bottom of the list, scrolling the dropdown to the bottom. Added a blank element to force list to start from the top.
