### PR TITLE
Fix #2817, Move Call to action button on Teach Page and design fixes on about pages.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4220,7 +4220,7 @@ md-card.preview-conversation-skin-supplemental-card {
 .oppia-static-card-content {
   margin: 0 auto;
   max-width: 600px;
-  padding: 4% 0 5% 0;
+  padding: 4% 0 1% 0;
 }
 
 .oppia-static-card-content-wide {
@@ -4266,11 +4266,15 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 
 .oppia-about-page-extra-info {
-  height: 220px;
+  height: 245px;
 }
 
 .oppia-about-tab-content {
   display: none;
+}
+
+.oppia-teach-tab-content{
+  padding-bottom: 7%;
 }
 
 .oppia-about-visible-content {
@@ -4341,7 +4345,7 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 
 .oppia-about-button {
-  background-color: rgba(0,0,0,0.2);
+  background-color: rgb(0, 121, 109);
   color: rgba(255,255,255,1.0);
   font-family: "Capriola", "Roboto", Arial, sans-serif;
   font-size: 18px;
@@ -4356,6 +4360,11 @@ md-card.preview-conversation-skin-supplemental-card {
 .oppia-about-button:hover {
   background-color: rgba(5,190,178,1);
   color: rgba(255,255,255,1);
+}
+
+.oppia-teach-button{
+  display: block;
+  margin: 0px auto 0 auto;
 }
 
 .oppia-about-buttons-container {
@@ -4420,9 +4429,13 @@ md-card.preview-conversation-skin-supplemental-card {
 */
 
 @media only screen and (min-width: 1400px) {
+  .oppia-about-extra-info {
+    height: 245px;
+  }
   .oppia-static-content, .oppia-static-extra-content {
     width: 960px;
   }
+
 }
 
 @media only screen and (max-width: 1140px) {
@@ -4453,7 +4466,7 @@ md-card.preview-conversation-skin-supplemental-card {
     padding: 10px;
   }
   .oppia-about-extra-info {
-    height: 400px;
+    height: 310px;
   }
 }
 
@@ -4480,11 +4493,16 @@ md-card.preview-conversation-skin-supplemental-card {
     margin: 0;
   }
   .oppia-about-extra-info {
-    height: 400px;
+    height: 320px;
   }
-
   .oppia-about-three-cols-layout {
     width: 100%;
+  }
+}
+
+@media only screen and (max-width: 440px) {
+  .oppia-about-extra-info {
+    height: 270px;
   }
 }
 

--- a/core/templates/dev/head/pages/teach/teach.html
+++ b/core/templates/dev/head/pages/teach/teach.html
@@ -41,7 +41,7 @@
         </div>
 
       <div class="about-tab-container">
-        <div class="teach oppia-about-tab-content oppia-about-visible-content">
+        <div class="teach oppia-about-tab-content oppia-teach-tab-content oppia-about-visible-content">
 
           <div class="oppia-static-card-content oppia-static-card-content-narrow">
             <h2>Teach with Oppia</h2>
@@ -99,8 +99,9 @@
               helping anyone learn anything they want in an effective and
               enjoyable way.
             </p>
-
           </div>
+          <div ng-click="onApplyToTeachWithOppia()" class="btn oppia-about-button oppia-teach-button"
+             translate="I18N_ACTION_APPLY_TO_TEACH_WITH_OPPIA" target="_blank"></div>
         </div>
 
           <div class="playbook oppia-about-tab-content">
@@ -221,8 +222,6 @@
           <div class="oppia-about-extra-info">
             <div class="oppia-static-content oppia-static-extra-content">
               <div class="oppia-static-card-content oppia-static-card-content-wide oppia-about-buttons-container">
-                 <div ng-click="onApplyToTeachWithOppia()" class="btn oppia-about-button"
-                    translate="I18N_ACTION_APPLY_TO_TEACH_WITH_OPPIA" target="_blank"></div>
                 <a href="/dashboard?mode=create" class="btn oppia-about-button"
                    translate="I18N_ACTION_CREATE_EXPLORATION"></a>
                 <a href="/library" class="btn oppia-about-button"


### PR DESCRIPTION
The button has been moved on teach page.
![screenshot from 2017-01-10 05-40-31](https://cloud.githubusercontent.com/assets/6849438/21795628/4d0dfec2-d729-11e6-807a-d679bd217126.png)
![screenshot from 2017-01-10 05-40-48](https://cloud.githubusercontent.com/assets/6849438/21795664/97b23a56-d729-11e6-8ed2-91919a3f1fbb.png)


Also i noticed unusual height on small screens on about page.
![screenshot from 2017-01-10 06-09-00](https://cloud.githubusercontent.com/assets/6849438/21795638/674d0dfa-d729-11e6-8aa2-996351d60427.png)

I have fixed it.
![screenshot from 2017-01-10 06-11-32](https://cloud.githubusercontent.com/assets/6849438/21795683/c32e2a0a-d729-11e6-8255-de23b39b181c.png)


