### PR TITLE
Fix #2679: Hide continue button when pagging back through the cards

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -101,6 +101,9 @@
       width: 18px;
       height: 18px;
     }
+    .oppia-progress-arrow-active {
+      color: #fff;
+    }
 
     .embeded-body {
       min-height: 100%;

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -50,8 +50,7 @@
       <nav class="bottom-nav-row">
         <div class="col-1-4 bottom-nav-left">
           <div ng-if="activeCard.answerFeedbackPairs[activeCard.answerFeedbackPairs.length - 1].oppiaFeedbackHtml &&
-                      !isCurrentSupplementalCardNonempty() && isCurrentCardAtEndOfTranscript() && !waitingForOppiaFeedback &&
-                      ((activeCard.interactionHtml && !activeCard.destStateName) || activeCard.destStateName) &&
+                      !isCurrentSupplementalCardNonempty() && isCurrentCardAtEndOfTranscript() && !waitingForOppiaFeedback && activeCard.destStateName &&
                       !isOnTerminalCard()">
             <md-button aria-label="" class="oppia-learner-continue-button protractor-test-continue-to-next-card-button" focus-on="<[::CONTINUE_BUTTON_FOCUS_LABEL]>" ng-click="showPendingCard(upcomingStateName, upcomingParams, upcomingContentHtml)" translate="I18N_PLAYER_CONTINUE_BUTTON">
             </md-button>

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -49,7 +49,10 @@
     <footer class="grid-container">
       <nav class="bottom-nav-row">
         <div class="col-1-4 bottom-nav-left">
-          <div ng-if="activeCard.destStateName && activeCard.answerFeedbackPairs[activeCard.answerFeedbackPairs.length - 1].oppiaFeedbackHtml && !isCurrentSupplementalCardNonempty()">
+          <div ng-if="activeCard.answerFeedbackPairs[activeCard.answerFeedbackPairs.length - 1].oppiaFeedbackHtml &&
+                      !isCurrentSupplementalCardNonempty() && isCurrentCardAtEndOfTranscript() && !waitingForOppiaFeedback &&
+                      ((activeCard.interactionHtml && !activeCard.destStateName) || activeCard.destStateName) &&
+                      !isOnTerminalCard()">
             <md-button aria-label="" class="oppia-learner-continue-button protractor-test-continue-to-next-card-button" focus-on="<[::CONTINUE_BUTTON_FOCUS_LABEL]>" ng-click="showPendingCard(upcomingStateName, upcomingParams, upcomingContentHtml)" translate="I18N_PLAYER_CONTINUE_BUTTON">
             </md-button>
           </div>


### PR DESCRIPTION
also changed the color of the active progressive arrow to white because the default one is green and was not clearly visible.