### PR TITLE
Part of #461: implement send_feedback_message_email function in feedback_services

### DIFF
--- a/core/domain/feedback_domain.py
+++ b/core/domain/feedback_domain.py
@@ -138,7 +138,7 @@ class Suggestion(object):
         }
 
 
-class FeedbackMessageReferences(object):
+class FeedbackMessageReference(object):
     """Domain object for feedback message references"""
 
     def __init__(self, exploration_id, thread_id, message_id):

--- a/core/domain/feedback_domain.py
+++ b/core/domain/feedback_domain.py
@@ -137,3 +137,18 @@ class Suggestion(object):
             'state_content': self.state_content
         }
 
+
+class FeedbackMessageReferences(object):
+    """Domain object for feedback message references"""
+
+    def __init__(self, exploration_id, thread_id, message_id):
+        self.exploration_id = exploration_id
+        self.thread_id = thread_id
+        self.message_id = message_id
+
+    def to_dict(self):
+        return {
+            'exploration_id': self.exploration_id,
+            'thread_id': self.thread_id,
+            'message_id': self.message_id
+        }

--- a/core/domain/feedback_domain_test.py
+++ b/core/domain/feedback_domain_test.py
@@ -143,3 +143,24 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
         self.assertDictEqual(expected_suggestion_dict,
                              observed_suggestion.to_dict())
 
+
+class FeedbackMessageReferencesDomainTests(test_utils.GenericTestBase):
+    def setUp(self):
+        super(FeedbackMessageReferencesDomainTests, self).setUp()
+        self.exp_id = 'exp'
+        self.message_id = 'message'
+        self.thread_id = 'thread'
+
+    def test_to_dict(self):
+        expected_feedback_message_reference = {
+            'exploration_id': self.exp_id,
+            'thread_id': self.thread_id,
+            'message_id': self.message_id
+        }
+
+        observed_feedback_message_reference = (
+            feedback_domain.FeedbackMessageReferences(
+                self.exp_id, self.thread_id, self.message_id))
+
+        self.assertDictEqual(observed_feedback_message_reference.to_dict(),
+                             expected_feedback_message_reference)

--- a/core/domain/feedback_domain_test.py
+++ b/core/domain/feedback_domain_test.py
@@ -144,9 +144,10 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
                              observed_suggestion.to_dict())
 
 
-class FeedbackMessageReferencesDomainTests(test_utils.GenericTestBase):
+class FeedbackMessageReferenceDomainTests(test_utils.GenericTestBase):
+
     def setUp(self):
-        super(FeedbackMessageReferencesDomainTests, self).setUp()
+        super(FeedbackMessageReferenceDomainTests, self).setUp()
         self.exp_id = 'exp'
         self.message_id = 'message'
         self.thread_id = 'thread'
