### PR TITLE
Refactor GLOBALS object to not parse its values using jinja templates

### DIFF
--- a/core/controllers/reader.py
+++ b/core/controllers/reader.py
@@ -169,6 +169,14 @@ def classify(state, answer):
         'exploration owner.')
 
 
+class OppiaBaseDataHandler(base.BaseHandler):
+    REQUIRE_PAYLOAD_CSRF_CHECK = False
+
+    def get(self):
+        self.update_base_data(self.values)
+        self.render_json(self.values)
+
+
 class ExplorationPage(base.BaseHandler):
     """Page describing a single exploration."""
 

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -83,6 +83,20 @@ oppia.config([
             }
             return config;
           },
+          response: function(response) {
+            // Making sure that csrf tokens are the latest
+            if (response.data.hasOwnProperty('csrf_token')) {
+              GLOBALS.csrf_token = response.data.csrf_token;
+            }
+            if (response.data.hasOwnProperty('csrf_token_create_exploration')) {
+              GLOBALS.csrf_token_create_exploration = (
+                response.data.csrf_token_create_exploration);
+            }
+            if (response.data.hasOwnProperty('csrf_token_i18n')) {
+              GLOBALS.csrf_token_i18n = response.data.csrf_token_i18n;
+            }
+            return response;
+          },
           responseError: function(rejection) {
             // A rejection status of -1 seems to indicate (it's hard to find
             // documentation) that the response has not completed,
@@ -668,4 +682,14 @@ oppia.factory('codeNormalizationService', [function() {
       return normalizedCodeLines.join('\n');
     }
   };
+}]);
+
+oppia.value('globals', {
+});
+
+oppia.run(['$http', 'globals', function($http, globals) {
+  var url = '/basedata/';
+  $http.get(url).then(function(response) {
+    globals.SUPPORTED_SITE_LANGUAGES = response.data.SUPPORTED_SITE_LANGUAGES;
+  });
 }]);

--- a/main.py
+++ b/main.py
@@ -167,6 +167,9 @@ URLS = MAPREDUCE_HANDLERS + [
         'admin_topics_csv_download_handler'),
 
     get_redirect_route(
+        r'/basedata', reader.OppiaBaseDataHandler, 'base_data'),
+
+    get_redirect_route(
         r'/notifications_dashboard', dashboard.NotificationsDashboardPage,
         'notifications_dashboard_handler'),
     get_redirect_route(


### PR DESCRIPTION
This is first commit to know about whether this is right approach or leave for a discussion. I will move variable from GLOBALS one by one to the new place.

Also, this commit shows how we could handle CSRF tokens.