### PR TITLE
Fix errors which occur due to precision error in Math.log

### DIFF
--- a/core/templates/dev/head/expressions/expressionSyntaxTree.js
+++ b/core/templates/dev/head/expressions/expressionSyntaxTree.js
@@ -393,7 +393,9 @@ oppia.factory('expressionSyntaxTreeService', [
         eval: function(args) {
           verifyNumArgs(args, 2);
           var numericArgs = _coerceAllArgsToNumber(args);
-          return Math.log(numericArgs[0]) / Math.log(numericArgs[1]);
+          var preciseAns = Math.log(numericArgs[0]) / Math.log(numericArgs[1]);
+          // Round answer upto 9 decimal places
+          return Math.round(preciseAns * Math.pow(10, 9)) / Math.pow(10, 9);
         },
         getType: function(args) {
           verifyNumArgs(args, 2);

--- a/core/templates/dev/head/expressions/expressionSyntaxTree.js
+++ b/core/templates/dev/head/expressions/expressionSyntaxTree.js
@@ -394,7 +394,8 @@ oppia.factory('expressionSyntaxTreeService', [
           verifyNumArgs(args, 2);
           var numericArgs = _coerceAllArgsToNumber(args);
           var preciseAns = Math.log(numericArgs[0]) / Math.log(numericArgs[1]);
-          // Round answer upto 9 decimal places
+          // We round answers to 9 decimal places, so that we don't run into
+          // issues like log(9, 3) = 2.0000000000004.
           return Math.round(preciseAns * Math.pow(10, 9)) / Math.pow(10, 9);
         },
         getType: function(args) {


### PR DESCRIPTION
Rounded the result of Math.log to 9 decimal places as discussed.

