### PR TITLE
Fix #2047: introduce multiple PageSession object (new).

### DIFF
--- a/core/tests/performance_framework/perf_domain.py
+++ b/core/tests/performance_framework/perf_domain.py
@@ -147,7 +147,10 @@ class PageSessionMetrics(object):
 
 
 class MultiplePageSessionMetrics(object):
-    """Domain object for multiple PageSessionMetrics.
+    """Domain object for multiple PageSessionMetrics to provide average
+    metrics, so as to reduce the variation between statistics obtained during
+    different page load sessions. This may happen due to various factors like
+    background processes.
     """
 
     def  __init__(self, page_session_metrics):
@@ -160,17 +163,17 @@ class MultiplePageSessionMetrics(object):
                 'Expected page_session_metrics to be a list, '
                 'received %s' % self.page_metrics)
 
-    def get_page_load_time_millisecs(self):
+    def get_average_page_load_time_millisecs(self):
         """Returns the average total page load time (in milliseconds)."""
         return (sum(item.get_page_load_time_millisecs()
-                    for item in self.page_metrics))/len(self.page_metrics)
+                    for item in self.page_metrics)) / len(self.page_metrics)
 
-    def get_dom_ready_time_millisecs(self):
+    def get_average_dom_ready_time_millisecs(self):
         """Returns the average total page load time (in milliseconds)."""
         return (sum(item.get_dom_ready_time_millisecs()
-                    for item in self.page_metrics))/len(self.page_metrics)
+                    for item in self.page_metrics)) / len(self.page_metrics)
 
-    def get_request_time_millisecs(self):
+    def get_average_request_time_millisecs(self):
         """Returns the average total page load time (in milliseconds)."""
         return (sum(item.get_request_time_millisecs()
-                    for item in self.page_metrics))/len(self.page_metrics)
+                    for item in self.page_metrics)) / len(self.page_metrics)

--- a/core/tests/performance_framework/perf_domain.py
+++ b/core/tests/performance_framework/perf_domain.py
@@ -35,19 +35,41 @@ class PageSessionMetrics(object):
     loading and includes the following keys:
 
         timing: maps to a dict containing the keys (all in milliseconds):
+            connectEnd: the Unix time the user agent finishes establishing the
+                connection to the server to retrive the current document.
+            connectStart: the Unix time before the user agent starts
+                establishing the connection to the server to retrive the
+                document.
+            domainLookupEnd: the Unix time the domain lookup ends.
+            domainLookupStart: the Unix time the domain lookup starts.
+            domComplete: the Unix time user agent sets the current document
+                readiness to "complete".
             domInteractive: the Unix time the the parser finished its work on
-                            the main document
-            domLoading: the Unix time the DOM started loading
-            fetchStart: the Unix time the page began loading
-            loadEventEnd: the Unix time the page finished loading
+                            the main document.
+            domLoading: the Unix time the DOM started loading.
+            fetchStart: the Unix time the page began loading.
+            loadEventEnd: the Unix time the load event of the current document
+                is completed.
+            loadEventStart: the Unix time the load event of the current document
+                is fired.
+            navigationStart: the Unix time  the prompt for unload terminates
+                on the previous document in the same browsing context
+            redirectEnd: the Unix time the last HTTP redirect is completed, that
+                is when the last byte of the HTTP response has been received
+            redirectStart: the Unix time the first HTTP redirect starts.
             requestStart: the Unix time the request started
-            responseStart: the Unix time the response started
             responseEnd: the Unix time the request finished
+            responseStart: the Unix time the response started
+            unloadEventEnd: the Unix time the unload event handler finishes.
+            unloadEventStart: the Unix time the unload event has been thrown.
     """
 
     TIMING_PROPERTIES = [
-        'loadEventEnd', 'fetchStart', 'domComplete', 'domInteractive',
-        'responseEnd', 'requestStart'
+        'connectEnd', 'connectStart', 'domainLookupEnd', 'domainLookupStart',
+        'domComplete', 'domInteractive', 'domLoading', 'fetchStart',
+        'loadEventEnd', 'loadEventStart', 'navigationStart', 'redirectEnd',
+        'redirectStart', 'requestStart', 'responseEnd', 'responseStart',
+        'unloadEventEnd', 'unloadEventStart'
     ]
 
     def __init__(self, page_session_stats=None, page_session_timings=None):
