### PR TITLE
Update guppy version from 0.0.2 to 1.0.0 

### DIFF
--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -1,9 +1,10 @@
-<link rel="stylesheet" href="/third_party/static/guppy-0.0.2/lib/katex/katex-modified.min.css">
-<script src="/third_party/static/guppy-0.0.2/lib/katex/katex-modified.min.js"></script>
-<script src="/third_party/static/guppy-0.0.2/guppy/guppy.js"></script>
+<link rel="stylesheet" href="/third_party/static/guppy-1.0.0/lib/katex/katex-modified.min.css">
+<script src="/third_party/static/guppy-1.0.0/lib/katex/katex-modified.min.js"></script>
+<script src="/third_party/static/guppy-1.0.0/lib/mousetrap/mousetrap.min.js"></script>
+<script src="/third_party/static/guppy-1.0.0/src/guppy.js"></script>
 
 <script>
   Guppy.guppy_init(
-    '/third_party/static/guppy-0.0.2/guppy/transform.xsl',
-    '/third_party/static/guppy-0.0.2/guppy/symbols.json');
+    '/third_party/static/guppy-1.0.0/src/transform.xsl',
+    '/third_party/static/guppy-1.0.0/src/symbols.json');
 </script>

--- a/manifest.json
+++ b/manifest.json
@@ -230,9 +230,9 @@
         }
       },
       "guppy": {
-        "version": "0.0.2",
+        "version": "1.0.0",
         "downloadFormat": "zip",
-        "url": "https://github.com/daniel3735928559/guppy/archive/v0.0.2.zip",
+        "url": "https://github.com/daniel3735928559/guppy/archive/v1.0.0.zip",
         "rootDirPrefix": "guppy-",
         "targetDirPrefix": "guppy-"
       },


### PR DESCRIPTION
As discussed in #2754, I have updated the Guppy version from 0.0.2 to 1.0.0
