### PR TITLE
handle extension resources

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -80,7 +80,10 @@ handlers:
   secure: always
   http_headers:
     Cache-Control: 'no-cache'
-# To serve extension resources in dev mode.
+# Serve js scripts for gadgets, interactions and rich_text_components under
+# extensions in dev mode. This regex allows us to recursively serve js scripts
+# under the three specified directories. "\1" and "\2" insert capture groups
+# from the url pattern.
 - url: /extensions/(gadgets|interactions|rich_text_components)/(.*\.(js))$
   static_files: extensions/\1/\2
   upload: extensions/(gadgets|interactions|rich_text_components)/(.*\.(js))$

--- a/app.yaml
+++ b/app.yaml
@@ -62,6 +62,10 @@ handlers:
   # TODO(Sean Lip): Add cache when system to break cache during
   # new release is figured out.
     Cache-Control: 'no-cache'
+- url: /extensions
+  static_dir: extensions
+  application_readable: true
+  secure: always
 - url: /extensions/gadgets/(.*)/static/(.*)
   static_files: extensions/gadgets/\1/static/\2
   upload: extensions/gadgets/(.*)/static/(.*)

--- a/app.yaml
+++ b/app.yaml
@@ -81,9 +81,9 @@ handlers:
   http_headers:
     Cache-Control: 'no-cache'
 # To serve extension resources in dev mode.
-- url: /extensions/(.*\.(js))$
-  static_files: extensions/\1
-  upload: extensions/(.*\.(js))$
+- url: /extensions/(gadgets|interactions|rich_text_components)/(.*\.(js))$
+  static_files: extensions/\1/\2
+  upload: extensions/(gadgets|interactions|rich_text_components)/(.*\.(js))$
   secure: always
 - url: /mapreduce/pipeline/images
   static_dir: third_party/gae-mapreduce-1.9.17.0/mapreduce/lib/pipeline/ui/images

--- a/app.yaml
+++ b/app.yaml
@@ -62,10 +62,6 @@ handlers:
   # TODO(Sean Lip): Add cache when system to break cache during
   # new release is figured out.
     Cache-Control: 'no-cache'
-- url: /extensions
-  static_dir: extensions
-  application_readable: true
-  secure: always
 - url: /extensions/gadgets/(.*)/static/(.*)
   static_files: extensions/gadgets/\1/static/\2
   upload: extensions/gadgets/(.*)/static/(.*)
@@ -84,6 +80,10 @@ handlers:
   secure: always
   http_headers:
     Cache-Control: 'no-cache'
+- url: /extensions
+  static_dir: extensions
+  application_readable: true
+  secure: always
 - url: /mapreduce/pipeline/images
   static_dir: third_party/gae-mapreduce-1.9.17.0/mapreduce/lib/pipeline/ui/images
   secure: always

--- a/app.yaml
+++ b/app.yaml
@@ -80,9 +80,10 @@ handlers:
   secure: always
   http_headers:
     Cache-Control: 'no-cache'
-- url: /extensions
-  static_dir: extensions
-  application_readable: true
+# To serve extension resources in dev mode.
+- url: /extensions/(.*\.(js))$
+  static_files: extensions/\1
+  upload: extensions/(.*\.(js))$
   secure: always
 - url: /mapreduce/pipeline/images
   static_dir: third_party/gae-mapreduce-1.9.17.0/mapreduce/lib/pipeline/ui/images

--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -193,9 +193,8 @@ class ExplorationPage(EditorHandler):
             rte_component_registry.Registry.get_html_for_all_components() +
             interaction_registry.Registry.get_interaction_html(
                 interaction_ids))
