### PR TITLE
Fix #2383: tests to check whether interaction template includes js script they require.

### DIFF
--- a/extensions/gadgets/base_test.py
+++ b/extensions/gadgets/base_test.py
@@ -214,6 +214,12 @@ class GadgetUnitTests(test_utils.GenericTestBase):
                 '<script type="text/ng-template" id="gadget/%s"' %
                 gadget_type,
                 html_file_content)
+            # Check that the html template includes js script for the
+            # gadget.
+            self.assertIn(
+                '<script src="{{cache_slug}}/extensions/gadgets/%s/%s.js">'
+                '</script>' % (gadget_type, gadget_type),
+                html_file_content)
             self.assertNotIn('<script>', js_file_content)
             self.assertNotIn('</script>', js_file_content)
 

--- a/extensions/interactions/base_test.py
+++ b/extensions/interactions/base_test.py
@@ -277,6 +277,16 @@ class InteractionUnitTests(test_utils.GenericTestBase):
             self.assertIn(
                 '%s id="response/%s"' % (directive_prefix, interaction_id),
                 html_file_content)
+            # Check that the html template includes js script for the
+            # interaction.
+            self.assertIn(
+                '<script src="{{cache_slug}}/extensions/interactions/%s/%s.js">'
+                '</script>' % (interaction_id, interaction_id),
+                html_file_content)
+            self.assertIn(
+                '<script src="{{cache_slug}}/extensions/interactions/%s/'
+                'validator.js"></script>' % interaction_id,
+                html_file_content)
             self.assertNotIn('<script>', js_file_content)
             self.assertNotIn('</script>', js_file_content)
             self.assertIn(


### PR DESCRIPTION
Fix #2383: tests to check whether interaction template includes js script they require.

/cc @BenHenning @maitbayev 