### PR TITLE
Prototype for #2485. Cached page

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -308,7 +308,8 @@ class BaseHandler(webapp2.RequestHandler):
 
             if iframe_restriction is not None:
                 if iframe_restriction in ['SAMEORIGIN', 'DENY']:
-                    self.response.headers['X-Frame-Options'] = iframe_restriction
+                    self.response.headers['X-Frame-Options'] = \
+                        iframe_restriction
                 else:
                     raise Exception(
                         'Invalid X-Frame-Options: %s' % iframe_restriction)

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -146,6 +146,7 @@ class LogoutPage(webapp2.RequestHandler):
         else:
             self.redirect(url_to_redirect_to)
 
+cached_pages = {}
 
 class BaseHandler(webapp2.RequestHandler):
     """Base class for all Oppia handlers."""
@@ -298,7 +299,25 @@ class BaseHandler(webapp2.RequestHandler):
 
     def render_template(
             self, filename, values=None, iframe_restriction='DENY',
-            redirect_url_on_logout=None):
+            redirect_url_on_logout=None, cached=False):
+        print 'id for base handler: ', id(cached_pages)
+        if cached and filename in cached_pages:
+            self.response.headers['Strict-Transport-Security'] = (
+                'max-age=31536000; includeSubDomains')
+            self.response.headers['X-Content-Type-Options'] = 'nosniff'
+
+            if iframe_restriction is not None:
+                if iframe_restriction in ['SAMEORIGIN', 'DENY']:
+                    self.response.headers['X-Frame-Options'] = iframe_restriction
+                else:
+                    raise Exception(
+                        'Invalid X-Frame-Options: %s' % iframe_restriction)
+
+            self.response.expires = 'Mon, 01 Jan 1990 00:00:00 GMT'
+            self.response.pragma = 'no-cache'
+            self.response.write(cached_pages[filename])
+            return
+
         if values is None:
             values = self.values
 
@@ -386,8 +405,10 @@ class BaseHandler(webapp2.RequestHandler):
         self.response.expires = 'Mon, 01 Jan 1990 00:00:00 GMT'
         self.response.pragma = 'no-cache'
 
-        self.response.write(self.jinja2_env.get_template(
-            filename).render(**values))
+        content = self.jinja2_env.get_template(
+            filename).render(**values)
+        cached_pages[filename] = content
+        self.response.write(content)
 
         # Calculate the processing time of this request.
         duration = datetime.datetime.utcnow() - self.start_time

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -146,7 +146,7 @@ class LogoutPage(webapp2.RequestHandler):
         else:
             self.redirect(url_to_redirect_to)
 
-cached_pages = {}
+CACHED_PAGES = {}
 
 class BaseHandler(webapp2.RequestHandler):
     """Base class for all Oppia handlers."""
@@ -300,8 +300,8 @@ class BaseHandler(webapp2.RequestHandler):
     def render_template(
             self, filename, values=None, iframe_restriction='DENY',
             redirect_url_on_logout=None, cached=False):
-        print 'id for base handler: ', id(cached_pages)
-        if cached and filename in cached_pages:
+        print 'id for base handler: ', id(CACHED_PAGES)
+        if cached and filename in CACHED_PAGES:
             self.response.headers['Strict-Transport-Security'] = (
                 'max-age=31536000; includeSubDomains')
             self.response.headers['X-Content-Type-Options'] = 'nosniff'
@@ -316,7 +316,7 @@ class BaseHandler(webapp2.RequestHandler):
 
             self.response.expires = 'Mon, 01 Jan 1990 00:00:00 GMT'
             self.response.pragma = 'no-cache'
-            self.response.write(cached_pages[filename])
+            self.response.write(CACHED_PAGES[filename])
             return
 
         if values is None:
@@ -408,7 +408,7 @@ class BaseHandler(webapp2.RequestHandler):
 
         content = self.jinja2_env.get_template(
             filename).render(**values)
-        cached_pages[filename] = content
+        CACHED_PAGES[filename] = content
         self.response.write(content)
 
         # Calculate the processing time of this request.

--- a/core/controllers/pages.py
+++ b/core/controllers/pages.py
@@ -49,7 +49,7 @@ class AboutPage(base.BaseHandler):
             'meta_description': feconf.ABOUT_PAGE_DESCRIPTION,
             'nav_mode': feconf.NAV_MODE_ABOUT,
         })
-        self.render_template('pages/about.html')
+        self.render_template('pages/about.html', cached=True)
 
 
 class TeachPage(base.BaseHandler):


### PR DESCRIPTION
Note: it is just a prototype to show my solution to #2485 . If we accept this approach, we have to design what we use as the key for each page thoroughly. And also do the necessary check before returning from the cache. Please don't take this PR as the final version.

With this approach, the loading time for `about` speeds up from 400-600 ms to 150-200 ms.
Actually, I think we didn't utilize memcached for the pages generated from controllers. Why wouldn't we do that? I think memcached is a more mature approach to achieve my idea.

@seanlip What's your opinion?