### PR TITLE
Convert collections settings GLOBALS to AJAX

### DIFF
--- a/core/templates/dev/head/domain/collection/CollectionRightsBackendApiService.js
+++ b/core/templates/dev/head/domain/collection/CollectionRightsBackendApiService.js
@@ -20,6 +20,24 @@ oppia.factory('CollectionRightsBackendApiService', [
     '$http', '$q', 'COLLECTION_RIGHTS_URL_TEMPLATE', 'UrlInterpolationService',
     function($http, $q, COLLECTION_RIGHTS_URL_TEMPLATE,
       UrlInterpolationService) {
+      var _getCollectionRights = function(collectionId, successCallback,
+        errorCallback) {
+        var collectionRightsUrl = UrlInterpolationService.interpolateUrl(
+          COLLECTION_RIGHTS_URL_TEMPLATE, {
+            collection_id: collectionId
+          });
+
+        $http.get(collectionRightsUrl).then(function(response) {
+          if (successCallback) {
+            successCallback(response.data);
+          }
+        }, function(errorResponse) {
+          if (errorCallback) {
+            errorCallback(errorResponse.data);
+          }
+        });
+      };
+
       var _setCollectionStatus = function(
           collectionId, collectionVersion, isPublic, successCallback,
           errorCallback) {
@@ -32,12 +50,12 @@ oppia.factory('CollectionRightsBackendApiService', [
           version: collectionVersion,
           is_public: isPublic
         };
-        $http.put(collectionRightsUrl, putParams).then(function() {
+        $http.put(collectionRightsUrl, putParams).then(function(response) {
           // TODO(bhenning): Consolidate the backend rights domain objects and
           // implement a frontend activity rights domain object. The rights
           // being passed in here should be used to create one of those objects.
           if (successCallback) {
-            successCallback();
+            successCallback(response.data);
           }
         }, function(errorResponse) {
           if (errorCallback) {
@@ -47,6 +65,15 @@ oppia.factory('CollectionRightsBackendApiService', [
       };
 
       return {
+        /**
+         * Gets a collection's rights, given its ID.
+         */
+        getCollectionRights: function(collectionId) {
+          return $q(function(resolve, reject) {
+            _getCollectionRights(collectionId, resolve, reject);
+          });
+        },
+
         /**
          * Updates a collection's rights to be have public learner access, given
          * its ID and version.

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
@@ -36,11 +36,15 @@ oppia.directive('collectionEditorNavbar', [function() {
           EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED) {
         $scope.collectionId = GLOBALS.collectionId;
         $scope.collection = CollectionEditorStateService.getCollection();
-        $scope.isPrivate = GLOBALS.isPrivate;
-        $scope.canUnpublish = GLOBALS.canUnpublish;
         $scope.validationIssues = [];
         $scope.isSaveInProgress = (
           CollectionEditorStateService.isSavingCollection);
+
+        CollectionRightsBackendApiService.getCollectionRights(
+          $scope.collectionId).then(function(response) {
+          $scope.isPrivate = response.is_private;
+          $scope.canUnpublish = response.can_unpublish;
+        });
 
         $scope.getTabStatuses = routerService.getTabStatuses;
         $scope.selectMainTab = routerService.navigateToMainTab;
@@ -68,11 +72,11 @@ oppia.directive('collectionEditorNavbar', [function() {
           // action since it is not reversible.
           CollectionRightsBackendApiService.setCollectionPublic(
             $scope.collectionId, $scope.collection.getVersion()).then(
-            function() {
+            function(response) {
               // TODO(bhenning): There should be a scope-level rights object
               // used, instead. The rights object should be loaded with the
               // collection.
-              $scope.isPrivate = false;
+              $scope.isPrivate = response.is_private;
             }, function() {
               alertsService.addWarning(
                 'There was an error when publishing the collection.');
@@ -228,8 +232,8 @@ oppia.directive('collectionEditorNavbar', [function() {
         $scope.unpublishCollection = function() {
           CollectionRightsBackendApiService.setCollectionPrivate(
             $scope.collectionId, $scope.collection.getVersion()).then(
-            function() {
-              $scope.isPrivate = true;
+            function(response) {
+              $scope.isPrivate = response.is_private;
             }, function() {
               alertsService.addWarning(
                 'There was an error when unpublishing the collection.');

--- a/core/templates/dev/head/pages/collection_editor/collection_editor.html
+++ b/core/templates/dev/head/pages/collection_editor/collection_editor.html
@@ -11,11 +11,7 @@
 {% block header_js %}
   {{ super() }}
   <script type="text/javascript">
-    GLOBALS.canEdit = JSON.parse('{{can_edit|js_string}}');
-    GLOBALS.canUnpublish = JSON.parse('{{can_unpublish|js_string}}');
     GLOBALS.collectionId = JSON.parse('{{collection_id|js_string}}');
-    GLOBALS.collectionTitle = JSON.parse('{{title|js_string}}');
-    GLOBALS.isPrivate = JSON.parse('{{is_private|js_string}}');
     GLOBALS.TAG_REGEX = JSON.parse('{{TAG_REGEX|js_string}}');
   </script>
 {% endblock header_js %}

--- a/core/templates/dev/head/pages/collection_editor/settings_tab/CollectionDetailsEditorDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/settings_tab/CollectionDetailsEditorDirective.js
@@ -47,7 +47,7 @@ oppia.directive('collectionDetailsEditor', [function() {
         );
 
         $scope.languageListForSelect = GLOBALS.ALL_LANGUAGE_CODES;
-        $scope.TAG_REGEX = GLOBALS.TAG_REGEX;
+        $scope.TAG_REGEX = $scope.collection.TAG_REGEX;
 
         var refreshSettingsTab = function() {
           $scope.displayedCollectionTitle = $scope.collection.getTitle();


### PR DESCRIPTION
This is a work in progress in converting GLOBALS into AJAX calls, so this PR is more focused on getting feedback than merging. Also, `TAG_REGEX` seems to not be elegant, would appreciate feedback/suggestions on how to handle that. 

(Please note that once the #2026 is merged, the permissions AJAX calls will be completed.) 