### PR TITLE
Fix part of #1366: Add pagination to creator dashboard explorations

### DIFF
--- a/core/controllers/dashboard.py
+++ b/core/controllers/dashboard.py
@@ -160,20 +160,25 @@ class DashboardHandler(base.BaseHandler):
             subscription_services.get_exploration_ids_subscribed_to(
                 self.user_id))
 
-        subscribed_exploration_summaries = filter(None, (
-            exp_services.get_exploration_summaries_matching_ids(
-                exploration_ids_subscribed_to)))
-        subscribed_collection_summaries = filter(None, (
-            collection_services.get_collection_summaries_matching_ids(
-                subscription_services.get_collection_ids_subscribed_to(
-                    self.user_id))))
-
         urlsafe_start_cursor = None
         res, new_urlsafe_start_cursor, more = (
             user_services.get_next_page_of_explorations(
                 exploration_ids_subscribed_to,
                 urlsafe_start_cursor=urlsafe_start_cursor))
         print res, new_urlsafe_start_cursor, more
+
+        subscribed_exploration_summaries = filter(None, (
+            exp_services.get_exploration_summaries_from_models(
+                res)))
+        subscribed_collection_summaries = filter(None, (
+            collection_services.get_collection_summaries_matching_ids(
+                subscription_services.get_collection_ids_subscribed_to(
+                    self.user_id))))
+
+        # res, new_urlsafe_start_cursor, more = (
+        #     user_services.get_next_page_of_explorations(
+        #         exploration_ids_subscribed_to,
+        #         urlsafe_start_cursor=urlsafe_start_cursor))
 
         exp_summary_list = summary_services.get_displayable_exp_summary_dicts(
             subscribed_exploration_summaries)

--- a/core/controllers/dashboard.py
+++ b/core/controllers/dashboard.py
@@ -156,33 +156,21 @@ class DashboardHandler(base.BaseHandler):
                 category in feconf.CATEGORIES_TO_COLORS else
                 feconf.DEFAULT_COLOR)
 
-        exploration_ids_subscribed_to = (
-            subscription_services.get_exploration_ids_subscribed_to(
-                self.user_id))
-
-        urlsafe_start_cursor = None
         res, new_urlsafe_start_cursor, more = (
-            user_services.get_next_page_of_explorations(
-                exploration_ids_subscribed_to,
-                urlsafe_start_cursor=urlsafe_start_cursor))
-        print res, new_urlsafe_start_cursor, more
+            user_services.get_next_page_of_explorations(self.user_id))
 
-        subscribed_exploration_summaries = filter(None, (
-            exp_services.get_exploration_summaries_from_models(
-                res)))
+        exp_summary_list = summary_services.get_displayable_exp_summary_dicts(
+            res)
+        collection_summary_list = []
+
         subscribed_collection_summaries = filter(None, (
             collection_services.get_collection_summaries_matching_ids(
                 subscription_services.get_collection_ids_subscribed_to(
                     self.user_id))))
 
-        # res, new_urlsafe_start_cursor, more = (
-        #     user_services.get_next_page_of_explorations(
-        #         exploration_ids_subscribed_to,
-        #         urlsafe_start_cursor=urlsafe_start_cursor))
-
-        exp_summary_list = summary_services.get_displayable_exp_summary_dicts(
-            subscribed_exploration_summaries)
-        collection_summary_list = []
+        exploration_ids_subscribed_to = (
+            subscription_services.get_exploration_ids_subscribed_to(
+                self.user_id))
 
         feedback_thread_analytics = (
             feedback_services.get_thread_analytics_multi(
@@ -234,7 +222,9 @@ class DashboardHandler(base.BaseHandler):
             'explorations_list': exp_summary_list,
             'collections_list': collection_summary_list,
             'dashboard_stats': user_services.get_user_dashboard_stats(
-                self.user_id)
+                self.user_id),
+            'cursor': new_urlsafe_start_cursor,
+            'more': more
         })
         self.render_json(self.values)
 

--- a/core/controllers/dashboard.py
+++ b/core/controllers/dashboard.py
@@ -168,6 +168,12 @@ class DashboardHandler(base.BaseHandler):
                 subscription_services.get_collection_ids_subscribed_to(
                     self.user_id))))
 
+        res, new_urlsafe_start_cursor, more = (
+            user_services.get_next_page_of_explorations(
+                urlsafe_start_cursor=urlsafe_start_cursor))
+
+        print res
+
         exp_summary_list = summary_services.get_displayable_exp_summary_dicts(
             subscribed_exploration_summaries)
         collection_summary_list = []

