### PR TITLE
Fix #2716: Show only simple editor tools on medium screens per spec

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -972,6 +972,11 @@ textarea {
     display: none;
   }
 }
+@media (max-width: 1023px) {
+  .oppia-navbar-hide-on-medium-width {
+    display: none !important;
+  }
+}
 
 .btn.oppia-unresolved-answer-button {
   background-color: white;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -973,8 +973,8 @@ textarea {
   }
 }
 @media (max-width: 1023px) {
-  .oppia-navbar-hide-on-medium-width {
-    display: none !important;
+  div.navbar-container .oppia-navbar-hide-on-medium-width {
+    display: none;
   }
 }
 

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
@@ -411,10 +411,12 @@ oppia.controller('EditorNavigation', [
     $scope.postTutorialHelpPopoverIsShown = false;
 
     $scope.$on('openPostTutorialHelpPopover', function() {
-      $scope.postTutorialHelpPopoverIsShown = true;
-      $timeout(function() {
-        $scope.postTutorialHelpPopoverIsShown = false;
-      }, 5000);
+      if ($(window).width() >= 1024) {
+        $scope.postTutorialHelpPopoverIsShown = true;
+        $timeout(function() {
+          $scope.postTutorialHelpPopoverIsShown = false;
+        }, 5000);
+      }
     });
 
     $scope.showUserHelpModal = function() {

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
@@ -401,17 +401,17 @@ oppia.controller('EditorNavigation', [
   'explorationRightsService', 'explorationWarningsService',
   'stateEditorTutorialFirstTimeService',
   'threadDataService', 'siteAnalyticsService',
-  'explorationContextService',
+  'explorationContextService', 'windowDimensionsService',
   function(
     $scope, $rootScope, $timeout, $modal, routerService,
     explorationRightsService, explorationWarningsService,
     stateEditorTutorialFirstTimeService,
     threadDataService, siteAnalyticsService,
-    explorationContextService) {
+    explorationContextService, windowDimensionsService) {
     $scope.postTutorialHelpPopoverIsShown = false;
 
     $scope.$on('openPostTutorialHelpPopover', function() {
-      if ($(window).width() >= 1024) {
+      if (windowDimensionsService.getWidth() >= 1024) {
         $scope.postTutorialHelpPopoverIsShown = true;
         $timeout(function() {
           $scope.postTutorialHelpPopoverIsShown = false;

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -105,7 +105,7 @@
       </li>
     {% endif %}
 
-    <li ng-class="{'active': getTabStatuses().active === 'settings'}">
+    <li class="oppia-navbar-hide-on-medium-width" ng-class="{'active': getTabStatuses().active === 'settings'}">
       <a href="#" tooltip="Settings" tooltip-placement="bottom" ng-click="selectSettingsTab()"
          class="oppia-editor-navbar-tab-anchor protractor-test-settings-tab">
         <i class="material-icons">&#xE8B8;</i>
@@ -113,7 +113,7 @@
     </li>
 
     {% if username %}
-      <li ng-class="{'active': getTabStatuses().active === 'stats'}">
+      <li class="oppia-navbar-hide-on-medium-width" ng-class="{'active': getTabStatuses().active === 'stats'}">
         <a href="#" tooltip="Statistics" tooltip-placement="bottom" ng-click="selectStatsTab()"
            class="oppia-editor-navbar-tab-anchor">
           <i class="material-icons">&#xE24B;</i>
@@ -121,7 +121,7 @@
       </li>
     {% endif %}
 
-    <li ng-class="{'active': getTabStatuses().active === 'history'}">
+    <li class="oppia-navbar-hide-on-medium-width" ng-class="{'active': getTabStatuses().active === 'history'}">
       <a href="#" tooltip="History" tooltip-placement="bottom" ng-click="selectHistoryTab()"
          disabled="explorationRightsService.isCloned()"
          class="oppia-editor-navbar-tab-anchor protractor-test-history-tab">
@@ -129,7 +129,7 @@
       </a>
     </li>
 
-    <li ng-class="{'active': getTabStatuses().active === 'feedback'}" ng-click="selectFeedbackTab()">
+    <li class="oppia-navbar-hide-on-medium-width" ng-class="{'active': getTabStatuses().active === 'feedback'}" ng-click="selectFeedbackTab()">
       <a href="#" tooltip="Feedback" tooltip-placement="bottom"
          class="oppia-editor-navbar-tab-anchor protractor-test-feedback-tab">
         <i class="material-icons">&#xE87F;</i>
@@ -142,7 +142,7 @@
     </li>
 
     {% if username %}
-      <li class="dropdown" popover-is-open="postTutorialHelpPopoverIsShown"
+      <li class="oppia-navbar-hide-on-medium-width" class="dropdown" popover-is-open="postTutorialHelpPopoverIsShown"
           popover-placement="bottom" popover-trigger="none"
           popover="To get help in the future, click here!">
         <a href="#" tooltip="Help" tooltip-placement="bottom"


### PR DESCRIPTION
This PR is just fixing the one issue #2716, showing only simple editor tools on the exploration editor for Medium screens (<1024px).