### PR TITLE
fix #2258: feedback messages should not be sent if user has already seen to them.

### DIFF
--- a/core/controllers/feedback.py
+++ b/core/controllers/feedback.py
@@ -32,8 +32,6 @@ class ThreadListHandler(base.BaseHandler):
         self.values.update({
             'threads': [t.to_dict() for t in feedback_services.get_all_threads(
                 exploration_id, False)]})
-        feedback_services.update_feedback_message_references(
-            self.user_id, exploration_id)
         self.render_json(self.values)
 
     @base.require_user
@@ -250,3 +248,16 @@ class UnsentFeedbackEmailHandler(base.BaseHandler):
         transaction_services.run_in_transaction(
             feedback_services.pop_feedback_message_references, user_id,
             len(references))
+
+
+class FeedbackMessageClear(base.BaseHandler):
+    """Task for clearing feedback messages from email."""
+
+    @base.require_user
+    def post(self):
+        exploration_id = self.payload.get('exploration_id')
+        thread_id = self.payload.get('thread_id')
+        transaction_services.run_in_transaction(
+            feedback_services.clear_feedback_message_references, self.user_id,
+            exploration_id, thread_id)
+        self.render_json(self.values)

--- a/core/controllers/feedback.py
+++ b/core/controllers/feedback.py
@@ -250,8 +250,10 @@ class UnsentFeedbackEmailHandler(base.BaseHandler):
             len(references))
 
 
-class FeedbackMessageClear(base.BaseHandler):
-    """Task for clearing feedback messages from email."""
+class FeedbackThreadViewEventHandler(base.BaseHandler):
+    """Records when the given user views a feedback thread, in order to clear
+    viewed feedback messages from emails that might be sent in future to this
+    user."""
 
     @base.require_user
     def post(self):

--- a/core/controllers/feedback.py
+++ b/core/controllers/feedback.py
@@ -32,6 +32,8 @@ class ThreadListHandler(base.BaseHandler):
         self.values.update({
             'threads': [t.to_dict() for t in feedback_services.get_all_threads(
                 exploration_id, False)]})
+        feedback_services.update_feedback_message_references(
+            self.user_id, exploration_id)
         self.render_json(self.values)
 
     @base.require_user
@@ -216,6 +218,10 @@ class UnsentFeedbackEmailHandler(base.BaseHandler):
         payload = json.loads(self.request.body)
         user_id = payload['user_id']
         references = feedback_services.get_feedback_message_references(user_id)
+        if not references:
+            # Model may not exist if user has already attended to the feedback.
+            return
+
         transaction_services.run_in_transaction(
             feedback_services.update_feedback_email_retries, user_id)
 

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -758,3 +758,16 @@ class FeedbackMessageEmailHandlerTests(test_utils.GenericTestBase):
             self.assertEqual(
                 messages[0].body.decode(),
                 expected_email_text_body)
+
+    def test_that_emails_are_not_sent_if_already_seen(self):
+        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
+            feedback_services.create_thread(
+                self.exploration.id, 'a_state_name',
+                self.new_user_id, 'a subject', 'some text')
+            self.login(self.EDITOR_EMAIL)
+            self.testapp.get('%s/%s' % (
+                feconf.FEEDBACK_THREADLIST_URL_PREFIX, self.exploration.id))
+
+            self.process_and_flush_pending_tasks()
+            messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)
+            self.assertEqual(len(messages), 0)

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -764,9 +764,17 @@ class FeedbackMessageEmailHandlerTests(test_utils.GenericTestBase):
             feedback_services.create_thread(
                 self.exploration.id, 'a_state_name',
                 self.new_user_id, 'a subject', 'some text')
+
+            threadlist = feedback_services.get_all_threads(
+                self.exploration.id, False)
+            thread_id = threadlist[0].get_thread_id()
+
             self.login(self.EDITOR_EMAIL)
