### PR TITLE
Fix #2530: dynamically change the title of the page

### DIFF
--- a/core/templates/dev/head/pages/base.html
+++ b/core/templates/dev/head/pages/base.html
@@ -66,6 +66,12 @@
     the page title because the head of the file is outside the scope of
     any other controller. -->
     <title itemprop="name" translate="{% block maintitle %}Oppia{% endblock maintitle %}"></title>
+
+    <!-- This block is used when we want to dynamically change the title of
+    the page.For example in exploration editor page we dynamically change the
+    title of the page based on the title of the exploration. -->
+    {% block dynamic_title %}{% endblock dynamic_title %}
+
     {% block base_url %}{% endblock base_url %}
 
     {% block header_css %}

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
@@ -478,10 +478,10 @@ oppia.controller('EditorNavigation', [
 
 oppia.controller('EditorNavbarBreadcrumb', [
   '$scope', 'explorationTitleService', 'routerService', 'focusService',
-  'EXPLORATION_TITLE_INPUT_FOCUS_LABEL', '$window',
+  'EXPLORATION_TITLE_INPUT_FOCUS_LABEL',
   function(
       $scope, explorationTitleService, routerService, focusService,
-      EXPLORATION_TITLE_INPUT_FOCUS_LABEL, $window) {
+      EXPLORATION_TITLE_INPUT_FOCUS_LABEL) {
     $scope.navbarTitle = null;
     $scope.$on('explorationPropertyChanged', function() {
       var _MAX_TITLE_LENGTH = 20;
@@ -489,13 +489,6 @@ oppia.controller('EditorNavbarBreadcrumb', [
       if ($scope.navbarTitle.length > _MAX_TITLE_LENGTH) {
         $scope.navbarTitle = (
           $scope.navbarTitle.substring(0, _MAX_TITLE_LENGTH - 3) + '...');
-      }
-
-      // Set the title of the page when the exploration title changes.
-      if ($scope.navbarTitle === '') {
-        $window.document.title = 'Untitled Exploration - Oppia Editor';
-      } else {
-        $window.document.title = $scope.navbarTitle + ' - Oppia Editor';
       }
     });
 
@@ -1005,5 +998,25 @@ oppia.controller('ExplorationSaveAndPublishButtons', [
         });
       });
     };
+  }
+]);
+
+oppia.controller('DynamicTitleEditor', [
+  '$scope', 'explorationTitleService', 'routerService', 'focusService',
+  'EXPLORATION_TITLE_INPUT_FOCUS_LABEL', '$window',
+  function(
+      $scope, explorationTitleService, routerService, focusService,
+      EXPLORATION_TITLE_INPUT_FOCUS_LABEL, $window) {
+    $scope.navbarTitle = null;
+    $scope.$on('explorationPropertyChanged', function() {
+      $scope.navbarTitle = explorationTitleService.savedMemento;
+
+      // Set the title of the page when the exploration title changes.
+      if ($scope.navbarTitle === '') {
+        $window.document.title = 'Untitled Exploration - Oppia Editor';
+      } else {
+        $window.document.title = $scope.navbarTitle + ' - Oppia Editor';
+      }
+    });
   }
 ]);

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
@@ -478,10 +478,10 @@ oppia.controller('EditorNavigation', [
 
 oppia.controller('EditorNavbarBreadcrumb', [
   '$scope', 'explorationTitleService', 'routerService', 'focusService',
-  'EXPLORATION_TITLE_INPUT_FOCUS_LABEL',
+  'EXPLORATION_TITLE_INPUT_FOCUS_LABEL', '$window',
   function(
       $scope, explorationTitleService, routerService, focusService,
-      EXPLORATION_TITLE_INPUT_FOCUS_LABEL) {
+      EXPLORATION_TITLE_INPUT_FOCUS_LABEL, $window) {
     $scope.navbarTitle = null;
     $scope.$on('explorationPropertyChanged', function() {
       var _MAX_TITLE_LENGTH = 20;
@@ -489,6 +489,13 @@ oppia.controller('EditorNavbarBreadcrumb', [
       if ($scope.navbarTitle.length > _MAX_TITLE_LENGTH) {
         $scope.navbarTitle = (
           $scope.navbarTitle.substring(0, _MAX_TITLE_LENGTH - 3) + '...');
+      }
+
+      // Set the title of the page when the exploration title changes.
+      if ($scope.navbarTitle === '') {
+        $window.document.title = 'Untitled Exploration - Oppia Editor';
+      } else {
+        $window.document.title = $scope.navbarTitle + ' - Oppia Editor';
       }
     });
 

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -1,13 +1,5 @@
 {% extends 'pages/base.html' %}
 
-{% block maintitle %}
-  {% if title %}
-    {{ title }} - Oppia Editor
-  {% else %}
-    Untitled Exploration - Oppia Editor
-  {% endif %}
-{% endblock maintitle %}
-
 {% block header_js %}
   {{ super() }}
   <script type="text/javascript">

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -1,5 +1,9 @@
 {% extends 'pages/base.html' %}
 
+{% block dynamic_title %}
+  <div ng-controller="DynamicTitleEditor"></div>
+{% endblock dynamic_title %}
+
 {% block header_js %}
   {{ super() }}
   <script type="text/javascript">


### PR DESCRIPTION
The title of the page is changed dynamically whenever the user changes the title of the exploration. We are already changing the title of the exploration in the navbar. So I just extended it to change the title of the page.
