### PR TITLE
Fix #1841: Fix view all button flushed right appearance

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -988,14 +988,37 @@ textarea {
 }
 
 .oppia-library-group-header-container {
-  max-width: calc(100% - 180px);
+  width: calc(100% - 143px);
+  max-width: 928px;
+  min-width: 315px;
 }
+
+@media(max-width: 720px) {
+  .oppia-library-group-header-container {
+    width: 80%;
+  }
+}
+
+@media(max-width: 480px) {
+  .oppia-library-group-header-container {
+    width: 100%;
+  }
+}
+
 .oppia-library-group-header {
   display: inline-block;
-  font-size: 2.2em;
+  font-size: 2em;
   margin-bottom: 24px;
   margin-left: 44px;
+  min-width: 126px;
 }
+
+@media(max-width: 720px) {
+  .oppia-library-group-header {
+    width: calc(80% - 143px);
+  }
+}
+
 .oppia-library-group-header a {
   color: #2c4841;
   font-family: "Capriola", "Roboto", Arial, sans-serif;
@@ -1011,20 +1034,29 @@ textarea {
   font-size: 14px;
   margin-right: 48px;
   margin-top: 30px;
+  position: absolute;
   text-transform: uppercase;
 }
+
 .oppia-library-group-view-all-btn:hover,
 .oppia-library-group-view-all-btn:focus,
 .oppia-library-group-view-all-btn:active {
   background-color: rgba(5, 190, 178, 1);
   color: rgba(255,255,255,1);
 }
-@media (max-width: 480px) {
-  .oppia-library-group-header {
-    font-size: 6vw;
+
+@media (max-width: 992px) {
+  .oppia-library-group-view-all-btn {
+    position: inherit;
   }
   .oppia-library-group-view-all-btn {
     margin-top: 18px;
+  }
+}
+
+@media (max-width: 720px) {
+  .oppia-library-group-header {
+    font-size: 6vw;
   }
 }
 

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -988,6 +988,7 @@ textarea {
 }
 
 .oppia-library-group-header-container {
+  width: 95%;
   width: calc(100% - 143px);
   max-width: 928px;
   min-width: 315px;
@@ -1015,6 +1016,7 @@ textarea {
 
 @media(max-width: 720px) {
   .oppia-library-group-header {
+    width: 76%;
     width: calc(80% - 143px);
   }
 }

--- a/core/templates/dev/head/library/library.html
+++ b/core/templates/dev/head/library/library.html
@@ -57,16 +57,14 @@
           </div>
 
           <div class="oppia-library-group" ng-repeat="group in libraryGroups track by $index">
-            <div>
+            <div class="row oppia-library-group-header-container">
+              <h2 class="oppia-library-group-header">
+                <a ng-click="showAllResultsForCategories(group.categories)" translate="<[group.translationId]>">
+                </a>
+              </h2>
               <div class="pull-right">
                 <button class="btn oppia-library-group-view-all-btn oppia-transition-200" ng-click="showAllResultsForCategories(group.categories)" translate="I18N_LIBRARY_VIEW_ALL">
                 </button>
-              </div>
-              <div class="oppia-library-group-header-container">
-                <h2 class="oppia-library-group-header">
-                  <a ng-click="showAllResultsForCategories(group.categories)" translate="<[group.translationId]>">
-                  </a>
-                </h2>
               </div>
             </div>
 


### PR DESCRIPTION
This PR makes adjustments to the positioning of the View All button so that it is not flushed right on half screens and smaller. The UI was tested on desktop (full to smallest Chrome supports), tablets, and mobile. 