### PR TITLE
Fix #2349: Add service for sending feedback email to thread participants.

### DIFF
--- a/core/controllers/feedback.py
+++ b/core/controllers/feedback.py
@@ -282,3 +282,29 @@ class SuggestionEmailHandler(base.BaseHandler):
         email_manager.send_suggestion_email(
             exploration.title, exploration.id, suggestion.author_id,
             exploration_rights.owner_ids)
+
+
+class InstantFeedbackEmailHandler(base.BaseHandler):
+    """Handles task of sending feedback message emails instantsly."""
+
+    def post(self):
+        payload = json.loads(self.request.body)
+        user_id = payload['user_id']
+        reference = payload['reference']
+        message = feedback_services.get_message(
+            reference['exploration_id'], reference['thread_id'],
+            reference['message_id'])
+        exploration = exp_services.get_exploration_by_id(
+            reference['exploration_id'])
+        thread = feedback_services.get_thread(
+            reference['exploration_id'], reference['thread_id'])
+
+        if 'updated_status' in payload:
+            status_info = payload['updated_status']
+            text = 'changed status from %s to %s' % (
+                status_info['old_status'], status_info['new_status'])
+        else:
+            text = message.text
+        email_manager.send_instant_feedback_message_email(
+            user_id, message.author_id, text, exploration.title,
+            reference['exploration_id'], thread.subject)

--- a/core/controllers/feedback.py
+++ b/core/controllers/feedback.py
@@ -284,25 +284,26 @@ class SuggestionEmailHandler(base.BaseHandler):
             exploration_rights.owner_ids)
 
 
-class InstantFeedbackEmailHandler(base.BaseHandler):
+class InstantFeedbackMessageEmailHandler(base.BaseHandler):
     """Handles task of sending feedback message emails instantly."""
 
     def post(self):
         payload = json.loads(self.request.body)
         user_id = payload['user_id']
-        reference = payload['reference']
+        reference_dict = payload['reference_dict']
 
         message = feedback_services.get_message(
-            reference['exploration_id'], reference['thread_id'],
-            reference['message_id'])
+            reference_dict['exploration_id'], reference_dict['thread_id'],
+            reference_dict['message_id'])
         exploration = exp_services.get_exploration_by_id(
-            reference['exploration_id'])
+            reference_dict['exploration_id'])
         thread = feedback_services.get_thread(
-            reference['exploration_id'], reference['thread_id'])
+            reference_dict['exploration_id'], reference_dict['thread_id'])
 
+        subject = 'New Oppia message in "%s"' % thread.subject
         email_manager.send_instant_feedback_message_email(
-            user_id, message.author_id, message.text, exploration.title,
-            reference['exploration_id'], thread.subject)
+            user_id, message.author_id, message.text, subject,
+            exploration.title, reference_dict['exploration_id'], thread.subject)
 
 
 class FeedbackThreadStatusChangeEmailHandler(base.BaseHandler):
@@ -312,20 +313,20 @@ class FeedbackThreadStatusChangeEmailHandler(base.BaseHandler):
     def post(self):
         payload = json.loads(self.request.body)
         user_id = payload['user_id']
-        reference = payload['reference']
-        status_info = payload['updated_status']
+        reference_dict = payload['reference_dict']
+        old_status = payload['old_status']
+        new_status = payload['new_status']
 
         message = feedback_services.get_message(
-            reference['exploration_id'], reference['thread_id'],
-            reference['message_id'])
+            reference_dict['exploration_id'], reference_dict['thread_id'],
+            reference_dict['message_id'])
         exploration = exp_services.get_exploration_by_id(
-            reference['exploration_id'])
+            reference_dict['exploration_id'])
         thread = feedback_services.get_thread(
-            reference['exploration_id'], reference['thread_id'])
+            reference_dict['exploration_id'], reference_dict['thread_id'])
 
-        text = 'changed status from %s to %s' % (
-            status_info['old_status'], status_info['new_status'])
-
+        text = 'changed status from %s to %s' % (old_status, new_status)
+        subject = 'Oppia thread status change: "%s"' % thread.subject
         email_manager.send_instant_feedback_message_email(
-            user_id, message.author_id, text, exploration.title,
-            reference['exploration_id'], thread.subject)
+            user_id, message.author_id, text, subject, exploration.title,
+            reference_dict['exploration_id'], thread.subject)

--- a/core/controllers/feedback.py
+++ b/core/controllers/feedback.py
@@ -291,6 +291,7 @@ class InstantFeedbackEmailHandler(base.BaseHandler):
         payload = json.loads(self.request.body)
         user_id = payload['user_id']
         reference = payload['reference']
+
         message = feedback_services.get_message(
             reference['exploration_id'], reference['thread_id'],
             reference['message_id'])
@@ -299,12 +300,32 @@ class InstantFeedbackEmailHandler(base.BaseHandler):
         thread = feedback_services.get_thread(
             reference['exploration_id'], reference['thread_id'])
 
-        if 'updated_status' in payload:
-            status_info = payload['updated_status']
-            text = 'changed status from %s to %s' % (
-                status_info['old_status'], status_info['new_status'])
-        else:
-            text = message.text
+        email_manager.send_instant_feedback_message_email(
+            user_id, message.author_id, message.text, exploration.title,
+            reference['exploration_id'], thread.subject)
+
+
+class FeedbackThreadStatusChangeEmailHandler(base.BaseHandler):
+    """Handles task of sending email instantly when feedback thread status is
+    changed."""
+
+    def post(self):
+        payload = json.loads(self.request.body)
+        user_id = payload['user_id']
+        reference = payload['reference']
+        status_info = payload['updated_status']
+
+        message = feedback_services.get_message(
+            reference['exploration_id'], reference['thread_id'],
+            reference['message_id'])
+        exploration = exp_services.get_exploration_by_id(
+            reference['exploration_id'])
+        thread = feedback_services.get_thread(
+            reference['exploration_id'], reference['thread_id'])
+
+        text = 'changed status from %s to %s' % (
+            status_info['old_status'], status_info['new_status'])
+
         email_manager.send_instant_feedback_message_email(
             user_id, message.author_id, text, exploration.title,
             reference['exploration_id'], thread.subject)

--- a/core/controllers/feedback.py
+++ b/core/controllers/feedback.py
@@ -285,7 +285,7 @@ class SuggestionEmailHandler(base.BaseHandler):
 
 
 class InstantFeedbackEmailHandler(base.BaseHandler):
-    """Handles task of sending feedback message emails instantsly."""
+    """Handles task of sending feedback message emails instantly."""
 
     def post(self):
         payload = json.loads(self.request.body)

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -1003,7 +1003,75 @@ class FeedbackMessageInstantEmailHandlerTests(test_utils.GenericTestBase):
                 messages[0].body.decode(),
                 expected_email_text_body)
 
