### PR TITLE
Update guppy to version be6f14.

### DIFF
--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -1,10 +1,10 @@
-<link rel="stylesheet" href="/third_party/static/guppy-06918a/lib/katex/katex-modified.min.css">
-<script src="/third_party/static/guppy-06918a/lib/katex/katex-modified.min.js"></script>
-<script src="/third_party/static/guppy-06918a/lib/mousetrap/mousetrap.min.js"></script>
-<script src="/third_party/static/guppy-06918a/src/guppy.js"></script>
+<link rel="stylesheet" href="/third_party/static/guppy-be6f14/lib/katex/katex-modified.min.css">
+<script src="/third_party/static/guppy-be6f14/lib/katex/katex-modified.min.js"></script>
+<script src="/third_party/static/guppy-be6f14/lib/mousetrap/mousetrap.min.js"></script>
+<script src="/third_party/static/guppy-be6f14/src/guppy.js"></script>
 
 <script>
   Guppy.guppy_init(
-    '/third_party/static/guppy-06918a/src/transform.xsl',
-    '/third_party/static/guppy-06918a/src/symbols.json');
+    '/third_party/static/guppy-be6f14/src/transform.xsl',
+    '/third_party/static/guppy-be6f14/src/symbols.json');
 </script>

--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -1,10 +1,10 @@
-<link rel="stylesheet" href="/third_party/static/guppy-1.0.0/lib/katex/katex-modified.min.css">
-<script src="/third_party/static/guppy-1.0.0/lib/katex/katex-modified.min.js"></script>
-<script src="/third_party/static/guppy-1.0.0/lib/mousetrap/mousetrap.min.js"></script>
-<script src="/third_party/static/guppy-1.0.0/src/guppy.js"></script>
+<link rel="stylesheet" href="/third_party/static/guppy-06918a/lib/katex/katex-modified.min.css">
+<script src="/third_party/static/guppy-06918a/lib/katex/katex-modified.min.js"></script>
+<script src="/third_party/static/guppy-06918a/lib/mousetrap/mousetrap.min.js"></script>
+<script src="/third_party/static/guppy-06918a/src/guppy.js"></script>
 
 <script>
   Guppy.guppy_init(
-    '/third_party/static/guppy-1.0.0/src/transform.xsl',
-    '/third_party/static/guppy-1.0.0/src/symbols.json');
+    '/third_party/static/guppy-06918a/src/transform.xsl',
+    '/third_party/static/guppy-06918a/src/symbols.json');
 </script>

--- a/manifest.json
+++ b/manifest.json
@@ -230,11 +230,11 @@
         }
       },
       "guppy": {
-        "version": "1.0.0",
+        "version": "06918aba8b03fa99f5a369ee94fdf96a696795f8",
         "downloadFormat": "zip",
-        "url": "https://github.com/daniel3735928559/guppy/archive/v1.0.0.zip",
+        "url": "https://github.com/daniel3735928559/guppy/archive/06918aba8b03fa99f5a369ee94fdf96a696795f8.zip",
         "rootDirPrefix": "guppy-",
-        "targetDirPrefix": "guppy-"
+        "targetDir": "guppy-06918a"
       },
       "hammerJs": {
         "version": "2.0.4",

--- a/manifest.json
+++ b/manifest.json
@@ -230,11 +230,11 @@
         }
       },
       "guppy": {
-        "version": "06918aba8b03fa99f5a369ee94fdf96a696795f8",
+        "version": "be6f14251b6b6c981925f438ddc556d6492649a5",
         "downloadFormat": "zip",
-        "url": "https://github.com/daniel3735928559/guppy/archive/06918aba8b03fa99f5a369ee94fdf96a696795f8.zip",
+        "url": "https://github.com/daniel3735928559/guppy/archive/be6f14251b6b6c981925f438ddc556d6492649a5.zip",
         "rootDirPrefix": "guppy-",
-        "targetDir": "guppy-06918a"
+        "targetDir": "guppy-be6f14"
       },
       "hammerJs": {
         "version": "2.0.4",


### PR DESCRIPTION
This aims to unblock @Arunabh98's work on #2754, which we ought to get in before the next release this weekend, since we've had several bug reports about the math expression input field. 