### PR TITLE
Add nav-block style to enable previous behavior for .nav elements

### DIFF
--- a/core/templates/dev/head/components/answer_group_editor_directive.html
+++ b/core/templates/dev/head/components/answer_group_editor_directive.html
@@ -5,7 +5,7 @@
       <strong>
         If the learner's answer...
       </strong>
-      <ul class="nav nav-block nav-stacked nav-pills" role="tablist" ng-model="rules">
+      <ul class="nav oppia-option-list nav-stacked nav-pills" role="tablist" ng-model="rules">
         <li ng-repeat="rule in rules" ng-class="{'active': activeRuleIndex === $index}" class="oppia-rule-block oppia-sortable-rule-block protractor-test-rule-block" style="margin-top: 0;" ng-style="$last ? {'border-bottom': '1px solid #ccc'} : {}">
           <a ng-click="openRuleEditor($index)" ng-hide="activeRuleIndex === $index" class="oppia-rule-tab protractor-test-answer-tab" ng-class="{'oppia-rule-tab-disabled': !isEditable}">
             <div class="oppia-rule-header">

--- a/core/templates/dev/head/components/answer_group_editor_directive.html
+++ b/core/templates/dev/head/components/answer_group_editor_directive.html
@@ -5,7 +5,7 @@
       <strong>
         If the learner's answer...
       </strong>
-      <ul class="nav nav-stacked nav-pills" role="tablist" ng-model="rules">
+      <ul class="nav nav-block nav-stacked nav-pills" role="tablist" ng-model="rules">
         <li ng-repeat="rule in rules" ng-class="{'active': activeRuleIndex === $index}" class="oppia-rule-block oppia-sortable-rule-block protractor-test-rule-block" style="margin-top: 0;" ng-style="$last ? {'border-bottom': '1px solid #ccc'} : {}">
           <a ng-click="openRuleEditor($index)" ng-hide="activeRuleIndex === $index" class="oppia-rule-tab protractor-test-answer-tab" ng-class="{'oppia-rule-tab-disabled': !isEditable}">
             <div class="oppia-rule-header">

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2565,6 +2565,10 @@ div#ng-curtain {
   padding: 17px 12px 10px 12px;
   text-transform: uppercase;
 }
+.nav-block {
+  display: block;
+  vertical-align: initial;
+}
 .oppia-navbar-dropdown-toggle,
 .oppia-navbar-tab {
   height: 56px;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2565,7 +2565,7 @@ div#ng-curtain {
   padding: 17px 12px 10px 12px;
   text-transform: uppercase;
 }
-.nav-block {
+.oppia-option-list {
   display: block;
   vertical-align: initial;
 }

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_fallbacks.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_fallbacks.html
@@ -10,7 +10,7 @@
           <!-- An HTML element marked ui-sortable should contain only one element,
           and this element should have an ng-repeat defined on it. See the
           ui-sortable documentation for more details. -->
-          <ul class="nav nav-stacked nav-pills" role="tablist"
+          <ul class="nav nav-block nav-stacked nav-pills" role="tablist"
               ui-sortable="FALLBACK_LIST_SORTABLE_OPTIONS"
               ng-model="stateFallbacksService.displayed">
             <!-- Note that adding "track by $index" here seems to mess up the final

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_fallbacks.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_fallbacks.html
@@ -10,7 +10,7 @@
           <!-- An HTML element marked ui-sortable should contain only one element,
           and this element should have an ng-repeat defined on it. See the
           ui-sortable documentation for more details. -->
-          <ul class="nav nav-block nav-stacked nav-pills" role="tablist"
+          <ul class="nav oppia-option-list nav-stacked nav-pills" role="tablist"
               ui-sortable="FALLBACK_LIST_SORTABLE_OPTIONS"
               ng-model="stateFallbacksService.displayed">
             <!-- Note that adding "track by $index" here seems to mess up the final

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
@@ -6,7 +6,7 @@
   <md-card class="oppia-editor-card-with-avatar">
     <div class="oppia-editor-card-body">
       <div ng-if="answerGroups.length > 0">
-        <ul class="nav nav-stacked nav-pills" role="tablist" ui-sortable="ANSWER_GROUP_LIST_SORTABLE_OPTIONS" ng-model="answerGroups">
+        <ul class="nav nav-block nav-stacked nav-pills" role="tablist" ui-sortable="ANSWER_GROUP_LIST_SORTABLE_OPTIONS" ng-model="answerGroups">
           <!-- An HTML element marked ui-sortable should contain only one element,
           and this element should have an ng-repeat defined on it. See the
           ui-sortable documentation for more details. -->
@@ -53,7 +53,7 @@
       </div>
 
       <div>
-        <ul class="nav nav-stacked nav-pills" role="tablist">
+        <ul class="nav nav-block nav-stacked nav-pills" role="tablist">
           <li ng-class="{'active': activeAnswerGroupIndex === answerGroups.length}" class="oppia-rule-block">
             <div class="oppia-rule-header-warning-placement" ng-if="isSelfLoopWithNoFeedback(defaultOutcome) && !suppressDefaultAnswerGroupWarnings()" ng-click="changeActiveAnswerGroupIndex(answerGroups.length)"
                  tooltip="<[getOutcomeTooltip(defaultOutcome)]>" tooltip-placement="bottom">

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
@@ -6,7 +6,7 @@
   <md-card class="oppia-editor-card-with-avatar">
     <div class="oppia-editor-card-body">
       <div ng-if="answerGroups.length > 0">
-        <ul class="nav nav-block nav-stacked nav-pills" role="tablist" ui-sortable="ANSWER_GROUP_LIST_SORTABLE_OPTIONS" ng-model="answerGroups">
+        <ul class="nav oppia-option-list nav-stacked nav-pills" role="tablist" ui-sortable="ANSWER_GROUP_LIST_SORTABLE_OPTIONS" ng-model="answerGroups">
           <!-- An HTML element marked ui-sortable should contain only one element,
           and this element should have an ng-repeat defined on it. See the
           ui-sortable documentation for more details. -->
@@ -53,7 +53,7 @@
       </div>
 
       <div>
-        <ul class="nav nav-block nav-stacked nav-pills" role="tablist">
+        <ul class="nav oppia-option-list nav-stacked nav-pills" role="tablist">
           <li ng-class="{'active': activeAnswerGroupIndex === answerGroups.length}" class="oppia-rule-block">
             <div class="oppia-rule-header-warning-placement" ng-if="isSelfLoopWithNoFeedback(defaultOutcome) && !suppressDefaultAnswerGroupWarnings()" ng-click="changeActiveAnswerGroupIndex(answerGroups.length)"
                  tooltip="<[getOutcomeTooltip(defaultOutcome)]>" tooltip-placement="bottom">


### PR DESCRIPTION
Fixes regression in exploration editor from #2927 