### PR TITLE
FIX #2538: Fix fallbacks triggering constantly

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2246,6 +2246,7 @@ md-card.oppia-dashboard-tile {
   background-color: #009688;
   border-radius: 5px;
   color: white;
+  display: inline-block;
   font-size: 10px;
   margin-left: 3px;
   padding: 4px 6px;

--- a/core/templates/dev/head/pages/exploration_player/PlayerServices.js
+++ b/core/templates/dev/head/pages/exploration_player/PlayerServices.js
@@ -262,6 +262,7 @@ oppia.factory('oppiaPlayerService', [
         AnswerClassificationService.getMatchingClassificationResult(
           _explorationId, oldState, answer, false, interactionRulesService
         ).then(function(classificationResult) {
+
           if (!_editorPreviewMode) {
             StatsReportingService.recordAnswerSubmitted(
               playerTranscriptService.getLastStateName(),
@@ -271,7 +272,9 @@ oppia.factory('oppiaPlayerService', [
               classificationResult.ruleSpecIndex);
           }
 
-          var outcome = classificationResult.outcome;
+          // Use Object.assign to clone the object, since classificationResult.outcome points at oldState.interaction.default_outcome
+          var outcome = Object.assign({}, classificationResult.outcome)
+
           // If this is a return to the same state, and the resubmission trigger
           // kicks in, replace the dest, feedback and param changes with that
           // of the trigger.
@@ -295,6 +298,7 @@ oppia.factory('oppiaPlayerService', [
           // Compute the data for the next state.
           var oldParams = LearnerParamsService.getAllParams();
           oldParams.answer = answer;
+
           var feedbackHtml = makeFeedback(outcome.feedback, [oldParams]);
           if (feedbackHtml === null) {
             answerIsBeingProcessed = false;

--- a/core/templates/dev/head/pages/exploration_player/PlayerServices.js
+++ b/core/templates/dev/head/pages/exploration_player/PlayerServices.js
@@ -272,8 +272,9 @@ oppia.factory('oppiaPlayerService', [
               classificationResult.ruleSpecIndex);
           }
 
-          // Use Object.assign to clone the object, since classificationResult.outcome points at oldState.interaction.default_outcome
-          var outcome = Object.assign({}, classificationResult.outcome)
+          // Use Object.assign to clone the object
+          // since classificationResult.outcome points at oldState.interaction.default_outcome
+          var outcome = Object.assign({}, classificationResult.outcome);
 
           // If this is a return to the same state, and the resubmission trigger
           // kicks in, replace the dest, feedback and param changes with that

--- a/core/templates/dev/head/pages/exploration_player/PlayerServices.js
+++ b/core/templates/dev/head/pages/exploration_player/PlayerServices.js
@@ -262,7 +262,6 @@ oppia.factory('oppiaPlayerService', [
         AnswerClassificationService.getMatchingClassificationResult(
           _explorationId, oldState, answer, false, interactionRulesService
         ).then(function(classificationResult) {
-
           if (!_editorPreviewMode) {
             StatsReportingService.recordAnswerSubmitted(
               playerTranscriptService.getLastStateName(),
@@ -273,7 +272,8 @@ oppia.factory('oppiaPlayerService', [
           }
 
           // Use Object.assign to clone the object
-          // since classificationResult.outcome points at oldState.interaction.default_outcome
+          // since classificationResult.outcome points
+          // at oldState.interaction.default_outcome
           var outcome = Object.assign({}, classificationResult.outcome);
 
           // If this is a return to the same state, and the resubmission trigger


### PR DESCRIPTION
Problem occured due to some quite nasty side effects regarding updating the "outcome" variable in [PlayerServices.js](https://github.com/oppia/oppia/blob/develop/core/templates/dev/head/pages/exploration_player/PlayerServices.js#L274).

The `classificationResult.outcome` pointed at `oldState.interaction.default_outcome`, so changing the `outcome`-object changed the `oldState`-object and thus the `default_outcome` was changed for the next state.

Fixed this by using `Object.assign()` to clone the `classificationResult.outcome`.