-            self.testapp.get('%s/%s' % (
-                feconf.FEEDBACK_THREADLIST_URL_PREFIX, self.exploration.id))
+            csrf_token = self.get_csrf_token_from_response(
+                self.testapp.get('/create/%s' % self.exploration.id))
+            self.post_json('%s' % feconf.FEEDBACK_MESSAGE_EMAIL_CLEAR_URL, {
+                'exploration_id': self.exploration.id,
+                'thread_id': thread_id}, csrf_token)
 
             self.process_and_flush_pending_tasks()
             messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -772,7 +772,7 @@ class FeedbackMessageEmailHandlerTests(test_utils.GenericTestBase):
             self.login(self.EDITOR_EMAIL)
             csrf_token = self.get_csrf_token_from_response(
                 self.testapp.get('/create/%s' % self.exploration.id))
-            self.post_json('%s' % feconf.FEEDBACK_MESSAGE_EMAIL_CLEAR_URL, {
+            self.post_json('%s' % feconf.FEEDBACK_THREAD_VIEW_EVENT_URL, {
                 'exploration_id': self.exploration.id,
                 'thread_id': thread_id}, csrf_token)
 

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -391,6 +391,9 @@ def send_feedback_message_email(recipient_id, feedback_messages):
         log_new_error('This app cannot send feedback message emails to users.')
         return
 
+    if not feedback_messages:
+        return
+
     recipient_user_settings = user_services.get_user_settings(recipient_id)
 
     messages_html = ''

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -391,9 +391,6 @@ def send_feedback_message_email(recipient_id, feedback_messages):
         log_new_error('This app cannot send feedback message emails to users.')
         return
 
-    if not feedback_messages:
-        return
-
     recipient_user_settings = user_services.get_user_settings(recipient_id)
 
     messages_html = ''

--- a/core/domain/feedback_services.py
+++ b/core/domain/feedback_services.py
@@ -379,10 +379,10 @@ def clear_feedback_message_references(user_id, exploration_id, thread_id):
         # Note that, since the task in the queue is not deleted, the following
         # scenario may occur: If creator attends to arrived feedback bedore
         # email is sent then model will be deleted but task will still execute
-        # after its countdown. Arrival new feedback arrives before task is
-        # executed will create new model and task. But actual email will be sent
-        # by first task. It means that email may be sent just after a few
-        # minutes of feedback's arrival.
+        # after its countdown. Arrival of new feedback (before task is executed)
+        # will create new model and task. But actual email will be sent by first
+        # task. It means that email may be sent just after a few minutes of
+        # feedback's arrival.
 
         # In PR #2261, we decided to leave things as they are for now, since it
         # looks like the obvious solution of keying tasks by user id doesn't

--- a/core/domain/feedback_services.py
+++ b/core/domain/feedback_services.py
@@ -294,9 +294,10 @@ def get_feedback_message_references(user_id):
     user id. If the user id is invalid or there are no messages for this user,
     returns an empty list."""
 
-    model = feedback_models.UnsentFeedbackEmailModel.get(user_id)
+    model = feedback_models.UnsentFeedbackEmailModel.get(user_id, strict=False)
 
     if model is None:
+        # Model may not exist is user has already attended to feedback.
         return []
 
     return [feedback_domain.FeedbackMessageReference(
@@ -355,6 +356,31 @@ def pop_feedback_message_references(user_id, references_length):
             feedback_message_references=message_references)
         model.put()
         enqueue_feedback_message_email_task(user_id)
+
+
+def update_feedback_message_references(user_id, exploration_id):
+    """Removes feedback message references associated with exploration."""
+    if not user_id:
+        # If user is not logged in this will be True.
+        return
+
+    model = feedback_models.UnsentFeedbackEmailModel.get(user_id, strict=False)
+    if model is None:
+        # Model exists only if user has received feedback on exploration.
+        return
+
+    updated_references = []
+    for reference in model.feedback_message_references:
+        if exploration_id not in reference.values():
+            updated_references.append(reference)
+
+    if not updated_references:
+        # Allow task to process even if model is deleted. Email will not be
+        # sent if model does not exist.
+        model.key.delete()
+    else:
+        model.feedback_message_references = updated_references
+        model.put()
 
 
 def add_message_to_email_buffer(author_id, exploration_id, thread_id,

--- a/core/templates/dev/head/exploration_editor/feedback_tab/FeedbackTab.js
+++ b/core/templates/dev/head/exploration_editor/feedback_tab/FeedbackTab.js
@@ -247,6 +247,7 @@ oppia.controller('FeedbackTab', [
 
     $scope.setActiveThread = function(threadId) {
       threadDataService.fetchMessages(threadId);
+      threadDataService.markThreadAsSeen(threadId);
 
       var allThreads = [].concat(
         $scope.threadData.feedbackThreads, $scope.threadData.suggestionThreads);

--- a/core/templates/dev/head/exploration_editor/feedback_tab/ThreadDataService.js
+++ b/core/templates/dev/head/exploration_editor/feedback_tab/ThreadDataService.js
@@ -70,11 +70,6 @@ oppia.factory('threadDataService', [
         }
       }
     });
-    var payload = {
-      exploration_id: _expId,
-      thread_id: threadId
-    };
-    $http.post(_FEEDBACK_THREAD_VIEW_EVENT_URL, payload);
   };
 
   return {
@@ -107,6 +102,12 @@ oppia.factory('threadDataService', [
       }, function() {
         _openThreadsCount -= 1;
         alertsService.addWarning('Error creating new thread.');
+      });
+    },
+    markThreadAsSeen: function(threadId) {
+      $http.post(_FEEDBACK_THREAD_VIEW_EVENT_URL, {
+        exploration_id: _expId,
+        thread_id: threadId
       });
     },
     addNewMessage: function(

--- a/core/templates/dev/head/exploration_editor/feedback_tab/ThreadDataService.js
+++ b/core/templates/dev/head/exploration_editor/feedback_tab/ThreadDataService.js
@@ -27,7 +27,7 @@ oppia.factory('threadDataService', [
   var _SUGGESTION_ACTION_HANDLER_URL = '/suggestionactionhandler/' +
     _expId + '/';
   var _THREAD_HANDLER_PREFIX = '/threadhandler/' + _expId + '/';
-  var _FEEDBACK_MESSAGE_CLEAR = '/task/email/feedbackmessageclear';
+  var _FEEDBACK_THREAD_VIEW_EVENT_URL = '/feedbackhandler/thread_view_event';
   var _THREAD_STATUS_OPEN = 'open';
 
   // All the threads for this exploration. This is a list whose entries are
@@ -74,7 +74,7 @@ oppia.factory('threadDataService', [
       exploration_id: _expId,
       thread_id: threadId
     };
-    $http.post(_FEEDBACK_MESSAGE_CLEAR, payload);
+    $http.post(_FEEDBACK_THREAD_VIEW_EVENT_URL, payload);
   };
 
   return {

--- a/core/templates/dev/head/exploration_editor/feedback_tab/ThreadDataService.js
+++ b/core/templates/dev/head/exploration_editor/feedback_tab/ThreadDataService.js
@@ -27,6 +27,7 @@ oppia.factory('threadDataService', [
   var _SUGGESTION_ACTION_HANDLER_URL = '/suggestionactionhandler/' +
     _expId + '/';
   var _THREAD_HANDLER_PREFIX = '/threadhandler/' + _expId + '/';
+  var _FEEDBACK_MESSAGE_CLEAR = '/task/email/feedbackmessageclear';
   var _THREAD_STATUS_OPEN = 'open';
 
   // All the threads for this exploration. This is a list whose entries are
@@ -69,6 +70,11 @@ oppia.factory('threadDataService', [
         }
       }
     });
+    var payload = {
+      exploration_id: _expId,
+      thread_id: threadId
+    };
+    $http.post(_FEEDBACK_MESSAGE_CLEAR, payload);
   };
 
   return {

--- a/feconf.py
+++ b/feconf.py
@@ -426,6 +426,8 @@ FEEDBACK_THREAD_URL_PREFIX = '/threadhandler'
 FEEDBACK_THREADLIST_URL_PREFIX = '/threadlisthandler'
 FEEDBACK_MESSAGE_EMAIL_HANDLER_URL = (
     '%s/feedbackemailhandler' % EMAILS_TASK_PREFIX)
+FEEDBACK_MESSAGE_EMAIL_CLEAR_URL = (
+    '%s/feedbackmessageclear' % EMAILS_TASK_PREFIX)
 LIBRARY_INDEX_URL = '/library'
 LIBRARY_INDEX_DATA_URL = '/libraryindexhandler'
 LIBRARY_SEARCH_URL = '/search/find'

--- a/feconf.py
+++ b/feconf.py
@@ -198,7 +198,7 @@ CAN_SEND_FEEDBACK_MESSAGE_EMAILS = False
 # Time to wait before sending feedback message emails (currently set to 1
 # hour).
 DEFAULT_FEEDBACK_MESSAGE_EMAIL_COUNTDOWN_SECS = 3600
-# Whether to send an email when new feedback message is recived for
+# Whether to send an email when new feedback message is received for
 # an exploration.
 DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE = True
 # Whether to send email updates to a user who has not specified a preference.

--- a/feconf.py
+++ b/feconf.py
@@ -426,8 +426,7 @@ FEEDBACK_THREAD_URL_PREFIX = '/threadhandler'
 FEEDBACK_THREADLIST_URL_PREFIX = '/threadlisthandler'
 FEEDBACK_MESSAGE_EMAIL_HANDLER_URL = (
     '%s/feedbackemailhandler' % EMAILS_TASK_PREFIX)
-FEEDBACK_MESSAGE_EMAIL_CLEAR_URL = (
-    '%s/feedbackmessageclear' % EMAILS_TASK_PREFIX)
+FEEDBACK_THREAD_VIEW_EVENT_URL = '/feedbackhandler/thread_view_event'
 LIBRARY_INDEX_URL = '/library'
 LIBRARY_INDEX_DATA_URL = '/libraryindexhandler'
 LIBRARY_SEARCH_URL = '/search/find'

--- a/main.py
+++ b/main.py
@@ -373,6 +373,9 @@ URLS = MAPREDUCE_HANDLERS + [
         r'%s' % feconf.FEEDBACK_MESSAGE_EMAIL_HANDLER_URL,
         feedback.UnsentFeedbackEmailHandler, 'feedback_message_email_handler'),
     get_redirect_route(
+        r'%s' % feconf.FEEDBACK_MESSAGE_EMAIL_CLEAR_URL,
+        feedback.FeedbackMessageClear, 'feedback_message_clearence'),
+    get_redirect_route(
         r'%s/<exploration_id>' % feconf.FEEDBACK_THREADLIST_URL_PREFIX,
         feedback.ThreadListHandler, 'feedback_threadlist_handler'),
     get_redirect_route(

--- a/main.py
+++ b/main.py
@@ -373,8 +373,8 @@ URLS = MAPREDUCE_HANDLERS + [
         r'%s' % feconf.FEEDBACK_MESSAGE_EMAIL_HANDLER_URL,
         feedback.UnsentFeedbackEmailHandler, 'feedback_message_email_handler'),
     get_redirect_route(
-        r'%s' % feconf.FEEDBACK_MESSAGE_EMAIL_CLEAR_URL,
-        feedback.FeedbackMessageClear, 'feedback_message_clearence'),
+        r'%s' % feconf.FEEDBACK_THREAD_VIEW_EVENT_URL,
+        feedback.FeedbackThreadViewEventHandler, 'feedback_thread_view_event'),
     get_redirect_route(
         r'%s/<exploration_id>' % feconf.FEEDBACK_THREADLIST_URL_PREFIX,
         feedback.ThreadListHandler, 'feedback_threadlist_handler'),


### PR DESCRIPTION
When feedback is already seen, feedback message email should not be sent. This commit takes care of that by removing corresponding feedback message references from UnsentFeedbackEmailModel instance so that they are not present in the sent email.