### PR TITLE
Remove functionality for opening the sidebar on swipe.

### DIFF
--- a/core/templates/dev/head/pages/Base.js
+++ b/core/templates/dev/head/pages/Base.js
@@ -26,7 +26,6 @@ oppia.controller('Base', [
     $rootScope.loadingMessage = '';
 
     $scope.isSidebarShown = SidebarStatusService.isSidebarShown;
-    $scope.openSidebarOnSwipe = SidebarStatusService.openSidebar;
     $scope.closeSidebarOnSwipe = SidebarStatusService.closeSidebar;
 
     // TODO(sll): use 'touchstart' for mobile.

--- a/core/templates/dev/head/pages/base.html
+++ b/core/templates/dev/head/pages/base.html
@@ -132,7 +132,7 @@
     {% else %}
       <div class="oppia-base-container"
            ng-class="{'oppia-sidebar-menu-open': isSidebarShown(), 'oppia-sidebar-menu-closed': !isSidebarShown()}"
-           ng-swipe-left="closeSidebarOnSwipe()" ng-swipe-right="openSidebarOnSwipe()">
+           ng-swipe-left="closeSidebarOnSwipe()">
         <div class="oppia-content-container">
           <div id="wrapper">
             <div class="oppia-main-body">


### PR DESCRIPTION
This is in response to a bug report we received that, when playing an exploration on mobile, it is too easy to open the sidebar, and this interferes with playing the exploration. On closer examination, I am not actually sure why we even need to implement swipe-to-open for the side menu on either mobile or desktop (clicking on the hamburger menu at the top left should be the "standard" way of triggering the 'open' action), so this PR removes this functionality.