### PR TITLE
Fix learner view: not clickable tutor card icon

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
@@ -111,6 +111,47 @@ oppia.animation('.conversation-skin-animate-tutor-card-on-narrow', function() {
   };
 });
 
+oppia.animation('.conversation-skin-animate-tutor-card-content', function() {
+  var animateCardChange = function(element, className, done) {
+    if (className !== 'animate-card-change') {
+      return;
+    }
+
+    var currentHeight = element.height();
+    var expectedNextHeight = $(
+      '.conversation-skin-future-tutor-card ' +
+      '.conversation-skin-tutor-card-content'
+    ).height();
+
+    // Fix the current card height, so that it does not change during the
+    // animation, even though its contents might.
+    element.css('height', currentHeight);
+
+    jQuery(element).animate({
+      opacity: 0
+    }, TIME_FADEOUT_MSEC).animate({
+      height: expectedNextHeight
+    }, TIME_HEIGHT_CHANGE_MSEC).animate({
+      opacity: 1
+    }, TIME_FADEIN_MSEC, function() {
+      element.css('height', '');
+      done();
+    });
+
+    return function(cancel) {
+      if (cancel) {
+        element.css('opacity', '1.0');
+        element.css('height', '');
+        element.stop();
+      }
+    };
+  };
+
+  return {
+    addClass: animateCardChange
+  };
+});
+
 oppia.animation('.conversation-skin-animate-cards', function() {
   // This removes the newly-added class once the animation is finished.
   var animateCards = function(element, className, done) {
@@ -513,14 +554,9 @@ oppia.directive('conversationSkin', ['urlService', function(urlService) {
                     oppiaPlayerService.getInteractionHtml(
                       newStateName, _nextFocusLabel
                     ) + oppiaPlayerService.getRandomSuffix() : '');
-
-                  $scope.$broadcast('destinationCardAvailable', {
-                    upcomingStateName: $scope.upcomingStateName,
-                    upcomingParams: $scope.upcomingParams,
-                    upcomingContentHtml: $scope.upcomingContentHtml,
-                    upcomingInlineInteractionHtml:
-                        $scope.upcomingInlineInteractionHtml
-                  });
+                  $scope.upcomingInteractionInstructions = (
+                    ExplorationPlayerStateService.getInteractionInstructions(
+                      $scope.upcomingStateName));
 
                   if (feedbackHtml) {
                     playerTranscriptService.addNewFeedback(feedbackHtml);
@@ -570,6 +606,7 @@ oppia.directive('conversationSkin', ['urlService', function(urlService) {
             $scope.upcomingParams = null;
             $scope.upcomingContentHtml = null;
             $scope.upcomingInlineInteractionHtml = null;
+            $scope.upcomingInteractionInstructions = null;
           }, TIME_FADEOUT_MSEC + 0.1 * TIME_HEIGHT_CHANGE_MSEC);
 
           $timeout(function() {

--- a/core/templates/dev/head/pages/exploration_player/TutorCardDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/TutorCardDirective.js
@@ -35,47 +35,6 @@ oppia.animation('.conversation-skin-responses-animate-slide', function() {
   };
 });
 
-oppia.animation('.conversation-skin-animate-tutor-card-content', function() {
-  var animateCardChange = function(element, className, done) {
-    if (className !== 'animate-card-change') {
-      return;
-    }
-
-    var currentHeight = element.height();
-    var expectedNextHeight = $(
-      '.conversation-skin-future-tutor-card ' +
-      '.conversation-skin-tutor-card-content'
-    ).height();
-
-    // Fix the current card height, so that it does not change during the
-    // animation, even though its contents might.
-    element.css('height', currentHeight);
-
-    jQuery(element).animate({
-      opacity: 0
-    }, TIME_FADEOUT_MSEC).animate({
-      height: expectedNextHeight
-    }, TIME_HEIGHT_CHANGE_MSEC).animate({
-      opacity: 1
-    }, TIME_FADEIN_MSEC, function() {
-      element.css('height', '');
-      done();
-    });
-
-    return function(cancel) {
-      if (cancel) {
-        element.css('opacity', '1.0');
-        element.css('height', '');
-        element.stop();
-      }
-    };
-  };
-
-  return {
-    addClass: animateCardChange
-  };
-});
-
 oppia.directive('tutorCard', [function() {
   return {
     restrict: 'E',
@@ -167,17 +126,6 @@ oppia.directive('tutorCard', [function() {
 
         $scope.$on(EVENT_ACTIVE_CARD_CHANGED, function() {
           updateActiveCard();
-        });
-
-        $scope.$on('destinationCardAvailable', function(event, card) {
-          $scope.upcomingContentHtml = card.upcomingContentHtml;
-          $scope.upcomingParams = card.upcomingParams;
-          $scope.upcomingStateName = card.upcomingStateName;
-          $scope.upcomingInlineInteractionHtml = (
-            card.upcomingInlineInteractionHtml);
-          $scope.upcomingInteractionInstructions = (
-            ExplorationPlayerStateService.getInteractionInstructions(
-              $scope.upcomingStateName));
         });
 
         $scope.$on('oppiaFeedbackAvailable', function() {

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -1,4 +1,36 @@
 <script type="text/ng-template" id="skins/Conversation">
+  <!--
+    Off-screen preview of the next card in order to pre-determine the target
+    height for the card content transition animation.
+  -->
+  <div class="conversation-skin-future-tutor-card" aria-hidden="true">
+    <div class="conversation-skin-tutor-card-content">
+      <div class="conversation-skin-tutor-card-top-section">
+        <div class="conversation-skin-tutor-card-top-content"
+             angular-html-bind="upcomingContentHtml">
+        </div>
+      </div>
+
+      <div ng-if="upcomingInlineInteractionHtml"
+           class="conversation-skin-inline-interaction"
+           angular-html-bind="upcomingInlineInteractionHtml">
+      </div>
+
+      <div ng-if="!upcomingInlineInteractionHtml"
+          class="conversation-skin-inline-interaction">
+        <div ng-if="!isViewportNarrow()" style="padding: 6px 12px;">
+          <[upcomingInteractionInstructions]>
+          <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
+        </div>
+        <div ng-if="isViewportNarrow()">
+          <md-button class="instructions-button">
+            <[upcomingInteractionInstructions]>
+          </md-button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div role="main" style="margin: 0 auto; position: relative;" ng-if="hasFullyLoaded">
     <progress-dots num-dots="numProgressDots" class="conversation-skin-progress-dots">
     </progress-dots>
@@ -153,6 +185,13 @@
       z-index: 1;
     }
 
+    .conversation-skin-future-tutor-card {
+      left: -30000px;
+      max-width: 560px;
+      position: fixed;
+      top: -30000px;
+    }
+
     .conversation-skin-supplemental-card-container {
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.24), 0 1px 3px rgba(0, 0, 0, 0.12);
       flex-shrink: 1;
@@ -160,6 +199,7 @@
       max-width: 1000px;
       min-width: 560px;
       position: relative;
+      z-index: 2;
     }
 
     /* These rules must be kept in sync with corresponding rules in oppia.css

--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -1,36 +1,4 @@
 <script type="text/ng-template" id="components/TutorCard">
-  <!--
-    Off-screen preview of the next card in order to pre-determine the target
-    height for the card content transition animation.
-  -->
-  <div class="conversation-skin-future-tutor-card" aria-hidden="true">
-    <div class="conversation-skin-tutor-card-content">
-      <div class="conversation-skin-tutor-card-top-section">
-        <div class="conversation-skin-tutor-card-top-content"
-             angular-html-bind="upcomingContentHtml">
-        </div>
-      </div>
-
-      <div ng-if="upcomingInlineInteractionHtml"
-           class="conversation-skin-inline-interaction"
-           angular-html-bind="upcomingInlineInteractionHtml">
-      </div>
-
-      <div ng-if="!upcomingInlineInteractionHtml"
-          class="conversation-skin-inline-interaction">
-        <div ng-if="!isViewportNarrow()" style="padding: 6px 12px;">
-          <[upcomingInteractionInstructions]>
-          <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
-        </div>
-        <div ng-if="isViewportNarrow()">
-          <md-button class="instructions-button">
-            <[upcomingInteractionInstructions]>
-          </md-button>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <div class="conversation-skin-tutor-card"
        ng-class="{'animate-card-width': startCardChangeAnimation,
                   'has-shadow': isViewportNarrow() && !isInteractionInline}">
@@ -155,13 +123,6 @@
       transition: width 500ms;
     }
 
-    .conversation-skin-future-tutor-card {
-      left: -30000px;
-      max-width: 560px;
-      position: fixed;
-      top: -30000px;
-    }
-
     .conversation-skin-tutor-card-top-section {
       position: relative;
     }
@@ -175,7 +136,6 @@
       margin-bottom: 18px;
       margin-top: 18px;
     }
-
 
     .conversation-skin-tutor-card-top-content {
       width: 100%;


### PR DESCRIPTION
...and fix animation jerking, both fix are when viewport is narrow.

When viewport is narrow and the tutor card is minimised, it was impossible to click the tutor avatar to maximise, the issue was due to progress dot directive being rendered on top of the tutor avatar.

The animation issue was about disappearing of the future tutor card when the tutor card disappears. 


