### PR TITLE
Fix #3102: Update Guppy to 260da66 to enable better compatibility with non-US keyboards

### DIFF
--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -1,8 +1,8 @@
-<link rel="stylesheet" href="/third_party/static/guppy-260da66/build/guppy.min.css">
-<script src="/third_party/static/guppy-260da66/build/guppy.min.js"></script>
+<link rel="stylesheet" href="/third_party/static/guppy-260da6/build/guppy.min.css">
+<script src="/third_party/static/guppy-260da6/build/guppy.min.js"></script>
 
 <script>
-  Guppy.get_symbols(['builtins', '/third_party/static/guppy-260da66/sym/symbols.json']);
+  Guppy.get_symbols(['builtins', '/third_party/static/guppy-260da6/sym/symbols.json']);
 </script>
 
 <style>

--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -1,8 +1,8 @@
-<link rel="stylesheet" href="/third_party/static/guppy-f6e0bb/build/guppy.min.css">
-<script src="/third_party/static/guppy-f6e0bb/build/guppy.min.js"></script>
+<link rel="stylesheet" href="/third_party/static/guppy-260da66/build/guppy.min.css">
+<script src="/third_party/static/guppy-260da66/build/guppy.min.js"></script>
 
 <script>
-  Guppy.get_symbols(['builtins', '/third_party/static/guppy-f6e0bb/sym/symbols.json']);
+  Guppy.get_symbols(['builtins', '/third_party/static/guppy-260da66/sym/symbols.json']);
 </script>
 
 <style>

--- a/extensions/interactions/MathExpressionInput/MathExpressionInput.js
+++ b/extensions/interactions/MathExpressionInput/MathExpressionInput.js
@@ -86,25 +86,6 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
                 fakeInputElement.value.length, fakeInputElement.value.length);
             };
 
-            // Guppy uses the Mousetrap (ccampbell/mousetrap) library for
-            // keyboard input. Mousetrap has a function call which allows
-            // sending key events, but for symbols like "^" they need to be
-            // sent as "shift+6" to be recognized. This object is used to
-            // convert symbols into strings that Mousetrap accepts via the
-            // Mousetrap.trigger() function.
-            var K_SYM_REVERSE_MAP = {
-              '^': 'shift+6',
-              '*': 'shift+8',
-              '(': 'shift+9',
-              '<': 'shift+,',
-              '>': 'shift+.',
-              '\\': 'shift+\\',
-              ' ': 'space',
-              ')': 'shift+0'
-              // Missing up/down. user needs to use [space], 'sub' instead.
-              // Mobile devices typically don't have arrow keys anyways.
-            };
-
             var setGuppyContentFromInput = function() {
               // Clear the Guppy instance by setting its content to the
               // output of get_content when empty.
@@ -116,10 +97,12 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
                 .querySelector('#fakeInputForMathExpression').value
                 .toLowerCase().split('');
 
+              // Replay key combination for each character on the document.
               for (var i = 0; i < textContent.length; i++) {
-                // Replay key combination for each character on the document.
-                if (textContent[i] in K_SYM_REVERSE_MAP) {
-                  Mousetrap.trigger(K_SYM_REVERSE_MAP[textContent[i]]);
+                // If the character is a space, send a 'right' to enable mobile
+                // users to complete expressions without arrow keys.
+                if (textContent[i] === ' ') {
+                  Mousetrap.trigger('right');
                 } else {
                   Mousetrap.trigger(textContent[i]);
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -230,11 +230,11 @@
         }
       },
       "guppy": {
-        "version": "f6e0bbf99d955b1700acb46fac6f70bcd554fcfe",
+        "version": "260da662c907e95f3da0a335c896fe9621fc165d",
         "downloadFormat": "zip",
-        "url": "https://github.com/daniel3735928559/guppy/archive/f6e0bbf99d955b1700acb46fac6f70bcd554fcfe.zip",
+        "url": "https://github.com/daniel3735928559/guppy/archive/260da662c907e95f3da0a335c896fe9621fc165d.zip",
         "rootDirPrefix": "guppy-",
-        "targetDir": "guppy-f6e0bb"
+        "targetDir": "guppy-260da6"
       },
       "hammerJs": {
         "version": "2.0.4",

--- a/manifest.json
+++ b/manifest.json
@@ -234,7 +234,7 @@
         "downloadFormat": "zip",
         "url": "https://github.com/daniel3735928559/guppy/archive/260da662c907e95f3da0a335c896fe9621fc165d.zip",
         "rootDirPrefix": "guppy-",
-        "targetDir": "guppy-260da66"
+        "targetDir": "guppy-260da6"
       },
       "hammerJs": {
         "version": "2.0.4",

--- a/manifest.json
+++ b/manifest.json
@@ -234,7 +234,7 @@
         "downloadFormat": "zip",
         "url": "https://github.com/daniel3735928559/guppy/archive/260da662c907e95f3da0a335c896fe9621fc165d.zip",
         "rootDirPrefix": "guppy-",
-        "targetDir": "guppy-260da6"
+        "targetDir": "guppy-260da66"
       },
       "hammerJs": {
         "version": "2.0.4",


### PR DESCRIPTION
Updates Guppy and MathExpressionInput.js to match changes in the new version.