### PR TITLE
Fix #2737: Do not wrap math formulae that are less than 500px wide.

### DIFF
--- a/core/templates/dev/head/pages/header_js_libs.html
+++ b/core/templates/dev/head/pages/header_js_libs.html
@@ -12,7 +12,8 @@ rendering.-->
     messageStyle: 'none',
     'HTML-CSS': {
       linebreaks: {
-        automatic: true
+        automatic: true,
+        width: '500px'
       },
       showMathMenu: false
     }


### PR DESCRIPTION
/cc @prateekkonduru 