### PR TITLE
Fix #2857: Added excluded_dirs in Lint pattern matching

### DIFF
--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -40,7 +40,7 @@ CUSTOMIZATION OPTIONS
 1.  To lint only files that have been touched in this commit
        python scripts/pre_commit_linter.py
 
-2.  To lint all files in  the folder or to lint just a specific file
+2.  To lint all files in the folder or to lint just a specific file
         python scripts/pre_commit_linter.py --path filepath
 
 3.  To lint a specific list of files (*.js/*.py only). Separate files by spaces
@@ -190,8 +190,8 @@ def _is_filename_excluded_for_bad_patterns_check(pattern, filename):
     """Checks if file is excluded from the bad patterns check.
 
     Args:
-        pattern: The pattern to be checked against.
-        filename: Name of the file.
+        pattern: str. The pattern to be checked against.
+        filename: str. Name of the file.
 
     Returns:
         bool: Whether to exclude the given file from this
@@ -206,7 +206,7 @@ def _get_changed_filenames():
     """Returns a list of modified files (both staged and unstaged)
 
     Returns:
-        a list of filenames of modified files
+        a list of filenames of modified files.
     """
     unstaged_files = subprocess.check_output([
         'git', 'diff', '--name-only']).splitlines()
@@ -240,7 +240,8 @@ def _get_all_files_in_directory(dir_path, excluded_glob_patterns):
 
     Args:
         dir_path: str. Path to the folder to be linted.
-        excluded_glob_patterns: set. Set of all files to be excluded.
+        excluded_glob_patterns: set(str). Set of all glob patterns
+        to be excluded.
 
     Returns:
         a list of files in directory and subdirectories without excluded files.
@@ -264,9 +265,9 @@ def _lint_js_files(node_path, jscs_path, config_jscsrc, files_to_lint, stdout,
         node_path: str. Path to the node binary.
         jscs_path: str. Path to the JSCS binary.
         config_jscsrc: str. Configuration args for the call to the JSCS binary.
-        files_to_lint: list of str. A list of filepaths to lint.
-        stdout:  multiprocessing.Queue. A queue to store JSCS outputs
-        result: multiprocessing.Queue. A queue to put results of test
+        files_to_lint: list(str). A list of filepaths to lint.
+        stdout:  multiprocessing.Queue. A queue to store JSCS outputs.
+        result: multiprocessing.Queue. A queue to put results of test.
 
     Returns:
         None
@@ -313,8 +314,8 @@ def _lint_py_files(config_pylint, files_to_lint, result):
 
     Args:
         config_pylint: str. Path to the .pylintrc file.
-        files_to_lint: list of str. A list of filepaths to lint.
-        result: multiprocessing.Queue. A queue to put results of test
+        files_to_lint: list(str). A list of filepaths to lint.
+        result: multiprocessing.Queue. A queue to put results of test.
 
     Returns:
         None
@@ -400,7 +401,7 @@ def _get_all_files():
 
 def _pre_commit_linter(all_files):
     """This function is used to check if node-jscs dependencies are installed
-    and pass JSCS binary path
+    and pass JSCS binary path.
     """
     print 'Starting linter...'
 

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -182,6 +182,16 @@ _MESSAGE_TYPE_SUCCESS = 'SUCCESS'
 _MESSAGE_TYPE_FAILED = 'FAILED'
 
 
+def _is_filename_excluded_for_bad_patterns_check(filename):
+    """Checks if file is excluded from the bad patterns check
+
+    Returns:
+        a boolean: true if excluded
+    """
+    return (any(filename.startswith(bad_pattern)
+                for bad_pattern in BAD_PATTERNS['\t']['excluded_dirs'])
+            or filename in BAD_PATTERNS['\t']['excluded_files'])
+
 def _get_changed_filenames():
     """Returns a list of modified files (both staged and unstaged)
 
@@ -464,10 +474,7 @@ def _check_bad_patterns(all_files):
             content = f.read()
             total_files_checked += 1
             for pattern in BAD_PATTERNS:
-                if pattern in content and not any(
-                        filename.startswith(bad_pattern) for bad_pattern in
-                        BAD_PATTERNS[pattern]['excluded_dirs']) and filename \
-                not in BAD_PATTERNS[pattern]['excluded_files']:
+                if not _is_filename_excluded_for_bad_patterns_check(filename):
                     failed = True
                     print '%s --> %s' % (
                         filename, BAD_PATTERNS[pattern]['message'])

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -241,7 +241,7 @@ def _get_all_files_in_directory(dir_path, excluded_glob_patterns):
     Args:
         dir_path: str. Path to the folder to be linted.
         excluded_glob_patterns: set(str). Set of all glob patterns
-        to be excluded.
+            to be excluded.
 
     Returns:
         a list of files in directory and subdirectories without excluded files.

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -194,7 +194,8 @@ def _is_filename_excluded_for_bad_patterns_check(pattern, filename):
         filename: Name of the file.
 
     Returns:
-        bool: Whether to exclude the given file from this particular pattern check.
+        bool: Whether to exclude the given file from this
+        particular pattern check.
     """
     return (any(filename.startswith(bad_pattern)
                 for bad_pattern in BAD_PATTERNS[pattern]['excluded_dirs'])

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -482,8 +482,9 @@ def _check_bad_patterns(all_files):
             content = f.read()
             total_files_checked += 1
             for pattern in BAD_PATTERNS:
-                if not _is_filename_excluded_for_bad_patterns_check(
-                        pattern, filename):
+                if (pattern in content and
+                        not _is_filename_excluded_for_bad_patterns_check(
+                            pattern, filename)):
                     failed = True
                     print '%s --> %s' % (
                         filename, BAD_PATTERNS[pattern]['message'])

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -220,7 +220,7 @@ def _get_glob_patterns_excluded_from_jscsrc(config_jscsrc):
     """Collects excludeFiles from jscsrc file.
 
     Args:
-    - config_jscsrc: str. Path to .jscsrc file.
+        config_jscsrc: str. Path to .jscsrc file.
 
     Returns:
         a list of files in excludeFiles.
@@ -239,8 +239,8 @@ def _get_all_files_in_directory(dir_path, excluded_glob_patterns):
     subdirectories of specified path.
 
     Args:
-    - dir_path: str. Path to the folder to be linted.
-    - excluded_glob_patterns: set. Set of all files to be excluded.
+        dir_path: str. Path to the folder to be linted.
+        excluded_glob_patterns: set. Set of all files to be excluded.
 
     Returns:
         a list of files in directory and subdirectories without excluded files.
@@ -261,12 +261,12 @@ def _lint_js_files(node_path, jscs_path, config_jscsrc, files_to_lint, stdout,
     """Prints a list of lint errors in the given list of JavaScript files.
 
     Args:
-    - node_path: str. Path to the node binary.
-    - jscs_path: str. Path to the JSCS binary.
-    - config_jscsrc: str. Configuration args for the call to the JSCS binary.
-    - files_to_lint: list of str. A list of filepaths to lint.
-    - stdout:  multiprocessing.Queue. A queue to store JSCS outputs
-    - result: multiprocessing.Queue. A queue to put results of test
+        node_path: str. Path to the node binary.
+        jscs_path: str. Path to the JSCS binary.
+        config_jscsrc: str. Configuration args for the call to the JSCS binary.
+        files_to_lint: list of str. A list of filepaths to lint.
+        stdout:  multiprocessing.Queue. A queue to store JSCS outputs
+        result: multiprocessing.Queue. A queue to put results of test
 
     Returns:
         None
@@ -312,9 +312,9 @@ def _lint_py_files(config_pylint, files_to_lint, result):
     """Prints a list of lint errors in the given list of Python files.
 
     Args:
-    - config_pylint: str. Path to the .pylintrc file.
-    - files_to_lint: list of str. A list of filepaths to lint.
-    - result: multiprocessing.Queue. A queue to put results of test
+        config_pylint: str. Path to the .pylintrc file.
+        files_to_lint: list of str. A list of filepaths to lint.
+        result: multiprocessing.Queue. A queue to put results of test
 
     Returns:
         None

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -84,7 +84,9 @@ BAD_PATTERNS = {
         'excluded_files': ()},
     '\t': {
         'message': 'Please use spaces instead of tabs.',
-        'excluded_files': ()},
+        'excluded_files': (),
+        'excluded_dirs': (
+            'assets/i18n/')},
     '\r': {
         'message': 'Please make sure all files only have LF endings (no CRLF).',
         'excluded_files': ()},
@@ -462,8 +464,10 @@ def _check_bad_patterns(all_files):
             content = f.read()
             total_files_checked += 1
             for pattern in BAD_PATTERNS:
-                if pattern in content and filename not in (
-                        BAD_PATTERNS[pattern]['excluded_files']):
+                if pattern in content and not any(
+                        filename.startswith(bad_pattern) for bad_pattern in
+                        BAD_PATTERNS[pattern]['excluded_dirs']) and filename \
+                not in BAD_PATTERNS[pattern]['excluded_files']:
                     failed = True
                     print '%s --> %s' % (
                         filename, BAD_PATTERNS[pattern]['message'])

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -187,18 +187,19 @@ _MESSAGE_TYPE_FAILED = 'FAILED'
 
 
 def _is_filename_excluded_for_bad_patterns_check(pattern, filename):
-    """Checks if file is excluded from the bad patterns check
+    """Checks if file is excluded from the bad patterns check.
 
     Args:
-    - pattern: The pattern to be checked against.
-    - filename: Name of the file.
+        pattern: The pattern to be checked against.
+        filename: Name of the file.
 
     Returns:
-        a boolean: true if excluded
+        bool: Whether to exclude the given file from this particular pattern check.
     """
     return (any(filename.startswith(bad_pattern)
                 for bad_pattern in BAD_PATTERNS[pattern]['excluded_dirs'])
             or filename in BAD_PATTERNS[pattern]['excluded_files'])
+
 
 def _get_changed_filenames():
     """Returns a list of modified files (both staged and unstaged)

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -77,23 +77,27 @@ _EXCLUSIVE_GROUP.add_argument(
 BAD_PATTERNS = {
     '__author__': {
         'message': 'Please remove author tags from this file.',
-        'excluded_files': ()},
+        'excluded_files': (),
+        'excluded_dirs': ()},
     'datetime.datetime.now()': {
         'message': 'Please use datetime.datetime.utcnow() instead of'
                    'datetime.datetime.now().',
-        'excluded_files': ()},
+        'excluded_files': (),
+        'excluded_dirs': ()},
     '\t': {
         'message': 'Please use spaces instead of tabs.',
         'excluded_files': (),
         'excluded_dirs': (
-            'assets/i18n/')},
+            'assets/i18n/',)},
     '\r': {
         'message': 'Please make sure all files only have LF endings (no CRLF).',
-        'excluded_files': ()},
+        'excluded_files': (),
+        'excluded_dirs': ()},
     'glyphicon': {
         'message': 'Please use equivalent material-icons '
                    'instead of glyphicons.',
-        'excluded_files': ()}
+        'excluded_files': (),
+        'excluded_dirs': ()}
 }
 
 BAD_PATTERNS_JS = {
@@ -182,15 +186,19 @@ _MESSAGE_TYPE_SUCCESS = 'SUCCESS'
 _MESSAGE_TYPE_FAILED = 'FAILED'
 
 
-def _is_filename_excluded_for_bad_patterns_check(filename):
+def _is_filename_excluded_for_bad_patterns_check(pattern, filename):
     """Checks if file is excluded from the bad patterns check
+
+    Args:
+    - pattern: The pattern to be checked against.
+    - filename: Name of the file.
 
     Returns:
         a boolean: true if excluded
     """
     return (any(filename.startswith(bad_pattern)
-                for bad_pattern in BAD_PATTERNS['\t']['excluded_dirs'])
-            or filename in BAD_PATTERNS['\t']['excluded_files'])
+                for bad_pattern in BAD_PATTERNS[pattern]['excluded_dirs'])
+            or filename in BAD_PATTERNS[pattern]['excluded_files'])
 
 def _get_changed_filenames():
     """Returns a list of modified files (both staged and unstaged)
@@ -474,7 +482,8 @@ def _check_bad_patterns(all_files):
             content = f.read()
             total_files_checked += 1
             for pattern in BAD_PATTERNS:
-                if not _is_filename_excluded_for_bad_patterns_check(filename):
+                if not _is_filename_excluded_for_bad_patterns_check(
+                        pattern, filename):
                     failed = True
                     print '%s --> %s' % (
                         filename, BAD_PATTERNS[pattern]['message'])


### PR DESCRIPTION
A fix for #2857. I have added an excluded_dirs parameter in the BAD_PATTERNS checker [here](https://github.com/arpan98/oppia/blob/lint-exclude-translatewiki/scripts/pre_commit_linter.py#L88). Should I add it as an empty parameter for the checks other than tabs and spaces as well?