### PR TITLE
Fix #2125: Changed position of class attribute legend-graph

### DIFF
--- a/core/templates/dev/head/components/version_diff_visualization_directive.html
+++ b/core/templates/dev/head/components/version_diff_visualization_directive.html
@@ -29,7 +29,7 @@
   }
   .legend-graph {
     position: absolute;
-    right: 25px;
-    top: 20px;
+    right: 40px;
+    top: 34px;
   }
 </style>

--- a/core/templates/dev/head/components/version_diff_visualization_directive.html
+++ b/core/templates/dev/head/components/version_diff_visualization_directive.html
@@ -29,7 +29,7 @@
   }
   .legend-graph {
     position: absolute;
-    right: -100px;
-    top: 10px;
+    right: 25px;
+    top: 20px;
   }
 </style>

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -346,6 +346,7 @@ body {
 */
 html p, body p {
   margin-top: -5px;
+  display: inline;
 }
 
 h1, h2 {


### PR DESCRIPTION
Changes made -
1. The division which displays the exploration graph legend has not been positioned within the md-card  `(<md-card class="oppia-editor-card md-default-theme" style="position: relative;" ng-if="diffData &amp;&amp; !hideHistoryGraph &amp;&amp; explorationVersionMetadata">)`.
Therefore I've made changes in the version_diff_visualization_directive.html file which contains styling properties(position) of the division  

Screenshots of changes made to the division -
**Before changes**
![div before](https://cloud.githubusercontent.com/assets/18189758/19830544/d36bd052-9e17-11e6-9efe-6e438472c990.png)
**After changes**
![divafter](https://cloud.githubusercontent.com/assets/18189758/19832015/766a4784-9e36-11e6-88af-b06c172317b5.png)

I tried checking the following possibilities which also causes the bug -
1. If division position is relative. It moves the element from where it would normally render and leaves the space that it would normally occupy there
2. The relative positioning on the parent is the big deal here. If the position is not relative then absolutely positioned elements position themselves in relation to the body element instead of their direct parent. So if the browser window grows, that one in the bottom left is going to stick with the browser window, not hang back inside.
The above possibilities are not causing any issues, they seem to be all right in the code

Proper positioning will solve the bug
