### PR TITLE
Fix #2944 : Adjust z-index on browse button.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3528,6 +3528,7 @@ md-card.preview-conversation-skin-supplemental-card {
   transform: translate(-150px, 10px);
   position: relative;
   width: 100%;
+  z-index: 10;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
The z-index was not present in .oppia-splash-button-container so I've set it to 10 there. Looks like it was only being set in the media query class selector so it already worked fine on certain screen sizes.