### PR TITLE
Fix #2669: Split up the admin page controller

### DIFF
--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -130,20 +130,10 @@ class AdminHandler(base.BaseHandler):
         try:
             if self.payload.get('action') == 'reload_exploration':
                 exploration_id = self.payload.get('exploration_id')
-                logging.info(
-                    '[ADMIN] %s reloaded exploration %s' %
-                    (self.user_id, exploration_id))
-                exp_services.load_demo(unicode(exploration_id))
-                rights_manager.release_ownership_of_exploration(
-                    feconf.SYSTEM_COMMITTER_ID, unicode(exploration_id))
+                self._reload_exploration(exploration_id)
             elif self.payload.get('action') == 'reload_collection':
                 collection_id = self.payload.get('collection_id')
-                logging.info(
-                    '[ADMIN] %s reloaded collection %s' %
-                    (self.user_id, collection_id))
-                collection_services.load_demo(unicode(collection_id))
-                rights_manager.release_ownership_of_collection(
-                    feconf.SYSTEM_COMMITTER_ID, unicode(collection_id))
+                self._reload_collection(collection_id)
             elif self.payload.get('action') == 'clear_search_index':
                 exp_services.clear_search_index()
             elif self.payload.get('action') == 'save_config_properties':
@@ -191,6 +181,28 @@ class AdminHandler(base.BaseHandler):
         except Exception as e:
             self.render_json({'error': unicode(e)})
             raise
+
+    def _reload_exploration(self, exploration_id):
+        if feconf.DEV_MODE:
+            logging.info(
+                '[ADMIN] %s reloaded exploration %s' %
+                (self.user_id, exploration_id))
+            exp_services.load_demo(unicode(exploration_id))
+            rights_manager.release_ownership_of_exploration(
+                feconf.SYSTEM_COMMITTER_ID, unicode(exploration_id))
+        else:
+            raise Exception('Cannot reload an exploration in production.')
+
+    def _reload_collection(self, collection_id):
+        if feconf.DEV_MODE:
+            logging.info(
+                '[ADMIN] %s reloaded collection %s' %
+                (self.user_id, collection_id))
+            collection_services.load_demo(unicode(collection_id))
+            rights_manager.release_ownership_of_collection(
+                feconf.SYSTEM_COMMITTER_ID, unicode(collection_id))
+        else:
+            raise Exception('Cannot reload a collection in production.')
 
 
 class AdminJobOutput(base.BaseHandler):

--- a/core/templates/dev/head/pages/admin/Admin.js
+++ b/core/templates/dev/head/pages/admin/Admin.js
@@ -16,324 +16,36 @@
  * @fileoverview Data and controllers for the Oppia admin page.
  */
 
-oppia.constant('ADMIN_TAB_URLS', {
-  ACTIVITIES: '#activities',
-  JOBS: '#jobs',
-  CONFIG: '#config',
-  MISC: '#misc'
-});
+oppia.constant('ADMIN_HANDLER_URL', '/adminhandler');
+oppia.constant('PROFILE_URL_TEMPLATE', '/profile/<username>');
+oppia.constant(
+  'ADMIN_JOB_OUTPUT_URL_TEMPLATE', '/adminjoboutput?job_id=<jobId>');
+oppia.constant(
+  'ADMIN_TOPICS_CSV_DOWNLOAD_HANDLER_URL', '/admintopicscsvdownloadhandler');
 
 oppia.controller('Admin', [
-  '$scope', '$http', 'UrlInterpolationService', 'ADMIN_TAB_URLS',
-  function($scope, $http, UrlInterpolationService, ADMIN_TAB_URLS) {
-    var ADMIN_JOB_OUTPUT_URL_PREFIX = '/adminjoboutput';
-    var ADMIN_HANDLER_URL = '/adminhandler';
-    var ADMIN_TOPICS_CSV_DOWNLOAD_HANDLER_URL = (
-      '/admintopicscsvdownloadhandler');
+  '$scope', '$http', 'AdminRouterService',
+  function($scope, $http, AdminRouterService) {
+    $scope.username = GLOBALS.USERNAME;
+    $scope.userEmail = GLOBALS.USER_EMAIL;
+    $scope.profilePictureDataUrl = GLOBALS.PROFILE_PICTURE_DATA_URL;
+    $scope.isModerator = GLOBALS.IS_MODERATOR;
+    $scope.isSuperAdmin = GLOBALS.IS_SUPER_ADMIN;
+    $scope.logoutUrl = GLOBALS.LOGOUT_URL;
+    $scope.inDevMode = GLOBALS.DEV_MODE;
 
-    $scope.message = '';
-    $scope.configProperties = {};
+    $scope.statusMessage = '';
+    $scope.isActivitiesTabOpen = AdminRouterService.isActivitiesTabOpen;
+    $scope.isJobsTabOpen = AdminRouterService.isJobsTabOpen;
+    $scope.isConfigTabOpen = AdminRouterService.isConfigTabOpen;
+    $scope.isMiscTabOpen = AdminRouterService.isMiscTabOpen;
 
-    $scope.ADMIN_TAB_URLS = ADMIN_TAB_URLS;
-    $scope.currentTab = $scope.ADMIN_TAB_URLS.ACTIVITIES;
-    $scope.logoWhiteImgUrl = UrlInterpolationService.getStaticImageUrl(
-      '/logo/288x128_logo_white.png');
+    $scope.setStatusMessage = function(statusMessage) {
+      $scope.statusMessage = statusMessage;
+    };
 
     $scope.$watch(function() {
       return window.location.hash;
-    }, function(newHash) {
-      for (var url in $scope.ADMIN_TAB_URLS) {
-        if ($scope.ADMIN_TAB_URLS[url] === newHash) {
-          $scope.currentTab = newHash;
-          break;
-        }
-      }
-    });
-
-    $scope.showTab = function(hash) {
-      if (hash !== window.location.hash) {
-        $scope.currentTab = hash;
-      }
-    };
-
-    $scope.showJobOutput = false;
-    $scope.getJobOutput = function(jobId) {
-      var adminJobOutputUrl = ADMIN_JOB_OUTPUT_URL_PREFIX + '?job_id=' + jobId;
-      $http.get(adminJobOutputUrl).then(function(response) {
-        $scope.showJobOutput = true;
-        $scope.jobOutput = response.data.output;
-        window.scrollTo(0, document.body.scrollHeight);
-      });
-    };
-
-    $scope.profileDropdownIsActive = false;
-    $scope.onMouseoverProfilePictureOrDropdown = function(evt) {
-      angular.element(evt.currentTarget).parent().addClass('open');
-      $scope.profileDropdownIsActive = true;
-    };
-
-    $scope.onMouseoutProfilePictureOrDropdown = function(evt) {
-      angular.element(evt.currentTarget).parent().removeClass('open');
-      $scope.profileDropdownIsActive = false;
-    };
-
-    $scope.isNonemptyObject = function(object) {
-      var hasAtLeastOneElement = false;
-      for (var property in object) {
-        hasAtLeastOneElement = true;
-      }
-      return hasAtLeastOneElement;
-    };
-
-    $scope.reloadConfigProperties = function() {
-      $http.get(ADMIN_HANDLER_URL).then(function(response) {
-        $scope.configProperties = response.data.config_properties;
-      });
-    };
-
-    $scope.reloadConfigProperties();
-
-    $scope.revertToDefaultConfigPropertyValue = function(configPropertyId) {
-      if (!confirm('This action is irreversible. Are you sure?')) {
-        return;
-      }
-
-      $http.post(ADMIN_HANDLER_URL, {
-        action: 'revert_config_property',
-        config_property_id: configPropertyId
-      }).then(function() {
-        $scope.message = 'Config property reverted successfully.';
-        $scope.reloadConfigProperties();
-      }, function(errorResponse) {
-        $scope.message = 'Server error: ' + errorResponse.data.error;
-      });
-    };
-
-    $scope.migrationInProcess = false;
-    $scope.migrateFeedback = function() {
-      $scope.migrationInProcess = true;
-
-      $http.post(ADMIN_HANDLER_URL, {
-        action: 'migrate_feedback'
-      }).then(function() {
-        $scope.message = 'Feedback migrated successfully.';
-        $scope.migrationInProcess = false;
-        window.reload();
-      }, function(errorResponse) {
-        $scope.message = 'Server error: ' + errorResponse.data.error;
-        $scope.migrationInProcess = false;
-      });
-    };
-
-    $scope.saveConfigProperties = function() {
-      if ($scope.message === 'Saving...') {
-        return;
-      }
-
-      if (!confirm('This action is irreversible. Are you sure?')) {
-        return;
-      }
-
-      $scope.message = 'Saving...';
-
-      var newConfigPropertyValues = {};
-      for (var property in $scope.configProperties) {
-        newConfigPropertyValues[property] = (
-          $scope.configProperties[property].value);
-      }
-
-      $http.post(ADMIN_HANDLER_URL, {
-        action: 'save_config_properties',
-        new_config_property_values: newConfigPropertyValues
-      }).then(function() {
-        $scope.message = 'Data saved successfully.';
-      }, function(errorResponse) {
-        $scope.message = 'Server error: ' + errorResponse.data.error;
-      });
-    };
-
-    $scope.clearSearchIndex = function() {
-      if ($scope.message.indexOf('Processing...') === 0) {
-        return;
-      }
-
-      if (!confirm('This action is irreversible. Are you sure?')) {
-        return;
-      }
-
-      $scope.message = 'Processing...';
-
-      $http.post(ADMIN_HANDLER_URL, {
-        action: 'clear_search_index'
-      }).then(function() {
-        $scope.message = 'Index successfully cleared.';
-      }, function(errorResponse) {
-        $scope.message = 'Server error: ' + errorResponse.data.error;
-      });
-    };
-
-    $scope.reloadExploration = function(explorationId) {
-      if ($scope.message.indexOf('Processing...') === 0) {
-        return;
-      }
-
-      if (!confirm('This action is irreversible. Are you sure?')) {
-        return;
-      }
-
-      $scope.message = 'Processing...';
-
-      $http.post(ADMIN_HANDLER_URL, {
-        action: 'reload_exploration',
-        exploration_id: String(explorationId)
-      }).then(function() {
-        $scope.message = 'Data reloaded successfully.';
-      }, function(errorResponse) {
-        $scope.message = 'Server error: ' + errorResponse.data.error;
-      });
-    };
-
-    $scope.reloadAllExplorations = function() {
-      if ($scope.message.indexOf('Processing...') === 0) {
-        return;
-      }
-
-      if (!confirm('This action is irreversible. Are you sure?')) {
-        return;
-      }
-
-      var numSucceeded = 0;
-      var numFailed = 0;
-      var numTried = 0;
-      $scope.message = 'Processing...';
-      var printResult = function() {
-        if (numTried < GLOBALS.DEMO_EXPLORATION_IDS.length) {
-          $scope.message = (
-            'Processing...' + numTried + '/' +
-            GLOBALS.DEMO_EXPLORATION_IDS.length);
-          return;
-        }
-        $scope.message = (
-          'Reloaded ' + GLOBALS.DEMO_EXPLORATION_IDS.length +
-          ' explorations: ' + numSucceeded + ' succeeded, ' + numFailed +
-          ' failed.');
-      };
-
-      for (var i = 0; i < GLOBALS.DEMO_EXPLORATION_IDS.length; ++i) {
-        var explorationId = GLOBALS.DEMO_EXPLORATION_IDS[i];
-
-        $http.post(ADMIN_HANDLER_URL, {
-          action: 'reload_exploration',
-          exploration_id: explorationId
-        }).then(function() {
-          ++numSucceeded;
-          ++numTried;
-          printResult();
-        }, function() {
-          ++numFailed;
-          ++numTried;
-          printResult();
-        });
-      }
-    };
-
-    $scope.reloadCollection = function(collectionId) {
-      if ($scope.message.indexOf('Processing...') === 0) {
-        return;
-      }
-
-      if (!confirm('This action is irreversible. Are you sure?')) {
-        return;
-      }
-
-      $scope.message = 'Processing...';
-
-      $http.post(ADMIN_HANDLER_URL, {
-        action: 'reload_collection',
-        collection_id: String(collectionId)
-      }).then(function() {
-        $scope.message = 'Data reloaded successfully.';
-      }, function(errorResponse) {
-        $scope.message = 'Server error: ' + errorResponse.data.error;
-      });
-    };
-
-    $scope.startNewJob = function(jobType) {
-      $scope.message = 'Starting new job...';
-
-      $http.post(ADMIN_HANDLER_URL, {
-        action: 'start_new_job',
-        job_type: jobType
-      }).then(function() {
-        $scope.message = 'Job started successfully.';
-        window.location.reload();
-      }, function(errorResponse) {
-        $scope.message = 'Server error: ' + errorResponse.data.error;
-      });
-    };
-
-    $scope.cancelJob = function(jobId, jobType) {
-      $scope.message = 'Cancelling job...';
-
-      $http.post(ADMIN_HANDLER_URL, {
-        action: 'cancel_job',
-        job_id: jobId,
-        job_type: jobType
-      }).then(function() {
-        $scope.message = 'Abort signal sent to job.';
-        window.location.reload();
-      }, function(errorResponse) {
-        $scope.message = 'Server error: ' + errorResponse.data.error;
-      });
-    };
-
-    $scope.startComputation = function(computationType) {
-      $scope.message = 'Starting computation...';
-
-      $http.post(ADMIN_HANDLER_URL, {
-        action: 'start_computation',
-        computation_type: computationType
-      }).then(function() {
-        $scope.message = 'Computation started successfully.';
-        window.location.reload();
-      }, function(errorResponse) {
-        $scope.message = 'Server error: ' + errorResponse.data.error;
-      });
-    };
-
-    $scope.stopComputation = function(computationType) {
-      $scope.message = 'Stopping computation...';
-
-      $http.post(ADMIN_HANDLER_URL, {
-        action: 'stop_computation',
-        computation_type: computationType
-      }).then(function() {
-        $scope.message = 'Abort signal sent to computation.';
-        window.location.reload();
-      }, function(errorResponse) {
-        $scope.message = 'Server error: ' + errorResponse.data.error;
-      });
-    };
-
-    $scope.uploadTopicSimilaritiesFile = function() {
-      var file = document.getElementById('topicSimilaritiesFile').files[0];
-      var reader = new FileReader();
-      reader.onload = function(e) {
-        var data = e.target.result;
-        $http.post(ADMIN_HANDLER_URL, {
-          action: 'upload_topic_similarities',
-          data: data
-        }).then(function() {
-          $scope.message = 'Topic similarities uploaded successfully.';
-        }, function(errorResponse) {
-          $scope.message = 'Server error: ' + errorResponse.data.error;
-        });
-      };
-      reader.readAsText(file);
-    };
-
-    $scope.downloadTopicSimilaritiesFile = function() {
-      window.location.href = ADMIN_TOPICS_CSV_DOWNLOAD_HANDLER_URL;
-    };
+    }, AdminRouterService.showTab);
   }
 ]);

