### PR TITLE
Fix bug in math expression input

### DIFF
--- a/extensions/interactions/MathExpressionInput/MathExpressionInput.js
+++ b/extensions/interactions/MathExpressionInput/MathExpressionInput.js
@@ -59,7 +59,7 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
           };
 
           $scope.isCurrentAnswerValid = function() {
-            var asciiAnswer = Guppy.instances[guppyDivId].get_content('calc');
+            var asciiAnswer = Guppy.instances[guppyDivId].get_content('text');
 
             try {
               MathExpression.fromText(answer.ascii);
@@ -71,7 +71,7 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
           };
 
           $scope.submitAnswer = function() {
-            answer.ascii = Guppy.instances[guppyDivId].get_content('calc');
+            answer.ascii = Guppy.instances[guppyDivId].get_content('text');
             answer.latex = Guppy.instances[guppyDivId].get_content('latex');
 
             if (answer === undefined || answer === null ||


### PR DESCRIPTION
PR #2759 introduced a bug, due to which Latex expressions were not evaluated properly. I have tested this for various latex expressions like x^2, x^3, x^2y^2, x^(y^z) and it has worked properly. One thing I would like to mention is that the bug reported in #2755 still exists.

