### PR TITLE
Add hover-descriptions to simple-editor control-buttons (add question & finish exploration)

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/simple_editor_body_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/simple_editor_body_directive.html
@@ -93,16 +93,14 @@
     margin-top: 80px;
   }
 
-
   simple-editor-body .advance-btn-wrapper {
-    display: inline-block;
-    position: fixed;
     bottom: 50px;
+    display: inline-block;
     margin-left: -25px;
+    position: fixed;
     width: 50px;
     white-space: nowrap;
   }
-
   simple-editor-body .advance-btn {
     border: 1px solid #009688;
     border-radius: 50%;
@@ -124,14 +122,13 @@
   simple-editor-body .end-exploration-btn-wrapper {
     margin-left: 40px;
   }
-
   simple-editor-body .advance-btn-description {
     color: #009688;
     display: block;
+    margin-bottom: 5px;
     margin-left: -100%;
     margin-right: -100%;
     text-align: center;
-    margin-bottom: 5px;
     text-shadow: -1px 0 white, 0 1px white, 1px 0 white, 0 -1px white;
   }
 </style>

--- a/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/simple_editor_body_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/simple_editor_body_directive.html
@@ -37,15 +37,23 @@
       </div>
     </div>
 
-    <button ng-disabled="!canAddNewQuestion()" type="button"
-            class="btn btn-default advance-btn" ng-click="addNewQuestion()">
-      <i class="material-icons md-30">&#xE5CF;</i>
-    </button>
-    <button ng-if="canTryToPublish()" type="button"
-            class="btn btn-default advance-btn end-exploration-btn"
-            ng-click="tryToPublishExploration()">
-      <i class="material-icons md-30">&#xE047;</i>
-    </button>
+    <div class="advance-btn-wrapper">
+      <span class="advance-btn-description" ng-show="advBtnHovered">Add new question</span>
+      <button ng-disabled="!canAddNewQuestion()" type="button"
+              class="btn btn-default advance-btn" ng-click="addNewQuestion(); advBtnHovered = false"
+              ng-mouseenter="advBtnHovered = true" ng-mouseleave="advBtnHovered = false">
+        <i class="material-icons md-30">&#xE5CF;</i>
+      </button>
+    </div>
+    <div class="advance-btn-wrapper end-exploration-btn-wrapper">
+      <span class="advance-btn-description" ng-show="finishBtnHovered">Finish exploration</span>
+      <button ng-show="canTryToPublish()" type="button"
+              class="btn btn-default advance-btn"
+              ng-click="tryToPublishExploration(); finishBtnHovered = false"
+              ng-mouseenter="finishBtnHovered = true" ng-mouseleave="finishBtnHovered = false">
+        <i class="material-icons md-30">&#xE047;</i>
+      </button>
+    </div>
   </div>
 </script>
 
@@ -85,14 +93,21 @@
     margin-top: 80px;
   }
 
+
+  simple-editor-body .advance-btn-wrapper {
+    display: inline-block;
+    position: fixed;
+    bottom: 50px;
+    margin-left: -25px;
+    width: 50px;
+    white-space: nowrap;
+  }
+
   simple-editor-body .advance-btn {
     border: 1px solid #009688;
     border-radius: 50%;
-    bottom: 50px;
     color: #009688;
     height: 50px;
-    margin-left: -25px;
-    position: fixed;
     width: 50px;
   }
   simple-editor-body .advance-btn:hover {
@@ -106,7 +121,17 @@
   simple-editor-body .advance-btn i {
     margin: 3px -2px;
   }
-  simple-editor-body .advance-btn.end-exploration-btn {
+  simple-editor-body .end-exploration-btn-wrapper {
     margin-left: 40px;
+  }
+
+  simple-editor-body .advance-btn-description {
+    color: #009688;
+    display: block;
+    margin-left: -100%;
+    margin-right: -100%;
+    text-align: center;
+    margin-bottom: 5px;
+    text-shadow: -1px 0 white, 0 1px white, 1px 0 white, 0 -1px white;
   }
 </style>


### PR DESCRIPTION
This adds texts above the two bottom buttons on the simple editor: "Add new question" & "Finish exploration". These texts are shown right above the button when the button is hovered.

I first tried doing this so the `<span>` description tag was inside the button element in the html, and setting it above the button using `position: relative`. This however broke looked different on different browsers. Decided to just make a wrapper for the button + description, I think this is a better solution and works different browsers.