### PR TITLE
Fixed issue 2075, interests not wrapping on profile page

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -245,6 +245,7 @@ body {
   width: calc(100% - 280px);
 }
 
+
 .oppia-profile-portfolio-container {
   margin: 0 auto;
   margin-bottom: 20px;

--- a/core/templates/dev/head/profile/profile.html
+++ b/core/templates/dev/head/profile/profile.html
@@ -86,7 +86,8 @@
         <span ng-if="subjectInterests.length > 0"><br>
           <!-- The following tag should remain on a single line due to http://bugzilla.mozilla.org/show_bug.cgi?id=922773. -->
           <span ng-repeat="interest in subjectInterests track by $index">
-               <span class="oppia-profile-subject-interest"><[interest]></span></span>
+            <span class="oppia-profile-subject-interest"><[interest]></span>
+          </span>
         </span>
         <span ng-if="subjectInterests.length === 0" class="oppia-profile-no-interests-text">
           <em>none specified</em>

--- a/core/templates/dev/head/profile/profile.html
+++ b/core/templates/dev/head/profile/profile.html
@@ -85,7 +85,8 @@
         Interests:
         <span ng-if="subjectInterests.length > 0"><br>
           <!-- The following tag should remain on a single line due to http://bugzilla.mozilla.org/show_bug.cgi?id=922773. -->
-          <span ng-repeat="interest in subjectInterests track by $index"><span class="oppia-profile-subject-interest"><[interest]></span></span>
+          <span ng-repeat="interest in subjectInterests track by $index">
+               <span class="oppia-profile-subject-interest"><[interest]></span></span>
         </span>
         <span ng-if="subjectInterests.length === 0" class="oppia-profile-no-interests-text">
           <em>none specified</em>

--- a/core/templates/dev/head/profile/profile.html
+++ b/core/templates/dev/head/profile/profile.html
@@ -84,7 +84,6 @@
       <p class="oppia-profile-subject-interest-container">
         Interests:
         <span ng-if="subjectInterests.length > 0"><br>
-          <!-- The following tag should remain on a single line due to http://bugzilla.mozilla.org/show_bug.cgi?id=922773. -->
           <span ng-repeat="interest in subjectInterests track by $index">
             <span class="oppia-profile-subject-interest"><[interest]></span>
           </span>


### PR DESCRIPTION
The interests listed by an Oppia user weren't wrapping within the column on the profile page.  I fixed the code in profile.html and now it seems to work fine.  