### PR TITLE
Fix #2536: Add a test for exp_domain.CMD_ADD_STATE

### DIFF
--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -924,6 +924,17 @@ class UpdateStateTests(ExplorationServicesUnitTests):
             'param_changes': []
         }
 
+    def test_add_state_name(self):
+        """Test adding of state"""
+        exploration = exp_services.get_exploration_by_id(self.EXP_ID)
+        exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
+            'cmd': 'add_state',
+            'state_name': 'new state',
+        }], 'Add state name')
+
+        exploration = exp_services.get_exploration_by_id(self.EXP_ID)
+        self.assertIn('new state', exploration.states)
+        
     def test_update_state_name(self):
         """Test updating of state name."""
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -934,7 +934,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
 
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         self.assertIn('new state', exploration.states)
-        
+
     def test_update_state_name(self):
         """Test updating of state name."""
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)

--- a/core/domain/user_jobs_continuous_test.py
+++ b/core/domain/user_jobs_continuous_test.py
@@ -22,7 +22,7 @@ from core import jobs_registry
 from core.domain import collection_services
 from core.domain import event_services
 from core.domain import exp_domain
-from core.domain import exp_jupdate_exploration()obs_one_off
+from core.domain import exp_jobs_one_off
 from core.domain import exp_services
 from core.domain import feedback_services
 from core.domain import rating_services

--- a/core/domain/user_jobs_continuous_test.py
+++ b/core/domain/user_jobs_continuous_test.py
@@ -22,7 +22,7 @@ from core import jobs_registry
 from core.domain import collection_services
 from core.domain import event_services
 from core.domain import exp_domain
-from core.domain import exp_jobs_one_off
+from core.domain import exp_jupdate_exploration()obs_one_off
 from core.domain import exp_services
 from core.domain import feedback_services
 from core.domain import rating_services


### PR DESCRIPTION
Fix #2536: Added a test for exp_domain.CMD_ADD_STATE using function 'test_add_state_name' in file exp_services_test.py
