### PR TITLE
Fix #2113: Added Wide option for non-terminal, non-narrow cards

### DIFF
--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -32,8 +32,8 @@
            class="conversation-skin-main-tutor-card"
            ng-class="{'animate-card-width': startCardChangeAnimation,
                       'has-shadow': isViewportNarrow() && isCurrentSupplementalCardNonempty(),
-                      'conversation-skin-animate-tutor-card-on-narrow': isViewportNarrow() &&
-                      isCurrentSupplementalCardNonempty()}">
+                      'conversation-skin-animate-tutor-card-on-narrow': isViewportNarrow() && isCurrentSupplementalCardNonempty(),
+                      'conversation-skin-main-tutor-card-wide': !isViewportNarrow() || !isOnTerminalCard()}">
         <div class="conversation-skin-tutor-card-content conversation-skin-animate-card-contents"
              ng-class="{'animate-card-change': startCardChangeAnimation}">
           <div class="conversation-skin-tutor-card-top-section">
@@ -648,11 +648,14 @@
       .conversation-skin-main-tutor-card {
         left: 0px;
         margin: 0 auto;
-        position: absolute;
         right: 0px;
         top: 40px;
         width: 100%;
         z-index: 15;
+      }
+
+      .conversation-skin-main-tutor-card-wide {
+        position: absolute;
       }
 
       .has-shadow {


### PR DESCRIPTION
This seems to be on account of the media screen size css rules, added a css rule for non-terminal, non-narrow, smaller media screen incidents. Note this does throw off the fluidity of the movement between moving between smaller and larger media screen in some cases. Let me know if there is a better way to do this.