### PR TITLE
Fix #2537: Add CSS to improve the display of a learner's answer to an item selection interaction.

### DIFF
--- a/core/templates/dev/head/components/version_diff_visualization_directive.html
+++ b/core/templates/dev/head/components/version_diff_visualization_directive.html
@@ -29,7 +29,7 @@
   }
   .legend-graph {
     position: absolute;
-    right: 25px;
-    top: 20px;
+    right: 40px;
+    top: 34px;
   }
 </style>

--- a/core/templates/dev/head/components/version_diff_visualization_directive.html
+++ b/core/templates/dev/head/components/version_diff_visualization_directive.html
@@ -29,7 +29,7 @@
   }
   .legend-graph {
     position: absolute;
-    right: -100px;
-    top: 10px;
+    right: 25px;
+    top: 20px;
   }
 </style>

--- a/core/templates/dev/head/components/version_diff_visualization_directive.html
+++ b/core/templates/dev/head/components/version_diff_visualization_directive.html
@@ -29,7 +29,7 @@
   }
   .legend-graph {
     position: absolute;
-    right: 40px;
-    top: 34px;
+    right: -100px;
+    top: 10px;
   }
 </style>

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -134,6 +134,10 @@ body {
   max-width: 800px;
 }
 
+.oppia-state-content-display-span span{
+  display: inherit;
+}
+
 .oppia-dashboard-container .exp-private-text {
   color: #aaa;
   font-style: italic;
@@ -346,7 +350,6 @@ body {
 */
 html p, body p {
   margin-top: -5px;
-  display: inline;
 }
 
 h1, h2 {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -346,6 +346,7 @@ body {
 */
 html p, body p {
   margin-top: -5px;
+  display: inline;
 }
 
 h1, h2 {

--- a/core/templates/dev/head/pages/exploration_player/answer_feedback_pair_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/answer_feedback_pair_directive.html
@@ -8,7 +8,7 @@
       </div>
     </div>
     <div class="conversation-skin-learner-answer-content" ng-if="!getShortAnswerHtml()">
-      <div class="conversation-skin-learner-answer" angular-html-bind="getAnswerHtml()">
+      <div class="conversation-skin-learner-answer oppia-state-content-display-span" angular-html-bind="getAnswerHtml()">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Changes made - I've declared a new css class **oppia-state-content-display-span** in oppia.css file and the class is added to div element   `(<div angular-html-bind="getAnswerHtml()" class="conversation-skin-learner-answer **oppia-state-content-display-span**">)` using multiple classes technique.

These are some commits I've pushed; waiting for your remarks.

