### PR TITLE
Fix #2455: Add lockfile functionality to prevent user error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 .DS_Store
 .idea
 .vagrant/*
+.lock
 
 # Oppia uses cache slugs for various resources and we need separate resource
 # directories for dev and prod. Resource directories for prod are generated

--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -25,6 +25,15 @@
 #
 # Note that the root folder MUST be named 'oppia'.
 
+LOCK_FILE="./.lock"
+touch $LOCK_FILE
+
+function cleanup {
+  rm -rf $LOCK_FILE
+}
+
+trap cleanup EXIT
+
 sudo apt-get update
 sudo apt-get install curl
 sudo apt-get install git

--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -25,14 +25,10 @@
 #
 # Note that the root folder MUST be named 'oppia'.
 
-LOCK_FILE="./.lock"
-touch $LOCK_FILE
-
-function cleanup {
-  rm -rf $LOCK_FILE
-}
-
-trap cleanup EXIT
+if [ -e "/etc/is_vagrant_vm" ]
+then
+  source $(dirname $0)/vagrant_lockfile.sh || exit 1
+fi
 
 sudo apt-get update
 sudo apt-get install curl

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -38,25 +38,9 @@ then
   exit 1
 fi
 
-LOCK_FILE="./.lock"
-
-function cleanup {
-  [ ! $NO_CLEAN ] && rm -rf $LOCK_FILE
-}
-
-trap cleanup EXIT
-
-if [ -e "$LOCK_FILE" ]
+if [ -e "/etc/is_vagrant_vm" ]
 then
-  echo ""
-  echo "  Another setup instance is already running "
-  echo ""
-  echo "  Please wait for that instance to complete or terminate it "
-  echo ""
-  NO_CLEAN=1
-  exit 1
-else
-  touch $LOCK_FILE
+  source $(dirname $0)/vagrant_lock.sh || exit 1
 fi
 
 set -e

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -35,7 +35,27 @@ then
   echo ""
   echo "     bash $0"
   echo ""
-  return 1
+  exit 1
+fi
+
+LOCK_FILE="./.lock"
+
+function cleanup {
+  rm -rf $LOCK_FILE
+}
+
+trap cleanup EXIT
+
+if [ -e "$LOCK_FILE" ]
+then
+  echo ""
+  echo "  Another setup instance is already running "
+  echo ""
+  echo "  Please wait for that instance to complete or terminate it "
+  echo ""
+  exit 1
+else
+  touch $LOCK_FILE
 fi
 
 set -e

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -41,7 +41,7 @@ fi
 LOCK_FILE="./.lock"
 
 function cleanup {
-  rm -rf $LOCK_FILE
+  [ ! $NO_CLEAN ] && rm -rf $LOCK_FILE
 }
 
 trap cleanup EXIT
@@ -53,6 +53,7 @@ then
   echo ""
   echo "  Please wait for that instance to complete or terminate it "
   echo ""
+  NO_CLEAN=1
   exit 1
 else
   touch $LOCK_FILE

--- a/scripts/vagrant_lock.sh
+++ b/scripts/vagrant_lock.sh
@@ -1,0 +1,65 @@
+# Copyright 2016 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########################################################################
+
+# This file should not be invoked directly, but sourced from other sh scripts.
+
+# Creates a lockfile to help with new user confusion when launching a vagrant
+# vm. See https://github.com/oppia/oppia/pull/2749 for details.
+#
+# It can be overridden by passing --nolock to start.sh
+
+
+# This keeps all the arguments passed in, except for --nolock just in case
+# its unexpected presence makes something downstream upset
+declare -a keep_args
+for arg in "$@"; do
+  case $arg in
+    --nolock)
+      NO_LOCK=true
+      ;;
+    *)
+    keep_args+=($arg)
+    ;;
+  esac
+done
+
+set -- "${keep_args[@]}"
+
+[ $NO_LOCK ] && return 0
+
+VAGRANT_LOCK_FILE="./.lock"
+
+function vagrant_lock_cleanup {
+  [ ! $NO_CLEAN ] && rm -rf $VAGRANT_LOCK_FILE
+}
+
+trap vagrant_lock_cleanup EXIT
+
+if [ -e "$VAGRANT_LOCK_FILE" ]
+then
+  echo ""
+  echo "  Another setup instance is already running "
+  echo ""
+  echo "  Please wait for that instance to complete or terminate it "
+  echo ""
+  echo "  If you ran $0 twice on purpose, you can override this with --nolock "
+  echo ""
+  NO_CLEAN=1
+  return 1
+else
+  touch $VAGRANT_LOCK_FILE
+fi
+

--- a/scripts/vagrant_lock.sh
+++ b/scripts/vagrant_lock.sh
@@ -22,28 +22,24 @@
 # It can be overridden by passing --nolock to start.sh
 
 
-# This keeps all the arguments passed in, except for --nolock just in case
-# its unexpected presence makes something downstream upset
-declare -a keep_args
 for arg in "$@"; do
   case $arg in
     --nolock)
       NO_LOCK=true
       ;;
-    *)
-    keep_args+=($arg)
-    ;;
   esac
 done
 
-set -- "${keep_args[@]}"
-
-[ $NO_LOCK ] && return 0
+if [ $NO_LOCK ]; then
+  return 0
+fi
 
 VAGRANT_LOCK_FILE="./.lock"
 
 function vagrant_lock_cleanup {
-  [ ! $NO_CLEAN ] && rm -rf $VAGRANT_LOCK_FILE
+  if [ ! $NO_CLEAN ]; then
+     rm -rf $VAGRANT_LOCK_FILE
+  fi
 }
 
 trap vagrant_lock_cleanup EXIT


### PR DESCRIPTION
`scripts/start.sh` and `scripts/install_prerequisites.sh` now use a lockfile mechanism to keep users from breaking the install under vagrant
Replaced a `return 1` outside of a function call with an `exit 1`
Added new `.lock` file to `.gitignore`