### PR TITLE
Fix #2667: Update the warning labels for changing the objective to be more clear

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -261,7 +261,7 @@
             Add a goal: what does the exploration help people to do?
             <input name="objectiveInput" type="text" class="form-control" ng-model="explorationObjectiveService.displayed"
                    placeholder="Learn how to ...">
-            <span class="help-block" ng-show="(objectiveForm.objectiveInput.$touched || objectiveHasBeenPreviouslyEdited) && explorationObjectiveService.displayed.length < 15" style="font-size: smaller; color: #a94442">Please provide a longer and more descriptive goal to help people understand what this exploration is about.</span>
+            <span class="help-block" ng-show="(objectiveForm.objectiveInput.$touched || objectiveHasBeenPreviouslyEdited) && explorationObjectiveService.displayed.length < 15" style="font-size: smaller; color: #a94442">A descriptive goal should be a complete sentence that helps people understand what this exploration is about.</span>
           </p>
         </form>
         <p ng-if="requireCategoryToBeSpecified">

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -261,7 +261,7 @@
             Add a goal: what does the exploration help people to do?
             <input name="objectiveInput" type="text" class="form-control" ng-model="explorationObjectiveService.displayed"
                    placeholder="Learn how to ...">
-            <span class="help-block" ng-show="(objectiveForm.objectiveInput.$touched || objectiveHasBeenPreviouslyEdited) && explorationObjectiveService.displayed.length < 15" style="font-size: smaller; color: #a94442">A descriptive goal should be a complete sentence that helps people understand what this exploration is about.</span>
+            <span class="help-block" ng-show="(objectiveForm.objectiveInput.$touched || objectiveHasBeenPreviouslyEdited) && explorationObjectiveService.displayed.length < 15" style="font-size: smaller; color: #a94442">Please provide a complete sentence that describes what this exploration is about.</span>
           </p>
         </form>
         <p ng-if="requireCategoryToBeSpecified">

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -261,7 +261,7 @@
             Add a goal: what does the exploration help people to do?
             <input name="objectiveInput" type="text" class="form-control" ng-model="explorationObjectiveService.displayed"
                    placeholder="Learn how to ...">
-            <span class="help-block" ng-show="(objectiveForm.objectiveInput.$touched || objectiveHasBeenPreviouslyEdited) && explorationObjectiveService.displayed.length < 15" style="font-size: smaller; color: #a94442">Please provide a descriptive goal to help people understand what this exploration is about.</span>
+            <span class="help-block" ng-show="(objectiveForm.objectiveInput.$touched || objectiveHasBeenPreviouslyEdited) && explorationObjectiveService.displayed.length < 15" style="font-size: smaller; color: #a94442">Please provide a longer and more descriptive goal to help people understand what this exploration is about.</span>
           </p>
         </form>
         <p ng-if="requireCategoryToBeSpecified">

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -23,7 +23,7 @@
                        ng-blur="saveExplorationObjective()" placeholder="Learn how to ...">
                 <span class="help-block" style="font-size: smaller">
                   What does this exploration help people to do?
-                  <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15">A descriptive goal should be longer.</span>
+                  <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15">Descriptive goals should be complete sentences.</span>
                 </span>
               </div>
             </div>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -23,6 +23,7 @@
                        ng-blur="saveExplorationObjective()" placeholder="Learn how to ...">
                 <span class="help-block" style="font-size: smaller">
                   What does this exploration help people to do?
+                  <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15">A descriptive goal should be longer.</span>
                 </span>
               </div>
             </div>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -23,7 +23,7 @@
                        ng-blur="saveExplorationObjective()" placeholder="Learn how to ...">
                 <span class="help-block" style="font-size: smaller">
                   What does this exploration help people to do?
-                  <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15">Descriptive goals should be complete sentences.</span>
+                  <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15">Please provide a complete, descriptive sentence.</span>
                 </span>
               </div>
             </div>


### PR DESCRIPTION
This is a proposal for updating the wording of the objective statement so that it's clearer about good description = longer description. We don't want to necessarily encourage people to arbitrarily make their objectives 15 chars or longer, but I think that's going to happen right now, anyway. The current warning basically makes people guess on how to fill out the form; I don't think a lack of clarity is going to help lead to better objective statements.
