### PR TITLE
Add diagnostic one-off job to highlight ItemSelectionInput interactions whose answer groups need to be fixed.

### DIFF
--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -39,7 +39,8 @@ ONE_OFF_JOB_MANAGERS = [
     exp_jobs_one_off.ExplorationMigrationJobManager,
     exp_jobs_one_off.ExplorationContributorsSummaryOneOffJob,
     email_jobs_one_off.EmailHashRegenerationOneOffJob,
-    user_jobs_one_off.UserProfilePictureOneOffJob]
+    user_jobs_one_off.UserProfilePictureOneOffJob,
+    exp_jobs_one_off.ItemSelectionInteractionOneOffJob]
 
 # List of all ContinuousComputation managers to show controls for on the
 # admin dashboard.


### PR DESCRIPTION
NB this is related to #1897