--- a/core/controllers/dashboard.py
+++ b/core/controllers/dashboard.py
@@ -168,11 +168,12 @@ class DashboardHandler(base.BaseHandler):
                 subscription_services.get_collection_ids_subscribed_to(
                     self.user_id))))
 
+        urlsafe_start_cursor = None
         res, new_urlsafe_start_cursor, more = (
             user_services.get_next_page_of_explorations(
+                exploration_ids_subscribed_to,
                 urlsafe_start_cursor=urlsafe_start_cursor))
-
-        print res
+        print res, new_urlsafe_start_cursor, more
 
         exp_summary_list = summary_services.get_displayable_exp_summary_dicts(
             subscribed_exploration_summaries)

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -291,7 +291,7 @@ def get_exploration_titles_and_categories(exp_ids):
     return result
 
 
-def _get_exploration_summaries_from_models(exp_summary_models):
+def get_exploration_summaries_from_models(exp_summary_models):
     """Given an iterable of ExpSummaryModel instances, create a dict containing
     corresponding exploration summary domain objects, keyed by id.
     """
@@ -362,7 +362,7 @@ def get_non_private_exploration_summaries():
     """Returns a dict with all non-private exploration summary domain objects,
     keyed by their id.
     """
-    return _get_exploration_summaries_from_models(
+    return get_exploration_summaries_from_models(
         exp_models.ExpSummaryModel.get_non_private())
 
 
@@ -370,7 +370,7 @@ def get_top_rated_exploration_summaries():
     """Returns a dict with top rated exploration summary domain objects,
     keyed by their id.
     """
-    return _get_exploration_summaries_from_models(
+    return get_exploration_summaries_from_models(
         exp_models.ExpSummaryModel.get_top_rated())
 
 
@@ -378,7 +378,7 @@ def get_recently_published_exploration_summaries():
     """Returns a dict with all featured exploration summary domain objects,
     keyed by their id.
     """
-    return _get_exploration_summaries_from_models(
+    return get_exploration_summaries_from_models(
         exp_models.ExpSummaryModel.get_recently_published())
 
 
@@ -386,7 +386,7 @@ def get_all_exploration_summaries():
     """Returns a dict with all exploration summary domain objects,
     keyed by their id.
     """
-    return _get_exploration_summaries_from_models(
+    return get_exploration_summaries_from_models(
         exp_models.ExpSummaryModel.get_all())
 
 

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -29,7 +29,8 @@ import utils
 from google.appengine.api import urlfetch
 
 current_user_services = models.Registry.import_current_user_services()
-(user_models,) = models.Registry.import_models([models.NAMES.user])
+(exp_models, user_models) = models.Registry.import_models(
+    [models.NAMES.exploration, models.NAMES.user])
 
 MAX_USERNAME_LENGTH = 50
 # Size (in px) of the gravatar being retrieved.
@@ -274,7 +275,7 @@ def get_profile_pictures_by_user_ids(user_ids):
 
 
 def get_next_page_of_explorations(
-        exp_ids,
+        user_id,
         page_size=feconf.DASHBOARD_EXPLORATIONS_PAGE_SIZE,
         urlsafe_start_cursor=None):
     """Returns a page of creator dashboard explorations in reverse time order.
@@ -285,11 +286,9 @@ def get_next_page_of_explorations(
         https://developers.google.com/appengine/docs/python/ndb/queryclass
     """
     results, new_urlsafe_start_cursor, more = (
-        user_models.UserSubscriptionsModel.get_subscribed_explorations_by_id(
-            exp_ids, page_size, urlsafe_start_cursor))
+        exp_models.ExpSummaryModel.get_explorations_of_user(
+            user_id, page_size, urlsafe_start_cursor))
 
-    # result_explorations = [exp_services.get_exploration_from_model(m)
-    #                        for m in results]
     return (results, new_urlsafe_start_cursor, more)
 
 

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -22,7 +22,6 @@ import imghdr
 import logging
 import re
 
-from core.domain import exp_services
 from core.platform import models
 import feconf
 import utils
@@ -289,9 +288,9 @@ def get_next_page_of_explorations(
         user_models.UserSubscriptionsModel.get_subscribed_explorations_by_id(
             exp_ids, page_size, urlsafe_start_cursor))
 
-    result_explorations = [exp_services.get_exploration_from_model(m)
-                           for m in results]
-    return (result_explorations, new_urlsafe_start_cursor, more)
+    # result_explorations = [exp_services.get_exploration_from_model(m)
+    #                        for m in results]
+    return (results, new_urlsafe_start_cursor, more)
 
 
 def get_user_settings(user_id, strict=False):

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -22,6 +22,7 @@ import imghdr
 import logging
 import re
 
+from core.domain import exp_services
 from core.platform import models
 import feconf
 import utils
@@ -274,13 +275,23 @@ def get_profile_pictures_by_user_ids(user_ids):
 
 
 def get_next_page_of_explorations(
-    page_size=feconf.DASHBOARD_EXPLORATIONS_PAGE_SIZE, urlsafe_start_cursor=None):
+        exp_ids,
+        page_size=feconf.DASHBOARD_EXPLORATIONS_PAGE_SIZE,
+        urlsafe_start_cursor=None):
+    """Returns a page of creator dashboard explorations in reverse time order.
 
+    The return value is a triple (results, cursor, more) as described in
+    fetch_page() at:
+
+        https://developers.google.com/appengine/docs/python/ndb/queryclass
+    """
     results, new_urlsafe_start_cursor, more = (
-        exp_models.ExpSummaryModel.get_subscribed_explorations_by_id(
-            page_size, urlsafe_start_cursor))
+        user_models.UserSubscriptionsModel.get_subscribed_explorations_by_id(
+            exp_ids, page_size, urlsafe_start_cursor))
 
-    return results
+    result_explorations = [exp_services.get_exploration_from_model(m)
+                           for m in results]
+    return (result_explorations, new_urlsafe_start_cursor, more)
 
 
 def get_user_settings(user_id, strict=False):

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -273,6 +273,16 @@ def get_profile_pictures_by_user_ids(user_ids):
     return result
 
 
+def get_next_page_of_explorations(
+    page_size=feconf.DASHBOARD_EXPLORATIONS_PAGE_SIZE, urlsafe_start_cursor=None):
+
+    results, new_urlsafe_start_cursor, more = (
+        exp_models.ExpSummaryModel.get_subscribed_explorations_by_id(
+            page_size, urlsafe_start_cursor))
+
+    return results
+
+
 def get_user_settings(user_id, strict=False):
     """Return the user settings for a single user."""
     user_settings = get_users_settings([user_id])[0]

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -555,6 +555,21 @@ class UserDashboardStatsTests(test_utils.GenericTestBase):
     def _mock_get_current_date_as_string(self):
         return self.CURRENT_DATE_AS_STRING
 
+    def test_get_next_page_of_explorations(self):
+        explorations_list = []
+        for i in range(10):
+            exp_id = 'exp%d' % i
+            explorations_list.append(self.save_new_valid_exploration(
+                exp_id, self.owner_id, end_state_name='End'))
+
+        dashboard_explorations = (
+            user_services.get_next_page_of_explorations(self.owner_id)[0])
+
+        self.assertEquals(
+            len(dashboard_explorations),
+            feconf.DASHBOARD_EXPLORATIONS_PAGE_SIZE
+        )
+
     def test_get_user_dashboard_stats(self):
         exploration = self.save_new_valid_exploration(
             self.EXP_ID, self.owner_id, end_state_name='End')

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -428,6 +428,6 @@ class ExpSummaryModel(base_models.BaseModel):
     @classmethod
     def get_explorations_of_user(
             cls, user_id, page_size, urlsafe_start_cursor):
-        query = cls.query(cls.contributor_ids.IN([user_id])).order(cls._key)
+        query = cls.query(cls.contributor_ids.IN([user_id]))
         return cls._fetch_page_sorted_by_last_updated(
             query, page_size, urlsafe_start_cursor)

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -424,3 +424,10 @@ class ExpSummaryModel(base_models.BaseModel):
         ).order(
             -ExpSummaryModel.first_published_msec
         ).fetch(feconf.RECENTLY_PUBLISHED_QUERY_LIMIT)
