### PR TITLE
Remove conversation-skin-main-tutor-card-wide

### DIFF
--- a/core/templates/dev/head/player/conversation_skin_directive.html
+++ b/core/templates/dev/head/player/conversation_skin_directive.html
@@ -32,8 +32,7 @@
            class="conversation-skin-main-tutor-card"
            ng-class="{'animate-card-width': startCardChangeAnimation,
                       'has-shadow': isViewportNarrow() && isCurrentSupplementalCardNonempty(),
-                      'conversation-skin-animate-tutor-card-on-narrow': isViewportNarrow() && isCurrentSupplementalCardNonempty(),
-                      'conversation-skin-main-tutor-card-wide': !isViewportNarrow() || !isOnTerminalCard()}">
+                      'conversation-skin-animate-tutor-card-on-narrow': isViewportNarrow() && isCurrentSupplementalCardNonempty() }">
         <div class="conversation-skin-tutor-card-content conversation-skin-animate-card-contents"
              ng-class="{'animate-card-change': startCardChangeAnimation}">
           <div class="conversation-skin-tutor-card-top-section">
@@ -665,10 +664,6 @@
         top: 40px;
         width: 100%;
         z-index: 15;
-      }
-
-      .conversation-skin-main-tutor-card-wide {
-        position: absolute;
       }
 
       .has-shadow {


### PR DESCRIPTION
I couldn't reproduce #2113.
Removing it if possible, otherwise we are introducing one more state of tutor card, which might increase difficulty of understanding the template, already tutor card can be in many states/shapes. 
