### PR TITLE
Fix for #1937, Splash page bullet text should be better spaced and ce…

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3257,12 +3257,27 @@ md-card.preview-conversation-skin-supplemental-card {
     width: 48%;
   }
 
-  .oppia-splash-block-left {
+  .oppia-splash-block-left-image {
     float: left;
   }
-  .oppia-splash-block-right {
+  .oppia-splash-block-right-image {
     float: right;
   }
+
+  .oppia-splash-block-left-text {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    float: left;
+  }
+  .oppia-splash-block-right-text {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    float: right;
+  }
+
+
 }
 
 .oppia-activity-summary-tile {

--- a/core/templates/dev/head/pages/splash.html
+++ b/core/templates/dev/head/pages/splash.html
@@ -153,28 +153,28 @@
 
       <div class="oppia-splash-section-two-content">
         <div class="oppia-splash-bullet">
-          <div class="oppia-splash-bullet-block oppia-splash-block-left">
+          <div class="oppia-splash-bullet-block oppia-splash-block-left-image">
             <img src="/images/splash/bullet1icon.svg">
           </div>
-          <div class="oppia-splash-bullet-block oppia-splash-block-right"
+          <div class="oppia-splash-bullet-block oppia-splash-block-right-text"
                translate="I18N_SPLASH_FIRST_EXPLORATION_DESCRIPTION">
           </div>
         </div>
 
         <div class="oppia-splash-bullet">
-          <div class="oppia-splash-bullet-block oppia-splash-block-right">
+          <div class="oppia-splash-bullet-block oppia-splash-block-right-image">
             <img src="/images/splash/bullet2icon.svg">
           </div>
-          <div class="oppia-splash-bullet-block oppia-splash-block-left"
+          <div class="oppia-splash-bullet-block oppia-splash-block-left-text"
                translate="I18N_SPLASH_SECOND_EXPLORATION_DESCRIPTION">
           </div>
         </div>
 
         <div class="oppia-splash-bullet">
-          <div class="oppia-splash-bullet-block oppia-splash-block-left">
+          <div class="oppia-splash-bullet-block oppia-splash-block-left-image">
             <img src="/images/splash/bullet3icon.svg">
           </div>
-          <div class="oppia-splash-bullet-block oppia-splash-block-right"
+          <div class="oppia-splash-bullet-block oppia-splash-block-right-text"
                translate="I18N_SPLASH_THIRD_EXPLORATION_DESCRIPTION">
           </div>
         </div>


### PR DESCRIPTION
Fix #1937, Splash page bullet text should be better spaced and centered on bullet icons. I created a new css class for the bullet text and renamed the existing class into -image to differentiate both. The new properties for text cannot be applied to the image.

Before fix
![before](https://cloud.githubusercontent.com/assets/2034660/15846428/eddd9748-2c31-11e6-8b22-d2464a0f4b72.PNG)

After fix
![after](https://cloud.githubusercontent.com/assets/2034660/15846433/f6b3abf0-2c31-11e6-977e-4c77aa8a1713.PNG)
