### PR TITLE
Fix #1894: Dropdown list creates empty item and scrolls to the bottom.

### DIFF
--- a/core/templates/dev/head/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/exploration_editor/ExplorationEditor.js
@@ -704,9 +704,7 @@ oppia.controller('ExplorationSaveAndPublishButtons', [
                   }
                 );
 
-                // Changed from to unshift to address #1894, now focus
-                // in the dropdown list always on first element if element
-                // not in list.
+                // If the current category is not in the dropdown, add it as the first option.
                 if (!categoryIsInSelect2) {
                   $scope.CATEGORY_LIST_FOR_SELECT2.unshift({
                     id: explorationCategoryService.savedMemento,

--- a/core/templates/dev/head/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/exploration_editor/ExplorationEditor.js
@@ -704,8 +704,11 @@ oppia.controller('ExplorationSaveAndPublishButtons', [
                   }
                 );
 
+                // Changed from to unshift to address #1894, now focus
+                // in the dropdown list always on first element if element
+                // not in list.
                 if (!categoryIsInSelect2) {
-                  $scope.CATEGORY_LIST_FOR_SELECT2.push({
+                  $scope.CATEGORY_LIST_FOR_SELECT2.unshift({
                     id: explorationCategoryService.savedMemento,
                     text: explorationCategoryService.savedMemento
                   });

--- a/core/templates/dev/head/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/exploration_editor/ExplorationEditor.js
@@ -704,7 +704,8 @@ oppia.controller('ExplorationSaveAndPublishButtons', [
                   }
                 );
 
-                // If the current category is not in the dropdown, add it as the first option.
+                // If the current category is not in the dropdown, add it
+                // as the first option.
                 if (!categoryIsInSelect2) {
                   $scope.CATEGORY_LIST_FOR_SELECT2.unshift({
                     id: explorationCategoryService.savedMemento,

--- a/core/templates/dev/head/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/exploration_editor/ExplorationEditor.js
@@ -706,7 +706,8 @@ oppia.controller('ExplorationSaveAndPublishButtons', [
 
                 // If the current category is not in the dropdown, add it
                 // as the first option.
-                if (!categoryIsInSelect2) {
+                if (!categoryIsInSelect2 &&
+                    explorationCategoryService.savedMemento) {
                   $scope.CATEGORY_LIST_FOR_SELECT2.unshift({
                     id: explorationCategoryService.savedMemento,
                     text: explorationCategoryService.savedMemento

--- a/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
@@ -90,7 +90,8 @@ oppia.controller('SettingsTab', [
           }
         );
 
-        // If the current category is not in the dropdown, add it as the first option.
+        // If the current category is not in the dropdown, add it 
+        // as the first option.
         if (!categoryIsInSelect2) {
           $scope.CATEGORY_LIST_FOR_SELECT2.unshift({
             id: explorationCategoryService.savedMemento,

--- a/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
@@ -90,9 +90,7 @@ oppia.controller('SettingsTab', [
           }
         );
 
-        // Changed from to unshift to address #1894, now focus
-        // in the dropdown list always on first element if element
-        // not in list.
+        // If the current category is not in the dropdown, add it as the first option.
         if (!categoryIsInSelect2) {
           $scope.CATEGORY_LIST_FOR_SELECT2.unshift({
             id: explorationCategoryService.savedMemento,

--- a/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
@@ -90,7 +90,7 @@ oppia.controller('SettingsTab', [
           }
         );
 
-        // If the current category is not in the dropdown, add it 
+        // If the current category is not in the dropdown, add it
         // as the first option.
         if (!categoryIsInSelect2) {
           $scope.CATEGORY_LIST_FOR_SELECT2.unshift({

--- a/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
@@ -92,7 +92,8 @@ oppia.controller('SettingsTab', [
 
         // If the current category is not in the dropdown, add it
         // as the first option.
-        if (!categoryIsInSelect2) {
+        if (!categoryIsInSelect2 &&
+            explorationCategoryService.savedMemento) {
           $scope.CATEGORY_LIST_FOR_SELECT2.unshift({
             id: explorationCategoryService.savedMemento,
             text: explorationCategoryService.savedMemento

--- a/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/exploration_editor/settings_tab/SettingsTab.js
@@ -90,8 +90,11 @@ oppia.controller('SettingsTab', [
           }
         );
 
+        // Changed from to unshift to address #1894, now focus
+        // in the dropdown list always on first element if element
+        // not in list.
         if (!categoryIsInSelect2) {
-          $scope.CATEGORY_LIST_FOR_SELECT2.push({
+          $scope.CATEGORY_LIST_FOR_SELECT2.unshift({
             id: explorationCategoryService.savedMemento,
             text: explorationCategoryService.savedMemento
           });


### PR DESCRIPTION
Fix for #1894. The category dropdown list was creating an empty element at the bottom, which caused the dropdown to scroll down to select the item. The fix changes the way new elements are inserted in the array backing the dropdown list, using unshift (insert at the top) instead of push (append).