### PR TITLE
Fix for #1894 dropdown list creates empty item at the bottom of the list

### DIFF
--- a/core/templates/dev/head/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/exploration_editor/ExplorationEditor.js
@@ -686,6 +686,8 @@ oppia.controller('ExplorationSaveAndPublishButtons', [
               $scope.TAG_REGEX = GLOBALS.TAG_REGEX;
 
               $scope.CATEGORY_LIST_FOR_SELECT2 = [];
+              //Empty category added to force dropdown to scroll top
+              $scope.CATEGORY_LIST_FOR_SELECT2.push({id: '', text: ''});
 
               for (var i = 0; i < CATEGORY_LIST.length; i++) {
                 $scope.CATEGORY_LIST_FOR_SELECT2.push({

--- a/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
@@ -40,6 +40,9 @@ oppia.controller('SettingsTab', [
       EXPLORATION_TITLE_INPUT_FOCUS_LABEL);
 
     $scope.CATEGORY_LIST_FOR_SELECT2 = [];
+    //Empty category added to force dropdown to scroll top
+    $scope.CATEGORY_LIST_FOR_SELECT2.push({id: '', text: ''});
+
     for (var i = 0; i < CATEGORY_LIST.length; i++) {
       $scope.CATEGORY_LIST_FOR_SELECT2.push({
         id: CATEGORY_LIST[i],


### PR DESCRIPTION
Fix for #1894. The category dropdown list was creating an empty element at the bottom, which caused the dropdown to scroll down to select the item. The fix creates a blank element at client-side at the top of the list.