@@ -163,12 +185,14 @@ class PageSessionMetrics(object):
             'unloadEventEnd', 'unloadEventStart')
 
     def get_lookup_domain_time_millisecs(self):
-        """Returns the time spent for DNS query."""
+        """Returns the time spent for the domain name lookup for the current
+        document."""
         return self._get_duration_millisecs(
             'domainLookupEnd', 'domainLookupStart')
 
     def get_connect_time_millisecs(self):
-        """Returns the time spent for TCP connection."""
+        """Returns the time spent for establishing the connection to the server
+        to retrieve the current document."""
         return self._get_duration_millisecs('connectEnd', 'connectStart')
 
     def get_init_dom_tree_time_millisecs(self):
@@ -176,11 +200,15 @@ class PageSessionMetrics(object):
         return self._get_duration_millisecs('domInteractive', 'responseEnd')
 
     def get_load_event_time_millisecs(self):
-        """Returns the time for load event."""
+        """Returns the time spent for completion of the load event of the
+        current document. The load event is fired when a resource and its
+        dependent resources have finished loading."""
         return self._get_duration_millisecs('loadEventEnd', 'loadEventStart')
 
     def print_details(self):
         """Helper function to print details for all the events."""
+        if not self.page_session_timings:
+            return
         print 'Page load time: %d' % self.get_page_load_time_millisecs()
         print 'Dom ready time: %d' % self.get_dom_ready_time_millisecs()
         print 'Request time: %d' % self.get_request_time_millisecs()

--- a/core/tests/performance_framework/perf_domain.py
+++ b/core/tests/performance_framework/perf_domain.py
@@ -134,16 +134,64 @@ class PageSessionMetrics(object):
         return end_timestamp - initial_timestamp
 
     def get_page_load_time_millisecs(self):
-        """Returns the total page load time (in milliseconds)."""
+        """Returns the total page load time."""
         return self._get_duration_millisecs('loadEventEnd', 'fetchStart')
 
     def get_dom_ready_time_millisecs(self):
-        """Returns the total dom ready time (in milliseconds)."""
+        """Returns the time spent constructing the dom tree."""
         return self._get_duration_millisecs('domComplete', 'domInteractive')
 
     def get_request_time_millisecs(self):
-        """Returns the total request time (in milliseconds)."""
+        """Returns the time spent during request."""
         return self._get_duration_millisecs('responseEnd', 'requestStart')
+
+    def get_ready_start_time_millisecs(self):
+        """Returns the time consumed preparing the new page."""
+        return self._get_duration_millisecs('fetchStart', 'navigationStart')
+
+    def get_redirect_time_millisecs(self):
+        """Returns the time spent during redirection."""
+        return self._get_duration_millisecs('redirectEnd', 'redirectStart')
+
+    def get_appcache_time_millisecs(self):
+        """Returns the time spent for appcache."""
+        return self._get_duration_millisecs('domainLookupStart', 'fetchStart')
+
+    def get_unload_event_time_millisecs(self):
+        """Returns the time spent unloading documents."""
+        return self._get_duration_millisecs(
+            'unloadEventEnd', 'unloadEventStart')
+
+    def get_lookup_domain_time_millisecs(self):
+        """Returns the time spent for DNS query."""
+        return self._get_duration_millisecs(
+            'domainLookupEnd', 'domainLookupStart')
+
+    def get_connect_time_millisecs(self):
+        """Returns the time spent for TCP connection."""
+        return self._get_duration_millisecs('connectEnd', 'connectStart')
+
+    def get_init_dom_tree_time_millisecs(self):
+        """Returns the time for request to completion of DOM loading."""
+        return self._get_duration_millisecs('domInteractive', 'responseEnd')
+
+    def get_load_event_time_millisecs(self):
+        """Returns the time for load event."""
+        return self._get_duration_millisecs('loadEventEnd', 'loadEventStart')
+
+    def print_details(self):
+        """Helper function to print details for all the events."""
+        print 'Page load time: %d' % self.get_page_load_time_millisecs()
+        print 'Dom ready time: %d' % self.get_dom_ready_time_millisecs()
+        print 'Request time: %d' % self.get_request_time_millisecs()
+        print 'Ready start time: %d' % self.get_ready_start_time_millisecs()
+        print 'Redirect time: %d' % self.get_redirect_time_millisecs()
+        print 'Appcache time: %d' % self.get_appcache_time_millisecs()
+        print 'Unload event time: %d' % self.get_unload_event_time_millisecs()
+        print 'DNS query time: %d' % self.get_lookup_domain_time_millisecs()
+        print 'TCP connection time: %d' % self.get_connect_time_millisecs()
+        print 'Init domtree time: %d' % self.get_init_dom_tree_time_millisecs()
+        print 'Load event time: %d' % self.get_load_event_time_millisecs()
 
 
 class MultiplePageSessionMetrics(object):