+
+    def get_subscribed_explorations_by_id(cls, user_id, exp_ids, page_size):
+        query = cls.query.filter(
+            ndb.AND(user_id IN cls.owner_ids,
+                    cls.id IN exp_ids))
+        return cls._fetch_page_sorted_by_last_updated(
+            query, page_size, urlsafe_start_cursor)

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -424,10 +424,3 @@ class ExpSummaryModel(base_models.BaseModel):
         ).order(
             -ExpSummaryModel.first_published_msec
         ).fetch(feconf.RECENTLY_PUBLISHED_QUERY_LIMIT)
-
-    def get_subscribed_explorations_by_id(cls, user_id, exp_ids, page_size):
-        query = cls.query.filter(
-            ndb.AND(user_id IN cls.owner_ids,
-                    cls.id IN exp_ids))
-        return cls._fetch_page_sorted_by_last_updated(
-            query, page_size, urlsafe_start_cursor)

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -424,3 +424,10 @@ class ExpSummaryModel(base_models.BaseModel):
         ).order(
             -ExpSummaryModel.first_published_msec
         ).fetch(feconf.RECENTLY_PUBLISHED_QUERY_LIMIT)
+
+    @classmethod
+    def get_explorations_of_user(
+            cls, user_id, page_size, urlsafe_start_cursor):
+        query = cls.query(cls.contributor_ids.IN([user_id])).order(cls._key)
+        return cls._fetch_page_sorted_by_last_updated(
+            query, page_size, urlsafe_start_cursor)

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -126,15 +126,6 @@ class UserSubscriptionsModel(base_models.BaseModel):
     # When the user last checked notifications. May be None.
     last_checked = ndb.DateTimeProperty(default=None)
 
