### PR TITLE
Fix #2154: xvfb not found.

### DIFF
--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -46,7 +46,6 @@ DIRS_TO_ADD_TO_SYS_PATH = [
         'lib', 'webob_0_9'),
     os.path.join(OPPIA_TOOLS_DIR, 'browsermob-proxy-0.7.1'),
     os.path.join(OPPIA_TOOLS_DIR, 'selenium-2.53.2'),
-    os.path.join(OPPIA_TOOLS_DIR, 'xvfbwrapper-0.2.8'),
     CURR_DIR,
     os.path.join(THIRD_PARTY_DIR, 'bleach-1.2.2'),
     os.path.join(THIRD_PARTY_DIR, 'gae-cloud-storage-1.9.15.0'),

--- a/core/tests/performance_framework/perf_services.py
+++ b/core/tests/performance_framework/perf_services.py
@@ -22,9 +22,6 @@ import urlparse
 from browsermobproxy import Server
 from selenium import webdriver
 
-# Used for headless testing i.e, making browser windows invisible to the user.
-from xvfbwrapper import Xvfb
-
 from core.tests.performance_framework import perf_domain
 
 CHROME_DRIVER_PATH = os.path.join(
@@ -73,25 +70,23 @@ class SeleniumPerformanceDataFetcher(object):
         resources. Used to obtain a uniform and warm-cache state for the tests,
         similar to a typical production server state.
         """
-        with Xvfb() as _:
-            driver = self._setup_driver(proxy=None, use_proxy=False)
+        driver = self._setup_driver(proxy=None, use_proxy=False)
 
-            driver.get(page_url)
+        driver.get(page_url)
 
         self._stop_driver(driver)
 
     def get_page_metrics_for_url(self, page_url):
         """Returns a PageSessionMetrics domain object for a given page URL.
         """
-        with Xvfb() as _:
-            server, proxy = self._setup_proxy_server()
-            driver = self._setup_driver(proxy=proxy, use_proxy=True)
+        server, proxy = self._setup_proxy_server()
+        driver = self._setup_driver(proxy=proxy, use_proxy=True)
 
-            proxy.new_har(page_url, options={'captureHeaders': True})
+        proxy.new_har(page_url, options={'captureHeaders': True})
 
-            driver.get(page_url)
+        driver.get(page_url)
 
-            self._wait_until_page_load_is_finished()
+        self._wait_until_page_load_is_finished()
 
         har_dict = proxy.har
 
@@ -108,19 +103,18 @@ class SeleniumPerformanceDataFetcher(object):
         Note: This method is stand-alone and does not require
         `get_page_session_metrics_for_url` to be called before it.
         """
-        with Xvfb() as _:
-            server, proxy = self._setup_proxy_server()
-            driver = self._setup_driver(proxy=proxy, use_proxy=True)
+        server, proxy = self._setup_proxy_server()
+        driver = self._setup_driver(proxy=proxy, use_proxy=True)
 
-            # Fetch the page once. This leads to caching of various resources.
-            driver.get(page_url)
-            self._wait_until_page_load_is_finished()
+        # Fetch the page once. This leads to caching of various resources.
+        driver.get(page_url)
+        self._wait_until_page_load_is_finished()
 
-            # Start recording har data for the next page fetch.
-            proxy.new_har(page_url, options={'captureHeaders': True})
-            driver.get(page_url)
+        # Start recording har data for the next page fetch.
+        proxy.new_har(page_url, options={'captureHeaders': True})
+        driver.get(page_url)
 
-            self._wait_until_page_load_is_finished()
+        self._wait_until_page_load_is_finished()
 
         har_dict = proxy.har
 
@@ -134,14 +128,13 @@ class SeleniumPerformanceDataFetcher(object):
         """Returns a PageSessionMetrics domain object initialized using
         page load timings for a page URL.
         """
-        with Xvfb() as _:
-            driver = self._setup_driver(proxy=None, use_proxy=False)
+        driver = self._setup_driver(proxy=None, use_proxy=False)
 
-            driver.get(page_url)
-            self._wait_until_page_load_is_finished()
+        driver.get(page_url)
+        self._wait_until_page_load_is_finished()
 
-            page_session_timings = (
-                driver.execute_script("return window.performance"))
+        page_session_timings = (
+            driver.execute_script("return window.performance"))
 
         self._stop_driver(driver)
 
@@ -153,18 +146,17 @@ class SeleniumPerformanceDataFetcher(object):
         load timings for a page URL while simulating a cached session i.e, a
         return user.
         """
-        with Xvfb() as _:
-            driver = self._setup_driver(proxy=None, use_proxy=False)
+        driver = self._setup_driver(proxy=None, use_proxy=False)
 
-            # Fetch the page once. This leads to caching of various resources.
-            driver.get(page_url)
-            self._wait_until_page_load_is_finished()
+        # Fetch the page once. This leads to caching of various resources.
+        driver.get(page_url)
+        self._wait_until_page_load_is_finished()
 
-            driver.get(page_url)
-            self._wait_until_page_load_is_finished()
+        driver.get(page_url)
+        self._wait_until_page_load_is_finished()
 
-            page_session_timings = (
-                driver.execute_script("return window.performance"))
+        page_session_timings = (
+            driver.execute_script("return window.performance"))
 
         self._stop_driver(driver)
 

--- a/scripts/install_third_party.sh
+++ b/scripts/install_third_party.sh
@@ -137,13 +137,6 @@ if [ ! -d "$TOOLS_DIR/selenium-2.53.2" ]; then
   pip install selenium==2.53.2 --target="$TOOLS_DIR/selenium-2.53.2"
 fi
 
-echo Checking if xvfbwrapper is installed in $TOOLS_DIR/pip_packages
-if [ ! -d "$TOOLS_DIR/xvfbwrapper-0.2.8" ]; then
-  echo Installing xvfbwrapper
-
-  pip install xvfbwrapper==0.2.8 --target="$TOOLS_DIR/xvfbwrapper-0.2.8"
-fi
-
 # install pre-push script
 echo Installing pre-push hook for git
 $PYTHON_CMD $OPPIA_DIR/scripts/pre_push_hook.py --install

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -144,7 +144,6 @@ _PATHS_TO_INSERT = [
     os.path.join(_PARENT_DIR, 'oppia_tools', 'numpy-1.6.1'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'browsermob-proxy-0.7.1'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'selenium-2.53.2'),
-    os.path.join(_PARENT_DIR, 'oppia_tools', 'xvfbwrapper-0.2.8'),
     os.path.join('third_party', 'gae-pipeline-1.9.17.0'),
     os.path.join('third_party', 'bleach-1.2.2'),
     os.path.join('third_party', 'gae-mapreduce-1.9.17.0'),

--- a/scripts/run_performance_tests.sh
+++ b/scripts/run_performance_tests.sh
@@ -77,7 +77,7 @@ chmod 744 $TOOLS_DIR/browsermob-proxy-2.1.1/bin/browsermob-proxy
 while ! nc -vz localhost 9501; do sleep 1; done
 
 # Install xvfb if not on travis, used in frontend, e2e tests and performance tests.
-if [ "$TRAVIS" = false ]; then
+if [ "$TRAVIS" = true ]; then
   export XVFB_PREFIX=""
 else
   sudo apt-get install xvfb

--- a/scripts/run_performance_tests.sh
+++ b/scripts/run_performance_tests.sh
@@ -76,7 +76,7 @@ chmod 744 $TOOLS_DIR/browsermob-proxy-2.1.1/bin/browsermob-proxy
 # Wait for the servers to come up.
 while ! nc -vz localhost 9501; do sleep 1; done
 
-$PYTHON_CMD scripts/backend_tests.py --test_path='core/tests/performance_tests' $@ 
+$XVFB_PREFIX $PYTHON_CMD scripts/backend_tests.py --test_path='core/tests/performance_tests' $@ 
 
 chmod 644 $TOOLS_DIR/browsermob-proxy-2.1.1/bin/browsermob-proxy
 rm bmp.log server.log

--- a/scripts/run_performance_tests.sh
+++ b/scripts/run_performance_tests.sh
@@ -81,7 +81,7 @@ if [ "$TRAVIS" = true ]; then
   export XVFB_PREFIX=""
 else
   # This installs xvfb for systems with apt-get installer like Ubuntu, and will fail for other systems.
-  # TODO: Install/provide xvfb for other systems.
+  # TODO(gvishal): Install/provide xvfb for other systems.
   sudo apt-get install xvfb
   export XVFB_PREFIX="/usr/bin/xvfb-run"
 fi

--- a/scripts/run_performance_tests.sh
+++ b/scripts/run_performance_tests.sh
@@ -76,10 +76,12 @@ chmod 744 $TOOLS_DIR/browsermob-proxy-2.1.1/bin/browsermob-proxy
 # Wait for the servers to come up.
 while ! nc -vz localhost 9501; do sleep 1; done
 
-# Install xvfb if not on travis, used in frontend, e2e tests and performance tests.
+# Install xvfb if not on travis, Used in frontend, e2e tests and performance tests.
 if [ "$TRAVIS" = true ]; then
   export XVFB_PREFIX=""
 else
+  # This installs xvfb for systems with apt-get installer like Ubuntu, and will fail for other systems.
+  # TODO: Install/provide xvfb for other systems.
   sudo apt-get install xvfb
   export XVFB_PREFIX="/usr/bin/xvfb-run"
 fi

--- a/scripts/run_performance_tests.sh
+++ b/scripts/run_performance_tests.sh
@@ -76,6 +76,14 @@ chmod 744 $TOOLS_DIR/browsermob-proxy-2.1.1/bin/browsermob-proxy
 # Wait for the servers to come up.
 while ! nc -vz localhost 9501; do sleep 1; done
 
+# Install xvfb if not on travis, used in frontend, e2e tests and performance tests.
+if [ "$TRAVIS" = false ]; then
+  export XVFB_PREFIX=""
+else
+  sudo apt-get install xvfb
+  export XVFB_PREFIX="/usr/bin/xvfb-run"
+fi
+
 $XVFB_PREFIX $PYTHON_CMD scripts/backend_tests.py --test_path='core/tests/performance_tests' $@ 
 
 chmod 644 $TOOLS_DIR/browsermob-proxy-2.1.1/bin/browsermob-proxy

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -188,15 +188,17 @@ if [ ! -d "$NODE_PATH" ]; then
   chmod -R 744 $NODE_MODULE_DIR
 fi
 
+# Install xvfb, used in frontend, e2e tests and performance tests.
+sudo apt-get install xvfb
+export XVFB_PREFIX="/usr/bin/xvfb-run"
+
 # Adjust path to support the default Chrome locations for Unix, Windows and Mac OS.
 if [ "$TRAVIS" = true ]; then
   export CHROME_BIN="/usr/bin/chromium-browser"
 elif [ "$VAGRANT" = true ]; then
   # XVFB is required for headless testing in Vagrant
-  sudo apt-get install xvfb chromium-browser
+  sudo apt-get install chromium-browser
   export CHROME_BIN="/usr/bin/chromium-browser"
-  # Used in frontend and e2e tests. Only gets set if using Vagrant VM.
-  export XVFB_PREFIX="/usr/bin/xvfb-run"
   # Enforce proper ownership on oppia, oppia_tools, and node_modules or else NPM installs will fail.
   sudo chown -R vagrant.vagrant /home/vagrant/oppia /home/vagrant/oppia_tools /home/vagrant/node_modules
 elif [ -f "/usr/bin/google-chrome" ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -188,17 +188,15 @@ if [ ! -d "$NODE_PATH" ]; then
   chmod -R 744 $NODE_MODULE_DIR
 fi
 
-# Install xvfb, used in frontend, e2e tests and performance tests.
-sudo apt-get install xvfb
-export XVFB_PREFIX="/usr/bin/xvfb-run"
-
 # Adjust path to support the default Chrome locations for Unix, Windows and Mac OS.
 if [ "$TRAVIS" = true ]; then
   export CHROME_BIN="/usr/bin/chromium-browser"
 elif [ "$VAGRANT" = true ]; then
   # XVFB is required for headless testing in Vagrant
-  sudo apt-get install chromium-browser
+  sudo apt-get install xvfb chromium-browser
   export CHROME_BIN="/usr/bin/chromium-browser"
+  # Used in frontend and e2e tests. Only gets set if using Vagrant VM.   
+  export XVFB_PREFIX="/usr/bin/xvfb-run"
   # Enforce proper ownership on oppia, oppia_tools, and node_modules or else NPM installs will fail.
   sudo chown -R vagrant.vagrant /home/vagrant/oppia /home/vagrant/oppia_tools /home/vagrant/node_modules
 elif [ -f "/usr/bin/google-chrome" ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -195,7 +195,7 @@ elif [ "$VAGRANT" = true ]; then
   # XVFB is required for headless testing in Vagrant
   sudo apt-get install xvfb chromium-browser
   export CHROME_BIN="/usr/bin/chromium-browser"
-  # Used in frontend and e2e tests. Only gets set if using Vagrant VM.   
+  # Used in frontend and e2e tests. Only gets set if using Vagrant VM.
   export XVFB_PREFIX="/usr/bin/xvfb-run"
   # Enforce proper ownership on oppia, oppia_tools, and node_modules or else NPM installs will fail.
   sudo chown -R vagrant.vagrant /home/vagrant/oppia /home/vagrant/oppia_tools /home/vagrant/node_modules


### PR DESCRIPTION
Fix #2154: We were installing xvfb only for vagrant, but we require it for performance tests. So, now installing it outside vagrant also. Installing it for all platform needs to be looked into. And, currently it requires `sudo` to install it, which is a bit obtrusive.