### PR TITLE
Fix 2624: Display a success toast when a new featured exploration is …

### DIFF
--- a/core/templates/dev/head/pages/moderator/Moderator.js
+++ b/core/templates/dev/head/pages/moderator/Moderator.js
@@ -104,6 +104,7 @@ oppia.controller('Moderator', [
         featured_activity_reference_dicts: activityReferencesToSave
       }).then(function() {
         $scope.lastSavedFeaturedActivityReferences = activityReferencesToSave;
+        alertsService.addSuccessMessage('Featured activities saved.');
       });
     };
   }


### PR DESCRIPTION
Fix #2624. I used 'Featured activities saved.' as a success message. 