### PR TITLE
Fixes #2197 and #2195: Refresh admin page keeps it at same location; Add auto-scroll to show output in jobs tab.

### DIFF
--- a/core/templates/dev/head/admin/Admin.js
+++ b/core/templates/dev/head/admin/Admin.js
@@ -27,6 +27,10 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
   $scope.TAB_JOBS = 'TAB_JOBS';
   $scope.TAB_CONFIG = 'TAB_CONFIG';
   $scope.TAB_MISC = 'TAB_MISC';
+  $scope.jobsUrl = '#jobs';
+  $scope.configUrl = '#config';
+  $scope.miscUrl = '#misc';
+  $scope.activitiesUrl = '#activities';
 
   $scope.currentTab = $scope.TAB_ACTIVITIES;
 
@@ -34,17 +38,17 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
     return window.location.hash;
   }, function(newHash) {
     switch (newHash) {
-      case '#jobs':
-        $scope.currentTab = $scope.TAB_JOBS;
+      case $scope.jobsUrl:
+        $scope.showJobsTab();
         break;
-      case '#config':
-        $scope.currentTab = $scope.TAB_CONFIG;
+      case $scope.configUrl:
+        $scope.showConfigTab();
         break;
-      case '#misc':
-        $scope.currentTab = $scope.TAB_MISC;
+      case $scope.miscUrl:
+        $scope.showMiscTab();
         break;
-      case '#activities':
-        $scope.currentTab = $scope.TAB_ACTIVITIES;
+      case $scope.activitiesUrl:
+        $scope.showActivitiesTab();
         break;
     }
   });

--- a/core/templates/dev/head/admin/Admin.js
+++ b/core/templates/dev/head/admin/Admin.js
@@ -30,6 +30,24 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
 
   $scope.currentTab = $scope.TAB_ACTIVITIES;
 
+  $scope.$watch(function() {
+    return window.location.hash;
+  }, function(newHash) {
+    switch (newHash) {
+      case '#jobs':
+        $scope.currentTab = $scope.TAB_JOBS;
+        break;
+      case '#config':
+        $scope.currentTab = $scope.TAB_CONFIG;
+        break;
+      case '#misc':
+        $scope.currentTab = $scope.TAB_MISC;
+        break;
+      default:
+        $scope.currentTab = $scope.TAB_ACTIVITIES;
+    }
+  });
+
   $scope.showActivitiesTab = function() {
     $scope.currentTab = $scope.TAB_ACTIVITIES;
   };
@@ -52,6 +70,7 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
     $http.get(adminJobOutputUrl).then(function(response) {
       $scope.showJobOutput = true;
       $scope.jobOutput = response.data.output;
+      window.scrollTo(0, document.body.scrollHeight);
     });
   };
 

--- a/core/templates/dev/head/admin/Admin.js
+++ b/core/templates/dev/head/admin/Admin.js
@@ -43,8 +43,9 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
       case '#misc':
         $scope.currentTab = $scope.TAB_MISC;
         break;
-      default:
+      case '#activities':
         $scope.currentTab = $scope.TAB_ACTIVITIES;
+        break;
     }
   });
 

--- a/core/templates/dev/head/admin/Admin.js
+++ b/core/templates/dev/head/admin/Admin.js
@@ -27,10 +27,10 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
   $scope.TAB_JOBS = 'TAB_JOBS';
   $scope.TAB_CONFIG = 'TAB_CONFIG';
   $scope.TAB_MISC = 'TAB_MISC';
-  $scope.jobsUrl = '#jobs';
-  $scope.configUrl = '#config';
-  $scope.miscUrl = '#misc';
-  $scope.activitiesUrl = '#activities';
+  $scope.JOBS_URL = '#jobs';
+  $scope.CONFIG_URL = '#config';
+  $scope.MISC_URL = '#misc';
+  $scope.ACTIVITIES_URL = '#activities';
 
   $scope.currentTab = $scope.TAB_ACTIVITIES;
 
