### PR TITLE
Fix #2588: Make LATEX smaller

### DIFF
--- a/core/templates/dev/head/pages/header_js_libs.html
+++ b/core/templates/dev/head/pages/header_js_libs.html
@@ -15,8 +15,8 @@ rendering.-->
         automatic: true,
         width: '500px'
       },
-      showMathMenu: false,
-      scale: 90
+      scale: 91,
+      showMathMenu: false
     }
   });
   MathJax.Hub.Configured();

--- a/core/templates/dev/head/pages/header_js_libs.html
+++ b/core/templates/dev/head/pages/header_js_libs.html
@@ -15,7 +15,8 @@ rendering.-->
         automatic: true,
         width: '500px'
       },
-      showMathMenu: false
+      showMathMenu: false,
+      scale: 90
     }
   });
   MathJax.Hub.Configured();


### PR DESCRIPTION
This is the easiest way to do it.
See the [original issue](https://github.com/oppia/oppia/issues/2588) for a screenshot and some more. 
