### PR TITLE
Fix .load() method breakage due to jQuery upgrade. Also fix error in #2594 arising due to mismatched RTE component HTML representations.

### DIFF
--- a/core/templates/dev/head/components/forms/FormBuilder.js
+++ b/core/templates/dev/head/components/forms/FormBuilder.js
@@ -604,11 +604,16 @@ oppia.factory('rteHelperService', [
       createRteElement: function(componentDefn, customizationArgsDict) {
         var el = $('<img/>');
         if (explorationContextService.isInExplorationContext()) {
-          customizationArgsDict = angular.extend(customizationArgsDict,
-            {
-              explorationId: explorationContextService.getExplorationId()
-            }
-          );
+          // TODO(sll): This extra key was introduced in commit
+          // 19a934ce20d592a3fc46bd97a2f05f41d33e3d66 in order to retrieve an
+          // image for RTE previews. However, it has had the unfortunate side-
+          // effect of adding an extra tag to the exploration RTE tags stored
+          // in the datastore. We are now removing this key in
+          // convertRteToHtml(), but we need to find a less invasive way to
+          // handle previews.
+          customizationArgsDict = angular.extend(customizationArgsDict, {
+            explorationId: explorationContextService.getExplorationId()
+          });
         }
         var interpolatedUrl = $interpolate(
           componentDefn.previewUrlTemplate, false, null, true)(
@@ -681,7 +686,11 @@ oppia.factory('rteHelperService', [
             var jQueryElt = $('<' + tagNameMatch[2] + '/>');
             for (var i = 0; i < this.attributes.length; i++) {
               var attr = this.attributes[i];
-              if (attr.name !== 'class' && attr.name !== 'src') {
+              // The exploration-id-with-value attribute was added in
+              // createRteElement(), and should be stripped. See commit
+              // 19a934ce20d592a3fc46bd97a2f05f41d33e3d66.
+              if (attr.name !== 'class' && attr.name !== 'src' &&
+                  attr.name !== 'exploration-id-with-value') {
                 jQueryElt.attr(attr.name, attr.value);
               }
             }

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -281,14 +281,12 @@ describe('Testing filters', function() {
     '&amp;quot;content&amp;quot;:&amp;quot;This is a first hint.&amp;quot;},' +
     '{&amp;quot;title&amp;quot;:&amp;quot;Hint 2&amp;quot;,' +
     '&amp;quot;content&amp;quot;:&amp;quot;&amp;lt;p&amp;gt;' +
-    'Stuff and things&amp;lt;/p&amp;gt;&amp;quot;}]" ' +
-    'exploration-id-with-value="&amp;quot');
+    'Stuff and things&amp;lt;/p&amp;gt;&amp;quot;}]">');
     var OPPIA_IMG = ('<img src="image.png" ' +
     'class="oppia-noninteractive-image block-element" ' +
     'alt-with-value="&amp;quot;&amp;quot;" ' +
     'caption-with-value="&amp;quot;&amp;quot;" ' +
-    'filepath-with-value="&amp;quot;DearIDPodcast_sm.png&amp;quot;" ' +
-    'exploration-id-with-value="&amp;quot;5WWM85JODA2X&amp;quot;">');
+    'filepath-with-value="&amp;quot;DearIDPodcast_sm.png&amp;quot;">');
     var OPPIA_VIDEO = ('<img ' +
     'src="https://img.youtube.com/vi/JcPwIQ6GCj8/hqdefault.jpg" ' +
     'class="oppia-noninteractive-video block-element" ' +

--- a/core/templates/dev/head/pages/header_js_libs.html
+++ b/core/templates/dev/head/pages/header_js_libs.html
@@ -1,10 +1,8 @@
 <!-- jquery.js, angular.js and jquery-ui.js are removed from bundled js because
 they need to be at the header. Including bundled js at the header will block
 rendering.-->
-<script src="/third_party/static/jquery-3.0.0/jquery.min.js">
-</script>
-<script src="/third_party/static/jqueryui-1.10.3/jquery-ui.min.js">
-</script>
+<script src="/third_party/static/jquery-3.0.0/jquery.min.js"></script>
+<script src="/third_party/static/jqueryui-1.10.3/jquery-ui.min.js"></script>
 <script src="/third_party/static/angularjs-1.5.8/angular.min.js"></script>
 <script src="/third_party/static/jquery-ui-touch-punch-0.3.1/jquery.ui.touch-punch-improved.js"></script>
 <!-- See http://docs.mathjax.org/en/latest/start.html#mathjax-cdn -->

--- a/extensions/objects/templates/ImageWithRegionsEditor.js
+++ b/extensions/objects/templates/ImageWithRegionsEditor.js
@@ -130,8 +130,8 @@ oppia.directive('imageWithRegionsEditor', [
           if (newVal !== '') {
             // Loads the image in hanging <img> tag so as to get the
             // width and height
-            $('<img/>').attr('src', $scope.getPreviewUrl(newVal)).load(
-              function() {
+            $('<img/>').attr('src', $scope.getPreviewUrl(newVal)).on(
+              'load', function() {
                 $scope.originalImageWidth = this.width;
                 $scope.originalImageHeight = this.height;
                 $scope.$apply();


### PR DESCRIPTION
Note: This is intended as a hotfix.

/cc @wxyxinyu @BenHenning 