### PR TITLE
Fix part of #2862: Add alt attributes to images

### DIFF
--- a/core/templates/dev/head/components/background/background_banner_directive.html
+++ b/core/templates/dev/head/components/background/background_banner_directive.html
@@ -1,6 +1,6 @@
 <script type="text/ng-template" id="background/banner">
   <div style="position: absolute; width: 100%; background-color: #aed2e9; text-align: center; overflow: hidden;">
     <img ng-src="<[bannerImageFileUrl]>" align="center"
-         style="width: 3000px; top: 65px; max-width: 3000px;">
+         style="width: 3000px; top: 65px; max-width: 3000px;" alt="">
   </div>
 </script>

--- a/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
@@ -43,7 +43,7 @@
 
       <li ng-class="{'active': NAV_MODE === 'blog'}">
         <a href="/blog">
-          <img ng-src="<[getStaticImageUrl('/sidebar/blogger.png')]>" class="oppia-sidebar-menu-icon">
+          <img ng-src="<[getStaticImageUrl('/sidebar/blogger.png')]>" class="oppia-sidebar-menu-icon" alt="Oppia Blog">
           <span translate="I18N_SIDEBAR_BLOG"></span>
         </a>
       </li>

--- a/core/templates/dev/head/components/social_buttons/social_buttons_directive.html
+++ b/core/templates/dev/head/components/social_buttons/social_buttons_directive.html
@@ -6,16 +6,16 @@
       </h4>
     </div>
     <a href="https://plus.google.com/109898456505810251700/about" target="_blank">
-      <img ng-src="<[getStaticImageUrl('/social/gplus.png')]>">
+      <img ng-src="<[getStaticImageUrl('/social/gplus.png')]>" alt="Google+">
     </a>
     <a href="https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw" target="_blank">
-      <img ng-src="<[getStaticImageUrl('/social/youtube.png')]>">
+      <img ng-src="<[getStaticImageUrl('/social/youtube.png')]>" alt="YouTube">
     </a>
     <a href="https://www.facebook.com/oppiaorg" target="_blank">
-      <img ng-src="<[getStaticImageUrl('/social/fb.png')]>">
+      <img ng-src="<[getStaticImageUrl('/social/fb.png')]>" alt="Facebook">
     </a>
     <a href="https://twitter.com/oppiaorg" target="_blank">
-      <img ng-src="<[getStaticImageUrl('/social/twitter.png')]>">
+      <img ng-src="<[getStaticImageUrl('/social/twitter.png')]>" alt="Twitter">
     </a>
   </div>
 </script>

--- a/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
@@ -2,7 +2,7 @@
   <md-card class="oppia-activity-summary-tile">
     <a ng-href="<[getCollectionLink()]>">
       <div class="title-section" style="background-color: <[getThumbnailBgColor()]>;">
-        <img class="collection-corner-image" ng-src="/assets/images/general/collection_corner.svg">
+        <img class="collection-corner-image" ng-src="/assets/images/general/collection_corner.svg" alt="">
         <img class="thumbnail-image" ng-src="<[getThumbnailIconUrl()]>">
         <h2 class="activity-title"><[getCollectionTitle()]></h2>
       </div>

--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -7,11 +7,11 @@
     <a class="oppia-navbar-brand-name oppia-transition-200" href="/"
        focus-on="<[::LABEL_FOR_CLEARING_FOCUS]>">
       <img ng-src="<[getStaticImageUrl('/logo/288x128_logo_white.png')]>" class="oppia-logo"
-           ng-class="windowIsNarrow ? 'oppia-logo-small' : 'oppia-logo-wide'">
+           ng-class="windowIsNarrow ? 'oppia-logo-small' : 'oppia-logo-wide'" alt="Oppia Home">
     </a>
     <!-- This is needed for the correct image to appear when an exploration is shared using G+. -->
     <a style="display: none;">
-      <img ng-src="<[getStaticImageUrl('/logo/288x128_logo_mint.png')]>" itemprop="image">
+      <img ng-src="<[getStaticImageUrl('/logo/288x128_logo_mint.png')]>" itemprop="image" alt="Oppia Home">
     </a>
   </div>
 
@@ -116,7 +116,7 @@
             ng-mouseleave="onMouseoutDropdownMenu($event)">
           <li>
             <a href style="padding: 0; width: 200px;" ng-click="onLoginButtonClicked()">
-              <img ng-src="<[getStaticImageUrl('/signin/Red-signin-Long-base-44dp.png')]>">
+              <img ng-src="<[getStaticImageUrl('/signin/Red-signin-Long-base-44dp.png')]>" alt="Sign in with Google">
             </a>
           </li>
         </ul>

--- a/core/templates/dev/head/pages/about/about.html
+++ b/core/templates/dev/head/pages/about/about.html
@@ -95,21 +95,21 @@
 
               <div class="oppia-static-card-content-wide oppia-about-three-cols-container">
                 <div class="oppia-about-three-cols-layout oppia-about-three-cols-feature">
-                  <img ng-src="<[getStaticImageUrl('/general/creator-create-exp.png')]>" alt="Create an Exploration">
+                  <img ng-src="<[getStaticImageUrl('/general/creator-create-exp.png')]>" alt="">
                   <h3>Create an Exploration</h3>
                   <p style="margin-top: -10px;">
                     about a topic you care about.
                   </p>
                 </div>
                 <div class="oppia-about-three-cols-layout oppia-about-three-cols-feature">
