### PR TITLE
Fix #2400: 'donations' and 'about' pages cosmetic changes - margins and box-shadow

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2736,7 +2736,7 @@ div#ng-curtain {
 
 .oppia-page-card {
   background: rgb(255,255,255);
-  box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
   margin-left: auto;
   margin-right: auto;
   margin-bottom: 80px;
@@ -4107,7 +4107,7 @@ md-card.preview-conversation-skin-supplemental-card {
 
 .oppia-donate-info {
   float: left;
-  padding-bottom:30px;
+  padding-bottom: 30px;
   width: calc(100% - 340px);
 }
 
@@ -4116,8 +4116,7 @@ md-card.preview-conversation-skin-supplemental-card {
   display: block;
   float: right;
   font-family: "Capriola", "Roboto", Arial, sans-serif;
-  padding: 10px;
-  padding-bottom:35px;
+  padding: 10px 10px 35px 10px;
   width: 340px;
 }
 

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2736,9 +2736,10 @@ div#ng-curtain {
 
 .oppia-page-card {
   background: rgb(255,255,255);
+  box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
   margin-left: auto;
   margin-right: auto;
-  margin-bottom: 30px;
+  margin-bottom: 80px;
   margin-top: 40px;
   padding: 30px 55px 30px 45px;
 }
@@ -4106,6 +4107,7 @@ md-card.preview-conversation-skin-supplemental-card {
 
 .oppia-donate-info {
   float: left;
+  padding-bottom:30px;
   width: calc(100% - 340px);
 }
 
@@ -4115,6 +4117,7 @@ md-card.preview-conversation-skin-supplemental-card {
   float: right;
   font-family: "Capriola", "Roboto", Arial, sans-serif;
   padding: 10px;
+  padding-bottom:35px;
   width: 340px;
 }
 


### PR DESCRIPTION
Fixes #2400: increases distance between oppia-page-card and footer, gives oppia-page-card a box shadow (e.g. on various of the 'about' pages and on the 'donate' page), and increases distance between the text on the 'donate' page and the end of the page-card.