### PR TITLE
Fix #2196: alternating colors of jobs list on admin page

### DIFF
--- a/core/templates/dev/head/admin/admin.html
+++ b/core/templates/dev/head/admin/admin.html
@@ -228,14 +228,12 @@
                   <button class="pull-right" ng-click="startNewJob('{{job_spec.job_type}}')">
                     Start new job
                   </button>
-                </td>
-                {% if job_spec.is_queued_or_running %}
-                  <td>
+                  {% if job_spec.is_queued_or_running %}
                     <span class="oppia-serious-warning-text">
                       <strong>(warning: an instance of this job type is already running)</strong>
                     </span>
-                  </td>
                 {% endif %}
+                </td>
               </tr>
             {% endfor %}
           </table>

--- a/core/templates/dev/head/admin/admin.html
+++ b/core/templates/dev/head/admin/admin.html
@@ -218,7 +218,7 @@
           <h3>Jobs</h3>
           <h4>Current time: {{human_readable_current_time}}</h4>
           <h4>One-off jobs</h4>
-          <table>
+          <table class="table table-striped">
             {% for job_spec in one_off_job_specs %}
               <tr>
                 <td>

--- a/core/templates/dev/head/admin/admin.html
+++ b/core/templates/dev/head/admin/admin.html
@@ -218,21 +218,27 @@
           <h3>Jobs</h3>
           <h4>Current time: {{human_readable_current_time}}</h4>
           <h4>One-off jobs</h4>
-          <ul>
+          <table>
             {% for job_spec in one_off_job_specs %}
-              <li>
-                {{job_spec.job_type}}
-                <button class="pull-right" ng-click="startNewJob('{{job_spec.job_type}}')">
-                  Start new job
-                </button>
+              <tr>
+                <td>
+                  {{job_spec.job_type}}
+                </td>
+                <td>
+                  <button class="pull-right" ng-click="startNewJob('{{job_spec.job_type}}')">
+                    Start new job
+                  </button>
+                </td>
                 {% if job_spec.is_queued_or_running %}
-                  <span class="oppia-serious-warning-text">
-                    <strong>(warning: an instance of this job type is already running)</strong>
-                  </span>
+                  <td>
+                    <span class="oppia-serious-warning-text">
+                      <strong>(warning: an instance of this job type is already running)</strong>
+                    </span>
+                  </td>
                 {% endif %}
-              </li>
+              </tr>
             {% endfor %}
-          </ul>
+          </table>
         </md-card>
 
         <md-card class="oppia-page-card oppia-long-text" ng-if="currentTab === TAB_JOBS" style="max-width: 900px">

--- a/core/templates/dev/head/admin/admin.html
+++ b/core/templates/dev/head/admin/admin.html
@@ -232,7 +232,7 @@
                     <span class="oppia-serious-warning-text">
                       <strong>(warning: an instance of this job type is already running)</strong>
                     </span>
-                {% endif %}
+                  {% endif %}
                 </td>
               </tr>
             {% endfor %}


### PR DESCRIPTION
Change ul structure to table and add striped rows in order to distinguish each Start new job button easily