### PR TITLE
Fix #2922: Hide hamburger menu >768px, add function to handle navbar overflow

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -463,17 +463,8 @@ oppia.factory('windowDimensionsService', ['$window', function($window) {
       onResizeHooks.push(hookFn);
     },
     isWindowNarrow: function() {
-      var NAVBAR_WITH_SEARCH_CUTOFF_WIDTH_PX = 1171;
       var NORMAL_NAVBAR_CUTOFF_WIDTH_PX = 768;
-      var navbarHasSearchBar = (
-        $window.location.pathname.indexOf('/search') === 0 ||
-        $window.location.pathname.indexOf('/library') === 0);
-
-      var navbarCutoffWidthPx = (
-        navbarHasSearchBar ?
-        NAVBAR_WITH_SEARCH_CUTOFF_WIDTH_PX :
-        NORMAL_NAVBAR_CUTOFF_WIDTH_PX);
-      return this.getWidth() <= navbarCutoffWidthPx;
+      return this.getWidth() <= NORMAL_NAVBAR_CUTOFF_WIDTH_PX;
     }
   };
 }]);
@@ -681,6 +672,7 @@ oppia.factory('oppiaDebouncer', [function() {
     }
   };
 }]);
+
 
 // Shim service for functions on $window that allows these functions to be
 // mocked in unit tests.

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -641,14 +641,14 @@ oppia.factory('oppiaDebouncer', [function() {
     // for `wait` milliseconds.
     debounce: function(func, millisecsToWait) {
       var timeout;
-      var context;
-      var args;
+      var context = this;
+      var args = arguments;
       var timestamp;
       var result;
 
       var later = function() {
         var last = new Date().getTime() - timestamp;
-        if (last < millisecsToWait && last > 0) {
+        if (last < millisecsToWait) {
           timeout = setTimeout(later, millisecsToWait - last);
         } else {
           timeout = null;

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -464,7 +464,7 @@ oppia.factory('windowDimensionsService', ['$window', function($window) {
     },
     isWindowNarrow: function() {
       var NAVBAR_WITH_SEARCH_CUTOFF_WIDTH_PX = 1171;
-      var NORMAL_NAVBAR_CUTOFF_WIDTH_PX = 800;
+      var NORMAL_NAVBAR_CUTOFF_WIDTH_PX = 768;
       var navbarHasSearchBar = (
         $window.location.pathname.indexOf('/search') === 0 ||
         $window.location.pathname.indexOf('/library') === 0);

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -673,7 +673,6 @@ oppia.factory('oppiaDebouncer', [function() {
   };
 }]);
 
-
 // Shim service for functions on $window that allows these functions to be
 // mocked in unit tests.
 oppia.factory('currentLocationService', ['$window', function($window) {

--- a/core/templates/dev/head/components/create_button/create_activity_button_directive.html
+++ b/core/templates/dev/head/components/create_button/create_activity_button_directive.html
@@ -1,5 +1,5 @@
 <script type="text/ng-template" id="components/createActivityButton">
-  <div class="pull-right oppia-navbar-button-container">
+  <div class="oppia-navbar-button-container">
     {% if not user_is_logged_in %}
       <!-- User must complete the registration process. -->
       <button class="btn oppia-navbar-button oppia-navbar-hide-on-small-width protractor-test-create-activity oppia-transition-200"

--- a/core/templates/dev/head/components/create_button/create_activity_button_directive.html
+++ b/core/templates/dev/head/components/create_button/create_activity_button_directive.html
@@ -4,17 +4,17 @@
       <!-- User must complete the registration process. -->
       <button class="btn oppia-navbar-button oppia-navbar-hide-on-small-width protractor-test-create-activity oppia-transition-200"
               ng-click="onRedirectToLogin('/dashboard?mode=create')">
-        <span translate="I18N_CREATE_EXPLORATION_CREATE"></span>
+        <span class="oppia-navbar-tab-content" translate="I18N_CREATE_EXPLORATION_CREATE"></span>
       </button>
     {% else %}
       <button class="btn oppia-navbar-button oppia-navbar-hide-on-small-width protractor-test-create-activity oppia-transition-200"
               ng-click="initCreationProcess()" ng-disabled="creationInProgress">
-        <span translate="I18N_CREATE_EXPLORATION_CREATE"></span>
+        <span class="oppia-navbar-tab-content" translate="I18N_CREATE_EXPLORATION_CREATE"></span>
       </button>
       {% if allow_yaml_file_upload %}
         <button class="btn oppia-navbar-button oppia-navbar-hide-on-small-width oppia-transition-200"
                 ng-click="showUploadExplorationModal()" ng-disabled="creationInProgress">
-          <span translate="I18N_CREATE_EXPLORATION_UPLOAD"></span>
+          <span class="oppia-navbar-tab-content" translate="I18N_CREATE_EXPLORATION_UPLOAD"></span>
         </button>
       {% endif %}
     {% endif %}

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -146,13 +146,13 @@ oppia.directive('topNavigationBar', [function() {
         var truncateNavbar = function() {
           // If the window is narrow, the standard nav tabs are not shown.
           if (windowDimensionsService.isWindowNarrow()) {
-            return false;
+            return;
           }
 
           // If i18n hasn't completed, retry after 100ms.
           if (!checkIfI18NCompleted()) {
             $timeout(truncateNavbar, 100);
-            return false;
+            return;
           }
 
           // Measured non-overflowed navbar height under 60px via inspector.
@@ -168,7 +168,7 @@ oppia.directive('topNavigationBar', [function() {
                 // This is due to setTimeout use in debounce.
                 $scope.$apply();
                 $timeout(truncateNavbar, 50);
-                return false;
+                return;
               }
             }
           }

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -109,7 +109,6 @@ oppia.directive('topNavigationBar', [function() {
           // Close the sidebar, if necessary.
           SidebarStatusService.closeSidebar();
           $scope.sidebarIsShown = SidebarStatusService.isSidebarShown();
-          });
           $scope.isSidebarShown = function() {
             if (SidebarStatusService.isSidebarShown()) {
               angular.element(document.body).addClass('oppia-stop-scroll');

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -129,11 +129,10 @@ oppia.directive('topNavigationBar', [function() {
          */
         var checkIfI18NCompleted = function() {
           var i18nCompleted = true;
-          document.querySelectorAll('.oppia-navbar-tabs a[translate], ' +
-            '.oppia-navbar-tabs span[translate]').forEach(function(element) {
+          document.querySelectorAll('.oppia-navbar-tab-content')
+            .forEach(function(element) {
             if (element.innerText.length === 0) {
               i18nCompleted = false;
-              return false;
             }
           });
           return i18nCompleted;

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -108,11 +108,12 @@ oppia.directive('topNavigationBar', [function() {
         windowDimensionsService.registerOnResizeHook(function() {
           $scope.windowIsNarrow = windowDimensionsService.isWindowNarrow();
           $scope.$apply();
-          // If the window is resized larger, try displaying the hidden elements.
+          // If window is resized larger, try displaying the hidden elements.
           if (currentWindowWidth < windowDimensionsService.getWidth()) {
             for (var i = 0; i < NAV_ELEMENTS_ORDER.length; i++) {
               if (!$scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]]) {
-                $scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]] = true;
+                $scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]] =
+                  true;
               }
             }
           }
@@ -134,7 +135,6 @@ oppia.directive('topNavigationBar', [function() {
         $scope.toggleSidebar = function() {
           SidebarStatusService.toggleSidebar();
         };
-
 
         /**
          * Checks if i18n has been run.

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -139,53 +139,6 @@ oppia.directive('topNavigationBar', [function() {
           return i18nCompleted;
         };
 
-        var calculateNavWidth = function() {
-          var navWidth = 0;
-          $('ul.oppia-navbar-tabs').children().each(function(i, element) {
-            // The "create" button has a 0 width on its top-level element.
-            // The <li> tag from the Donate button has a large/invalid width.
-            // Use widths of their first-level child elements instead.
-            if (element.clientWidth === 0 || element.clientWidth >= 176) {
-              $(element).children().each(function(i, element) {
-                // Adding a small padding accounts for any unexpected padding
-                // or font differences. It may be possible to safely eliminate
-                // the extra by using Web Font Loader.
-                navWidth += 5;
-                navWidth += element.clientWidth;
-              });
-            } else {
-              navWidth += 5;
-              navWidth += element.clientWidth;
-            }
-          });
-
-          // Add the width of the gravatar or sign in button.
-          navWidth += $('ul.nav.oppia-navbar-profile').width();
-
-          return navWidth;
-        };
-
-        var setNavbarTabsWidth = function() {
-          $('ul.nav.oppia-navbar-tabs').css('min-width', calculateNavWidth());
-        };
-
-        var hideNavbarElement = function() {
-          // Measured non-overflowed navbar height under 60px via inspector.
-          if ($('div.collapse.navbar-collapse').height() > 60) {
-            for (element in $scope.navElementsVisibilityStatus) {
-              if ($scope.navElementsVisibilityStatus[element]) {
-                // Hide one element, then check again after 10ms.
-                // This gives the browser time to render the visibility change.
-                console.log('Hiding:', element);
-                $scope.navElementsVisibilityStatus[element] = false;
-                $timeout(setNavbarTabsWidth, 10);
-                $timeout(truncateNavbar, 50);
-                return false;
-              }
-            }
-          }
-        };
-
         /**
          * Sets the min-width for the tabs part of the navbar, then checks
          * for overflow. If overflow is detected hides the least important
@@ -204,12 +157,27 @@ oppia.directive('topNavigationBar', [function() {
             return false;
           }
 
-          setNavbarTabsWidth();
 
-          $timeout(hideNavbarElement, 10);
+
+          // Measured non-overflowed navbar height under 60px via inspector.
+          if ($('div.collapse.navbar-collapse').height() > 60) {
+            for (element in $scope.navElementsVisibilityStatus) {
+              if ($scope.navElementsVisibilityStatus[element]) {
+                // Hide one element, then check again after 50ms.
+                // This gives the browser time to render the visibility change.
+                console.log(Date.now(), 'Hiding:', element);
+                $scope.navElementsVisibilityStatus[element] = false;
+                // Force a digest cycle to hide element immediately.
+                // Otherwise it would be hidden after the next call.
+                $scope.$apply();
+                $timeout(truncateNavbar, 50);
+                return false;
+              }
+            }
+          }
         };
 
-        var truncateNavbarDebounced = oppiaDebouncer.debounce(truncateNavbar, 500);
+        var truncateNavbarDebounced = oppiaDebouncer.debounce(truncateNavbar, 100);
 
         // For Chrome, timeout 0 appears to run after i18n.
         $timeout(truncateNavbar, 0);

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -155,7 +155,10 @@ oppia.directive('topNavigationBar', [function() {
             return;
           }
 
-          // Measured non-overflowed navbar height under 60px via inspector.
+          // The value of 60px used here comes from measuring the normal height
+          // of the navbar (56px) in Chrome's inspector and rounding up. If the
+          // height of the navbar is changed in the future this will need to be
+          // updated.
           if (document.querySelector('div.collapse.navbar-collapse')
             .clientHeight > 60) {
             for (element in $scope.navElementsVisibilityStatus) {
@@ -177,7 +180,10 @@ oppia.directive('topNavigationBar', [function() {
         var truncateNavbarDebounced =
           oppiaDebouncer.debounce(truncateNavbar, 500);
 
-        // For Chrome, timeout 0 appears to run after i18n.
+        // The function needs to be run after i18n. A timeout of 0 appears to
+        // run after i18n in Chrome, but not other browsers. The function will
+        // check if i18n is complete and set a new timeout if it is not. Since
+        // a timeout of 0 works for at least one browser, it is used here.
         $timeout(truncateNavbar, 0);
         $scope.toggleSidebar = SidebarStatusService.toggleSidebar;
       }

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -140,9 +140,9 @@ oppia.directive('topNavigationBar', [function() {
         };
 
         /**
-         * Sets the min-width for the tabs part of the navbar, then checks
+         * Checks if window is >768px and i18n is completed, then checks
          * for overflow. If overflow is detected hides the least important
-         * tab and then calls itself again after a 10ms delay.
+         * tab and then calls itself again after a 50ms delay.
          */
         var truncateNavbar = function() {
           // If the window is narrow, the standard nav tabs are not shown.
@@ -166,6 +166,7 @@ oppia.directive('topNavigationBar', [function() {
                 $scope.navElementsVisibilityStatus[element] = false;
                 // Force a digest cycle to hide element immediately.
                 // Otherwise it would be hidden after the next call.
+                // This is due to setTimeout use in debounce.
                 $scope.$apply();
                 $timeout(truncateNavbar, 50);
                 return false;

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -199,7 +199,6 @@ oppia.directive('topNavigationBar', [function() {
         // check if i18n is complete and set a new timeout if it is not. Since
         // a timeout of 0 works for at least one browser, it is used here.
         $timeout(truncateNavbar, 0);
-        $scope.toggleSidebar = SidebarStatusService.toggleSidebar;
         $scope.$on('searchBarLoaded', function() {
           $timeout(truncateNavbar, 100);
         });

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -174,7 +174,7 @@ oppia.directive('topNavigationBar', [function() {
           }
         };
 
-        var truncateNavbarDebounced = oppiaDebouncer.debounce(truncateNavbar, 100);
+        var truncateNavbarDebounced = oppiaDebouncer.debounce(truncateNavbar, 500);
 
         // For Chrome, timeout 0 appears to run after i18n.
         $timeout(truncateNavbar, 0);

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -111,28 +111,28 @@ oppia.directive('topNavigationBar', [function() {
           // Close the sidebar, if necessary.
           SidebarStatusService.closeSidebar();
           $scope.sidebarIsShown = SidebarStatusService.isSidebarShown();
-          $scope.isSidebarShown = function() {
-            if (SidebarStatusService.isSidebarShown()) {
-              angular.element(document.body).addClass('oppia-stop-scroll');
-            } else {
-              angular.element(document.body).removeClass('oppia-stop-scroll');
-            }
-            return SidebarStatusService.isSidebarShown();
-          };
-          $scope.toggleSidebar = function() {
-            SidebarStatusService.toggleSidebar();
-          };
-          // If the window is resized larger, try displaying the hidden elements
-          if (currentWindowWidth < windowDimensionsService.getWidth()) {
-            for (var i = 0; i < navElementsOrder.length; i++) {
-              if (!$scope.navElementsVisibilityStatus[navElementsOrder[i]]) {
-                $scope.navElementsVisibilityStatus[navElementsOrder[i]] = true;
-              }
-            }
-          }
           currentWindowWidth = windowDimensionsService.getWidth();
           truncateNavbarDebounced();
         });
+        $scope.isSidebarShown = function() {
+          if (SidebarStatusService.isSidebarShown()) {
+            angular.element(document.body).addClass('oppia-stop-scroll');
+          } else {
+            angular.element(document.body).removeClass('oppia-stop-scroll');
+          }
+          return SidebarStatusService.isSidebarShown();
+        };
+        $scope.toggleSidebar = function() {
+          SidebarStatusService.toggleSidebar();
+        };
+        // If the window is resized larger, try displaying the hidden elements
+        if (currentWindowWidth < windowDimensionsService.getWidth()) {
+          for (var i = 0; i < navElementsOrder.length; i++) {
+            if (!$scope.navElementsVisibilityStatus[navElementsOrder[i]]) {
+              $scope.navElementsVisibilityStatus[navElementsOrder[i]] = true;
+            }
+          }
+        }
 
         /**
          * Checks if i18n has been run.

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -125,7 +125,7 @@ oppia.directive('topNavigationBar', [function() {
         $scope.toggleSidebar = function() {
           SidebarStatusService.toggleSidebar();
         };
-        // If the window is resized larger, try displaying the hidden elements
+        // If the window is resized larger, try displaying the hidden elements.
         if (currentWindowWidth < windowDimensionsService.getWidth()) {
           for (var i = 0; i < NAV_ELEMENTS_ORDER.length; i++) {
             if (!$scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]]) {

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -102,6 +102,10 @@ oppia.directive('topNavigationBar', [function() {
           I18N_CREATE_EXPLORATION_CREATE: true,
           I18N_TOPNAV_LIBRARY: true
         };
+        // The order of the elements in this array specifies the order in which
+        // they will be hidden.
+        navElementsOrder = ['I18N_TOPNAV_DONATE', 'I18N_TOPNAV_ABOUT',
+          'I18N_CREATE_EXPLORATION_CREATE', 'I18N_TOPNAV_LIBRARY'];
 
         windowDimensionsService.registerOnResizeHook(function() {
           $scope.windowIsNarrow = windowDimensionsService.isWindowNarrow();
@@ -122,9 +126,9 @@ oppia.directive('topNavigationBar', [function() {
           };
           // If the window is resized larger, try displaying the hidden elements
           if (currentWindowWidth < windowDimensionsService.getWidth()) {
-            for (element in $scope.navElementsVisibilityStatus) {
-              if (!$scope.navElementsVisibilityStatus[element]) {
-                $scope.navElementsVisibilityStatus[element] = true;
+            for (var i = 0; i < navElementsOrder.length; i++) {
+              if (!$scope.navElementsVisibilityStatus[navElementsOrder[i]]) {
+                $scope.navElementsVisibilityStatus[navElementsOrder[i]] = true;
               }
             }
           }
@@ -172,11 +176,12 @@ oppia.directive('topNavigationBar', [function() {
           // updated.
           if (document.querySelector('div.collapse.navbar-collapse')
             .clientHeight > 60) {
-            for (element in $scope.navElementsVisibilityStatus) {
-              if ($scope.navElementsVisibilityStatus[element]) {
+            for (var i = 0; i < navElementsOrder.length; i++) {
+              if ($scope.navElementsVisibilityStatus[navElementsOrder[i]]) {
                 // Hide one element, then check again after 50ms.
                 // This gives the browser time to render the visibility change.
-                $scope.navElementsVisibilityStatus[element] = false;
+                $scope.navElementsVisibilityStatus[navElementsOrder[i]] =
+                  false;
                 // Force a digest cycle to hide element immediately.
                 // Otherwise it would be hidden after the next call.
                 // This is due to setTimeout use in debounce.
@@ -197,6 +202,9 @@ oppia.directive('topNavigationBar', [function() {
         // a timeout of 0 works for at least one browser, it is used here.
         $timeout(truncateNavbar, 0);
         $scope.toggleSidebar = SidebarStatusService.toggleSidebar;
+        $scope.$on('searchBarLoaded', function(evt, searchBarLoaded) {
+          $timeout(truncateNavbar, 100);
+        });
       }
     ]
   };

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -140,7 +140,7 @@ oppia.directive('topNavigationBar', [function() {
 
         /**
          * Checks if window is >768px and i18n is completed, then checks
-         * for overflow. If overflow is detected hides the least important
+         * for overflow. If overflow is detected, hides the least important
          * tab and then calls itself again after a 50ms delay.
          */
         var truncateNavbar = function() {

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -96,16 +96,14 @@ oppia.directive('topNavigationBar', [function() {
 
         $scope.windowIsNarrow = windowDimensionsService.isWindowNarrow();
         var currentWindowWidth = windowDimensionsService.getWidth();
-        $scope.navElementsVisibilityStatus = {
-          I18N_TOPNAV_DONATE: true,
-          I18N_TOPNAV_ABOUT: true,
-          I18N_CREATE_EXPLORATION_CREATE: true,
-          I18N_TOPNAV_LIBRARY: true
-        };
+        $scope.navElementsVisibilityStatus = {};
         // The order of the elements in this array specifies the order in which
         // they will be hidden.
         navElementsOrder = ['I18N_TOPNAV_DONATE', 'I18N_TOPNAV_ABOUT',
           'I18N_CREATE_EXPLORATION_CREATE', 'I18N_TOPNAV_LIBRARY'];
+        for (var i = 0; i < navElementsOrder.length; i++) {
+          $scope.navElementsVisibilityStatus[navElementsOrder[i]] = true;
+        }
 
         windowDimensionsService.registerOnResizeHook(function() {
           $scope.windowIsNarrow = windowDimensionsService.isWindowNarrow();

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -202,7 +202,7 @@ oppia.directive('topNavigationBar', [function() {
         // a timeout of 0 works for at least one browser, it is used here.
         $timeout(truncateNavbar, 0);
         $scope.toggleSidebar = SidebarStatusService.toggleSidebar;
-        $scope.$on('searchBarLoaded', function(evt, searchBarLoaded) {
+        $scope.$on('searchBarLoaded', function() {
           $timeout(truncateNavbar, 100);
         });
       }

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -98,10 +98,10 @@ oppia.directive('topNavigationBar', [function() {
         var handleOverflowResizeTimer;
         var initialWindowWidth = windowDimensionsService.getWidth();
         var hideNavElements = {
-          'I18N_TOPNAV_DONATE': false,
-          'I18N_TOPNAV_ABOUT': false,
-          'I18N_CREATE_EXPLORATION_CREATE': false,
-          'I18N_TOPNAV_LIBRARY': false
+          I18N_TOPNAV_DONATE: false,
+          I18N_TOPNAV_ABOUT: false,
+          I18N_CREATE_EXPLORATION_CREATE: false,
+          I18N_TOPNAV_LIBRARY: false
         };
 
         windowDimensionsService.registerOnResizeHook(function() {
@@ -115,8 +115,9 @@ oppia.directive('topNavigationBar', [function() {
           // If the window is resized larger, try displaying the hidden elements
           if (initialWindowWidth < windowDimensionsService.getWidth()) {
             $.each(hideNavElements, function(element, state) {
-              if ( state == true ) {
-                $('[translate='+element+']').closest('div, li').css('display', 'block');
+              if (state === true) {
+                $('[translate=' + element + ']')
+                  .closest('div, li').css('display', 'block');
                 hideNavElements[element] = false;
               }
             });
@@ -125,50 +126,51 @@ oppia.directive('topNavigationBar', [function() {
           handleOverflowResizeTimer = $timeout(handleOverflow, 500);
         });
 
-        var handleOverflow = function () {
+        var handleOverflow = function() {
           if (windowDimensionsService.getWidth() < 768) {
             return false;
           }
 
           var navReady = true;
           // Wait until i18n is completed.
-          $('.oppia-navbar-tabs a[translate], .oppia-navbar-tabs span[translate]')
-            .each(function(i,e) {
-              if ( e.innerText.length == 0 ) {
-                console.log("Setting new timeout from: "+e.getAttribute('translate'));
+          $('.oppia-navbar-tabs a[translate], ' +
+            '.oppia-navbar-tabs span[translate]').each(function(index, element) {
+              if (element.innerText.length === 0) {
                 $timeout(handleOverflow, 100);
                 navReady = false;
                 return false;
               }
             });
-          if ( !navReady ) {
+          if (!navReady) {
             return false;
           }
 
           var navWidth = 0;
-          $('ul.oppia-navbar-tabs').children().each(function(i, e) {
-              // Some nav elements have invalid widths, use widths of their child elements instead
-              if (e.clientWidth == 0 || e.clientWidth >= 176) {
-                  $(e).children().each(function(i, e) {
-                      navWidth += 5; // Padding
-                      navWidth += e.clientWidth;
-                  });
-              } else {
-                  navWidth += 5; // Padding
-                  navWidth += e.clientWidth;
-              }
+          $('ul.oppia-navbar-tabs').children().each(function(i, element) {
+            // Some nav elements have invalid widths from floating
+            // Use widths of their first-level child elements instead
+            if (element.clientWidth === 0 || element.clientWidth >= 176) {
+              $(element).children().each(function(i, element) {
+                navWidth += 5;
+                navWidth += element.clientWidth;
+              });
+            } else {
+              navWidth += 5;
+              navWidth += element.clientWidth;
+            }
           });
 
-          if ( $('ul.nav.oppia-navbar-profile').length > 0 ) {
+          if ($('ul.nav.oppia-navbar-profile').length > 0) {
             navWidth += $('ul.nav.oppia-navbar-profile').width();
           }
 
           $('ul.nav.oppia-navbar-tabs').css('min-width', navWidth);
 
-          if ( $('div.collapse.navbar-collapse').height() > 60 ) {
+          if ($('div.collapse.navbar-collapse').height() > 60) {
             $.each(hideNavElements, function(element, state) {
-              if (state == false) {
-                $('[translate='+element+']').closest('div, li').css('display', 'None');
+              if (state === false) {
+                $('[translate=' + element + ']')
+                  .closest('div, li').css('display', 'None');
                 hideNavElements[element] = true;
                 $timeout(handleOverflow, 10);
                 return false;

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -108,6 +108,15 @@ oppia.directive('topNavigationBar', [function() {
         windowDimensionsService.registerOnResizeHook(function() {
           $scope.windowIsNarrow = windowDimensionsService.isWindowNarrow();
           $scope.$apply();
+          // If the window is resized larger, try displaying the hidden elements.
+          if (currentWindowWidth < windowDimensionsService.getWidth()) {
+            for (var i = 0; i < NAV_ELEMENTS_ORDER.length; i++) {
+              if (!$scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]]) {
+                $scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]] = true;
+              }
+            }
+          }
+
           // Close the sidebar, if necessary.
           SidebarStatusService.closeSidebar();
           $scope.sidebarIsShown = SidebarStatusService.isSidebarShown();
@@ -125,14 +134,7 @@ oppia.directive('topNavigationBar', [function() {
         $scope.toggleSidebar = function() {
           SidebarStatusService.toggleSidebar();
         };
-        // If the window is resized larger, try displaying the hidden elements.
-        if (currentWindowWidth < windowDimensionsService.getWidth()) {
-          for (var i = 0; i < NAV_ELEMENTS_ORDER.length; i++) {
-            if (!$scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]]) {
-              $scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]] = true;
-            }
-          }
-        }
+
 
         /**
          * Checks if i18n has been run.

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -111,7 +111,7 @@ oppia.directive('topNavigationBar', [function() {
 
           // If the window is resized larger, try displaying the hidden elements
           if (currentWindowWidth < windowDimensionsService.getWidth()) {
-            for(element in $scope.navElementsVisibilityStatus) {
+            for (element in $scope.navElementsVisibilityStatus) {
               if (!$scope.navElementsVisibilityStatus[element]) {
                 $scope.navElementsVisibilityStatus[element] = true;
               }
@@ -130,7 +130,7 @@ oppia.directive('topNavigationBar', [function() {
         var checkIfI18NCompleted = function() {
           var i18nCompleted = true;
           document.querySelectorAll('.oppia-navbar-tabs a[translate], ' +
-            '.oppia-navbar-tabs span[translate]').forEach(function(element){
+            '.oppia-navbar-tabs span[translate]').forEach(function(element) {
             if (element.innerText.length === 0) {
               i18nCompleted = false;
               return false;
@@ -174,7 +174,8 @@ oppia.directive('topNavigationBar', [function() {
           }
         };
 
-        var truncateNavbarDebounced = oppiaDebouncer.debounce(truncateNavbar, 500);
+        var truncateNavbarDebounced =
+          oppiaDebouncer.debounce(truncateNavbar, 500);
 
         // For Chrome, timeout 0 appears to run after i18n.
         $timeout(truncateNavbar, 0);

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -99,10 +99,10 @@ oppia.directive('topNavigationBar', [function() {
         $scope.navElementsVisibilityStatus = {};
         // The order of the elements in this array specifies the order in which
         // they will be hidden.
-        navElementsOrder = ['I18N_TOPNAV_DONATE', 'I18N_TOPNAV_ABOUT',
+        NAV_ELEMENTS_ORDER = ['I18N_TOPNAV_DONATE', 'I18N_TOPNAV_ABOUT',
           'I18N_CREATE_EXPLORATION_CREATE', 'I18N_TOPNAV_LIBRARY'];
-        for (var i = 0; i < navElementsOrder.length; i++) {
-          $scope.navElementsVisibilityStatus[navElementsOrder[i]] = true;
+        for (var i = 0; i < NAV_ELEMENTS_ORDER.length; i++) {
+          $scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]] = true;
         }
 
         windowDimensionsService.registerOnResizeHook(function() {
@@ -127,9 +127,9 @@ oppia.directive('topNavigationBar', [function() {
         };
         // If the window is resized larger, try displaying the hidden elements
         if (currentWindowWidth < windowDimensionsService.getWidth()) {
-          for (var i = 0; i < navElementsOrder.length; i++) {
-            if (!$scope.navElementsVisibilityStatus[navElementsOrder[i]]) {
-              $scope.navElementsVisibilityStatus[navElementsOrder[i]] = true;
+          for (var i = 0; i < NAV_ELEMENTS_ORDER.length; i++) {
+            if (!$scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]]) {
+              $scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]] = true;
             }
           }
         }
@@ -174,11 +174,11 @@ oppia.directive('topNavigationBar', [function() {
           // updated.
           if (document.querySelector('div.collapse.navbar-collapse')
             .clientHeight > 60) {
-            for (var i = 0; i < navElementsOrder.length; i++) {
-              if ($scope.navElementsVisibilityStatus[navElementsOrder[i]]) {
+            for (var i = 0; i < NAV_ELEMENTS_ORDER.length; i++) {
+              if ($scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]]) {
                 // Hide one element, then check again after 50ms.
                 // This gives the browser time to render the visibility change.
-                $scope.navElementsVisibilityStatus[navElementsOrder[i]] =
+                $scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]] =
                   false;
                 // Force a digest cycle to hide element immediately.
                 // Otherwise it would be hidden after the next call.

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -129,8 +129,8 @@ oppia.directive('topNavigationBar', [function() {
          */
         var checkIfI18NCompleted = function() {
           var i18nCompleted = true;
-          $('.oppia-navbar-tabs a[translate], ' +
-            '.oppia-navbar-tabs span[translate]').each(function(i, element) {
+          document.querySelectorAll('.oppia-navbar-tabs a[translate], ' +
+            '.oppia-navbar-tabs span[translate]').forEach(function(element){
             if (element.innerText.length === 0) {
               i18nCompleted = false;
               return false;
@@ -145,7 +145,6 @@ oppia.directive('topNavigationBar', [function() {
          * tab and then calls itself again after a 10ms delay.
          */
         var truncateNavbar = function() {
-          console.log('Called at', Date.now());
           // If the window is narrow, the standard nav tabs are not shown.
           if (windowDimensionsService.isWindowNarrow()) {
             return false;
@@ -157,15 +156,13 @@ oppia.directive('topNavigationBar', [function() {
             return false;
           }
 
-
-
           // Measured non-overflowed navbar height under 60px via inspector.
-          if ($('div.collapse.navbar-collapse').height() > 60) {
+          if (document.querySelector('div.collapse.navbar-collapse')
+            .clientHeight > 60) {
             for (element in $scope.navElementsVisibilityStatus) {
               if ($scope.navElementsVisibilityStatus[element]) {
                 // Hide one element, then check again after 50ms.
                 // This gives the browser time to render the visibility change.
-                console.log(Date.now(), 'Hiding:', element);
                 $scope.navElementsVisibilityStatus[element] = false;
                 // Force a digest cycle to hide element immediately.
                 // Otherwise it would be hidden after the next call.

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -98,8 +98,8 @@ oppia.directive('topNavigationBar', [function() {
         var currentWindowWidth = windowDimensionsService.getWidth();
         $scope.navElementsVisibilityStatus = {};
         // The order of the elements in this array specifies the order in which
-        // they will be hidden.
-        NAV_ELEMENTS_ORDER = ['I18N_TOPNAV_DONATE', 'I18N_TOPNAV_ABOUT',
+        // they will be hidden. Earlier elements will be hidden first.
+        var NAV_ELEMENTS_ORDER = ['I18N_TOPNAV_DONATE', 'I18N_TOPNAV_ABOUT',
           'I18N_CREATE_EXPLORATION_CREATE', 'I18N_TOPNAV_LIBRARY'];
         for (var i = 0; i < NAV_ELEMENTS_ORDER.length; i++) {
           $scope.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]] = true;

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -111,11 +111,11 @@ oppia.directive('topNavigationBar', [function() {
 
           // If the window is resized larger, try displaying the hidden elements
           if (currentWindowWidth < windowDimensionsService.getWidth()) {
-            $.each($scope.navElementsVisibilityStatus, function(e, visible) {
-              if (!visible) {
-                $scope.navElementsVisibilityStatus[e] = true;
+            for(element in $scope.navElementsVisibilityStatus) {
+              if (!$scope.navElementsVisibilityStatus[element]) {
+                $scope.navElementsVisibilityStatus[element] = true;
               }
-            });
+            }
           }
           currentWindowWidth = windowDimensionsService.getWidth();
           oppiaDebouncer.debounce(truncateNavbar, 500)();
@@ -189,15 +189,15 @@ oppia.directive('topNavigationBar', [function() {
 
           // Measured non-overflowed navbar height under 60px via inspector.
           if ($('div.collapse.navbar-collapse').height() > 60) {
-            $.each($scope.navElementsVisibilityStatus, function(e, visible) {
-              if (visible) {
+            for (element in $scope.navElementsVisibilityStatus) {
+              if ($scope.navElementsVisibilityStatus[element]) {
                 // Hide one element, then check again after 10ms.
                 // This gives the browser time to render the visibility change.
-                $scope.navElementsVisibilityStatus[e] = false;
+                $scope.navElementsVisibilityStatus[element] = false;
                 $timeout(truncateNavbar, 10);
                 return false;
               }
-            });
+            }
           }
         };
 

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -111,9 +111,9 @@ oppia.directive('topNavigationBar', [function() {
 
           // If the window is resized larger, try displaying the hidden elements
           if (currentWindowWidth < windowDimensionsService.getWidth()) {
-            $.each($scope.navElementsVisibilityStatus, function(element, visible) {
+            $.each($scope.navElementsVisibilityStatus, function(e, visible) {
               if (!visible) {
-                $scope.navElementsVisibilityStatus[element] = true;
+                $scope.navElementsVisibilityStatus[e] = true;
               }
             });
           }
@@ -187,13 +187,13 @@ oppia.directive('topNavigationBar', [function() {
 
           $('ul.nav.oppia-navbar-tabs').css('min-width', calculateNavWidth());
 
-          // Measured non-overflowed navbar height to be under 60px via inspector.
+          // Measured non-overflowed navbar height under 60px via inspector.
           if ($('div.collapse.navbar-collapse').height() > 60) {
-            $.each($scope.navElementsVisibilityStatus, function(element, visible) {
+            $.each($scope.navElementsVisibilityStatus, function(e, visible) {
               if (visible) {
                 // Hide one element, then check again after 10ms.
                 // This gives the browser time to render the visibility change.
-                $scope.navElementsVisibilityStatus[element] = false;
+                $scope.navElementsVisibilityStatus[e] = false;
                 $timeout(truncateNavbar, 10);
                 return false;
               }

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -134,7 +134,7 @@ oppia.directive('topNavigationBar', [function() {
           var navReady = true;
           // Wait until i18n is completed.
           $('.oppia-navbar-tabs a[translate], ' +
-            '.oppia-navbar-tabs span[translate]').each(function(index, element) {
+            '.oppia-navbar-tabs span[translate]').each(function(i, element) {
               if (element.innerText.length === 0) {
                 $timeout(handleOverflow, 100);
                 navReady = false;

--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -128,8 +128,8 @@
         <create-activity-button></create-activity-button>
       </ul>
       <ul ng-if="!windowIsNarrow" class="nav oppia-navbar-tabs">
-        <create-activity-button></create-activity-button>
-        <li>
+        <create-activity-button ng-show="navElementsVisibilityStatus.I18N_CREATE_EXPLORATION_CREATE"></create-activity-button>
+        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_DONATE">
           <div class="pull-right oppia-navbar-button-container">
             <a href="/donate"
                class="btn oppia-navbar-button oppia-navbar-hide-on-small-width protractor-test-create-activity oppia-transition-200">
@@ -138,7 +138,7 @@
           </div>
         </li>
 
-        <li class="dropdown oppia-navbar-clickable-dropdown pull-right protractor-test-about-oppia-list-item">
+        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_ABOUT" class="dropdown oppia-navbar-clickable-dropdown pull-right protractor-test-about-oppia-list-item">
           <a class="oppia-navbar-tab">
             <span translate="I18N_TOPNAV_ABOUT"></span>
             <span class="caret"></span>
@@ -154,7 +154,7 @@
             <li><a class="protractor-test-contact-link" href="/contact" translate="I18N_TOPNAV_CONTACT_US"></a></li>
           </ul>
         </li>
-        <li class="oppia-clickable-navbar-element pull-right">
+        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_LIBRARY" class="oppia-clickable-navbar-element pull-right">
           <a class="oppia-navbar-tab" href="/library" translate="I18N_TOPNAV_LIBRARY"></a>
         </li>
       </ul>

--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -45,7 +45,7 @@
         <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_DONATE">
           <div class="oppia-navbar-button-container">
             <a href="/donate"
-               class="btn oppia-navbar-button oppia-navbar-hide-on-small-width protractor-test-create-activity oppia-transition-200">
+               class="btn oppia-navbar-button oppia-navbar-hide-on-small-width oppia-transition-200">
               <span class="oppia-navbar-tab-content" translate="I18N_TOPNAV_DONATE"></span>
             </a>
           </div>

--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -130,7 +130,7 @@
       <ul ng-if="!windowIsNarrow" class="nav oppia-navbar-tabs">
         <create-activity-button ng-show="navElementsVisibilityStatus.I18N_CREATE_EXPLORATION_CREATE"></create-activity-button>
         <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_DONATE">
-          <div class="pull-right oppia-navbar-button-container">
+          <div class="oppia-navbar-button-container">
             <a href="/donate"
                class="btn oppia-navbar-button oppia-navbar-hide-on-small-width protractor-test-create-activity oppia-transition-200">
               <span translate="I18N_TOPNAV_DONATE"></span>
@@ -138,7 +138,7 @@
           </div>
         </li>
 
-        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_ABOUT" class="dropdown oppia-navbar-clickable-dropdown pull-right protractor-test-about-oppia-list-item">
+        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_ABOUT" class="dropdown oppia-navbar-clickable-dropdown protractor-test-about-oppia-list-item">
           <a class="oppia-navbar-tab">
             <span translate="I18N_TOPNAV_ABOUT"></span>
             <span class="caret"></span>
@@ -154,7 +154,7 @@
             <li><a class="protractor-test-contact-link" href="/contact" translate="I18N_TOPNAV_CONTACT_US"></a></li>
           </ul>
         </li>
-        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_LIBRARY" class="oppia-clickable-navbar-element pull-right">
+        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_LIBRARY" class="oppia-clickable-navbar-element">
           <a class="oppia-navbar-tab" href="/library" translate="I18N_TOPNAV_LIBRARY"></a>
         </li>
       </ul>

--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -22,29 +22,29 @@
       </ul>
       <ul ng-if="!windowIsNarrow" class="nav oppia-navbar-tabs">
         <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_LIBRARY" class="oppia-clickable-navbar-element">
-          <a class="oppia-navbar-tab" href="/library" translate="I18N_TOPNAV_LIBRARY"></a>
+          <a class="oppia-navbar-tab oppia-navbar-tab-content" href="/library" translate="I18N_TOPNAV_LIBRARY"></a>
         </li>
         <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_ABOUT" class="dropdown oppia-navbar-clickable-dropdown protractor-test-about-oppia-list-item">
           <a class="oppia-navbar-tab">
-            <span translate="I18N_TOPNAV_ABOUT"></span>
+            <span class="oppia-navbar-tab-content" translate="I18N_TOPNAV_ABOUT"></span>
             <span class="caret"></span>
           </a>
           <ul class="dropdown-menu oppia-navbar-dropdown"
               ng-mouseover="onMouseoverDropdownMenu($event)"
               ng-mouseleave="onMouseoutDropdownMenu($event)">
-            <li><a class="protractor-test-about-link" href="/about" translate="I18N_TOPNAV_ABOUT_OPPIA"></a></li>
-            <li><a class="protractor-test-get-started-link" href="/get_started" translate="I18N_TOPNAV_GET_STARTED"></a></li>
-            <li><a class="protractor-test-teach-link" href="/teach" translate="I18N_TOPNAV_TEACH_WITH_OPPIA"></a></li>
-            <li><a href="/blog" translate="I18N_TOPNAV_BLOG"></a></li>
-            <li><a href="/forum" translate="I18N_TOPNAV_FORUM"></a></li>
-            <li><a class="protractor-test-contact-link" href="/contact" translate="I18N_TOPNAV_CONTACT_US"></a></li>
+            <li><a class="protractor-test-about-link oppia-navbar-tab-content" href="/about" translate="I18N_TOPNAV_ABOUT_OPPIA"></a></li>
+            <li><a class="protractor-test-get-started-link oppia-navbar-tab-content" href="/get_started" translate="I18N_TOPNAV_GET_STARTED"></a></li>
+            <li><a class="protractor-test-teach-link oppia-navbar-tab-content" href="/teach" translate="I18N_TOPNAV_TEACH_WITH_OPPIA"></a></li>
+            <li><a href="/blog" class="oppia-navbar-tab-content" translate="I18N_TOPNAV_BLOG"></a></li>
+            <li><a href="/forum" class="oppia-navbar-tab-content" translate="I18N_TOPNAV_FORUM"></a></li>
+            <li><a class="protractor-test-contact-link oppia-navbar-tab-content" href="/contact" translate="I18N_TOPNAV_CONTACT_US"></a></li>
           </ul>
         </li>
         <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_DONATE">
           <div class="oppia-navbar-button-container">
             <a href="/donate"
                class="btn oppia-navbar-button oppia-navbar-hide-on-small-width protractor-test-create-activity oppia-transition-200">
-              <span translate="I18N_TOPNAV_DONATE"></span>
+              <span class="oppia-navbar-tab-content" translate="I18N_TOPNAV_DONATE"></span>
             </a>
           </div>
         </li>

--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -16,8 +16,43 @@
   </div>
 
   <div ng-cloak class="navbar-header pull-right" ng-if="userMenuIsShown">
+    <ul class="nav oppia-navbar-nav" ng-if="standardNavIsShown">
+      <ul ng-if="windowIsNarrow" class="nav oppia-navbar-tabs-narrow">
+        <create-activity-button></create-activity-button>
+      </ul>
+      <ul ng-if="!windowIsNarrow" class="nav oppia-navbar-tabs">
+        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_LIBRARY" class="oppia-clickable-navbar-element">
+          <a class="oppia-navbar-tab" href="/library" translate="I18N_TOPNAV_LIBRARY"></a>
+        </li>
+        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_ABOUT" class="dropdown oppia-navbar-clickable-dropdown protractor-test-about-oppia-list-item">
+          <a class="oppia-navbar-tab">
+            <span translate="I18N_TOPNAV_ABOUT"></span>
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu oppia-navbar-dropdown"
+              ng-mouseover="onMouseoverDropdownMenu($event)"
+              ng-mouseleave="onMouseoutDropdownMenu($event)">
+            <li><a class="protractor-test-about-link" href="/about" translate="I18N_TOPNAV_ABOUT_OPPIA"></a></li>
+            <li><a class="protractor-test-get-started-link" href="/get_started" translate="I18N_TOPNAV_GET_STARTED"></a></li>
+            <li><a class="protractor-test-teach-link" href="/teach" translate="I18N_TOPNAV_TEACH_WITH_OPPIA"></a></li>
+            <li><a href="/blog" translate="I18N_TOPNAV_BLOG"></a></li>
+            <li><a href="/forum" translate="I18N_TOPNAV_FORUM"></a></li>
+            <li><a class="protractor-test-contact-link" href="/contact" translate="I18N_TOPNAV_CONTACT_US"></a></li>
+          </ul>
+        </li>
+        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_DONATE">
+          <div class="oppia-navbar-button-container">
+            <a href="/donate"
+               class="btn oppia-navbar-button oppia-navbar-hide-on-small-width protractor-test-create-activity oppia-transition-200">
+              <span translate="I18N_TOPNAV_DONATE"></span>
+            </a>
+          </div>
+        </li>
+        <create-activity-button ng-show="navElementsVisibilityStatus.I18N_CREATE_EXPLORATION_CREATE"></create-activity-button>
+      </ul>
+    </ul>
     <ul class="nav oppia-navbar-nav oppia-navbar-profile">
-      <li ng-if="username" class="dropdown pull-right protractor-test-profile-dropdown">
+      <li ng-if="username" class="dropdown protractor-test-profile-dropdown">
         <a class="dropdown-toggle oppia-navbar-dropdown-toggle" data-toggle="dropdown"
            ng-mouseover="onMouseoverProfilePictureOrDropdown($event)"
            ng-mouseleave="onMouseoutProfilePictureOrDropdown($event)">
@@ -102,7 +137,7 @@
         </ul>
       </li>
 
-      <li ng-if="!username" class="dropdown oppia-navbar-clickable-dropdown pull-right">
+      <li ng-if="!username" class="dropdown oppia-navbar-clickable-dropdown">
         <div class="oppia-navbar-button-container" style="margin-right: 10px;">
           <button class="btn oppia-navbar-button"
                   ng-click="onLoginButtonClicked()">
@@ -121,43 +156,6 @@
           </li>
         </ul>
       </li>
-    </ul>
-
-    <ul class="nav oppia-navbar-nav" ng-if="standardNavIsShown">
-      <ul ng-if="windowIsNarrow" class="nav oppia-navbar-tabs-narrow">
-        <create-activity-button></create-activity-button>
-      </ul>
-      <ul ng-if="!windowIsNarrow" class="nav oppia-navbar-tabs">
-        <create-activity-button ng-show="navElementsVisibilityStatus.I18N_CREATE_EXPLORATION_CREATE"></create-activity-button>
-        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_DONATE">
-          <div class="oppia-navbar-button-container">
-            <a href="/donate"
-               class="btn oppia-navbar-button oppia-navbar-hide-on-small-width protractor-test-create-activity oppia-transition-200">
-              <span translate="I18N_TOPNAV_DONATE"></span>
-            </a>
-          </div>
-        </li>
-
-        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_ABOUT" class="dropdown oppia-navbar-clickable-dropdown protractor-test-about-oppia-list-item">
-          <a class="oppia-navbar-tab">
-            <span translate="I18N_TOPNAV_ABOUT"></span>
-            <span class="caret"></span>
-          </a>
-          <ul class="dropdown-menu oppia-navbar-dropdown"
-              ng-mouseover="onMouseoverDropdownMenu($event)"
-              ng-mouseleave="onMouseoutDropdownMenu($event)">
-            <li><a class="protractor-test-about-link" href="/about" translate="I18N_TOPNAV_ABOUT_OPPIA"></a></li>
-            <li><a class="protractor-test-get-started-link" href="/get_started" translate="I18N_TOPNAV_GET_STARTED"></a></li>
-            <li><a class="protractor-test-teach-link" href="/teach" translate="I18N_TOPNAV_TEACH_WITH_OPPIA"></a></li>
-            <li><a href="/blog" translate="I18N_TOPNAV_BLOG"></a></li>
-            <li><a href="/forum" translate="I18N_TOPNAV_FORUM"></a></li>
-            <li><a class="protractor-test-contact-link" href="/contact" translate="I18N_TOPNAV_CONTACT_US"></a></li>
-          </ul>
-        </li>
-        <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_LIBRARY" class="oppia-clickable-navbar-element">
-          <a class="oppia-navbar-tab" href="/library" translate="I18N_TOPNAV_LIBRARY"></a>
-        </li>
-      </ul>
     </ul>
   </div>
 </script>

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2533,7 +2533,6 @@ div#ng-curtain {
   white-space: nowrap;
 }
 .nav, .oppia-navbar-tabs > li, .oppia-navbar-tabs > create-activity-button {
-  /* background: #F00; */
   display: inline-block;
   vertical-align: top;
 }

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2530,13 +2530,6 @@ div#ng-curtain {
 }
 
 @media (min-width: 500px) {
-  .oppia-navbar-tabs-narrow {
-    /*
-      This needs to take i18n of the "Create" and "Sign in" buttons into
-      account.
-    */
-    min-width: 260px;
-  }
   .oppia-navbar-tabs {
     white-space: nowrap;
   }
@@ -2552,6 +2545,10 @@ div#ng-curtain {
   .oppia-navbar-nav .dropdown-menu {
     left: auto;
     right: 0;
+  }
+  .navbar-header {
+    /* Prevent whitespace from inline-block elements from adding space. */
+    font-size: 0;
   }
 }
 .nav > li > a.oppia-navbar-tab {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2523,6 +2523,7 @@ div#ng-curtain {
 }
 .oppia-logo-wide {
   margin-left: 25px;
+  width: 90px;
 }
 .oppia-logo-small {
   margin-left: 6px;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2538,19 +2538,20 @@ div#ng-curtain {
     min-width: 260px;
   }
   .oppia-navbar-tabs {
-    /*
-      86px is for logged in users, if the user is logged out the width
-      will be set by javascript for i18n.
-     */
-    margin-right: 86px;
-    height: 100%;
-    width: 100%;
     white-space: nowrap;
   }
-  .oppia-navbar-tabs > li, .oppia-navbar-tabs > create-activity-button {
+  .nav, .oppia-navbar-tabs > li, .oppia-navbar-tabs > create-activity-button {
     /* background: #F00; */
     display: inline-block;
     vertical-align: top;
+  }
+  .oppia-navbar-clickable-dropdown:hover ul.dropdown-menu, .oppia-clickable-navbar-element:hover {
+    /* Should this be changed at line 852? */
+    display: inline-block;
+  }
+  .oppia-navbar-nav .dropdown-menu {
+    left: auto;
+    right: 0;
   }
 }
 .nav > li > a.oppia-navbar-tab {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2537,7 +2537,6 @@ div#ng-curtain {
   vertical-align: top;
 }
 .oppia-navbar-clickable-dropdown:hover ul.dropdown-menu, .oppia-clickable-navbar-element:hover {
-  /* Should this be changed at line 852? */
   display: inline-block;
 }
 .oppia-navbar-nav .dropdown-menu {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2539,10 +2539,18 @@ div#ng-curtain {
   }
   .oppia-navbar-tabs {
     /*
-      This needs to take i18n of the "Create" and "Sign in" buttons into
-      account.
-    */
-    min-width: 580px;
+      86px is for logged in users, if the user is logged out the width
+      will be set by javascript for i18n.
+     */
+    margin-right: 86px;
+    height: 100%;
+    width: 100%;
+    white-space: nowrap;
+  }
+  .oppia-navbar-tabs > li, .oppia-navbar-tabs > create-activity-button {
+    /* background: #F00; */
+    display: inline-block;
+    vertical-align: top;
   }
 }
 .nav > li > a.oppia-navbar-tab {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2529,28 +2529,27 @@ div#ng-curtain {
   margin-left: 6px;
 }
 
-@media (min-width: 500px) {
-  .oppia-navbar-tabs {
-    white-space: nowrap;
-  }
-  .nav, .oppia-navbar-tabs > li, .oppia-navbar-tabs > create-activity-button {
-    /* background: #F00; */
-    display: inline-block;
-    vertical-align: top;
-  }
-  .oppia-navbar-clickable-dropdown:hover ul.dropdown-menu, .oppia-clickable-navbar-element:hover {
-    /* Should this be changed at line 852? */
-    display: inline-block;
-  }
-  .oppia-navbar-nav .dropdown-menu {
-    left: auto;
-    right: 0;
-  }
-  .navbar-header {
-    /* Prevent whitespace from inline-block elements from adding space. */
-    font-size: 0;
-  }
+.oppia-navbar-tabs {
+  white-space: nowrap;
 }
+.nav, .oppia-navbar-tabs > li, .oppia-navbar-tabs > create-activity-button {
+  /* background: #F00; */
+  display: inline-block;
+  vertical-align: top;
+}
+.oppia-navbar-clickable-dropdown:hover ul.dropdown-menu, .oppia-clickable-navbar-element:hover {
+  /* Should this be changed at line 852? */
+  display: inline-block;
+}
+.oppia-navbar-nav .dropdown-menu {
+  left: auto;
+  right: 0;
+}
+.navbar-header {
+  /* Prevent whitespace from inline-block elements from adding space. */
+  font-size: 0;
+}
+
 .nav > li > a.oppia-navbar-tab {
   font-family: "Capriola", "Roboto", Arial, sans-serif;
   font-size: 14px;

--- a/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
@@ -27,14 +27,14 @@ oppia.directive('editorNavigation', [function() {
       'explorationWarningsService',
       'stateEditorTutorialFirstTimeService',
       'threadDataService', 'siteAnalyticsService',
-      'explorationContextService',
+      'explorationContextService', 'windowDimensionsService',
       function(
           $scope, $rootScope, $timeout, $modal,
           routerService, explorationRightsService,
           explorationWarningsService,
           stateEditorTutorialFirstTimeService,
           threadDataService, siteAnalyticsService,
-          explorationContextService) {
+          explorationContextService, windowDimensionsService) {
         $scope.postTutorialHelpPopoverIsShown = false;
 
         $scope.$on('openPostTutorialHelpPopover', function() {
@@ -96,6 +96,11 @@ oppia.directive('editorNavigation', [function() {
         $scope.selectHistoryTab = routerService.navigateToHistoryTab;
         $scope.selectFeedbackTab = routerService.navigateToFeedbackTab;
         $scope.getOpenThreadsCount = threadDataService.getOpenThreadsCount;
+        $scope.isLargeScreen = (windowDimensionsService.getWidth() >= 1024);
+
+        windowDimensionsService.registerOnResizeHook(function() {
+          $scope.isLargeScreen = (windowDimensionsService.getWidth() >= 1024);
+        });
       }
     ]
   };

--- a/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
@@ -33,7 +33,7 @@
       </li>
     {% endif %}
 
-    <li ng-class="{'active': getTabStatuses().active === 'settings'}">
+    <li ng-if="isLargeScreen" ng-class="{'active': getTabStatuses().active === 'settings'}">
       <a href="#" tooltip="Settings" tooltip-placement="bottom" ng-click="selectSettingsTab()"
          class="oppia-editor-navbar-tab-anchor protractor-test-settings-tab">
         <i class="material-icons">&#xE8B8;</i>
@@ -41,7 +41,7 @@
     </li>
 
     {% if username %}
-      <li ng-class="{'active': getTabStatuses().active === 'stats'}">
+      <li ng-if="isLargeScreen" ng-class="{'active': getTabStatuses().active === 'stats'}">
         <a href="#" tooltip="Statistics" tooltip-placement="bottom" ng-click="selectStatsTab()"
            class="oppia-editor-navbar-tab-anchor">
           <i class="material-icons">&#xE24B;</i>
@@ -49,7 +49,7 @@
       </li>
     {% endif %}
 
-    <li ng-class="{'active': getTabStatuses().active === 'history'}">
+    <li ng-if="isLargeScreen" ng-class="{'active': getTabStatuses().active === 'history'}">
       <a href="#" tooltip="History" tooltip-placement="bottom" ng-click="selectHistoryTab()"
          disabled="explorationRightsService.isCloned()"
          class="oppia-editor-navbar-tab-anchor protractor-test-history-tab">
@@ -57,7 +57,7 @@
       </a>
     </li>
 
-    <li ng-class="{'active': getTabStatuses().active === 'feedback'}" ng-click="selectFeedbackTab()">
+    <li ng-if="isLargeScreen" ng-class="{'active': getTabStatuses().active === 'feedback'}" ng-click="selectFeedbackTab()">
       <a href="#" tooltip="Feedback" tooltip-placement="bottom"
          class="oppia-editor-navbar-tab-anchor protractor-test-feedback-tab">
         <i class="material-icons">&#xE87F;</i>
@@ -70,7 +70,7 @@
     </li>
 
     {% if username %}
-      <li class="dropdown" popover-is-open="postTutorialHelpPopoverIsShown"
+      <li ng-if="isLargeScreen" class="dropdown" popover-is-open="postTutorialHelpPopoverIsShown"
           popover-placement="bottom" popover-trigger="none"
           popover="To get help in the future, click here!">
         <a href="#" tooltip="Help" tooltip-placement="bottom"

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -39,11 +39,12 @@
       }
     }
     @media(max-width: 600px) {
-      .oppia-logo {
+      img.oppia-logo {
         height: 48px;
         margin-left: 0;
         margin-top: 8px;
         max-width: none;
+        width: auto;
       }
       .oppia-exploration-header {
         max-width: 180px;

--- a/core/templates/dev/head/pages/library/SearchBarDirective.js
+++ b/core/templates/dev/head/pages/library/SearchBarDirective.js
@@ -205,6 +205,9 @@ oppia.directive('searchBar', [function() {
             }
 
             refreshSearchBarLabels();
+
+            // Notify the function that handles overflow in case the search
+            // elements load after it has already been run.
             $rootScope.$broadcast('searchBarLoaded', true);
           }
         );

--- a/core/templates/dev/head/pages/library/SearchBarDirective.js
+++ b/core/templates/dev/head/pages/library/SearchBarDirective.js
@@ -205,6 +205,7 @@ oppia.directive('searchBar', [function() {
             }
 
             refreshSearchBarLabels();
+            $rootScope.$broadcast('searchBarLoaded', true);
           }
         );
 

--- a/core/templates/dev/head/pages/library/search_bar_directive.html
+++ b/core/templates/dev/head/pages/library/search_bar_directive.html
@@ -117,7 +117,7 @@
     color: rgba(255,255,255,0.7);
   }
 
-  @media (max-width: 1275px) {
+  @media (max-width: 1024px) {
     .oppia-search-bar-language-selector {
       display: none;
     }
@@ -127,7 +127,7 @@
     }
   }
 
-  @media (max-width: 940px) {
+  @media (max-width: 768px) {
     .oppia-search-bar-text-input {
       border-bottom-right-radius: 4px;
       border-top-right-radius: 4px;

--- a/core/tests/protractor_utils/general.js
+++ b/core/tests/protractor_utils/general.js
@@ -139,8 +139,11 @@ var ensurePageHasNoTranslationIds = function() {
       // not displayed
       var REGEX_TRANSLATE_ATTR = new RegExp('translate="I18N_', 'g');
       var REGEX_NG_VARIABLE = new RegExp('<\\[\'I18N_', 'g');
+      var REGEX_NG_TOP_NAV_VISIBILITY =
+        new RegExp('ng-show="navElementsVisibilityStatus.I18N_', 'g');
       expect(promiseValue.replace(REGEX_TRANSLATE_ATTR, '')
-        .replace(REGEX_NG_VARIABLE, '')).not.toContain('I18N');
+        .replace(REGEX_NG_VARIABLE, '')
+        .replace(REGEX_NG_TOP_NAV_VISIBILITY, '')).not.toContain('I18N');
     });
 };
 


### PR DESCRIPTION
This PR hides the hamburger menu on most pages at >768px by changing NORMAL_NAVBAR_CUTOFF_WIDTH_PX from 800px to 768px.

This PR uses the $timeout method to run after the navbar has rendered. Still todo look into using a second navbar offscreen to measure.

Example video: https://drive.google.com/open?id=0ByhzG72M0KJuRkNKSzRpa2VSS2M

Overflow on page load is very brief, overflow during resize is up to about 500ms.