@@ -159,7 +160,7 @@ class FeedbackMessageReferencesDomainTests(test_utils.GenericTestBase):
         }
 
         observed_feedback_message_reference = (
-            feedback_domain.FeedbackMessageReferences(
+            feedback_domain.FeedbackMessageReference(
                 self.exp_id, self.thread_id, self.message_id))
 
         self.assertDictEqual(observed_feedback_message_reference.to_dict(),

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 """Tests for feedback-related services."""
-
+from core.domain import exp_domain
+from core.domain import exp_services
 from core.domain import feedback_services
 from core.domain import user_services
 from core.platform import models
@@ -252,10 +253,74 @@ class EmailsTaskqueueTests(test_utils.GenericTestBase):
     def test_create_new_task(self):
         user_id = 'user'
         feedback_services.enqueue_feedback_message_email_task(user_id)
-        self.assertEqual(
-            self.count_jobs_in_taskqueue(), 1)
+        self.assertEqual(self.count_jobs_in_taskqueue(), 1)
 
         tasks = self.get_pending_tasks()
         self.assertEqual(
             tasks[0].url, feconf.FEEDBACK_MESSAGE_EMAIL_HANDLER_URL)
+        self.process_and_flush_pending_tasks()
+
+
+class FeedbackMessageEmailTests(test_utils.GenericTestBase):
+    """Tests for feedback message emails."""
+
+    def setUp(self):
+        super(FeedbackMessageEmailTests, self).setUp()
+        self.signup('a@example.com', 'A')
+        self.user_id_a = self.get_user_id_from_email('a@example.com')
+        self.exp_id = 'exp'
+        self.thread_id = 'thread'
+        self.message_id1 = 'msg1'
+        self.message_id2 = 'msg2'
+
+    def test_send_feedback_message_email(self):
+        exp = exp_domain.Exploration.create_default_exploration(self.exp_id)
+        exp_services.save_new_exploration(self.user_id_a, exp)
+
+        feedback_services.send_feedback_message_email(
+            self.exp_id, self.thread_id, self.message_id1)
+        self.assertEqual(self.count_jobs_in_taskqueue(), 1)
+
+        expected_feedback_message_dict = {
+            'exploration_id': self.exp_id,
+            'thread_id': self.thread_id,
+            'message_id': self.message_id1
+        }
+        model = feedback_models.UnsentFeedbackEmailModel.get(self.user_id_a)
+        self.assertEqual(
+            sorted(model.feedback_messages[0]),
+            sorted(expected_feedback_message_dict))
+        self.assertEqual(model.retries, 0)
+        self.process_and_flush_pending_tasks()
+
+    def test_add_new_feedback_message(self):
+        exp = exp_domain.Exploration.create_default_exploration(self.exp_id)
+        exp_services.save_new_exploration(self.user_id_a, exp)
+
+        feedback_services.send_feedback_message_email(
+            self.exp_id, self.thread_id, self.message_id1)
+        feedback_services.send_feedback_message_email(
+            self.exp_id, self.thread_id, self.message_id2)
+
+        self.assertEqual(self.count_jobs_in_taskqueue(), 1)
+
+        expected_feedback_message_dict1 = {
+            'exploration_id': self.exp_id,
+            'thread_id': self.thread_id,
+            'message_id': self.message_id1
+        }
+        expected_feedback_message_dict2 = {
+            'exploration_id': self.exp_id,
+            'thread_id': self.thread_id,
+            'message_id': self.message_id2
+        }
+
+        model = feedback_models.UnsentFeedbackEmailModel.get(self.user_id_a)
+        self.assertEqual(
+            sorted(model.feedback_messages[0]),
+            sorted(expected_feedback_message_dict1))
+        self.assertEqual(
+            sorted(model.feedback_messages[1]),
+            sorted(expected_feedback_message_dict2))
+        self.assertEqual(model.retries, 0)
         self.process_and_flush_pending_tasks()

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -287,7 +287,7 @@ class FeedbackMessageEmailTests(test_utils.GenericTestBase):
             'message_id': self.message_id1
         }
         model = feedback_models.UnsentFeedbackEmailModel.get(self.user_id_a)
-        self.assertEqual(
+        self.assertDictEqual(
             model.feedback_message_references[0],
             expected_feedback_message_dict)
         self.assertEqual(model.retries, 0)
@@ -316,10 +316,10 @@ class FeedbackMessageEmailTests(test_utils.GenericTestBase):
         }
 
         model = feedback_models.UnsentFeedbackEmailModel.get(self.user_id_a)
-        self.assertEqual(
+        self.assertDictEqual(
             model.feedback_message_references[0],
             expected_feedback_message_dict1)
-        self.assertEqual(
+        self.assertDictEqual(
             model.feedback_message_references[1],
             expected_feedback_message_dict2)
         self.assertEqual(model.retries, 0)

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -288,8 +288,8 @@ class FeedbackMessageEmailTests(test_utils.GenericTestBase):
         }
         model = feedback_models.UnsentFeedbackEmailModel.get(self.user_id_a)
         self.assertEqual(
-            sorted(model.feedback_messages[0]),
-            sorted(expected_feedback_message_dict))
+            model.feedback_message_references[0],
+            expected_feedback_message_dict)
         self.assertEqual(model.retries, 0)
         self.process_and_flush_pending_tasks()
 
@@ -317,10 +317,10 @@ class FeedbackMessageEmailTests(test_utils.GenericTestBase):
 
         model = feedback_models.UnsentFeedbackEmailModel.get(self.user_id_a)
         self.assertEqual(
-            sorted(model.feedback_messages[0]),
-            sorted(expected_feedback_message_dict1))
+            model.feedback_message_references[0],
+            expected_feedback_message_dict1)
         self.assertEqual(
-            sorted(model.feedback_messages[1]),
-            sorted(expected_feedback_message_dict2))
+            model.feedback_message_references[1],
+            expected_feedback_message_dict2)
         self.assertEqual(model.retries, 0)
         self.process_and_flush_pending_tasks()

