### PR TITLE
Fix #2473: Make collection tiles in dashboard similar as in library.

### DIFF
--- a/core/controllers/dashboard.py
+++ b/core/controllers/dashboard.py
@@ -204,6 +204,7 @@ class DashboardHandler(base.BaseHandler):
                     'created_on': utils.get_time_in_millisecs(
                         collection_summary.collection_model_created_on),
                     'status': collection_summary.status,
+                    'node_count': collection_summary.node_count,
                     'community_owned': collection_summary.community_owned,
                     'thumbnail_icon_url': (
                         utils.get_thumbnail_icon_url_for_category(

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2242,7 +2242,7 @@ md-card.oppia-dashboard-tile {
 
 ul.oppia-dashboard-tiles {
   list-style-type: none;
-  margin-top: 30px;
+  margin-top: 15px;
   padding-left: 0;
 }
 
@@ -3691,6 +3691,15 @@ md-card.preview-conversation-skin-supplemental-card {
   font-size: 1.1em;
   font-weight: bold;
   padding: 5px 8px 4px 8px;
+}
+
+.oppia-activity-summary-tile.oppia-dashboard-collection-tile {
+  margin-left: 7.5px;
+  margin-right: 7.5px;
+}
+
+.oppia-activity-summary-tile.oppia-dashboard-collection-tile a:hover {
+  text-decoration: none;
 }
 
 .oppia-activity-summary-tile.oppia-dashboard-card-view-item {

--- a/core/templates/dev/head/dashboard/Dashboard.js
+++ b/core/templates/dev/head/dashboard/Dashboard.js
@@ -73,6 +73,10 @@ oppia.controller('Dashboard', [
       $window.location = '/create/' + explorationId;
     };
 
+    $scope.showCollectionEditor = function(collectionId) {
+      $window.location = '/collection_editor/create/' + collectionId;
+    };
+
     $scope.myExplorationsView = 'card';
     $scope.setMyExplorationsView = function(viewType) {
       $scope.myExplorationsView = viewType;

--- a/core/templates/dev/head/dashboard/dashboard.html
+++ b/core/templates/dev/head/dashboard/dashboard.html
@@ -304,7 +304,7 @@
 
                     <ul layout="row" class="metrics" layout-align="space-between center">
                       <li>
-                        <span> COLLECTION</span>
+                        <span> COLLECTION (<[collection.node_count]>)</span>
                       </li>
 
                       <li>

--- a/core/templates/dev/head/dashboard/dashboard.html
+++ b/core/templates/dev/head/dashboard/dashboard.html
@@ -277,72 +277,50 @@
           <em>There are no collections to display.</em>
         </div>
 
-        <ul class="oppia-dashboard-tiles" ng-if="activeTab === 'myCollections'">
-          <li ng-repeat="collection in collectionsList">
-            <md-card layout="row" class="oppia-dashboard-tile">
-              <a ng-href="/collection_editor/create/<[collection.id]>" class="oppia-dashboard-tile-container-link" style="text-decoration: none;">
-                <div class="oppia-dashboard-tile-metadata-parent hidden-xs">
-                  <div class="oppia-dashboard-tile-metadata">
-                    Created:<span style="color: black;">
-                      <[getLocaleAbbreviatedDatetimeString(collection.created_on)]>
-                    </span>
-
-                    <br>
-                    <br>
-                    <br>
-
-                    Status:
-                    <span ng-if="collection.status !== 'private'">
-                      <span class="oppia-dashboard-status-green">
-                        Published
-                      </span>
-                    </span>
-                    <span ng-if="collection.status === 'private'">
-                      <span class="oppia-dashboard-status-grey">
-                        Private
-                      </span>
-                    </span>
+        <ul class="oppia-dashboard-tiles"
+            ng-if="activeTab === 'myCollections' && collectionsList.length > 0">
+          <md-card class="oppia-activity-summary-tile bottom-card"
+                   ng-repeat="collection in collectionsList">
+            <div class="title-section"
+                 style="background-color: <[collection.thumbnail_bg_color]>;">
+            </div>
+            <md-card class="oppia-activity-summary-tile middle-card">
+              <div class="title-section"
+                   style="background-color: <[collection.thumbnail_bg_color]>;">
+              </div>
+              <md-card class="oppia-activity-summary-tile top-card">
+                <a ng-click="showCollectionEditor(collection.id)">
+                  <div class="title-section"
+                       style="background-color: <[collection.thumbnail_bg_color]>;">
+                    <img class="thumbnail-image" ng-src="<[collection.thumbnail_icon_url]>">
+                    <h2 class="activity-title"><[collection.title || 'Untitled']></h2>
                   </div>
-                </div>
-                <div class="oppia-dashboard-tile-contents">
-                  <span class="oppia-dashboard-tile-image-container" style="position: absolute;">
-                    <img class="oppia-dashboard-tile-image" ng-src="<[collection.thumbnail_icon_url]>" style="background-color: <[collection.thumbnail_bg_color]>" ng-class="{'oppia-dashboard-tile-image-private': collection.status === 'private'}">
-                  </span>
 
-                  <div class="oppia-dashboard-tile-details">
-                    <div class="oppia-dashboard-tile-first-row">
-                      <span class="oppia-dashboard-tile-title">
-                        <span ng-if="collection.title"><[collection.title]></span>
-                        <span ng-if="!collection.title">Untitled</span>
-                      </span>
-                      <span style="font-weight: bold;">&middot;</span>
-                      <span style="color: #888; font-size: 0.9em;">
-                        <span ng-if="collection.objective">
-                          <[collection.objective | truncateAndCapitalize: 105]>
-                        </span>
-                        <span ng-if="!collection.objective">
-                          <em>No objective specified.</em>
-                        </span>
-                      </span>
+                  <div>
+                    <div class="objective">
+                      <span ng-if="collection.objective"><[collection.objective | truncateAndCapitalize: 45]></span>
+                      <span ng-if="!collection.objective">No objective specified.</span>
                     </div>
 
-                    <div class="oppia-dashboard-tile-second-row">
-                      <span style="color: #888">
-                        <strong><[collection.category]></strong>
-                        <span style="font-weight: bold;" ng-if="collection.category">&middot;</span>
-                        Last updated <[getLocaleAbbreviatedDatetimeString(collection.last_updated)]>
-                      </span>
+                    <ul layout="row" class="metrics" layout-align="space-between center">
+                      <li>
+                        <span> COLLECTION</span>
+                      </li>
 
-                      <span ng-if="collection.status === 'publicized'">
-                        <span style="font-weight: bold;">&middot;</span>
-                        <span style="color: #888">Featured</span>
-                      </span>
-                    </div>
+                      <li>
+                        <span>
+                          <[getLocaleAbbreviatedDatetimeString(collection.last_updated)]>
+                        </span>
+                      </li>
+                    </ul>
                   </div>
-                </div>
-              </a>
+                  <div class="title-section-mask top-card-mask"></div>
+                </a>
+              </md-card>
+              <div class="title-section-mask"></div>
             </md-card>
-          </li>
+            <div class="title-section-mask"></div>
+          </md-card>
         </ul>
       </div>
     {% endif %}

--- a/core/templates/dev/head/dashboard/dashboard.html
+++ b/core/templates/dev/head/dashboard/dashboard.html
@@ -279,7 +279,7 @@
 
         <ul class="oppia-dashboard-tiles"
             ng-if="activeTab === 'myCollections' && collectionsList.length > 0">
-          <md-card class="oppia-activity-summary-tile bottom-card"
+          <md-card class="oppia-activity-summary-tile oppia-dashboard-collection-tile bottom-card"
                    ng-repeat="collection in collectionsList">
             <div class="title-section"
                  style="background-color: <[collection.thumbnail_bg_color]>;">


### PR DESCRIPTION
@seanlip Just one minor thing - the data for collections is obtained through the backend when the creator dashboard is loaded. For each collection, the value of number of nodes it has is absent in this case (in dashboard data), while it's present in the library collection tiles. If it's worth displaying, then I'll go ahead and see how the node_count can also be sent to frontend. wdyt ?
