### PR TITLE
Pull Request: Fix issue #2730: Social media icons stay within the card

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3836,7 +3836,7 @@ md-card.preview-conversation-skin-supplemental-card {
   margin-left: 7.5px;
   margin-right: 7.5px;
   position: static;
-  width: 184px;
+  width: 210px;
 }
 
 .oppia-dashboard-card-view-item .mask-wrap {


### PR DESCRIPTION
Fix #2730 : Social media icons stay within the card