-                  <img ng-src="<[getStaticImageUrl('/general/creator-pub-share.png')]>" alt="Publish & Share">
+                  <img ng-src="<[getStaticImageUrl('/general/creator-pub-share.png')]>" alt="">
                   <h3>Publish &amp; Share</h3>
                   <p style="margin-top: -10px;">
                     your creations with the community.
                   </p>
                 </div>
                 <div class="oppia-about-three-cols-layout oppia-about-three-cols-feature">
-                  <img ng-src="<[getStaticImageUrl('/general/creator-feedback.png')]>" alt="Earn Feedback">
+                  <img ng-src="<[getStaticImageUrl('/general/creator-feedback.png')]>" alt="">
                   <h3>Earn feedback</h3>
                   <p style="margin-top: -10px;">
                     to improve your exploration.

--- a/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
@@ -5,7 +5,7 @@
         <ul class="author-profile">
           <li>
             <img ng-src="<[getStaticImageUrl('/general/apple.svg')]>" class="exploration-footer-img"
-                 ng-if="contributorNames.length > 0">
+                 ng-if="contributorNames.length > 0" alt="">
           </li>
           <li class="hover-link"
               ng-mouseenter="hovering = true"

--- a/core/templates/dev/head/pages/profile/profile.html
+++ b/core/templates/dev/head/pages/profile/profile.html
@@ -37,11 +37,11 @@
               </div>
             </div>
           </a>
-          <img ng-src="<[profilePictureDataUrl]>" class="oppia-profile-picture-fullsize">
+          <img ng-src="<[profilePictureDataUrl]>" class="oppia-profile-picture-fullsize" alt="">
         </div>
 
         <img ng-if="!profileIsOfCurrentUser" ng-src="<[profilePictureDataUrl]>"
-             class="oppia-profile-picture-fullsize">
+             class="oppia-profile-picture-fullsize" alt="">
       </div>
 
       <h2 class="oppia-profile-username-large-screen">

--- a/core/templates/dev/head/pages/splash/splash.html
+++ b/core/templates/dev/head/pages/splash/splash.html
@@ -22,7 +22,7 @@
       <div style="position: relative; margin-left: auto; margin-right: auto; max-width: 2000px;">
         <div style="padding-left: 200px;">
           <div class="oppia-splash-background-icon-row">
-            <img ng-src="<[getStaticImageUrl('/splash/books.svg')]>" class="oppia-splash-books" style="margin-left: -250px; width: 500px; top: 95px;">
+            <img ng-src="<[getStaticImageUrl('/splash/books.svg')]>" class="oppia-splash-books" style="margin-left: -250px; width: 500px; top: 95px;" alt="">
 
             <img ng-src="<[getStaticSubjectImageUrl('Humor')]>" class="oppia-splash-background-icon" alt="">
             <img ng-src="<[getStaticSubjectImageUrl('Combinatorics')]>" class="oppia-splash-background-icon" alt="">

--- a/core/templates/dev/head/pages/splash/splash_ah1.html
+++ b/core/templates/dev/head/pages/splash/splash_ah1.html
@@ -29,7 +29,7 @@
       <div style="position: relative;">
         <div style="padding-left: 200px;">
           <div class="oppia-splash-background-icon-row">
-            <img ng-src="<[getStaticImageUrl('/splash/books.svg')]>" class="oppia-splash-books" style="margin-left: -250px; width: 500px; top: 95px;">
+            <img ng-src="<[getStaticImageUrl('/splash/books.svg')]>" class="oppia-splash-books" style="margin-left: -250px; width: 500px; top: 95px;" alt="">
 
             <img ng-src="<[getStaticSubjectImageUrl('Humor')]>" class="oppia-splash-background-icon" alt="">
             <img ng-src="<[getStaticSubjectImageUrl('Combinatorics')]>" class="oppia-splash-background-icon" alt="">


### PR DESCRIPTION
This PR addresses the following issues from #2862:

- Sign in with Google image, Oppia logo, sidebar social link images need alt attribute that indicates where its link goes. **NOTE:** I noticed that the sidebar social links seem to now be in the footer. Is this changing?
- Books.svg image needs an alt attribute. Since the image is decorative, it can be empty.
- Corner images on exploration collection "cards" needs alt attribute. It can be empty since these images are decorative.
- Exploration background banner has no alt attribute. Since this image is purely decorative, it may be empty.
- Author profile apple image has no alt attribute. Since this image is purely decorative, it may be empty.
- Background banners on About pages have no alt attribute. Since these images are purely decorative, it may be empty.
- Alt attributes for the images for "create an exploration"," publish & share", and "earn feedback" are all flagged as redundant. The header below serves the purpose. Recommend empty alt attribute since these images are decorative.
-  Background banner on the Profile page is missing an alt attribute. Since the image is purely decorative, it may be empty.
- Profile picture has no alt attribute. Since the username is beneath it, this attribute may be empty.  

**NOTE:** On the live site, a user with no image has an icon, but on the development site, this image is a generated svg avatar. I noticed that this avatar in the navbar also doesn't have an alt attribute. Every image should have an alt attribute, but should this attribute be the person's username or be empty?
