### PR TITLE
Fix #2274: I18n.js: Use $translate.proposedLanguage to  eliminate blank field.

### DIFF
--- a/core/templates/dev/head/i18n.js
+++ b/core/templates/dev/head/i18n.js
@@ -51,7 +51,12 @@ oppia.controller('I18nFooter', [
   // The $timeout seems to be necessary for the dropdown to show anything
   // at the outset, if the default language is not English.
   $timeout(function() {
-    $scope.currentLanguageCode = $translate.use();
+    // $translate.use() returns undefined until the language file is fully
+    // loaded, which causes a blank field in the dropdown, hence we use
+    // $translate.proposedLanguage() as suggested in
+    // http://stackoverflow.com/a/28903658
+    $scope.currentLanguageCode = $translate.use() ||
+      $translate.proposedLanguage();
   }, 50);
 
   $scope.changeLanguage = function() {


### PR DESCRIPTION
In order to get the currentLanguageCode use
$translate.proposedLanguage() alongside $transalte.use()
Fixes https://github.com/oppia/oppia/issues/2274

currentLanguageCode was set to undefined because the language file could not be loaded within the timeout, hence we got an empty blank field.