### PR TITLE
Fix part of #2862: create logical heading order

### DIFF
--- a/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
@@ -4,7 +4,7 @@
       <div class="title-section" style="background-color: <[getThumbnailBgColor()]>;">
         <img class="collection-corner-image" ng-src="/assets/images/general/collection_corner.svg" alt="">
         <img class="thumbnail-image" ng-src="<[getThumbnailIconUrl()]>">
-        <h2 class="activity-title"><[getCollectionTitle()]></h2>
+        <h3 class="activity-title"><[getCollectionTitle()]></h3>
       </div>
 
       <div>

--- a/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
@@ -3,10 +3,10 @@
     <a ng-href="<[getExplorationLink()]>" target="<[openInNewWindow ? '_blank' : '_self']>">
       <div class="title-section" style="background-color: <[getThumbnailBgColor()]>;">
         <img class="thumbnail-image" ng-src="<[getThumbnailIconUrl()]>">
-        <h2 class="activity-title protractor-test-exp-summary-tile-title">
+        <h3 class="activity-title protractor-test-exp-summary-tile-title">
           <span ng-if="isWindowLarge"><[getExplorationTitle()|truncate:40]></span>
           <span ng-if="!isWindowLarge"><[getExplorationTitle()|truncate:40]></span>
-        </h2>
+        </h3>
 
         <!-- Note that if this is ng-if instead, the avatar area will not detect a mouseover and the tile will behave incorrectly. -->
         <div ng-show="isWindowLarge && avatarsList.length > 0" class="exploration-summary-avatars" ng-show="avatarsList.length > 0">
@@ -84,7 +84,7 @@
   </md-card>
 </script>
 
