### PR TITLE
Fix #2311: Add word-wrap for exploration card content

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4166,7 +4166,3 @@ md-card.preview-conversation-skin-supplemental-card {
   right: -25px;
   top: 175px;
 }
-
-.conversation-skin-tutor-card-content {
-  word-wrap: break-word;
-}

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4166,3 +4166,7 @@ md-card.preview-conversation-skin-supplemental-card {
   right: -25px;
   top: 175px;
 }
+
+.conversation-skin-tutor-card-content {
+  word-wrap: break-word;
+}

--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -642,6 +642,10 @@
         border: none;
     }
 
+    .conversation-skin-tutor-card-content {
+      word-wrap: break-word;
+    }
+
     @media screen and (max-width: 959px) {
       .conversation-skin-cards-container {
         display: block;


### PR DESCRIPTION
Addresses: #2311 
Breaks words that are too long onto separate lines in exploration cards, so that they do not overflow the width of the card.