### PR TITLE
Fix #2538: fix fallbacks triggering when they are not supposed to.

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/PlayerServices.js
+++ b/core/templates/dev/head/pages/exploration_player/PlayerServices.js
@@ -274,7 +274,7 @@ oppia.factory('oppiaPlayerService', [
           // Use Object.assign to clone the object
           // since classificationResult.outcome points
           // at oldState.interaction.default_outcome
-          var outcome = Object.assign({}, classificationResult.outcome);
+          var outcome = angular.copy(classificationResult.outcome);
 
           // If this is a return to the same state, and the resubmission trigger
           // kicks in, replace the dest, feedback and param changes with that

--- a/core/templates/dev/head/pages/exploration_player/PlayerServices.js
+++ b/core/templates/dev/head/pages/exploration_player/PlayerServices.js
@@ -271,7 +271,7 @@ oppia.factory('oppiaPlayerService', [
               classificationResult.ruleSpecIndex);
           }
 
-          // Use Object.assign to clone the object
+          // Use angular.copy() to clone the object
           // since classificationResult.outcome points
           // at oldState.interaction.default_outcome
           var outcome = angular.copy(classificationResult.outcome);

--- a/core/templates/dev/head/pages/exploration_player/PlayerServices.js
+++ b/core/templates/dev/head/pages/exploration_player/PlayerServices.js
@@ -271,7 +271,11 @@ oppia.factory('oppiaPlayerService', [
               classificationResult.ruleSpecIndex);
           }
 
-          var outcome = classificationResult.outcome;
+          // Use Object.assign to clone the object
+          // since classificationResult.outcome points
+          // at oldState.interaction.default_outcome
+          var outcome = Object.assign({}, classificationResult.outcome);
+
           // If this is a return to the same state, and the resubmission trigger
           // kicks in, replace the dest, feedback and param changes with that
           // of the trigger.


### PR DESCRIPTION
Problem occured due to some quite nasty side effects regarding updating the "outcome" variable in [PlayerServices.js](https://github.com/oppia/oppia/blob/develop/core/templates/dev/head/pages/exploration_player/PlayerServices.js#L274).

The `classificationResult.outcome` pointed at `oldState.interaction.default_outcome`, so changing the `outcome`-object changed the `oldState`-object and thus the `default_outcome` was changed for the next state.

Fixed this by using `Object.assign()` to clone the `classificationResult.outcome`.
