### PR TITLE
Fix #1862: Creator no longer has to remove pre-existing text in RTEs

### DIFF
--- a/core/templates/dev/head/forms/formBuilder.js
+++ b/core/templates/dev/head/forms/formBuilder.js
@@ -902,7 +902,8 @@ oppia.directive('textAngularRte', [
         },
         template: (
           '<div text-angular="" ta-toolbar="<[toolbarOptionsJson]>" ' +
-          '     ta-paste="stripFormatting($html)" ng-model="tempContent">' +
+          '     ta-paste="stripFormatting($html)" ng-model="tempContent"' +
+          '     placeholder="<[placeholderText]>">' +
           '</div>'),
         controller: ['$scope', function($scope) {
           // Currently, operations affecting the filesystem are allowed only in
@@ -913,6 +914,10 @@ oppia.directive('textAngularRte', [
             ['ol', 'ul', 'pre', 'indent', 'outdent'],
             []
           ];
+
+          if ($scope.uiConfig() && $scope.uiConfig().placeholder) {
+            $scope.placeholderText = $scope.uiConfig().placeholder;
+          }
 
           rteHelperService.getRichTextComponents().forEach(
             function(componentDefn) {

--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.py
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.py
@@ -58,11 +58,12 @@ class ItemSelectionInput(base.BaseInteraction):
                 'type': 'html',
                 'ui_config': {
                     'hide_complex_extensions': True,
+                    'placeholder': 'Sample item answer',
                 },
             },
             'ui_config': {
                 'add_element_text': 'Add item for selection',
             }
         },
-        'default_value': ['Sample item answer'],
+        'default_value': [''],
     }]

--- a/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.py
+++ b/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.py
@@ -43,11 +43,12 @@ class MultipleChoiceInput(base.BaseInteraction):
                 'type': 'html',
                 'ui_config': {
                     'hide_complex_extensions': True,
+                    'placeholder': 'Sample multiple-choice answer',
                 },
             },
             'ui_config': {
                 'add_element_text': 'Add multiple choice option',
             }
         },
-        'default_value': ['Sample multiple-choice answer'],
+        'default_value': [''],
     }]

--- a/schema_utils_test.py
+++ b/schema_utils_test.py
@@ -70,6 +70,9 @@ UI_CONFIG_SPECS = {
     SCHEMA_TYPE_HTML: {
         'hide_complex_extensions': {
             'type': SCHEMA_TYPE_BOOL,
+        },
+        'placeholder': {
+            'type': SCHEMA_TYPE_UNICODE,
         }
     },
     SCHEMA_TYPE_INT: {},


### PR DESCRIPTION
This PR addresses issue #1862. The creator no longer has to remove pre-existing text. The text is replaced by a placeholder which gets removed when the user starts typing.