--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -308,22 +308,3 @@ class UnsentFeedbackEmailModel(base_models.BaseModel):
     # The number of failed attempts that have been made (so far) to
     # send an email to this user.
     retries = ndb.IntegerProperty(default=0, required=True, indexed=True)
-
-    @classmethod
-    def create_or_modify(cls, owner_id, feedback_message_reference):
-        """Creates a new instance of UnsentFeedbackEmailModel for sending
-        feedback message email"""
-
-        model = cls.get(owner_id, strict=False)
-        new_instance = True
-
-        if model:
-            model.feedback_message_references.append(feedback_message_reference)
-            model.put()
-            return not new_instance
-        else:
-            model = cls(
-                id=owner_id,
-                feedback_message_references=[feedback_message_reference])
-            model.put()
-            return new_instance

--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -304,7 +304,26 @@ class UnsentFeedbackEmailModel(base_models.BaseModel):
     # Each element in this list is a dict with keys 'exploration_id',
     # 'thread_id' and 'message_id'; this information is used to retrieve
     # corresponding FeedbackMessageModel instance.
-    feedback_messages = ndb.JsonProperty(repeated=True)
+    feedback_message_references = ndb.JsonProperty(repeated=True)
     # The number of failed attempts that have been made (so far) to
     # send an email to this user.
     retries = ndb.IntegerProperty(default=0, required=True, indexed=True)
+
+    @classmethod
+    def create_or_modify(cls, owner_id, feedback_message_reference):
+        """Creates a new instance of UnsentFeedbackEmailModel for sending
+        feedback message email"""
+
+        model = cls.get(owner_id, strict=False)
+        new_instance = True
+
+        if model:
+            model.feedback_message_references.append(feedback_message_reference)
+            model.put()
+            return not new_instance
+        else:
+            model = cls(
+                id=owner_id,
+                feedback_message_references=[feedback_message_reference])
+            model.put()
+            return new_instance

--- a/core/storage/feedback/gae_models_test.py
+++ b/core/storage/feedback/gae_models_test.py
@@ -120,12 +120,13 @@ class UnsentFeedbackEmailModelTest(test_utils.GenericTestBase):
             'message_id': 'message_id1'
         }
         email_instance = feedback_models.UnsentFeedbackEmailModel(
-            id=user_id, feedback_messages=[feedback_messages_dict])
+            id=user_id, feedback_message_references=[feedback_messages_dict])
         email_instance.put()
 
         retrieved_instance = (
             feedback_models.UnsentFeedbackEmailModel.get_by_id(id=user_id))
 
         self.assertEqual(
-            retrieved_instance.feedback_messages, [feedback_messages_dict])
+            retrieved_instance.feedback_message_references,
+            [feedback_messages_dict])
         self.assertEqual(retrieved_instance.retries, 0)

--- a/core/storage/feedback/gae_models_test.py
+++ b/core/storage/feedback/gae_models_test.py
@@ -114,13 +114,13 @@ class UnsentFeedbackEmailModelTest(test_utils.GenericTestBase):
 
     def test_new_instances_stores_correct_data(self):
         user_id = 'A'
-        feedback_messages_dict = {
+        message_reference_dict = {
             'exploration_id': 'ABC123',
             'thread_id': 'thread_id1',
             'message_id': 'message_id1'
         }
         email_instance = feedback_models.UnsentFeedbackEmailModel(
-            id=user_id, feedback_message_references=[feedback_messages_dict])
+            id=user_id, feedback_message_references=[message_reference_dict])
         email_instance.put()
 
         retrieved_instance = (
@@ -128,5 +128,5 @@ class UnsentFeedbackEmailModelTest(test_utils.GenericTestBase):
 
         self.assertEqual(
             retrieved_instance.feedback_message_references,
-            [feedback_messages_dict])
+            [message_reference_dict])
         self.assertEqual(retrieved_instance.retries, 0)


### PR DESCRIPTION
Milestone 3 of feedback message email service

Implements send_feedback_message_email function in feedback_services. Relevant tests have been added to feedback_services_test.

This function is responsible for creating new model or modifying existing model of UnsentFeedbackEmailModel, depending upon whether model already exists or not.