### PR TITLE
Fix #2754: Math expression input box is more clear

### DIFF
--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -16,7 +16,7 @@
     }
 
     .guppy_inactive {
-        background: #ffffff !important;
+      background: #ffffff !important;
     }
 
     .guppy_active .main_cursor {

--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -10,25 +10,30 @@
 </script>
 
 <style>
-    .guppy_active {
-      box-shadow: 0 0 5px rgba(81, 203, 238, 1) !important;
-      border: 1px solid rgba(81, 203, 238, 1) !important;
-    }
+  .guppy-container:active,
+  .guppy-container:focus {
+    box-shadow: 0 0 5px rgba(81, 203, 238, 1);
+  }
 
-    .guppy_inactive {
-      background: #ffffff !important;
-    }
+  .guppy_active {
+    border: 1px solid rgba(81, 203, 238, 1);
+  }
 
-    .guppy_active .main_cursor {
-      animation: blink-animation 1s steps(2, start) infinite;
-      -webkit-animation: blink-animation 1s steps(2, start) infinite;
-    }
+  .guppy_inactive {
+    background: #ffffff;
+    border: 1px solid black;
+  }
 
-    @keyframes blink-animation {
-      to { visibility: hidden; }
-    }
+  .guppy_active .main_cursor {
+    animation: guppy-blink-animation 1s steps(2, start) infinite;
+    -webkit-animation: guppy-blink-animation 1s steps(2, start) infinite;
+  }
 
-    @-webkit-keyframes blink-animation {
-      to { visibility: hidden; }
-    }
+  @keyframes guppy-blink-animation {
+    to { visibility: hidden; }
+  }
+
+  @-webkit-keyframes guppy-blink-animation {
+    to { visibility: hidden; }
+  }
 </style>

--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -10,11 +10,6 @@
 </script>
 
 <style>
-  .guppy-container:active,
-  .guppy-container:focus {
-    box-shadow: 0 0 5px rgba(81, 203, 238, 1);
-  }
-
   .guppy_active {
     border: 1px solid rgba(81, 203, 238, 1);
   }

--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -8,3 +8,27 @@
     '/third_party/static/guppy-be6f14/src/transform.xsl',
     '/third_party/static/guppy-be6f14/src/symbols.json');
 </script>
+
+<style>
+    .guppy_active {
+      box-shadow: 0 0 5px rgba(81, 203, 238, 1) !important;
+      border: 1px solid rgba(81, 203, 238, 1) !important;
+    }
+
+    .guppy_inactive {
+        background: #ffffff !important;
+    }
+
+    .guppy_active .main_cursor {
+      animation: blink-animation 1s steps(2, start) infinite;
+      -webkit-animation: blink-animation 1s steps(2, start) infinite;
+    }
+
+    @keyframes blink-animation {
+      to { visibility: hidden; }
+    }
+
+    @-webkit-keyframes blink-animation {
+      to { visibility: hidden; }
+    }
+</style>

--- a/extensions/interactions/MathExpressionInput/MathExpressionInput.html
+++ b/extensions/interactions/MathExpressionInput/MathExpressionInput.html
@@ -2,8 +2,10 @@
 <script src="{{cache_slug}}/extensions/interactions/MathExpressionInput/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/MathExpressionInput">
-  <div class="guppy-div"
-       style="border: 1px solid black; width: 100%; height: 100px; padding: 5px;">
+  <div class="guppy-container">
+    <div class="guppy-div"
+         style="width: 100%; height: 100px; padding: 5px;">
+    </div>
   </div>
   <button type="button" class="btn btn-default"
           ng-click="submitAnswer()" style="margin-top: 10px;">

--- a/extensions/interactions/MathExpressionInput/MathExpressionInput.html
+++ b/extensions/interactions/MathExpressionInput/MathExpressionInput.html
@@ -2,10 +2,8 @@
 <script src="{{cache_slug}}/extensions/interactions/MathExpressionInput/validator.js"></script>
 
 <script type="text/ng-template" id="interaction/MathExpressionInput">
-  <div class="guppy-container">
-    <div class="guppy-div"
-         style="width: 100%; height: 100px; padding: 5px;">
-    </div>
+  <div class="guppy-div"
+       style="width: 100%; height: 100px; padding: 5px;">
   </div>
   <button type="button" class="btn btn-default"
           ng-click="submitAnswer()" style="margin-top: 10px;">


### PR DESCRIPTION
I had to use !important in some places because the styles defined in index.css of guppy file appear as inline style attributes which I don't think can be overcome by any other way.

