### PR TITLE
Fix #1979 : Right scroll button of the library carousel is flushed to the right at 514px

### DIFF
--- a/core/templates/dev/head/library/Library.js
+++ b/core/templates/dev/head/library/Library.js
@@ -79,7 +79,8 @@ oppia.controller('Library', [
 
       var windowWidth = $(window).width() * 0.85;
       $scope.tileDisplayCount = Math.min(
-        Math.floor(windowWidth / tileDisplayWidth), MAX_NUM_TILES_PER_ROW);
+        Math.floor(windowWidth / (tileDisplayWidth + 20)),
+        MAX_NUM_TILES_PER_ROW);
 
       $('.oppia-library-carousel').css({
         width: ($scope.tileDisplayCount * tileDisplayWidth) + 'px'

--- a/core/templates/dev/head/library/Library.js
+++ b/core/templates/dev/head/library/Library.js
@@ -78,8 +78,8 @@ oppia.controller('Library', [
       }
 
       var windowWidth = $(window).width() * 0.85;
-      // The number 20 is added to titleDisplayWidth used to compensate for
-      // padding and margins. 20 is just an arbitrary number.
+      // The number 20 is added to tileDisplayWidth in order to compensate
+      // for padding and margins. 20 is just an arbitrary number.
       $scope.tileDisplayCount = Math.min(
         Math.floor(windowWidth / (tileDisplayWidth + 20)),
         MAX_NUM_TILES_PER_ROW);

--- a/core/templates/dev/head/library/Library.js
+++ b/core/templates/dev/head/library/Library.js
@@ -78,6 +78,8 @@ oppia.controller('Library', [
       }
 
       var windowWidth = $(window).width() * 0.85;
+      // The number 20 is added to titleDisplayWidth used to compensate for
+      // padding and margins. 20 is just an arbitrary number.
       $scope.tileDisplayCount = Math.min(
         Math.floor(windowWidth / (tileDisplayWidth + 20)),
         MAX_NUM_TILES_PER_ROW);


### PR DESCRIPTION
I think the issue was due to a one-larger value of variable `titleDisplayCount` which resulted in the `oppia-library-carousel` being assigned 416px instead of 208px. Adding 20px to the `titleDisplayWidth` while calculating `titleDisplayCount` fixed the issue.