### PR TITLE
Fix #2164: Expand exploration summary tile width to match collection summary tile width

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -684,7 +684,7 @@ textarea {
   .oppia-footer-padding {
     height: 464px;
   }
-  
+
   .oppia-footer-container {
     padding: 30px;
   }
@@ -3378,7 +3378,7 @@ md-card.preview-conversation-skin-supplemental-card {
   cursor: pointer;
   display: inline-block;
   height: 258px;
-  margin: 12px 4px;
+  margin: 12px 7px;
   padding: 0;
   position: relative;
   text-align: left;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -974,7 +974,7 @@ textarea {
 }
 @media (max-width: 420px) {
   .oppia-exp-summary-tiles-container {
-    width: 208px;
+    width: 214px;
   }
 }
 

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3378,6 +3378,10 @@ md-card.preview-conversation-skin-supplemental-card {
   cursor: pointer;
   display: inline-block;
   height: 258px;
+  /*
+    The margin setting is so that exploration summary tiles and collection
+    summary tiles would be the same widths (214px).
+  */
   margin: 12px 7px;
   padding: 0;
   position: relative;

--- a/core/templates/dev/head/library/Library.js
+++ b/core/templates/dev/head/library/Library.js
@@ -47,7 +47,7 @@ oppia.controller('Library', [
       // Pause is necessary to ensure all elements have loaded, same for
       // initCarousels.
       // TODO(sll): On small screens, the tiles do not have a defined width.
-      // The use of 208 here is a hack, and the underlying problem of the tiles
+      // The use of 214 here is a hack, and the underlying problem of the tiles
       // not having a defined width on small screens needs to be fixed.
       $timeout(function() {
         tileDisplayWidth = $('exploration-summary-tile').width() || 214;

--- a/core/templates/dev/head/library/Library.js
+++ b/core/templates/dev/head/library/Library.js
@@ -50,7 +50,7 @@ oppia.controller('Library', [
       // The use of 208 here is a hack, and the underlying problem of the tiles
       // not having a defined width on small screens needs to be fixed.
       $timeout(function() {
-        tileDisplayWidth = $('exploration-summary-tile').width() || 208;
+        tileDisplayWidth = $('exploration-summary-tile').width() || 214;
       }, 20);
 
       // Initialize the carousel(s) on the library index page.


### PR DESCRIPTION
This PR fixes #2164, the decision to maximize the exploration summary tile was to ensure that the carousel width would fit all 4 collections if present and that the carousel width is consistent for all groups. 

Only explorations:
![image](https://cloud.githubusercontent.com/assets/5758256/16405022/25454f68-3cb9-11e6-8632-8149aaa6a209.png)

Mixed:
![image](https://cloud.githubusercontent.com/assets/5758256/16405059/74982644-3cb9-11e6-96b4-e3764b7042e1.png)
