### PR TITLE
Fix #2531: show multiple rules for an answer group

### DIFF
--- a/core/templates/dev/head/components/ResponseHeaderDirective.js
+++ b/core/templates/dev/head/components/ResponseHeaderDirective.js
@@ -26,7 +26,7 @@ oppia.directive('responseHeader', [function() {
       getShortSummary: '&shortSummary',
       isActive: '&isActive',
       getOnDeleteFn: '&onDeleteFn',
-      extraRules: '&extraRules'
+      getNumRules: '&numRules'
     },
     templateUrl: 'components/responseHeader',
     controller: [

--- a/core/templates/dev/head/components/ResponseHeaderDirective.js
+++ b/core/templates/dev/head/components/ResponseHeaderDirective.js
@@ -25,7 +25,8 @@ oppia.directive('responseHeader', [function() {
       getSummary: '&summary',
       getShortSummary: '&shortSummary',
       isActive: '&isActive',
-      getOnDeleteFn: '&onDeleteFn'
+      getOnDeleteFn: '&onDeleteFn',
+      extraRules: '&extraRules'
     },
     templateUrl: 'components/responseHeader',
     controller: [

--- a/core/templates/dev/head/components/response_header_directive.html
+++ b/core/templates/dev/head/components/response_header_directive.html
@@ -3,6 +3,9 @@
     <div class="oppia-response-header">
       <span ng-if="!isActive()" ng-attr-title="<[getSummary()]>">
         <[getShortSummary()]>
+        <span ng-if="extraRules() > 0" class="label label-primary" style="position: relative; bottom: 4px;">
+          +<[extraRules()]>
+        </span>
       </span>
       <span ng-if="isActive()">&nbsp;</span>
     </div>

--- a/core/templates/dev/head/components/response_header_directive.html
+++ b/core/templates/dev/head/components/response_header_directive.html
@@ -3,8 +3,8 @@
     <div class="oppia-response-header">
       <span ng-if="!isActive()" ng-attr-title="<[getSummary()]>">
         <[getShortSummary()]>
-        <span ng-if="extraRules() > 0" class="label label-primary" style="position: relative; bottom: 4px;">
-          +<[extraRules()]>
+        <span ng-if="getNumRules() > 1" class="label label-primary" style="position: relative; bottom: 4px;">
+          +<[getNumRules() - 1]>
         </span>
       </span>
       <span ng-if="isActive()">&nbsp;</span>

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
@@ -29,7 +29,7 @@
                                is-active="$index === activeAnswerGroupIndex"
                                on-delete-fn="deleteAnswerGroup"
                                outcome="answerGroup.outcome"
-                               extra-rules="answerGroup.rule_specs.length - 1">
+                               num-rules="answerGroup.rule_specs.length">
               </response-header>
             </a>
 

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
@@ -28,7 +28,8 @@
                                short-summary="answerGroup | summarizeAnswerGroup : getCurrentInteractionId():getAnswerChoices():true"
                                is-active="$index === activeAnswerGroupIndex"
                                on-delete-fn="deleteAnswerGroup"
-                               outcome="answerGroup.outcome">
+                               outcome="answerGroup.outcome"
+                               extra-rules="answerGroup.rule_specs.length - 1">
               </response-header>
             </a>
 


### PR DESCRIPTION
Added a way to view multiple rules to a answer group.

Thank you @andromfins for helping with this issue.
