### PR TITLE
Cache images served via ImageHandler

### DIFF
--- a/core/controllers/resources.py
+++ b/core/controllers/resources.py
@@ -75,7 +75,9 @@ class ImageHandler(base.BaseHandler):
                 fs_domain.ExplorationFileSystem(exploration_id))
             raw = fs.get(filepath)
 
-            self.response.cache_control = 'public, max-age=600'
+            self.response.cache_control.no_cache = None
+            self.response.cache_control.public = True
+            self.response.cache_control.max-age = 600
             self.response.write(raw)
         except:
             raise self.PageNotFoundException

--- a/core/controllers/resources.py
+++ b/core/controllers/resources.py
@@ -74,6 +74,8 @@ class ImageHandler(base.BaseHandler):
             fs = fs_domain.AbstractFileSystem(
                 fs_domain.ExplorationFileSystem(exploration_id))
             raw = fs.get(filepath)
+
+            self.response.cache_control = 'public, max-age=600'
             self.response.write(raw)
         except:
             raise self.PageNotFoundException

--- a/core/controllers/resources.py
+++ b/core/controllers/resources.py
@@ -77,7 +77,7 @@ class ImageHandler(base.BaseHandler):
 
             self.response.cache_control.no_cache = None
             self.response.cache_control.public = True
-            self.response.cache_control.max-age = 600
+            self.response.cache_control.max_age = 600
             self.response.write(raw)
         except:
             raise self.PageNotFoundException


### PR DESCRIPTION
Added cache headers to images served via ImageHandler and set cache duration to 600secs.

/cc @BenHenning @maitbayev PTAL!