### PR TITLE
Standardize truncation of objectives and display of titles on summary tiles.

### DIFF
--- a/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
@@ -8,10 +8,15 @@
       </div>
 
       <div>
-        <div class="objective">
-          <span ng-if="getObjective()"><[getObjective() | truncateAndCapitalize: 40]></span>
-          <span ng-if="!getObjective()">No objective specified.</span>
-        </div>
+        <span ng-if="getObjective()" class="oppia-activity-summary-popover">
+          <span popover="<[getObjective()|capitalize]>" popover-placement="top" popover-trigger="mouseenter">
+            <div class="objective">
+              <[getObjective() | truncateAndCapitalize: 40]>
+            </div>
+          </span>
+        </span>
+
+        <span ng-if="!getObjective()">No objective specified.</span>
 
         <ul layout="row" class="metrics" layout-align="space-between center">
           <li>

--- a/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
@@ -9,7 +9,7 @@
 
       <div>
         <div class="objective">
-          <span ng-if="getObjective()"><[getObjective() | truncateAndCapitalize: 45]></span>
+          <span ng-if="getObjective()"><[getObjective() | truncateAndCapitalize: 40]></span>
           <span ng-if="!getObjective()">No objective specified.</span>
         </div>
 

--- a/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
@@ -44,7 +44,7 @@
 
       <div ng-attr-section="<[isWindowLarge ? undefined : 'right-section']>">
         <span ng-if="getObjective()" class="oppia-activity-summary-popover">
-          <span popover="<[getObjective()]>" popover-placement="top" popover-trigger="mouseenter">
+          <span popover="<[getObjective()|capitalize]>" popover-placement="top" popover-trigger="mouseenter">
             <div ng-if="isWindowLarge" class="objective protractor-test-exp-summary-tile-objective">
               <[getObjective() | truncateAndCapitalize: 40]>
             </div>
@@ -81,23 +81,3 @@
     </a>
   </md-card>
 </script>
-
-<style>
-  .oppia-activity-summary-popover .popover.right {
-    bottom: -10px;
-    min-width: 200px;
-  }
-
-  .oppia-activity-summary-popover .popover.top {
-    margin-top: 10px;
-  }
-
-  .oppia-activity-summary-popover .popover-content {
-    padding: 8px 8px;
-  }
-
-  .oppia-activity-summary-popover .popover {
-    font-size: 14px;
-    line-height: 1.42857143;
-  }
-</style>

--- a/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
@@ -46,7 +46,7 @@
         <span ng-if="getObjective()" class="oppia-activity-summary-popover">
           <span popover="<[getObjective()]>" popover-placement="top" popover-trigger="mouseenter">
             <div ng-if="isWindowLarge" class="objective protractor-test-exp-summary-tile-objective">
-              <[getObjective() | truncateAndCapitalize: 25]>
+              <[getObjective() | truncateAndCapitalize: 40]>
             </div>
           </span>
         </span>

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3653,8 +3653,22 @@ md-card.preview-conversation-skin-supplemental-card {
     transform: translateY(-50%);
     float: right;
   }
+}
 
