### PR TITLE
Fix #3094: Changed URL of license-term link in insert image.

### DIFF
--- a/extensions/objects/templates/filepath_editor.html
+++ b/extensions/objects/templates/filepath_editor.html
@@ -30,7 +30,7 @@
 
   <div ng-if="imageUploaderIsActive" style="border: 1px solid black; padding: 5px;">
     <div class="oppia-warning">
-      Before uploading any images, please ensure that they are compatible with the <a href="/about#license" target="_blank">license terms</a> of this site (the link opens in a new window).
+      Before uploading any images, please ensure that they are compatible with the <a href="/about#foundation" target="_blank">license terms</a> of this site (the link opens in a new window).
     </div>
 
     <br>


### PR DESCRIPTION
Changed the URL of license-term for image insert in editor. Directs to foundation tab of about page.
