### PR TITLE
Remove thumbnail images that are showing up in exploration summary tiles on the search page.

### DIFF
--- a/core/domain/summary_services.py
+++ b/core/domain/summary_services.py
@@ -63,13 +63,9 @@ def get_human_readable_contributors_summary(contributors_summary):
     contributor_ids = contributors_summary.keys()
     contributor_usernames = user_services.get_human_readable_user_ids(
         contributor_ids)
-    contributor_profile_pictures = (
-        user_services.get_profile_pictures_by_user_ids(contributor_ids))
     return {
         contributor_usernames[ind]: {
             'num_commits': contributors_summary[contributor_ids[ind]],
-            'profile_picture_data_url': contributor_profile_pictures[
-                contributor_ids[ind]]
         }
         for ind in xrange(len(contributor_ids))
     }

--- a/core/domain/summary_services_test.py
+++ b/core/domain/summary_services_test.py
@@ -149,13 +149,9 @@ class ExplorationDisplayableSummariesTest(
         self.assertEqual({
             self.ALBERT_NAME: {
                 'num_commits': 10,
-                'profile_picture_data_url': (
-                    user_services.DEFAULT_IDENTICON_DATA_URL)
             },
             self.BOB_NAME: {
                 'num_commits': 13,
-                'profile_picture_data_url': (
-                    user_services.DEFAULT_IDENTICON_DATA_URL)
             }
         }, summary_services.get_human_readable_contributors_summary(
             contributors_summary))
@@ -164,12 +160,9 @@ class ExplorationDisplayableSummariesTest(
         self.assertEqual({
             self.USER_C_NAME: {
                 'num_commits': 1,
-                'profile_picture_data_url': self.USER_C_PROFILE_PICTURE
             },
             self.USER_D_NAME: {
                 'num_commits': 2,
-                'profile_picture_data_url': (
-                    user_services.DEFAULT_IDENTICON_DATA_URL)
             }
         }, summary_services.get_human_readable_contributors_summary(
             contributors_summary))

--- a/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
+++ b/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
@@ -89,25 +89,6 @@ oppia.directive('explorationSummaryTile', [function() {
         );
 
         $scope.avatarsList = [];
-        $scope.contributors.forEach(function(contributorName) {
-          var DEFAULT_PROFILE_IMAGE_PATH = (
-            UrlInterpolationService.getStaticImageUrl(
-              '/avatar/user_blue_72px.png'));
-
-          var avatarData = {
-            image: contributorsSummary[
-              contributorName].profile_picture_data_url ||
-              DEFAULT_PROFILE_IMAGE_PATH,
-            tooltipText: contributorName
-          };
-
-          if (GLOBALS.SYSTEM_USERNAMES.indexOf(contributorName) === -1) {
-            avatarData.link = '/profile/' + contributorName;
-          }
-
-          $scope.avatarsList.push(avatarData);
-        });
-
         if ($scope.isCommunityOwned()) {
           var COMMUNITY_OWNED_IMAGE_PATH = (
             UrlInterpolationService.getStaticImageUrl(


### PR DESCRIPTION
Context: PR #2694 added a fixed footer for explorations, and, as part of doing so, added a human_readable_contributor_summary to the exploration summaries dict. This actually caused a regression in another part of the site: contributor avatars now show up in the top right of exploration summary tiles in the library search page. We discontinued this a while back because there was a lot of bandwidth consumed in transferring lots of image files over the wire (which made the page slow), and also because it looks ugly.

The aim of this PR is to preserve the inclusion of human_readable_contributor_summary, but removing the profile_picture_data_url part of it.

