### PR TITLE
Fix 2679: Use the correct colors for the progress dots.

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
@@ -25,7 +25,7 @@
       animation-timing-function: linear;
     }
     .oppia-progress-arrow {
-      color: #609688;
+      color: #02544e;
       display: inline-block;
       margin-left: 10px;
       vertical-align: middle;
@@ -53,7 +53,7 @@
       bottom: -10px;
     }
     .oppia-progress-dot-active {
-      background-color: #06b9ac;
+      background-color: #009788;
     }
     .oppia-progress-dot-inactive {
       background-color: #fff;

--- a/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
@@ -25,7 +25,7 @@
       animation-timing-function: linear;
     }
     .oppia-progress-arrow {
-      color: #02544e;
+      color: rgba(2,84,78,0.25);
       display: inline-block;
       margin-left: 10px;
       vertical-align: middle;
@@ -33,6 +33,7 @@
       user-select: none;
     }
     .oppia-progress-arrow-active {
+      color: rgba(2,84,78,1);
       cursor: pointer;
     }
 

--- a/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
@@ -25,7 +25,7 @@
       animation-timing-function: linear;
     }
     .oppia-progress-arrow {
-      color: #ccc;
+      color: #609688;
       display: inline-block;
       margin-left: 10px;
       vertical-align: middle;
@@ -33,7 +33,6 @@
       user-select: none;
     }
     .oppia-progress-arrow-active {
-      color: #fff;
       cursor: pointer;
     }
 
@@ -54,10 +53,10 @@
       bottom: -10px;
     }
     .oppia-progress-dot-active {
-      background-color: #fff;
+      background-color: #06b9ac;
     }
     .oppia-progress-dot-inactive {
-      background-color: #ccc;
+      background-color: #fff;
       cursor: pointer;
     }
     .oppia-progress-dot-gradient-left {


### PR DESCRIPTION
Followed the examples given in #2676, here's a [screenshot](https://pageshot.net/z2DJtov3x8hut2hM/oppia-dev).