@@ -38,16 +38,16 @@ oppia.controller('Admin', ['$scope', '$http', function($scope, $http) {
     return window.location.hash;
   }, function(newHash) {
     switch (newHash) {
-      case $scope.jobsUrl:
+      case $scope.JOBS_URL:
         $scope.showJobsTab();
         break;
-      case $scope.configUrl:
+      case $scope.CONFIG_URL:
         $scope.showConfigTab();
         break;
-      case $scope.miscUrl:
+      case $scope.MISC_URL:
         $scope.showMiscTab();
         break;
-      case $scope.activitiesUrl:
+      case $scope.ACTIVITIES_URL:
         $scope.showActivitiesTab();
         break;
     }

--- a/core/templates/dev/head/admin/admin.html
+++ b/core/templates/dev/head/admin/admin.html
@@ -104,22 +104,22 @@
 
             <ul class="nav oppia-navbar-tabs oppia-navbar-tabs-admin">
               <li class="oppia-clickable-navbar-element pull-right">
-                <a class="oppia-navbar-tab" ng-href="<[miscUrl]>" tooltip="Miscellaneous" tooltip-placement="bottom" ng-click="showMiscTab()">
+                <a class="oppia-navbar-tab" ng-href="<[MISC_URL]>" tooltip="Miscellaneous" tooltip-placement="bottom" ng-click="showMiscTab()">
                   Misc
                 </a>
               </li>
               <li class="oppia-clickable-navbar-element pull-right">
-                <a class="oppia-navbar-tab protractor-test-admin-config-tab" ng-href="<[configUrl]>" tooltip="Config" tooltip-placement="bottom" ng-click="showConfigTab()">
+                <a class="oppia-navbar-tab protractor-test-admin-config-tab" ng-href="<[CONFIG_URL]>" tooltip="Config" tooltip-placement="bottom" ng-click="showConfigTab()">
                   Config
                 </a>
               </li>
               <li class="oppia-clickable-navbar-element pull-right">
-                <a class="oppia-navbar-tab" ng-href="<[jobsUrl]>" tooltip="Jobs" tooltip-placement="bottom" ng-click="showJobsTab()">
+                <a class="oppia-navbar-tab" ng-href="<[JOBS_URL]>" tooltip="Jobs" tooltip-placement="bottom" ng-click="showJobsTab()">
                   Jobs
                 </a>
               </li>
               <li class="dropdown oppia-navbar-clickable-dropdown pull-right">
-                <a class="oppia-navbar-tab" ng-href="<[activitiesUrl]>" tooltip="Activities" tooltip-placement="bottom" ng-click="showActivitiesTab()">
+                <a class="oppia-navbar-tab" ng-href="<[ACTIVITIES_URL]>" tooltip="Activities" tooltip-placement="bottom" ng-click="showActivitiesTab()">
                   Activities
                 </a>
               </li>

--- a/core/templates/dev/head/admin/admin.html
+++ b/core/templates/dev/head/admin/admin.html
@@ -104,22 +104,22 @@
 
             <ul class="nav oppia-navbar-tabs oppia-navbar-tabs-admin">
               <li class="oppia-clickable-navbar-element pull-right">
-                <a class="oppia-navbar-tab" href="#misc" tooltip="Miscellaneous" tooltip-placement="bottom" ng-click="showMiscTab()">
+                <a class="oppia-navbar-tab" ng-href="<[miscUrl]>" tooltip="Miscellaneous" tooltip-placement="bottom" ng-click="showMiscTab()">
                   Misc
                 </a>
               </li>
               <li class="oppia-clickable-navbar-element pull-right">
-                <a class="oppia-navbar-tab protractor-test-admin-config-tab" href="#config" tooltip="Config" tooltip-placement="bottom" ng-click="showConfigTab()">
+                <a class="oppia-navbar-tab protractor-test-admin-config-tab" ng-href="<[configUrl]>" tooltip="Config" tooltip-placement="bottom" ng-click="showConfigTab()">
                   Config
                 </a>
               </li>
               <li class="oppia-clickable-navbar-element pull-right">
-                <a class="oppia-navbar-tab" href="#jobs" tooltip="Jobs" tooltip-placement="bottom" ng-click="showJobsTab()">
+                <a class="oppia-navbar-tab" ng-href="<[jobsUrl]>" tooltip="Jobs" tooltip-placement="bottom" ng-click="showJobsTab()">
                   Jobs
                 </a>
               </li>
               <li class="dropdown oppia-navbar-clickable-dropdown pull-right">
-                <a class="oppia-navbar-tab" href="#activities" tooltip="Activities" tooltip-placement="bottom" ng-click="showActivitiesTab()">
+                <a class="oppia-navbar-tab" ng-href="<[activitiesUrl]>" tooltip="Activities" tooltip-placement="bottom" ng-click="showActivitiesTab()">
                   Activities
                 </a>
               </li>


### PR DESCRIPTION

Fixes #2197 and #2195: Refresh admin page keeps it at the same location; Auto-scroll for viewing output in jobs tab in admin panel.
