### PR TITLE
Fix #2334: Remove title, goal, and category alertService alerts

### DIFF
--- a/core/templates/dev/head/collection_editor/settings_tab/CollectionDetailsEditorDirective.js
+++ b/core/templates/dev/head/collection_editor/settings_tab/CollectionDetailsEditorDirective.js
@@ -80,31 +80,16 @@ oppia.directive('collectionDetailsEditor', [function() {
         $scope.$on(EVENT_COLLECTION_REINITIALIZED, refreshSettingsTab);
 
         $scope.updateCollectionTitle = function() {
-          if (!$scope.displayedCollectionTitle) {
-            alertsService.addWarning(
-              'Please specify a title for the collection.');
-            return;
-          }
           CollectionUpdateService.setCollectionTitle(
             $scope.collection, $scope.displayedCollectionTitle);
         };
 
         $scope.updateCollectionObjective = function() {
-          if (!$scope.displayedCollectionObjective) {
-            alertsService.addWarning(
-              'Please specify a goal for the collection.');
-            return;
-          }
           CollectionUpdateService.setCollectionObjective(
             $scope.collection, $scope.displayedCollectionObjective);
         };
 
         $scope.updateCollectionCategory = function() {
-          if (!$scope.displayedCollectionCategory) {
-            alertsService.addWarning(
-              'Please specify a category for the collection.');
-            return;
-          }
           CollectionUpdateService.setCollectionCategory(
             $scope.collection, $scope.displayedCollectionCategory);
         };


### PR DESCRIPTION
~~Note: There were some arithmetic errors during frontend testing, so I'm opening a PR to do a Travis test to check if it is replicate-able. **Please do not merge yet.**~~

It is okay to review now, the error above is local. 

Note to reviewer: The alert service was constantly adding errors to the warnings list (disregarding that it already sent an error). Because we will be doing a final check prior to publishing like we do in the exploration editor, I decided we should remove the `alertService` errors and ask the creator to resolve those issues until the very end (which is the same suggestion in the issue comment thread).