### PR TITLE
Fix #2078: prevent unsaved changes from being lost when editing a state name.

### DIFF
--- a/core/templates/dev/head/exploration_editor/main_tab/SidebarStateName.js
+++ b/core/templates/dev/head/exploration_editor/main_tab/SidebarStateName.js
@@ -58,8 +58,9 @@ oppia.controller('SidebarStateName', [
         explorationStatesService.renameState(
           editorContextService.getActiveStateName(), normalizedNewName);
         $scope.stateNameEditorIsShown = false;
+        // Save the contents of other open fields.
+        $rootScope.$broadcast('externalSave');
         $scope.initStateNameEditor();
-        $rootScope.$broadcast('refreshStateEditor');
         return true;
       }
     };


### PR DESCRIPTION
#2078