### PR TITLE
Fix part of #2269: Add config property to set authorised query users.

### DIFF
--- a/core/domain/config_domain.py
+++ b/core/domain/config_domain.py
@@ -239,6 +239,6 @@ WHITELISTED_COLLECTION_EDITOR_USERNAMES = ConfigProperty(
     'Names of users allowed to use the collection editor',
     [])
 
-AUTHORIZED_QUERY_USERS = ConfigProperty(
-    'authorized_query_users', SET_OF_STRINGS_SCHEMA,
-    'Authorized users who can execute query', [])
+AUTHORISED_QUERY_USERS = ConfigProperty(
+    'authorised_query_users', SET_OF_STRINGS_SCHEMA,
+    'Authorised users who can execute query', [])

--- a/core/domain/config_domain.py
+++ b/core/domain/config_domain.py
@@ -235,7 +235,10 @@ BANNED_USERNAMES = ConfigProperty(
     [])
 
 WHITELISTED_COLLECTION_EDITOR_USERNAMES = ConfigProperty(
-    'collection_editor_whitelist',
-    SET_OF_STRINGS_SCHEMA,
+    'collection_editor_whitelist', SET_OF_STRINGS_SCHEMA,
     'Names of users allowed to use the collection editor',
     [])
+
+AUTHORIZED_QUERY_USERS = ConfigProperty(
+    'authorized_query_users', SET_OF_STRINGS_SCHEMA,
+    'Authorized users who can execute query', [])

--- a/core/domain/config_domain.py
+++ b/core/domain/config_domain.py
@@ -239,6 +239,6 @@ WHITELISTED_COLLECTION_EDITOR_USERNAMES = ConfigProperty(
     'Names of users allowed to use the collection editor',
     [])
 
-AUTHORISED_QUERY_USERS = ConfigProperty(
-    'authorised_query_users', SET_OF_STRINGS_SCHEMA,
-    'Authorised users who can execute query', [])
+WHITELISTED_EMAIL_SENDER = ConfigProperty(
+    'whitelisted_email_sender', SET_OF_STRINGS_SCHEMA,
+    'Names of users allowed to send emails via the query interface.', [])

--- a/core/domain/config_domain.py
+++ b/core/domain/config_domain.py
@@ -239,6 +239,6 @@ WHITELISTED_COLLECTION_EDITOR_USERNAMES = ConfigProperty(
     'Names of users allowed to use the collection editor',
     [])
 
-WHITELISTED_EMAIL_SENDER = ConfigProperty(
-    'whitelisted_email_sender', SET_OF_STRINGS_SCHEMA,
+WHITELISTED_EMAIL_SENDERS = ConfigProperty(
+    'whitelisted_email_senders', SET_OF_STRINGS_SCHEMA,
     'Names of users allowed to send emails via the query interface.', [])


### PR DESCRIPTION
Added config property so that admin can set authorised users who can execute query from query page.