-    def test_that_email_is_sent_for_change_in_status(self):
+    def test_that_emails_are_sent_for_both_status_change_and_message(self):
+        expected_email_html_body = (
+            'Hi newuser,<br><br>'
+            'New update to thread "a subject" on '
+            '<a href="https://www.oppia.org/A">Title</a>:<br>'
+            '<ul><li>editor: editor message<br></li></ul>'
+            '(You received this message because you are a '
+            'participant in this thread.)<br><br>'
+            'Best wishes,<br>'
+            'The Oppia team<br>'
+            '<br>'
+            'You can change your email preferences via the '
+            '<a href="https://www.example.com">Preferences</a> page.')
+
+        expected_email_text_body = (
+            'Hi newuser,\n'
+            '\n'
+            'New update to thread "a subject" on Title:\n'
+            '- editor: editor message\n'
+            '(You received this message because you are a'
+            ' participant in this thread.)\n'
+            '\n'
+            'Best wishes,\n'
+            'The Oppia team\n'
+            '\n'
+            'You can change your email preferences via the Preferences page.')
+        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
+            feedback_services.create_thread(
+                self.exploration.id, 'a_state_name',
+                self.new_user_id, 'a subject', 'some text')
+            self.process_and_flush_pending_tasks()
+
+            threadlist = feedback_services.get_all_threads(
+                self.exploration.id, False)
+            thread_id = threadlist[0].get_thread_id()
+
+            feedback_services.create_message(
+                self.exploration.id, thread_id, self.editor_id,
+                feedback_models.STATUS_CHOICES_FIXED, None, 'editor message')
+            self.process_and_flush_pending_tasks()
+
+            messages = self.mail_stub.get_sent_messages(to=self.NEW_USER_EMAIL)
+            self.assertEqual(len(messages), 2)
+            self.assertEqual(
+                messages[1].html.decode(),
+                expected_email_html_body)
+            self.assertEqual(
+                messages[1].body.decode(),
+                expected_email_text_body)
+
+
+class FeedbackThreadStatusChangeEmailTests(test_utils.GenericTestBase):
+
+    def setUp(self):
+        super(FeedbackThreadStatusChangeEmailTests, self).setUp()
+        self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
+        self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
+
+        self.signup(self.NEW_USER_EMAIL, self.NEW_USER_USERNAME)
+        self.new_user_id = self.get_user_id_from_email(self.NEW_USER_EMAIL)
+
+        self.exploration = self.save_new_default_exploration(
+            'A', self.editor_id, 'Title')
+        self.can_send_emails_ctx = self.swap(
+            feconf, 'CAN_SEND_EMAILS', True)
+        self.can_send_feedback_email_ctx = self.swap(
+            feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
+
+    def test_that_emails_are_sent(self):
         expected_email_html_body = (
             'Hi newuser,<br><br>'
             'New update to thread "a subject" on '
@@ -1054,7 +1122,7 @@ class FeedbackMessageInstantEmailHandlerTests(test_utils.GenericTestBase):
                 expected_email_text_body)
 
     def test_that_emails_are_sent_for_both_status_change_and_message(self):
-        expected_email_html_body_for_status = (
+        expected_email_html_body = (
             'Hi newuser,<br><br>'
             'New update to thread "a subject" on '
             '<a href="https://www.oppia.org/A">Title</a>:<br>'
@@ -1067,7 +1135,7 @@ class FeedbackMessageInstantEmailHandlerTests(test_utils.GenericTestBase):
             'You can change your email preferences via the '
             '<a href="https://www.example.com">Preferences</a> page.')
 
-        expected_email_text_body_for_status = (
+        expected_email_text_body = (
             'Hi newuser,\n'
             '\n'
             'New update to thread "a subject" on Title:\n'
@@ -1080,31 +1148,6 @@ class FeedbackMessageInstantEmailHandlerTests(test_utils.GenericTestBase):
             '\n'
             'You can change your email preferences via the Preferences page.')
 
-        expected_email_html_body_for_message = (
-            'Hi newuser,<br><br>'
-            'New update to thread "a subject" on '
-            '<a href="https://www.oppia.org/A">Title</a>:<br>'
-            '<ul><li>editor: editor message<br></li></ul>'
-            '(You received this message because you are a '
-            'participant in this thread.)<br><br>'
-            'Best wishes,<br>'
-            'The Oppia team<br>'
-            '<br>'
-            'You can change your email preferences via the '
-            '<a href="https://www.example.com">Preferences</a> page.')
-
-        expected_email_text_body_for_message = (
-            'Hi newuser,\n'
-            '\n'
-            'New update to thread "a subject" on Title:\n'
-            '- editor: editor message\n'
-            '(You received this message because you are a'
-            ' participant in this thread.)\n'
-            '\n'
-            'Best wishes,\n'
-            'The Oppia team\n'
-            '\n'
-            'You can change your email preferences via the Preferences page.')
         with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
             feedback_services.create_thread(
                 self.exploration.id, 'a_state_name',
@@ -1124,13 +1167,7 @@ class FeedbackMessageInstantEmailHandlerTests(test_utils.GenericTestBase):
             self.assertEqual(len(messages), 2)
             self.assertEqual(
                 messages[0].html.decode(),
-                expected_email_html_body_for_status)
+                expected_email_html_body)
             self.assertEqual(
                 messages[0].body.decode(),
-                expected_email_text_body_for_status)
-            self.assertEqual(
-                messages[1].html.decode(),
-                expected_email_html_body_for_message)
-            self.assertEqual(
-                messages[1].body.decode(),
-                expected_email_text_body_for_message)
+                expected_email_text_body)

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -1052,3 +1052,85 @@ class FeedbackMessageInstantEmailHandlerTests(test_utils.GenericTestBase):
             self.assertEqual(
                 messages[0].body.decode(),
                 expected_email_text_body)
+
+    def test_that_emails_are_sent_for_both_status_change_and_message(self):
+        expected_email_html_body_for_status = (
+            'Hi newuser,<br><br>'
+            'New update to thread "a subject" on '
+            '<a href="https://www.oppia.org/A">Title</a>:<br>'
+            '<ul><li>editor: changed status from open to fixed<br></li></ul>'
+            '(You received this message because you are a '
+            'participant in this thread.)<br><br>'
+            'Best wishes,<br>'
+            'The Oppia team<br>'
+            '<br>'
+            'You can change your email preferences via the '
+            '<a href="https://www.example.com">Preferences</a> page.')
+
+        expected_email_text_body_for_status = (
+            'Hi newuser,\n'
+            '\n'
+            'New update to thread "a subject" on Title:\n'
+            '- editor: changed status from open to fixed\n'
+            '(You received this message because you are a'
+            ' participant in this thread.)\n'
+            '\n'
+            'Best wishes,\n'
+            'The Oppia team\n'
+            '\n'
+            'You can change your email preferences via the Preferences page.')
+
+        expected_email_html_body_for_message = (
+            'Hi newuser,<br><br>'
+            'New update to thread "a subject" on '
+            '<a href="https://www.oppia.org/A">Title</a>:<br>'
+            '<ul><li>editor: editor message<br></li></ul>'
+            '(You received this message because you are a '
+            'participant in this thread.)<br><br>'
+            'Best wishes,<br>'
+            'The Oppia team<br>'
+            '<br>'
+            'You can change your email preferences via the '
+            '<a href="https://www.example.com">Preferences</a> page.')
+
+        expected_email_text_body_for_message = (
+            'Hi newuser,\n'
+            '\n'
+            'New update to thread "a subject" on Title:\n'
+            '- editor: editor message\n'
+            '(You received this message because you are a'
+            ' participant in this thread.)\n'
+            '\n'
+            'Best wishes,\n'
+            'The Oppia team\n'
+            '\n'
+            'You can change your email preferences via the Preferences page.')
+        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
+            feedback_services.create_thread(
+                self.exploration.id, 'a_state_name',
+                self.new_user_id, 'a subject', 'some text')
+            self.process_and_flush_pending_tasks()
+
+            threadlist = feedback_services.get_all_threads(
+                self.exploration.id, False)
+            thread_id = threadlist[0].get_thread_id()
+
+            feedback_services.create_message(
+                self.exploration.id, thread_id, self.editor_id,
+                feedback_models.STATUS_CHOICES_FIXED, None, 'editor message')
+            self.process_and_flush_pending_tasks()
+
+            messages = self.mail_stub.get_sent_messages(to=self.NEW_USER_EMAIL)
+            self.assertEqual(len(messages), 2)
+            self.assertEqual(
+                messages[0].html.decode(),
+                expected_email_html_body_for_status)
+            self.assertEqual(
+                messages[0].body.decode(),
+                expected_email_text_body_for_status)
+            self.assertEqual(
+                messages[1].html.decode(),
+                expected_email_html_body_for_message)
+            self.assertEqual(
+                messages[1].body.decode(),
+                expected_email_text_body_for_message)

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -1053,7 +1053,6 @@ class FeedbackMessageInstantEmailHandlerTests(test_utils.GenericTestBase):
                 messages[0].body.decode(),
                 expected_email_text_body)
 
-
     def test_that_emails_are_sent_for_both_status_change_and_message(self):
         expected_email_html_body_message = (
             'Hi newuser,<br><br>'

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -626,10 +626,10 @@ class SuggestionsIntegrationTests(test_utils.GenericTestBase):
         self.assertEqual(len(threads), 4)
 
 
-class FeedbackMessageEmailHandlerTests(test_utils.GenericTestBase):
+class FeedbackMessageBatchEmailHandlerTests(test_utils.GenericTestBase):
 
     def setUp(self):
-        super(FeedbackMessageEmailHandlerTests, self).setUp()
+        super(FeedbackMessageBatchEmailHandlerTests, self).setUp()
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
 
@@ -933,3 +933,122 @@ class SuggestionEmailHandlerTest(test_utils.GenericTestBase):
             self.assertEqual(
                 owner_messages[0].body.decode(),
                 expected_owner_email_text_body)
+
+
+class FeedbackMessageInstantEmailHandlerTests(test_utils.GenericTestBase):
+
+    def setUp(self):
+        super(FeedbackMessageInstantEmailHandlerTests, self).setUp()
+        self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
+        self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
+
+        self.signup(self.NEW_USER_EMAIL, self.NEW_USER_USERNAME)
+        self.new_user_id = self.get_user_id_from_email(self.NEW_USER_EMAIL)
+
+        self.exploration = self.save_new_default_exploration(
+            'A', self.editor_id, 'Title')
+        self.can_send_emails_ctx = self.swap(
+            feconf, 'CAN_SEND_EMAILS', True)
+        self.can_send_feedback_email_ctx = self.swap(
+            feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
+
+    def test_that_emails_are_sent(self):
+        expected_email_html_body = (
+            'Hi newuser,<br><br>'
+            'New update to thread "a subject" on '
+            '<a href="https://www.oppia.org/A">Title</a>:<br>'
+            '<ul><li>editor: editor message<br></li></ul>'
+            '(You received this message because you are a '
+            'participant in this thread.)<br><br>'
+            'Best wishes,<br>'
+            'The Oppia team<br>'
+            '<br>'
+            'You can change your email preferences via the '
+            '<a href="https://www.example.com">Preferences</a> page.')
+
+        expected_email_text_body = (
+            'Hi newuser,\n'
+            '\n'
+            'New update to thread "a subject" on Title:\n'
+            '- editor: editor message\n'
+            '(You received this message because you are a'
+            ' participant in this thread.)\n'
+            '\n'
+            'Best wishes,\n'
+            'The Oppia team\n'
+            '\n'
+            'You can change your email preferences via the Preferences page.')
+
+        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
+            feedback_services.create_thread(
+                self.exploration.id, 'a_state_name',
+                self.new_user_id, 'a subject', 'some text')
+            self.process_and_flush_pending_tasks()
+
+            threadlist = feedback_services.get_all_threads(
+                self.exploration.id, False)
+            thread_id = threadlist[0].get_thread_id()
+
+            feedback_services.create_message(
+                self.exploration.id, thread_id, self.editor_id, None, None,
+                'editor message')
+            self.process_and_flush_pending_tasks()
+
+            messages = self.mail_stub.get_sent_messages(to=self.NEW_USER_EMAIL)
+            self.assertEqual(len(messages), 1)
+            self.assertEqual(
+                messages[0].html.decode(),
+                expected_email_html_body)
+            self.assertEqual(
+                messages[0].body.decode(),
+                expected_email_text_body)
+
+    def test_that_email_is_sent_for_change_in_status(self):
+        expected_email_html_body = (
+            'Hi newuser,<br><br>'
+            'New update to thread "a subject" on '
+            '<a href="https://www.oppia.org/A">Title</a>:<br>'
+            '<ul><li>editor: changed status from open to fixed<br></li></ul>'
+            '(You received this message because you are a '
+            'participant in this thread.)<br><br>'
+            'Best wishes,<br>'
+            'The Oppia team<br>'
+            '<br>'
+            'You can change your email preferences via the '
+            '<a href="https://www.example.com">Preferences</a> page.')
+
+        expected_email_text_body = (
+            'Hi newuser,\n'
+            '\n'
+            'New update to thread "a subject" on Title:\n'
+            '- editor: changed status from open to fixed\n'
+            '(You received this message because you are a'
+            ' participant in this thread.)\n'
+            '\n'
+            'Best wishes,\n'
+            'The Oppia team\n'
+            '\n'
+            'You can change your email preferences via the Preferences page.')
+        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
+            feedback_services.create_thread(
+                self.exploration.id, 'a_state_name',
+                self.new_user_id, 'a subject', 'some text')
+            self.process_and_flush_pending_tasks()
+
+            threadlist = feedback_services.get_all_threads(
+                self.exploration.id, False)
+            thread_id = threadlist[0].get_thread_id()
+
+            feedback_services.create_message(
+                self.exploration.id, thread_id, self.editor_id,
+                feedback_models.STATUS_CHOICES_FIXED, None, '')
+            self.process_and_flush_pending_tasks()
+
+            messages = self.mail_stub.get_sent_messages(to=self.NEW_USER_EMAIL)
+            self.assertEqual(len(messages), 1)
+            self.assertEqual(
+                messages[0].html.decode(),
+                expected_email_html_body)
+            self.assertEqual(
+                messages[0].body.decode(),
+                expected_email_text_body)

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -952,7 +952,7 @@ class FeedbackMessageInstantEmailHandlerTests(test_utils.GenericTestBase):
         self.can_send_feedback_email_ctx = self.swap(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
 
-    def test_that_emails_are_sent(self):
+    def test_that_emails_are_sent_for_feedback_message(self):
         expected_email_html_body = (
             'Hi newuser,<br><br>'
             'New update to thread "a subject" on '
@@ -1003,75 +1003,7 @@ class FeedbackMessageInstantEmailHandlerTests(test_utils.GenericTestBase):
                 messages[0].body.decode(),
                 expected_email_text_body)
 
-    def test_that_emails_are_sent_for_both_status_change_and_message(self):
-        expected_email_html_body = (
-            'Hi newuser,<br><br>'
-            'New update to thread "a subject" on '
-            '<a href="https://www.oppia.org/A">Title</a>:<br>'
-            '<ul><li>editor: editor message<br></li></ul>'
-            '(You received this message because you are a '
-            'participant in this thread.)<br><br>'
-            'Best wishes,<br>'
-            'The Oppia team<br>'
-            '<br>'
-            'You can change your email preferences via the '
-            '<a href="https://www.example.com">Preferences</a> page.')
-
-        expected_email_text_body = (
-            'Hi newuser,\n'
-            '\n'
-            'New update to thread "a subject" on Title:\n'
-            '- editor: editor message\n'
-            '(You received this message because you are a'
-            ' participant in this thread.)\n'
-            '\n'
-            'Best wishes,\n'
-            'The Oppia team\n'
-            '\n'
-            'You can change your email preferences via the Preferences page.')
-        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
-            feedback_services.create_thread(
-                self.exploration.id, 'a_state_name',
-                self.new_user_id, 'a subject', 'some text')
-            self.process_and_flush_pending_tasks()
-
-            threadlist = feedback_services.get_all_threads(
-                self.exploration.id, False)
-            thread_id = threadlist[0].get_thread_id()
-
-            feedback_services.create_message(
-                self.exploration.id, thread_id, self.editor_id,
-                feedback_models.STATUS_CHOICES_FIXED, None, 'editor message')
-            self.process_and_flush_pending_tasks()
-
-            messages = self.mail_stub.get_sent_messages(to=self.NEW_USER_EMAIL)
-            self.assertEqual(len(messages), 2)
-            self.assertEqual(
-                messages[1].html.decode(),
-                expected_email_html_body)
-            self.assertEqual(
-                messages[1].body.decode(),
-                expected_email_text_body)
-
-
-class FeedbackThreadStatusChangeEmailTests(test_utils.GenericTestBase):
-
-    def setUp(self):
-        super(FeedbackThreadStatusChangeEmailTests, self).setUp()
-        self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
-        self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
-
-        self.signup(self.NEW_USER_EMAIL, self.NEW_USER_USERNAME)
-        self.new_user_id = self.get_user_id_from_email(self.NEW_USER_EMAIL)
-
-        self.exploration = self.save_new_default_exploration(
-            'A', self.editor_id, 'Title')
-        self.can_send_emails_ctx = self.swap(
-            feconf, 'CAN_SEND_EMAILS', True)
-        self.can_send_feedback_email_ctx = self.swap(
-            feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
-
-    def test_that_emails_are_sent(self):
+    def test_that_emails_are_sent_for_status_change(self):
         expected_email_html_body = (
             'Hi newuser,<br><br>'
             'New update to thread "a subject" on '
@@ -1121,8 +1053,35 @@ class FeedbackThreadStatusChangeEmailTests(test_utils.GenericTestBase):
                 messages[0].body.decode(),
                 expected_email_text_body)
 
+
     def test_that_emails_are_sent_for_both_status_change_and_message(self):
-        expected_email_html_body = (
+        expected_email_html_body_message = (
+            'Hi newuser,<br><br>'
+            'New update to thread "a subject" on '
+            '<a href="https://www.oppia.org/A">Title</a>:<br>'
+            '<ul><li>editor: editor message<br></li></ul>'
+            '(You received this message because you are a '
+            'participant in this thread.)<br><br>'
+            'Best wishes,<br>'
+            'The Oppia team<br>'
+            '<br>'
+            'You can change your email preferences via the '
+            '<a href="https://www.example.com">Preferences</a> page.')
+
+        expected_email_text_body_message = (
+            'Hi newuser,\n'
+            '\n'
+            'New update to thread "a subject" on Title:\n'
+            '- editor: editor message\n'
+            '(You received this message because you are a'
+            ' participant in this thread.)\n'
+            '\n'
+            'Best wishes,\n'
+            'The Oppia team\n'
+            '\n'
+            'You can change your email preferences via the Preferences page.')
+
+        expected_email_html_body_status = (
             'Hi newuser,<br><br>'
             'New update to thread "a subject" on '
             '<a href="https://www.oppia.org/A">Title</a>:<br>'
@@ -1135,7 +1094,7 @@ class FeedbackThreadStatusChangeEmailTests(test_utils.GenericTestBase):
             'You can change your email preferences via the '
             '<a href="https://www.example.com">Preferences</a> page.')
 
-        expected_email_text_body = (
+        expected_email_text_body_status = (
             'Hi newuser,\n'
             '\n'
             'New update to thread "a subject" on Title:\n'
@@ -1147,7 +1106,6 @@ class FeedbackThreadStatusChangeEmailTests(test_utils.GenericTestBase):
             'The Oppia team\n'
             '\n'
             'You can change your email preferences via the Preferences page.')
-
         with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
             feedback_services.create_thread(
                 self.exploration.id, 'a_state_name',
@@ -1167,7 +1125,13 @@ class FeedbackThreadStatusChangeEmailTests(test_utils.GenericTestBase):
             self.assertEqual(len(messages), 2)
             self.assertEqual(
                 messages[0].html.decode(),
-                expected_email_html_body)
+                expected_email_html_body_status)
             self.assertEqual(
                 messages[0].body.decode(),
-                expected_email_text_body)
+                expected_email_text_body_status)
+            self.assertEqual(
+                messages[1].html.decode(),
+                expected_email_html_body_message)
+            self.assertEqual(
+                messages[1].body.decode(),
+                expected_email_text_body_message)

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -468,9 +468,8 @@ def send_suggestion_email(
 
 
 def send_instant_feedback_message_email(
-        recipient_id, sender_id, message, exploration_title, exploration_id,
-        thread_title):
-    email_subject_template = 'New Oppia message in "%s"'
+        recipient_id, sender_id, message, email_subject, exploration_title,
+        exploration_id, thread_title):
 
     email_body_template = (
         'Hi %s,<br><br>'
@@ -500,7 +499,6 @@ def send_instant_feedback_message_email(
             recipient_settings.username, thread_title, exploration_id,
             exploration_title, sender_settings.username, message,
             EMAIL_FOOTER.value)
-        email_subject = email_subject_template % (thread_title)
         _send_email(
             recipient_id, feconf.SYSTEM_COMMITTER_ID,
             feconf.EMAIL_INTENT_FEEDBACK_MESSAGE_NOTIFICATION, email_subject,

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -465,3 +465,42 @@ def send_suggestion_email(
                 recipient_id, feconf.SYSTEM_COMMITTER_ID,
                 feconf.EMAIL_INTENT_SUGGESTION_NOTIFICATION,
                 email_subject, email_body, feconf.NOREPLY_EMAIL_ADDRESS)
+
+
+def send_instant_feedback_message_email(
+        recipient_id, sender_id, message, exploration_title, exploration_id,
+        thread_title):
+    email_subject = 'New Oppia message'
+
+    email_body_template = (
+        'Hi %s,<br><br>'
+        'New update to thread "%s" on '
+        '<a href="https://www.oppia.org/%s">%s</a>:<br>'
+        '<ul><li>%s: %s<br></li></ul>'
+        '(You received this message because you are a '
+        'participant in this thread.)<br><br>'
+        'Best wishes,<br>'
+        'The Oppia team<br>'
+        '<br>%s')
+
+    if not feconf.CAN_SEND_EMAILS:
+        log_new_error('This app cannot send emails to users.')
+        return
+
+    if not feconf.CAN_SEND_FEEDBACK_MESSAGE_EMAILS:
+        log_new_error('This app cannot send feedback message emails to users.')
+        return
+
+    sender_settings = user_services.get_user_settings(sender_id)
+    recipient_settings = user_services.get_user_settings(recipient_id)
+    recipient_preferences = user_services.get_email_preferences(recipient_id)
+
+    if recipient_preferences['can_receive_feedback_message_email']:
+        email_body = email_body_template % (
+            recipient_settings.username, thread_title, exploration_id,
+            exploration_title, sender_settings.username, message,
+            EMAIL_FOOTER.value)
+        _send_email(
+            recipient_id, feconf.SYSTEM_COMMITTER_ID,
+            feconf.EMAIL_INTENT_FEEDBACK_MESSAGE_NOTIFICATION, email_subject,
+            email_body, feconf.NOREPLY_EMAIL_ADDRESS)

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -470,7 +470,7 @@ def send_suggestion_email(
 def send_instant_feedback_message_email(
         recipient_id, sender_id, message, exploration_title, exploration_id,
         thread_title):
-    email_subject = 'New Oppia message'
+    email_subject_template = 'New Oppia message in "%s"'
 
     email_body_template = (
         'Hi %s,<br><br>'
@@ -500,6 +500,7 @@ def send_instant_feedback_message_email(
             recipient_settings.username, thread_title, exploration_id,
             exploration_title, sender_settings.username, message,
             EMAIL_FOOTER.value)
+        email_subject = email_subject_template % (thread_title)
         _send_email(
             recipient_id, feconf.SYSTEM_COMMITTER_ID,
             feconf.EMAIL_INTENT_FEEDBACK_MESSAGE_NOTIFICATION, email_subject,

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -1264,7 +1264,7 @@ class FeedbackMessageInstantEmailTests(test_utils.GenericTestBase):
         self.can_send_feedback_email_ctx = self.swap(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
 
-    def test_that_suggestion_emails_are_correct(self):
+    def test_that_feedback_message_emails_are_correct(self):
         expected_email_subject = 'New Oppia message in "a subject"'
 
         expected_email_html_body = (
@@ -1296,7 +1296,8 @@ class FeedbackMessageInstantEmailTests(test_utils.GenericTestBase):
         with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
             email_manager.send_instant_feedback_message_email(
                 self.new_user_id, self.editor_id, 'editor message',
-                self.exploration.title, self.exploration.id, 'a subject')
+                'New Oppia message in "a subject"', self.exploration.title,
+                self.exploration.id, 'a subject')
 
             # make sure correct email is sent.
             messages = self.mail_stub.get_sent_messages(to=self.NEW_USER_EMAIL)

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -1265,7 +1265,7 @@ class FeedbackMessageInstantEmailTests(test_utils.GenericTestBase):
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
 
     def test_that_suggestion_emails_are_correct(self):
-        expected_email_subject = 'New Oppia message'
+        expected_email_subject = 'New Oppia message in "a subject"'
 
         expected_email_html_body = (
             'Hi newuser,<br><br>'

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -1071,10 +1071,10 @@ class DuplicateEmailTests(test_utils.GenericTestBase):
                 sent_email_model1.email_hash, sent_email_model3.email_hash)
 
 
-class FeedbackMessageEmailTests(test_utils.GenericTestBase):
+class FeedbackMessageBatchEmailTests(test_utils.GenericTestBase):
 
     def setUp(self):
-        super(FeedbackMessageEmailTests, self).setUp()
+        super(FeedbackMessageBatchEmailTests, self).setUp()
 
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
@@ -1243,3 +1243,85 @@ class SuggestionEmailTest(test_utils.GenericTestBase):
             self.assertEqual(
                 sent_email_model.intent,
                 feconf.EMAIL_INTENT_SUGGESTION_NOTIFICATION)
+
+
+class FeedbackMessageInstantEmailTests(test_utils.GenericTestBase):
+    def setUp(self):
+        super(FeedbackMessageInstantEmailTests, self).setUp()
+
+        self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
+        self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
+
+        self.signup(self.NEW_USER_EMAIL, self.NEW_USER_USERNAME)
+        self.new_user_id = self.get_user_id_from_email(self.NEW_USER_EMAIL)
+
+        self.exploration = self.save_new_default_exploration(
+            'A', self.editor_id, 'Title')
+        self.recipient_list = [self.editor_id]
+
+        self.can_send_emails_ctx = self.swap(
+            feconf, 'CAN_SEND_EMAILS', True)
+        self.can_send_feedback_email_ctx = self.swap(
+            feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
+
+    def test_that_suggestion_emails_are_correct(self):
+        expected_email_subject = 'New Oppia message'
+
+        expected_email_html_body = (
+            'Hi newuser,<br><br>'
+            'New update to thread "a subject" on '
+            '<a href="https://www.oppia.org/A">Title</a>:<br>'
+            '<ul><li>editor: editor message<br></li></ul>'
+            '(You received this message because you are a '
+            'participant in this thread.)<br><br>'
+            'Best wishes,<br>'
+            'The Oppia team<br>'
+            '<br>'
+            'You can change your email preferences via the '
+            '<a href="https://www.example.com">Preferences</a> page.')
+
+        expected_email_text_body = (
+            'Hi newuser,\n'
+            '\n'
+            'New update to thread "a subject" on Title:\n'
+            '- editor: editor message\n'
+            '(You received this message because you are a'
+            ' participant in this thread.)\n'
+            '\n'
+            'Best wishes,\n'
+            'The Oppia team\n'
+            '\n'
+            'You can change your email preferences via the Preferences page.')
+
+        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
+            email_manager.send_instant_feedback_message_email(
+                self.new_user_id, self.editor_id, 'editor message',
+                self.exploration.title, self.exploration.id, 'a subject')
+
+            # make sure correct email is sent.
+            messages = self.mail_stub.get_sent_messages(to=self.NEW_USER_EMAIL)
+            self.assertEqual(len(messages), 1)
+            self.assertEqual(
+                messages[0].html.decode(),
+                expected_email_html_body)
+            self.assertEqual(
+                messages[0].body.decode(),
+                expected_email_text_body)
+
+            # Make sure correct email model is stored.
+            all_models = email_models.SentEmailModel.get_all().fetch()
+            sent_email_model = all_models[0]
+            self.assertEqual(
+                sent_email_model.subject, expected_email_subject)
+            self.assertEqual(
+                sent_email_model.recipient_id, self.new_user_id)
+            self.assertEqual(
+                sent_email_model.recipient_email, self.NEW_USER_EMAIL)
+            self.assertEqual(
+                sent_email_model.sender_id, feconf.SYSTEM_COMMITTER_ID)
+            self.assertEqual(
+                sent_email_model.sender_email,
+                'Site Admin <%s>' % feconf.NOREPLY_EMAIL_ADDRESS)
+            self.assertEqual(
+                sent_email_model.intent,
+                feconf.EMAIL_INTENT_FEEDBACK_MESSAGE_NOTIFICATION)

--- a/core/domain/feedback_services.py
+++ b/core/domain/feedback_services.py
@@ -326,7 +326,7 @@ def _enqueue_feedback_thread_status_change_email_task(
         'new_status': new_status
     }
     taskqueue_services.enqueue_task(
-        feconf.FEEDBACK_THREAD_STATUS_CHANGE_EMAIL, payload, 0)
+        feconf.FEEDBACK_STATUS_EMAIL_HANDLER_URL, payload, 0)
 
 
 def _enqueue_suggestion_email_task(exploration_id, thread_id):
@@ -509,7 +509,7 @@ def _add_message_to_email_buffer(
         exploration_id: id of exploration that received new message.
         thread_id: id of thread that received new message.
         message_id: id of new message.
-        status_changed: True if thread status is changed else False.
+        message_length: length of the feedback message to be sent.
         old_status: value of old thread status.
         new_status: value of new thread status.
     """
@@ -519,13 +519,13 @@ def _add_message_to_email_buffer(
         _get_all_recipient_ids(exploration_id, thread_id, author_id))
 
     if old_status != new_status:
-        # send email for feedback thread status change.
+        # Send email for feedback thread status change.
         _send_feedback_thread_status_change_emails(
             other_recipient_ids, feedback_message_reference,
             old_status, new_status)
 
     if message_length > 0:
-        # send feedback message email only if message text is non empty.
-        # it can be empty in case when only status is changed.
+        # Send feedback message email only if message text is non empty.
+        # It can be empty in the case when only status is changed.
         _send_batch_emails(batch_recipient_ids, feedback_message_reference)
         _send_instant_emails(other_recipient_ids, feedback_message_reference)

--- a/core/domain/feedback_services.py
+++ b/core/domain/feedback_services.py
@@ -309,7 +309,7 @@ def enqueue_feedback_message_instant_email_task(user_id, reference):
 
     payload = {
         'user_id': user_id,
-        'reference': reference.to_dict()
+        'reference_dict': reference.to_dict()
     }
     taskqueue_services.enqueue_task(
         feconf.INSTANT_FEEDBACK_EMAIL_HANDLER_URL, payload, 0)
@@ -321,11 +321,9 @@ def _enqueue_feedback_thread_status_change_email_task(
 
     payload = {
         'user_id': user_id,
-        'reference': reference.to_dict(),
-        'updated_status': {
-            'old_status': old_status,
-            'new_status': new_status
-        }
+        'reference_dict': reference.to_dict(),
+        'old_status': old_status,
+        'new_status': new_status
     }
     taskqueue_services.enqueue_task(
         feconf.FEEDBACK_THREAD_STATUS_CHANGE_EMAIL, payload, 0)
@@ -447,7 +445,7 @@ def clear_feedback_message_references(user_id, exploration_id, thread_id):
         model.put()
 
 
-def get_all_recipient_ids(exploration_id, thread_id, author_id):
+def _get_all_recipient_ids(exploration_id, thread_id, author_id):
     """Fetches all valid recipient ids from exploration and thread.
 
     Returns a tuple with batch_recipients and other_recipients.
@@ -487,7 +485,7 @@ def _send_instant_emails(
                 feedback_message_reference)
 
 
-def _send_feedback_thread_status_change_email(
+def _send_feedback_thread_status_change_emails(
         recipient_list, feedback_message_reference, old_status, new_status):
     """send email feedback thread status change."""
     for recipient_id in recipient_list:
@@ -518,11 +516,11 @@ def _add_message_to_email_buffer(
     feedback_message_reference = feedback_domain.FeedbackMessageReference(
         exploration_id, thread_id, message_id)
     batch_recipient_ids, other_recipient_ids = (
-        get_all_recipient_ids(exploration_id, thread_id, author_id))
+        _get_all_recipient_ids(exploration_id, thread_id, author_id))
 
     if old_status != new_status:
         # send email for feedback thread status change.
-        _send_feedback_thread_status_change_email(
+        _send_feedback_thread_status_change_emails(
             other_recipient_ids, feedback_message_reference,
             old_status, new_status)
 

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 """Tests for feedback-related services."""
+import json
+
 from core.domain import feedback_domain
 from core.domain import feedback_jobs_continuous_test
 from core.domain import feedback_services
@@ -337,22 +339,24 @@ class EmailsTaskqueueTests(test_utils.GenericTestBase):
 
     def test_create_new_instant_task(self):
         user_id = 'user'
-        reference = {
+        reference_dict = {
             'exploration_id': 'eid',
             'thread_id': 'tid',
             'message_id': 'mid'
         }
-        reference_domain = feedback_domain.FeedbackMessageReference(
-            reference['exploration_id'], reference['thread_id'],
-            reference['message_id'])
+        reference = feedback_domain.FeedbackMessageReference(
+            reference_dict['exploration_id'], reference_dict['thread_id'],
+            reference_dict['message_id'])
 
         feedback_services.enqueue_feedback_message_instant_email_task(
-            user_id, reference_domain)
+            user_id, reference)
         self.assertEqual(self.count_jobs_in_taskqueue(), 1)
 
         tasks = self.get_pending_tasks()
+        payload = json.loads(tasks[0].payload)
         self.assertEqual(
             tasks[0].url, feconf.INSTANT_FEEDBACK_EMAIL_HANDLER_URL)
+        self.assertDictEqual(payload['reference_dict'], reference_dict)
 
 
 class FeedbackMessageEmailTests(test_utils.GenericTestBase):

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -347,7 +347,7 @@ class EmailsTaskqueueTests(test_utils.GenericTestBase):
             reference['message_id'])
 
         feedback_services.enqueue_feedback_message_instant_email_task(
-            user_id, reference_domain, False, None, None)
+            user_id, reference_domain)
         self.assertEqual(self.count_jobs_in_taskqueue(), 1)
 
         tasks = self.get_pending_tasks()

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for feedback-related services."""
+from core.domain import feedback_domain
 from core.domain import feedback_jobs_continuous_test
 from core.domain import feedback_services
 from core.domain import user_services
@@ -336,9 +337,17 @@ class EmailsTaskqueueTests(test_utils.GenericTestBase):
 
     def test_create_new_instant_task(self):
         user_id = 'user'
-        reference = 'reference'
+        reference = {
+            'exploration_id': 'eid',
+            'thread_id': 'tid',
+            'message_id': 'mid'
+        }
+        reference_domain = feedback_domain.FeedbackMessageReference(
+            reference['exploration_id'], reference['thread_id'],
+            reference['message_id'])
+
         feedback_services.enqueue_feedback_message_instant_email_task(
-            user_id, reference, False, None, None)
+            user_id, reference_domain, False, None, None)
         self.assertEqual(self.count_jobs_in_taskqueue(), 1)
 
         tasks = self.get_pending_tasks()

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -325,14 +325,25 @@ class FeedbackThreadUnitTests(test_utils.GenericTestBase):
 class EmailsTaskqueueTests(test_utils.GenericTestBase):
     """Tests for tasks in emails taskqueue."""
 
-    def test_create_new_task(self):
+    def test_create_new_batch_task(self):
         user_id = 'user'
-        feedback_services.enqueue_feedback_message_email_task(user_id)
+        feedback_services.enqueue_feedback_message_batch_email_task(user_id)
         self.assertEqual(self.count_jobs_in_taskqueue(), 1)
 
         tasks = self.get_pending_tasks()
         self.assertEqual(
             tasks[0].url, feconf.FEEDBACK_MESSAGE_EMAIL_HANDLER_URL)
+
+    def test_create_new_instant_task(self):
+        user_id = 'user'
+        reference = 'reference'
+        feedback_services.enqueue_feedback_message_instant_email_task(
+            user_id, reference, False, None, None)
+        self.assertEqual(self.count_jobs_in_taskqueue(), 1)
+
+        tasks = self.get_pending_tasks()
+        self.assertEqual(
+            tasks[0].url, feconf.INSTANT_FEEDBACK_EMAIL_HANDLER_URL)
 
 
 class FeedbackMessageEmailTests(test_utils.GenericTestBase):
@@ -346,64 +357,81 @@ class FeedbackMessageEmailTests(test_utils.GenericTestBase):
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
         self.exploration = self.save_new_default_exploration(
             'A', self.editor_id, 'Title')
-        self.thread_id = 'thread'
-        self.message_id1 = 'msg1'
-        self.message_id2 = 'msg2'
         self.can_send_emails_ctx = self.swap(
             feconf, 'CAN_SEND_EMAILS', True)
         self.can_send_feedback_email_ctx = self.swap(
             feconf, 'CAN_SEND_FEEDBACK_MESSAGE_EMAILS', True)
 
     def test_send_feedback_message_email(self):
-        feedback_services.add_message_to_email_buffer(
-            self.user_id_a, self.exploration.id, self.thread_id,
-            self.message_id1)
-        self.assertEqual(self.count_jobs_in_taskqueue(), 1)
+        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
+            feedback_services.create_thread(
+                self.exploration.id, 'a_state_name', self.user_id_a,
+                'a subject', 'some text')
+            threadlist = feedback_services.get_all_threads(
+                self.exploration.id, False)
+            thread_id = threadlist[0].get_thread_id()
 
-        expected_feedback_message_dict = {
-            'exploration_id': self.exploration.id,
-            'thread_id': self.thread_id,
-            'message_id': self.message_id1
-        }
-        model = feedback_models.UnsentFeedbackEmailModel.get(self.editor_id)
+            messagelist = feedback_services.get_messages(
+                self.exploration.id, thread_id)
+            self.assertEqual(len(messagelist), 1)
 
-        self.assertEqual(len(model.feedback_message_references), 1)
-        self.assertDictEqual(
-            model.feedback_message_references[0],
-            expected_feedback_message_dict)
-        self.assertEqual(model.retries, 0)
+            expected_feedback_message_dict = {
+                'exploration_id': self.exploration.id,
+                'thread_id': thread_id,
+                'message_id': messagelist[0].message_id
+            }
+            # There are two jobs in the taskqueue: one for the realtime event
+            # associated with creating a thread, and one for sending the email.
+            self.assertEqual(self.count_jobs_in_taskqueue(), 2)
+            model = feedback_models.UnsentFeedbackEmailModel.get(self.editor_id)
+
+            self.assertEqual(len(model.feedback_message_references), 1)
+            self.assertDictEqual(
+                model.feedback_message_references[0],
+                expected_feedback_message_dict)
+            self.assertEqual(model.retries, 0)
 
     def test_add_new_feedback_message(self):
-        feedback_services.add_message_to_email_buffer(
-            self.user_id_a, self.exploration.id, self.thread_id,
-            self.message_id1)
-        feedback_services.add_message_to_email_buffer(
-            self.user_id_a, self.exploration.id, self.thread_id,
-            self.message_id2)
+        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
+            feedback_services.create_thread(
+                self.exploration.id, 'a_state_name', self.user_id_a,
+                'a subject', 'some text')
+            threadlist = feedback_services.get_all_threads(
+                self.exploration.id, False)
+            thread_id = threadlist[0].get_thread_id()
 
-        self.assertEqual(self.count_jobs_in_taskqueue(), 1)
+            feedback_services.create_message(
+                self.exploration.id, thread_id, self.user_id_a, None, None,
+                'editor message')
+            # There are two jobs in the taskqueue: one for the realtime event
+            # associated with creating a thread, and one for sending the email.
+            self.assertEqual(self.count_jobs_in_taskqueue(), 2)
 
-        expected_feedback_message_dict1 = {
-            'exploration_id': self.exploration.id,
-            'thread_id': self.thread_id,
-            'message_id': self.message_id1
-        }
-        expected_feedback_message_dict2 = {
-            'exploration_id': self.exploration.id,
-            'thread_id': self.thread_id,
-            'message_id': self.message_id2
-        }
+            messagelist = feedback_services.get_messages(
+                self.exploration.id, thread_id)
+            self.assertEqual(len(messagelist), 2)
 
-        model = feedback_models.UnsentFeedbackEmailModel.get(self.editor_id)
+            expected_feedback_message_dict1 = {
+                'exploration_id': self.exploration.id,
+                'thread_id': thread_id,
+                'message_id': messagelist[0].message_id
+            }
+            expected_feedback_message_dict2 = {
+                'exploration_id': self.exploration.id,
+                'thread_id': thread_id,
+                'message_id': messagelist[1].message_id
+            }
 
-        self.assertEqual(len(model.feedback_message_references), 2)
-        self.assertDictEqual(
-            model.feedback_message_references[0],
-            expected_feedback_message_dict1)
-        self.assertDictEqual(
-            model.feedback_message_references[1],
-            expected_feedback_message_dict2)
-        self.assertEqual(model.retries, 0)
+            model = feedback_models.UnsentFeedbackEmailModel.get(self.editor_id)
+
+            self.assertEqual(len(model.feedback_message_references), 2)
+            self.assertDictEqual(
+                model.feedback_message_references[0],
+                expected_feedback_message_dict1)
+            self.assertDictEqual(
+                model.feedback_message_references[1],
+                expected_feedback_message_dict2)
+            self.assertEqual(model.retries, 0)
 
     def test_email_is_not_sent_if_recipient_has_declined_such_emails(self):
         user_services.update_email_preferences(
@@ -440,7 +468,7 @@ class FeedbackMessageEmailTests(test_utils.GenericTestBase):
                 self.exploration.id, 'a_state_name', self.user_id_a,
                 'a subject', 'some text')
 
-            # There are two jobs in the taskqueue: one for the realtime even
+            # There are two jobs in the taskqueue: one for the realtime event
             # associated with creating a thread, and one for sending the email.
             self.assertEqual(self.count_jobs_in_taskqueue(), 2)
 
@@ -494,3 +522,71 @@ class FeedbackMessageEmailTests(test_utils.GenericTestBase):
             self.process_and_flush_pending_tasks()
             messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)
             self.assertEqual(len(messages), 0)
+
+    def test_that_email_is_sent_for_reply_on_feedback(self):
+        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
+            feedback_services.create_thread(
+                self.exploration.id, 'a_state_name', self.user_id_a,
+                'a subject', 'A message')
+            # There are two jobs in the taskqueue: one for the realtime event
+            # associated with creating a thread, and one for sending the email.
+            self.assertEqual(self.count_jobs_in_taskqueue(), 2)
+            self.process_and_flush_pending_tasks()
+
+            threadlist = feedback_services.get_all_threads(
+                self.exploration.id, False)
+            thread_id = threadlist[0].get_thread_id()
+
+            feedback_services.create_message(
+                self.exploration.id, thread_id, self.editor_id, None, None,
+                'editor message')
+            self.assertEqual(self.count_jobs_in_taskqueue(), 1)
+            self.process_and_flush_pending_tasks()
+
+    def test_that_email_is_sent_for_changing_status_of_thread(self):
+        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
+            feedback_services.create_thread(
+                self.exploration.id, 'a_state_name', self.user_id_a,
+                'a subject', 'A message')
+            # There are two jobs in the taskqueue: one for the realtime event
+            # associated with creating a thread, and one for sending the email.
+            self.assertEqual(self.count_jobs_in_taskqueue(), 2)
+            self.process_and_flush_pending_tasks()
+
+            threadlist = feedback_services.get_all_threads(
+                self.exploration.id, False)
+            thread_id = threadlist[0].get_thread_id()
+
+            feedback_services.create_message(
+                self.exploration.id, thread_id, self.editor_id,
+                feedback_models.STATUS_CHOICES_FIXED, None, '')
+            # There are two jobs in the taskqueue: one for the realtime event
+            # associated with changing subject of thread, and one for sending
+            # the email.
+            self.assertEqual(self.count_jobs_in_taskqueue(), 2)
+            self.process_and_flush_pending_tasks()
+
+    def test_that_email_is_sent_for_each_feedback_message(self):
+        with self.can_send_emails_ctx, self.can_send_feedback_email_ctx:
+            feedback_services.create_thread(
+                self.exploration.id, 'a_state_name', self.user_id_a,
+                'a subject', 'A message')
+            threadlist = feedback_services.get_all_threads(
+                self.exploration.id, False)
+            thread_id = threadlist[0].get_thread_id()
+            # There are two jobs in the taskqueue: one for the realtime event
+            # associated with creating a thread, and one for sending the email.
+            self.assertEqual(self.count_jobs_in_taskqueue(), 2)
+            self.process_and_flush_pending_tasks()
+
+            feedback_services.create_message(
+                self.exploration.id, thread_id, self.editor_id, None, None,
+                'editor message')
+            self.assertEqual(self.count_jobs_in_taskqueue(), 1)
+            self.process_and_flush_pending_tasks()
+
+            feedback_services.create_message(
+                self.exploration.id, thread_id, self.editor_id, None, None,
+                'editor message2')
+            self.assertEqual(self.count_jobs_in_taskqueue(), 1)
+            self.process_and_flush_pending_tasks()

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -502,11 +502,8 @@ def get_email_preferences(user_id):
     """Returns a boolean representing whether the user has chosen to receive
     email updates.
     """
-    if user_id:
-        email_preferences_model = user_models.UserEmailPreferencesModel.get(
-            user_id, strict=False)
-    else:
-        email_preferences_model = None
+    email_preferences_model = user_models.UserEmailPreferencesModel.get(
+        user_id, strict=False)
     return {
         'can_receive_email_updates': (
             feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -502,8 +502,11 @@ def get_email_preferences(user_id):
     """Returns a boolean representing whether the user has chosen to receive
     email updates.
     """
-    email_preferences_model = user_models.UserEmailPreferencesModel.get(
-        user_id, strict=False)
+    if user_id:
+        email_preferences_model = user_models.UserEmailPreferencesModel.get(
+            user_id, strict=False)
+    else:
+        email_preferences_model = None
     return {
         'can_receive_email_updates': (
             feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE

--- a/feconf.py
+++ b/feconf.py
@@ -434,9 +434,11 @@ FEEDBACK_THREAD_URL_PREFIX = '/threadhandler'
 FEEDBACK_THREADLIST_URL_PREFIX = '/threadlisthandler'
 FEEDBACK_MESSAGE_EMAIL_HANDLER_URL = (
     '%s/email/batchfeedbackemailhandler' % TASKQUEUE_URL_PREFIX)
+FEEDBACK_THREAD_VIEW_EVENT_URL = '/feedbackhandler/thread_view_event'
+FEEDBACK_THREAD_STATUS_CHANGE_EMAIL = (
+    '%s/email/feedbackthreadstatuschangeemailhandler' % TASKQUEUE_URL_PREFIX)
 INSTANT_FEEDBACK_EMAIL_HANDLER_URL = (
     '%s/email/instantfeedbackemailhandler' % TASKQUEUE_URL_PREFIX)
-FEEDBACK_THREAD_VIEW_EVENT_URL = '/feedbackhandler/thread_view_event'
 LIBRARY_INDEX_URL = '/library'
 LIBRARY_INDEX_DATA_URL = '/libraryindexhandler'
 LIBRARY_SEARCH_URL = '/search/find'

--- a/feconf.py
+++ b/feconf.py
@@ -190,13 +190,13 @@ NOREPLY_EMAIL_ADDRESS = 'noreply@example.com'
 # correspond to owners of the app before setting this to True. If
 # SYSTEM_EMAIL_ADDRESS is not that of an app owner, email messages from this
 # address cannot be sent. If True then emails can be sent to any user.
-CAN_SEND_EMAILS = True
+CAN_SEND_EMAILS = False
 # If you want to turn on this facility please check the email templates in the
 # send_role_notification_email() function in email_manager.py and modify them
 # accordingly.
 CAN_SEND_EDITOR_ROLE_EMAILS = False
 # If enabled then emails will be sent to creators for feedback messages.
-CAN_SEND_FEEDBACK_MESSAGE_EMAILS = True
+CAN_SEND_FEEDBACK_MESSAGE_EMAILS = False
 # Time to wait before sending feedback message emails (currently set to 1
 # hour).
 DEFAULT_FEEDBACK_MESSAGE_EMAIL_COUNTDOWN_SECS = 3600

--- a/feconf.py
+++ b/feconf.py
@@ -433,12 +433,12 @@ FEEDBACK_STATS_URL_PREFIX = '/feedbackstatshandler'
 FEEDBACK_THREAD_URL_PREFIX = '/threadhandler'
 FEEDBACK_THREADLIST_URL_PREFIX = '/threadlisthandler'
 FEEDBACK_MESSAGE_EMAIL_HANDLER_URL = (
-    '%s/email/batchfeedbackemailhandler' % TASKQUEUE_URL_PREFIX)
+    '%s/email/batchfeedbackmessageemailhandler' % TASKQUEUE_URL_PREFIX)
 FEEDBACK_THREAD_VIEW_EVENT_URL = '/feedbackhandler/thread_view_event'
 FEEDBACK_THREAD_STATUS_CHANGE_EMAIL = (
     '%s/email/feedbackthreadstatuschangeemailhandler' % TASKQUEUE_URL_PREFIX)
 INSTANT_FEEDBACK_EMAIL_HANDLER_URL = (
-    '%s/email/instantfeedbackemailhandler' % TASKQUEUE_URL_PREFIX)
+    '%s/email/instantfeedbackmessageemailhandler' % TASKQUEUE_URL_PREFIX)
 LIBRARY_INDEX_URL = '/library'
 LIBRARY_INDEX_DATA_URL = '/libraryindexhandler'
 LIBRARY_SEARCH_URL = '/search/find'

--- a/feconf.py
+++ b/feconf.py
@@ -190,13 +190,13 @@ NOREPLY_EMAIL_ADDRESS = 'noreply@example.com'
 # correspond to owners of the app before setting this to True. If
 # SYSTEM_EMAIL_ADDRESS is not that of an app owner, email messages from this
 # address cannot be sent. If True then emails can be sent to any user.
-CAN_SEND_EMAILS = False
+CAN_SEND_EMAILS = True
 # If you want to turn on this facility please check the email templates in the
 # send_role_notification_email() function in email_manager.py and modify them
 # accordingly.
 CAN_SEND_EDITOR_ROLE_EMAILS = False
 # If enabled then emails will be sent to creators for feedback messages.
-CAN_SEND_FEEDBACK_MESSAGE_EMAILS = False
+CAN_SEND_FEEDBACK_MESSAGE_EMAILS = True
 # Time to wait before sending feedback message emails (currently set to 1
 # hour).
 DEFAULT_FEEDBACK_MESSAGE_EMAIL_COUNTDOWN_SECS = 3600
@@ -433,7 +433,9 @@ FEEDBACK_STATS_URL_PREFIX = '/feedbackstatshandler'
 FEEDBACK_THREAD_URL_PREFIX = '/threadhandler'
 FEEDBACK_THREADLIST_URL_PREFIX = '/threadlisthandler'
 FEEDBACK_MESSAGE_EMAIL_HANDLER_URL = (
-    '%s/email/feedbackemailhandler' % TASKQUEUE_URL_PREFIX)
+    '%s/email/batchfeedbackemailhandler' % TASKQUEUE_URL_PREFIX)
+INSTANT_FEEDBACK_EMAIL_HANDLER_URL = (
+    '%s/email/instantfeedbackemailhandler' % TASKQUEUE_URL_PREFIX)
 FEEDBACK_THREAD_VIEW_EVENT_URL = '/feedbackhandler/thread_view_event'
 LIBRARY_INDEX_URL = '/library'
 LIBRARY_INDEX_DATA_URL = '/libraryindexhandler'

--- a/feconf.py
+++ b/feconf.py
@@ -435,7 +435,7 @@ FEEDBACK_THREADLIST_URL_PREFIX = '/threadlisthandler'
 FEEDBACK_MESSAGE_EMAIL_HANDLER_URL = (
     '%s/email/batchfeedbackmessageemailhandler' % TASKQUEUE_URL_PREFIX)
 FEEDBACK_THREAD_VIEW_EVENT_URL = '/feedbackhandler/thread_view_event'
-FEEDBACK_THREAD_STATUS_CHANGE_EMAIL = (
+FEEDBACK_STATUS_EMAIL_HANDLER_URL = (
     '%s/email/feedbackthreadstatuschangeemailhandler' % TASKQUEUE_URL_PREFIX)
 INSTANT_FEEDBACK_EMAIL_HANDLER_URL = (
     '%s/email/instantfeedbackmessageemailhandler' % TASKQUEUE_URL_PREFIX)

--- a/main_taskqueue.py
+++ b/main_taskqueue.py
@@ -33,6 +33,9 @@ URLS = [
     main.get_redirect_route(
         r'%s' % feconf.SUGGESTION_EMAIL_HANDLER_URL,
         feedback.SuggestionEmailHandler, 'suggestion_email_handler'),
+    main.get_redirect_route(
+        r'%s' % feconf.INSTANT_FEEDBACK_EMAIL_HANDLER_URL,
+        feedback.InstantFeedbackEmailHandler, 'suggestion_email_handler'),
 ]
 
 app = transaction_services.toplevel_wrapper(  # pylint: disable=invalid-name

--- a/main_taskqueue.py
+++ b/main_taskqueue.py
@@ -38,7 +38,7 @@ URLS = [
         feedback.InstantFeedbackMessageEmailHandler,
         'instant_feedback_message_email_handler'),
     main.get_redirect_route(
-        r'%s' % feconf.FEEDBACK_THREAD_STATUS_CHANGE_EMAIL,
+        r'%s' % feconf.FEEDBACK_STATUS_EMAIL_HANDLER_URL,
         feedback.FeedbackThreadStatusChangeEmailHandler,
         'feedback_thread_status_change_email_handler'),
 ]

--- a/main_taskqueue.py
+++ b/main_taskqueue.py
@@ -35,7 +35,7 @@ URLS = [
         feedback.SuggestionEmailHandler, 'suggestion_email_handler'),
     main.get_redirect_route(
         r'%s' % feconf.INSTANT_FEEDBACK_EMAIL_HANDLER_URL,
-        feedback.InstantFeedbackEmailHandler,
+        feedback.InstantFeedbackMessageEmailHandler,
         'instant_feedback_message_email_handler'),
     main.get_redirect_route(
         r'%s' % feconf.FEEDBACK_THREAD_STATUS_CHANGE_EMAIL,

--- a/main_taskqueue.py
+++ b/main_taskqueue.py
@@ -35,7 +35,12 @@ URLS = [
         feedback.SuggestionEmailHandler, 'suggestion_email_handler'),
     main.get_redirect_route(
         r'%s' % feconf.INSTANT_FEEDBACK_EMAIL_HANDLER_URL,
-        feedback.InstantFeedbackEmailHandler, 'suggestion_email_handler'),
+        feedback.InstantFeedbackEmailHandler,
+        'instant_feedback_message_email_handler'),
+    main.get_redirect_route(
+        r'%s' % feconf.FEEDBACK_THREAD_STATUS_CHANGE_EMAIL,
+        feedback.FeedbackThreadStatusChangeEmailHandler,
+        'feedback_thread_status_change_email_handler'),
 ]
 
 app = transaction_services.toplevel_wrapper(  # pylint: disable=invalid-name


### PR DESCRIPTION
Till now Oppia was sending feedback message email to owners of exploration
only. This commit will enable Oppia to be able to send emails to other
participants (other than owners) of thread as well.

For implementation details refer to this [design](https://docs.google.com/document/d/1r0IfWD6AiaeBPUOe-mZnihPMPO0a4Z9Hj_5ImWBeUcg/edit) doc.