### PR TITLE
#2637 Determine Vagrant env by checking existence of a file and env var

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,7 @@ $script = <<SCRIPT
 cd /home/vagrant/oppia
 bash ./scripts/install_prerequisites.sh
 bash ./scripts/start.sh
+touch /etc/is_vagrant_vm
 SCRIPT
 
 Vagrant.configure(2) do |config|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,11 +8,17 @@
 
 # The recommended method for short, multi-line shell scripts in Vagrant.
 # Usage: http://stackoverflow.com/questions/2500436/how-does-cat-eof-work-in-bash
+$env_script = <<SCRIPT
+# General-purpose env var to let scripts know we are in Vagrant.
+echo "export VAGRANT=true" >> /etc/profile
+# Create file (if it does not exist already) to let scripts know we are in Vagrant.
+touch /etc/is_vagrant_vm
+SCRIPT
+
 $script = <<SCRIPT
 cd /home/vagrant/oppia
 bash ./scripts/install_prerequisites.sh
 bash ./scripts/start.sh
-touch /etc/is_vagrant_vm
 SCRIPT
 
 Vagrant.configure(2) do |config|
@@ -20,8 +26,8 @@ Vagrant.configure(2) do |config|
     v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     v.memory = 2048
   end
-  # General-purpose env var to let scripts know we are in Vagrant.
-  config.vm.provision "shell", inline: 'echo "export VAGRANT=true" >> /etc/profile'
+
+  config.vm.provision "shell", inline: $env_script
   # Tell apt to default to "yes" when installing packages. Necessary for unattended installs.
   config.vm.provision "shell", inline: 'echo \'APT::Get::Assume-Yes "true";\' > /etc/apt/apt.conf.d/90yes'
   config.vm.network "forwarded_port", guest: 8000, host: 8000

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -208,7 +208,7 @@ fi
 # Adjust path to support the default Chrome locations for Unix, Windows and Mac OS.
 if [ "$TRAVIS" = true ]; then
   export CHROME_BIN="/usr/bin/chromium-browser"
-elif [ "$VAGRANT" = true ]; then
+elif [ "$VAGRANT" = true ] || [ -f "/etc/is_vagrant_vm" ]; then
   # XVFB is required for headless testing in Vagrant
   sudo apt-get install xvfb chromium-browser
   export CHROME_BIN="/usr/bin/chromium-browser"


### PR DESCRIPTION
Currently, vagrant env is checked for existence of an environment variable that is set at provision time. This does not work all the time when the vagrant system is rebooted.
This fix, adds a file and checks the existence of the file `/etc/is_vagrant_vm` along with environment variable `$VAGRANT` to determine if the host is vagrant and invokes other scripts accordingly.

