### PR TITLE
Fixed #1867: Flickering on profile page

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -246,7 +246,7 @@ body {
 }
 
 /* For issue #1867 (https://github.com/oppia/oppia/issues/1867) 
-   Added "overflow:hidden;"" to this class to fix a problem with the screen 
+   Added "overflow:hidden;" to this class to fix a problem with the screen 
    flickering between 2 and 3 columns when someone hovered over either 
    the rating or the number of views explorations in the second row and 
    on when there are at least four explorations listed. */

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -245,10 +245,14 @@ body {
   width: calc(100% - 280px);
 }
 
+/* Added overflow:hidden; to this class to fix a problem with the screen flickering between 2 and 3 columns
+   when someone hovered over either the rating or the number of views explorations in the second row and 
+   on when there are at least four explorations listed. */
 .oppia-profile-portfolio-container {
   margin: 0 auto;
   margin-bottom: 20px;
   width: 100%;
+  overflow: hidden;
 }
 
 .oppia-profile-portfolio-pages {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -245,14 +245,16 @@ body {
   width: calc(100% - 280px);
 }
 
-/* Added overflow:hidden; to this class to fix a problem with the screen flickering between 2 and 3 columns
-   when someone hovered over either the rating or the number of views explorations in the second row and 
+/* For issue #1867 (https://github.com/oppia/oppia/issues/1867) 
+   Added "overflow:hidden;"" to this class to fix a problem with the screen 
+   flickering between 2 and 3 columns when someone hovered over either 
+   the rating or the number of views explorations in the second row and 
    on when there are at least four explorations listed. */
 .oppia-profile-portfolio-container {
   margin: 0 auto;
   margin-bottom: 20px;
-  width: 100%;
   overflow: hidden;
+  width: 100%;
 }
 
 .oppia-profile-portfolio-pages {


### PR DESCRIPTION
The problem was highlighting the ratings or number of views on the second row of explorations caused Oppia to try to create a scroll bar on the right side.  But the container wasn't wide enough, so the program switched from 3 columns to 2 columns.  Then the container was more than wide enough, causing Oppia to switch back from 2 columns to three columns.

To fix this, I added "overflow: hidden;" to oppia-profile-portfolio-container class in oppia.css  The problem is now gone.