### PR TITLE
Fixes #2023

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3808,7 +3808,6 @@ md-card.preview-conversation-skin-supplemental-card {
 .oppia-about-tabs {
   border-bottom: 1px solid #eee;
   display: flex;
-  flex-wrap: wrap;
   text-align: center;
   margin-bottom: 0;
 }

--- a/core/templates/dev/head/pages/about.html
+++ b/core/templates/dev/head/pages/about.html
@@ -30,10 +30,10 @@
     <div class="about-nav oppia-profile-tabs md-tab">
       <ul class="oppia-about-tabs">
         <li class="oppia-profile-tabs oppia-about-tabs-active">
-          <a class="oppia-about-tabs-text" href="about">About Oppia</a>
+          <a class="oppia-about-tabs-text" href="about">About</a>
         </li>
         <li class="oppia-profile-tabs">
-          <a class="oppia-about-tabs-text" href="foundation" name="foundation">The Oppia Foundation</a>
+          <a class="oppia-about-tabs-text" href="foundation" name="foundation">Foundations</a>
         </li>
         <li class="oppia-profile-tabs">
           <a class="oppia-about-tabs-text" href="credits" name="credits">Credits</a>


### PR DESCRIPTION
Simple fix for the issue  'Improve About pages tabs for iOS #2023'.
As suggested in the discussion, changed the names to shorter version and removed the `flex-wrap` property which was making the tabs to stack up when screen sizes were small.
Tested it with smallest browser width possible, seems fine 
![screenshot from 2016-07-03 13-10-48](https://cloud.githubusercontent.com/assets/10217535/16544382/65526afc-4121-11e6-8803-781c8037f117.png)
