### PR TITLE
Fix #2620: Remove deadzone between title and description section

### DIFF
--- a/core/templates/dev/head/pages/dashboard/dashboard.html
+++ b/core/templates/dev/head/pages/dashboard/dashboard.html
@@ -294,7 +294,7 @@
           <div ng-attr-section="'<['right-section']>">
             <a ng-href="<[getExplorationUrl(exploration.id)]>"
                ng-if="exploration.status === 'private'"
-               style="text-decoration: none; display: block; height: 75px">
+               style="display: inline-block; height: 88px; text-decoration: none; width: 100%;">
               <div class="exp-private-text">
                 <[publishText]>
               </div>


### PR DESCRIPTION
I tested this for various devices and screen sizes and I think these changes give the desired outcome.

