### PR TITLE
Fix #2091 Adjust footer on smaller screens

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -686,10 +686,7 @@ textarea {
   }
   
   .oppia-footer-container {
-    max-width: 800px;
-    margin-left: auto;
-    margin-right: auto;
-    padding: 30px 80px 30px 30px;
+    padding: 30px;
   }
 
 }

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -686,11 +686,11 @@ textarea {
   }
   
   .oppia-footer-container {
-  max-width: 800px;
-  margin-left: auto;
-  margin-right: auto;
-  padding: 30px 80px 30px 30px;
-}
+    max-width: 800px;
+    margin-left: auto;
+    margin-right: auto;
+    padding: 30px 80px 30px 30px;
+  }
 
 }
 

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -680,18 +680,19 @@ textarea {
   height: 198px;
 }
 
-.oppia-footer-margin{
-
-}
-
 @media (max-width: 768px) {
   .oppia-footer-padding {
     height: 464px;
+    padding-left: -100px;
   }
+  
+  .oppia-footer-container {
+  max-width: 800px;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 30px 80px 30px 30px;
+}
 
-  .oppia-footer-margin {
-    margin-left: -60px;
-  }
 }
 
 /*

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -680,9 +680,17 @@ textarea {
   height: 198px;
 }
 
+.oppia-footer-margin{
+
+}
+
 @media (max-width: 768px) {
   .oppia-footer-padding {
     height: 464px;
+  }
+
+  .oppia-footer-margin {
+    margin-left: -60px;
   }
 }
 

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -683,7 +683,6 @@ textarea {
 @media (max-width: 768px) {
   .oppia-footer-padding {
     height: 464px;
-    padding-left: -100px;
   }
   
   .oppia-footer-container {

--- a/core/templates/dev/head/footer.html
+++ b/core/templates/dev/head/footer.html
@@ -3,7 +3,7 @@
 
 <footer class="oppia-footer">
   <div class="oppia-footer-container">
-    <div class="row oppia-footer-margin">
+    <div class="row">
       <div class="col-sm-3">
         <h4 translate="I18N_FOOTER_ABOUT_ALL_CAPS"></h4>
         <ul>

--- a/core/templates/dev/head/footer.html
+++ b/core/templates/dev/head/footer.html
@@ -3,7 +3,7 @@
 
 <footer class="oppia-footer">
   <div class="oppia-footer-container">
-    <div class="row">
+    <div class="row oppia-footer-margin">
       <div class="col-sm-3">
         <h4 translate="I18N_FOOTER_ABOUT_ALL_CAPS"></h4>
         <ul>


### PR DESCRIPTION
New css class is added in``` oppia.css ```  in the media query to adjust the left margin on smaller screens to get expected styling

