### PR TITLE
Fix part of #2862: Fix link-related issues

### DIFF
--- a/core/templates/dev/head/components/attribution_guide/attribution_guide_directive.html
+++ b/core/templates/dev/head/components/attribution_guide/attribution_guide_directive.html
@@ -2,9 +2,14 @@
   <div class="oppia-cc-icon oppia-transition-200">
     <div style="height: 1px; width: 1px;" class="protractor-test-neutral-element"></div>
 
-    <a rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">
-      <img alt="Creative Commons Licence" style="border-width: 0; height: 24px;" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png">
+    <a class="oppia-attribution-image-link" rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">
+      <img alt="Creative Commons License" style="border-width: 0; height: 24px;" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png">
     </a><br>
-    <a href="/about#license" target="_blank" style="color: white; font-size: 9px;">Attribution Guide</a>
+    <a href="/about#foundation" target="_blank" style="font-size: 10px;">Attribution Guide</a>
   </div>
+  <style>
+    a.oppia-attribution-image-link {
+      text-decoration: none;
+    }
+  </style>
 </script>

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1505,7 +1505,7 @@ md-card.oppia-dashboard-tile {
 }
 
 .oppia-cc-icon {
-  bottom: 34px;
+  bottom: 50px;
   opacity: 0.4;
   position: fixed;
   right: 25px;
@@ -1513,6 +1513,7 @@ md-card.oppia-dashboard-tile {
 
 .oppia-cc-icon:hover {
   opacity: 0.7;
+  text-decoration: none;
 }
 
 .oppia-wide-panel {

--- a/core/templates/dev/head/pages/donate/donate.html
+++ b/core/templates/dev/head/pages/donate/donate.html
@@ -46,7 +46,7 @@
           </button>
         </div>
         <div style="text-align: center;">
-          <div ng-click="onDonateThroughAmazon()" class="btn oppia-donate-options-button">Amazon Smile</div>
+          <a ng-click="onDonateThroughAmazon()" class="btn oppia-donate-options-button">Amazon Smile</a>
         </div>
         <h2 style="color: #fff; font-size: 20px; margin-bottom: 20px; margin-top: 20px;">
           Your generous gift funds:</h2>

--- a/core/templates/dev/head/pages/get_started/get_started.html
+++ b/core/templates/dev/head/pages/get_started/get_started.html
@@ -60,7 +60,9 @@
         <li><a href="https://www.oppia.org/collection/inDXV0w8-p1C" target="new">Programming with Carla</a></li>
       </ul>
       <p>
-        More information about creating explorations can be found <a href="https://oppia.github.io/#/CreatingAnExploration" target="new">here</a>.
+        More information about creating explorations can be found
+        <a href="https://oppia.github.io/#/CreatingAnExploration" target="new">
+          in our user documentation</a>.
       </p>
 
       <h2>Publish Your Exploration</h2>

--- a/core/templates/dev/head/pages/teach/teach.html
+++ b/core/templates/dev/head/pages/teach/teach.html
@@ -100,8 +100,8 @@
               enjoyable way.
             </p>
           </div>
-          <div ng-click="onApplyToTeachWithOppia()" class="btn oppia-about-button oppia-teach-button"
-             translate="I18N_ACTION_APPLY_TO_TEACH_WITH_OPPIA" target="_blank"></div>
+          <a ng-click="onApplyToTeachWithOppia()" class="btn oppia-about-button oppia-teach-button"
+             translate="I18N_ACTION_APPLY_TO_TEACH_WITH_OPPIA" target="_blank"></a>
         </div>
 
           <div class="playbook oppia-about-tab-content">

--- a/core/templates/dev/head/pages/terms/terms.html
+++ b/core/templates/dev/head/pages/terms/terms.html
@@ -91,9 +91,10 @@
         is then immediately licensed by us under the Creative Commons
         CC-BY-SA 4.0 license with a waiver of the attribution (BY) requirement,
         which means that all of the content on Oppia is irrevocably licensed to
-        the general public and can be freely used, reused, and shared. You can
-        read more about the CC-BY-SA 4.0 license
-        <a href="https://creativecommons.org/licenses/by-sa/4.0/legalcode">here</a>.
+        the general public and can be freely used, reused, and shared. Read
+        more about the CC-BY-SA 4.0 license
+        <a href="https://creativecommons.org/licenses/by-sa/4.0/legalcode">
+          on CreativeCommons.org</a>.
       </p>
 
       <p>
@@ -250,8 +251,9 @@
       <p>
         Oppia may update, change, modify, add, or remove portions of these
         Terms from time to time. If we do, we will notify you (and all our
-        registered Users) by sending an email to our Google Group mailing list
-        (which you may sign up for <a href="https://groups.google.com/forum/#!forum/oppia-announce">here</a>).
+        registered Users) by sending an email to our
+        <a href="https://groups.google.com/forum/#!forum/oppia-announce">
+          Google Group mailing list</a>.
         Your continued use of the Website, including logging into your account
         after such changes, indicates to us that you accept the changes and
         agree to be bound by them.

--- a/core/templates/dev/head/pages/terms/terms.html
+++ b/core/templates/dev/head/pages/terms/terms.html
@@ -91,10 +91,10 @@
         is then immediately licensed by us under the Creative Commons
         CC-BY-SA 4.0 license with a waiver of the attribution (BY) requirement,
         which means that all of the content on Oppia is irrevocably licensed to
-        the general public and can be freely used, reused, and shared. Read
-        more about the CC-BY-SA 4.0 license
+        the general public and can be freely used, reused, and shared.
+        You can read more about the CC-BY-SA 4.0 license
         <a href="https://creativecommons.org/licenses/by-sa/4.0/legalcode">
-          on CreativeCommons.org</a>.
+          here</a>.
       </p>
 
       <p>
@@ -251,9 +251,10 @@
       <p>
         Oppia may update, change, modify, add, or remove portions of these
         Terms from time to time. If we do, we will notify you (and all our
-        registered Users) by sending an email to our
+        registered Users) by sending an email to our Google Group mailing list
+        (which you may sign up for
         <a href="https://groups.google.com/forum/#!forum/oppia-announce">
-          Google Group mailing list</a>.
+          here</a>).
         Your continued use of the Website, including logging into your account
         after such changes, indicates to us that you accept the changes and
         agree to be bound by them.


### PR DESCRIPTION
This PR addresses the following parts of issue #2862:

- Under the CC license image (found on explorations and collection pages) is a link with the text Attribution Guide. This text is covered by the footer and WAVE flags it as having very low contrast. (Solution: Edited CSS to move this link up a bit; also removed the color style. Edited the link href to actually go to the Foundation part of the About page)
- On the About Oppia page, ensure the "I want to Learn" and "I want to teach" links do not have aria roles; These are links masquerading as buttons. (Solution: No change needed; they were fine.)
- On the Get Started page, the "More information about creating explorations can be found here" sentence has the anchor tag on "here". This is considered bad practice. The link text should be more descriptive about where it will take the user. (Solution: Edited the copy to read "More information about creating explorations can be found in our user documentation." The link is now on the "in our user documentation" part of the sentence.)
- On the Terms of Use page, there is a link in the sentence that reads "You can read more about the CC-BY-SA 4.0 license here." The link is on "here" which is not very descriptive. (Solution: Rewrote the copy to read: "Read more about the CC-BY-SA 4.0 license on CreativeCommons.org." The link is on "on CreativeCommons.org")
- On the Terms of Use page, there is a sentence that includes "by sending an email to our Google Group mailing list (which you may sign up for here)" has the link on here, which is not descriptive.(Solution: Rewrote the copy to read "If we do, we will notify you (and all our registered Users) by sending an email to our Google Group mailing list." The link is on "Google Group mailing list.")

## Notes
There are two outstanding link-related issues: The Donate page and the Teach with Oppia page each have a link that has an ARIA role of "button." We decided to remove these as these were in fact links, masquerading as buttons. 

However, further investigation showed that these two links are actually div elements that use ng-click, which seems to be automatically giving these an ARIA role. I saw this [Angular issue from 2015](https://github.com/angular/angular.js/issues/11580), which seems to suggest that there is someway to blacklist certain things. Any suggestions would be appreciated.