### PR TITLE
Update release info output to fit format of changelog

### DIFF
--- a/scripts/release_info.py
+++ b/scripts/release_info.py
@@ -226,7 +226,7 @@ def main():
         out.write('\n### Commit History:\n')
         for name, title in [(log.author, log.message.split('\n\n')[0])
                             for log in logs]:
-            out.write('%s: %s  \n' % (name, title))
+            out.write('* %s\n' % title)
 
         if issue_links:
             out.write('\n### Issues mentioned in commits:\n')


### PR DESCRIPTION
We don't typically include the PR author's name in the changelog, but the release info script includes the name, which necessitates deleting the name later on. Changing the output to be a bullet point with the commit title will streamline the process of compiling the changelog.