### PR TITLE
Fix background color regression.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -32,8 +32,7 @@
 }
 
 /* Angular material overrides. */
-md-input-group.long > input
-{
+md-input-group.long > input {
   width: 100%;
   height: 45px;
 }
@@ -87,6 +86,7 @@ button.md-button.md-default-theme.oppia-learner-continue-button:hover {
 
 /* Bootstrap overrides and additions. */
 html {
+  background-color: #e8e7e3;
   /*
     The HTML font-size is set to 62.5% in order to make 'em' units easier to
     work with. Modern browsers set their default font-size to 16px. This means


### PR DESCRIPTION
On the preferences page, the background color cuts off mid-screen. This also happens in other pages (such as the admin page). Bisecting shows that this is due to a regression due to #2794; this PR fixes that.