@@ -155,6 +203,14 @@ class MultiplePageSessionMetrics(object):
     def  __init__(self, page_session_metrics):
         self.page_metrics = page_session_metrics
         self._validate()
+
+    def _log_details(self):
+        """Helper function to print details for all the sessions."""
+        print 'No of sessions: %d' % len(self.page_metrics)
+
+        for i, item in enumerate(self.page_metrics):
+            print 'Session %d details: ' % (i + 1)
+            item.print_details()
 
     def _validate(self):
         if not isinstance(self.page_metrics, list):

--- a/core/tests/performance_framework/perf_domain.py
+++ b/core/tests/performance_framework/perf_domain.py
@@ -144,3 +144,33 @@ class PageSessionMetrics(object):
     def get_request_time_millisecs(self):
         """Returns the total request time (in milliseconds)."""
         return self._get_duration_millisecs('responseEnd', 'requestStart')
+
+
+class MultiplePageSessionMetrics(object):
+    """Domain object for multiple PageSessionMetrics.
+    """
+
+    def  __init__(self, page_session_metrics):
+        self.page_metrics = page_session_metrics
+        self._validate()
+
+    def _validate(self):
+        if not isinstance(self.page_metrics, list):
+            raise utils.ValidationError(
+                'Expected page_session_metrics to be a list, '
+                'received %s' % self.page_metrics)
+
+    def get_page_load_time_millisecs(self):
+        """Returns the average total page load time (in milliseconds)."""
+        return (sum(item.get_page_load_time_millisecs()
+                    for item in self.page_metrics))/len(self.page_metrics)
+
+    def get_dom_ready_time_millisecs(self):
+        """Returns the average total page load time (in milliseconds)."""
+        return (sum(item.get_dom_ready_time_millisecs()
+                    for item in self.page_metrics))/len(self.page_metrics)
+
+    def get_request_time_millisecs(self):
+        """Returns the average total page load time (in milliseconds)."""
+        return (sum(item.get_request_time_millisecs()
+                    for item in self.page_metrics))/len(self.page_metrics)

--- a/core/tests/performance_framework/perf_domain.py
+++ b/core/tests/performance_framework/perf_domain.py
@@ -152,7 +152,6 @@ class MultiplePageSessionMetrics(object):
     different page load sessions. This may happen due to various factors like
     background processes.
     """
-
     def  __init__(self, page_session_metrics):
         self.page_metrics = page_session_metrics
         self._validate()
@@ -169,11 +168,11 @@ class MultiplePageSessionMetrics(object):
                     for item in self.page_metrics)) / len(self.page_metrics)
 
     def get_average_dom_ready_time_millisecs(self):
-        """Returns the average total page load time (in milliseconds)."""
+        """Returns the average dom ready time (in milliseconds)."""
         return (sum(item.get_dom_ready_time_millisecs()
                     for item in self.page_metrics)) / len(self.page_metrics)
 
     def get_average_request_time_millisecs(self):
-        """Returns the average total page load time (in milliseconds)."""
+        """Returns the average request time (in milliseconds)."""
         return (sum(item.get_request_time_millisecs()
                     for item in self.page_metrics)) / len(self.page_metrics)

--- a/core/tests/performance_framework/perf_services.py
+++ b/core/tests/performance_framework/perf_services.py
@@ -38,7 +38,7 @@ class SeleniumPerformanceDataFetcher(object):
     """Fetches performance data for locally served Oppia pages using Selenium
     and Browsermob-proxy.
 
