### PR TITLE
Fix part of #2557:  Refactoring of email preferences and add functionality to incorporate user's preferences of feedback / suggestions 

### DIFF
--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -141,11 +141,11 @@ class PreferencesHandler(base.BaseHandler):
             'user_bio': user_settings.user_bio,
             'subject_interests': user_settings.subject_interests,
             'can_receive_email_updates': (
-                user_email_preferences['can_receive_email_updates']),
+                user_email_preferences.can_receive_email_updates),
             'can_receive_editor_role_email': (
-                user_email_preferences['can_receive_editor_role_email']),
+                user_email_preferences.can_receive_editor_role_email),
             'can_receive_feedback_message_email': (
-                user_email_preferences['can_receive_feedback_message_email'])
+                user_email_preferences.can_receive_feedback_message_email)
         })
         self.render_json(self.values)
 

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -169,29 +169,29 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
         # is.
         editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', True):
+            email_preferences = user_services.get_email_preferences(editor_id)
+            self.assertEqual(email_preferences.can_receive_email_updates, True)
             self.assertEqual(
-                user_services.get_email_preferences(editor_id),
-                {
-                    'can_receive_email_updates': True,
-                    'can_receive_editor_role_email': (
-                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE),
-                    'can_receive_feedback_message_email': (
-                        feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE),
-                    'can_receive_subscription_email': (
-                        feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
-                })
+                email_preferences.can_receive_editor_role_email,
+                feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_feedback_message_email,
+                feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_subscription_email,
+                feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
+            email_preferences = user_services.get_email_preferences(editor_id)
+            self.assertEqual(email_preferences.can_receive_email_updates, False)
             self.assertEqual(
-                user_services.get_email_preferences(editor_id),
-                {
-                    'can_receive_email_updates': False,
-                    'can_receive_editor_role_email': (
-                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE),
-                    'can_receive_feedback_message_email': (
-                        feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE),
-                    'can_receive_subscription_email': (
-                        feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
-                })
+                email_preferences.can_receive_editor_role_email,
+                feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_feedback_message_email,
+                feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_subscription_email,
+                feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
 
     def test_user_allowing_emails_on_signup(self):
         self.login(self.EDITOR_EMAIL)
@@ -206,29 +206,29 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
         # The email update preference should be True in all cases.
         editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', True):
+            email_preferences = user_services.get_email_preferences(editor_id)
+            self.assertEqual(email_preferences.can_receive_email_updates, True)
             self.assertEqual(
-                user_services.get_email_preferences(editor_id),
-                {
-                    'can_receive_email_updates': True,
-                    'can_receive_editor_role_email': (
-                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE),
-                    'can_receive_feedback_message_email': (
-                        feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE),
-                    'can_receive_subscription_email': (
-                        feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
-                })
+                email_preferences.can_receive_editor_role_email,
+                feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_feedback_message_email,
+                feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_subscription_email,
+                feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
+            email_preferences = user_services.get_email_preferences(editor_id)
+            self.assertEqual(email_preferences.can_receive_email_updates, True)
             self.assertEqual(
-                user_services.get_email_preferences(editor_id),
-                {
-                    'can_receive_email_updates': True,
-                    'can_receive_editor_role_email': (
-                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE),
-                    'can_receive_feedback_message_email': (
-                        feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE),
-                    'can_receive_subscription_email': (
-                        feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
-                })
+                email_preferences.can_receive_editor_role_email,
+                feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_feedback_message_email,
+                feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_subscription_email,
+                feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
 
     def test_user_disallowing_emails_on_signup(self):
         self.login(self.EDITOR_EMAIL)
@@ -243,29 +243,29 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
         # The email update preference should be False in all cases.
         editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', True):
+            email_preferences = user_services.get_email_preferences(editor_id)
+            self.assertEqual(email_preferences.can_receive_email_updates, False)
             self.assertEqual(
-                user_services.get_email_preferences(editor_id),
-                {
-                    'can_receive_email_updates': False,
-                    'can_receive_editor_role_email': (
-                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE),
-                    'can_receive_feedback_message_email': (
-                        feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE),
-                    'can_receive_subscription_email': (
-                        feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
-                })
+                email_preferences.can_receive_editor_role_email,
+                feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_feedback_message_email,
+                feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_subscription_email,
+                feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
         with self.swap(feconf, 'DEFAULT_EMAIL_UPDATES_PREFERENCE', False):
+            email_preferences = user_services.get_email_preferences(editor_id)
+            self.assertEqual(email_preferences.can_receive_email_updates, False)
             self.assertEqual(
-                user_services.get_email_preferences(editor_id),
-                {
-                    'can_receive_email_updates': False,
-                    'can_receive_editor_role_email': (
-                        feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE),
-                    'can_receive_feedback_message_email': (
-                        feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE),
-                    'can_receive_subscription_email': (
-                        feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
-                })
+                email_preferences.can_receive_editor_role_email,
+                feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_feedback_message_email,
+                feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE)
+            self.assertEqual(
+                email_preferences.can_receive_subscription_email,
+                feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
 
 
 class ProfileLinkTests(test_utils.GenericTestBase):

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -661,6 +661,23 @@ def send_feedback_message_email(recipient_id, feedback_messages):
         email_subject, email_body, feconf.NOREPLY_EMAIL_ADDRESS)
 
 
+def _can_receive_suggestion_email(user_id, exploration_id):
+    """Returns if user can receive suggestion email
+
+    Args:
+        recipient_id: str. ID of person that should receive the email.
+        exploration_id: str. ID of exploration that received new message.
+
+    Returns:
+        bool. True if user can receive the email, False otherwise."""
+    user_global_prefs = user_services.get_email_preferences(user_id)
+    user_exploration_prefs = (
+        user_services.get_email_preferences_for_exploration(
+            user_id, exploration_id))
+    return (user_global_prefs['can_receive_feedback_message_email']
+            and not user_exploration_prefs['mute_suggestion_notifications'])
+
+
 def send_suggestion_email(
         exploration_title, exploration_id, author_id, recipient_list):
     """Send emails to notify the given recipients about new suggestion.
@@ -701,10 +718,7 @@ def send_suggestion_email(
     author_settings = user_services.get_user_settings(author_id)
     for recipient_id in recipient_list:
         recipient_user_settings = user_services.get_user_settings(recipient_id)
-        recipient_preferences = (
-            user_services.get_email_preferences(recipient_id))
-
-        if recipient_preferences['can_receive_feedback_message_email']:
+        if _can_receive_suggestion_email(recipient_id, exploration_id):
             # Send email only if recipient wants to receive.
             email_body = email_body_template % (
                 recipient_user_settings.username, author_settings.username,

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -523,7 +523,7 @@ def send_role_notification_email(
     inviter_user_settings = user_services.get_user_settings(inviter_id)
     recipient_preferences = user_services.get_email_preferences(recipient_id)
 
-    if not recipient_preferences['can_receive_editor_role_email']:
+    if not recipient_preferences.can_receive_editor_role_email:
         # Do not send email if recipient has declined.
         return
 
@@ -588,7 +588,7 @@ def send_emails_to_subscribers(creator_id, exploration_id, exploration_title):
     recipients_preferences = user_services.get_users_email_preferences(
         recipient_list)
     for index, username in enumerate(recipients_usernames):
-        if recipients_preferences[index]['can_receive_subscription_email']:
+        if recipients_preferences[index].can_receive_subscription_email:
             email_body = email_body_template % (
                 username, creator_name, exploration_id,
                 exploration_title, EMAIL_FOOTER.value)
@@ -661,22 +661,38 @@ def send_feedback_message_email(recipient_id, feedback_messages):
         email_subject, email_body, feconf.NOREPLY_EMAIL_ADDRESS)
 
 
-def _can_receive_suggestion_email(user_id, exploration_id):
-    """Returns if user can receive suggestion email
+def can_users_receive_thread_email(
+        recipient_ids, exploration_id, has_suggestion):
+    """Returns if users can receive email.
 
     Args:
-        recipient_id: str. ID of person that should receive the email.
+        recipient_ids: list(str). IDs of persons that should receive the email.
         exploration_id: str. ID of exploration that received new message.
+        has_suggestion: bool. True if thread contains suggestion.
 
     Returns:
-        bool. True if user can receive the email, False otherwise."""
-    user_global_prefs = user_services.get_email_preferences(user_id)
-    user_exploration_prefs = (
-        user_services.get_email_preferences_for_exploration(
-            user_id, exploration_id))
-    return (user_global_prefs['can_receive_feedback_message_email']
-            and not user_exploration_prefs['mute_suggestion_notifications'])
+        list(bool). True if user can receive the email, False otherwise.
+    """
+    users_global_prefs = (
+        user_services.get_users_email_preferences(recipient_ids))
+    users_exploration_prefs = (
+        user_services.get_users_email_preferences_for_exploration(
+            recipient_ids, exploration_id))
+    zipped_preferences = zip(users_global_prefs, users_exploration_prefs)
 
+    result = []
+    if has_suggestion:
+        for user_global_prefs, user_exploration_prefs in zipped_preferences:
+            result.append(
+                user_global_prefs.can_receive_feedback_message_email
+                and not user_exploration_prefs.mute_suggestion_notifications)
+    else:
+        for user_global_prefs, user_exploration_prefs in zipped_preferences:
+            result.append(
+                user_global_prefs.can_receive_feedback_message_email
+                and not user_exploration_prefs.mute_feedback_notifications)
+
+    return result
 
 def send_suggestion_email(
         exploration_title, exploration_id, author_id, recipient_list):
@@ -716,9 +732,11 @@ def send_suggestion_email(
         return
 
     author_settings = user_services.get_user_settings(author_id)
-    for recipient_id in recipient_list:
+    can_users_receive_email = (
+        can_users_receive_thread_email(recipient_list, exploration_id, True))
+    for index, recipient_id in enumerate(recipient_list):
         recipient_user_settings = user_services.get_user_settings(recipient_id)
-        if _can_receive_suggestion_email(recipient_id, exploration_id):
+        if can_users_receive_email[index]:
             # Send email only if recipient wants to receive.
             email_body = email_body_template % (
                 recipient_user_settings.username, author_settings.username,
@@ -769,7 +787,7 @@ def send_instant_feedback_message_email(
     recipient_settings = user_services.get_user_settings(recipient_id)
     recipient_preferences = user_services.get_email_preferences(recipient_id)
 
-    if recipient_preferences['can_receive_feedback_message_email']:
+    if recipient_preferences.can_receive_feedback_message_email:
         email_body = email_body_template % (
             recipient_settings.username, thread_title, exploration_id,
             exploration_title, sender_settings.username, message,

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -1785,3 +1785,73 @@ class BulkEmailsTests(test_utils.GenericTestBase):
 
         all_models = email_models.BulkEmailModel.get_all().fetch()
         self.assertEqual(len(all_models), 0)
+
+
+class EmailPreferencesTests(test_utils.GenericTestBase):
+
+    def test_can_users_receive_thread_email(self):
+        user_ids = ('someUser1', 'someUser2')
+        exp_id = 'someExploration'
+        usernames = ('username1', 'username2')
+        emails = ('user1@example.com', 'user2@example.com')
+
+        for user_id, username, user_email in zip(user_ids, usernames, emails):
+            user_services.get_or_create_user(user_id, user_email)
+            user_services.set_username(user_id, username)
+
+        # Both users can receive all emails in default setting.
+        self.assertListEqual(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, True), [True, True])
+        self.assertTrue(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, False), [True, True])
+
+        # First user have muted feedback notifications for this exploration,
+        # therefore he should receive only suggestion emails.
+        user_services.set_email_preferences_for_exploration(
+            user_ids[0], exp_id, mute_feedback_notifications=True)
+        self.assertListEqual(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, True), [True, True])
+        self.assertListEqual(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, False), [False, True])
+
+        # Second user have muted suggestion notifications for this exploration,
+        # therefore he should receive only feedback emails.
+        user_services.set_email_preferences_for_exploration(
+            user_ids[1], exp_id, mute_suggestion_notifications=True)
+        self.assertListEqual(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, True), [True, False])
+        self.assertListEqual(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, False), [False, True])
+
+        # Both users have disabled all emails globally, therefore they
+        # should not receive any emails.
+        for user_id in user_ids:
+            user_services.update_email_preferences(user_id, True, True, False)
+
+        self.assertListEqual(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, True), [False, False])
+        self.assertTrue(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, False), [False, False])
+
+        # Both users have unmuted feedback/suggestion emails for this
+        # exploration, but all emails are still disabled globally,
+        # therefore they should not receive any emails.
+        user_services.set_email_preferences_for_exploration(
+            user_ids[0], exp_id, mute_feedback_notifications=False)
+        user_services.set_email_preferences_for_exploration(
+            user_ids[1], exp_id, mute_suggestion_notifications=False)
+        user_services.update_email_preferences(user_id, True, True, False)
+        self.assertListEqual(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, True), [False, False])
+        self.assertTrue(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, False), [False, False])
+
+        # Both user have enabled all emails globally, therefore they should
+        # receive all emails.
+        for user_id in user_ids:
+            user_services.update_email_preferences(user_id, True, True, True)
+
+        self.assertListEqual(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, True), [True, True])
+        self.assertTrue(email_manager.can_users_receive_thread_email(
+            user_ids, exp_id, False), [True, True])

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=protected-access
-
 """Tests for feedback-related services."""
 import json
 
@@ -75,59 +73,6 @@ class FeedbackServicesUnitTests(test_utils.GenericTestBase):
         threadlist = feedback_services.get_all_threads(exp_id, False)
         thread_status = threadlist[0].status
         self.assertEqual(thread_status, feedback_models.STATUS_CHOICES_OPEN)
-
-    def test_can_receive_email(self):
-        user_id = 'someUser'
-        exp_id = 'someExploration'
-        username = 'username'
-        user_email = 'user@example.com'
-
-        user_services.get_or_create_user(user_id, user_email)
-        user_services.set_username(user_id, username)
-
-        # User can receive all emails in default setting.
-        self.assertTrue(
-            feedback_services._can_receive_email(user_id, exp_id, True))
-        self.assertTrue(
-            feedback_services._can_receive_email(user_id, exp_id, False))
-
-        # User have muted feedback notifications for this exploration,
-        # therefore he should receive only feedback emails.
-        user_services.set_email_preferences_for_exploration(
-            user_id, exp_id, mute_feedback_notifications=True)
-        self.assertTrue(
-            feedback_services._can_receive_email(user_id, exp_id, True))
-        self.assertFalse(
-            feedback_services._can_receive_email(user_id, exp_id, False))
-
-        # User have muted suggestion notifications for this exploration too,
-        # therefore he should not receive any emails.
-        user_services.set_email_preferences_for_exploration(
-            user_id, exp_id, mute_suggestion_notifications=True)
-        self.assertFalse(
-            feedback_services._can_receive_email(user_id, exp_id, True))
-        self.assertFalse(
-            feedback_services._can_receive_email(user_id, exp_id, False))
-
-        # User have unmuted feedback/suggestion emails for this exploration, but
-        # disabled all emails globally, therefore he should not receive any
-        # emails.
-        user_services.set_email_preferences_for_exploration(
-            user_id, exp_id, mute_feedback_notifications=False,
-            mute_suggestion_notifications=False)
-        user_services.update_email_preferences(user_id, True, True, False)
-        self.assertFalse(
-            feedback_services._can_receive_email(user_id, exp_id, True))
-        self.assertFalse(
-            feedback_services._can_receive_email(user_id, exp_id, False))
-
-        # User have enabled all emails globally, therefore he should
-        # receive all emails.
-        user_services.update_email_preferences(user_id, True, True, True)
-        self.assertTrue(
-            feedback_services._can_receive_email(user_id, exp_id, True))
-        self.assertTrue(
-            feedback_services._can_receive_email(user_id, exp_id, False))
 
 
 class SuggestionQueriesUnitTests(test_utils.GenericTestBase):

--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+#
+# Copyright 2014 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Domain objects for user."""
+
+import feconf
+
+class UserGlobalPrefs(object):
+    """Domain object for user global email preferences"""
+
+    def __init__(self, site_updates, editor_role_notifications,
+                 feedback_message_notifications, subscription_notifications):
+        self.can_receive_email_updates = site_updates
+        self.can_receive_editor_role_email = editor_role_notifications
+        self.can_receive_feedback_message_email = feedback_message_notifications
+        self.can_receive_subscription_email = subscription_notifications
+
+    @classmethod
+    def create_default_prefs(cls):
+        return cls(
+            feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE,
+            feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE,
+            feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE,
+            feconf.DEFAULT_SUBSCRIPTION_EMAIL_PREFERENCE)
+
+
+class UserExplorationPrefs(object):
+    """Domain object for user global email preferences"""
+
+    def __init__(self, mute_feedback_notifications,
+                 mute_suggestion_notifications):
+        self.mute_feedback_notifications = mute_feedback_notifications
+        self.mute_suggestion_notifications = mute_suggestion_notifications
+
+    @classmethod
+    def create_default_prefs(cls):
+        return cls(
+            feconf.DEFAULT_FEEDBACK_NOTIFICATIONS_MUTED_PREFERENCE,
+            feconf.DEFAULT_SUGGESTION_NOTIFICATIONS_MUTED_PREFERENCE)

--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -19,17 +19,43 @@
 import feconf
 
 class UserGlobalPrefs(object):
-    """Domain object for user global email preferences"""
+    """Domain object for user global email preferences.
 
-    def __init__(self, site_updates, editor_role_notifications,
-                 feedback_message_notifications, subscription_notifications):
-        self.can_receive_email_updates = site_updates
-        self.can_receive_editor_role_email = editor_role_notifications
-        self.can_receive_feedback_message_email = feedback_message_notifications
-        self.can_receive_subscription_email = subscription_notifications
+    Attributes:
+        can_receive_email_updates: bool. Whether the user can receive
+            email updates.
+        can_receive_editor_role_email: bool. Whether the user can receive
+            emails notifying them of role changes.
+        can_receive_feedback_message_email: bool. Whether the user can
+            receive emails when users submit feedback to their explorations.
+        can_receive_subscription_email: bool. Whether the user can receive
+             subscription emails notifying them about new explorations.
+    """
+
+    def __init__(
+            self, can_receive_email_updates, can_receive_editor_role_email,
+            can_receive_feedback_message_email, can_receive_subscription_email):
+        """Constructs a UserGlobalPrefs domain object.
+
+        Args:
+            can_receive_email_updates: bool. Whether the user can receive
+                email updates.
+            can_receive_editor_role_email: bool. Whether the user can receive
+                emails notifying them of role changes.
+            can_receive_feedback_message_email: bool. Whether the user can
+                receive emails when users submit feedback to their explorations.
+            can_receive_subscription_email: bool. Whether the user can receive
+                 subscription emails notifying them about new explorations.
+        """
+        self.can_receive_email_updates = can_receive_email_updates
+        self.can_receive_editor_role_email = can_receive_editor_role_email
+        self.can_receive_feedback_message_email = ( #pylint: disable=invalid-name
+            can_receive_feedback_message_email)
+        self.can_receive_subscription_email = can_receive_subscription_email
 
     @classmethod
     def create_default_prefs(cls):
+        """Returns UserGlobalPrefs with default attributes."""
         return cls(
             feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE,
             feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE,
@@ -38,15 +64,31 @@ class UserGlobalPrefs(object):
 
 
 class UserExplorationPrefs(object):
-    """Domain object for user global email preferences"""
+    """Domain object for user exploration email preferences.
+
+    Attributes:
+        mute_feedback_notifications: bool. Whether the given user has muted
+            feedback emails.
+        mute_suggestion_notifications: bool. Whether the given user has
+            muted suggestion emails.
+    """
 
     def __init__(self, mute_feedback_notifications,
                  mute_suggestion_notifications):
+        """Constructs a UserExplorationPrefs domain object.
+
+        Args:
+            mute_feedback_notifications: bool. Whether the given user has muted
+                feedback emails.
+            mute_suggestion_notifications: bool. Whether the given user has
+                muted suggestion emails.
+        """
         self.mute_feedback_notifications = mute_feedback_notifications
         self.mute_suggestion_notifications = mute_suggestion_notifications
 
     @classmethod
     def create_default_prefs(cls):
+        """Returns UserExplorationPrefs with default attributes."""
         return cls(
             feconf.DEFAULT_FEEDBACK_NOTIFICATIONS_MUTED_PREFERENCE,
             feconf.DEFAULT_SUGGESTION_NOTIFICATIONS_MUTED_PREFERENCE)

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -218,12 +218,12 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         # the value returned by get_email_preferences() should be True.
         email_preferences = user_services.get_email_preferences(user_id)
         self.assertEquals(
-            email_preferences['can_receive_editor_role_email'],
+            email_preferences.can_receive_editor_role_email,
             feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
 
         email_preferences = user_services.get_email_preferences(user_id)
         self.assertEquals(
-            email_preferences['can_receive_feedback_message_email'],
+            email_preferences.can_receive_feedback_message_email,
             feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE)
 
         # The user retrieves their email preferences. This initializes
@@ -235,10 +235,10 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
 
         email_preferences = user_services.get_email_preferences(user_id)
         self.assertEquals(
-            email_preferences['can_receive_editor_role_email'],
+            email_preferences.can_receive_editor_role_email,
             feconf.DEFAULT_EDITOR_ROLE_EMAIL_PREFERENCE)
         self.assertEquals(
-            email_preferences['can_receive_feedback_message_email'],
+            email_preferences.can_receive_feedback_message_email,
             feconf.DEFAULT_FEEDBACK_MESSAGE_EMAIL_PREFERENCE)
 
         # The user sets their membership email preference to False.
@@ -246,10 +246,8 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             user_id, feconf.DEFAULT_EMAIL_UPDATES_PREFERENCE, False, False)
 
         email_preferences = user_services.get_email_preferences(user_id)
-        self.assertEquals(
-            email_preferences['can_receive_editor_role_email'], False)
-        self.assertEquals(
-            email_preferences['can_receive_feedback_message_email'], False)
+        self.assertFalse(email_preferences.can_receive_editor_role_email)
+        self.assertFalse(email_preferences.can_receive_feedback_message_email)
 
     def test_set_and_get_user_email_preferences_for_exploration(self):
         user_id = 'someUser'
@@ -270,10 +268,10 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         email_preferences = user_services.get_email_preferences_for_exploration(
             user_id, exploration_id)
         self.assertEquals(
-            email_preferences['mute_feedback_notifications'],
+            email_preferences.mute_feedback_notifications,
             feconf.DEFAULT_FEEDBACK_NOTIFICATIONS_MUTED_PREFERENCE)
         self.assertEquals(
-            email_preferences['mute_suggestion_notifications'],
+            email_preferences.mute_suggestion_notifications,
             feconf.DEFAULT_SUGGESTION_NOTIFICATIONS_MUTED_PREFERENCE)
 
         # This initializes a ExplorationUserDataModel instance with
@@ -286,10 +284,10 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         email_preferences = user_services.get_email_preferences_for_exploration(
             user_id, exploration_id)
         self.assertEquals(
-            email_preferences['mute_feedback_notifications'],
+            email_preferences.mute_feedback_notifications,
             feconf.DEFAULT_FEEDBACK_NOTIFICATIONS_MUTED_PREFERENCE)
         self.assertEquals(
-            email_preferences['mute_suggestion_notifications'],
+            email_preferences.mute_suggestion_notifications,
             feconf.DEFAULT_SUGGESTION_NOTIFICATIONS_MUTED_PREFERENCE)
 
         # This sets only mute_suggestion_notifications property to True.
@@ -300,10 +298,9 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         email_preferences = user_services.get_email_preferences_for_exploration(
             user_id, exploration_id)
         self.assertEquals(
-            email_preferences['mute_feedback_notifications'],
+            email_preferences.mute_feedback_notifications,
             feconf.DEFAULT_FEEDBACK_NOTIFICATIONS_MUTED_PREFERENCE)
-        self.assertEquals(
-            email_preferences['mute_suggestion_notifications'], True)
+        self.assertTrue(email_preferences.mute_suggestion_notifications)
 
         # This sets only mute_feedback_notifications property to True.
         # mute_suggestion_notifications should remain same as before.
@@ -312,10 +309,8 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
 
         email_preferences = user_services.get_email_preferences_for_exploration(
             user_id, exploration_id)
-        self.assertEquals(
-            email_preferences['mute_feedback_notifications'], True)
-        self.assertEquals(
-            email_preferences['mute_suggestion_notifications'], True)
+        self.assertTrue(email_preferences.mute_feedback_notifications)
+        self.assertTrue(email_preferences.mute_suggestion_notifications)
 
     def test_get_current_date_as_string(self):
         custom_datetimes = [

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -287,6 +287,14 @@ class ExplorationUserDataModel(base_models.BaseModel):
         return super(ExplorationUserDataModel, cls).get(
             instance_id, strict=False)
 
+    @classmethod
+    def get_multi(cls, user_ids, exploration_id):
+        """Gets the ExplorationUserDataModel for the given ids."""
+        instance_ids = (
+            cls._generate_id(user_id, exploration_id) for user_id in user_ids)
+        return super(ExplorationUserDataModel, cls).get_multi(
+            instance_ids)
+
 
 class CollectionProgressModel(base_models.BaseModel):
     """Stores progress a user has made within a collection, including all


### PR DESCRIPTION
Creating new pull request with both commits because I forgot to create local branch before, therefore I had problems with rebasing.

I addressed all comments in #2880

- Created get_multi in ExplorationUserDataModel
- Started using get_multi for all functions with multiple recepients.
- Created UserGlobalPrefs and UserExplorationPrefs domain models.
- Fixed docstrings
