### PR TITLE
Delete verbose flag from .jscsrc

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -19,7 +19,6 @@
     "fileExtensions": [".js"],
     "extract": ["*.html"],
     "maxErrors": null,
-    "verbose": true,
 
     "disallowEmptyBlocks": true,
     "disallowFunctionDeclarations": true,


### PR DESCRIPTION
It breaks some editors (e.g atom) when jscs version is at least 3.0:
Error in atom:
    Error:  Config values to remove in 3.0: The verbose option is enabled
    by  default.

Also relevant information extracted from jscs.info/overview:
    The verbose flag is removed in 3.0 since it will be on by
    default (so you know which rule is erroring).