-    Selenium is used to programitically interact with a browser.
+    Selenium is used to programmitically interact with a browser.
     Browsermob-proxy is used to capture HTTP Archive (referred to as HAR) data.
 
     The HTTP Archive format is a JSON-formatted archive file format used for

--- a/core/tests/performance_framework/perf_services.py
+++ b/core/tests/performance_framework/perf_services.py
@@ -68,6 +68,15 @@ class SeleniumPerformanceDataFetcher(object):
             error_msg = 'Unsupported browser specified: %s' % browser
             raise ValueError(error_msg)
 
+    def get_url(self, page_url):
+        """Loads the specified url."""
+        with Xvfb() as _:
+            driver = self._setup_driver(proxy=None, use_proxy=False)
+
+            driver.get(page_url)
+
+        self._stop_driver(driver)
+
     def get_page_metrics_for_url(self, page_url):
         """Returns a PageSessionMetrics domain object for a given page URL.
         """

--- a/core/tests/performance_framework/perf_services.py
+++ b/core/tests/performance_framework/perf_services.py
@@ -38,7 +38,7 @@ class SeleniumPerformanceDataFetcher(object):
     """Fetches performance data for locally served Oppia pages using Selenium
     and Browsermob-proxy.
 
-    Selenium is used to programmitically interact with a browser.
+    Selenium is used to programmatically interact with a browser.
     Browsermob-proxy is used to capture HTTP Archive (referred to as HAR) data.
 
     The HTTP Archive format is a JSON-formatted archive file format used for

--- a/core/tests/performance_framework/perf_services.py
+++ b/core/tests/performance_framework/perf_services.py
@@ -69,7 +69,10 @@ class SeleniumPerformanceDataFetcher(object):
             raise ValueError(error_msg)
 
     def load_url(self, page_url):
-        """Loads the specified url."""
+        """Loads the specified url, resulting in server-side caching of related
+        resources. Used to obtain a uniform and warm-cache state for the tests,
+        similar to a typical production server state.
+        """
         with Xvfb() as _:
             driver = self._setup_driver(proxy=None, use_proxy=False)
 

--- a/core/tests/performance_framework/perf_services.py
+++ b/core/tests/performance_framework/perf_services.py
@@ -68,7 +68,7 @@ class SeleniumPerformanceDataFetcher(object):
             error_msg = 'Unsupported browser specified: %s' % browser
             raise ValueError(error_msg)
 
-    def get_url(self, page_url):
+    def load_url(self, page_url):
         """Loads the specified url."""
         with Xvfb() as _:
             driver = self._setup_driver(proxy=None, use_proxy=False)

--- a/core/tests/performance_tests/base.py
+++ b/core/tests/performance_tests/base.py
@@ -17,6 +17,7 @@
 import unittest
 
 from core.tests.performance_framework import perf_services
+from core.tests.performance_framework import perf_domain
 
 
 class TestBase(unittest.TestCase):
@@ -36,9 +37,22 @@ class TestBase(unittest.TestCase):
             self.data_fetcher.get_page_metrics_from_cached_session(page_url))
 
     def _record_page_timings_for_url(self, page_url):
-        self.page_metrics = (
-            self.data_fetcher.get_page_timings_for_url(page_url))
+        page_session_metrics = []
+
+        for _ in range(3):
+            page_session_metrics.append(
+                self.data_fetcher.get_page_timings_for_url(page_url))
+
+        self.page_metrics = perf_domain.MultiplePageSessionMetrics(
+            page_session_metrics)
 
     def _record_page_timings_from_cached_session(self, page_url):
-        self.page_metrics = (
-            self.data_fetcher.get_page_timings_from_cached_session(page_url))
+        page_session_metrics = []
+
+        for _ in range(3):
+            page_session_metrics.append(
+                self.data_fetcher.get_page_timings_from_cached_session(
+                    page_url))
+
+        self.page_metrics = perf_domain.MultiplePageSessionMetrics(
+            page_session_metrics)

--- a/core/tests/performance_tests/base.py
+++ b/core/tests/performance_tests/base.py
@@ -23,13 +23,17 @@ from core.tests.performance_framework import perf_domain
 class TestBase(unittest.TestCase):
     """Base class for performance tests."""
     # Count of the number of page load sessions that we consider for
-    # calculating timing     metrics.
+    # calculating timing metrics.
     SESSION_COUNT = 3
 
     def setUp(self):
         self.data_fetcher = perf_services.SeleniumPerformanceDataFetcher(
             browser='chrome')
         self.page_metrics = None
+
+    def _load_page_to_cache_server_resources(self, page_url):
+        """Load the specified page url to cache server resources."""
+        self.data_fetcher.get_url(page_url)
 
     def _record_page_metrics_for_url(self, page_url):
         self.page_metrics = (

--- a/core/tests/performance_tests/base.py
+++ b/core/tests/performance_tests/base.py
@@ -22,6 +22,9 @@ from core.tests.performance_framework import perf_domain
 
 class TestBase(unittest.TestCase):
     """Base class for performance tests."""
+    # Count of the number of page load sessions that we consider for
+    # calculating timing     metrics.
+    SESSION_COUNT = 3
 
     def setUp(self):
         self.data_fetcher = perf_services.SeleniumPerformanceDataFetcher(
@@ -36,21 +39,20 @@ class TestBase(unittest.TestCase):
         self.page_metrics = (
             self.data_fetcher.get_page_metrics_from_cached_session(page_url))
 
-    def _record_page_timings_for_url(self, page_url, session_count=3):
+    def _record_page_timings_for_url(self, page_url):
         page_session_metrics = []
 
-        for _ in range(session_count):
+        for _ in range(self.SESSION_COUNT):
             page_session_metrics.append(
                 self.data_fetcher.get_page_timings_for_url(page_url))
 
         self.page_metrics = perf_domain.MultiplePageSessionMetrics(
             page_session_metrics)
 
-    def _record_page_timings_from_cached_session(
-            self, page_url, session_count=3):
+    def _record_page_timings_from_cached_session(self, page_url):
         page_session_metrics = []
 
-        for _ in range(session_count):
+        for _ in range(self.SESSION_COUNT):
             page_session_metrics.append(
                 self.data_fetcher.get_page_timings_from_cached_session(
                     page_url))

--- a/core/tests/performance_tests/base.py
+++ b/core/tests/performance_tests/base.py
@@ -22,9 +22,8 @@ from core.tests.performance_framework import perf_domain
 
 class TestBase(unittest.TestCase):
     """Base class for performance tests."""
-    # Count of the number of page load sessions that we consider for
-    # calculating timing metrics.
-    SESSION_COUNT = 3
+    # The default number of page load sessions used to collect timing metrics.
+    DEFAULT_SESSION_SAMPLE_COUNT = 3
 
     def setUp(self):
         self.data_fetcher = perf_services.SeleniumPerformanceDataFetcher(
@@ -32,8 +31,7 @@ class TestBase(unittest.TestCase):
         self.page_metrics = None
 
     def _load_page_to_cache_server_resources(self, page_url):
-        """Load the specified page url to cache server resources."""
-        self.data_fetcher.get_url(page_url)
+        self.data_fetcher.load_url(page_url)
 
     def _record_page_metrics_for_url(self, page_url):
         self.page_metrics = (
@@ -43,20 +41,22 @@ class TestBase(unittest.TestCase):
         self.page_metrics = (
             self.data_fetcher.get_page_metrics_from_cached_session(page_url))
 
-    def _record_page_timings_for_url(self, page_url):
+    def _record_average_page_timings_for_url(
+            self, page_url, session_count=DEFAULT_SESSION_SAMPLE_COUNT):
         page_session_metrics = []
 
-        for _ in range(self.SESSION_COUNT):
+        for _ in range(session_count):
             page_session_metrics.append(
                 self.data_fetcher.get_page_timings_for_url(page_url))
 
         self.page_metrics = perf_domain.MultiplePageSessionMetrics(
             page_session_metrics)
 
-    def _record_page_timings_from_cached_session(self, page_url):
+    def _record_average_page_timings_from_cached_session(
+            self, page_url, session_count=DEFAULT_SESSION_SAMPLE_COUNT):
         page_session_metrics = []
 
-        for _ in range(self.SESSION_COUNT):
+        for _ in range(session_count):
             page_session_metrics.append(
                 self.data_fetcher.get_page_timings_from_cached_session(
                     page_url))

--- a/core/tests/performance_tests/base.py
+++ b/core/tests/performance_tests/base.py
@@ -36,20 +36,21 @@ class TestBase(unittest.TestCase):
         self.page_metrics = (
             self.data_fetcher.get_page_metrics_from_cached_session(page_url))
 
-    def _record_page_timings_for_url(self, page_url):
+    def _record_page_timings_for_url(self, page_url, session_count=3):
         page_session_metrics = []
 
-        for _ in range(3):
+        for _ in range(session_count):
             page_session_metrics.append(
                 self.data_fetcher.get_page_timings_for_url(page_url))
 
         self.page_metrics = perf_domain.MultiplePageSessionMetrics(
             page_session_metrics)
 
-    def _record_page_timings_from_cached_session(self, page_url):
+    def _record_page_timings_from_cached_session(
+            self, page_url, session_count=3):
         page_session_metrics = []
 
-        for _ in range(3):
+        for _ in range(session_count):
             page_session_metrics.append(
                 self.data_fetcher.get_page_timings_from_cached_session(
                     page_url))

--- a/core/tests/performance_tests/base.py
+++ b/core/tests/performance_tests/base.py
@@ -43,23 +43,23 @@ class TestBase(unittest.TestCase):
 
     def _record_average_page_timings_for_url(
             self, page_url, session_count=DEFAULT_SESSION_SAMPLE_COUNT):
-        page_session_metrics = []
+        page_session_metrics_list = []
 
         for _ in range(session_count):
-            page_session_metrics.append(
+            page_session_metrics_list.append(
                 self.data_fetcher.get_page_timings_for_url(page_url))
 
         self.page_metrics = perf_domain.MultiplePageSessionMetrics(
-            page_session_metrics)
+            page_session_metrics_list)
 
     def _record_average_page_timings_from_cached_session(
             self, page_url, session_count=DEFAULT_SESSION_SAMPLE_COUNT):
-        page_session_metrics = []
+        page_session_metrics_list = []
 
         for _ in range(session_count):
-            page_session_metrics.append(
+            page_session_metrics_list.append(
                 self.data_fetcher.get_page_timings_from_cached_session(
                     page_url))
 
         self.page_metrics = perf_domain.MultiplePageSessionMetrics(
-            page_session_metrics)
+            page_session_metrics_list)

--- a/core/tests/performance_tests/splash_test.py
+++ b/core/tests/performance_tests/splash_test.py
@@ -33,7 +33,7 @@ class SplashPagePerformanceTest(base.TestBase):
             self.page_metrics.get_total_page_size_bytes(), 10000000)
 
     def test_splash_page_loads_under_10_seconds(self):
-        self._record_page_timings_for_url(self.SPLASH_URL)
+        self._record_average_page_timings_for_url(self.SPLASH_URL)
 
         self.assertLessEqual(
             self.page_metrics.get_average_page_load_time_millisecs(), 10000)
@@ -56,7 +56,7 @@ class SplashPagePerformanceForCachedSessionTest(base.TestBase):
             self.page_metrics.get_total_page_size_bytes(), 1000000)
 
     def test_splash_page_loads_under_3_seconds(self):
-        self._record_page_timings_from_cached_session(self.SPLASH_URL)
+        self._record_average_page_timings_from_cached_session(self.SPLASH_URL)
 
         self.assertLessEqual(
             self.page_metrics.get_average_page_load_time_millisecs(), 3000)

--- a/core/tests/performance_tests/splash_test.py
+++ b/core/tests/performance_tests/splash_test.py
@@ -32,7 +32,7 @@ class SplashPagePerformanceTest(base.TestBase):
             self.page_metrics.get_total_page_size_bytes(), 10000000)
 
     def test_splash_page_loads_under_10_seconds(self):
-        self._record_page_timings_for_url(self.SPLASH_URL, session_count=3)
+        self._record_page_timings_for_url(self.SPLASH_URL)
 
         self.assertLessEqual(
             self.page_metrics.get_average_page_load_time_millisecs(), 10000)
@@ -54,8 +54,7 @@ class SplashPagePerformanceForCachedSessionTest(base.TestBase):
             self.page_metrics.get_total_page_size_bytes(), 1000000)
 
     def test_splash_page_loads_under_3_seconds(self):
-        self._record_page_timings_from_cached_session(
-            self.SPLASH_URL, session_count=3)
+        self._record_page_timings_from_cached_session(self.SPLASH_URL)
 
         self.assertLessEqual(
             self.page_metrics.get_average_page_load_time_millisecs(), 3000)

--- a/core/tests/performance_tests/splash_test.py
+++ b/core/tests/performance_tests/splash_test.py
@@ -32,20 +32,20 @@ class SplashPagePerformanceTest(base.TestBase):
             self.page_metrics.get_total_page_size_bytes(), 10000000)
 
     def test_splash_page_loads_under_10_seconds(self):
-        self._record_page_timings_for_url(self.SPLASH_URL)
+        self._record_page_timings_for_url(self.SPLASH_URL, session_count=3)
 
         self.assertLessEqual(
-            self.page_metrics.get_page_load_time_millisecs(), 10000)
+            self.page_metrics.get_average_page_load_time_millisecs(), 10000)
 
 
-class SplashPagePerformanceForCachedStateTest(base.TestBase):
-    """Performance tests for the splash page for the cached state or
+class SplashPagePerformanceForCachedSessionTest(base.TestBase):
+    """Performance tests for the splash page for the cached session or
     return user.
     """
     SPLASH_URL = 'http://localhost:9501/splash'
 
     def setUp(self):
