### PR TITLE
Fix #1984: update the collection editor to use a single service to store and maintain the single collection object state shared throughout the collection editor

### DIFF
--- a/core/templates/dev/head/collection_editor/CollectionEditor.js
+++ b/core/templates/dev/head/collection_editor/CollectionEditor.js
@@ -29,16 +29,17 @@ oppia.constant(
   'EXPLORATION_SUMMARY_DATA_URL_TEMPLATE', '/explorationsummarieshandler/data');
 
 oppia.controller('CollectionEditor', [
-  '$scope', 'WritableCollectionBackendApiService',
-  'CollectionRightsBackendApiService', 'CollectionObjectFactory',
-  'SkillListObjectFactory', 'CollectionValidationService',
-  'CollectionUpdateService', 'UndoRedoService', 'alertsService', function(
-    $scope, WritableCollectionBackendApiService,
-    CollectionRightsBackendApiService, CollectionObjectFactory,
-    SkillListObjectFactory, CollectionValidationService,
-    CollectionUpdateService, UndoRedoService, alertsService) {
-    $scope.collection = null;
-    $scope.collectionSkillList = SkillListObjectFactory.create([]);
+  '$scope', 'CollectionEditorStateService', 'CollectionRightsBackendApiService',
+  'CollectionValidationService', 'UndoRedoService', 'alertsService',
+  'COLLECTION_EDITOR_INITIALIZED_COLLECTION',
+  'COLLECTION_EDITOR_UPDATED_COLLECTION',
+  'UNDO_REDO_SERVICE_CHANGE_APPLIED',
+  function(
+    $scope, CollectionEditorStateService, CollectionRightsBackendApiService,
+    CollectionValidationService, UndoRedoService, alertsService,
+    COLLECTION_EDITOR_INITIALIZED_COLLECTION,
+    COLLECTION_EDITOR_UPDATED_COLLECTION,
+    UNDO_REDO_SERVICE_CHANGE_APPLIED) {
     $scope.isPrivate = GLOBALS.isPrivate;
     $scope.canUnpublish = GLOBALS.canUnpublish;
     $scope.validationIssues = [];
@@ -46,71 +47,40 @@ oppia.controller('CollectionEditor', [
     var _collectionId = GLOBALS.collectionId;
 
     var _validateCollection = function() {
+      var collection = CollectionEditorStateService.getCollection();
       if ($scope.isPrivate) {
         $scope.validationIssues = (
           CollectionValidationService.findValidationIssuesForPrivateCollection(
-            $scope.collection));
+            collection));
       } else {
         $scope.validationIssues = (
           CollectionValidationService.findValidationIssuesForPublicCollection(
-            $scope.collection));
+            collection));
       }
     };
 
-    var _updateCollection = function(newBackendCollectionObject) {
-      $scope.collection = CollectionObjectFactory.create(
-        newBackendCollectionObject);
-      $scope.collectionSkillList.setSkills(newBackendCollectionObject.skills);
-      _validateCollection();
-    };
-
     // Load the collection to be edited.
-    WritableCollectionBackendApiService.fetchWritableCollection(
-      _collectionId).then(
-        _updateCollection, function(error) {
-          alertsService.addWarning(
-            error || 'There was an error when loading the collection.');
-        });
+    CollectionEditorStateService.loadCollection(_collectionId);
 
-    UndoRedoService.setOnChangedCallback(_validateCollection);
+    $scope.$on(COLLECTION_EDITOR_INITIALIZED_COLLECTION, _validateCollection);
+    $scope.$on(COLLECTION_EDITOR_UPDATED_COLLECTION, _validateCollection);
+    $scope.$on(UNDO_REDO_SERVICE_CHANGE_APPLIED, _validateCollection);
 
     $scope.getChangeListCount = function() {
       return UndoRedoService.getChangeCount();
     };
 
-    // To be used after mutating the prerequisite and/or acquired skill lists.
-    $scope.updateSkillList = function() {
-      $scope.collectionSkillList.clearSkills();
-      $scope.collectionSkillList.addSkillsFromSkillList(
-        $scope.collection.getSkillList());
-      $scope.collectionSkillList.sortSkills();
-    };
-
     // An explicit save is needed to push all changes to the backend at once
     // because some likely working states of the collection will cause
     // validation errors when trying to incrementally save them.
-    $scope.saveCollection = function(commitMessage) {
-      // Don't attempt to save the collection if there are no changes pending.
-      if (!UndoRedoService.hasChanges()) {
-        return;
-      }
-      WritableCollectionBackendApiService.updateCollection(
-        $scope.collection.getId(), $scope.collection.getVersion(),
-        commitMessage, UndoRedoService.getCommittableChangeList()).then(
-        function(collectionBackendObject) {
-          _updateCollection(collectionBackendObject);
-          UndoRedoService.clearChanges();
-        }, function(error) {
-          alertsService.addWarning(
-            error || 'There was an error when updating the collection.');
-        });
-    };
+    $scope.saveCollection = CollectionEditorStateService.saveCollection;
 
     $scope.publishCollection = function() {
       // TODO(bhenning): This also needs a confirmation of destructive action
       // since it is not reversible.
+      var collection = CollectionEditorStateService.getCollection();
       CollectionRightsBackendApiService.setCollectionPublic(
-        _collectionId, $scope.collection.getVersion()).then(
+        _collectionId, collection.getVersion()).then(
         function() {
           // TODO(bhenning): There should be a scope-level rights object used,
           // instead. The rights object should be loaded with the collection.
@@ -124,8 +94,9 @@ oppia.controller('CollectionEditor', [
     // Unpublish the collection. Will only show up if the collection is public
     // and the user have access to the collection.
     $scope.unpublishCollection = function() {
+      var collection = CollectionEditorStateService.getCollection();
       CollectionRightsBackendApiService.setCollectionPrivate(
-        _collectionId, $scope.collection.getVersion()).then(
+        _collectionId, collection.getVersion()).then(
         function() {
           $scope.isPrivate = true;
         }, function() {

--- a/core/templates/dev/head/collection_editor/CollectionEditorStateService.js
+++ b/core/templates/dev/head/collection_editor/CollectionEditorStateService.js
@@ -1,0 +1,175 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Service to maintain the state of a single collection shared
+ * throughout the collection editor. This service provides functionality for
+ * retrieving the collection, saving it, and listening for changes. The service
+ * also maintains a list of all skills stored within the collection.
+ */
+
+oppia.constant(
+  'COLLECTION_EDITOR_INITIALIZED_COLLECTION',
+  'collectionEditorInitializedCollection');
+oppia.constant(
+  'COLLECTION_EDITOR_UPDATED_COLLECTION', 'collectionEditorUpdatedCollection');
+
+oppia.factory('CollectionEditorStateService', [
+  '$rootScope', 'alertsService', 'CollectionObjectFactory',
+  'SkillListObjectFactory', 'UndoRedoService',
+  'WritableCollectionBackendApiService',
+  'COLLECTION_EDITOR_INITIALIZED_COLLECTION',
+  'COLLECTION_EDITOR_UPDATED_COLLECTION',
+  'UNDO_REDO_SERVICE_CHANGE_APPLIED',
+  function(
+    $rootScope, alertsService, CollectionObjectFactory,
+    SkillListObjectFactory, UndoRedoService,
+    WritableCollectionBackendApiService,
+    COLLECTION_EDITOR_INITIALIZED_COLLECTION,
+    COLLECTION_EDITOR_UPDATED_COLLECTION,
+    UNDO_REDO_SERVICE_CHANGE_APPLIED) {
+    var _collection = CollectionObjectFactory.createEmptyCollection();
+    var _collectionSkillList = SkillListObjectFactory.create([]);
+    var _collectionIsInitialized = false;
+    var _isLoadingCollection = false;
+    var _isSavingCollection = false;
+
+    var _updateSkillList = function() {
+      _collectionSkillList.clearSkills();
+      _collectionSkillList.addSkillsFromSkillList(_collection.getSkillList());
+      _collectionSkillList.sortSkills();
+    };
+    var _setCollection = function(collection) {
+      _collection.copyFromCollection(collection);
+      if (_collectionIsInitialized) {
+        $rootScope.$broadcast(COLLECTION_EDITOR_UPDATED_COLLECTION);
+      } else {
+        $rootScope.$broadcast(COLLECTION_EDITOR_INITIALIZED_COLLECTION);
+        _collectionIsInitialized = true;
+      }
+      _updateSkillList();
+    };
+    var _updateCollection = function(newBackendCollectionObject) {
+      _setCollection(CollectionObjectFactory.create(
+        newBackendCollectionObject));
+    };
+
+    // TODO(bhenning): Do this more efficiently by passing the change object and
+    // whether it was a forward change from the UndoRedoService through the
+    // event pipeline, then checking whether the change actually affects the
+    // skill list before recomputing it.
+    $rootScope.$on(UNDO_REDO_SERVICE_CHANGE_APPLIED, _updateSkillList);
+
+    return {
+      /**
+       * Loads, or reloads, the collection stored by this service given a
+       * specified collection ID. See setCollection() for more information on
+       * additional behavior of this function.
+       */
+      loadCollection: function(collectionId) {
+        _isLoadingCollection = true;
+        WritableCollectionBackendApiService.fetchWritableCollection(
+          collectionId).then(
+          function(newBackendCollectionObject) {
+            _updateCollection(newBackendCollectionObject);
+            _isLoadingCollection = false;
+          },
+          function(error) {
+            alertsService.addWarning(
+              error || 'There was an error when loading the collection.');
+          });
+      },
+
+      /**
+       * Returns whether this service is currently attempting to load the
+       * collection maintained by this service.
+       */
+      isLoadingCollection: function() {
+        return _isLoadingCollection;
+      },
+
+      /**
+       * Returns the current collection to be shared among the collection
+       * editor. Please note any changes to this collection will be propogated
+       * to all bindings to it. This collection object will be retained for the
+       * lifetime of the editor. This function never returns null, though it may
+       * return an empty collection object if the collection has not yet been
+       * loaded for this editor instance.
+       */
+      getCollection: function() {
+        return _collection;
+      },
+
+      /**
+       * Sets the collection stored within this service, propogating changes to
+       * all bindings to the collection returned by getCollection(). The first
+       * time this is called it will fire a global event based on the
+       * COLLECTION_EDITOR_INITIALIZED_COLLECTION constant. All subsequent
+       * calls will similarly fire a COLLECTION_EDITOR_UPDATED_COLLECTION event.
+       */
+      setCollection: function(collection) {
+        _setCollection(collection);
+      },
+
+      /**
+       * Attempts to save the current collection given a commit message. This
+       * function cannot be called until after a collection has been initialized
+       * in this service. Returns false if a save is not performed due to no
+       * changes pending, or true if otherwise. This function, upon success,
+       * will clear the UndoRedoService of pending changes. This function also
+       * shares behavior with setCollection(), when it succeeds.
+       */
+      saveCollection: function(commitMessage) {
+        if (!_collectionIsInitialized) {
+          alertsService.fatalWarning(
+            'Cannot save a collection before one is loaded.');
+        }
+
+        // Don't attempt to save the collection if there are no changes pending.
+        if (!UndoRedoService.hasChanges()) {
+          return false;
+        }
+        _isSavingCollection = true;
+        WritableCollectionBackendApiService.updateCollection(
+          _collection.getId(), _collection.getVersion(),
+          commitMessage, UndoRedoService.getCommittableChangeList()).then(
+          function(collectionBackendObject) {
+            _updateCollection(collectionBackendObject);
+            UndoRedoService.clearChanges();
+            _isSavingCollection = false;
+          }, function(error) {
+            alertsService.addWarning(
+              error || 'There was an error when saving the collection.');
+          });
+        return true;
+      },
+
+      /**
+       * Returns whether this service is currently attempting to save the
+       * collection maintained by this service.
+       */
+      isSavingCollection: function() {
+        return _isSavingCollection;
+      },
+
+      /**
+       * Returns a collective skill list of all skills within the collection.
+       * This object is defined exactly once, so it may be bound to. It will be
+       * updated automatically as the collection is loaded and changed.
+       */
+      getCollectionSkillList: function() {
+        return _collectionSkillList;
+      }
+    };
+  }]);

--- a/core/templates/dev/head/collection_editor/CollectionEditorStateServiceSpec.js
+++ b/core/templates/dev/head/collection_editor/CollectionEditorStateServiceSpec.js
@@ -1,0 +1,317 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for CollectionEditorStateService.
+ */
+
+describe('Collection editor state service', function() {
+  var CollectionEditorStateService = null;
+  var CollectionObjectFactory = null;
+  var CollectionUpdateService = null;
+
+  // TODO(bhenning): Consider moving this to a more shareable location.
+  var FakeWritableCollectionBackendApiService = function() {
+    var self = {};
+
+    var _fetchOrUpdateCollection = function() {
+      return $q(function(resolve, reject) {
+        if (!self.failure) {
+          resolve(self.newBackendCollectionObject);
+        } else {
+          reject();
+        }
+      });
+    };
+
+    self.newBackendCollectionObject = {};
+    self.failure = null;
+    self.fetchWritableCollection = _fetchOrUpdateCollection;
+    self.updateCollection = _fetchOrUpdateCollection;
+
+    return self;
+  };
+  var fakeWritableCollectionBackendApiService = (
+    new FakeWritableCollectionBackendApiService());
+
+  beforeEach(module('oppia'));
+  beforeEach(module('oppia', GLOBALS.TRANSLATOR_PROVIDER_FOR_TESTS));
+  beforeEach(module('oppia', function($provide) {
+    $provide.value(
+      'WritableCollectionBackendApiService',
+      fakeWritableCollectionBackendApiService);
+  }));
+
+  beforeEach(inject(function($injector) {
+    CollectionEditorStateService = $injector.get(
+      'CollectionEditorStateService');
+    CollectionObjectFactory = $injector.get('CollectionObjectFactory');
+    CollectionUpdateService = $injector.get('CollectionUpdateService');
+    $q = $injector.get('$q');
+    $rootScope = $injector.get('$rootScope');
+    $scope = $rootScope.$new();
+
+    fakeWritableCollectionBackendApiService.newBackendCollectionObject = {
+      id: '0',
+      title: 'Collection Under Test',
+      category: 'Test',
+      objective: 'To pass',
+      schema_version: '1',
+      version: '1',
+      nodes: [{
+        exploration_id: '0',
+        prerequisite_skills: [],
+        acquired_skills: ['skill2']
+      }, {
+        exploration_id: '1',
+        prerequisite_skills: ['skill2'],
+        acquired_skills: ['skill1']
+      }]
+    };
+    secondBackendCollectionObject = {
+      id: '5',
+      title: 'Interesting collection',
+      category: 'Test',
+      objective: 'To be interesting',
+      language_code: 'en',
+      schema_version: '2',
+      version: '3',
+      nodes: [{
+        exploration_id: '0',
+        prerequisite_skills: [],
+        acquired_skills: ['interest']
+      }]
+    };
+  }));
+
+  it('should request to load the collection from the backend', function() {
+    spyOn(
+      fakeWritableCollectionBackendApiService,
+      'fetchWritableCollection').andCallThrough();
+
+    CollectionEditorStateService.loadCollection(5);
+    expect(fakeWritableCollectionBackendApiService.fetchWritableCollection)
+      .toHaveBeenCalled();
+  });
+
+  it('should fire an init event after loading the first collection',
+      function() {
+    spyOn($rootScope, '$broadcast').andCallThrough();
+
+    CollectionEditorStateService.loadCollection(5);
+    $rootScope.$apply();
+
+    expect($rootScope.$broadcast).toHaveBeenCalledWith(
+      'collectionEditorInitializedCollection');
+  });
+
+  it('should fire an update event after loading more collections', function() {
+    // Load initial collection.
+    CollectionEditorStateService.loadCollection(5);
+    $rootScope.$apply();
+
+    spyOn($rootScope, '$broadcast').andCallThrough();
+
+    // Load a second collection.
+    CollectionEditorStateService.loadCollection(1);
+    $rootScope.$apply();
+
+    expect($rootScope.$broadcast).toHaveBeenCalledWith(
+      'collectionEditorUpdatedCollection');
+  });
+
+  it('should track whether it is currently loading the collection', function() {
+    expect(CollectionEditorStateService.isLoadingCollection()).toBe(false);
+
+    CollectionEditorStateService.loadCollection(5);
+    expect(CollectionEditorStateService.isLoadingCollection()).toBe(true);
+
+    $rootScope.$apply();
+    expect(CollectionEditorStateService.isLoadingCollection()).toBe(false);
+  });
+
+  it('should initially return an empty collection', function() {
+    var collection = CollectionEditorStateService.getCollection();
+    expect(collection.getId()).toBeUndefined();
+    expect(collection.getTitle()).toBeUndefined();
+    expect(collection.getObjective()).toBeUndefined();
+    expect(collection.getCategory()).toBeUndefined();
+    expect(collection.getCollectionNodes()).toEqual([]);
+  });
+
+  it('should return the last collection loaded as the same object', function() {
+    var previousCollection = CollectionEditorStateService.getCollection();
+    var expectedCollection = CollectionObjectFactory.create(
+      fakeWritableCollectionBackendApiService.newBackendCollectionObject);
+    expect(previousCollection).not.toEqual(expectedCollection);
+
+    CollectionEditorStateService.loadCollection(5);
+    $rootScope.$apply();
+
+    var actualCollection = CollectionEditorStateService.getCollection();
+    expect(actualCollection).toEqual(expectedCollection);
+
+    // Although the actual collection equals the expected collection, they are
+    // different objects. Ensure that the actual collection is still the same
+    // object from before loading it, however.
+    expect(actualCollection).toBe(previousCollection);
+    expect(actualCollection).not.toBe(expectedCollection);
+  });
+
+  it('should be able to set a new collection with an in-place copy',
+      function() {
+    var previousCollection = CollectionEditorStateService.getCollection();
+    var expectedCollection = CollectionObjectFactory.create(
+      secondBackendCollectionObject);
+    expect(previousCollection).not.toEqual(expectedCollection);
+
+    CollectionEditorStateService.setCollection(expectedCollection);
+
+    var actualCollection = CollectionEditorStateService.getCollection();
+    expect(actualCollection).toEqual(expectedCollection);
+
+    // Although the actual collection equals the expected collection, they are
+    // different objects. Ensure that the actual collection is still the same
+    // object from before loading it, however.
+    expect(actualCollection).toBe(previousCollection);
+    expect(actualCollection).not.toBe(expectedCollection);
+  });
+
+  it('should fire an update event after setting the new collection',
+      function() {
+    // Load initial collection.
+    CollectionEditorStateService.loadCollection(5);
+    $rootScope.$apply();
+
+    spyOn($rootScope, '$broadcast').andCallThrough();
+
+    var newCollection = CollectionObjectFactory.create(
+      secondBackendCollectionObject);
+    CollectionEditorStateService.setCollection(newCollection);
+
+    expect($rootScope.$broadcast).toHaveBeenCalledWith(
+      'collectionEditorUpdatedCollection');
+  });
+
+  it('should fail to save the collection without first loading one',
+      function() {
+    expect(function() {
+      CollectionEditorStateService.saveCollection('Commit message');
+    }).toThrow();
+  });
+
+  it('should not save the collection if there are no pending changes',
+      function() {
+    CollectionEditorStateService.loadCollection(5);
+    $rootScope.$apply();
+
+    spyOn($rootScope, '$broadcast').andCallThrough();
+    expect(CollectionEditorStateService.saveCollection(
+      'Commit message')).toBe(false);
+    expect($rootScope.$broadcast).not.toHaveBeenCalled();
+  });
+
+  it('should be able to save the collection and pending changes', function() {
+    spyOn(
+      fakeWritableCollectionBackendApiService,
+      'updateCollection').andCallThrough();
+
+    CollectionEditorStateService.loadCollection(0);
+    CollectionUpdateService.setCollectionTitle(
+      CollectionEditorStateService.getCollection(), 'New title');
+    $rootScope.$apply();
+
+    expect(CollectionEditorStateService.saveCollection(
+      'Commit message')).toBe(true);
+    $rootScope.$apply();
+
+    var expectedId = '0';
+    var expectedVersion = '1';
+    var expectedCommitMessage = 'Commit message';
+    var updateCollectionSpy = (
+      fakeWritableCollectionBackendApiService.updateCollection);
+    expect(updateCollectionSpy).toHaveBeenCalledWith(
+      expectedId, expectedVersion, expectedCommitMessage, jasmine.any(Object));
+  });
+
+  it('should fire an update event after saving the collection', function() {
+    CollectionEditorStateService.loadCollection(5);
+    CollectionUpdateService.setCollectionTitle(
+      CollectionEditorStateService.getCollection(), 'New title');
+    $rootScope.$apply();
+
+    spyOn($rootScope, '$broadcast').andCallThrough();
+    CollectionEditorStateService.saveCollection('Commit message');
+    $rootScope.$apply();
+
+    expect($rootScope.$broadcast).toHaveBeenCalledWith(
+      'collectionEditorUpdatedCollection');
+  });
+
+  it('should track whether it is currently saving the collection', function() {
+    CollectionEditorStateService.loadCollection(5);
+    CollectionUpdateService.setCollectionTitle(
+      CollectionEditorStateService.getCollection(), 'New title');
+    $rootScope.$apply();
+
+    expect(CollectionEditorStateService.isSavingCollection()).toBe(false);
+    CollectionEditorStateService.saveCollection('Commit message');
+    expect(CollectionEditorStateService.isSavingCollection()).toBe(true);
+
+    $rootScope.$apply();
+    expect(CollectionEditorStateService.isSavingCollection()).toBe(false);
+  });
+
+  it('should initially return an empty skill list', function() {
+    var collectionSkillList = (
+      CollectionEditorStateService.getCollectionSkillList());
+    expect(collectionSkillList.getSkills()).toEqual([]);
+  });
+
+  it('should return an aggregate of the collection\'s skill lists', function() {
+    var prevCollectionSkillList = (
+      CollectionEditorStateService.getCollectionSkillList());
+    expect(prevCollectionSkillList.getSkills()).toEqual([]);
+
+    CollectionEditorStateService.loadCollection(5);
+    $rootScope.$apply();
+
+    var collectionSkillList = (
+      CollectionEditorStateService.getCollectionSkillList());
+    expect(collectionSkillList.getSkills()).toEqual(['skill1', 'skill2']);
+    expect(collectionSkillList).toBe(prevCollectionSkillList);
+  });
+
+  it('should update the collection\'s skill list with UndoRedoService changes',
+      function() {
+    CollectionEditorStateService.loadCollection(5);
+    $rootScope.$apply();
+
+    var prevCollectionSkillList = (
+      CollectionEditorStateService.getCollectionSkillList());
+    expect(prevCollectionSkillList.getSkills()).toEqual(['skill1', 'skill2']);
+
+    // Simply applying a change is adequate for updating the skill list.
+    var collection = CollectionEditorStateService.getCollection();
+    CollectionUpdateService.setAcquiredSkills(
+      collection, '0', ['skill2', 'skill3']);
+    $rootScope.$apply();
+
+    var collectionSkillList = (
+      CollectionEditorStateService.getCollectionSkillList());
+    expect(collectionSkillList.getSkills()).toEqual([
+      'skill1', 'skill2', 'skill3']);
+    expect(collectionSkillList).toBe(prevCollectionSkillList);
+  });
+});

--- a/core/templates/dev/head/collection_editor/collection_editor.html
+++ b/core/templates/dev/head/collection_editor/collection_editor.html
@@ -40,7 +40,7 @@
 {% block content %}
   <div ng-controller="CollectionEditor">
     <div ng-if="getTabStatuses().active === 'main'">
-      <collection-main-tab collection="collection" collection-skill-list="collectionSkillList">
+      <collection-main-tab>
       </collection-main-tab>
 
       <!-- A list of validation errors, if there are any -->
@@ -72,7 +72,7 @@
 
       <hr>
 
-      <collection-node-creator collection="collection">
+      <collection-node-creator>
       </collection-node-creator>
     </div>
 
@@ -121,6 +121,7 @@
     {{ include_js_file('collection_editor/CollectionEditor.js') }}
     {{ include_js_file('collection_editor/CollectionEditorNavbarBreadcrumbDirective.js') }}
     {{ include_js_file('collection_editor/CollectionEditorNavbarDirective.js') }}
+    {{ include_js_file('collection_editor/CollectionEditorStateService.js') }}
     {{ include_js_file('collection_editor/editor_tab/CollectionDetailsEditorDirective.js') }}
     {{ include_js_file('collection_editor/editor_tab/CollectionMainTabDirective.js') }}
     {{ include_js_file('collection_editor/editor_tab/CollectionNodeCreatorDirective.js') }}

--- a/core/templates/dev/head/collection_editor/editor_tab/CollectionDetailsEditorDirective.js
+++ b/core/templates/dev/head/collection_editor/editor_tab/CollectionDetailsEditorDirective.js
@@ -21,21 +21,21 @@
 oppia.directive('collectionDetailsEditor', [function() {
   return {
     restrict: 'E',
-    scope: {
-      getCollection: '&collection'
-    },
     templateUrl: 'inline/collection_details_editor_directive',
     controller: [
-        '$scope', 'CollectionUpdateService', 'alertsService',
-        function($scope, CollectionUpdateService, alertsService) {
+        '$scope', 'CollectionEditorStateService', 'CollectionUpdateService',
+        'alertsService',
+        function(
+          $scope, CollectionEditorStateService, CollectionUpdateService,
+          alertsService) {
+      $scope.collection = CollectionEditorStateService.getCollection();
       $scope.updateCollectionTitle = function() {
         if (!$scope.newCollectionTitle) {
           alertsService.addWarning('Cannot set empty collection title.');
           return;
         }
-        var collection = $scope.getCollection();
         CollectionUpdateService.setCollectionTitle(
-          collection, $scope.newCollectionTitle);
+          $scope.collection, $scope.newCollectionTitle);
         $scope.newCollectionTitle = '';
       };
 
@@ -44,9 +44,8 @@ oppia.directive('collectionDetailsEditor', [function() {
           alertsService.addWarning('Cannot set empty collection category.');
           return;
         }
-        var collection = $scope.getCollection();
         CollectionUpdateService.setCollectionCategory(
-          collection, $scope.newCollectionCategory);
+          $scope.collection, $scope.newCollectionCategory);
         $scope.newCollectionCategory = '';
       };
 
@@ -55,9 +54,8 @@ oppia.directive('collectionDetailsEditor', [function() {
           alertsService.addWarning('Cannot set empty collection objective.');
           return;
         }
-        var collection = $scope.getCollection();
         CollectionUpdateService.setCollectionObjective(
-          collection, $scope.newCollectionObjective);
+          $scope.collection, $scope.newCollectionObjective);
         $scope.newCollectionObjective = '';
       };
     }]

--- a/core/templates/dev/head/collection_editor/editor_tab/CollectionMainTabDirective.js
+++ b/core/templates/dev/head/collection_editor/editor_tab/CollectionMainTabDirective.js
@@ -19,12 +19,10 @@
 oppia.directive('collectionMainTab', [function() {
   return {
     restrict: 'E',
-    scope: {
-      getCollection: '&collection',
-      getCollectionSkillList: '&collectionSkillList'
-    },
     templateUrl: 'inline/collection_main_tab_directive',
-    controller: [function() {
+    controller: ['$scope', 'CollectionEditorStateService',
+    function($scope, CollectionEditorStateService) {
+      $scope.collection = CollectionEditorStateService.getCollection();
     }]
   };
 }]);

--- a/core/templates/dev/head/collection_editor/editor_tab/CollectionNodeCreatorDirective.js
+++ b/core/templates/dev/head/collection_editor/editor_tab/CollectionNodeCreatorDirective.js
@@ -19,20 +19,18 @@
 oppia.directive('collectionNodeCreator', [function() {
   return {
     restrict: 'E',
-    scope: {
-      getCollection: '&collection'
-    },
     templateUrl: 'collectionEditor/newNodeCreator',
     controller: [
       '$scope', '$http', '$window', '$filter', 'alertsService',
-      'validatorsService', 'CollectionUpdateService',
-      'CollectionNodeObjectFactory', 'ExplorationSummaryBackendApiService',
-      'siteAnalyticsService',
+      'validatorsService', 'CollectionEditorStateService',
+      'CollectionUpdateService', 'CollectionNodeObjectFactory',
+      'ExplorationSummaryBackendApiService', 'siteAnalyticsService',
       function(
           $scope, $http, $window, $filter, alertsService,
-          validatorsService, CollectionUpdateService,
-          CollectionNodeObjectFactory, ExplorationSummaryBackendApiService,
-          siteAnalyticsService) {
+          validatorsService, CollectionEditorStateService,
+          CollectionUpdateService, CollectionNodeObjectFactory,
+          ExplorationSummaryBackendApiService, siteAnalyticsService) {
+        $scope.collection = CollectionEditorStateService.getCollection();
         $scope.newExplorationId = '';
         $scope.newExplorationTitle = '';
         var CREATE_NEW_EXPLORATION_URL_TEMPLATE = '/create/<exploration_id>';
@@ -42,8 +40,7 @@ oppia.directive('collectionNodeCreator', [function() {
             alertsService.addWarning('Cannot add an empty exploration ID.');
             return;
           }
-          var collection = $scope.getCollection();
-          if (collection.containsCollectionNode(newExplorationId)) {
+          if ($scope.collection.containsCollectionNode(newExplorationId)) {
             alertsService.addWarning(
               'Exploration with id ' + newExplorationId + ' is already added');
             return;
@@ -59,7 +56,7 @@ oppia.directive('collectionNodeCreator', [function() {
               }
               if (summaryBackendObject) {
                 CollectionUpdateService.addCollectionNode(
-                  collection, newExplorationId, summaryBackendObject);
+                  $scope.collection, newExplorationId, summaryBackendObject);
               } else {
                 alertsService.addWarning(
                   'That exploration does not exist or you do not have edit ' +

--- a/core/templates/dev/head/collection_editor/editor_tab/CollectionNodeEditorDirective.js
+++ b/core/templates/dev/head/collection_editor/editor_tab/CollectionNodeEditorDirective.js
@@ -22,13 +22,16 @@ oppia.directive('collectionNodeEditor', [function() {
   return {
     restrict: 'E',
     scope: {
-      getCollection: '&collection',
-      getCollectionNode: '&collectionNode',
-      updateSkillList: '&'
+      getCollectionNode: '&collectionNode'
     },
     templateUrl: 'inline/collection_node_editor_directive',
-    controller: ['$scope', 'CollectionUpdateService', 'alertsService',
-      function($scope, CollectionUpdateService, alertsService) {
+    controller: ['$scope', 'CollectionEditorStateService',
+    'CollectionUpdateService', 'alertsService',
+      function(
+        $scope, CollectionEditorStateService,
+        CollectionUpdateService, alertsService) {
+      $scope.collection = CollectionEditorStateService.getCollection();
+
       var _addSkill = function(skillList, newSkillName) {
         // Ensure the user entered a skill name.
         if (!newSkillName) {
@@ -60,9 +63,8 @@ oppia.directive('collectionNodeEditor', [function() {
           return;
         }
         CollectionUpdateService.setPrerequisiteSkills(
-          $scope.getCollection(), collectionNode.getExplorationId(),
+          $scope.collection, collectionNode.getExplorationId(),
           prerequisiteSkillList.getSkills());
-        $scope.updateSkillList();
         $scope.prerequisiteSkillName = '';
       };
 
@@ -73,9 +75,8 @@ oppia.directive('collectionNodeEditor', [function() {
         var prerequisiteSkillList = _copyPrerequisiteSkillList();
         prerequisiteSkillList.removeSkillByIndex(index);
         CollectionUpdateService.setPrerequisiteSkills(
-          $scope.getCollection(), collectionNode.getExplorationId(),
+          $scope.collection, collectionNode.getExplorationId(),
           prerequisiteSkillList.getSkills());
-        $scope.updateSkillList();
       };
 
       // Adds an acquired skill to the frontend collection object and also
@@ -87,9 +88,8 @@ oppia.directive('collectionNodeEditor', [function() {
           return;
         }
         CollectionUpdateService.setAcquiredSkills(
-          $scope.getCollection(), collectionNode.getExplorationId(),
+          $scope.collection, collectionNode.getExplorationId(),
           acquiredSkillList.getSkills());
-        $scope.updateSkillList();
         $scope.acquiredSkillName = '';
       };
 
@@ -100,24 +100,22 @@ oppia.directive('collectionNodeEditor', [function() {
         var acquiredSkillList = _copyAcquiredSkillList();
         acquiredSkillList.removeSkillByIndex(index);
         CollectionUpdateService.setAcquiredSkills(
-          $scope.getCollection(), collectionNode.getExplorationId(),
+          $scope.collection, collectionNode.getExplorationId(),
           acquiredSkillList.getSkills());
-        $scope.updateSkillList();
       };
 
       // Deletes this collection node from the frontend collection object and
       // also updates the changelist.
       $scope.deleteCollectionNode = function() {
-        var collection = $scope.getCollection();
         var collectionNode = $scope.getCollectionNode();
         var explorationId = collectionNode.getExplorationId();
-        if (!collection.containsCollectionNode(explorationId)) {
+        if (!$scope.collection.containsCollectionNode(explorationId)) {
           alertsService.fatalWarning(
             'Internal collection editor error. Could not delete exploration ' +
             'by ID: ' + explorationId);
         }
         CollectionUpdateService.deleteCollectionNode(
-          collection, explorationId);
+          $scope.collection, explorationId);
       };
     }]
   };

--- a/core/templates/dev/head/collection_editor/editor_tab/CollectionSkillListDirective.js
+++ b/core/templates/dev/head/collection_editor/editor_tab/CollectionSkillListDirective.js
@@ -20,9 +20,11 @@
 oppia.directive('collectionSkillList', [function() {
   return {
     restrict: 'E',
-    scope: {
-      getCollectionSkillList: '&collectionSkillList'
-    },
-    templateUrl: 'inline/collection_skill_list_directive'
+    templateUrl: 'inline/collection_skill_list_directive',
+    controller: ['$scope', 'CollectionEditorStateService',
+    function($scope, CollectionEditorStateService) {
+      $scope.collectionSkillList = (
+        CollectionEditorStateService.getCollectionSkillList());
+    }]
   };
 }]);

--- a/core/templates/dev/head/collection_editor/editor_tab/collection_details_editor_directive.html
+++ b/core/templates/dev/head/collection_editor/editor_tab/collection_details_editor_directive.html
@@ -1,8 +1,8 @@
 <script type="text/ng-template" id="inline/collection_details_editor_directive">
-  <p>title: <[getCollection().getTitle()]> </p>
-  <p>category: <[getCollection().getCategory()]> </p>
-  <p>objective: <[getCollection().getObjective()]> </p>
-  <p>version: <em><[getCollection().getVersion()]></em></p>
+  <p>title: <[collection.getTitle()]> </p>
+  <p>category: <[collection.getCategory()]> </p>
+  <p>objective: <[collection.getObjective()]> </p>
+  <p>version: <em><[collection.getVersion()]></em></p>
 
   <br>
   <input ng-model="newCollectionTitle" type="text" placeholder="New collection title"><button ng-click="updateCollectionTitle()">Set Collection Title</button>

--- a/core/templates/dev/head/collection_editor/editor_tab/collection_main_tab_directive.html
+++ b/core/templates/dev/head/collection_editor/editor_tab/collection_main_tab_directive.html
@@ -1,10 +1,9 @@
 <script type="text/ng-template" id="inline/collection_main_tab_directive">
-  <div ng-if="getCollection()">
+  <div ng-if="collection">
     <!-- Collection details -->
-    <collection-details-editor collection="getCollection()">
-    </collection-details-editor>
+    <collection-details-editor></collection-details-editor>
 
-    <a ng-href="/collection/<[getCollection().getId()]>" target="_blank">
+    <a ng-href="/collection/<[collection.getId()]>" target="_blank">
       Go to Collection
     </a>
 
@@ -12,15 +11,14 @@
     <br>
     <br>
     <strong>Skills</strong>
-    <collection-skill-list collection-skill-list="getCollectionSkillList()">
-    </collection-skill-list>
+    <collection-skill-list></collection-skill-list>
 
     <!-- List of explorations -->
     <br>
     <strong>Explorations</strong>
     <ul>
-      <li ng-repeat="node in getCollection().getBindableCollectionNodes()">
-        <collection-node-editor collection="getCollection()" collection-node="node" update-skill-list="updateSkillList()">
+      <li ng-repeat="node in collection.getBindableCollectionNodes()">
+        <collection-node-editor collection-node="node">
         </collection-node-editor>
       </li>
     </ul>

--- a/core/templates/dev/head/collection_editor/editor_tab/collection_skill_list_directive.html
+++ b/core/templates/dev/head/collection_editor/editor_tab/collection_skill_list_directive.html
@@ -1,5 +1,5 @@
 <script type="text/ng-template" id="inline/collection_skill_list_directive">
-  <li ng-repeat="skill in getCollectionSkillList().getBindableSkills()">
+  <li ng-repeat="skill in collectionSkillList.getBindableSkills()">
     <[skill]>
   </li>
 </script>

--- a/core/templates/dev/head/domain/collection/CollectionObjectFactory.js
+++ b/core/templates/dev/head/domain/collection/CollectionObjectFactory.js
@@ -122,6 +122,15 @@ oppia.factory('CollectionObjectFactory', [
       return false;
     };
 
+    // Deletes all collection nodes within this collection.
+    Collection.prototype.clearCollectionNodes = function() {
+      // Clears the existing array in-place, since there may be Angular bindings
+      // to this array and they can't be reset to empty arrays.See for context:
+      // http://stackoverflow.com/a/1232046
+      this._nodes.length = 0;
+      this._explorationIdToNodeIndexMap  = {};
+    };
+
     // Returns whether any collection nodes in this collection reference the
     // provided exploration ID.
     Collection.prototype.containsCollectionNode = function(explorationId) {
@@ -185,11 +194,37 @@ oppia.factory('CollectionObjectFactory', [
       return skillList;
     };
 
+    // Reassigns all values within this collection to match the existing
+    // collection. This is performed as a deep copy such that none of the
+    // internal, bindable objects are changed within this collection. Note that
+    // the collection nodes within this collection will be completely redefined
+    // as copies from the specified collection.
+    Collection.prototype.copyFromCollection = function(otherCollection) {
+      this._id = otherCollection.getId();
+      this.setTitle(otherCollection.getTitle());
+      this.setObjective(otherCollection.getObjective());
+      this.setLanguageCode(otherCollection.getLanguageCode());
+      this.setCategory(otherCollection.getCategory());
+      this._version = otherCollection.getVersion();
+      this.clearCollectionNodes();
+
+      var nodes = otherCollection.getCollectionNodes();
+      for (var i = 0; i < nodes.length; i++) {
+        this.addCollectionNode(angular.copy(nodes[i]));
+      }
+    };
+
     // Static class methods. Note that "this" is not available in static
     // contexts. This function takes a JSON object which represents a backend
     // collection python dict.
     Collection.create = function(collectionBackendObject) {
       return new Collection(collectionBackendObject);
+    };
+
+    // Create a new, empty collection. This is not guaranteed to pass validation
+    // tests.
+    Collection.createEmptyCollection = function() {
+      return new Collection({ nodes: [] })
     };
 
     return Collection;

--- a/core/templates/dev/head/domain/collection/CollectionObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/collection/CollectionObjectFactorySpec.js
@@ -54,6 +54,17 @@ describe('Collection object factory', function() {
     return _sampleCollection.getCollectionNodeByExplorationId(explorationId);
   };
 
+  it('should be able to create an empty collection object', function() {
+    var collection = CollectionObjectFactory.createEmptyCollection();
+    expect(collection.getId()).toBeUndefined();
+    expect(collection.getTitle()).toBeUndefined();
+    expect(collection.getObjective()).toBeUndefined();
+    expect(collection.getLanguageCode()).toBeUndefined();
+    expect(collection.getCategory()).toBeUndefined();
+    expect(collection.getVersion()).toBeUndefined();
+    expect(collection.getCollectionNodes()).toEqual([]);
+  });
+
   it('should contain a collection node defined in the backend object',
       function() {
     var collectionNodeBackendObject = {
@@ -66,7 +77,7 @@ describe('Collection object factory', function() {
       id: 'collection_id',
       nodes: [collectionNodeBackendObject]
     });
-    expect(collection.containsCollectionNode('exp_id0')).toBeTruthy();
+    expect(collection.containsCollectionNode('exp_id0')).toBe(true);
     expect(collection.getCollectionNodes()).toEqual([
       CollectionNodeObjectFactory.create(collectionNodeBackendObject)
     ]);
@@ -74,7 +85,7 @@ describe('Collection object factory', function() {
 
   it('should contain added explorations and not contain removed ones',
       function() {
-    expect(_sampleCollection.containsCollectionNode('exp_id0')).toBeFalsy();
+    expect(_sampleCollection.containsCollectionNode('exp_id0')).toBe(false);
     expect(_sampleCollection.getCollectionNodeCount()).toEqual(0);
 
     var collectionNodeBackendObject = {
@@ -86,15 +97,15 @@ describe('Collection object factory', function() {
     var collectionNode = CollectionNodeObjectFactory.create(
       collectionNodeBackendObject);
 
-    expect(_sampleCollection.addCollectionNode(collectionNode)).toBeTruthy();
-    expect(_sampleCollection.containsCollectionNode('exp_id0')).toBeTruthy();
+    expect(_sampleCollection.addCollectionNode(collectionNode)).toBe(true);
+    expect(_sampleCollection.containsCollectionNode('exp_id0')).toBe(true);
     expect(_sampleCollection.getCollectionNodes()).toEqual([
       CollectionNodeObjectFactory.create(collectionNodeBackendObject)
     ]);
     expect(_sampleCollection.getCollectionNodeCount()).toEqual(1);
 
-    expect(_sampleCollection.deleteCollectionNode('exp_id0')).toBeTruthy();
-    expect(_sampleCollection.containsCollectionNode('exp_id0')).toBeFalsy();
+    expect(_sampleCollection.deleteCollectionNode('exp_id0')).toBe(true);
+    expect(_sampleCollection.containsCollectionNode('exp_id0')).toBe(false);
     expect(_sampleCollection.getCollectionNodeCount()).toEqual(0);
   });
 
@@ -108,12 +119,46 @@ describe('Collection object factory', function() {
     var collectionNode = CollectionNodeObjectFactory.create(
       collectionNodeBackendObject);
 
-    expect(_sampleCollection.addCollectionNode(collectionNode)).toBeTruthy();
-    expect(_sampleCollection.addCollectionNode(collectionNode)).toBeFalsy();
+    expect(_sampleCollection.addCollectionNode(collectionNode)).toBe(true);
+    expect(_sampleCollection.addCollectionNode(collectionNode)).toBe(false);
   });
 
   it('should fail to delete nonexistent explorations', function() {
-    expect(_sampleCollection.deleteCollectionNode('fake_exp_id')).toBeFalsy();
+    expect(_sampleCollection.deleteCollectionNode('fake_exp_id')).toBe(false);
+  });
+
+  it('should be able to clear all nodes from a collection', function() {
+    expect(_sampleCollection.getCollectionNodeCount()).toEqual(0);
+
+    var collectionNodeBackendObject1 = {
+      exploration_id: 'exp_id0',
+      prerequisite_skills: [],
+      acquired_skills: [],
+      exploration: {}
+    };
+    var collectionNodeBackendObject2 = {
+      exploration_id: 'exp_id1',
+      prerequisite_skills: [],
+      acquired_skills: [],
+      exploration: {}
+    };
+    var collectionNode1 = CollectionNodeObjectFactory.create(
+      collectionNodeBackendObject1);
+    var collectionNode2 = CollectionNodeObjectFactory.create(
+      collectionNodeBackendObject2);
+
+    _sampleCollection.addCollectionNode(collectionNode1);
+    expect(_sampleCollection.getCollectionNodeCount()).toEqual(1);
+    expect(_sampleCollection.containsCollectionNode('exp_id0')).toBe(true);
+
+    _sampleCollection.clearCollectionNodes();
+    expect(_sampleCollection.getCollectionNodeCount()).toEqual(0);
+    expect(_sampleCollection.containsCollectionNode('exp_id0')).toBe(false);
+    expect(_sampleCollection.getCollectionNodes()).toEqual([]);
+
+    _sampleCollection.addCollectionNode(collectionNode2);
+    expect(_sampleCollection.getCollectionNodeCount()).toEqual(1);
+    expect(_sampleCollection.containsCollectionNode('exp_id1')).toBe(true);
   });
 
   it('should be able to retrieve a mutable collection node by exploration id',
@@ -141,7 +186,7 @@ describe('Collection object factory', function() {
     expect(collectionNodeAfter).not.toEqual(CollectionNodeObjectFactory.create(
       collectionNodeBackendObject));
     expect(collectionNodeAfter.getPrerequisiteSkillList().containsSkill(
-      'example')).toBeTruthy();
+      'example')).toBe(true);
   });
 
   it('should return a list of collection nodes in the order they were added',
@@ -266,5 +311,33 @@ describe('Collection object factory', function() {
 
     skillList.sortSkills();
     expect(skillList.getSkills()).toEqual(expectedSkills);
+  });
+
+  it('should be able to copy from another collection', function() {
+    var secondCollection = CollectionObjectFactory.create({
+      id: 'col_id0',
+      title: 'Another title',
+      objective: 'Another objective',
+      category: 'Another category',
+      language_code: 'en',
+      version: '15',
+      nodes: []
+    });
+    secondCollection.addCollectionNode(CollectionNodeObjectFactory.create({
+      exploration_id: 'exp_id5',
+      prerequisite_skills: [],
+      acquired_skills: [],
+      exploration: {}
+    }));
+
+    _addCollectionNode('exp_id0');
+    _addCollectionNode('exp_id1');
+
+    expect(_sampleCollection).not.toBe(secondCollection);
+    expect(_sampleCollection).not.toEqual(secondCollection);
+
+    _sampleCollection.copyFromCollection(secondCollection);
+    expect(_sampleCollection).not.toBe(secondCollection);
+    expect(_sampleCollection).toEqual(secondCollection);
   });
 });


### PR DESCRIPTION
Updates the collection editor to use a single service to encapsulate and maintain the single collection stored within the collection editor. Updated all directives to no longer pass in the collection through binding variables but, instead, to access the collection using the new service. Updated UndoRedoService to use broadcasted events rather than a callback function. The new service also makes extensive use of Angular events.