### PR TITLE
Fix #2049: hide site feedback text on smaller devices

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -497,6 +497,11 @@ textarea {
   opacity: 1.0;
   text-decoration: none;
 }
+@media (max-width: 1100px) {
+  .oppia-site-feedback span {
+    display: none;
+  }
+}
 
 /*
   Styles for the global navigation sidebar menu.


### PR DESCRIPTION
Created media query to 1100px so as to completely remove overlap between site feedback and exploration cards on library page.