### PR TITLE
Fix #2687: Fix tutor card position when viewport is narrow

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -10,7 +10,10 @@
 
       <div class="conversation-skin-tutor-card-container"
           ng-show="!isViewportNarrow() || isScreenNarrowAndShowingTutorCard()"
-          ng-class="{ 'conversation-skin-animate-tutor-card-on-narrow': isViewportNarrow() && isCurrentSupplementalCardNonempty()}">
+          ng-class="{ 'conversation-skin-animate-tutor-card-on-narrow':
+                        isViewportNarrow() && isCurrentSupplementalCardNonempty(),
+                      'conversation-skin-tutor-card-alone':
+                        isViewportNarrow() && !isCurrentSupplementalCardNonempty()}">
         <tutor-card show-next-card="showUpcomingCard()"
                     show-supplemental-card="showSupplementalCardIfScreenIsNarrow()"
                     start-card-change-animation="startCardChangeAnimation"
@@ -336,12 +339,18 @@
       }
 
       .conversation-skin-tutor-card-container {
+        position: absolute;
         left: 0px;
         margin: 0 auto;
         right: 0px;
         top: 40px;
         width: 100%;
         z-index: 15;
+      }
+
+      .conversation-skin-tutor-card-alone {
+        position: relative;
+        top: 0px;
       }
 
       .conversation-skin-supplemental-card-container {


### PR DESCRIPTION
This PR fixes #2687 only when the terminal card doesn't contain supplemental interaction.
So the solution is: to use relative position when tutor-card is alone, otherwise use absolute as it was before. 
The fix described in #2687 won't work good with supplemental as well.

The proper solution might be by refactoring layouting, e.g making tutor-card relative position.

