### PR TITLE
Fix #2832 Add space between footer and summary explorations container

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -989,6 +989,7 @@ textarea {
   padding-top: 24px;
   width: 100vw;
 }
+
 /* Ensure that the summary tiles tiles remain centered. Note that these values
    would need to be updated if the summary tiles are changed. */
 @media (max-width: 844px) {

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -71,7 +71,8 @@
                       class="conversation-skin-bottom-gadget-panel">
   </oppia-gadget-panel>
 
-  <div ng-if="isOnTerminalCard() && isCurrentCardAtEndOfTranscript()">
+  <div ng-if="isOnTerminalCard() && isCurrentCardAtEndOfTranscript()"
+       class="conversation-skin-final-summary">
     <div ng-if="isLoggedIn && !isInPreviewMode" class="conversation-skin-final-ratings">
       <div class="conversation-skin-final-ratings-header" translate="I18N_PLAYER_RATE_EXPLORATION">
       </div>
@@ -88,7 +89,7 @@
             translate="I18N_PLAYER_RECOMMEND_EXPLORATIONS">
       </span>
 
-      <div class="oppia-exp-summary-tiles-container" style="padding-top: 10px;">
+      <div class="oppia-exp-summary-tiles-container conversation-skin-recommended-explorations-container">
         <exploration-summary-tile ng-repeat="exp in (recommendedExplorationSummaries|limitTo:3) track by $index"
                                   collection-id="collectionId"
                                   exploration-id="exp.id"
@@ -344,6 +345,14 @@
     }
     .conversation-skin-oppia-feedback.ng-enter.ng-enter-active {
       opacity: 1;
+    }
+
+    .conversation-skin-final-summary {
+      margin-bottom: 25px;
+    }
+
+    .conversation-skin-recommended-explorations-container {
+      padding-top: 10px;
     }
 
     @media screen and (max-width: 959px) {


### PR DESCRIPTION
@Oishikatta I have added a bottom margin of 25px to the explorations summary container. Can you verify if its okay?