### PR TITLE
Fix:#2306 Opening a new tab while in signup page causes session to ex…

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -392,7 +392,7 @@ class BaseHandler(webapp2.RequestHandler):
         self.response.write(
             self.jinja2_env.get_template(filename).render(**values))
 
-    def _render_exception(self, error_code, values, redirectTime):
+    def _render_exception(self, error_code, values, redirectTime = None):
         assert error_code in [400, 401, 404, 500]
         values['code'] = error_code
         if redirectTime:

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -250,8 +250,9 @@ class BaseHandler(webapp2.RequestHandler):
 
                 if not is_csrf_token_valid:
                     raise self.UnauthorizedUserException(
-                        'Your session has expired, and unfortunately your '
-                        'changes cannot be saved. Please refresh the page.')
+                        'Sorry, you have been logged out'
+                        '[probably in another window]. Please log in again.'
+                        'you will  redirect to main page in 3 seconds !!')
             except Exception as e:
                 logging.error(
                     '%s: payload %s',
@@ -391,9 +392,11 @@ class BaseHandler(webapp2.RequestHandler):
         self.response.write(
             self.jinja2_env.get_template(filename).render(**values))
 
-    def _render_exception(self, error_code, values):
+    def _render_exception(self, error_code, values, redirectTime = None):
         assert error_code in [400, 401, 404, 500]
         values['code'] = error_code
+        if redirectTime:
+            values['redirectTime'] = redirectTime
 
         # This checks if the response should be JSON or HTML.
         # For GET requests, there is no payload, so we check against
@@ -429,7 +432,8 @@ class BaseHandler(webapp2.RequestHandler):
 
         if isinstance(exception, self.UnauthorizedUserException):
             self.error(401)
-            self._render_exception(401, {'error': unicode(exception)})
+            redirectTime = 3000
+            self._render_exception(401, {'error': unicode(exception)}, redirectTime)
             return
 
         if isinstance(exception, self.InvalidInputException):

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -392,7 +392,7 @@ class BaseHandler(webapp2.RequestHandler):
         self.response.write(
             self.jinja2_env.get_template(filename).render(**values))
 
-    def _render_exception(self, error_code, values, redirectTime = None):
+    def _render_exception(self, error_code, values, redirectTime):
         assert error_code in [400, 401, 404, 500]
         values['code'] = error_code
         if redirectTime:

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -125,7 +125,12 @@ oppia.config([
               if (rejection.data && rejection.data.error) {
                 warningMessage = rejection.data.error;
               }
-              alertsService.addWarning(warningMessage);
+              if (rejection.data.redirectTime) {
+                var redirectTime = rejection.data.redirectTime
+                alertsService.addWarning(warningMessage, redirectTime);
+              } else {
+                alertsService.addWarning(warningMessage);
+              }
             }
             return $q.reject(rejection);
           }

--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -126,7 +126,7 @@ oppia.config([
                 warningMessage = rejection.data.error;
               }
               if (rejection.data.redirectTime) {
-                var redirectTime = rejection.data.redirectTime
+                var redirectTime = rejection.data.redirectTime;
                 alertsService.addWarning(warningMessage, redirectTime);
               } else {
                 alertsService.addWarning(warningMessage);

--- a/core/templates/dev/head/services/alertsService.js
+++ b/core/templates/dev/head/services/alertsService.js
@@ -44,7 +44,7 @@ oppia.factory('alertsService', ['$log', '$window', function($log, $window) {
    * @param {string} warning - The warning message to display.
    * @param {int} redirectTime - The time before redirecting to main page.
    */
-  alertsService.addWarning = function(warning, redirectTime = null) {
+  alertsService.addWarning = function(warning, redirectTime) {
     $log.error(warning);
     if (alertsService.warnings.length >= MAX_TOTAL_WARNINGS) {
       return;
@@ -54,7 +54,7 @@ oppia.factory('alertsService', ['$log', '$window', function($log, $window) {
       content: warning
     });
     if (redirectTime) {
-      setTimeout(function () {
+      setTimeout(function() {
         $window.location.href = '/splash';
       }, redirectTime);
     }

--- a/core/templates/dev/head/services/alertsService.js
+++ b/core/templates/dev/head/services/alertsService.js
@@ -16,7 +16,7 @@
  * @fileoverview Factory for handling warnings and info messages.
  */
 
-oppia.factory('alertsService', ['$log', function($log) {
+oppia.factory('alertsService', ['$log', '$window', function($log, $window) {
   var alertsService = {
     /**
      * Each element in each of the arrays here is an object with two keys:
@@ -42,8 +42,9 @@ oppia.factory('alertsService', ['$log', function($log) {
   /**
    * Adds a warning message.
    * @param {string} warning - The warning message to display.
+   * @param {int} redirectTime - The time before redirecting to main page.
    */
-  alertsService.addWarning = function(warning) {
+  alertsService.addWarning = function(warning, redirectTime = null) {
     $log.error(warning);
     if (alertsService.warnings.length >= MAX_TOTAL_WARNINGS) {
       return;
@@ -52,6 +53,11 @@ oppia.factory('alertsService', ['$log', function($log) {
       type: 'warning',
       content: warning
     });
+    if (redirectTime) {
+      setTimeout(function () {
+        $window.location.href = '/splash';
+      }, redirectTime);
+    }
   };
 
   /**


### PR DESCRIPTION
I have implemented this by sending a variable redirectTime from the back-end for only unauthorized errors . So when this error occurs , the time for redirecting is set on the back-end in basy.py . At the front-end in alertservices.js , the add warning service takes 2 parameters warning and redirectTime .
If redirectTime is present it will redirect the user to the /splash page after the given number of seconds , else redirectTime will be set to null.

@seanlip I tried to create a model and black out the background but as this service is reused in many places and the ng-cloak part is written common for all errors , warning and messages , i couldn't change the css or it will affect in many other places .