### PR TITLE
Fix #2025: strip the formatting before pasting in the RTE

### DIFF
--- a/core/templates/dev/head/components/forms/FormBuilder.js
+++ b/core/templates/dev/head/components/forms/FormBuilder.js
@@ -939,8 +939,12 @@ oppia.directive('textAngularRte', [
           };
 
           $scope.stripFormatting = function(html) {
-            console.log(html);
-            return $filter('stripFormatting')(html, whitelistedTags);
+            var safeHtml = $filter('stripFormatting')(html, whitelistedTags);
+            // The '.' default is needed, otherwise some tags are not stripped
+            // properly. To reproduce, copy the image from this page
+            // (https://en.wikipedia.org/wiki/C._Auguste_Dupin) and paste it
+            // into the RTE.
+            return safeHtml || '.';
           };
 
           $scope.init = function() {

--- a/core/templates/dev/head/components/forms/FormBuilder.js
+++ b/core/templates/dev/head/components/forms/FormBuilder.js
@@ -914,6 +914,7 @@ oppia.directive('textAngularRte', [
             ['ol', 'ul', 'pre', 'indent', 'outdent'],
             []
           ];
+          var whitelistedTags = [];
 
           if ($scope.uiConfig() && $scope.uiConfig().placeholder) {
             $scope.placeholderText = $scope.uiConfig().placeholder;
@@ -926,6 +927,9 @@ oppia.directive('textAngularRte', [
                     componentDefn.isComplex)) {
                 toolbarOptions[2].push(componentDefn.name);
               }
+              var tagName = 'oppia-noninteractive-';
+              tagName += componentDefn.name;
+              whitelistedTags.push(tagName);
             }
           );
           $scope.toolbarOptionsJson = JSON.stringify(toolbarOptions);
@@ -935,19 +939,8 @@ oppia.directive('textAngularRte', [
           };
 
           $scope.stripFormatting = function(html) {
-            var whitelistedTags = [
-              'oppia-noninteractive-collapsible',
-              'oppia-noninteractive-image',
-              'oppia-noninteractive-link',
-              'oppia-noninteractive-math',
-              'oppia-noninteractive-tabs',
-              'oppia-noninteractive-video'
-            ];
-            // Strip out anything between and including <>,
-            // unless it contains the RTE tags.
-            var regex = new RegExp('(?!.*(' + whitelistedTags.join('|') +
-                                    '))<[^>]+>', 'gm');
-            return html ? String(html).replace(regex, '') : '';
+            console.log(html);
+            return $filter('stripFormatting')(html, whitelistedTags);
           };
 
           $scope.init = function() {

--- a/core/templates/dev/head/components/forms/FormBuilder.js
+++ b/core/templates/dev/head/components/forms/FormBuilder.js
@@ -914,7 +914,7 @@ oppia.directive('textAngularRte', [
             ['ol', 'ul', 'pre', 'indent', 'outdent'],
             []
           ];
-          var whitelistedTags = [];
+          var whitelistedImgClasses = [];
 
           if ($scope.uiConfig() && $scope.uiConfig().placeholder) {
             $scope.placeholderText = $scope.uiConfig().placeholder;
@@ -927,9 +927,8 @@ oppia.directive('textAngularRte', [
                     componentDefn.isComplex)) {
                 toolbarOptions[2].push(componentDefn.name);
               }
-              var tagName = 'oppia-noninteractive-';
-              tagName += componentDefn.name;
-              whitelistedTags.push(tagName);
+              var imgClassName = 'oppia-noninteractive-' + componentDefn.name;
+              whitelistedImgClasses.push(imgClassName);
             }
           );
           $scope.toolbarOptionsJson = JSON.stringify(toolbarOptions);
@@ -939,7 +938,9 @@ oppia.directive('textAngularRte', [
           };
 
           $scope.stripFormatting = function(html) {
-            var safeHtml = $filter('stripFormatting')(html, whitelistedTags);
+            var safeHtml = $filter(
+              'stripFormatting'
+            )(html, whitelistedImgClasses);
             // The '.' default is needed, otherwise some tags are not stripped
             // properly. To reproduce, copy the image from this page
             // (https://en.wikipedia.org/wiki/C._Auguste_Dupin) and paste it

--- a/core/templates/dev/head/components/forms/FormBuilder.js
+++ b/core/templates/dev/head/components/forms/FormBuilder.js
@@ -935,7 +935,19 @@ oppia.directive('textAngularRte', [
           };
 
           $scope.stripFormatting = function(html) {
-            return $filter('sanitizeHtmlForRte')(html);
+            var whitelistedTags = [
+              'oppia-noninteractive-collapsible',
+              'oppia-noninteractive-image',
+              'oppia-noninteractive-link',
+              'oppia-noninteractive-math',
+              'oppia-noninteractive-tabs',
+              'oppia-noninteractive-video'
+            ];
+            // Strip out anything between and including <>,
+            // unless it contains the RTE tags.
+            var regex = new RegExp('(?!.*(' + whitelistedTags.join('|') +
+                                    '))<[^>]+>', 'gm');
+            return html ? String(html).replace(regex, '') : '';
           };
 
           $scope.init = function() {

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -443,14 +443,12 @@ oppia.filter('removeDuplicatesInArray', [function() {
 }]);
 
 oppia.filter('stripFormatting', [function() {
-  return function(html, whitelistedTags){
+  return function(html, whitelistedTags) {
     // Strip out anything between and including <>,
     // unless it contains the RTE tags.
     var regex = new RegExp('(?!.*(' + whitelistedTags.join('|') +
                             '))<[^>]+>', 'gm');
     var strippedText = html ? String(html).replace(regex, '') : '';
-    console.log(html);
-    console.log(strippedText);
     return strippedText;
   };
 }]);

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -443,11 +443,12 @@ oppia.filter('removeDuplicatesInArray', [function() {
 }]);
 
 oppia.filter('stripFormatting', [function() {
-  return function(html, whitelistedTags) {
+  return function(html, whitelistedImgClasses) {
     // Strip out anything between and including <>,
-    // unless it contains the RTE tags.
-    var regex = new RegExp('(?!.*(' + whitelistedTags.join('|') +
-                            '))<[^>]+>', 'gm');
+    // unless it is an img whose class includes one of the whitelisted classes.
+    var regex = new RegExp(
+      '(?!<img.*class=".*(' + whitelistedImgClasses.join('|') +
+      ').*>)<[^>]+>', 'gm');
     var strippedText = html ? String(html).replace(regex, '') : '';
     return strippedText;
   };

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -441,3 +441,16 @@ oppia.filter('removeDuplicatesInArray', [function() {
     });
   };
 }]);
+
+oppia.filter('stripFormatting', [function() {
+  return function(html, whitelistedTags){
+    // Strip out anything between and including <>,
+    // unless it contains the RTE tags.
+    var regex = new RegExp('(?!.*(' + whitelistedTags.join('|') +
+                            '))<[^>]+>', 'gm');
+    var strippedText = html ? String(html).replace(regex, '') : '';
+    console.log(html);
+    console.log(strippedText);
+    return strippedText;
+  };
+}]);

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -300,6 +300,9 @@ describe('Testing filters', function() {
     'src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/' +
     'The_Purloined_Letter.jpg/220px-The_Purloined_Letter.jpg" width="220" ' +
     'height="178"></a>');
+    var OTHER_TAG_LINK = ('<a href=""><img src="linkimage.jpg" ' +
+    'class="other-tag"></a>');
+    var INVALID_TAG_LINK = ('<a href="example.com" class="invalid-tag"></a>');
     var DANGEROUS_SCRIPT_IMG = ('<img src="w3javascript.gif" ' +
     'onload="loadImage()" width="100" height="132">');
     var DANGEROUS_NESTED_SCRIPT = ('<scr<script>ipt>alert(42);' +
@@ -310,7 +313,8 @@ describe('Testing filters', function() {
       'oppia-noninteractive-link',
       'oppia-noninteractive-math',
       'oppia-noninteractive-tabs',
-      'oppia-noninteractive-video'
+      'oppia-noninteractive-video',
+      'other-tag'
     ];
 
     expect(
@@ -330,6 +334,12 @@ describe('Testing filters', function() {
     ).toEqual(OPPIA_VIDEO);
     expect(
       $filter('stripFormatting')(DANGEROUS_SCRIPT_IMG, whitelistedTags)
+    ).toEqual('');
+    expect(
+      $filter('stripFormatting')(OTHER_TAG_LINK, whitelistedTags)
+    ).toEqual('<a href=""><img src="linkimage.jpg" class="other-tag">');
+    expect(
+      $filter('stripFormatting')(INVALID_TAG_LINK, whitelistedTags)
     ).toEqual('');
     expect(
       $filter('stripFormatting')(DANGEROUS_NESTED_SCRIPT, whitelistedTags)

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -34,7 +34,8 @@ describe('Testing filters', function() {
     'summarizeAnswerGroup',
     'summarizeDefaultOutcome',
     'summarizeNonnegativeNumber',
-    'truncateAndCapitalize'
+    'truncateAndCapitalize',
+    'stripFormatting'
   ];
 
   beforeEach(angular.mock.module('oppia'));
@@ -263,5 +264,75 @@ describe('Testing filters', function() {
     // return whole objective.
     expect(filter('please do not test empty string', 100)).toEqual(
       'Please do not test empty string');
+  }));
+
+  it('should strip out all tags unless they contain the RTE tags',
+      inject(function($filter) {
+    var LINK_HTML = ('<li><a href="/wiki/1800" title="1800">1800</a></li>');
+    var OPPIA_TABS = ('<img src="data:image/png;base64,' +
+    'iVBORw0KGgoAAAANSUhEUgAABNQAAAFgCAIAAAD8SbMaAAAM' +
+    'FWlDQ1BJQ0MgUHJvZmlsZQAASImV%0AlwdUk8kWx" ' +
+    'class="oppia-noninteractive-tabs block-element" ' +
+    'tab_contents-with-value="[{&amp;quot;title&amp;quot;:&amp;quot;' +
+    'Hint introduction&amp;quot;,&amp;quot;content&amp;quot;:&amp;quot;' +
+    'This set of tabs shows some hints.' +
+    ' Click on the other tabs to display the relevant hints.&amp;quot;},' +
+    '{&amp;quot;title&amp;quot;:&amp;quot;Hint 1&amp;quot;,'+
+    '&amp;quot;content&amp;quot;:&amp;quot;This is a first hint.&amp;quot;},'+
+    '{&amp;quot;title&amp;quot;:&amp;quot;Hint 2&amp;quot;,'+
+    '&amp;quot;content&amp;quot;:&amp;quot;&amp;lt;p&amp;gt;' +
+    'Stuff and things&amp;lt;/p&amp;gt;&amp;quot;}]" ' +
+    'exploration-id-with-value="&amp;quot');
+    var OPPIA_IMG = ('<img src="image.png" ' +
+    'class="oppia-noninteractive-image block-element" ' +
+    'alt-with-value="&amp;quot;&amp;quot;" ' +
+    'caption-with-value="&amp;quot;&amp;quot;" ' +
+    'filepath-with-value="&amp;quot;DearIDPodcast_sm.png&amp;quot;" ' +
+    'exploration-id-with-value="&amp;quot;5WWM85JODA2X&amp;quot;">');
+    var OPPIA_VIDEO= ('<img ' +
+    'src="https://img.youtube.com/vi/JcPwIQ6GCj8/hqdefault.jpg" ' +
+    'class="oppia-noninteractive-video block-element" ' +
+    'video_id-with-value="" start-with-value="0" end-with-value="0" ' +
+    'autoplay-with-value="false" exploration-id-with-value="">');
+    var IMG_HTML = ('<a ' +
+    'href="https://en.wikipedia.org/wiki/File:The_Purloined_Letter.jpg" ' +
+    'class="image"><img alt="The Purloined Letter.jpg" ' +
+    'src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/' +
+    'The_Purloined_Letter.jpg/220px-The_Purloined_Letter.jpg" width="220" ' +
+    'height="178"></a>');
+    var DANGEROUS_SCRIPT_IMG = ('<img src="w3javascript.gif" ' +
+    'onload="loadImage()" width="100" height="132">');
+    var DANGEROUS_NESTED_SCRIPT = ('<scr<script>ipt>alert(42);' +
+    '</scr</script>ipt>');
+    var whitelistedTags = [
+      "oppia-noninteractive-collapsible",
+      "oppia-noninteractive-image",
+      "oppia-noninteractive-link",
+      "oppia-noninteractive-math",
+      "oppia-noninteractive-tabs",
+      "oppia-noninteractive-video"
+    ];
+
+    expect(
+      $filter('stripFormatting')(LINK_HTML, whitelistedTags)
+    ).toEqual('1800');
+    expect(
+      $filter('stripFormatting')(IMG_HTML, whitelistedTags)
+    ).toEqual('');
+    expect(
+      $filter('stripFormatting')(OPPIA_TABS, whitelistedTags)
+    ).toEqual(OPPIA_TABS);
+    expect(
+      $filter('stripFormatting')(OPPIA_IMG, whitelistedTags)
+    ).toEqual(OPPIA_IMG);
+    expect(
+      $filter('stripFormatting')(OPPIA_VIDEO, whitelistedTags)
+    ).toEqual(OPPIA_VIDEO);
+    expect(
+      $filter('stripFormatting')(DANGEROUS_SCRIPT_IMG, whitelistedTags)
+    ).toEqual('');
+    expect(
+      $filter('stripFormatting')(DANGEROUS_NESTED_SCRIPT, whitelistedTags)
+    ).toEqual('ipt>alert(42);ipt>');
   }));
 });

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -277,9 +277,9 @@ describe('Testing filters', function() {
     'Hint introduction&amp;quot;,&amp;quot;content&amp;quot;:&amp;quot;' +
     'This set of tabs shows some hints.' +
     ' Click on the other tabs to display the relevant hints.&amp;quot;},' +
-    '{&amp;quot;title&amp;quot;:&amp;quot;Hint 1&amp;quot;,'+
-    '&amp;quot;content&amp;quot;:&amp;quot;This is a first hint.&amp;quot;},'+
-    '{&amp;quot;title&amp;quot;:&amp;quot;Hint 2&amp;quot;,'+
+    '{&amp;quot;title&amp;quot;:&amp;quot;Hint 1&amp;quot;,' +
+    '&amp;quot;content&amp;quot;:&amp;quot;This is a first hint.&amp;quot;},' +
+    '{&amp;quot;title&amp;quot;:&amp;quot;Hint 2&amp;quot;,' +
     '&amp;quot;content&amp;quot;:&amp;quot;&amp;lt;p&amp;gt;' +
     'Stuff and things&amp;lt;/p&amp;gt;&amp;quot;}]" ' +
     'exploration-id-with-value="&amp;quot');
@@ -289,7 +289,7 @@ describe('Testing filters', function() {
     'caption-with-value="&amp;quot;&amp;quot;" ' +
     'filepath-with-value="&amp;quot;DearIDPodcast_sm.png&amp;quot;" ' +
     'exploration-id-with-value="&amp;quot;5WWM85JODA2X&amp;quot;">');
-    var OPPIA_VIDEO= ('<img ' +
+    var OPPIA_VIDEO = ('<img ' +
     'src="https://img.youtube.com/vi/JcPwIQ6GCj8/hqdefault.jpg" ' +
     'class="oppia-noninteractive-video block-element" ' +
     'video_id-with-value="" start-with-value="0" end-with-value="0" ' +
@@ -305,12 +305,12 @@ describe('Testing filters', function() {
     var DANGEROUS_NESTED_SCRIPT = ('<scr<script>ipt>alert(42);' +
     '</scr</script>ipt>');
     var whitelistedTags = [
-      "oppia-noninteractive-collapsible",
-      "oppia-noninteractive-image",
-      "oppia-noninteractive-link",
-      "oppia-noninteractive-math",
-      "oppia-noninteractive-tabs",
-      "oppia-noninteractive-video"
+      'oppia-noninteractive-collapsible',
+      'oppia-noninteractive-image',
+      'oppia-noninteractive-link',
+      'oppia-noninteractive-math',
+      'oppia-noninteractive-tabs',
+      'oppia-noninteractive-video'
     ];
 
     expect(

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -266,7 +266,7 @@ describe('Testing filters', function() {
       'Please do not test empty string');
   }));
 
-  it('should strip out all tags unless they contain the RTE tags',
+  it('should remove all tags except img tags with the whitelisted classes',
       inject(function($filter) {
     var LINK_HTML = ('<li><a href="/wiki/1800" title="1800">1800</a></li>');
     var OPPIA_TABS = ('<img src="data:image/png;base64,' +
@@ -307,7 +307,11 @@ describe('Testing filters', function() {
     'onload="loadImage()" width="100" height="132">');
     var DANGEROUS_NESTED_SCRIPT = ('<scr<script>ipt>alert(42);' +
     '</scr</script>ipt>');
-    var whitelistedTags = [
+    var NO_TAG = ('The quick brown fox jumps over the lazy dog.');
+    var NON_IMAGE = ('<a href="example.com" ' +
+    'class="oppia-noninteractive-link">Example.com</a>');
+    var IMAGE_INVALID = ('<img src="linkimage.jpg" class="invalid-tag">');
+    var whitelistedImgClasses = [
       'oppia-noninteractive-collapsible',
       'oppia-noninteractive-image',
       'oppia-noninteractive-link',
@@ -318,31 +322,40 @@ describe('Testing filters', function() {
     ];
 
     expect(
-      $filter('stripFormatting')(LINK_HTML, whitelistedTags)
+      $filter('stripFormatting')(LINK_HTML, whitelistedImgClasses)
     ).toEqual('1800');
     expect(
-      $filter('stripFormatting')(IMG_HTML, whitelistedTags)
+      $filter('stripFormatting')(IMG_HTML, whitelistedImgClasses)
     ).toEqual('');
     expect(
-      $filter('stripFormatting')(OPPIA_TABS, whitelistedTags)
+      $filter('stripFormatting')(OPPIA_TABS, whitelistedImgClasses)
     ).toEqual(OPPIA_TABS);
     expect(
-      $filter('stripFormatting')(OPPIA_IMG, whitelistedTags)
+      $filter('stripFormatting')(OPPIA_IMG, whitelistedImgClasses)
     ).toEqual(OPPIA_IMG);
     expect(
-      $filter('stripFormatting')(OPPIA_VIDEO, whitelistedTags)
+      $filter('stripFormatting')(OPPIA_VIDEO, whitelistedImgClasses)
     ).toEqual(OPPIA_VIDEO);
     expect(
-      $filter('stripFormatting')(DANGEROUS_SCRIPT_IMG, whitelistedTags)
+      $filter('stripFormatting')(DANGEROUS_SCRIPT_IMG, whitelistedImgClasses)
     ).toEqual('');
     expect(
-      $filter('stripFormatting')(OTHER_TAG_LINK, whitelistedTags)
-    ).toEqual('<a href=""><img src="linkimage.jpg" class="other-tag">');
+      $filter('stripFormatting')(OTHER_TAG_LINK, whitelistedImgClasses)
+    ).toEqual('<img src="linkimage.jpg" class="other-tag">');
     expect(
-      $filter('stripFormatting')(INVALID_TAG_LINK, whitelistedTags)
+      $filter('stripFormatting')(INVALID_TAG_LINK, whitelistedImgClasses)
     ).toEqual('');
     expect(
-      $filter('stripFormatting')(DANGEROUS_NESTED_SCRIPT, whitelistedTags)
+      $filter('stripFormatting')(DANGEROUS_NESTED_SCRIPT, whitelistedImgClasses)
     ).toEqual('ipt>alert(42);ipt>');
+    expect(
+      $filter('stripFormatting')(NO_TAG, whitelistedImgClasses)
+    ).toEqual(NO_TAG);
+    expect(
+      $filter('stripFormatting')(NON_IMAGE, whitelistedImgClasses)
+    ).toEqual('Example.com');
+    expect(
+      $filter('stripFormatting')(IMAGE_INVALID, whitelistedImgClasses)
+    ).toEqual('');
   }));
 });


### PR DESCRIPTION
Created an array of whitelisted tags to check for before removing all other tags in pasted content. Tested with Oppia images and tabs and with various styled content from Wikipedia and Stack Overflow.