--- a/core/templates/dev/head/pages/admin/Admin.js
+++ b/core/templates/dev/head/pages/admin/Admin.js
@@ -24,8 +24,8 @@ oppia.constant(
   'ADMIN_TOPICS_CSV_DOWNLOAD_HANDLER_URL', '/admintopicscsvdownloadhandler');
 
 oppia.controller('Admin', [
-  '$scope', '$http', 'AdminRouterService',
-  function($scope, $http, AdminRouterService) {
+  '$scope', '$http', '$window', 'AdminRouterService',
+  function($scope, $http, $window, AdminRouterService) {
     $scope.username = GLOBALS.USERNAME;
     $scope.userEmail = GLOBALS.USER_EMAIL;
     $scope.profilePictureDataUrl = GLOBALS.PROFILE_PICTURE_DATA_URL;
@@ -45,7 +45,7 @@ oppia.controller('Admin', [
     };
 
     $scope.$watch(function() {
-      return window.location.hash;
+      return $window.location.hash;
     }, AdminRouterService.showTab);
   }
 ]);

--- a/core/templates/dev/head/pages/admin/AdminNavbarDirective.js
+++ b/core/templates/dev/head/pages/admin/AdminNavbarDirective.js
@@ -35,7 +35,6 @@ oppia.directive('adminNavbar', [
       templateUrl: 'pages/admin/navbar',
       controller: ['$scope', function($scope) {
         $scope.ADMIN_TAB_URLS = ADMIN_TAB_URLS;
-        $scope.getCurrentTab = AdminRouterService.getCurrentTab;
         $scope.showTab = AdminRouterService.showTab;
 
         $scope.logoWhiteImgUrl = UrlInterpolationService.getStaticImageUrl(

--- a/core/templates/dev/head/pages/admin/AdminNavbarDirective.js
+++ b/core/templates/dev/head/pages/admin/AdminNavbarDirective.js
@@ -32,7 +32,7 @@ oppia.directive('adminNavbar', [
         isSuperAdmin: '&isSuperAdmin',
         getLogoutUrl: '&logoutUrl'
       },
-      templateUrl: 'pages/admin/navbar',
+      templateUrl: 'admin/navbar',
       controller: ['$scope', function($scope) {
         $scope.ADMIN_TAB_URLS = ADMIN_TAB_URLS;
         $scope.showTab = AdminRouterService.showTab;

--- a/core/templates/dev/head/pages/admin/AdminNavbarDirective.js
+++ b/core/templates/dev/head/pages/admin/AdminNavbarDirective.js
@@ -1,0 +1,63 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Directive for the navigation bar in the admin panel.
+ */
+
+oppia.directive('adminNavbar', [
+  'AdminRouterService', 'UrlInterpolationService', 'ADMIN_TAB_URLS',
+  'PROFILE_URL_TEMPLATE',
+  function(
+      AdminRouterService, UrlInterpolationService, ADMIN_TAB_URLS,
+      PROFILE_URL_TEMPLATE) {
+    return {
+      restrict: 'E',
+      scope: {
+        getUsername: '&username',
+        getUserEmail: '&userEmail',
+        getProfilePictureDataUrl: '&profilePictureDataUrl',
+        isModerator: '&isModerator',
+        isSuperAdmin: '&isSuperAdmin',
+        getLogoutUrl: '&logoutUrl'
+      },
+      templateUrl: 'pages/admin/navbar',
+      controller: ['$scope', function($scope) {
+        $scope.ADMIN_TAB_URLS = ADMIN_TAB_URLS;
+        $scope.getCurrentTab = AdminRouterService.getCurrentTab;
+        $scope.showTab = AdminRouterService.showTab;
+
+        $scope.logoWhiteImgUrl = UrlInterpolationService.getStaticImageUrl(
+          '/logo/288x128_logo_white.png');
+
+        $scope.profileDropdownIsActive = false;
+        $scope.onMouseoverProfilePictureOrDropdown = function(evt) {
+          angular.element(evt.currentTarget).parent().addClass('open');
+          $scope.profileDropdownIsActive = true;
+        };
+
+        $scope.onMouseoutProfilePictureOrDropdown = function(evt) {
+          angular.element(evt.currentTarget).parent().removeClass('open');
+          $scope.profileDropdownIsActive = false;
+        };
+
+        $scope.getProfileUrl = function() {
+          return UrlInterpolationService.interpolateUrl(PROFILE_URL_TEMPLATE, {
+            username: $scope.getUsername()
+          });
+        };
+      }]
+    };
+  }
+]);

--- a/core/templates/dev/head/pages/admin/AdminRouterService.js
+++ b/core/templates/dev/head/pages/admin/AdminRouterService.js
@@ -1,0 +1,90 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Service to maintain the routing state of the admin page,
+ * provide routing functionality, and store all available tab states.
+ */
+
+oppia.constant('ADMIN_TAB_URLS', {
+  ACTIVITIES: '#activities',
+  JOBS: '#jobs',
+  CONFIG: '#config',
+  MISC: '#misc'
+});
+
+oppia.factory('AdminRouterService', [
+  'ADMIN_TAB_URLS',
+  function(ADMIN_TAB_URLS) {
+    var currentTabHash = ADMIN_TAB_URLS.ACTIVITIES;
+
+    var _showTab = function(tabHash) {
+      currentTabHash = tabHash;
+    };
+    var getTabNameByHash = function(tabHash) {
+      for (var tabName in ADMIN_TAB_URLS) {
+        if (ADMIN_TAB_URLS[tabName] === tabHash) {
+          return tabName;
+        }
+      }
+      return null;
+    };
+
+    return {
+      /**
+       * Navigates the page to the specified tab based on its HTML hash.
+       */
+      showTab: function(tabHash) {
+        if (getTabNameByHash(tabHash)) {
+          _showTab(tabHash);
+        }
+      },
+
+      /**
+       * Returns the current tab
+       */
+      getCurrentTab: function() {
+        return getTabNameByHash(currentTabHash);
+      },
+
+      /**
+       * Returns whether the activities tab is open.
+       */
+      isActivitiesTabOpen: function() {
+        return currentTabHash === ADMIN_TAB_URLS.ACTIVITIES;
+      },
+
+      /**
+       * Returns whether the jobs tab is open.
+       */
+      isJobsTabOpen: function() {
+        return currentTabHash === ADMIN_TAB_URLS.JOBS;
+      },
+
+      /**
+       * Returns whether the config tab is open.
+       */
+      isConfigTabOpen: function() {
+        return currentTabHash === ADMIN_TAB_URLS.CONFIG;
+      },
+
+      /**
+       * Returns whether the miscellaneous tab is open.
+       */
+      isMiscTabOpen: function() {
+        return currentTabHash === ADMIN_TAB_URLS.MISC;
+      }
+    };
+  }
+]);

--- a/core/templates/dev/head/pages/admin/AdminRouterService.js
+++ b/core/templates/dev/head/pages/admin/AdminRouterService.js
@@ -29,9 +29,6 @@ oppia.factory('AdminRouterService', [
   function(ADMIN_TAB_URLS) {
     var currentTabHash = ADMIN_TAB_URLS.ACTIVITIES;
 
-    var _showTab = function(tabHash) {
-      currentTabHash = tabHash;
-    };
     var getTabNameByHash = function(tabHash) {
       for (var tabName in ADMIN_TAB_URLS) {
         if (ADMIN_TAB_URLS[tabName] === tabHash) {
@@ -47,15 +44,8 @@ oppia.factory('AdminRouterService', [
        */
       showTab: function(tabHash) {
         if (getTabNameByHash(tabHash)) {
-          _showTab(tabHash);
+          currentTabHash = tabHash;
         }
-      },
-
-      /**
-       * Returns the current tab
-       */
-      getCurrentTab: function() {
-        return getTabNameByHash(currentTabHash);
       },
 
       /**

--- a/core/templates/dev/head/pages/admin/AdminRouterServiceSpec.js
+++ b/core/templates/dev/head/pages/admin/AdminRouterServiceSpec.js
@@ -1,0 +1,95 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Tests for AdminRouterService.
+ */
+
+describe('Admin router service', function() {
+  var AdminRouterService = null;
+
+  beforeEach(module('oppia'));
+
+  beforeEach(inject(function($injector) {
+    AdminRouterService = $injector.get('AdminRouterService');
+  }));
+
+  it('should initially be routed to the activities tab', function() {
+    expect(AdminRouterService.isActivitiesTabOpen()).toBe(true);
+    expect(AdminRouterService.isConfigTabOpen()).toBe(false);
+    expect(AdminRouterService.isJobsTabOpen()).toBe(false);
+    expect(AdminRouterService.isMiscTabOpen()).toBe(false);
+  });
+
+  it('should be able to navigate to the activities tab', function() {
+    // Navigate away from the activities tab (relying on other tests to verify
+    // this works correctly) in order to navigate back.
+    AdminRouterService.showTab('#jobs');
+
+    expect(AdminRouterService.isActivitiesTabOpen()).toBe(false);
+    AdminRouterService.showTab('#activities');
+    expect(AdminRouterService.isActivitiesTabOpen()).toBe(true);
+    expect(AdminRouterService.isConfigTabOpen()).toBe(false);
+    expect(AdminRouterService.isJobsTabOpen()).toBe(false);
+    expect(AdminRouterService.isMiscTabOpen()).toBe(false);
+  });
+
+  it('should be able to navigate to the config tab', function() {
+    expect(AdminRouterService.isConfigTabOpen()).toBe(false);
+    AdminRouterService.showTab('#config');
+    expect(AdminRouterService.isActivitiesTabOpen()).toBe(false);
+    expect(AdminRouterService.isConfigTabOpen()).toBe(true);
+    expect(AdminRouterService.isJobsTabOpen()).toBe(false);
+    expect(AdminRouterService.isMiscTabOpen()).toBe(false);
+  });
+
+  it('should be able to navigate to the jobs tab', function() {
+    expect(AdminRouterService.isJobsTabOpen()).toBe(false);
+    AdminRouterService.showTab('#jobs');
+    expect(AdminRouterService.isActivitiesTabOpen()).toBe(false);
+    expect(AdminRouterService.isConfigTabOpen()).toBe(false);
+    expect(AdminRouterService.isJobsTabOpen()).toBe(true);
+    expect(AdminRouterService.isMiscTabOpen()).toBe(false);
+  });
+
+  it('should be able to navigate to the misc tab', function() {
+    expect(AdminRouterService.isMiscTabOpen()).toBe(false);
+    AdminRouterService.showTab('#misc');
+    expect(AdminRouterService.isActivitiesTabOpen()).toBe(false);
+    expect(AdminRouterService.isConfigTabOpen()).toBe(false);
+    expect(AdminRouterService.isJobsTabOpen()).toBe(false);
+    expect(AdminRouterService.isMiscTabOpen()).toBe(true);
+  });
+
+  it('should be able to navigate to the same tab twice', function() {
+    expect(AdminRouterService.isJobsTabOpen()).toBe(false);
+
+    AdminRouterService.showTab('#jobs');
+    expect(AdminRouterService.isJobsTabOpen()).toBe(true);
+
+    AdminRouterService.showTab('#jobs');
+    expect(AdminRouterService.isActivitiesTabOpen()).toBe(false);
+    expect(AdminRouterService.isConfigTabOpen()).toBe(false);
+    expect(AdminRouterService.isJobsTabOpen()).toBe(true);
+    expect(AdminRouterService.isMiscTabOpen()).toBe(false);
+  });
+
+  it('should stay on the current tab if an invalid tab is shown', function() {
+    AdminRouterService.showTab('#jobs');
+
+    expect(AdminRouterService.isJobsTabOpen()).toBe(true);
+    AdminRouterService.showTab('#unknown');
+    expect(AdminRouterService.isJobsTabOpen()).toBe(true);
+  });
+});

--- a/core/templates/dev/head/pages/admin/AdminTaskManagerService.js
+++ b/core/templates/dev/head/pages/admin/AdminTaskManagerService.js
@@ -1,0 +1,47 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Service to query and start new tasks synchronously in the admin
+ * page.
+ */
+
+oppia.factory('AdminTaskManagerService', [
+  function() {
+    var taskIsRunning = false;
+
+    return {
+      /**
+       * Notifies the manager a new task is starting.
+       */
+      startTask: function() {
+        taskIsRunning = true;
+      },
+
+      /**
+       * Returns whether a task is currently running.
+       */
+      isTaskRunning: function() {
+        return taskIsRunning;
+      },
+
+      /**
+       * Notifies the manager a task has completed.
+       */
+      finishTask: function() {
+        taskIsRunning = false;
+      }
+    };
+  }
+]);

--- a/core/templates/dev/head/pages/admin/AdminTaskManagerServiceSpec.js
+++ b/core/templates/dev/head/pages/admin/AdminTaskManagerServiceSpec.js
@@ -1,0 +1,60 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Tests for AdminTaskManagerService.
+ */
+
+describe('Admin task manager service', function() {
+  var AdminTaskManagerService = null;
+
+  beforeEach(module('oppia'));
+
+  beforeEach(inject(function($injector) {
+    AdminTaskManagerService = $injector.get('AdminTaskManagerService');
+  }));
+
+  it('should initially have no tasks running', function() {
+    expect(AdminTaskManagerService.isTaskRunning()).toBe(false);
+  });
+
+  it('should be able to start a task and record it as running', function() {
+    expect(AdminTaskManagerService.isTaskRunning()).toBe(false);
+    AdminTaskManagerService.startTask();
+    expect(AdminTaskManagerService.isTaskRunning()).toBe(true);
+  });
+
+  it('should not change running state when stopping no tasks', function() {
+    expect(AdminTaskManagerService.isTaskRunning()).toBe(false);
+    AdminTaskManagerService.finishTask();
+    expect(AdminTaskManagerService.isTaskRunning()).toBe(false);
+  });
+
+  it('should be able to stop a running task', function() {
+    AdminTaskManagerService.startTask();
+
+    expect(AdminTaskManagerService.isTaskRunning()).toBe(true);
+    AdminTaskManagerService.finishTask();
+    expect(AdminTaskManagerService.isTaskRunning()).toBe(false);
+  });
+
+  it('should be able to start a task twice and stop it once', function() {
+    AdminTaskManagerService.startTask();
+    AdminTaskManagerService.startTask();
+    expect(AdminTaskManagerService.isTaskRunning()).toBe(true);
+
+    AdminTaskManagerService.finishTask();
+    expect(AdminTaskManagerService.isTaskRunning()).toBe(false);
+  });
+});

--- a/core/templates/dev/head/pages/admin/activities_tab/AdminDevModeActivitiesTabDirective.js
+++ b/core/templates/dev/head/pages/admin/activities_tab/AdminDevModeActivitiesTabDirective.js
@@ -1,0 +1,125 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Directive for the activities tab in the admin panel when Oppia
+ * is in developer mode.
+ */
+
+oppia.directive('adminDevModeActivitiesTab', [
+  '$http', 'AdminTaskManagerService', 'ADMIN_HANDLER_URL',
+  function($http, AdminTaskManagerService, ADMIN_HANDLER_URL) {
+    return {
+      restrict: 'E',
+      scope: {
+        setStatusMessage: '='
+      },
+      templateUrl: 'pages/admin/dev_mode_activities_tab_directive',
+      controller: ['$scope', function($scope) {
+        $scope.reloadExploration = function(explorationId) {
+          if (AdminTaskManagerService.isTaskRunning()) {
+            return;
+          }
+          if (!confirm('This action is irreversible. Are you sure?')) {
+            return;
+          }
+
+          $scope.setStatusMessage('Processing...');
+
+          AdminTaskManagerService.startTask();
+          $http.post(ADMIN_HANDLER_URL, {
+            action: 'reload_exploration',
+            exploration_id: String(explorationId)
+          }).then(function() {
+            $scope.setStatusMessage('Data reloaded successfully.');
+            AdminTaskManagerService.finishTask();
+          }, function(errorResponse) {
+            $scope.setStatusMessage(
+              'Server error: ' + errorResponse.data.error);
+            AdminTaskManagerService.finishTask();
+          });
+        };
+
+        $scope.reloadAllExplorations = function() {
+          if (AdminTaskManagerService.isTaskRunning()) {
+            return;
+          }
+          if (!confirm('This action is irreversible. Are you sure?')) {
+            return;
+          }
+
+          $scope.setStatusMessage('Processing...');
+          AdminTaskManagerService.startTask();
+
+          var numSucceeded = 0;
+          var numFailed = 0;
+          var numTried = 0;
+          var printResult = function() {
+            if (numTried < GLOBALS.DEMO_EXPLORATION_IDS.length) {
+              $scope.setStatusMessage(
+                'Processing...' + numTried + '/' +
+                GLOBALS.DEMO_EXPLORATION_IDS.length);
+              return;
+            }
+            $scope.setStatusMessage(
+              'Reloaded ' + GLOBALS.DEMO_EXPLORATION_IDS.length +
+              ' explorations: ' + numSucceeded + ' succeeded, ' + numFailed +
+              ' failed.');
+            AdminTaskManagerService.finishTask();
+          };
+
+          for (var i = 0; i < GLOBALS.DEMO_EXPLORATION_IDS.length; ++i) {
+            var explorationId = GLOBALS.DEMO_EXPLORATION_IDS[i];
+
+            $http.post(ADMIN_HANDLER_URL, {
+              action: 'reload_exploration',
+              exploration_id: explorationId
+            }).then(function() {
+              ++numSucceeded;
+              ++numTried;
+              printResult();
+            }, function() {
+              ++numFailed;
+              ++numTried;
+              printResult();
+            });
+          }
+        };
+
+        $scope.reloadCollection = function(collectionId) {
+          if (AdminTaskManagerService.isTaskRunning()) {
+            return;
+          }
+          if (!confirm('This action is irreversible. Are you sure?')) {
+            return;
+          }
+
+          $scope.setStatusMessage('Processing...');
+
+          AdminTaskManagerService.startTask();
+          $http.post(ADMIN_HANDLER_URL, {
+            action: 'reload_collection',
+            collection_id: String(collectionId)
+          }).then(function() {
+            $scope.setStatusMessage('Data reloaded successfully.');
+          }, function(errorResponse) {
+            $scope.setStatusMessage(
+              'Server error: ' + errorResponse.data.error);
+          });
+          AdminTaskManagerService.finishTask();
+        };
+      }]
+    };
+  }
+]);

--- a/core/templates/dev/head/pages/admin/activities_tab/AdminDevModeActivitiesTabDirective.js
+++ b/core/templates/dev/head/pages/admin/activities_tab/AdminDevModeActivitiesTabDirective.js
@@ -25,7 +25,7 @@ oppia.directive('adminDevModeActivitiesTab', [
       scope: {
         setStatusMessage: '='
       },
-      templateUrl: 'pages/admin/dev_mode_activities_tab_directive',
+      templateUrl: 'admin/activitiesTabDevMode',
       controller: ['$scope', function($scope) {
         $scope.reloadExploration = function(explorationId) {
           if (AdminTaskManagerService.isTaskRunning()) {
@@ -50,6 +50,9 @@ oppia.directive('adminDevModeActivitiesTab', [
             AdminTaskManagerService.finishTask();
           });
         };
+
+        $scope.DEMO_EXPLORATIONS = GLOBALS.DEMO_EXPLORATIONS;
+        $scope.DEMO_COLLECTIONS = GLOBALS.DEMO_COLLECTIONS;
 
         $scope.reloadAllExplorations = function() {
           if (AdminTaskManagerService.isTaskRunning()) {

--- a/core/templates/dev/head/pages/admin/activities_tab/AdminProdModeActivitiesTabDirective.js
+++ b/core/templates/dev/head/pages/admin/activities_tab/AdminProdModeActivitiesTabDirective.js
@@ -21,7 +21,7 @@ oppia.directive('adminProdModeActivitiesTab', [
   function() {
     return {
       restrict: 'E',
-      templateUrl: 'pages/admin/prod_mode_activities_tab_directive'
+      templateUrl: 'admin/activitiesTabProdMode'
     };
   }
 ]);

--- a/core/templates/dev/head/pages/admin/activities_tab/AdminProdModeActivitiesTabDirective.js
+++ b/core/templates/dev/head/pages/admin/activities_tab/AdminProdModeActivitiesTabDirective.js
@@ -1,0 +1,27 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Directive for the activities tab in the admin panel when Oppia
+ * is in production mode.
+ */
+
+oppia.directive('adminProdModeActivitiesTab', [
+  function() {
+    return {
+      restrict: 'E',
+      templateUrl: 'pages/admin/prod_mode_activities_tab_directive'
+    };
+  }
+]);

--- a/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
@@ -1,21 +1,20 @@
-<script type="text/ng-template" id="pages/admin/dev_mode_activities_tab_directive">
+<script type="text/ng-template" id="admin/activitiesTabDevMode">
   <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
     <div class="container" style="margin-left: 0;">
       <h3>Reload a single exploration</h3>
-      {% for exploration in demo_explorations %}
-        <div class="row protractor-test-reload-exploration-row">
-          <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-exploration-title">
-            {{exploration[1]}}
-          </span>
-          <span class="col-lg-2 col-md-2 col-sm-2">
-            <button type="button"
-                    class="btn btn-default protractor-test-reload-exploration-button pull-right"
-                    ng-click="reloadExploration({{exploration[0]}})">
-            Reload
-            </button>
-          </span>
-        </div>
-      {% endfor %}
+      <div ng-repeat="exploration in DEMO_EXPLORATIONS"
+           class="row protractor-test-reload-exploration-row">
+        <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-exploration-title">
+          <[exploration[1]]>
+        </span>
+        <span class="col-lg-2 col-md-2 col-sm-2">
+          <button type="button"
+                  class="btn btn-default protractor-test-reload-exploration-button pull-right"
+                  ng-click="reloadExploration(exploration[0])">
+          Reload
+          </button>
+        </span>
+      </div>
       <button type="button"
               class="btn btn-default protractor-test-reload-all-explorations-button"
               ng-click="reloadAllExplorations()">
@@ -27,20 +26,19 @@
   <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
     <div class="container" style="margin-left: 0;">
       <h3>Reload a single collection</h3>
-      {% for collection in demo_collections %}
-        <div class="row protractor-test-reload-collection-row">
-          <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-collection-title">
-            {{collection[1]}}
-          </span>
-          <span class="col-lg-2 col-md-2 col-sm-2">
-            <button type="button"
-                    class="btn btn-default protractor-test-reload-collection-button pull-right"
-                    ng-click="reloadCollection({{collection[0]}})">
-              Reload
-            </button>
-          </span>
-        </div>
-      {% endfor %}
+      <div ng-repeat="collection in DEMO_COLLECTIONS"
+           class="row protractor-test-reload-collection-row">
+        <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-collection-title">
+          <[collection[1]]>
+        </span>
+        <span class="col-lg-2 col-md-2 col-sm-2">
+          <button type="button"
+                  class="btn btn-default protractor-test-reload-collection-button pull-right"
+                  ng-click="reloadCollection(collection[0])">
+            Reload
+          </button>
+        </span>
+      </div>
     </div>
   </md-card>
 </script>

--- a/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
@@ -1,0 +1,46 @@
+<script type="text/ng-template" id="pages/admin/dev_mode_activities_tab_directive">
+  <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
+    <div class="container" style="margin-left: 0;">
+      <h3>Reload a single exploration</h3>
+      {% for exploration in demo_explorations %}
+        <div class="row protractor-test-reload-exploration-row">
+          <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-exploration-title">
+            {{exploration[1]}}
+          </span>
+          <span class="col-lg-2 col-md-2 col-sm-2">
+            <button type="button"
+                    class="btn btn-default protractor-test-reload-exploration-button pull-right"
+                    ng-click="reloadExploration({{exploration[0]}})">
+            Reload
+            </button>
+          </span>
+        </div>
+      {% endfor %}
+      <button type="button"
+              class="btn btn-default protractor-test-reload-all-explorations-button"
+              ng-click="reloadAllExplorations()">
+        Reload All Explorations
+      </button>
+    </div>
+  </md-card>
+
+  <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
+    <div class="container" style="margin-left: 0;">
+      <h3>Reload a single collection</h3>
+      {% for collection in demo_collections %}
+        <div class="row protractor-test-reload-collection-row">
+          <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-collection-title">
+            {{collection[1]}}
+          </span>
+          <span class="col-lg-2 col-md-2 col-sm-2">
+            <button type="button"
+                    class="btn btn-default protractor-test-reload-collection-button pull-right"
+                    ng-click="reloadCollection({{collection[0]}})">
+              Reload
+            </button>
+          </span>
+        </div>
+      {% endfor %}
+    </div>
+  </md-card>
+</script>

--- a/core/templates/dev/head/pages/admin/activities_tab/admin_prod_mode_activities_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/activities_tab/admin_prod_mode_activities_tab_directive.html
@@ -1,4 +1,4 @@
-<script type="text/ng-template" id="pages/admin/prod_mode_activities_tab_directive">
+<script type="text/ng-template" id="admin/activitiesTabProdMode">
   <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
     The 'Activities' tab is not available in the production environment.
   </md-card>

--- a/core/templates/dev/head/pages/admin/activities_tab/admin_prod_mode_activities_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/activities_tab/admin_prod_mode_activities_tab_directive.html
@@ -1,0 +1,5 @@
+<script type="text/ng-template" id="pages/admin/prod_mode_activities_tab_directive">
+  <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
+    The 'Activities' tab is not available in the production environment.
+  </md-card>
+</script>

--- a/core/templates/dev/head/pages/admin/admin.html
+++ b/core/templates/dev/head/pages/admin/admin.html
@@ -15,7 +15,16 @@
         IS_SUPER_ADMIN: JSON.parse('{{is_super_admin|js_string}}'),
         LOGOUT_URL: JSON.parse('{{logout_url|js_string}}'),
         ASSET_DIR_PREFIX: JSON.parse('{{ASSET_DIR_PREFIX|js_string}}'),
+        DEMO_EXPLORATIONS: JSON.parse('{{demo_explorations|js_string}}'),
         DEMO_EXPLORATION_IDS: JSON.parse('{{demo_exploration_ids|js_string}}'),
+        DEMO_COLLECTIONS: JSON.parse('{{demo_collections|js_string}}'),
+        HUMAN_READABLE_CURRENT_TIME: JSON.parse(
+          '{{human_readable_current_time|js_string}}'),
+        CONTINUOUS_COMPUTATIONS_DATA: JSON.parse(
+          '{{continuous_computations_data|js_string}}'),
+        ONE_OFF_JOB_SPECS: JSON.parse('{{one_off_job_specs|js_string}}'),
+        UNFINISHED_JOB_DATA: JSON.parse('{{unfinished_job_data|js_string}}'),
+        RECENT_JOB_DATA: JSON.parse('{{recent_job_data|js_string}}'),
         DEV_MODE: JSON.parse('{{DEV_MODE|js_string}}')
       }
     </script>
@@ -42,7 +51,7 @@
 
     <div style="padding-top: 16px;">
       <admin-dev-mode-activities-tab ng-if="isActivitiesTabOpen() && inDevMode"
-                            set-status-message="setStatusMessage">
+                                     set-status-message="setStatusMessage">
       </admin-dev-mode-activities-tab>
       <admin-prod-mode-activities-tab ng-if="isActivitiesTabOpen() && !inDevMode">
       </admin-prod-mode-activities-tab>
@@ -60,11 +69,9 @@
       </admin-misc-tab>
     </div>
 
-    {% if DEV_MODE %}
-      <div class="oppia-dev-mode">
-        Dev Mode
-      </div>
-    {% endif %}
+    <div ng-if="inDevMode" class="oppia-dev-mode">
+      Dev Mode
+    </div>
 
     {% include 'components/forms/form_builder_templates.html' %}
     {% include 'pages/footer_js_libs.html' %}

--- a/core/templates/dev/head/pages/admin/admin.html
+++ b/core/templates/dev/head/pages/admin/admin.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="oppia">
+<html ng-app="oppia" ng-controller="Admin">
   <head>
     <title>Oppia Admin Panel</title>
 
@@ -8,8 +8,15 @@
     <script>
       var GLOBALS = {
         csrf_token: JSON.parse('{{csrf_token|js_string}}'),
+        USERNAME: JSON.parse('{{username|js_string}}'),
+        USER_EMAIL: JSON.parse('{{user_email|js_string}}'),
+        PROFILE_PICTURE_DATA_URL: JSON.parse('{{profile_picture_data_url|js_string}}'),
+        IS_MODERATOR: JSON.parse('{{is_moderator|js_string}}'),
+        IS_SUPER_ADMIN: JSON.parse('{{is_super_admin|js_string}}'),
+        LOGOUT_URL: JSON.parse('{{logout_url|js_string}}'),
         ASSET_DIR_PREFIX: JSON.parse('{{ASSET_DIR_PREFIX|js_string}}'),
-        DEMO_EXPLORATION_IDS: JSON.parse('{{demo_exploration_ids|js_string}}')
+        DEMO_EXPLORATION_IDS: JSON.parse('{{demo_exploration_ids|js_string}}'),
+        DEV_MODE: JSON.parse('{{DEV_MODE|js_string}}')
       }
     </script>
     <style>
@@ -19,406 +26,38 @@
     </style>
   </head>
 
-  <body ng-controller="Admin" ng-cloak>
-    <nav class="navbar navbar-default oppia-navbar oppia-prevent-selection" role="navigation">
-      <div class="navbar-container" style="background-color: #00376d">
-        <div class="navbar-header protractor-test-navbar-header pull-left">
-          <a class="oppia-navbar-brand-name oppia-transition-200" href="/library">
-            <img ng-src="<[logoWhiteImgUrl]>" class="oppia-logo" ng-class="'oppia-logo-wide'">
-          </a>
-          <ul class="nav navbar-nav oppia-navbar-breadcrumb">
-            <li>
-              <span class="oppia-navbar-breadcrumb-separator"></span>
-              Admin
-            </li>
-          </ul>
-        </div>
-
-        <div ng-cloak class="navbar-header pull-right">
-          <ul class="nav oppia-navbar-nav oppia-navbar-profile-admin">
-            <li class="dropdown pull-right">
-              <a class="dropdown-toggle oppia-navbar-dropdown-toggle"
-                 data-toggle="dropdown"
-                 ng-mouseover="onMouseoverProfilePictureOrDropdown($event)"
-                 ng-mouseleave="onMouseoutProfilePictureOrDropdown($event)">
-                <div class="oppia-navbar-profile-picture-container" ng-cloak>
-                  {% if profile_picture_data_url %}
-                    <img src="{{profile_picture_data_url}}" class="oppia-navbar-profile-picture img-circle">
-                    <span class="caret" style="margin-top: 10px;"></span>
-                  {% else %}
-                    <i class="material-icons md-40" style="margin-top: -1px;">&#xE853;</i>
-                    <span class="caret" style="margin-top: -26px;"></span>
-                  {% endif %}
-
-                  <div class="oppia-navbar-dashboard-indicator ng-cloak" ng-if="numUnseenNotifications > 0">
-                    <span class="oppia-navbar-dashboard-indicator-text">
-                      <[numUnseenNotifications]>
-                    </span>
-                  </div>
-
-                  <div style="display: none;" class="oppia-user-email">
-                    {{user_email}}
-                  </div>
-                </div>
-              </a>
-              <ul class="dropdown-menu ng-cloak oppia-navbar-dropdown"
-                  role="menu"
-                  ng-mouseover="onMouseoverProfilePictureOrDropdown($event)"
-                  ng-mouseleave="onMouseoutProfilePictureOrDropdown($event)"
-                  ng-show="profileDropdownIsActive">
-                <li>
-                  <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
-                     href="/profile/{{username}}"
-                     style="color: #00376d">
-                    <strong>{{username}}</strong>
-                  </a>
-                </li>
-                <hr class="oppia-top-right-menu-item-separator">
-                <li>
-                  <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
-                     href="/dashboard"
-                     style="color: #00376d">
-                    Creator Dashboard
-                  </a>
-                </li>
-                <li>
-                  <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
-                     href="/notifications_dashboard"
-                     style="color: #00376d">
-                    Notifications
-                    <span ng-if="numUnseenNotifications > 0">
-                      (<[numUnseenNotifications]>)
-                    </span>
-                  </a>
-                </li>
-                <li>
-                  <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
-                     href="/preferences"
-                     style="color: #00376d">Preferences</a>
-                </li>
-
-                {% if is_moderator %}
-                  <li>
-                    <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
-                       href="/moderator"
-                       target="_blank"
-                       style="color: #00376d">
-                      Moderator Page
-                    </a>
-                  </li>
-                {% endif %}
-                {% if is_super_admin %}
-                  <li>
-                    <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
-                       href="/admin"
-                       target="_blank"
-                       style="color: #00376d">
-                      Admin Page
-                    </a>
-                  </li>
-                {% endif %}
-                <hr class="oppia-top-right-menu-item-separator">
-                <li>
-                  <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
-                     href="{{logout_url}}"
-                     style="color: #00376d">Logout</a>
-                </li>
-              </ul>
-            </li>
-
-            <ul class="nav oppia-navbar-tabs oppia-navbar-tabs-admin">
-              <li class="oppia-clickable-navbar-element pull-right">
-                <a class="oppia-navbar-tab"
-                   ng-click="showTab(ADMIN_TAB_URLS.MISC)"
-                   ng-href="<[::ADMIN_TAB_URLS.MISC]>"
-                   tooltip="Miscellaneous"
-                   tooltip-placement="bottom">
-                  Misc
-                </a>
-              </li>
-              <li class="oppia-clickable-navbar-element pull-right">
-                <a class="oppia-navbar-tab protractor-test-admin-config-tab"
-                   ng-click="showTab(ADMIN_TAB_URLS.CONFIG)"
-                   ng-href="<[::ADMIN_TAB_URLS.CONFIG]>"
-                   tooltip="Config"
-                   tooltip-placement="bottom">
-                  Config
-                </a>
-              </li>
-              <li class="oppia-clickable-navbar-element pull-right">
-                <a class="oppia-navbar-tab"
-                   ng-click="showTab(ADMIN_TAB_URLS.JOBS)"
-                   ng-href="<[::ADMIN_TAB_URLS.JOBS]>"
-                   tooltip="Jobs"
-                   tooltip-placement="bottom">
-                  Jobs
-                </a>
-              </li>
-              <li class="dropdown oppia-navbar-clickable-dropdown pull-right">
-                <a class="oppia-navbar-tab"
-                   ng-click="showTab(ADMIN_TAB_URLS.ACTIVITIES)"
-                   ng-href="<[::ADMIN_TAB_URLS.ACTIVITIES]>"
-                   tooltip="Activities"
-                   tooltip-placement="bottom">
-                  Activities
-                </a>
-              </li>
-            </ul>
-          </ul>
-        </div>
-      </div>
-    </nav>
+  <body>
+    <admin-navbar username="username" user-email="userEmail"
+                  profile-picture-data-url="profilePictureDataUrl"
+                  is-moderator="isModerator" is-super-admin="isSuperAdmin"
+                  logout-url="logoutUrl">
+    </admin-navbar>
 
     <div align="center"
-         ng-if="message"
+         ng-if="statusMessage"
          style="background-color: #ffffff; position: fixed; max-width: 30%; z-index: 3000; border: 1px solid #00376d; right: 30px; bottom: 30px">
-      <[message]>
+      <[statusMessage]>
     </div>
     <br>
 
-    <div class="row">
-      {% if DEV_MODE %}
-        <div class="col-lg-12 col-md-12 col-sm-12"
-             ng-if="currentTab === ADMIN_TAB_URLS.ACTIVITIES"
-             style="margin-top: 16px;">
-          <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
-            <div class="container" style="margin-left: 0;">
-              <h3>Reload a single exploration</h3>
-              {% for exploration in demo_explorations %}
-                <div class="row protractor-test-reload-exploration-row">
-                  <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-exploration-title">
-                    {{exploration[1]}}
-                  </span>
-                  <span class="col-lg-2 col-md-2 col-sm-2">
-                    <button type="button"
-                            class="btn btn-default protractor-test-reload-exploration-button pull-right"
-                            ng-click="reloadExploration({{exploration[0]}})">
-                    Reload
-                    </button>
-                  </span>
-                </div>
-              {% endfor %}
-              <button type="button"
-                      class="btn btn-default protractor-test-reload-all-explorations-button"
-                      ng-click="reloadAllExplorations()">
-                Reload All Explorations
-              </button>
-            </div>
-          </md-card>
+    <div style="padding-top: 16px;">
+      <admin-dev-mode-activities-tab ng-if="isActivitiesTabOpen() && inDevMode"
+                            set-status-message="setStatusMessage">
+      </admin-dev-mode-activities-tab>
+      <admin-prod-mode-activities-tab ng-if="isActivitiesTabOpen() && !inDevMode">
+      </admin-prod-mode-activities-tab>
 
-          <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
-            <div class="container" style="margin-left: 0;">
-              <h3>Reload a single collection</h3>
-              {% for collection in demo_collections %}
-                <div class="row protractor-test-reload-collection-row">
-                  <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-collection-title">
-                    {{collection[1]}}
-                  </span>
-                  <span class="col-lg-2 col-md-2 col-sm-2">
-                    <button type="button"
-                            class="btn btn-default protractor-test-reload-collection-button pull-right"
-                            ng-click="reloadCollection({{collection[0]}})">
-                      Reload
-                    </button>
-                  </span>
-                </div>
-              {% endfor %}
-            </div>
-          </md-card>
-        </div><br><br>
-      {% else %}
-        <div class="col-lg-12 col-md-12 col-sm-12"
-             ng-if="currentTab === ADMIN_TAB_URLS.ACTIVITIES"
-             style="margin-top: 16px;">
-          <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
-            The 'Activities' tab is not available in the production environment.
-          </md-card>
-        </div>
-      {% endif %}
+      <admin-jobs-tab ng-if="isJobsTabOpen()"
+                      set-status-message="setStatusMessage">
+      </admin-jobs-tab>
 
-      <div class="col-lg-12 col-md-12 col-sm-12" style="margin-top: -30px; margin-bottom: -30px">
-        <md-card class="oppia-page-card oppia-long-text"
-                 ng-if="currentTab === ADMIN_TAB_URLS.JOBS"
-                 style="max-width: 900px">
-          <h3>Continuous computations</h3>
-          <table class="table">
-            <tr>
-              <th>Type</th>
-              <th>Status</th>
-              <th>Last started</th>
-              <th>Last stop signal sent</th>
-              <th>Last finished</th>
-              <th>Active realtime layer</th>
-              <th>Controls</th>
-            </tr>
-            {% for computation in continuous_computations_data %}
-              <tr>
-                <td>{{computation.computation_type}}</td>
-                <td>{{computation.status_code}}</td>
-                <td>{{computation.human_readable_last_started}}</td>
-                <td>{{computation.human_readable_last_stopped}}</td>
-                <td>{{computation.human_readable_last_finished}}</td>
-                <td>{{computation.active_realtime_layer_index}}</td>
-                <td>
-              {% if computation.is_startable %}
-                <button ng-click="startComputation('{{computation.computation_type}}')">
-                  Start
-                </button>
-              {% endif %}
-              {% if computation.is_stoppable %}
-                <button ng-click="stopComputation('{{computation.computation_type}}')">
-                  Stop
-                </button>
-              {% endif %}
-                </td>
-              </tr>
-            {% endfor %}
-          </table>
-        </md-card>
+      <admin-config-tab ng-if="isConfigTabOpen()"
+                        set-status-message="setStatusMessage">
+      </admin-config-tab>
 
-        <md-card class="oppia-page-card oppia-long-text"
-                 ng-if="currentTab === ADMIN_TAB_URLS.JOBS"
-                 style="max-width: 900px">
-          <h3>One-off jobs</h3>
-          <h4>Current time: {{human_readable_current_time}}</h4>
-          <table class="table table-striped">
-            {% for job_spec in one_off_job_specs %}
-              <tr>
-                <td>
-                  {{job_spec.job_type}}
-                </td>
-                <td>
-                  <button class="pull-right" ng-click="startNewJob('{{job_spec.job_type}}')">
-                    Start new job
-                  </button>
-                  {% if job_spec.is_queued_or_running %}
-                    <span class="oppia-serious-warning-text">
-                      <strong>(warning: an instance of this job type is already running)</strong>
-                    </span>
-                  {% endif %}
-                </td>
-              </tr>
-            {% endfor %}
-          </table>
-        </md-card>
-
-        <md-card class="oppia-page-card oppia-long-text"
-                 ng-if="currentTab === ADMIN_TAB_URLS.JOBS"
-                 style="max-width: 900px">
-          <h3>Unfinished jobs</h3>
-          <em>Note: This table may be stale; refresh to see the latest state.</em>
-          <table class="table">
-            <tr>
-              <th>Job ID</th>
-              <th>Status</th>
-              <th>Time started</th>
-              <th>Time finished</th>
-              <th></th>
-            </tr>
-            {% for job in unfinished_job_data %}
-              <tr>
-                <td>{{job.id}}</td>
-                <td>{{job.status_code}}</td>
-                <td>{{job.human_readable_time_started}}</td>
-                <td>{{job.human_readable_time_finished}}</td>
-                <td>
-                  {% if job.can_be_canceled %}
-                    <button ng-click="cancelJob('{{job['id']}}', '{{job['job_type']}}')">
-                      Cancel
-                    </button>
-                  {% endif %}
-                </td>
-              </tr>
-            {% endfor %}
-          </table>
-        </md-card>
-
-        <md-card class="oppia-page-card oppia-long-text"
-                 ng-if="currentTab === ADMIN_TAB_URLS.JOBS"
-                 style="max-width: 900px">
-          <h3>Recent jobs</h3>
-          <em>Note: This table may be stale; refresh to see the latest state.</em>
-          <table class="table">
-            <tr>
-              <th>Job ID</th>
-              <th>Status</th>
-              <th>Time started</th>
-              <th>Time finished</th>
-              <th></th>
-            </tr>
-            {% for job in recent_job_data %}
-              <tr>
-                <td>{{job.id}}</td>
-                <td>{{job.status_code}}</td>
-                <td>{{job.human_readable_time_started}}</td>
-                <td>{{job.human_readable_time_finished}}</td>
-                <td>
-                  <button ng-click="getJobOutput('{{job['id']}}')">
-                    View Output
-                  </button>
-                </td>
-              </tr>
-            {% endfor %}
-          </table>
-          <div ng-if="showJobOutput">
-            <h4>Job Output</h4>
-            <p>
-              <[jobOutput]>
-            </p>
-          </div>
-        </md-card>
-
-        <md-card class="oppia-page-card oppia-long-text"
-                 ng-if="currentTab === ADMIN_TAB_URLS.CONFIG"
-                 style="max-width: 1050px">
-          <h3>Configuration properties</h3>
-          <div class="container" ng-if="isNonemptyObject(configProperties)" style="margin-left: 0;">
-            <div ng-repeat="(configPropertyId, configPropertyData) in configProperties">
-              <div class="row protractor-test-config-property" style="padding-bottom: 10px;">
-                <span class="col-lg-2 col-md-2 col-sm-2">
-                  <em class="protractor-test-config-title"><[configPropertyData.description]></em>
-                </span>
-                <span class="col-lg-6 col-md-6 col-sm-6">
-                  <schema-based-editor schema="configPropertyData.schema" local-value="configPropertyData.value">
-                  </schema-based-editor>
-                </span>
-                <span class="col-lg-2 col-md-2 col-sm-2">
-                  <button type="button" class="btn btn-default" ng-click="revertToDefaultConfigPropertyValue(configPropertyId)">
-                    Revert to default
-                  </button>
-                </span>
-              </div>
-            </div>
-
-            <button ng-click="saveConfigProperties()" class="protractor-test-save-all-configs">Save</button>
-            <button ng-click="reloadConfigProperties()">Undo changes</button>
-          </div>
-
-          <div ng-if="!isNonemptyObject(configProperties)">
-            No configuration properties are available.
-          </div>
-        </md-card>
-
-        <md-card class="oppia-page-card oppia-long-text"
-                 ng-if="currentTab === ADMIN_TAB_URLS.MISC"
-                 style="max-width: 700px">
-          <h3>Topic Similarities</h3>
-          <div>
-            Upload a csv file:<br>
-            The first line of data should be a list of topic names. The next lines should be a symmetric adjacency matrix of similarities, which are values between 0 and 1.<br>
-            <input type="file" id="topicSimilaritiesFile">
-            <button ng-click="uploadTopicSimilaritiesFile()">Upload</button><br>
-            <button ng-click="downloadTopicSimilaritiesFile()">Download current topic similarities</button>
-          </div>
-        </md-card>
-
-        <md-card class="oppia-page-card oppia-long-text"
-                 ng-if="currentTab === ADMIN_TAB_URLS.MISC"
-                 style="max-width: 700px">
-          <h3>Search Index</h3>
-          <button ng-click="clearSearchIndex()">Clear Search Index</button>
-        </md-card>
-      </div>
+      <admin-misc-tab ng-if="isMiscTabOpen()"
+                      set-status-message="setStatusMessage">
+      </admin-misc-tab>
     </div>
 
     {% if DEV_MODE %}
@@ -429,10 +68,24 @@
 
     {% include 'components/forms/form_builder_templates.html' %}
     {% include 'pages/footer_js_libs.html' %}
+    {% include 'pages/admin/admin_navbar_directive.html' %}
+    {% include 'pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html' %}
+    {% include 'pages/admin/activities_tab/admin_prod_mode_activities_tab_directive.html' %}
+    {% include 'pages/admin/config_tab/admin_config_tab_directive.html' %}
+    {% include 'pages/admin/jobs_tab/admin_jobs_tab_directive.html' %}
+    {% include 'pages/admin/misc_tab/admin_misc_tab_directive.html' %}
 
     <script src="{{TEMPLATE_DIR_PREFIX}}/app.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/pages/Base.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/pages/admin/Admin.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/pages/admin/AdminNavbarDirective.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/pages/admin/AdminRouterService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/pages/admin/AdminTaskManagerService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/pages/admin/activities_tab/AdminDevModeActivitiesTabDirective.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/pages/admin/activities_tab/AdminProdModeActivitiesTabDirective.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/pages/admin/config_tab/AdminConfigTabDirective.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/pages/admin/jobs_tab/AdminJobsTabDirective.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/pages/admin/misc_tab/AdminMiscTabDirective.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/directives.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/services/alertsService.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/services/explorationContextService.js"></script>

--- a/core/templates/dev/head/pages/admin/admin_navbar_directive.html
+++ b/core/templates/dev/head/pages/admin/admin_navbar_directive.html
@@ -1,4 +1,4 @@
-<script type="text/ng-template" id="pages/admin/navbar">
+<script type="text/ng-template" id="admin/navbar">
   <nav class="navbar navbar-default oppia-navbar oppia-prevent-selection" role="navigation">
     <div class="navbar-container" style="background-color: #00376d">
       <div class="navbar-header protractor-test-navbar-header pull-left">

--- a/core/templates/dev/head/pages/admin/admin_navbar_directive.html
+++ b/core/templates/dev/head/pages/admin/admin_navbar_directive.html
@@ -1,0 +1,139 @@
+<script type="text/ng-template" id="pages/admin/navbar">
+  <nav class="navbar navbar-default oppia-navbar oppia-prevent-selection" role="navigation">
+    <div class="navbar-container" style="background-color: #00376d">
+      <div class="navbar-header protractor-test-navbar-header pull-left">
+        <a class="oppia-navbar-brand-name oppia-transition-200" href="/library">
+          <img ng-src="<[logoWhiteImgUrl]>" class="oppia-logo" ng-class="'oppia-logo-wide'">
+        </a>
+        <ul class="nav navbar-nav oppia-navbar-breadcrumb">
+          <li>
+            <span class="oppia-navbar-breadcrumb-separator"></span>
+            Admin
+          </li>
+        </ul>
+      </div>
+
+      <div ng-cloak class="navbar-header pull-right">
+        <ul class="nav oppia-navbar-nav oppia-navbar-profile-admin">
+          <li class="dropdown pull-right">
+            <a class="dropdown-toggle oppia-navbar-dropdown-toggle"
+               data-toggle="dropdown"
+               ng-mouseover="onMouseoverProfilePictureOrDropdown($event)"
+               ng-mouseleave="onMouseoutProfilePictureOrDropdown($event)">
+              <div class="oppia-navbar-profile-picture-container" ng-cloak>
+                <div ng-if="getProfilePictureDataUrl()">
+                  <img ng-src="<[getProfilePictureDataUrl()]>"
+                       class="oppia-navbar-profile-picture img-circle">
+                  <span class="caret" style="margin-top: 10px;"></span>
+                </div>
+                <div ng-if="!getProfilePictureDataUrl()">
+                  <i class="material-icons md-40" style="margin-top: -1px;">&#xE853;</i>
+                  <span class="caret" style="margin-top: -26px;"></span>
+                </div>
+
+                <div style="display: none;" class="oppia-user-email">
+                  <[getUserEmail()]>
+                </div>
+              </div>
+            </a>
+            <ul class="dropdown-menu ng-cloak oppia-navbar-dropdown"
+                role="menu"
+                ng-mouseover="onMouseoverProfilePictureOrDropdown($event)"
+                ng-mouseleave="onMouseoutProfilePictureOrDropdown($event)"
+                ng-show="profileDropdownIsActive">
+              <li>
+                <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
+                   ng-href="<[getProfileUrl()]>"
+                   style="color: #00376d">
+                  <strong><[getUsername()]></strong>
+                </a>
+              </li>
+              <hr class="oppia-top-right-menu-item-separator">
+              <li>
+                <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
+                   href="/dashboard"
+                   style="color: #00376d">
+                  Creator Dashboard
+                </a>
+              </li>
+              <li>
+                <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
+                   href="/notifications_dashboard"
+                   style="color: #00376d">
+                  Notifications
+                </a>
+              </li>
+              <li>
+                <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
+                   href="/preferences"
+                   style="color: #00376d">Preferences</a>
+              </li>
+
+              <li ng-if="isModerator()">
+                <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
+                   href="/moderator"
+                   target="_blank"
+                   style="color: #00376d">
+                  Moderator Page
+                </a>
+              </li>
+              <li ng-if="isSuperAdmin()">
+                <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
+                   href="/admin"
+                   target="_blank"
+                   style="color: #00376d">
+                  Admin Page
+                </a>
+              </li>
+              <hr class="oppia-top-right-menu-item-separator">
+              <li>
+                <a ng-click="onMouseoutProfilePictureOrDropdown($event)"
+                   ng-href="<[getLogoutUrl()]>"
+                   style="color: #00376d">Logout</a>
+              </li>
+            </ul>
+          </li>
+
+          <ul class="nav oppia-navbar-tabs oppia-navbar-tabs-admin">
+            <li class="oppia-clickable-navbar-element pull-right">
+              <a class="oppia-navbar-tab"
+                 ng-click="showTab(ADMIN_TAB_URLS.MISC)"
+                 ng-href="<[::ADMIN_TAB_URLS.MISC]>"
+                 tooltip="Miscellaneous"
+                 tooltip-placement="bottom">
+                Misc
+              </a>
+            </li>
+            <li class="oppia-clickable-navbar-element pull-right">
+              <a class="oppia-navbar-tab protractor-test-admin-config-tab"
+                 ng-click="showTab(ADMIN_TAB_URLS.CONFIG)"
+                 ng-href="<[::ADMIN_TAB_URLS.CONFIG]>"
+                 tooltip="Config"
+                 tooltip-placement="bottom">
+                Config
+              </a>
+            </li>
+            <li class="oppia-clickable-navbar-element pull-right">
+              <a class="oppia-navbar-tab"
+                 ng-click="showTab(ADMIN_TAB_URLS.JOBS)"
+                 ng-href="<[::ADMIN_TAB_URLS.JOBS]>"
+                 tooltip="Jobs"
+                 tooltip-placement="bottom">
+                Jobs
+              </a>
+            </li>
+            <li class="oppia-clickable-navbar-element pull-right">
+              <a class="oppia-navbar-tab"
+                 ng-click="showTab(ADMIN_TAB_URLS.ACTIVITIES)"
+                 ng-href="<[::ADMIN_TAB_URLS.ACTIVITIES]>"
+                 tooltip="Activities"
+                 tooltip-placement="bottom">
+                Activities
+              </a>
+            </li>
+          </ul>
+        </ul>
+      </div>
+    </div>
+  </nav>
+</script>

--- a/core/templates/dev/head/pages/admin/config_tab/AdminConfigTabDirective.js
+++ b/core/templates/dev/head/pages/admin/config_tab/AdminConfigTabDirective.js
@@ -1,0 +1,96 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Directive for the configuration tab in the admin panel.
+ */
+
+oppia.directive('adminConfigTab', [
+  '$http', 'AdminTaskManagerService', 'ADMIN_HANDLER_URL',
+  function($http, AdminTaskManagerService, ADMIN_HANDLER_URL) {
+    return {
+      restrict: 'E',
+      scope: {
+        setStatusMessage: '='
+      },
+      templateUrl: 'pages/admin/config_tab_directive',
+      controller: ['$scope', function($scope) {
+        $scope.configProperties = {};
+
+        $scope.isNonemptyObject = function(object) {
+          var hasAtLeastOneElement = false;
+          for (var property in object) {
+            hasAtLeastOneElement = true;
+          }
+          return hasAtLeastOneElement;
+        };
+
+        $scope.reloadConfigProperties = function() {
+          $http.get(ADMIN_HANDLER_URL).then(function(response) {
+            $scope.configProperties = response.data.config_properties;
+          });
+        };
+
+        $scope.revertToDefaultConfigPropertyValue = function(configPropertyId) {
+          if (!confirm('This action is irreversible. Are you sure?')) {
+            return;
+          }
+
+          $http.post(ADMIN_HANDLER_URL, {
+            action: 'revert_config_property',
+            config_property_id: configPropertyId
+          }).then(function() {
+            $scope.setStatusMessage('Config property reverted successfully.');
+            $scope.reloadConfigProperties();
+          }, function(errorResponse) {
+            $scope.setStatusMessage(
+              'Server error: ' + errorResponse.data.error);
+          });
+        };
+
+        $scope.saveConfigProperties = function() {
+          if (AdminTaskManagerService.isTaskRunning()) {
+            return;
+          }
+          if (!confirm('This action is irreversible. Are you sure?')) {
+            return;
+          }
+
+          $scope.setStatusMessage('Saving...');
+
+          AdminTaskManagerService.startTask();
+          var newConfigPropertyValues = {};
+          for (var property in $scope.configProperties) {
+            newConfigPropertyValues[property] = (
+              $scope.configProperties[property].value);
+          }
+
+          $http.post(ADMIN_HANDLER_URL, {
+            action: 'save_config_properties',
+            new_config_property_values: newConfigPropertyValues
+          }).then(function() {
+            $scope.setStatusMessage('Data saved successfully.');
+            AdminTaskManagerService.finishTask();
+          }, function(errorResponse) {
+            $scope.setStatusMessage(
+              'Server error: ' + errorResponse.data.error);
+            AdminTaskManagerService.finishTask();
+          });
+        };
+
+        $scope.reloadConfigProperties();
+      }]
+    };
+  }
+]);

--- a/core/templates/dev/head/pages/admin/config_tab/AdminConfigTabDirective.js
+++ b/core/templates/dev/head/pages/admin/config_tab/AdminConfigTabDirective.js
@@ -24,7 +24,7 @@ oppia.directive('adminConfigTab', [
       scope: {
         setStatusMessage: '='
       },
-      templateUrl: 'pages/admin/config_tab_directive',
+      templateUrl: 'admin/configTag',
       controller: ['$scope', function($scope) {
         $scope.configProperties = {};
 

--- a/core/templates/dev/head/pages/admin/config_tab/admin_config_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/config_tab/admin_config_tab_directive.html
@@ -1,4 +1,4 @@
-<script type="text/ng-template" id="pages/admin/config_tab_directive">
+<script type="text/ng-template" id="admin/configTag">
   <md-card class="oppia-page-card oppia-long-text" style="max-width: 1050px">
     <h3>Configuration properties</h3>
     <div class="container" ng-if="isNonemptyObject(configProperties)" style="margin-left: 0;">

--- a/core/templates/dev/head/pages/admin/config_tab/admin_config_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/config_tab/admin_config_tab_directive.html
@@ -1,0 +1,30 @@
+<script type="text/ng-template" id="pages/admin/config_tab_directive">
+  <md-card class="oppia-page-card oppia-long-text" style="max-width: 1050px">
+    <h3>Configuration properties</h3>
+    <div class="container" ng-if="isNonemptyObject(configProperties)" style="margin-left: 0;">
+      <div ng-repeat="(configPropertyId, configPropertyData) in configProperties">
+        <div class="row protractor-test-config-property" style="padding-bottom: 10px;">
+          <span class="col-lg-2 col-md-2 col-sm-2">
+            <em class="protractor-test-config-title"><[configPropertyData.description]></em>
+          </span>
+          <span class="col-lg-6 col-md-6 col-sm-6">
+            <schema-based-editor schema="configPropertyData.schema" local-value="configPropertyData.value">
+            </schema-based-editor>
+          </span>
+          <span class="col-lg-2 col-md-2 col-sm-2">
+            <button type="button" class="btn btn-default" ng-click="revertToDefaultConfigPropertyValue(configPropertyId)">
+              Revert to default
+            </button>
+          </span>
+        </div>
+      </div>
+
+      <button ng-click="saveConfigProperties()" class="protractor-test-save-all-configs">Save</button>
+      <button ng-click="reloadConfigProperties()">Undo changes</button>
+    </div>
+
+    <div ng-if="!isNonemptyObject(configProperties)">
+      No configuration properties are available.
+    </div>
+  </md-card>
+</script>

--- a/core/templates/dev/head/pages/admin/jobs_tab/AdminJobsTabDirective.js
+++ b/core/templates/dev/head/pages/admin/jobs_tab/AdminJobsTabDirective.js
@@ -1,0 +1,110 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Directive for the jobs tab in the admin panel.
+ */
+
+oppia.directive('adminJobsTab', [
+  '$http', '$timeout', 'UrlInterpolationService', 'ADMIN_HANDLER_URL',
+  'ADMIN_JOB_OUTPUT_URL_TEMPLATE',
+  function(
+      $http, $timeout, UrlInterpolationService, ADMIN_HANDLER_URL,
+      ADMIN_JOB_OUTPUT_URL_TEMPLATE) {
+    return {
+      restrict: 'E',
+      scope: {
+        setStatusMessage: '='
+      },
+      templateUrl: 'pages/admin/jobs_tab_directive',
+      controller: ['$scope', function($scope) {
+        $scope.showingJobOutput = false;
+        $scope.showJobOutput = function(jobId) {
+          var adminJobOutputUrl = UrlInterpolationService.interpolateUrl(
+            ADMIN_JOB_OUTPUT_URL_TEMPLATE, {
+              jobId: jobId
+            });
+          $http.get(adminJobOutputUrl).then(function(response) {
+            $scope.showingJobOutput = true;
+            $scope.jobOutput = response.data.output;
+            $timeout(function() {
+              document.querySelector('#job-output').scrollIntoView();
+            });
+          });
+        };
+
+        $scope.startNewJob = function(jobType) {
+          $scope.setStatusMessage('Starting new job...');
+
+          $http.post(ADMIN_HANDLER_URL, {
+            action: 'start_new_job',
+            job_type: jobType
+          }).then(function() {
+            $scope.setStatusMessage('Job started successfully.');
+            window.location.reload();
+          }, function(errorResponse) {
+            $scope.setStatusMessage(
+              'Server error: ' + errorResponse.data.error);
+          });
+        };
+
+        $scope.cancelJob = function(jobId, jobType) {
+          $scope.setStatusMessage('Cancelling job...');
+
+          $http.post(ADMIN_HANDLER_URL, {
+            action: 'cancel_job',
+            job_id: jobId,
+            job_type: jobType
+          }).then(function() {
+            $scope.setStatusMessage('Abort signal sent to job.');
+            window.location.reload();
+          }, function(errorResponse) {
+            $scope.setStatusMessage(
+              'Server error: ' + errorResponse.data.error);
+          });
+        };
+
+        $scope.startComputation = function(computationType) {
+          $scope.setStatusMessage('Starting computation...');
+
+          $http.post(ADMIN_HANDLER_URL, {
+            action: 'start_computation',
+            computation_type: computationType
+          }).then(function() {
+            $scope.setStatusMessage('Computation started successfully.');
+            window.location.reload();
+          }, function(errorResponse) {
+            $scope.setStatusMessage(
+              'Server error: ' + errorResponse.data.error);
+          });
+        };
+
+        $scope.stopComputation = function(computationType) {
+          $scope.setStatusMessage('Stopping computation...');
+
+          $http.post(ADMIN_HANDLER_URL, {
+            action: 'stop_computation',
+            computation_type: computationType
+          }).then(function() {
+            $scope.setStatusMessage('Abort signal sent to computation.');
+            window.location.reload();
+          }, function(errorResponse) {
+            $scope.setStatusMessage(
+              'Server error: ' + errorResponse.data.error);
+          });
+        };
+      }]
+    };
+  }
+]);

--- a/core/templates/dev/head/pages/admin/jobs_tab/AdminJobsTabDirective.js
+++ b/core/templates/dev/head/pages/admin/jobs_tab/AdminJobsTabDirective.js
@@ -27,8 +27,16 @@ oppia.directive('adminJobsTab', [
       scope: {
         setStatusMessage: '='
       },
-      templateUrl: 'pages/admin/jobs_tab_directive',
+      templateUrl: 'admin/jobsTab',
       controller: ['$scope', function($scope) {
+        $scope.HUMAN_READABLE_CURRENT_TIME = (
+          GLOBALS.HUMAN_READABLE_CURRENT_TIME);
+        $scope.CONTINUOUS_COMPUTATIONS_DATA = (
+          GLOBALS.CONTINUOUS_COMPUTATIONS_DATA);
+        $scope.ONE_OFF_JOB_SPECS = GLOBALS.ONE_OFF_JOB_SPECS;
+        $scope.UNFINISHED_JOB_DATA = GLOBALS.UNFINISHED_JOB_DATA;
+        $scope.RECENT_JOB_DATA = GLOBALS.RECENT_JOB_DATA;
+
         $scope.showingJobOutput = false;
         $scope.showJobOutput = function(jobId) {
           var adminJobOutputUrl = UrlInterpolationService.interpolateUrl(

--- a/core/templates/dev/head/pages/admin/jobs_tab/admin_jobs_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/jobs_tab/admin_jobs_tab_directive.html
@@ -1,4 +1,4 @@
-<script type="text/ng-template" id="pages/admin/jobs_tab_directive">
+<script type="text/ng-template" id="admin/jobsTab">
   <md-card class="oppia-page-card oppia-long-text" style="max-width: 900px">
     <h3>Continuous computations</h3>
     <table class="table">
@@ -11,56 +11,51 @@
         <th>Active realtime layer</th>
         <th>Controls</th>
       </tr>
-      {% for computation in continuous_computations_data %}
-        <tr>
-          <td>{{computation.computation_type}}</td>
-          <td>{{computation.status_code}}</td>
-          <td>{{computation.human_readable_last_started}}</td>
-          <td>{{computation.human_readable_last_stopped}}</td>
-          <td>{{computation.human_readable_last_finished}}</td>
-          <td>{{computation.active_realtime_layer_index}}</td>
-          <td>
-        {% if computation.is_startable %}
-          <button ng-click="startComputation('{{computation.computation_type}}')">
+      <tr ng-repeat="computation in CONTINUOUS_COMPUTATIONS_DATA">
+        <td><[computation.computation_type]></td>
+        <td><[computation.status_code]></td>
+        <td><[computation.human_readable_last_started]></td>
+        <td><[computation.human_readable_last_stopped]></td>
+        <td><[computation.human_readable_last_finished]></td>
+        <td><[computation.active_realtime_layer_index]></td>
+        <td>
+          <button ng-if="computation.is_startable"
+                  ng-click="startComputation(computation.computation_type)">
             Start
           </button>
-        {% endif %}
-        {% if computation.is_stoppable %}
-          <button ng-click="stopComputation('{{computation.computation_type}}')">
+          <button ng-if="computation.is_stoppable"
+                  ng-click="stopComputation(computation.computation_type)">
             Stop
           </button>
-        {% endif %}
-          </td>
-        </tr>
-      {% endfor %}
+        </td>
+      </tr>
     </table>
   </md-card>
 
   <md-card class="oppia-page-card oppia-long-text" style="max-width: 900px">
     <h3>One-off jobs</h3>
-    <h4>Current time: {{human_readable_current_time}}</h4>
+    <h4>Current time: <[HUMAN_READABLE_CURRENT_TIME]></h4>
     <table class="table table-striped">
-      {% for job_spec in one_off_job_specs %}
-        <tr>
-          <td>
-            {{job_spec.job_type}}
-          </td>
-          <td>
-            <button class="pull-right" ng-click="startNewJob('{{job_spec.job_type}}')">
-              Start new job
-            </button>
-            {% if job_spec.is_queued_or_running %}
-              <span class="oppia-serious-warning-text">
-                <strong>(warning: an instance of this job type is already running)</strong>
-              </span>
-            {% endif %}
-          </td>
-        </tr>
-      {% endfor %}
+      <tr ng-repeat="job_spec in ONE_OFF_JOB_SPECS">
+        <td><[job_spec.job_type]></td>
+        <td>
+          <button ng-click="startNewJob(job_spec.job_type)"
+                  class="pull-right">
+            Start new job
+          </button>
+          <span ng-if="job_spec.is_queued_or_running"
+                class="oppia-serious-warning-text">
+            <strong>
+              (warning: an instance of this job type is already running)
+            </strong>
+          </span>
+        </td>
+      </tr>
     </table>
   </md-card>
 
-  <md-card class="oppia-page-card oppia-long-text" style="max-width: 900px">
+  <md-card ng-if="UNFINISHED_JOB_DATA.length > 0"
+           class="oppia-page-card oppia-long-text" style="max-width: 900px">
     <h3>Unfinished jobs</h3>
     <em>Note: This table may be stale; refresh to see the latest state.</em>
     <table class="table">
@@ -71,25 +66,23 @@
         <th>Time finished</th>
         <th></th>
       </tr>
-      {% for job in unfinished_job_data %}
-        <tr>
-          <td>{{job.id}}</td>
-          <td>{{job.status_code}}</td>
-          <td>{{job.human_readable_time_started}}</td>
-          <td>{{job.human_readable_time_finished}}</td>
-          <td>
-            {% if job.can_be_canceled %}
-              <button ng-click="cancelJob('{{job['id']}}', '{{job['job_type']}}')">
-                Cancel
-              </button>
-            {% endif %}
-          </td>
-        </tr>
-      {% endfor %}
+      <tr ng-repeat="job in UNFINISHED_JOB_DATA track by $index">
+        <td><[job.id]></td>
+        <td><[job.status_code]></td>
+        <td><[job.human_readable_time_started]></td>
+        <td><[job.human_readable_time_finished]></td>
+        <td>
+          <button ng-if="job.can_be_canceled"
+                  ng-click="cancelJob(job.id, job.job_type)">
+            Cancel
+          </button>
+        </td>
+      </tr>
     </table>
   </md-card>
 
-  <md-card class="oppia-page-card oppia-long-text" style="max-width: 900px">
+  <md-card ng-if="RECENT_JOB_DATA.length > 0"
+           class="oppia-page-card oppia-long-text" style="max-width: 900px">
     <h3>Recent jobs</h3>
     <em>Note: This table may be stale; refresh to see the latest state.</em>
     <table class="table">
@@ -100,25 +93,21 @@
         <th>Time finished</th>
         <th></th>
       </tr>
-      {% for job in recent_job_data %}
-        <tr>
-          <td>{{job.id}}</td>
-          <td>{{job.status_code}}</td>
-          <td>{{job.human_readable_time_started}}</td>
-          <td>{{job.human_readable_time_finished}}</td>
-          <td>
-            <button ng-click="showJobOutput('{{job['id']}}')">
-              View Output
-            </button>
-          </td>
-        </tr>
-      {% endfor %}
+      <tr ng-repeat="job in RECENT_JOB_DATA track by $index">
+        <td><[job.id]></td>
+        <td><[job.status_code]></td>
+        <td><[job.human_readable_time_started]></td>
+        <td><[job.human_readable_time_finished]></td>
+        <td>
+          <button ng-click="showJobOutput(job.id)">
+            View Output
+          </button>
+        </td>
+      </tr>
     </table>
     <div ng-show="showingJobOutput" id="job-output">
       <h4>Job Output</h4>
-      <p>
-        <[jobOutput]>
-      </p>
+      <p><[jobOutput]></p>
     </div>
   </md-card>
 </script>

--- a/core/templates/dev/head/pages/admin/jobs_tab/admin_jobs_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/jobs_tab/admin_jobs_tab_directive.html
@@ -1,0 +1,124 @@
+<script type="text/ng-template" id="pages/admin/jobs_tab_directive">
+  <md-card class="oppia-page-card oppia-long-text" style="max-width: 900px">
+    <h3>Continuous computations</h3>
+    <table class="table">
+      <tr>
+        <th>Type</th>
+        <th>Status</th>
+        <th>Last started</th>
+        <th>Last stop signal sent</th>
+        <th>Last finished</th>
+        <th>Active realtime layer</th>
+        <th>Controls</th>
+      </tr>
+      {% for computation in continuous_computations_data %}
+        <tr>
+          <td>{{computation.computation_type}}</td>
+          <td>{{computation.status_code}}</td>
+          <td>{{computation.human_readable_last_started}}</td>
+          <td>{{computation.human_readable_last_stopped}}</td>
+          <td>{{computation.human_readable_last_finished}}</td>
+          <td>{{computation.active_realtime_layer_index}}</td>
+          <td>
+        {% if computation.is_startable %}
+          <button ng-click="startComputation('{{computation.computation_type}}')">
+            Start
+          </button>
+        {% endif %}
+        {% if computation.is_stoppable %}
+          <button ng-click="stopComputation('{{computation.computation_type}}')">
+            Stop
+          </button>
+        {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+  </md-card>
+
+  <md-card class="oppia-page-card oppia-long-text" style="max-width: 900px">
+    <h3>One-off jobs</h3>
+    <h4>Current time: {{human_readable_current_time}}</h4>
+    <table class="table table-striped">
+      {% for job_spec in one_off_job_specs %}
+        <tr>
+          <td>
+            {{job_spec.job_type}}
+          </td>
+          <td>
+            <button class="pull-right" ng-click="startNewJob('{{job_spec.job_type}}')">
+              Start new job
+            </button>
+            {% if job_spec.is_queued_or_running %}
+              <span class="oppia-serious-warning-text">
+                <strong>(warning: an instance of this job type is already running)</strong>
+              </span>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+  </md-card>
+
+  <md-card class="oppia-page-card oppia-long-text" style="max-width: 900px">
+    <h3>Unfinished jobs</h3>
+    <em>Note: This table may be stale; refresh to see the latest state.</em>
+    <table class="table">
+      <tr>
+        <th>Job ID</th>
+        <th>Status</th>
+        <th>Time started</th>
+        <th>Time finished</th>
+        <th></th>
+      </tr>
+      {% for job in unfinished_job_data %}
+        <tr>
+          <td>{{job.id}}</td>
+          <td>{{job.status_code}}</td>
+          <td>{{job.human_readable_time_started}}</td>
+          <td>{{job.human_readable_time_finished}}</td>
+          <td>
+            {% if job.can_be_canceled %}
+              <button ng-click="cancelJob('{{job['id']}}', '{{job['job_type']}}')">
+                Cancel
+              </button>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+  </md-card>
+
+  <md-card class="oppia-page-card oppia-long-text" style="max-width: 900px">
+    <h3>Recent jobs</h3>
+    <em>Note: This table may be stale; refresh to see the latest state.</em>
+    <table class="table">
+      <tr>
+        <th>Job ID</th>
+        <th>Status</th>
+        <th>Time started</th>
+        <th>Time finished</th>
+        <th></th>
+      </tr>
+      {% for job in recent_job_data %}
+        <tr>
+          <td>{{job.id}}</td>
+          <td>{{job.status_code}}</td>
+          <td>{{job.human_readable_time_started}}</td>
+          <td>{{job.human_readable_time_finished}}</td>
+          <td>
+            <button ng-click="showJobOutput('{{job['id']}}')">
+              View Output
+            </button>
+          </td>
+        </tr>
+      {% endfor %}
+    </table>
+    <div ng-show="showingJobOutput" id="job-output">
+      <h4>Job Output</h4>
+      <p>
+        <[jobOutput]>
+      </p>
+    </div>
+  </md-card>
+</script>

--- a/core/templates/dev/head/pages/admin/misc_tab/AdminMiscTabDirective.js
+++ b/core/templates/dev/head/pages/admin/misc_tab/AdminMiscTabDirective.js
@@ -1,0 +1,80 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Directive for the miscellaneous tab in the admin panel.
+ */
+
+oppia.directive('adminMiscTab', [
+  '$http', 'AdminTaskManagerService', 'ADMIN_HANDLER_URL',
+  'ADMIN_TOPICS_CSV_DOWNLOAD_HANDLER_URL',
+  function(
+      $http, AdminTaskManagerService, ADMIN_HANDLER_URL,
+      ADMIN_TOPICS_CSV_DOWNLOAD_HANDLER_URL) {
+    return {
+      restrict: 'E',
+      scope: {
+        setStatusMessage: '='
+      },
+      templateUrl: 'pages/admin/misc_tab_directive',
+      controller: ['$scope', function($scope) {
+        $scope.clearSearchIndex = function() {
+          if (AdminTaskManagerService.isTaskRunning()) {
+            return;
+          }
+          if (!confirm('This action is irreversible. Are you sure?')) {
+            return;
+          }
+
+          $scope.setStatusMessage('Clearing search index...');
+
+          AdminTaskManagerService.startTask();
+          $http.post(ADMIN_HANDLER_URL, {
+            action: 'clear_search_index'
+          }).then(function() {
+            $scope.setStatusMessage('Index successfully cleared.');
+            AdminTaskManagerService.finishTask();
+          }, function(errorResponse) {
+            $scope.setStatusMessage(
+              'Server error: ' + errorResponse.data.error);
+            AdminTaskManagerService.finishTask();
+          });
+        };
+
+        $scope.uploadTopicSimilaritiesFile = function() {
+          var file = document.getElementById('topicSimilaritiesFile').files[0];
+          var reader = new FileReader();
+          reader.onload = function(e) {
+            var data = e.target.result;
+            $http.post(ADMIN_HANDLER_URL, {
+              action: 'upload_topic_similarities',
+              data: data
+            }).then(function() {
+              $scope.setStatusMessage(
+                'Topic similarities uploaded successfully.');
+            }, function(errorResponse) {
+              $scope.setStatusMessage(
+                'Server error: ' + errorResponse.data.error);
+            });
+          };
+          reader.readAsText(file);
+        };
+
+        $scope.downloadTopicSimilaritiesFile = function() {
+          window.location.href = ADMIN_TOPICS_CSV_DOWNLOAD_HANDLER_URL;
+        };
+      }]
+    };
+  }
+]);

--- a/core/templates/dev/head/pages/admin/misc_tab/AdminMiscTabDirective.js
+++ b/core/templates/dev/head/pages/admin/misc_tab/AdminMiscTabDirective.js
@@ -17,17 +17,17 @@
  */
 
 oppia.directive('adminMiscTab', [
-  '$http', 'AdminTaskManagerService', 'ADMIN_HANDLER_URL',
+  '$http', '$window', 'AdminTaskManagerService', 'ADMIN_HANDLER_URL',
   'ADMIN_TOPICS_CSV_DOWNLOAD_HANDLER_URL',
   function(
-      $http, AdminTaskManagerService, ADMIN_HANDLER_URL,
+      $http, $window, AdminTaskManagerService, ADMIN_HANDLER_URL,
       ADMIN_TOPICS_CSV_DOWNLOAD_HANDLER_URL) {
     return {
       restrict: 'E',
       scope: {
         setStatusMessage: '='
       },
-      templateUrl: 'pages/admin/misc_tab_directive',
+      templateUrl: 'admin/miscTab',
       controller: ['$scope', function($scope) {
         $scope.clearSearchIndex = function() {
           if (AdminTaskManagerService.isTaskRunning()) {
@@ -72,7 +72,7 @@ oppia.directive('adminMiscTab', [
         };
 
         $scope.downloadTopicSimilaritiesFile = function() {
-          window.location.href = ADMIN_TOPICS_CSV_DOWNLOAD_HANDLER_URL;
+          $window.location.href = ADMIN_TOPICS_CSV_DOWNLOAD_HANDLER_URL;
         };
       }]
     };

--- a/core/templates/dev/head/pages/admin/misc_tab/admin_misc_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/misc_tab/admin_misc_tab_directive.html
@@ -1,4 +1,4 @@
-<script type="text/ng-template" id="pages/admin/misc_tab_directive">
+<script type="text/ng-template" id="admin/miscTab">
   <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
     <h3>Topic Similarities</h3>
     <div>

--- a/core/templates/dev/head/pages/admin/misc_tab/admin_misc_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/misc_tab/admin_misc_tab_directive.html
@@ -1,0 +1,17 @@
+<script type="text/ng-template" id="pages/admin/misc_tab_directive">
+  <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
+    <h3>Topic Similarities</h3>
+    <div>
+      Upload a csv file:<br>
+      The first line of data should be a list of topic names. The next lines should be a symmetric adjacency matrix of similarities, which are values between 0 and 1.<br>
+      <input type="file" id="topicSimilaritiesFile">
+      <button ng-click="uploadTopicSimilaritiesFile()">Upload</button><br>
+      <button ng-click="downloadTopicSimilaritiesFile()">Download current topic similarities</button>
+    </div>
+  </md-card>
+
+  <md-card class="oppia-page-card oppia-long-text" style="max-width: 700px">
+    <h3>Search Index</h3>
+    <button ng-click="clearSearchIndex()">Clear Search Index</button>
+  </md-card>
+</script>


### PR DESCRIPTION
Please see #2669 for detailed information about how the controller was split up. Also, some additional work was done:
- The admin page's `ng-controller` declaration is at the `html` tag rather than a `body` or `div` tag
- I updated the scroll-to-job-output logic to scroll to the top of the job output rather than the bottom of the page (the previous logic did not work so well with large amounts of output)
- I removed all Jinja variables used outside of the controller, which required adding some more variables to the `GLOBALS` array
- Removed the table-style formatting and just used `md-cards` for subsequent directives (they didn't need the table structure anymore, since some of them weren't even really using it)
- Some other minor renames and changes
