### PR TITLE
Fix #2814: Add new items button visibility in the SetInput interaction on mobile

### DIFF
--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
@@ -146,7 +146,6 @@ oppia.directive('schemaBasedListEditor', [
 
           $scope.lastElementOnBlur = function() {
             _deleteLastElementIfUndefined();
-            _deleteElementIfEmpty();
             $scope.showAddItemButton();
           };
 
@@ -158,6 +157,10 @@ oppia.directive('schemaBasedListEditor', [
           $scope.hideAddItemButton = function() {
             $scope.isAddItemButtonPresent = false;
           };
+
+          if ($scope.localValue.length === 0) {
+            $scope.addElement();
+          }
 
           $scope._onChildFormSubmit = function(evt) {
             if (!$scope.isAddItemButtonPresent) {

--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
@@ -136,7 +136,7 @@ oppia.directive('schemaBasedListEditor', [
           };
 
           var _deleteElementIfEmpty = function() {
-            for (var i = 0; i < $scope.localValue.length; i++) {
+            for (var i = 0; i < $scope.localValue.length - 1; i++) {
               if ($scope.localValue[i].length === 0) {
                 $scope.deleteElement(i);
                 i--;
@@ -156,13 +156,7 @@ oppia.directive('schemaBasedListEditor', [
           };
 
           $scope.hideAddItemButton = function() {
-            var lastValueIndex = $scope.localValue.length - 1;
             $scope.isAddItemButtonPresent = false;
-            if (lastValueIndex >= 0) {
-              if ($scope.localValue[lastValueIndex].length > 0) {
-                $scope.isAddItemButtonPresent = true;
-              }
-            }
           };
 
           $scope._onChildFormSubmit = function(evt) {

--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
@@ -135,17 +135,34 @@ oppia.directive('schemaBasedListEditor', [
             }
           };
 
+          var _deleteElementIfEmpty = function() {
+            for (var i = 0; i < $scope.localValue.length; i++) {
+              if ($scope.localValue[i].length === 0) {
+                $scope.deleteElement(i);
+                i--;
+              }
+            }
+          };
+
           $scope.lastElementOnBlur = function() {
             _deleteLastElementIfUndefined();
+            _deleteElementIfEmpty();
             $scope.showAddItemButton();
           };
 
           $scope.showAddItemButton = function() {
+            _deleteElementIfEmpty();
             $scope.isAddItemButtonPresent = true;
           };
 
           $scope.hideAddItemButton = function() {
+            var lastValueIndex = $scope.localValue.length - 1;
             $scope.isAddItemButtonPresent = false;
+            if (lastValueIndex >= 0) {
+              if ($scope.localValue[lastValueIndex].length > 0) {
+                $scope.isAddItemButtonPresent = true;
+              }
+            }
           };
 
           $scope._onChildFormSubmit = function(evt) {
@@ -180,6 +197,16 @@ oppia.directive('schemaBasedListEditor', [
             // Need to let the RTE know that HtmlContent has been changed.
             $scope.$broadcast('externalHtmlContentChange');
             $scope.localValue.splice(index, 1);
+          };
+
+          $scope.showbutton = function() {
+            var lastValueIndex = $scope.localValue.length - 1;
+            if (lastValueIndex >= 0) {
+              if ($scope.localValue[lastValueIndex].length > 0) {
+                return true;
+              }
+            }
+            return false;
           };
         } else {
           if ($scope.len <= 0) {

--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
@@ -145,7 +145,7 @@ oppia.directive('schemaBasedListEditor', [
           };
 
           if ($scope.localValue.length === 1) {
-            if ($scope.localValue[$scope.localValue.length - 1].length === 0) {
+            if ($scope.localValue[0].length === 0) {
               $scope.isAddItemButtonPresent = false;
             }
           }

--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
@@ -158,9 +158,11 @@ oppia.directive('schemaBasedListEditor', [
             $scope.isAddItemButtonPresent = false;
           };
 
-          if ($scope.localValue.length === 0) {
-            $scope.addElement();
-          }
+          if ($scope.itemSchema().value === 'setInput') {
+            if ($scope.localValue.length === 0) {
+              $scope.addElement();
+            }
+          };
 
           $scope._onChildFormSubmit = function(evt) {
             if (!$scope.isAddItemButtonPresent) {

--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
@@ -144,6 +144,12 @@ oppia.directive('schemaBasedListEditor', [
             }
           };
 
+          if ($scope.localValue.length === 1) {
+            if ($scope.localValue[$scope.localValue.length - 1].length === 0) {
+              $scope.isAddItemButtonPresent = false;
+            }
+          }
+
           $scope.lastElementOnBlur = function() {
             _deleteLastElementIfUndefined();
             $scope.showAddItemButton();
@@ -156,12 +162,6 @@ oppia.directive('schemaBasedListEditor', [
 
           $scope.hideAddItemButton = function() {
             $scope.isAddItemButtonPresent = false;
-          };
-
-          if ($scope.itemSchema().value === 'setInput') {
-            if ($scope.localValue.length === 0) {
-              $scope.addElement();
-            }
           };
 
           $scope._onChildFormSubmit = function(evt) {

--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
@@ -198,16 +198,6 @@ oppia.directive('schemaBasedListEditor', [
             $scope.$broadcast('externalHtmlContentChange');
             $scope.localValue.splice(index, 1);
           };
-
-          $scope.showbutton = function() {
-            var lastValueIndex = $scope.localValue.length - 1;
-            if (lastValueIndex >= 0) {
-              if ($scope.localValue[lastValueIndex].length > 0) {
-                return true;
-              }
-            }
-            return false;
-          };
         } else {
           if ($scope.len <= 0) {
             throw 'Invalid length for list editor: ' + $scope.len;

--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
@@ -135,7 +135,7 @@ oppia.directive('schemaBasedListEditor', [
             }
           };
 
-          var _deleteElementIfEmpty = function() {
+          var deleteEmptyElements = function() {
             for (var i = 0; i < $scope.localValue.length - 1; i++) {
               if ($scope.localValue[i].length === 0) {
                 $scope.deleteElement(i);
@@ -150,7 +150,7 @@ oppia.directive('schemaBasedListEditor', [
           };
 
           $scope.showAddItemButton = function() {
-            _deleteElementIfEmpty();
+            deleteEmptyElements();
             $scope.isAddItemButtonPresent = true;
           };
 

--- a/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
+++ b/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
@@ -25,7 +25,7 @@
 
   <!-- The margin-left is added here to left-align the button with the previous list items. -->
   <div style="height: 30px; margin-top: 4px;">
-    <button ng-show="!isOneLineInput || isAddItemButtonPresent"
+    <button ng-show="!isOneLineInput || isAddItemButtonPresent || showbutton()"
             ng-if="!len && (maxListLength === null || localValue.length < maxListLength)"
             type="button" class="btn btn-default btn-sm protractor-test-add-list-entry" ng-click="addElement()"
             ng-disabled="isDisabled()" style="margin-left: 0;">

--- a/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
+++ b/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
@@ -9,7 +9,7 @@
                              on-input-focus="($last ? hideAddItemButton : showAddItemButton)">
         </schema-based-editor>
       </td>
-      <td ng-if="!len && (!minListLength || localValue.length > minListLength) && (localValue.length > 1)" style="vertical-align: top;">
+      <td ng-if="!len && (!minListLength || localValue.length > minListLength) && localValue.length > 1" style="vertical-align: top;">
         <button class="oppia-delete-list-entry-button oppia-transition-200 protractor-test-delete-list-entry" type="button"
                 ng-click="deleteElement($index)"
                 ng-disabled="isDisabled()">

--- a/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
+++ b/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
@@ -9,7 +9,7 @@
                              on-input-focus="($last ? hideAddItemButton : showAddItemButton)">
         </schema-based-editor>
       </td>
-      <td ng-if="!len && (!minListLength || localValue.length > minListLength)" style="vertical-align: top;">
+      <td ng-if="!len && (!minListLength || localValue.length > minListLength) && (localValue.length > 1)" style="vertical-align: top;">
         <button class="oppia-delete-list-entry-button oppia-transition-200 protractor-test-delete-list-entry" type="button"
                 ng-click="deleteElement($index)"
                 ng-disabled="isDisabled()">

--- a/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
+++ b/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
@@ -25,7 +25,7 @@
 
   <!-- The margin-left is added here to left-align the button with the previous list items. -->
   <div style="height: 30px; margin-top: 4px;">
-    <button ng-show="!isOneLineInput || isAddItemButtonPresent || showbutton()"
+    <button ng-show="!isOneLineInput || isAddItemButtonPresent || (localValue.length && localValue[localValue.length - 1].length)"
             ng-if="!len && (maxListLength === null || localValue.length < maxListLength)"
             type="button" class="btn btn-default btn-sm protractor-test-add-list-entry" ng-click="addElement()"
             ng-disabled="isDisabled()" style="margin-left: 0;">

--- a/extensions/interactions/SetInput/SetInput.js
+++ b/extensions/interactions/SetInput/SetInput.js
@@ -32,7 +32,8 @@ oppia.directive('oppiaInteractiveSetInput', [function() {
       $scope.schema = {
         type: 'list',
         items: {
-          type: 'unicode'
+          type: 'unicode',
+          value: 'setInput'
         },
         ui_config: {
           // TODO(mili): Translate this in the HTML.

--- a/extensions/interactions/SetInput/SetInput.js
+++ b/extensions/interactions/SetInput/SetInput.js
@@ -32,8 +32,7 @@ oppia.directive('oppiaInteractiveSetInput', [function() {
       $scope.schema = {
         type: 'list',
         items: {
-          type: 'unicode',
-          value: 'setInput'
+          type: 'unicode'
         },
         ui_config: {
           // TODO(mili): Translate this in the HTML.
@@ -42,7 +41,8 @@ oppia.directive('oppiaInteractiveSetInput', [function() {
         }
       };
 
-      $scope.answer = [];
+      // Adds an input field by default
+      $scope.answer = [''];
 
       var hasDuplicates = function(answer) {
         for (var i = 0; i < answer.length; i++) {


### PR DESCRIPTION
Fix https://github.com/oppia/oppia/issues/2814: The add item button is now visible whenever the length of the input field is greater than zero and empty response fields are automatically removed.