### PR TITLE
Fix #2789: Remove white panel behind exploration cards. Remove 'Portfolio' text.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -257,10 +257,10 @@ body {
 }
 
 .oppia-profile-content-card {
-  background-color: #fff;
+  box-shadow: none;
   float: left;
   min-height: 630px;
-  padding: 30px;
+  padding: 0 30 30 30;
   position: relative;
   width: -webkit-calc(100% - 280px);
   width: -moz-calc(100% - 280px);
@@ -283,9 +283,10 @@ body {
 .oppia-profile-portfolio-pages {
   bottom: 0;
   display: block;
-  font-size: .7em;
-  margin-bottom: 20px;
-  margin-right: 40px;
+  font-size: .9em;
+  font-weight: bold;
+  margin-bottom: 60px;
+  margin-right: 65px;
   position: absolute;
   right: 0;
   text-align: right;
@@ -3606,7 +3607,7 @@ md-card.preview-conversation-skin-supplemental-card {
     The margin setting is so that exploration summary tiles and collection
     summary tiles would be the same widths (214px).
   */
-  margin: 12px 5.5px;
+  margin: 8px 5.5px;
   padding: 0;
   position: relative;
   text-align: left;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -260,12 +260,17 @@ body {
   box-shadow: none;
   float: left;
   min-height: 630px;
-  padding: 0 30 30 30;
+  padding: 0 30px 30px 30px;
   position: relative;
   width: -webkit-calc(100% - 280px);
   width: -moz-calc(100% - 280px);
   width: -o-calc(100% - 280px);
   width: calc(100% - 280px);
+}
+
+md-card.oppia-profile-content-card {
+  margin-top: 0;
+  padding-top: 0;
 }
 
 /* For issue #1867 (https://github.com/oppia/oppia/issues/1867)
@@ -278,6 +283,10 @@ body {
   margin-bottom: 20px;
   overflow: hidden;
   width: 100%;
+}
+
+md-content.oppia-profile-portfolio-container {
+  background-color: transparent;
 }
 
 .oppia-profile-portfolio-pages {

--- a/core/templates/dev/head/pages/profile/profile.html
+++ b/core/templates/dev/head/pages/profile/profile.html
@@ -100,8 +100,8 @@
       <hr class="oppia-profile-stat-container-line-small-screen">
     </md-card>
 
-    <md-card class="oppia-profile-content-card" style="margin-top: 0; padding-top: 0;">
-      <md-content class="oppia-profile-portfolio-container" style="background-color: transparent;">
+    <md-card class="oppia-profile-content-card">
+      <md-content class="oppia-profile-portfolio-container">
         <exploration-summary-tile ng-repeat="expl in getExplorationsToDisplay()"
           exploration-id="expl.id"
           exploration-title="expl.title"

--- a/core/templates/dev/head/pages/profile/profile.html
+++ b/core/templates/dev/head/pages/profile/profile.html
@@ -100,9 +100,8 @@
       <hr class="oppia-profile-stat-container-line-small-screen">
     </md-card>
 
-    <md-card class="oppia-profile-content-card">
-      <strong>Portfolio</strong>
-      <md-content class="oppia-profile-portfolio-container">
+    <md-card class="oppia-profile-content-card" style="margin-top: 0; padding-top: 0;">
+      <md-content class="oppia-profile-portfolio-container" style="background-color: transparent;">
         <exploration-summary-tile ng-repeat="expl in getExplorationsToDisplay()"
           exploration-id="expl.id"
           exploration-title="expl.title"


### PR DESCRIPTION
![capture](https://cloud.githubusercontent.com/assets/11807091/20864154/9e8ba40a-b9b2-11e6-9597-80982d27a62a.JPG)