-    @classmethod
-    def get_subscribed_explorations_by_id(
-            cls,
-            exp_ids, page_size,
-            urlsafe_start_cursor):
-        query = cls.query(cls.activity_ids.IN(exp_ids)).order(cls._key)
-        return cls._fetch_page_sorted_by_last_updated(
-            query, page_size, urlsafe_start_cursor)
-
 
 class UserRecentChangesBatchModel(base_models.BaseMapReduceBatchResultsModel):
     """A list of recent changes corresponding to things a user subscribes to.

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -126,6 +126,15 @@ class UserSubscriptionsModel(base_models.BaseModel):
     # When the user last checked notifications. May be None.
     last_checked = ndb.DateTimeProperty(default=None)
 
+    @classmethod
+    def get_subscribed_explorations_by_id(
+            cls,
+            exp_ids, page_size,
+            urlsafe_start_cursor):
+        query = cls.query(cls.activity_ids.IN(exp_ids)).order(cls._key)
+        return cls._fetch_page_sorted_by_last_updated(
+            query, page_size, urlsafe_start_cursor)
+
 
 class UserRecentChangesBatchModel(base_models.BaseMapReduceBatchResultsModel):
     """A list of recent changes corresponding to things a user subscribes to.

--- a/feconf.py
+++ b/feconf.py
@@ -102,7 +102,7 @@ COMMIT_LIST_PAGE_SIZE = 50
 FEEDBACK_TAB_PAGE_SIZE = 20
 
 # The default number of explorations to show on a page in the creator dashboard.
-DASHBOARD_EXPLORATIONS_PAGE_SIZE = 8
+DASHBOARD_EXPLORATIONS_PAGE_SIZE = 2
 
 # Default title for a newly-minted exploration.
 DEFAULT_EXPLORATION_TITLE = ''

--- a/feconf.py
+++ b/feconf.py
@@ -101,6 +101,9 @@ COMMIT_LIST_PAGE_SIZE = 50
 # tab.
 FEEDBACK_TAB_PAGE_SIZE = 20
 
+# The default number of explorations to show on a page in the creator dashboard.
+DASHBOARD_EXPLORATIONS_PAGE_SIZE = 8
+
 # Default title for a newly-minted exploration.
 DEFAULT_EXPLORATION_TITLE = ''
 # Default category for a newly-minted exploration.

--- a/index.yaml
+++ b/index.yaml
@@ -44,6 +44,12 @@ indexes:
   - name: scaled_average_rating
     direction: desc
 
+- kind: ExpSummaryModel
+  properties:
+  - name: owner_ids
+  - name: last_updated
+    direction: desc
+
 - kind: ExpSummaryRealtimeModel
   properties:
   - name: realtime_layer

--- a/index.yaml
+++ b/index.yaml
@@ -27,6 +27,12 @@ indexes:
 
 - kind: ExpSummaryModel
   properties:
+  - name: contributor_ids
+  - name: last_updated
+    direction: desc
+
+- kind: ExpSummaryModel
+  properties:
   - name: deleted
   - name: status
 


### PR DESCRIPTION
Tasks to be completed as a part of this PR:
- [x] Fetch the explorations in the dashboard paginated (page size = 8).
- [ ] Make re-fetching request with next page's cursor detecting the user scroll.