### PR TITLE
Fix #2064: Add a test for keys present in source code and not in en.json

### DIFF
--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -296,7 +296,7 @@ class I18nDictsTest(test_utils.GenericTestBase):
     def test_keys_in_source_code_match_en(self):
         """Tests that keys in HTML files are present in en.json."""
         en_key_list = self._extract_keys_from_json_file('en.json')
-        for root, dirs, files in os.walk(os.path.join(
+        for root, _, files in os.walk(os.path.join(
                 os.getcwd(), self.get_static_asset_filepath())):
             for filename in files:
                 if filename.endswith('.html'):

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -307,8 +307,7 @@ class I18nDictsTest(test_utils.GenericTestBase):
                         files_checked += 1
                         html_key_list = self._extract_keys_from_html_file(
                             os.path.join(root, filename))
-                        #pylint: disable=unneeded-not
-                        if not set(html_key_list) <= set(en_key_list):
+                        if not set(html_key_list) <= set(en_key_list): #pylint: disable=unneeded-not
                             self.log_line('ERROR: Undefined keys in %s:'
                                           % os.path.join(root, filename))
                             missing_keys = list(

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -307,9 +307,8 @@ class I18nDictsTest(test_utils.GenericTestBase):
                         files_checked += 1
                         html_key_list = self._extract_keys_from_html_file(
                             os.path.join(root, filename))
-                        if set(html_key_list) <= set(en_key_list):
-                            pass
-                        else:
+                        #pylint: disable=unneeded-not
+                        if not set(html_key_list) <= set(en_key_list):
                             self.log_line('ERROR: Undefined keys in %s:'
                                           % os.path.join(root, filename))
                             missing_keys = list(

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -298,14 +298,14 @@ class I18nDictsTest(test_utils.GenericTestBase):
         en_key_list = self._extract_keys_from_json_file('en.json')
         for root, dirs, files in os.walk(os.path.join(
                 os.getcwd(), self.get_static_asset_filepath())):
-            for file in files:
-                if file.endswith('.html'):
+            for filename in files:
+                if filename.endswith('.html'):
                     html_key_list = self._extract_keys_from_html_file(
-                        os.path.join(root, file))
+                        os.path.join(root, filename))
                     self.assertLessEqual(set(html_key_list), set(en_key_list))
-                    if not set(html_key_list) <= set(en_key_list):
+                    if set(html_key_list) > set(en_key_list):
                         self.log_line('ERROR: Undefined keys in %s...'
-                                      % os.path.join(root, file))
+                                      % os.path.join(root, filename))
                         missing_keys = list(
                             set(html_key_list) - set(en_key_list))
                         for key in missing_keys:

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -236,7 +236,7 @@ class I18nDictsTest(test_utils.GenericTestBase):
         )).keys())
 
     def _extract_keys_from_html_file(self, filename):
-        regex_pattern = r"(I18N_[A-Z/_\d]*)"
+        regex_pattern = r'(I18N_[A-Z/_\d]*)'
         return re.findall(regex_pattern, utils.get_file_contents(
             filename))
 
@@ -296,21 +296,30 @@ class I18nDictsTest(test_utils.GenericTestBase):
     def test_keys_in_source_code_match_en(self):
         """Tests that keys in HTML files are present in en.json."""
         en_key_list = self._extract_keys_from_json_file('en.json')
-        for root, _, files in os.walk(os.path.join(
-                os.getcwd(), self.get_static_asset_filepath())):
-            for filename in files:
-                if filename.endswith('.html'):
-                    html_key_list = self._extract_keys_from_html_file(
-                        os.path.join(root, filename))
-                    self.assertLessEqual(set(html_key_list), set(en_key_list))
-                    if set(html_key_list) > set(en_key_list):
-                        self.log_line('ERROR: Undefined keys in %s...'
-                                      % os.path.join(root, filename))
-                        missing_keys = list(
-                            set(html_key_list) - set(en_key_list))
-                        for key in missing_keys:
-                            self.log_line(' - %s' % key)
-                        self.log_line('')
+        dirs_to_search = ['core', 'extensions']
+        files_checked = 0
+        missing_keys_count = 0
+        for directory in dirs_to_search:
+            for root, _, files in os.walk(os.path.join(
+                    os.getcwd(), directory)):
+                for filename in files:
+                    if filename.endswith('.html'):
+                        files_checked += 1
+                        html_key_list = self._extract_keys_from_html_file(
+                            os.path.join(root, filename))
+                        if set(html_key_list) <= set(en_key_list):
+                            pass
+                        else:
+                            self.log_line('ERROR: Undefined keys in %s:'
+                                          % os.path.join(root, filename))
+                            missing_keys = list(
+                                set(html_key_list) - set(en_key_list))
+                            missing_keys_count += len(missing_keys)
+                            for key in missing_keys:
+                                self.log_line(' - %s' % key)
+                            self.log_line('')
+        self.assertEqual(missing_keys_count, 0)
+        self.assertGreater(files_checked, 0)
 
 
 class GetHandlerTypeIfExceptionRaisedTest(test_utils.GenericTestBase):

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -305,7 +305,7 @@ class I18nDictsTest(test_utils.GenericTestBase):
                     self.assertLessEqual(set(html_key_list), set(en_key_list))
                     if not set(html_key_list) <= set(en_key_list):
                         self.log_line('ERROR: Undefined keys in %s...'
-                            % os.path.join(root, file))
+                                      % os.path.join(root, file))
                         missing_keys = list(
                             set(html_key_list) - set(en_key_list))
                         for key in missing_keys:


### PR DESCRIPTION
Fixes #2064 . This walks through the entire root directory and reports any keys in html files which aren't present in en.json.