### PR TITLE
Fix #1799: The explorations are now centered for a non-mobile device

### DIFF
--- a/core/templates/dev/head/components/activity_tiles_infinity_grid_directive.html
+++ b/core/templates/dev/head/components/activity_tiles_infinity_grid_directive.html
@@ -1,7 +1,7 @@
 <script type="text/ng-template" id="components/activityTilesInfinityGrid">
-  <div infinite-scroll="showMoreActivities()" infinite-scroll-distance="1"
-       infinite-scroll-disabled="endOfPageIsReached || searchResultsAreLoading"
-       style="max-width: 856px; margin-left: auto; margin-right: auto;">
+  <div class="oppia-activities-infinity-grid-container" infinite-scroll="
+       showMoreActivities()" infinite-scroll-distance="1"
+       infinite-scroll-disabled="endOfPageIsReached || searchResultsAreLoading">
     <div ng-repeat="activity in allActivitiesInOrder track by $index" style="display: inline-block;">
       <collection-summary-tile ng-if="activity.activity_type === 'collection'"
                                collection-id="activity.id"
@@ -38,6 +38,12 @@
 </script>
 
 <style>
+  .oppia-activities-infinity-grid-container {
+    max-width: 856px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
   .oppia-search-results-loading-message {
     background-color: #e9e9e9;
     bottom: 0;

--- a/core/templates/dev/head/components/activity_tiles_infinity_grid_directive.html
+++ b/core/templates/dev/head/components/activity_tiles_infinity_grid_directive.html
@@ -1,6 +1,7 @@
 <script type="text/ng-template" id="components/activityTilesInfinityGrid">
   <div infinite-scroll="showMoreActivities()" infinite-scroll-distance="1"
-       infinite-scroll-disabled="endOfPageIsReached || searchResultsAreLoading">
+       infinite-scroll-disabled="endOfPageIsReached || searchResultsAreLoading"
+       style="max-width: 856px; margin-left: auto; margin-right: auto;">
     <div ng-repeat="activity in allActivitiesInOrder track by $index" style="display: inline-block;">
       <collection-summary-tile ng-if="activity.activity_type === 'collection'"
                                collection-id="activity.id"


### PR DESCRIPTION
This is a partial fix for #1799. The explorations are centered for a non-mobile device.