-<style> 
+<style>
   .oppia-activity-summary-tooltip .tooltip.right {
     bottom: -10px;
     min-width: 200px;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3824,6 +3824,7 @@ md-card.preview-conversation-skin-supplemental-card {
   color: white;
   font-family: "Capriola", "Roboto", Arial, sans-serif;
   font-size: 1em;
+  font-weight: normal;
   line-height: 1.2em;
   margin: 12px;
   padding: 0;

--- a/core/templates/dev/head/domain/collection/CollectionNodeObjectFactory.js
+++ b/core/templates/dev/head/domain/collection/CollectionNodeObjectFactory.js
@@ -103,8 +103,7 @@ oppia.factory('CollectionNodeObjectFactory', [
         explorationSummaryBackendObject);
     };
 
-    CollectionNode.prototype.getCapitalizedObjective = function(
-        explorationObjective) {
+    CollectionNode.prototype.getCapitalizedObjective = function() {
       return this._explorationSummaryObject.objective.charAt(0).toUpperCase() +
               this._explorationSummaryObject.objective.slice(1);
     };

--- a/core/templates/dev/head/domain/collection/CollectionNodeObjectFactory.js
+++ b/core/templates/dev/head/domain/collection/CollectionNodeObjectFactory.js
@@ -103,6 +103,12 @@ oppia.factory('CollectionNodeObjectFactory', [
         explorationSummaryBackendObject);
     };
 
+    CollectionNode.prototype.getCapitalizedObjective = function(
+        explorationObjective) {
+      return explorationObjective.charAt(0).toUpperCase() +
+              explorationObjective.slice(1);
+    };
+
     // Static class methods. Note that "this" is not available in static
     // contexts. This function takes a JSON object which represents a backend
     // collection node python dict.

--- a/core/templates/dev/head/domain/collection/CollectionNodeObjectFactory.js
+++ b/core/templates/dev/head/domain/collection/CollectionNodeObjectFactory.js
@@ -105,8 +105,8 @@ oppia.factory('CollectionNodeObjectFactory', [
 
     CollectionNode.prototype.getCapitalizedObjective = function(
         explorationObjective) {
-      return explorationObjective.charAt(0).toUpperCase() +
-              explorationObjective.slice(1);
+      return this._explorationSummaryObject.objective.charAt(0).toUpperCase() +
+              this._explorationSummaryObject.objective.slice(1);
     };
 
     // Static class methods. Note that "this" is not available in static

--- a/core/templates/dev/head/pages/about/about.html
+++ b/core/templates/dev/head/pages/about/about.html
@@ -40,6 +40,7 @@
         <div class="about-tab-container">
           <div class="about oppia-about-tab-content oppia-about-visible-content">
             <div class="oppia-static-card-content oppia-static-card-content-narrow">
+              <h2>About Oppia</h2>
               <div class="pull-right">
                 <em>Oppia "O-pee-yah" (Finnish) - "to learn"</em>
               </div>

--- a/core/templates/dev/head/pages/collection_player/collection_player.html
+++ b/core/templates/dev/head/pages/collection_player/collection_player.html
@@ -104,7 +104,7 @@
             </td>
             <td class="hidden-md hidden-sm hidden-xs oppia-exploration-list-table-item">
               <p>
-                <[node.getCapitalizedObjective(node.getExplorationSummaryObject().objective)]>
+                <[node.getCapitalizedObjective()]>
               </p>
             </td>
           </tr>

--- a/core/templates/dev/head/pages/collection_player/collection_player.html
+++ b/core/templates/dev/head/pages/collection_player/collection_player.html
@@ -103,12 +103,11 @@
               </a>
             </td>
             <td class="hidden-md hidden-sm hidden-xs oppia-exploration-list-table-item">
-              <a ng-href="/explore/<[node.getExplorationId()]>"
-                 ng-mouseover="updateExplorationPreview(node.getExplorationId())"
-                 ng-mouseleave="togglePreviewCard()"
-                 class="oppia-dashboard-list-summary">
-                <[node.getExplorationSummaryObject().objective]>
-              </a>
+              <p>
+                <[node.getExplorationSummaryObject().objective
+                  .charAt(0).toUpperCase() +
+                  node.getExplorationSummaryObject().objective.slice(1)]>
+              </p>
             </td>
           </tr>
         </table>

--- a/core/templates/dev/head/pages/collection_player/collection_player.html
+++ b/core/templates/dev/head/pages/collection_player/collection_player.html
@@ -73,13 +73,13 @@
   <div ng-controller="CollectionPlayer">
     <background-banner></background-banner>
     <div ng-if="collection" class="oppia-collection-player-tiles-container">
-      <h2 ng-if="!collectionPlaythrough.hasFinishedCollection()" class="oppia-page-heading">
+      <h1 ng-if="!collectionPlaythrough.hasFinishedCollection()" class="oppia-page-heading">
         <span ng-if="!collectionPlaythrough.hasStartedCollection()" class="oppia-collection-player-title-font">Begin <[collection.getTitle()]>:</span>
         <span ng-if="collectionPlaythrough.hasStartedCollection()">Continue <[collection.getTitle()]>:</span>
-      </h2>
-      <h2 ng-if="collectionPlaythrough.hasFinishedCollection()" class="oppia-page-heading">
+      </h1>
+      <h1 ng-if="collectionPlaythrough.hasFinishedCollection()" class="oppia-page-heading">
         <span>You have finished the collection! Feel free to replay any explorations below.</span>
-      </h2>
+      </h1>
 
       <div ng-if="collection" class="oppia-exploration-list-table">
 
@@ -136,7 +136,7 @@
                                     is-community-owned="summaryToPreview.community_owned"
                                     style="position: absolute; left: 75px; top: 30px; z-index: 10;">
           <exploration-summary-tile/>
-          
+
         </div>
       </div>
     </div>

--- a/core/templates/dev/head/pages/collection_player/collection_player.html
+++ b/core/templates/dev/head/pages/collection_player/collection_player.html
@@ -104,9 +104,7 @@
             </td>
             <td class="hidden-md hidden-sm hidden-xs oppia-exploration-list-table-item">
               <p>
-                <[node.getExplorationSummaryObject().objective
-                  .charAt(0).toUpperCase() +
-                  node.getExplorationSummaryObject().objective.slice(1)]>
+                <[node.getCapitalizedObjective(node.getExplorationSummaryObject().objective)]>
               </p>
             </td>
           </tr>

--- a/core/templates/dev/head/pages/contact/contact.html
+++ b/core/templates/dev/head/pages/contact/contact.html
@@ -28,7 +28,7 @@
         Thanks for your interest in helping out with the Oppia project!
       </p>
 
-      <h3>We're all volunteers</h3>
+      <h2 class="oppia-contact-h2">We're all volunteers</h2>
       <p>
         We're a team of volunteers around the world who want to improve access
         to high-quality education. Currently, we're working on building scalable
@@ -42,7 +42,7 @@
         <a href="mailto:admin@oppia.org" class="inline-links">admin@oppia.org</a>.
       </p>
 
-      <h3>How Oppia is different from other learning platforms</h3>
+      <h2 class="oppia-contact-h2">How Oppia is different from other learning platforms</h2>
       <p>
         There is lots of educational research that suggests that active learning
         and targeted feedback lead to large learning gains, and providing support
@@ -166,6 +166,13 @@
   </div>
   <div class="oppia-footer-padding-below-banner">
   </div>
+  <style>
+    h2.oppia-contact-h2 {
+      font-size: 1.17em;
+      font-weight: bold;
+      text-align: left;
+    }
+  </style>
 {% endblock %}
 
 {% block footer%}

--- a/core/templates/dev/head/pages/donate/donate.html
+++ b/core/templates/dev/head/pages/donate/donate.html
@@ -20,37 +20,14 @@
 {% block content %}
   <div class="oppia-page-card oppia-static-content" ng-controller="Donate">
     <div class="oppia-donation-card-content-wide">
-      <div class="oppia-donate-info">
-        <div style="height: 0; margin: 60px auto 0px auto; width: 70%; padding-bottom: 56.25%; position: relative;">
-          <iframe title="Meet Oppia's Contributors" width="100%"
-                  height="100%" src="https://www.youtube.com/embed/OConyxG7HaM"
-                  frameborder="0" allowfullscreen
-                  style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
-          </iframe>
-        </div>
-        <h6 style="text-align: center;"><em>Hear from our Oppia community</em></h6>
-        <div style="margin: 0 auto; width: 70%;">
-          <p style="font-size: 0.825em;">
-            In 2012, Oppia started with a simple idea: to improve the education of
-            students around the world while improving the quality of teaching.
-            This vision has since turned into an educational platform with over
-            8,000 explorations that are used by almost 250,000 users worldwide.
-          </p>
-          <p style="font-size: 0.825em;">
-            Please donate to The Oppia Foundation, a registered 501(c)(3) nonprofit,
-            and join us in bringing the joys of teaching and learning to people
-            everywhere.
-          </p>
-        </div>
-      </div>
       <div class="oppia-donate-options">
         <div ng-if="windowIsNarrow">
-          <h2 style="color: #fff; margin-top: 60px;">Donate to the</h2>
-          <h2 style="color: #fff; margin-top: 10px;">Oppia Foundation</h2>
+          <h1 class="oppia-donate-h1">Donate to the <br>
+          Oppia Foundation</h1>
         </div>
         <div ng-if="!windowIsNarrow">
-          <h2 style="color: #fff; margin-top: 60px;">Donate to</h2>
-          <h2 style="color: #fff; margin-top: 10px;">The Oppia Foundation</h2>
+          <h1 class="oppia-donate-h1">Donate to <br>
+          The Oppia Foundation</h1>
         </div>
         <div style="text-align: center;">
           <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top" ng-submit="onDonateThroughPayPal()">
@@ -77,8 +54,47 @@
           <img ng-src="<[donateImgUrl]>" alt="Server costs, student outreach, marketing">
         </div>
       </div>
+      <div class="oppia-donate-info">
+        <div style="height: 0; margin: 60px auto 0px auto; width: 70%; padding-bottom: 56.25%; position: relative;">
+          <iframe title="Meet Oppia's Contributors" width="100%"
+                  height="100%" src="https://www.youtube.com/embed/OConyxG7HaM"
+                  frameborder="0" allowfullscreen
+                  style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+          </iframe>
+        </div>
+        <h3 class="oppia-donate-h3"><em>Hear from our Oppia community</em></h3>
+        <div style="margin: 0 auto; width: 70%;">
+          <p style="font-size: 0.825em;">
+            In 2012, Oppia started with a simple idea: to improve the education of
+            students around the world while improving the quality of teaching.
+            This vision has since turned into an educational platform with over
+            8,000 explorations that are used by almost 250,000 users worldwide.
+          </p>
+          <p style="font-size: 0.825em;">
+            Please donate to The Oppia Foundation, a registered 501(c)(3) nonprofit,
+            and join us in bringing the joys of teaching and learning to people
+            everywhere.
+          </p>
+        </div>
+      </div>
+
     </div>
   </div>
+  <style>
+    h1.oppia-donate-h1 {
+      color: #fff;
+      font-size: 1.5em;
+      margin-top: 60px;
+      text-align: center;
+      line-height: 1.7em;
+    }
+    h3.oppia-donate-h3 {
+      font-size: .75em;
+      font-weight: normal;
+      margin: 2.33em 0;
+      text-align: center;
+    }
+  </style>
 {% endblock %}
 
 {% block footer_js %}

--- a/core/templates/dev/head/pages/error/error.html
+++ b/core/templates/dev/head/pages/error/error.html
@@ -21,7 +21,7 @@
 
     <div class="oppia-wide-panel oppia-error-wide-container">
       <div class="oppia-wide-panel-content protractor-test-error-container">
-        <h4>
+        <h1 class="oppia-error-h1">
           {% if code == 400 %}
             <span translate="I18N_ERROR_HEADER_400"></span>
             - Bad Request
@@ -35,27 +35,36 @@
             <span translate="I18N_ERROR_HEADER_500"></span>
             - System Error
           {% endif %}
-        </h4>
+        </h1>
 
         <br>
 
         <img ng-src="<[oopsMintImgUrl]>" alt="Oops!" width="299" height="142"/>
-        <p><h3>
+        <p>
           {% if code == 400 %}
-            <h3 translate="I18N_ERROR_MESSAGE_400"></h3>
+            <h2 class="oppia-error-h2" translate="I18N_ERROR_MESSAGE_400"></h2>
           {% elif code == 401 %}
-            <h3 translate="I18N_ERROR_MESSAGE_401"></h3>
+            <h2 class="oppia-error-h2" translate="I18N_ERROR_MESSAGE_401"></h2>
           {% elif code == 404 %}
-            <h3 translate="I18N_ERROR_MESSAGE_404"></h3>
+            <h2 class="oppia-error-h2" translate="I18N_ERROR_MESSAGE_404"></h2>
           {% elif code == 500 %}
-            <h3 translate="I18N_ERROR_MESSAGE_500"></h3>
+            <h2 class="oppia-error-h2" translate="I18N_ERROR_MESSAGE_500"></h2>
           {% endif %}
         </p>
         <p><span translate="I18N_ERROR_NEXT_STEPS" translate-values="{issueTrackerUrl: 'https://github.com/oppia/oppia/issues/new', homeUrl: '/'}"></span></p>
       </div>
     </div>
-
   </div>
+  <style>
+    .oppia-error-h1 {
+      font-size: 1em;
+      margin: 1.33em 0;
+    }
+    .oppia-error-h2 {
+      font-size: 1.17em;
+      font-weight: 700;
+    }
+  </style>
 {% endblock %}
 
 {% block footer_js %}

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -68,7 +68,7 @@
   <ul class="nav navbar-nav oppia-navbar-breadcrumb" ng-controller="LearnerViewBreadcrumb">
     <li>
       <span class="oppia-navbar-breadcrumb-separator"></span>
-      <span class="protractor-test-exploration-header oppia-exploration-header" itemprop="description">{{exploration_title}}</span>
+      <h1 class="oppia-exploration-h1"><span class="protractor-test-exploration-header oppia-exploration-header" itemprop="description">{{exploration_title}}</span></h1>
     </li>
     <li ng-click="showInformationCard()" tooltip="<['I18N_PLAYER_INFO_TOOLTIP' | translate]>" tooltip-placement="bottom" style="cursor: pointer;" class="protractor-test-exploration-info-icon">
       <i class="material-icons oppia-navbar-breadcrumb-icon" style="font-size: 20px;">&#xE88E;</i>
@@ -122,7 +122,14 @@
       <attribution-guide></attribution-guide>
     {% endif %}
   </div>
-
+  <style>
+    .oppia-exploration-h1 {
+      color: #ffffff;
+      display: inline;
+      font-size: 1em;
+      font-weight: normal;
+    }
+  </style>
   {% include 'components/attribution_guide/attribution_guide_directive.html' %}
   {% include 'components/embed_modal/embed_exploration_modal_directive.html' %}
   {% include 'components/gadget/gadget_directive.html' %}

--- a/core/templates/dev/head/pages/footer.html
+++ b/core/templates/dev/head/pages/footer.html
@@ -1,7 +1,7 @@
 <div class="oppia-footer-padding">
 </div>
 
-<footer class="oppia-footer">
+<footer class="oppia-footer" role="contentinfo">
   <div class="oppia-footer-container">
     <div class="row">
       <div class="col-sm-3">

--- a/core/templates/dev/head/pages/get_started/get_started.html
+++ b/core/templates/dev/head/pages/get_started/get_started.html
@@ -22,7 +22,7 @@
 
   <background-banner></background-banner>
   <div class="oppia-page-card oppia-static-content oppia-static-content-below-banner">
-    <div class="oppia-static-card-content oppia-static-card-content-narrow">
+    <div class="oppia-static-card-content oppia-static-card-content-narrow oppia-get-started">
 
       <p>
         Creating an exploration is easy and free. Share your knowledge with
@@ -30,7 +30,7 @@
         your exploration's effectiveness.
       </p>
 
-      <h3>Choose a Topic</h3>
+      <h2>Choose a Topic</h2>
       <p>All you need to get started is a topic you want to teach. You can
         create an exploration about any topic, large or small. The ideal size
         of topic for an exploration is one that you would cover in a single
@@ -39,7 +39,7 @@
       </p>
 
 
-      <h3>Create Your Exploration</h3>
+      <h2>Create Your Exploration</h2>
       <p>
         When you have chosen a topic, just click ‘Create’, and log in with your Google account.
         If you don't have a Google account, you can <a href="https://accounts.google.com/SignUp" target="new">create one here</a>.
@@ -63,14 +63,14 @@
         More information about creating explorations can be found <a href="https://oppia.github.io/#/CreatingAnExploration" target="new">here</a>.
       </p>
 
-      <h3>Publish Your Exploration</h3>
+      <h2>Publish Your Exploration</h2>
       <p>
         Once you've created your exploration and you're ready for learners to see it, click the
         'Publish' button at the top of the page.  This will make your exploration available to
         learners around the world!
       </p>
 
-      <h3>Share Your Exploration</h3>
+      <h2>Share Your Exploration</h2>
       <p>
         After you publish the exploration, you can share it via a
         link, or even <a href="https://oppia.github.io/#/EmbeddingAnExploration" target="new">embed
@@ -79,7 +79,7 @@
 
       <!-- todo: make it easy to get the right link to share, update this doc with that info -->
 
-      <h3>Improve Your Exploration</h3>
+      <h2>Improve Your Exploration</h2>
       <p>
         When learners go through your exploration, they can send you feedback to alert you to problems
         or to share ideas for making it better.
@@ -92,7 +92,7 @@
         step, or "go deeper" by asking another question.
       </p>
 
-      <h3>Get Involved</h3>
+      <h2>Get Involved</h2>
       <p>
         To get involved in the Oppia
         project and help us bring about our mission of free, high-quality
@@ -105,6 +105,13 @@
   </div>
   <div class="oppia-footer-padding-below-banner">
   </div>
+  <style>
+    .oppia-get-started h2 {
+      font-size: 1.17em;
+      font-weight: bold;
+      text-align: left;
+    }
+  </style>
 {% endblock %}
 
 {% block footer%}

--- a/core/templates/dev/head/pages/privacy/privacy.html
+++ b/core/templates/dev/head/pages/privacy/privacy.html
@@ -20,7 +20,7 @@
 {% block content %}
   <div class="oppia-page-cards-container">
     <md-card class="oppia-page-card oppia-long-text">
-      <h2>Privacy Policy</h2>
+      <h1>Privacy Policy</h1>
 
       <p>
         Oppia's mission is to make it easy for users to learn anything they
@@ -28,7 +28,7 @@
         mission, Oppia (also "we" or "us") collects some information from its
         users to deliver an interactive and engaging experience. This Privacy
         Policy describes the types of information we collect from users of the
-        Oppia website (<a href="https://www.oppia.org">https:www.oppia.org</a>)
+        Oppia website (<a href="https://www.oppia.org">https://www.oppia.org</a>)
         (the "Site") and how Oppia collects, uses, and protects that
         information.
       </p>
@@ -44,9 +44,9 @@
       </p>
 
       <a class="oppia-about-anchor" name="what-information-does-oppia-collect"></a>
-      <h3>What information does Oppia collect?</h3>
+      <h2>What information does Oppia collect?</h2>
 
-      <strong>Usage Data</strong>
+      <h3>Usage Data</h3>
       <p>
         When a visitor uses the Site, we and our service providers collect
         usage data ("Usage Data") including:
@@ -98,7 +98,7 @@
         Explorations is correlated with the user’s account.
       </p>
 
-      <strong>Personal Information</strong>
+      <h3>Personal Information</h3>
 
       <p>
         Oppia is designed to be open and free, which means that you do not have
@@ -135,7 +135,7 @@
         for product development and other internal business purposes.
       </p>
 
-      <strong>Other Information</strong>
+      <h3>Other Information</h3>
 
       <p>
         "Other Information" is any information that does not reveal your
@@ -202,7 +202,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="how-is-your-information-shared-or-disclosed"></a>
-      <h3>How is your information shared or disclosed?</h3>
+      <h2>How is your information shared or disclosed?</h2>
       <p>
         Please note that certain information is publicly accessible on the Site,
         such as: usernames, profile photos, and any other information contained
@@ -228,7 +228,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="how-do-we-protect-personal-information"></a>
-      <h3>How do we protect Personal Information?</h3>
+      <h2>How do we protect Personal Information?</h2>
       <p>
         Oppia is committed to protecting your information. We seek to use
         reasonable organizational, technical and administrative measures to
@@ -243,7 +243,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="updating-your-personal-information"></a>
-      <h3>Updating your personal information</h3>
+      <h2>Updating your personal information</h2>
       <p>
         If you register and provide Oppia with Personal Information, you may
         update your Personal Information at any time by reviewing your profile
@@ -259,7 +259,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="use-by-children"></a>
-      <h3>Use by children</h3>
+      <h2>Use by children</h2>
       <p>
         The Site is not directed to individuals under the age of thirteen (13).
         If you are under 13, we do not want your Personal Information and you
@@ -270,7 +270,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="jurisdictional-issues"></a>
-      <h3>Jurisdictional issues</h3>
+      <h2>Jurisdictional issues</h2>
       <p>
         The Site is controlled and operated by us from the United States, and
         is not intended to subject us to the laws or jurisdiction of any state,
@@ -283,7 +283,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="links-to-third-party-sites"></a>
-      <h3>Links to third-party sites</h3>
+      <h2>Links to third-party sites</h2>
       <p>
         Our Site and content may feature links to third party websites that
         offer goods, services or information. When you click on one of these
@@ -296,7 +296,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="changes-and-updates-to-this-privacy-policy"></a>
-      <h3>Changes and updates to this Privacy Policy</h3>
+      <h2>Changes and updates to this Privacy Policy</h2>
       <p>
         Oppia will continue to evolve and we may update our Privacy Policy from
         time to time to reflect our practices. Any changes to this Policy will
@@ -306,7 +306,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="contacting-us"></a>
-      <h3>Contacting Us</h3>
+      <h2>Contacting Us</h2>
       <p>
         If you have questions about this Privacy Policy or would like to
         provide feedback, please send an e-mail to admin@oppia.org.

--- a/core/templates/dev/head/pages/profile/profile.html
+++ b/core/templates/dev/head/pages/profile/profile.html
@@ -18,7 +18,7 @@
       <span class="oppia-navbar-breadcrumb-separator"></span>
       Profile
       <span class="oppia-navbar-breadcrumb-separator" style="padding-left: 10px;"></span>
-      {{PROFILE_USERNAME}}
+      <h1 class="oppia-profile-h1">{{PROFILE_USERNAME}}</h1>
     </li>
   </ul>
 {% endblock navbar_breadcrumb %}
@@ -141,6 +141,14 @@
       </button>
     </div>
   </div>
+  <style>
+    .oppia-profile-h1 {
+      color: #ffffff;
+      display: inline;
+      font-size: 1em;
+      font-weight: normal;
+    }
+  </style>
 {% endblock %}
 
 {% block footer %}

--- a/core/templates/dev/head/pages/terms/terms.html
+++ b/core/templates/dev/head/pages/terms/terms.html
@@ -20,7 +20,7 @@
 {% block content %}
   <div class="oppia-page-cards-container">
     <md-card class="oppia-page-card oppia-long-text">
-      <h2>Terms of Use</h2>
+      <h1>Terms of Use</h1>
 
       <p>
         Hello! Thanks for your interest in Oppia Foundation Inc., a nonprofit
@@ -40,7 +40,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="our-services"></a>
-      <h3>Our Services</h3>
+      <h2>Our Services</h2>
       <p>
         Oppia is a learning platform that allows Users to participate in an
         interactive learning experience by uploading and editing a wide variety
@@ -57,7 +57,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="privacy-policy"></a>
-      <h3>Privacy Policy</h3>
+      <h2>Privacy Policy</h2>
       <p>
         For more information about how we use your personal information and
         what types of information we collect and why, please refer to our
@@ -65,7 +65,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="hosted-created-content"></a>
-      <h3>Hosted Created Content and Intellectual Property</h3>
+      <h2>Hosted Created Content and Intellectual Property</h2>
       <p>
         All our Educational Content is meant to be shared, refined, and &mdash;
         obviously &mdash; explored! You can further this goal by uploading or
@@ -118,7 +118,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="refraining-from-certain-activities"></a>
-      <h3 style="margin-top: 40px;">Refraining from Certain Activities</h3>
+      <h2 style="margin-top: 40px;">Refraining from Certain Activities</h2>
 
       <p>
         Oppia is an extremely collaborative environment that allows users to
@@ -168,7 +168,7 @@
       </ul>
 
       <a class="oppia-about-anchor" name="termination"></a>
-      <h3>Termination</h3>
+      <h2>Termination</h2>
       <p>
         If you violate any of the Terms of Use above, break any laws, engage in
         behavior that disrupts the Oppia community, or otherwise engage in any
@@ -187,7 +187,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="disclaimer-of-warranty"></a>
-      <h3>Disclaimer of Warranty</h3>
+      <h2>Disclaimer of Warranty</h2>
       <p>
         Oppia does not make any promises about its services. We make no
         commitments or warranties about their specific functions, reliability,
@@ -215,7 +215,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="limitation-of-liability"></a>
-      <h3>Limitation of Liability</h3>
+      <h2>Limitation of Liability</h2>
       <p>
         In any event (and notwithstanding anything else in this Agreement),
         Oppia's liability will be limited to the fullest extent permitted by
@@ -236,7 +236,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="disputes-and-jurisdiction"></a>
-      <h3>Disputes and Jurisdiction</h3>
+      <h2>Disputes and Jurisdiction</h2>
       <p>
         These Terms shall be governed by and construed according to the laws of
         the State of California. If you seek to file a legal claim against us,
@@ -246,7 +246,7 @@
       </p>
 
       <a class="oppia-about-anchor" name="modifications-to-these-terms"></a>
-      <h3>Modifications to These Terms</h3>
+      <h2>Modifications to These Terms</h2>
       <p>
         Oppia may update, change, modify, add, or remove portions of these
         Terms from time to time. If we do, we will notify you (and all our
@@ -263,7 +263,7 @@
         for reference only and may not always be accurate and up-to-date.
       </p>
 
-      <h3>Changelog</h3>
+      <h2>Changelog</h2>
       <ul>
         <li>13 Oct 2015: Minor updates for clarity.</li>
         <li>26 Sep 2015: Revised terms added.</li>


### PR DESCRIPTION
The following issues are addressed in this PR:

- No H1 on 404 page. First heading is an h4. Then it goes to h3. (Solution: The page now goes from h1 to h2)
- Category headings in the Library (and elsewhere) are h2s and then exploration "card" headings are also h2s, which doesn't provide a great hierarchy. (Solution: Card headings are now h3s)
- No H1 on Exploration page. (Solution: Exploration title in the navbar is now an h1)
- There is no h2 on this page (the about page, not the foundation or credits pages). Skips from h1 to h3. (Solution: Added an h1 with the text "About Oppia"; moved pronunciation pull-right element beneath it)
- At the beginning of the Contact Us page, we skip from h1 to h3. (Solution: Headings before the "Ways you can Help" heading are now h2s)
- There is no h1 on Donate page. The first heading is an h6, then goes to h2. (Solution: I reordered the divs so that the green sidebar with the "Donate to the Oppia Project" text comes first and changed those headings to h1 and h2. I tested on various window sizes and the page design remains in tact.)
- There is no h1 on Terms page. The first heading is an h2. (Solution: Changed headings to begin with h1; I did not preserve the styles as they seemed to just be defaults instead of specially chosen)
- There is no h1 on Privacy Policy page. The first heading is an h2. (Solution: Changed headings to begin with h1; I did not preserve the styles as they seemed to just be defaults instead of specially chosen)
- No h1 on Profile page. Skips to h2. (Solution: I updated the profile name in the navbar to be an h1, but I'm wondering if it would be better to update the profile name under the image to be the h1 instead. Thoughts?)

## Other Notes
- Unless otherwise noted, I updated the styles with the new headings to match the styles with the old headings.
- I noticed that the Collection page (the page you go to when you click on a collection in the library) also did not have an h1. I changed the current h2s to h1s. I did not update the styles. The current design looks different from the collection page on the production site and I wasn't sure if the design was finished. Thoughts?
- On the Terms of Use page, I noticed that several of the headings under the "What Information Does Oppia Collect?" section weren't headings at all; they were just bolded text. I changed them to headings of the appropriate order.