### PR TITLE
Fix #2549: featured-label no more breaks to two lines.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2246,6 +2246,7 @@ md-card.oppia-dashboard-tile {
   background-color: #009688;
   border-radius: 5px;
   color: white;
+  display: inline-block;
   font-size: 10px;
   margin-left: 3px;
   padding: 4px 6px;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2248,7 +2248,6 @@ md-card.oppia-dashboard-tile {
   color: white;
   display: inline-block;
   font-size: 10px;
-  margin-left: 3px;
   padding: 4px 6px;
   text-transform: uppercase;
   vertical-align: middle;


### PR DESCRIPTION
Added `display: inline-block` style to featured-label `span`-tag.