### PR TITLE
Add a new main_taskqueue.py file for taskqueue handlers.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -98,6 +98,10 @@ handlers:
   login: admin
   script: main_cron.app
   secure: always
+- url: /task/.*
+  login: admin
+  script: main_taskqueue.app
+  secure: always
 - url: /.*
   script: main.app
   secure: always

--- a/feconf.py
+++ b/feconf.py
@@ -404,6 +404,9 @@ EMBEDDED_GOOGLE_GROUP_URL = (
 # Whether to allow YAML file uploads.
 ALLOW_YAML_FILE_UPLOAD = False
 
+# Prefix for all taskqueue-related URLs.
+TASKQUEUE_URL_PREFIX = '/task'
+
 # TODO(sll): Add all other URLs here.
 ADMIN_URL = '/admin'
 COLLECTION_DATA_URL_PREFIX = '/collection_handler/data'
@@ -415,7 +418,6 @@ DASHBOARD_URL = '/dashboard'
 DASHBOARD_CREATE_MODE_URL = '%s?mode=create' % DASHBOARD_URL
 DASHBOARD_DATA_URL = '/dashboardhandler/data'
 EDITOR_URL_PREFIX = '/create'
-EMAILS_TASK_PREFIX = '/task/email'
 EXPLORATION_DATA_PREFIX = '/createhandler/data'
 EXPLORATION_INIT_URL_PREFIX = '/explorehandler/init'
 EXPLORATION_RIGHTS_PREFIX = '/createhandler/rights'
@@ -425,7 +427,7 @@ FEEDBACK_STATS_URL_PREFIX = '/feedbackstatshandler'
 FEEDBACK_THREAD_URL_PREFIX = '/threadhandler'
 FEEDBACK_THREADLIST_URL_PREFIX = '/threadlisthandler'
 FEEDBACK_MESSAGE_EMAIL_HANDLER_URL = (
-    '%s/feedbackemailhandler' % EMAILS_TASK_PREFIX)
+    '%s/email/feedbackemailhandler' % TASKQUEUE_URL_PREFIX)
 FEEDBACK_THREAD_VIEW_EVENT_URL = '/feedbackhandler/thread_view_event'
 LIBRARY_INDEX_URL = '/library'
 LIBRARY_INDEX_DATA_URL = '/libraryindexhandler'

--- a/main.py
+++ b/main.py
@@ -370,9 +370,6 @@ URLS = MAPREDUCE_HANDLERS + [
         'recent_feedback_messages_handler'),
 
     get_redirect_route(
-        r'%s' % feconf.FEEDBACK_MESSAGE_EMAIL_HANDLER_URL,
-        feedback.UnsentFeedbackEmailHandler, 'feedback_message_email_handler'),
-    get_redirect_route(
         r'%s' % feconf.FEEDBACK_THREAD_VIEW_EVENT_URL,
         feedback.FeedbackThreadViewEventHandler, 'feedback_thread_view_event'),
     get_redirect_route(

--- a/main_taskqueue.py
+++ b/main_taskqueue.py
@@ -1,0 +1,36 @@
+# Copyright 2016 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Main package for URL routing for requests originating from the task queue."""
+
+# pylint: disable=relative-import
+from core.controllers import feedback
+from core.platform import models
+import feconf
+import main
+# pylint: enable=relative-import
+
+import webapp2
+
+transaction_services = models.Registry.import_transaction_services()
+
+# Register the URLs with the classes responsible for handling them.
+URLS = [
+    main.get_redirect_route(
+        r'%s' % feconf.FEEDBACK_MESSAGE_EMAIL_HANDLER_URL,
+        feedback.UnsentFeedbackEmailHandler, 'feedback_message_email_handler'),
+]
+
+app = transaction_services.toplevel_wrapper(  # pylint: disable=invalid-name
+    webapp2.WSGIApplication(URLS, debug=feconf.DEBUG))


### PR DESCRIPTION
The aim of this PR is to secure the taskqueue handlers per the guidance at the bottom of [this page](https://cloud.google.com/appengine/docs/python/taskqueue/push/creating-handlers#securing_task_handler_urls).