-        super(SplashPagePerformanceForCachedStateTest, self).setUp()
+        super(SplashPagePerformanceForCachedSessionTest, self).setUp()
 
     def test_splash_page_has_less_than_1_megabytes_sent_to_the_client(self):
         self._record_page_metrics_from_cached_session(self.SPLASH_URL)
@@ -54,7 +54,8 @@ class SplashPagePerformanceForCachedStateTest(base.TestBase):
             self.page_metrics.get_total_page_size_bytes(), 1000000)
 
     def test_splash_page_loads_under_3_seconds(self):
-        self._record_page_timings_from_cached_session(self.SPLASH_URL)
+        self._record_page_timings_from_cached_session(
+            self.SPLASH_URL, session_count=3)
 
         self.assertLessEqual(
-            self.page_metrics.get_page_load_time_millisecs(), 3000)
+            self.page_metrics.get_average_page_load_time_millisecs(), 3000)

--- a/core/tests/performance_tests/splash_test.py
+++ b/core/tests/performance_tests/splash_test.py
@@ -24,6 +24,7 @@ class SplashPagePerformanceTest(base.TestBase):
 
     def setUp(self):
         super(SplashPagePerformanceTest, self).setUp()
+        self._load_page_to_cache_server_resources(self.SPLASH_URL)
 
     def test_splash_page_has_less_than_10_megabytes_sent_to_the_client(self):
         self._record_page_metrics_for_url(self.SPLASH_URL)
@@ -46,6 +47,7 @@ class SplashPagePerformanceForCachedSessionTest(base.TestBase):
 
     def setUp(self):
         super(SplashPagePerformanceForCachedSessionTest, self).setUp()
+        self._load_page_to_cache_server_resources(self.SPLASH_URL)
 
     def test_splash_page_has_less_than_1_megabytes_sent_to_the_client(self):
         self._record_page_metrics_from_cached_session(self.SPLASH_URL)


### PR DESCRIPTION
This is the second PR for #2047, in continuation with #2068. It implements a domain object for containing multiple PageSession objects and returning average metrics.