-
+/* Styles for the popover on the exploration and collection summary tiles. */
+.oppia-activity-summary-popover .popover.right {
+  bottom: -10px;
+  min-width: 200px;
+}
+.oppia-activity-summary-popover .popover.top {
+  margin-top: 10px;
+}
+.oppia-activity-summary-popover .popover-content {
+  padding: 8px 8px;
+}
+.oppia-activity-summary-popover .popover {
+  font-size: 14px;
+  line-height: 1.42857143;
 }
 
 .oppia-activity-summary-tile {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3662,6 +3662,13 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 .oppia-activity-summary-popover .popover.top {
   margin-top: 10px;
+  /*
+    This moves the base of the popover down to the second line of the
+    objective. Unfortunately, the !important is needed here because the styles
+    on the popover are set inline, so they override any CSS selectors in this
+    file regardless of how specific they are.
+  */
+  top: 100px !important;
 }
 .oppia-activity-summary-popover .popover-content {
   padding: 8px 8px;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3951,7 +3951,7 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 
 .oppia-dashboard-card-view-item {
-  height: inherit;
+  height: 250px;
   margin-left: 7.5px;
   margin-right: 7.5px;
   position: static;

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -372,6 +372,17 @@ oppia.filter('truncateAndCapitalize', [function() {
   };
 }]);
 
+oppia.filter('capitalize', [function() {
+  return function(input) {
+    if (!input) {
+      return input;
+    }
+
+    var trimmedInput = input.trim();
+    return trimmedInput.charAt(0).toUpperCase() + trimmedInput.slice(1);
+  };
+}]);
+
 oppia.filter('removeDuplicatesInArray', [function() {
   return function(input) {
     return input.filter(function(val, pos) {

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -394,10 +394,10 @@ describe('Testing filters', function() {
     expect(filter('  a')).toEqual('A');
     expect(filter('  a  ')).toEqual('A');
 
-    expect(filter('a  b ')).toEqual('A b');
-    expect(filter('  a  b ')).toEqual('A b');
+    expect(filter('a  b ')).toEqual('A  b');
+    expect(filter('  a  b ')).toEqual('A  b');
     expect(filter('  ab c ')).toEqual('Ab c');
-    expect(filter('  only First lettEr is Affected ')).toEqual(
-      'Only First lettEr is Affected');
+    expect(filter('  only First lettEr is  Affected ')).toEqual(
+      'Only First lettEr is  Affected');
   }));
 });

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -35,6 +35,7 @@ describe('Testing filters', function() {
     'summarizeDefaultOutcome',
     'summarizeNonnegativeNumber',
     'truncateAndCapitalize',
+    'capitalize',
     'stripFormatting'
   ];
 
@@ -379,5 +380,24 @@ describe('Testing filters', function() {
     expect(
       $filter('stripFormatting')(ITALIC_TEXT, whitelistedImgClasses)
     ).toEqual('<i>MVP Ben Zobrist pictured</i>');
+  }));
+
+  it('should correctly capitalize strings', inject(function($filter) {
+    var filter = $filter('capitalize');
+
+    expect(filter('')).toEqual('');
+    expect(filter(null)).toEqual(null);
+    expect(filter(undefined)).toEqual(undefined);
+
+    expect(filter('a')).toEqual('A');
+    expect(filter('a  ')).toEqual('A');
+    expect(filter('  a')).toEqual('A');
+    expect(filter('  a  ')).toEqual('A');
+
+    expect(filter('a  b ')).toEqual('A b');
+    expect(filter('  a  b ')).toEqual('A b');
+    expect(filter('  ab c ')).toEqual('Ab c');
+    expect(filter('  only First lettEr is Affected ')).toEqual(
+      'Only First lettEr is Affected');
   }));
 });


### PR DESCRIPTION
This PR does the following, in preparation for a hotfix to the live site:
- Truncates objectives in both exploration and collection summary tiles to 40 characters, reverting a change made in https://github.com/oppia/oppia/pull/3038/files#diff-18d8b5b4069371fcbffffdb8e95e57ecR49.
- Removes word-break:break-all on titles, reverting a change that was introduced in #2971.

Reviewers:
- @kevintab95, who reported this issue (since it affects the collection learner view)
- @jblair87, who wrote #3038 
- @jaredsilver, who reviewed #3038
- @nikhilsangwan007, who wrote #2971 
- @kevinlee12, who reviewed #2971 
- @526avijitgupta, who reviewed #2971 

FYI:
- @wxyxinyu, who is doing a post-release hotfix 

Important questions:
(a) @nikhilsangwan007, @kevinlee12, @526avijitgupta: what is the aim of "word-break: break-all"? Does something else break if that rule is not present?
(b) @jblair87, @jaredsilver: what is the aim of truncating the objective to 25 chars in #3038? Does something else break if that is not done?

**All**: Please manually test PRs more carefully prior to their merge into develop, in order to prevent this sort of thing happening in the future.