### PR TITLE
Fix #2092: Placeholder sometimes shows 'I18N_PREFERENCES...' on subject interests and preferred languages.

### DIFF
--- a/core/templates/dev/head/profile/Preferences.js
+++ b/core/templates/dev/head/profile/Preferences.js
@@ -32,10 +32,14 @@ oppia.controller('Preferences', [
       });
     };
 
-    var _forceDOMRefresh = function() {
-      $scope.isClean = false;
+    // Select2 dropdown cannot automatically refresh its display
+    // after being translated.
+    // Use $scope.select2DropdownIsShown in its ng-if attribute
+    // and this function to force it to reload
+    var _forceSelect2Refresh = function() {
+      $scope.select2DropdownIsShown = false;
       $timeout(function() {
-        $scope.isClean = true;
+        $scope.select2DropdownIsShown = true;
       }, 100);
     };
 
@@ -85,7 +89,7 @@ oppia.controller('Preferences', [
     $scope.savePreferredSiteLanguageCodes = function(
       preferredSiteLanguageCode) {
       $translate.use(preferredSiteLanguageCode);
-      _forceDOMRefresh();
+      _forceSelect2Refresh();
       _saveDataItem(
         'preferred_site_language_code', preferredSiteLanguageCode);
     };
@@ -192,7 +196,7 @@ oppia.controller('Preferences', [
       $scope.canReceiveEditorRoleEmail = data.can_receive_editor_role_email;
       $scope.preferredSiteLanguageCode = data.preferred_site_language_code;
       $scope.hasPageLoaded = true;
-      _forceDOMRefresh();
+      _forceSelect2Refresh();
     });
   }
 ]);

--- a/core/templates/dev/head/profile/Preferences.js
+++ b/core/templates/dev/head/profile/Preferences.js
@@ -32,6 +32,13 @@ oppia.controller('Preferences', [
       });
     };
 
+    var _forceDOMRefresh = function() {
+      $scope.isClean = false;
+      $timeout(function() {
+        $scope.isClean = true;
+      }, 100);
+    };
+
     $scope.saveUserBio = function(userBio) {
       _saveDataItem('user_bio', userBio);
     };
@@ -78,6 +85,7 @@ oppia.controller('Preferences', [
     $scope.savePreferredSiteLanguageCodes = function(
       preferredSiteLanguageCode) {
       $translate.use(preferredSiteLanguageCode);
+      _forceDOMRefresh();
       _saveDataItem(
         'preferred_site_language_code', preferredSiteLanguageCode);
     };
@@ -184,6 +192,7 @@ oppia.controller('Preferences', [
       $scope.canReceiveEditorRoleEmail = data.can_receive_editor_role_email;
       $scope.preferredSiteLanguageCode = data.preferred_site_language_code;
       $scope.hasPageLoaded = true;
+      _forceDOMRefresh();
     });
   }
 ]);

--- a/core/templates/dev/head/profile/preferences.html
+++ b/core/templates/dev/head/profile/preferences.html
@@ -75,7 +75,7 @@
           <div class="form-group">
             <label class="col-lg-2 col-md-2 col-sm-2" translate="I18N_PREFERENCES_SUBJECT_INTERESTS"></label>
             <div class="col-lg-10 col-md-10 col-sm-10">
-              <div ng-if="hasPageLoaded">
+              <div ng-if="hasPageLoaded && isClean">
                 <select2-dropdown
                   item="$parent.subjectInterests"
                   ng-model="subjectInterests"
@@ -127,7 +127,7 @@
                 If the ng-if is omitted, the select2-dropdown directive won't be
                 updated after the initial page load.
               -->
-              <div ng-if="hasPageLoaded">
+              <div ng-if="hasPageLoaded && isClean">
                 <select2-dropdown choices="SITE_LANGUAGE_CHOICES"
                   class="protractor-test-system-language-selector"
                   item="$parent.preferredSiteLanguageCode"

--- a/core/templates/dev/head/profile/preferences.html
+++ b/core/templates/dev/head/profile/preferences.html
@@ -75,7 +75,7 @@
           <div class="form-group">
             <label class="col-lg-2 col-md-2 col-sm-2" translate="I18N_PREFERENCES_SUBJECT_INTERESTS"></label>
             <div class="col-lg-10 col-md-10 col-sm-10">
-              <div ng-if="hasPageLoaded && isClean">
+              <div ng-if="hasPageLoaded && select2DropdownIsShown">
                 <select2-dropdown
                   item="$parent.subjectInterests"
                   ng-model="subjectInterests"
@@ -127,7 +127,7 @@
                 If the ng-if is omitted, the select2-dropdown directive won't be
                 updated after the initial page load.
               -->
-              <div ng-if="hasPageLoaded && isClean">
+              <div ng-if="hasPageLoaded && select2DropdownIsShown">
                 <select2-dropdown choices="SITE_LANGUAGE_CHOICES"
                   class="protractor-test-system-language-selector"
                   item="$parent.preferredSiteLanguageCode"


### PR DESCRIPTION
Added function to force select2 dropdown refresh after its content being translated.