-        interaction_validators_html = (
-            interaction_registry.Registry.get_validators_html(
-                interaction_ids))
+        interaction_base_validator_html = (
+            interaction_registry.Registry.get_base_validator_html())
 
         gadget_types = gadget_registry.Registry.get_all_gadget_types()
         gadget_templates = (
@@ -235,8 +234,8 @@ class ExplorationPage(EditorHandler):
             'gadget_templates': jinja2.utils.Markup(gadget_templates),
             'interaction_templates': jinja2.utils.Markup(
                 interaction_templates),
-            'interaction_validators_html': jinja2.utils.Markup(
-                interaction_validators_html),
+            'interaction_base_validator_html': jinja2.utils.Markup(
+                interaction_base_validator_html),
             'meta_description': feconf.CREATE_PAGE_DESCRIPTION,
             'nav_mode': feconf.NAV_MODE_CREATE,
             'value_generators_js': jinja2.utils.Markup(

--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -193,8 +193,6 @@ class ExplorationPage(EditorHandler):
             rte_component_registry.Registry.get_html_for_all_components() +
             interaction_registry.Registry.get_interaction_html(
                 interaction_ids))
-        interaction_base_validator_html = (
-            interaction_registry.Registry.get_base_validator_html())
 
         gadget_types = gadget_registry.Registry.get_all_gadget_types()
         gadget_templates = (
@@ -234,8 +232,6 @@ class ExplorationPage(EditorHandler):
             'gadget_templates': jinja2.utils.Markup(gadget_templates),
             'interaction_templates': jinja2.utils.Markup(
                 interaction_templates),
-            'interaction_base_validator_html': jinja2.utils.Markup(
-                interaction_base_validator_html),
             'meta_description': feconf.CREATE_PAGE_DESCRIPTION,
             'nav_mode': feconf.NAV_MODE_CREATE,
             'value_generators_js': jinja2.utils.Markup(

--- a/core/domain/interaction_registry.py
+++ b/core/domain/interaction_registry.py
@@ -21,7 +21,6 @@ import os
 import pkgutil
 
 import feconf
-import utils
 
 
 class Registry(object):

--- a/core/domain/interaction_registry.py
+++ b/core/domain/interaction_registry.py
@@ -85,18 +85,6 @@ class Registry(object):
             for interaction_id in interaction_ids])
 
     @classmethod
-    def get_base_validator_html(cls):
-        """Returns the HTML body for the base validator."""
-
-        # Add the base validator.
-        html_fragments = [
-            '<script>%s</script>' %
-            utils.get_file_contents(os.path.join(
-                feconf.INTERACTIONS_DIR, 'baseValidator.js'))]
-
-        return ' \n'.join(html_fragments)
-
-    @classmethod
     def get_deduplicated_dependency_ids(cls, interaction_ids):
         """Return a list of dependency ids for the given interactions.
 

--- a/core/domain/interaction_registry.py
+++ b/core/domain/interaction_registry.py
@@ -85,19 +85,14 @@ class Registry(object):
             for interaction_id in interaction_ids])
 
     @classmethod
-    def get_validators_html(cls, interaction_ids):
-        """Returns the HTML bodies for the interaction validators."""
+    def get_base_validator_html(cls):
+        """Returns the HTML body for the base validator."""
 
         # Add the base validator.
         html_fragments = [
             '<script>%s</script>' %
             utils.get_file_contents(os.path.join(
                 feconf.INTERACTIONS_DIR, 'baseValidator.js'))]
-
-        # Add individual validators for each interaction.
-        html_fragments += [
-            cls.get_interaction_by_id(interaction_id).validator_html
-            for interaction_id in interaction_ids]
 
         return ' \n'.join(html_fragments)
 

--- a/core/templates/dev/head/exploration_editor/editor_extensions.html
+++ b/core/templates/dev/head/exploration_editor/editor_extensions.html
@@ -1,1 +1,0 @@
-<link rel="import" href="/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.html"> 

--- a/core/templates/dev/head/exploration_editor/editor_extensions.html
+++ b/core/templates/dev/head/exploration_editor/editor_extensions.html
@@ -1,0 +1,1 @@
+<link rel="import" href="/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.html"> 

--- a/core/templates/dev/head/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/exploration_editor/exploration_editor.html
@@ -572,7 +572,7 @@
     {{ include_js_file('expressions/expressionInterpolationService.js') }}
   </script>
 
-  {{ interaction_base_validator_html }}
+  <script src="{{ASSET_DIR_PREFIX}}/extensions/interactions/baseValidator.js"></script>
   {{ interaction_templates }}
   {{ gadget_templates }}
 {% endblock footer_js %}

--- a/core/templates/dev/head/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/exploration_editor/exploration_editor.html
@@ -239,6 +239,7 @@
 {% endblock local_top_nav_options %}
 
 {% block content %}
+  {% include 'exploration_editor/editor_extensions.html' %}
   <div ng-controller="ExplorationEditor" ng-cloak>
 
     <script type="text/ng-template" id="modals/addExplorationMetadata">
@@ -572,7 +573,6 @@
     {{ include_js_file('expressions/expressionInterpolationService.js') }}
   </script>
 
-  {{ interaction_templates }}
   {{ interaction_validators_html }}
   {{ gadget_templates }}
 {% endblock footer_js %}

--- a/core/templates/dev/head/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/exploration_editor/exploration_editor.html
@@ -572,7 +572,7 @@
     {{ include_js_file('expressions/expressionInterpolationService.js') }}
   </script>
 
+  {{ interaction_base_validator_html }}
   {{ interaction_templates }}
-  {{ interaction_validators_html }}
   {{ gadget_templates }}
 {% endblock footer_js %}

--- a/core/templates/dev/head/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/exploration_editor/exploration_editor.html
@@ -239,7 +239,6 @@
 {% endblock local_top_nav_options %}
 
 {% block content %}
-  {% include 'exploration_editor/editor_extensions.html' %}
   <div ng-controller="ExplorationEditor" ng-cloak>
 
     <script type="text/ng-template" id="modals/addExplorationMetadata">
@@ -573,6 +572,7 @@
     {{ include_js_file('expressions/expressionInterpolationService.js') }}
   </script>
 
+  {{ interaction_templates }}
   {{ interaction_validators_html }}
   {{ gadget_templates }}
 {% endblock footer_js %}

--- a/extensions/gadgets/AdviceBar/AdviceBar.html
+++ b/extensions/gadgets/AdviceBar/AdviceBar.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/gadgets/AdviceBar/AdviceBar.js"></script>
+
 <script type="text/ng-template" id="gadget/AdviceBar">
   <link rel="stylesheet" type="text/css" ng-href="<[getStaticResourceUrl('/extensions/gadgets/AdviceBar/static/css/adviceBar.css')]>">
   <div class="oppia-advice-bar-container">

--- a/extensions/gadgets/ScoreBar/ScoreBar.html
+++ b/extensions/gadgets/ScoreBar/ScoreBar.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/gadgets/ScoreBar/ScoreBar.js"></script>
+
 <script type="text/ng-template" id="gadget/ScoreBar">
   <link rel="stylesheet" type="text/css" ng-href="<[getStaticResourceUrl('/extensions/gadgets/ScoreBar/static/css/scoreBar.css')]>">
   <progressbar class="scorebar-progressbar protractor-test-scorebar-progressbar" max="maxValue" value="getScoreValue()"><span class="scorebar-label protractor-test-scorebar-label"><[scoreBarLabel]></span></progressbar>

--- a/extensions/gadgets/TestGadget/TestGadget.html
+++ b/extensions/gadgets/TestGadget/TestGadget.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/gadgets/TestGadget/TestGadget.js"></script>
+
 <link rel="stylesheet" type="text/css" ng-href="<[extensionResourcePrefix]>/extensions/gadgets/AdviceBar/static/css/adviceBar.css">
 
 <script type="text/ng-template" id="gadget/TestGadget">

--- a/extensions/gadgets/base.py
+++ b/extensions/gadgets/base.py
@@ -21,6 +21,7 @@ import os
 
 from extensions import domain
 import feconf
+import jinja_utils
 import schema_utils
 import utils
 
@@ -82,11 +83,9 @@ class BaseGadget(object):
         gadget. This contains everything needed to display the gadget
         once the necessary attributes are supplied.
         """
-        js_directives = utils.get_file_contents(os.path.join(
-            feconf.GADGETS_DIR, self.type, '%s.js' % self.type))
         html_templates = utils.get_file_contents(os.path.join(
             feconf.GADGETS_DIR, self.type, '%s.html' % self.type))
-        return '<script>%s</script>\n%s' % (js_directives, html_templates)
+        return jinja_utils.interpolate_cache_slug('%s' % html_templates)
 
     def validate(self, customization_args):
         """Subclasses may override to perform additional validation."""

--- a/extensions/interactions/CodeRepl/CodeRepl.html
+++ b/extensions/interactions/CodeRepl/CodeRepl.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/CodeRepl/CodeRepl.js"></script>
+
 <style>
   .code-repl-input-box {
     border: 1px solid #ccc;

--- a/extensions/interactions/CodeRepl/CodeRepl.html
+++ b/extensions/interactions/CodeRepl/CodeRepl.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/CodeRepl/CodeRepl.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/CodeRepl/validator.js"></script>
 
 <style>
   .code-repl-input-box {

--- a/extensions/interactions/Continue/Continue.html
+++ b/extensions/interactions/Continue/Continue.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/Continue/Continue.js"></script>
+
 <script type="text/ng-template" id="interaction/Continue">
   <md-button class="oppia-learner-continue-button" ng-click="submitAnswer()"><[buttonText]></md-button>
 </script>

--- a/extensions/interactions/Continue/Continue.html
+++ b/extensions/interactions/Continue/Continue.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/Continue/Continue.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/Continue/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/Continue">
   <md-button class="oppia-learner-continue-button" ng-click="submitAnswer()"><[buttonText]></md-button>

--- a/extensions/interactions/EndExploration/EndExploration.html
+++ b/extensions/interactions/EndExploration/EndExploration.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/EndExploration/EndExploration.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/EndExploration/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/EndExploration">
   <div ng-if="!isIframed && !isInEditorPreviewMode">

--- a/extensions/interactions/EndExploration/EndExploration.html
+++ b/extensions/interactions/EndExploration/EndExploration.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/EndExploration/EndExploration.js"></script>
+
 <script type="text/ng-template" id="interaction/EndExploration">
   <div ng-if="!isIframed && !isInEditorPreviewMode">
     <a href="/library">

--- a/extensions/interactions/GraphInput/GraphInput.html
+++ b/extensions/interactions/GraphInput/GraphInput.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/GraphInput/GraphInput.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/GraphInput/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/GraphInput">
   <div class="graph-input-container">

--- a/extensions/interactions/GraphInput/GraphInput.html
+++ b/extensions/interactions/GraphInput/GraphInput.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/GraphInput/GraphInput.js"></script>
+
 <script type="text/ng-template" id="interaction/GraphInput">
   <div class="graph-input-container">
     <graph-viz graph="graph"

--- a/extensions/interactions/ImageClickInput/ImageClickInput.html
+++ b/extensions/interactions/ImageClickInput/ImageClickInput.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/ImageClickInput/ImageClickInput.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/ImageClickInput/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/ImageClickInput">
   <style>

--- a/extensions/interactions/ImageClickInput/ImageClickInput.html
+++ b/extensions/interactions/ImageClickInput/ImageClickInput.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/ImageClickInput/ImageClickInput.js"></script>
+
 <script type="text/ng-template" id="interaction/ImageClickInput">
   <style>
     .image-click-container {

--- a/extensions/interactions/InteractiveMap/InteractiveMap.html
+++ b/extensions/interactions/InteractiveMap/InteractiveMap.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/InteractiveMap/InteractiveMap.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/InteractiveMap/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/InteractiveMap">
   <style>

--- a/extensions/interactions/InteractiveMap/InteractiveMap.html
+++ b/extensions/interactions/InteractiveMap/InteractiveMap.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/InteractiveMap/InteractiveMap.js"></script>
+
 <script type="text/ng-template" id="interaction/InteractiveMap">
   <style>
     /* Fixes for Google Maps zoom controls. */

--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.html
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/ItemSelectionInput/ItemSelectionInput.js"></script>
+
 <style>
   /* The following is needed so that the radio button does not show. */
   .item-selection-input-radio-button {

--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.html
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.html
@@ -1,3 +1,4 @@
+<script src="{{cache_slug}}/extensions/interactions/ItemSelectionInput/ItemSelectionInput.js"></script>
 <style>
   /* The following is needed so that the radio button does not show. */
   .item-selection-input-radio-button {

--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.html
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/ItemSelectionInput/ItemSelectionInput.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/ItemSelectionInput/validator.js"></script>
 
 <style>
   /* The following is needed so that the radio button does not show. */

--- a/extensions/interactions/LogicProof/LogicProof.html
+++ b/extensions/interactions/LogicProof/LogicProof.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/LogicProof/LogicProof.js"></script>
+
 <style>
   .logic-proof-input-box {
     border: 1px solid #ccc;

--- a/extensions/interactions/LogicProof/LogicProof.html
+++ b/extensions/interactions/LogicProof/LogicProof.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/LogicProof/LogicProof.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/LogicProof/validator.js"></script>
 
 <style>
   .logic-proof-input-box {

--- a/extensions/interactions/MathExpressionInput/MathExpressionInput.html
+++ b/extensions/interactions/MathExpressionInput/MathExpressionInput.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/MathExpressionInput/MathExpressionInput.js"></script>
+
 <script type="text/ng-template" id="interaction/MathExpressionInput">
   <div class="guppy-div"
        style="border: 1px solid black; width: 100%; height: 100px; padding: 5px;">

--- a/extensions/interactions/MathExpressionInput/MathExpressionInput.html
+++ b/extensions/interactions/MathExpressionInput/MathExpressionInput.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/MathExpressionInput/MathExpressionInput.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/MathExpressionInput/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/MathExpressionInput">
   <div class="guppy-div"

--- a/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.html
+++ b/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.html
@@ -1,4 +1,5 @@
-<script src="/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/MultipleChoiceInput/validator.js"></script>
 
 <style>
   .multiple-choice-option-container {

--- a/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.html
+++ b/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.html
@@ -1,3 +1,4 @@
+<script src="{{cache_slug}}/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.js"></script>
 <style>
   .multiple-choice-option-container {
     padding: 4px 0;

--- a/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.html
+++ b/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.html
@@ -1,4 +1,5 @@
-<script src="{{cache_slug}}/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.js"></script>
+<script src="/extensions/interactions/MultipleChoiceInput/MultipleChoiceInput.js"></script>
+
 <style>
   .multiple-choice-option-container {
     padding: 4px 0;

--- a/extensions/interactions/MusicNotesInput/MusicNotesInput.html
+++ b/extensions/interactions/MusicNotesInput/MusicNotesInput.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/MusicNotesInput/MusicNotesInput.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/MusicNotesInput/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/MusicNotesInput">
   <link rel="stylesheet" type="text/css" ng-href="<[getStaticResourceUrl('/extensions/interactions/MusicNotesInput/static/css/musicNotesInput.css')]>">

--- a/extensions/interactions/MusicNotesInput/MusicNotesInput.html
+++ b/extensions/interactions/MusicNotesInput/MusicNotesInput.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/MusicNotesInput/MusicNotesInput.js"></script>
+
 <script type="text/ng-template" id="interaction/MusicNotesInput">
   <link rel="stylesheet" type="text/css" ng-href="<[getStaticResourceUrl('/extensions/interactions/MusicNotesInput/static/css/musicNotesInput.css')]>">
   <div class="music-notes-input-container">

--- a/extensions/interactions/NumericInput/NumericInput.html
+++ b/extensions/interactions/NumericInput/NumericInput.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/NumericInput/NumericInput.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/NumericInput/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/NumericInput">
   <div class="row numeric-input-container">

--- a/extensions/interactions/NumericInput/NumericInput.html
+++ b/extensions/interactions/NumericInput/NumericInput.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/NumericInput/NumericInput.js"></script>
+
 <script type="text/ng-template" id="interaction/NumericInput">
   <div class="row numeric-input-container">
     <form ng-submit="submitAnswer(answer)" role="form" class="form-horizontal">

--- a/extensions/interactions/PencilCodeEditor/PencilCodeEditor.html
+++ b/extensions/interactions/PencilCodeEditor/PencilCodeEditor.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/PencilCodeEditor/PencilCodeEditor.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/PencilCodeEditor/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/PencilCodeEditor">
   <div class="pencil-code-editor-container">

--- a/extensions/interactions/PencilCodeEditor/PencilCodeEditor.html
+++ b/extensions/interactions/PencilCodeEditor/PencilCodeEditor.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/PencilCodeEditor/PencilCodeEditor.js"></script>
+
 <script type="text/ng-template" id="interaction/PencilCodeEditor">
   <div class="pencil-code-editor-container">
     <div style="height: 500px; position: relative;" class="pencil-code-editor-iframe">

--- a/extensions/interactions/SetInput/SetInput.html
+++ b/extensions/interactions/SetInput/SetInput.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/SetInput/SetInput.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/SetInput/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/SetInput">
   <div ng-if="answer.length === 0">

--- a/extensions/interactions/SetInput/SetInput.html
+++ b/extensions/interactions/SetInput/SetInput.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/SetInput/SetInput.js"></script>
+
 <script type="text/ng-template" id="interaction/SetInput">
   <div ng-if="answer.length === 0">
     <em translate="I18N_INTERACTIONS_SET_INPUT_EMPTY_SET"></em>

--- a/extensions/interactions/TextInput/TextInput.html
+++ b/extensions/interactions/TextInput/TextInput.html
@@ -1,4 +1,5 @@
 <script src="{{cache_slug}}/extensions/interactions/TextInput/TextInput.js"></script>
+<script src="{{cache_slug}}/extensions/interactions/TextInput/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/TextInput">
   <!-- This outer div is needed, otherwise the textarea will overlap the footer of the page. -->

--- a/extensions/interactions/TextInput/TextInput.html
+++ b/extensions/interactions/TextInput/TextInput.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/interactions/TextInput/TextInput.js"></script>
+
 <script type="text/ng-template" id="interaction/TextInput">
   <!-- This outer div is needed, otherwise the textarea will overlap the footer of the page. -->
   <div class="text-input-container">

--- a/extensions/interactions/base.py
+++ b/extensions/interactions/base.py
@@ -173,7 +173,7 @@ class BaseInteraction(object):
         """
         html_templates = utils.get_file_contents(os.path.join(
             feconf.INTERACTIONS_DIR, self.id, '%s.html' % self.id))
-        return jinja_utils.interpolate_cache_slug('%s' % (html_templates))
+        return jinja_utils.interpolate_cache_slug('%s' % html_templates)
 
     @property
     def validator_html(self):

--- a/extensions/interactions/base.py
+++ b/extensions/interactions/base.py
@@ -171,11 +171,9 @@ class BaseInteraction(object):
         interaction itself and the other for displaying the learner's response
         in a read-only view after it has been submitted.
         """
-        js_directives = utils.get_file_contents(os.path.join(
-            feconf.INTERACTIONS_DIR, self.id, '%s.js' % self.id))
         html_templates = utils.get_file_contents(os.path.join(
             feconf.INTERACTIONS_DIR, self.id, '%s.html' % self.id))
-        return '<script>%s</script>\n%s' % (js_directives, html_templates)
+        return jinja_utils.interpolate_cache_slug('%s' % (html_templates))
 
     @property
     def validator_html(self):

--- a/extensions/rich_text_components/Collapsible/Collapsible.html
+++ b/extensions/rich_text_components/Collapsible/Collapsible.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/rich_text_components/Collapsible/Collapsible.js"></script>
+
 <script type="text/ng-template" id="richTextComponent/Collapsible">
   <accordion>
     <accordion-group is-open="isOpen">

--- a/extensions/rich_text_components/Image/Image.html
+++ b/extensions/rich_text_components/Image/Image.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/rich_text_components/Image/Image.js"></script>
+
 <script type="text/ng-template" id="richTextComponent/Image">
   <figure>
     <img ng-src="<[imageUrl]>" alt="<[imageAltText]>"

--- a/extensions/rich_text_components/Link/Link.html
+++ b/extensions/rich_text_components/Link/Link.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/rich_text_components/Link/Link.js"></script>
+
 <!--
   The extra comments in this file are needed to prevent extra whitespace from
   being added before and after the link. See http://stackoverflow.com/q/5078239

--- a/extensions/rich_text_components/Math/Math.html
+++ b/extensions/rich_text_components/Math/Math.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/rich_text_components/Math/Math.js"></script>
+
 <script type="text/ng-template" id="richTextComponent/Math">
   <span mathjax-bind="rawLatex"></span>
 </script>

--- a/extensions/rich_text_components/Tabs/Tabs.html
+++ b/extensions/rich_text_components/Tabs/Tabs.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/rich_text_components/Tabs/Tabs.js"></script>
+
 <script type="text/ng-template" id="richTextComponent/Tabs">
   <tabset>
     <tab ng-repeat="tabContent in tabContents" heading="<[tabContent.title]>">

--- a/extensions/rich_text_components/Video/Video.html
+++ b/extensions/rich_text_components/Video/Video.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/rich_text_components/Video/Video.js"></script>
+
 <script type="text/ng-template" id="richTextComponent/Video">
   <center>
     <div class="oppia-noninteractive-video-iframe-container">

--- a/extensions/rich_text_components/VideoMp4/VideoMp4.html
+++ b/extensions/rich_text_components/VideoMp4/VideoMp4.html
@@ -1,3 +1,5 @@
+<script src="{{cache_slug}}/extensions/rich_text_components/VideoMp4/VideoMp4.js"></script>
+
 <script type="text/ng-template" id="richTextComponent/VideoMp4">
   <div>
     <video height="240" controls="yes" aria-label="Video Player" style="width: 100%;">

--- a/extensions/rich_text_components/base.py
+++ b/extensions/rich_text_components/base.py
@@ -20,6 +20,7 @@ import os
 
 from extensions import domain
 import feconf
+import jinja_utils
 import utils
 
 
@@ -84,11 +85,9 @@ class BaseRichTextComponent(object):
         necessary attributes are supplied. For rich-text components, this
         consists of a single directive/template pair.
         """
-        js_directives = utils.get_file_contents(os.path.join(
-            feconf.RTE_EXTENSIONS_DIR, self.id, '%s.js' % self.id))
         html_templates = utils.get_file_contents(os.path.join(
             feconf.RTE_EXTENSIONS_DIR, self.id, '%s.html' % self.id))
-        return '<script>%s</script>\n%s' % (js_directives, html_templates)
+        return jinja_utils.interpolate_cache_slug('%s' % html_templates)
 
     def to_dict(self):
         """Gets a dict representing this component. Only the default values for

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,8 +30,7 @@ var argv = yargs
         })
         .option('output_directory', {
           describe: 'A path to the directory where the files will be generated'
-        })
-        .argv;
+        }).argv;
     })
   .command('start_devserver', 'start GAE development server',
     function(yargs) {

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -22,7 +22,6 @@ import sys
 import yaml
 
 
-
 HEAD_DIR = os.path.join('core', 'templates', 'dev', 'head', '')
 OUT_DIR = os.path.join('core', 'templates', 'prod', 'head', '')
 REMOVE_WS = re.compile(r'\s{2,}').sub

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -22,8 +22,7 @@ import sys
 import yaml
 
 
-# ensure_directory_exists method trims file paths passed to it. Hence, directory
-# paths require a trailing slash.
+
 HEAD_DIR = os.path.join('core', 'templates', 'dev', 'head', '')
 OUT_DIR = os.path.join('core', 'templates', 'prod', 'head', '')
 REMOVE_WS = re.compile(r'\s{2,}').sub
@@ -106,20 +105,22 @@ def copy_files_source_to_target(source, target):
             shutil.copyfile(source_path, target_path)
 
 
-def _build_files():
-    ensure_directory_exists(OUT_DIR)
-    shutil.rmtree(OUT_DIR)
+def build_files(source, target):
+    print 'Processing %s' % os.path.join(os.getcwd(), source)
+    print 'Generating into %s' % os.path.join(os.getcwd(), target)
+    ensure_directory_exists(target)
+    shutil.rmtree(target)
 
-    for root, dirs, files in os.walk(os.path.join(os.getcwd(), HEAD_DIR)):
+    for root, dirs, files in os.walk(os.path.join(os.getcwd(), source)):
         for directory in dirs:
             print 'Processing %s' % os.path.join(root, directory)
         for filename in files:
             source_path = os.path.join(root, filename)
-            if source_path.find(OUT_DIR) > 0:
+            if target in source_path:
                 continue
-            if source_path.find(HEAD_DIR) == -1:
+            if source not in source_path:
                 continue
-            target_path = source_path.replace(HEAD_DIR, OUT_DIR)
+            target_path = source_path.replace(source, target)
             if filename.endswith('.html'):
                 process_html(source_path, target_path)
             if filename.endswith('.css'):
@@ -141,6 +142,8 @@ if __name__ == '__main__':
     CACHE_SLUG = get_cache_slug()
     BUILD_DIR = os.path.join('build', CACHE_SLUG)
 
+    # ensure_directory_exists trims file paths passed to it. Hence, directory
+    # paths require a trailing slash.
     # Process assets, copy it to build/[cache_slug]/assets
     ASSETS_SRC_DIR = os.path.join('assets', '')
     ASSETS_OUT_DIR = os.path.join(BUILD_DIR, 'assets', '')
@@ -157,7 +160,9 @@ if __name__ == '__main__':
     EXTENSIONS_OUT_DIR = os.path.join(BUILD_DIR, 'extensions', '')
     copy_files_source_to_target(EXTENSIONS_SRC_DIR, EXTENSIONS_OUT_DIR)
 
-    _build_files()
+    TEMPLATES_HEAD_DIR = os.path.join('core', 'templates', 'dev', 'head', '')
+    TEMPLATES_OUT_DIR = os.path.join('core', 'templates', 'prod', 'head', '')
+    build_files(TEMPLATES_HEAD_DIR, TEMPLATES_OUT_DIR)
 
     # Process core/templates/prod/head/css, copy it to build/[cache_slug]/css
     CSS_SRC_DIR = os.path.join('core', 'templates', 'prod', 'head', 'css', '')

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -130,16 +130,11 @@ def build_files(source, target, ignore=None):
                 continue
             target_path = source_path.replace(source, target)
 
-            only_copy_file = False
             # Only copy files in ignore or with extensions mentioned in
             # FILE_EXTENSIONS_TO_COPY_WITHOUT_MINIFICATION variable.
-            # We do not copy any py scripts.
-            if (any(p in source_path for p in ignore) or
-                    any(p in source_path
-                        for p in FILE_EXTENSIONS_TO_COPY_WITHOUT_MINIFICATION)):
-                only_copy_file = True
-
-            if only_copy_file:
+            file_patterns_to_ignore = (
+                ignore + FILE_EXTENSIONS_TO_COPY_WITHOUT_MINIFICATION)
+            if any(p in source_path for p in file_patterns_to_ignore):
                 ensure_directory_exists(target_path)
                 shutil.copyfile(source_path, target_path)
                 continue
@@ -154,8 +149,8 @@ def build_files(source, target, ignore=None):
 
 def get_cache_slug():
     """Returns the cache slug read from file."""
-    with open('cache_slug.yaml', 'r') as _:
-        content = _.read()
+    with open('cache_slug.yaml', 'r') as cache_slug_file:
+        content = cache_slug_file.read()
     retrieved_dict = yaml.safe_load(content)
     assert isinstance(retrieved_dict, dict)
     return retrieved_dict['cache_slug']

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -29,7 +29,7 @@ REMOVE_WS = re.compile(r'\s{2,}').sub
 YUICOMPRESSOR_DIR = os.path.join(
     '..', 'oppia_tools', 'yuicompressor-2.4.8', 'yuicompressor-2.4.8.jar')
 
-FILE_EXTENSIONS_TO_COPY_WITHOUT_MINIFICATION = ['.json']
+FILE_EXTENSIONS_TO_COPY_WITHOUT_MINIFICATION = ['.json', '.png']
 
 
 def _minify(source_path, target_path):

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -160,8 +160,10 @@ if __name__ == '__main__':
     CACHE_SLUG = get_cache_slug()
     BUILD_DIR = os.path.join('build', CACHE_SLUG)
 
-    # ensure_directory_exists trims file paths passed to it. Hence, directory
-    # paths require a trailing slash.
+    # os.path.dirname(path)(in ensure_directory_exists()) returns parent
+    # directory of a path passed as an argument to it. This is as intended
+    # for file paths, but for directory paths we do not want this to happen,
+    # hence we append a trailing slash to it.
     # Process assets, copy it to build/[cache_slug]/assets
     ASSETS_SRC_DIR = os.path.join('assets', '')
     ASSETS_OUT_DIR = os.path.join(BUILD_DIR, 'assets', '')

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -106,7 +106,7 @@ def copy_files_source_to_target(source, target):
             shutil.copyfile(source_path, target_path)
 
 
-def build_files(source, target, ignore=None):
+def build_files(source, target, ignore):
     """Minifies all css and js files, and removes whitespace from html in source
     directory and copies it to target, ignoring paths/files mentioned in ignore.
     Copies files in ignore to target without any changes.

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -179,7 +179,8 @@ if __name__ == '__main__':
         BUILD_DIR, 'third_party', 'generated')
     build_minified_third_party_libs(THIRD_PARTY_GENERATED_OUT_DIR)
 
-    # Minify extensions, copy it to build/[cache_slug]/extensions
+    # Minify extension static resources, copy it to
+    # build/[cache_slug]/extensions
     EXTENSIONS_SRC_DIR = os.path.join('extensions', '')
     EXTENSIONS_OUT_DIR = os.path.join(BUILD_DIR, 'extensions', '')
     # Certain files' syntax become incorrect after minification and hence


### PR DESCRIPTION
Implement handling extension resources as per: https://docs.google.com/document/d/1feeZnLnCzgUUOLj52cwb5g3eWj5uRRLpVQnDFUJs7Y8/edit#heading=h.us2l758grks

- [x] Remove js inlining and include as script tags for interactions, gadgets and rte.
- [ ] Remove js inlining from objects/templates (separate issue: #2380)
- [x] Modify templates for editor / player / others.
- [x] Modify python controllers for editor
- [x] Modify python controllers for reader
- [x] Fix app.yaml.
- [x] Modify build.py to handle extension resources.
- [x] Add minification to extension resources. (Fix #2278)
- [x] Fix to prevent extension tests being copied to build directory and causing errors. (As mentioned in the email by @seanlip)
- [ ] Tests to check whether corresponding js file is included in html template (separate issue: #2383)

/cc @BenHenning @seanlip 