### PR TITLE
Fix #3010: Replace nodelist.forEach use with for loop for better compatability.

### DIFF
--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -144,12 +144,13 @@ oppia.directive('topNavigationBar', [function() {
          */
         var checkIfI18NCompleted = function() {
           var i18nCompleted = true;
-          document.querySelectorAll('.oppia-navbar-tab-content')
-            .forEach(function(element) {
-            if (element.innerText.length === 0) {
+          var tabs = document.querySelectorAll('.oppia-navbar-tab-content');
+          for (i = 0; i < tabs.length; i++) {
+            if (tabs[i].innerText.length === 0) {
               i18nCompleted = false;
+              break;
             }
-          });
+          }
           return i18nCompleted;
         };
 

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -145,7 +145,7 @@ oppia.directive('topNavigationBar', [function() {
         var checkIfI18NCompleted = function() {
           var i18nCompleted = true;
           var tabs = document.querySelectorAll('.oppia-navbar-tab-content');
-          for (i = 0; i < tabs.length; i++) {
+          for (var i = 0; i < tabs.length; i++) {
             if (tabs[i].innerText.length === 0) {
               i18nCompleted = false;
               break;


### PR DESCRIPTION
NodeList.forEach is not supported in older browsers (#3010), so this PR replaces it with a standard for loop.