### PR TITLE
Fix #1966: remove the option Open in same window in editor

### DIFF
--- a/extensions/rich_text_components/Link/Link.html
+++ b/extensions/rich_text_components/Link/Link.html
@@ -3,6 +3,6 @@
   being added before and after the link. See http://stackoverflow.com/q/5078239
 -->
 <script type="text/ng-template" id="richTextComponent/Link"><!--
-  --><a ng-if="showUrlInTooltip" href="<[url]>" target="<[target]>" tooltip="<[url]>" tabindex="<[tabIndexVal]>"><[text]></a><!--
-  --><a ng-if="!showUrlInTooltip" href="<[url]>" target="<[target]>" tabindex="<[tabIndexVal]>"><[url]></a><!--
+  --><a ng-if="showUrlInTooltip" href="<[url]>" target="_blank" tooltip="<[url]>" tabindex="<[tabIndexVal]>"><[text]></a><!--
+  --><a ng-if="!showUrlInTooltip" href="<[url]>" target="_blank" tabindex="<[tabIndexVal]>"><[url]></a><!--
 --></script>

--- a/extensions/rich_text_components/Link/Link.js
+++ b/extensions/rich_text_components/Link/Link.js
@@ -27,14 +27,8 @@ oppia.directive('oppiaNoninteractiveLink', [
       templateUrl: 'richTextComponent/Link',
       controller: ['$scope', '$attrs', 'explorationContextService',
         function($scope, $attrs, explorationContextService) {
-          if (!$attrs.openLinkInSameWindowWithValue) {
-            // This is done for backward-compatibility.
-            $scope.target = '_blank';
-          } else {
-            $scope.target = (
-              oppiaHtmlEscaper.escapedJsonToObj(
-                $attrs.openLinkInSameWindowWithValue) ? '_top' : '_blank');
-          }
+          // Always open link in new tab/window
+          $scope.target = '_blank';
 
           var untrustedUrl = encodeURI(oppiaHtmlEscaper.escapedJsonToObj(
             $attrs.urlWithValue));

--- a/extensions/rich_text_components/Link/Link.js
+++ b/extensions/rich_text_components/Link/Link.js
@@ -27,9 +27,6 @@ oppia.directive('oppiaNoninteractiveLink', [
       templateUrl: 'richTextComponent/Link',
       controller: ['$scope', '$attrs', 'explorationContextService',
         function($scope, $attrs, explorationContextService) {
-          // Always open link in new tab/window
-          $scope.target = '_blank';
-
           var untrustedUrl = encodeURI(oppiaHtmlEscaper.escapedJsonToObj(
             $attrs.urlWithValue));
           if (untrustedUrl.indexOf('http://') !== 0 &&

--- a/extensions/rich_text_components/Link/Link.py
+++ b/extensions/rich_text_components/Link/Link.py
@@ -43,11 +43,4 @@ class Link(base.BaseRichTextComponent):
             'type': 'unicode',
         },
         'default_value': '',
-    }, {
-        'name': 'open_link_in_same_window',
-        'description': 'Open the link in the same window?',
-        'schema': {
-            'type': 'bool'
-        },
-        'default_value': False,
     }]

--- a/extensions/rich_text_components/Link/protractor.js
+++ b/extensions/rich_text_components/Link/protractor.js
@@ -19,20 +19,16 @@
 
 var objects = require('../../objects/protractor.js');
 
-var customizeComponent = function(modal, url, openInSameWindow) {
+var customizeComponent = function(modal, url) {
   objects.SanitizedUrlEditor(
     modal.element(by.tagName('sanitized-url-editor'))
   ).setValue(url);
-  objects.BooleanEditor(
-    modal.element(by.tagName('schema-based-bool-editor'))
-  ).setValue(openInSameWindow);
 };
 
-var expectComponentDetailsToMatch = function(elem, url, openInSameWindow) {
+var expectComponentDetailsToMatch = function(elem, url) {
   expect(elem.element(by.tagName('a')).getAttribute('href')).toBe(url);
   expect(
-    elem.element(by.tagName('a')).getAttribute('target')
-  ).toBe(openInSameWindow ? '_top' : '_blank');
+    elem.element(by.tagName('a')).getAttribute('target')).toBe('_blank');
 };
 
 exports.customizeComponent = customizeComponent;


### PR DESCRIPTION
Since users wouldn't want open a link on the same window as the currently played exploration, the option "Open in same window" is not necessary. My commit removes it from the modal that displays when creator clicks on Link option, on toolbar of a card editor.