### PR TITLE
Fix part of #3082: Make icon buttons and links screenreader accessible

### DIFF
--- a/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
+++ b/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
@@ -14,6 +14,7 @@
                 ng-click="deleteElement($index)"
                 ng-disabled="isDisabled()">
           <i class="material-icons md-18">&#xE5CD;</i>
+          <span class="oppia-icon-btn-label">Delete this list entry</span>
         </button>
       </td>
     </tr>

--- a/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
+++ b/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
@@ -14,7 +14,7 @@
                 ng-click="deleteElement($index)"
                 ng-disabled="isDisabled()">
           <i class="material-icons md-18">&#xE5CD;</i>
-          <span class="oppia-icon-btn-label">Delete this list entry</span>
+          <span class="oppia-icon-accessibility-label">Delete this list entry</span>
         </button>
       </td>
     </tr>

--- a/core/templates/dev/head/components/rating_display.html
+++ b/core/templates/dev/head/components/rating_display.html
@@ -1,7 +1,7 @@
 <script type="text/ng-template" id="components/ratingSummary">
   <span style="<[getCursorStyle()]>" ng-mouseleave="leaveArea()">
     <span ng-if="ratingValue || isEditable" ng-repeat="star in stars" class="fa <[star.cssClass]> oppia-rating-star protractor-test-rating-star" ng-click="clickStar(star.value)" ng-mouseenter="enterStar(star.value)">
-      <span class="oppia-icon-btn-label">Rate this <[$index + 1]> stars</span>
+      <span class="oppia-icon-accessibility-label">Rate this <[$index + 1]> stars</span>
     </span>
   </span>
 </script>

--- a/core/templates/dev/head/components/rating_display.html
+++ b/core/templates/dev/head/components/rating_display.html
@@ -1,5 +1,7 @@
 <script type="text/ng-template" id="components/ratingSummary">
   <span style="<[getCursorStyle()]>" ng-mouseleave="leaveArea()">
-    <span ng-if="ratingValue || isEditable" ng-repeat="star in stars" class="fa <[star.cssClass]> oppia-rating-star protractor-test-rating-star" ng-click="clickStar(star.value)" ng-mouseenter="enterStar(star.value)"></span>
+    <span ng-if="ratingValue || isEditable" ng-repeat="star in stars" class="fa <[star.cssClass]> oppia-rating-star protractor-test-rating-star" ng-click="clickStar(star.value)" ng-mouseenter="enterStar(star.value)">
+      <span class="oppia-icon-btn-label">Rate this <[$index + 1]> stars</span>
+    </span>
   </span>
 </script>

--- a/core/templates/dev/head/components/share/sharing_links_directive.html
+++ b/core/templates/dev/head/components/share/sharing_links_directive.html
@@ -21,7 +21,7 @@
     <li>
       <a ng-click="showEmbedExplorationModal(explorationId)" tooltip="Embed" tooltip-placement="top" tabindex="0">
         <i class="material-icons md-48 embed-link">&#xE86F;</i>
-        <span class="oppia-icon-btn-label">Embed this Exploration</span>
+        <span class="oppia-icon-accessibility-label">Embed this Exploration</span>
       </a>
     </li>
   </ul>

--- a/core/templates/dev/head/components/share/sharing_links_directive.html
+++ b/core/templates/dev/head/components/share/sharing_links_directive.html
@@ -21,6 +21,7 @@
     <li>
       <a ng-click="showEmbedExplorationModal(explorationId)" tooltip="Embed" tooltip-placement="top" tabindex="0">
         <i class="material-icons md-48 embed-link">&#xE86F;</i>
+        <span class="oppia-icon-btn-label">Embed this Exploration</span>
       </a>
     </li>
   </ul>

--- a/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
@@ -27,7 +27,7 @@
 
           <li>
             <span>
-              <span class="oppia-icon-btn-label">Last Updated</span>
+              <span class="oppia-icon-accessibility-label">Last Updated</span>
               <[getLastUpdatedDatetime()]>
             </span>
           </li>

--- a/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
@@ -27,6 +27,7 @@
 
           <li>
             <span>
+              <span class="oppia-icon-btn-label">Last Updated</span>
               <[getLastUpdatedDatetime()]>
             </span>
           </li>

--- a/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
@@ -36,6 +36,7 @@
           <li>
             <span class="protractor-test-exp-summary-tile-rating" ng-class="{'rating-disabled': !getAverageRating()}">
               <span class="fa fa-star fa-lg" tooltip="<['I18N_LIBRARY_RATINGS_TOOLTIP' | translate]>" tooltip-placement="top">
+                <span class="oppia-icon-btn-label"><['I18N_LIBRARY_RATINGS_TOOLTIP' | translate]></span>
               </span>
               <span ng-if="getAverageRating()">
                 <[getAverageRating() | number:1]>
@@ -47,12 +48,14 @@
 
           <li>
             <span class="fa fa-eye fa-lg" tooltip="<['I18N_LIBRARY_VIEWS_TOOLTIP' | translate]>" tooltip-placement="top">
+              <span class="oppia-icon-btn-label"><['I18N_LIBRARY_VIEWS_TOOLTIP' | translate]></span>
             </span>
             <[getNumViews() | summarizeNonnegativeNumber]>
           </li>
 
           <li>
             <span>
+              <span class="oppia-icon-btn-label">Last Updated</span>
               <[getLastUpdatedDatetime()]>
             </span>
           </li>

--- a/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
@@ -36,7 +36,7 @@
           <li>
             <span class="protractor-test-exp-summary-tile-rating" ng-class="{'rating-disabled': !getAverageRating()}">
               <span class="fa fa-star fa-lg" tooltip="<['I18N_LIBRARY_RATINGS_TOOLTIP' | translate]>" tooltip-placement="top">
-                <span class="oppia-icon-btn-label"><['I18N_LIBRARY_RATINGS_TOOLTIP' | translate]></span>
+                <span class="oppia-icon-accessibility-label"><['I18N_LIBRARY_RATINGS_TOOLTIP' | translate]></span>
               </span>
               <span ng-if="getAverageRating()">
                 <[getAverageRating() | number:1]>
@@ -48,14 +48,14 @@
 
           <li>
             <span class="fa fa-eye fa-lg" tooltip="<['I18N_LIBRARY_VIEWS_TOOLTIP' | translate]>" tooltip-placement="top">
-              <span class="oppia-icon-btn-label"><['I18N_LIBRARY_VIEWS_TOOLTIP' | translate]></span>
+              <span class="oppia-icon-accessibility-label"><['I18N_LIBRARY_VIEWS_TOOLTIP' | translate]></span>
             </span>
             <[getNumViews() | summarizeNonnegativeNumber]>
           </li>
 
           <li>
             <span>
-              <span class="oppia-icon-btn-label">Last Updated</span>
+              <span class="oppia-icon-accessibility-label">Last Updated</span>
               <[getLastUpdatedDatetime()]>
             </span>
           </li>

--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -27,13 +27,18 @@
           <a class="oppia-navbar-tab oppia-navbar-tab-content" href="/library" translate="I18N_TOPNAV_LIBRARY"></a>
         </li>
         <li ng-show="navElementsVisibilityStatus.I18N_TOPNAV_ABOUT" class="dropdown oppia-navbar-clickable-dropdown protractor-test-about-oppia-list-item">
-          <a class="oppia-navbar-tab" tabindex="0">
+          <a class="oppia-navbar-tab"
+             role="menuitem"
+             aria-haspopup="true"
+             aria-expanded="false"
+             tabindex="0">
             <span class="oppia-navbar-tab-content" translate="I18N_TOPNAV_ABOUT"></span>
             <span class="caret"></span>
           </a>
           <ul class="dropdown-menu oppia-navbar-dropdown"
               ng-mouseover="onMouseoverDropdownMenu($event)"
-              ng-mouseleave="onMouseoutDropdownMenu($event)">
+              ng-mouseleave="onMouseoutDropdownMenu($event)"
+              role="menu">
             <li><a class="protractor-test-about-link oppia-navbar-tab-content" href="/about" translate="I18N_TOPNAV_ABOUT_OPPIA"></a></li>
             <li><a class="protractor-test-get-started-link oppia-navbar-tab-content" href="/get_started" translate="I18N_TOPNAV_GET_STARTED"></a></li>
             <li><a class="protractor-test-teach-link oppia-navbar-tab-content" href="/teach" translate="I18N_TOPNAV_TEACH_WITH_OPPIA"></a></li>
@@ -57,7 +62,11 @@
       <li ng-if="username" class="dropdown protractor-test-profile-dropdown">
         <a class="dropdown-toggle oppia-navbar-dropdown-toggle" data-toggle="dropdown"
            ng-mouseover="onMouseoverProfilePictureOrDropdown($event)"
-           ng-mouseleave="onMouseoutProfilePictureOrDropdown($event)" tabindex="0">
+           ng-mouseleave="onMouseoutProfilePictureOrDropdown($event)"
+           role="menuitem"
+           aria-haspopup="true"
+           aria-expanded="false"
+           tabindex="0">
           <div class="oppia-navbar-profile-picture-container">
             <span ng-if="profilePictureDataUrl">
               <img ng-src="<[profilePictureDataUrl]>" class="oppia-navbar-profile-picture img-circle" alt="User Avatar">

--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -66,6 +66,7 @@
            role="menuitem"
            aria-haspopup="true"
            aria-expanded="false"
+           aria-label="User Menu"
            tabindex="0">
           <div class="oppia-navbar-profile-picture-container">
             <span ng-if="profilePictureDataUrl">
@@ -74,6 +75,7 @@
             </span>
             <span ng-if="!profilePictureDataUrl">
               <i class="material-icons md-40" style="margin-top: -1px;">&#xE853;</i>
+              <span class="oppia-icon-accessibility-label">User Avatar</span>
               <span class="caret" style="margin-top: -26px;"></span>
             </span>
 

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3991,8 +3991,9 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 /* Accessibility workaround for icon buttons and links
   Taken from:
-  https://www.nczonline.net/blog/2013/04/01/making-accessible-icon-buttons/ */
-.oppia-icon-btn-label {
+  https://www.nczonline.net/blog/2013/04/01/making-accessible-icon-buttons/
+  Use for all links and buttons that only use an icon */
+.oppia-icon-accessibility-label {
   display: block;
   font-size: 0;
   height: 1px;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3989,6 +3989,15 @@ md-card.preview-conversation-skin-supplemental-card {
   margin-right: 2px;
   vertical-align: initial;
 }
+/* Accessibility workaround for icon buttons and links
+  Taken from:
+  https://www.nczonline.net/blog/2013/04/01/making-accessible-icon-buttons/ */
+.oppia-icon-btn-label {
+  display: block;
+  font-size: 0;
+  height: 1px;
+  overflow: hidden;
+}
 
 .oppia-activity-summary-tile .recently-updated {
   color: rgb(19,105,193);

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3997,6 +3997,7 @@ md-card.preview-conversation-skin-supplemental-card {
   font-size: 0;
   height: 1px;
   overflow: hidden;
+  width: 0px;
 }
 
 .oppia-activity-summary-tile .recently-updated {

--- a/core/templates/dev/head/pages/collection_player/collection_player.html
+++ b/core/templates/dev/head/pages/collection_player/collection_player.html
@@ -197,7 +197,7 @@
       <li>
         <a ng-href="/collection_editor/create/{{collection_id}}" tooltip="Edit" tooltip-placement="bottom" target="_blank">
           <i class="material-icons">&#xE254;</i>
-          <span class="oppia-icon-btn-label">Edit</span>
+          <span class="oppia-icon-accessibility-label">Edit</span>
         </a>
       </li>
     {% endif %}

--- a/core/templates/dev/head/pages/collection_player/collection_player.html
+++ b/core/templates/dev/head/pages/collection_player/collection_player.html
@@ -197,6 +197,7 @@
       <li>
         <a ng-href="/collection_editor/create/{{collection_id}}" tooltip="Edit" tooltip-placement="bottom" target="_blank">
           <i class="material-icons">&#xE254;</i>
+          <span class="oppia-icon-btn-label">Edit</span>
         </a>
       </li>
     {% endif %}

--- a/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
@@ -14,8 +14,13 @@
               aria-haspopup="true"
               aria-expanded="false">
             <div class="dropup" ng-class="{'open':hovering}">
-              <a id="dropdownMenu2" class="dropdown-toggle" ng-class="{'hovered-text':hovering}"
-                 data-toggle="dropdown" ng-if="contributorNames.length > 0">
+              <a id="dropdownMenu2" class="dropdown-toggle"
+                 ng-class="{'hovered-text':hovering}"
+                 data-toggle="dropdown" 
+                 ng-if="contributorNames.length > 0"
+                 role="menuitem"
+                 aria-haspopup="true"
+                 aria-expanded="false">
                 <h4 translate="I18N_FOOTER_AUTHOR_PROFILES" class="author-profile-text"
                     ng-class="{'hovered-text':hovering, 'not-hovered' : !hovering}"></h4>
               </a>

--- a/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
@@ -10,7 +10,9 @@
           <li class="hover-link"
               ng-mouseenter="hovering = true"
               ng-mouseleave="hovering = false"
-              tabindex="0">
+              tabindex="0"
+              aria-haspopup="true"
+              aria-expanded="false">
             <div class="dropup" ng-class="{'open':hovering}">
               <a id="dropdownMenu2" class="dropdown-toggle" ng-class="{'hovered-text':hovering}"
                  data-toggle="dropdown" ng-if="contributorNames.length > 0">

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -73,7 +73,7 @@
     </li>
     <li ng-click="showInformationCard()" tooltip="<['I18N_PLAYER_INFO_TOOLTIP' | translate]>" tooltip-placement="bottom" style="cursor: pointer;" class="oppia-exploration-info-icon protractor-test-exploration-info-icon" tabindex="0">
       <i class="material-icons oppia-navbar-breadcrumb-icon" style="font-size: 20px;">&#xE88E;</i>
-      <span class="oppia-icon-btn-label"><['I18N_PLAYER_INFO_TOOLTIP' | translate]></span>
+      <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_INFO_TOOLTIP' | translate]></span>
     </li>
   </ul>
 {% endblock navbar_breadcrumb %}

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -73,6 +73,7 @@
     </li>
     <li ng-click="showInformationCard()" tooltip="<['I18N_PLAYER_INFO_TOOLTIP' | translate]>" tooltip-placement="bottom" style="cursor: pointer;" class="oppia-exploration-info-icon protractor-test-exploration-info-icon" tabindex="0">
       <i class="material-icons oppia-navbar-breadcrumb-icon" style="font-size: 20px;">&#xE88E;</i>
+      <span class="oppia-icon-btn-label"><['I18N_PLAYER_INFO_TOOLTIP' | translate]></span>
     </li>
   </ul>
 {% endblock navbar_breadcrumb %}

--- a/core/templates/dev/head/pages/exploration_player/information_card_modal.html
+++ b/core/templates/dev/head/pages/exploration_player/information_card_modal.html
@@ -14,7 +14,7 @@
       <ul layout="row" class="card-metrics" layout-align="space-between center">
         <li class="protractor-test-info-card-rating">
           <span class="fa fa-star fa-lg" tooltip="<['I18N_PLAYER_RATINGS_TOOLTIP' | translate]>" tooltip-placement="top">
-            <span class="oppia-icon-btn-label"><['I18N_PLAYER_RATINGS_TOOLTIP' | translate]></span>
+            <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_RATINGS_TOOLTIP' | translate]></span>
           </span>
           <span ng-if="!averageRating" translate="I18N_PLAYER_UNRATED">Unrated</span>
           <span ng-if="averageRating"><[averageRating | number:1]></span>
@@ -22,21 +22,21 @@
 
         <li>
           <span class="fa fa-eye fa-lg" tooltip="<['I18N_PLAYER_VIEWS_TOOLTIP' | translate]>" tooltip-placement="top">
-            <span class="oppia-icon-btn-label"><['I18N_PLAYER_VIEWS_TOOLTIP' | translate]></span>
+            <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_VIEWS_TOOLTIP' | translate]></span>
           </span>
           <[numViews | summarizeNonnegativeNumber]>
         </li>
 
         <li>
           <span class="fa fa-clock-o fa-lg" tooltip="<['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]>" tooltip-placement="top">
-            <span class="oppia-icon-btn-label"><['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]></span>
+            <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]></span>
           </span>
           <[lastUpdatedString]>
         </li>
 
         <ul layout="row" layout-align="space-between center" class="oppia-info-card-exploration-contributors-profile">
           <i class="material-icons" tooltip="<['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]>" tooltip-placement="top" style="cursor: default; margin-right: 5px;">&#xE7EF;</i>
-          <span class="oppia-icon-btn-label"><['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]></span>
+          <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]></span>
           <li ng-repeat="name in contributorNames| limitTo: 2"
             tooltip="<[name]>" tooltip-placement="top">
             <profile-link-image username="name">
@@ -62,7 +62,7 @@
               <span class="fa fa-tags fa-lg" tooltip-append-to-body="true"
                     tooltip="<['I18N_PLAYER_TAGS_TOOLTIP' | translate]>"
                     tooltip-placement="top">
-                <span class="oppia-icon-btn-label"><['I18N_PLAYER_TAGS_TOOLTIP' | translate]></span>
+                <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_TAGS_TOOLTIP' | translate]></span>
               </span>
             </div>
             <md-chips layout-align="center center">
@@ -92,7 +92,7 @@
     </div>
     <button type="button" class="oppia-close-popover-button" ng-click="cancel()">
       <i class="material-icons md-18" style="color: white;">&#xE5CD;</i>
-      <span class="oppia-icon-btn-label">Close</span>
+      <span class="oppia-icon-accessibility-label">Close</span>
     </button>
   </md-card>
 </script>

--- a/core/templates/dev/head/pages/exploration_player/information_card_modal.html
+++ b/core/templates/dev/head/pages/exploration_player/information_card_modal.html
@@ -13,23 +13,30 @@
 
       <ul layout="row" class="card-metrics" layout-align="space-between center">
         <li class="protractor-test-info-card-rating">
-          <span class="fa fa-star fa-lg" tooltip="<['I18N_PLAYER_RATINGS_TOOLTIP' | translate]>" tooltip-placement="top"></span>
+          <span class="fa fa-star fa-lg" tooltip="<['I18N_PLAYER_RATINGS_TOOLTIP' | translate]>" tooltip-placement="top">
+            <span class="oppia-icon-btn-label"><['I18N_PLAYER_RATINGS_TOOLTIP' | translate]></span>
+          </span>
           <span ng-if="!averageRating" translate="I18N_PLAYER_UNRATED">Unrated</span>
           <span ng-if="averageRating"><[averageRating | number:1]></span>
         </li>
 
         <li>
-          <span class="fa fa-eye fa-lg" tooltip="<['I18N_PLAYER_VIEWS_TOOLTIP' | translate]>" tooltip-placement="top"></span>
+          <span class="fa fa-eye fa-lg" tooltip="<['I18N_PLAYER_VIEWS_TOOLTIP' | translate]>" tooltip-placement="top">
+            <span class="oppia-icon-btn-label"><['I18N_PLAYER_VIEWS_TOOLTIP' | translate]></span>
+          </span>
           <[numViews | summarizeNonnegativeNumber]>
         </li>
 
         <li>
-          <span class="fa fa-clock-o fa-lg" tooltip="<['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]>" tooltip-placement="top"></span>
+          <span class="fa fa-clock-o fa-lg" tooltip="<['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]>" tooltip-placement="top">
+            <span class="oppia-icon-btn-label"><['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]></span>
+          </span>
           <[lastUpdatedString]>
         </li>
 
         <ul layout="row" layout-align="space-between center" class="oppia-info-card-exploration-contributors-profile">
           <i class="material-icons" tooltip="<['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]>" tooltip-placement="top" style="cursor: default; margin-right: 5px;">&#xE7EF;</i>
+          <span class="oppia-icon-btn-label"><['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]></span>
           <li ng-repeat="name in contributorNames| limitTo: 2"
             tooltip="<[name]>" tooltip-placement="top">
             <profile-link-image username="name">
@@ -55,6 +62,7 @@
               <span class="fa fa-tags fa-lg" tooltip-append-to-body="true"
                     tooltip="<['I18N_PLAYER_TAGS_TOOLTIP' | translate]>"
                     tooltip-placement="top">
+                <span class="oppia-icon-btn-label"><['I18N_PLAYER_TAGS_TOOLTIP' | translate]></span>
               </span>
             </div>
             <md-chips layout-align="center center">
@@ -84,6 +92,7 @@
     </div>
     <button type="button" class="oppia-close-popover-button" ng-click="cancel()">
       <i class="material-icons md-18" style="color: white;">&#xE5CD;</i>
+      <span class="oppia-icon-btn-label">Close</span>
     </button>
   </md-card>
 </script>

--- a/core/templates/dev/head/pages/exploration_player/learner_local_nav.html
+++ b/core/templates/dev/head/pages/exploration_player/learner_local_nav.html
@@ -3,16 +3,19 @@
   <li popover-placement="bottom" popover-template="'popover/feedback'" popover-trigger="click">
     <a href="" class="protractor-test-exploration-feedback-popup-link" tooltip="<['I18N_PLAYER_FEEDBACK_TOOLTIP' | translate]>" tooltip-placement="bottom">
       <i class="material-icons">&#xE87F;</i>
+      <span class="oppia-icon-btn-label"><['I18N_PLAYER_FEEDBACK_TOOLTIP' | translate]></span>
     </a>
   </li>
   <li>
     {% if can_edit %}
       <a ng-href="/create/<[explorationId]>" tooltip="<['I18N_PLAYER_EDIT_TOOLTIP' | translate]>" tooltip-placement="bottom" target="_blank">
         <i class="material-icons">&#xE254;</i>
+        <span class="oppia-icon-btn-label"><['I18N_PLAYER_EDIT_TOOLTIP' | translate]></span>
       </a>
     {% elif username %}
       <a ng-click="showLearnerSuggestionModal()" tooltip="Suggest Changes" tooltip-placement="bottom" target="_blank">
         <i class="material-icons">&#xE254;</i>
+        <span class="oppia-icon-btn-label">Suggest Changes</span>
       </a>
     {% endif %}
   </li>
@@ -20,6 +23,7 @@
     {% if username %}
       <a ng-click="showFlagExplorationModal()" tooltip="<['I18N_PLAYER_REPORT_TOOLTIP' | translate]>" tooltip-placement="bottom" tabindex="0">
         <i class="material-icons">&#xE153;</i>
+        <span class="oppia-icon-btn-label"><['I18N_PLAYER_REPORT_TOOLTIP' | translate]></span>
       </a>
     {% endif %}
   </li>

--- a/core/templates/dev/head/pages/exploration_player/learner_local_nav.html
+++ b/core/templates/dev/head/pages/exploration_player/learner_local_nav.html
@@ -3,19 +3,19 @@
   <li popover-placement="bottom" popover-template="'popover/feedback'" popover-trigger="click">
     <a href="" class="protractor-test-exploration-feedback-popup-link" tooltip="<['I18N_PLAYER_FEEDBACK_TOOLTIP' | translate]>" tooltip-placement="bottom">
       <i class="material-icons">&#xE87F;</i>
-      <span class="oppia-icon-btn-label"><['I18N_PLAYER_FEEDBACK_TOOLTIP' | translate]></span>
+      <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_FEEDBACK_TOOLTIP' | translate]></span>
     </a>
   </li>
   <li>
     {% if can_edit %}
       <a ng-href="/create/<[explorationId]>" tooltip="<['I18N_PLAYER_EDIT_TOOLTIP' | translate]>" tooltip-placement="bottom" target="_blank">
         <i class="material-icons">&#xE254;</i>
-        <span class="oppia-icon-btn-label"><['I18N_PLAYER_EDIT_TOOLTIP' | translate]></span>
+        <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_EDIT_TOOLTIP' | translate]></span>
       </a>
     {% elif username %}
       <a ng-click="showLearnerSuggestionModal()" tooltip="Suggest Changes" tooltip-placement="bottom" target="_blank">
         <i class="material-icons">&#xE254;</i>
-        <span class="oppia-icon-btn-label">Suggest Changes</span>
+        <span class="oppia-icon-accessibility-label">Suggest Changes</span>
       </a>
     {% endif %}
   </li>
@@ -23,7 +23,7 @@
     {% if username %}
       <a ng-click="showFlagExplorationModal()" tooltip="<['I18N_PLAYER_REPORT_TOOLTIP' | translate]>" tooltip-placement="bottom" tabindex="0">
         <i class="material-icons">&#xE153;</i>
-        <span class="oppia-icon-btn-label"><['I18N_PLAYER_REPORT_TOOLTIP' | translate]></span>
+        <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_REPORT_TOOLTIP' | translate]></span>
       </a>
     {% endif %}
   </li>

--- a/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
@@ -105,7 +105,7 @@
             ng-if="$index === currentDotIndex" ng-show="dots.length > 1"
             tooltip="<['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]>" tooltip-placement="left"
             tooltip-trigger="none" tooltip-is-open="opened" mobile-friendly-tooltip tabindex="0">
-        <span class="oppia-icon-btn-label"><['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]></span>
+        <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]></span>
       </span>
       <span class="oppia-progress-dot oppia-progress-dot-inactive"
             ng-class="$index === leftmostVisibleDotIndex && $index !== 0 ? 'oppia-progress-dot-gradient-left':
@@ -115,7 +115,7 @@
             ng-click="changeActiveDot($index)"
             tooltip="<['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]>" tooltip-placement="left"
             tooltip-trigger="none" tooltip-is-open="opened" mobile-friendly-tooltip tabindex="0">
-        <span class="oppia-icon-btn-label"><['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]></span>
+        <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]></span>
       </span>
     </li>
     <li class="oppia-progress-arrow" ng-show="dots.length > 1"

--- a/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
@@ -105,6 +105,7 @@
             ng-if="$index === currentDotIndex" ng-show="dots.length > 1"
             tooltip="<['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]>" tooltip-placement="left"
             tooltip-trigger="none" tooltip-is-open="opened" mobile-friendly-tooltip tabindex="0">
+        <span class="oppia-icon-btn-label"><['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]></span>
       </span>
       <span class="oppia-progress-dot oppia-progress-dot-inactive"
             ng-class="$index === leftmostVisibleDotIndex && $index !== 0 ? 'oppia-progress-dot-gradient-left':
@@ -114,6 +115,7 @@
             ng-click="changeActiveDot($index)"
             tooltip="<['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]>" tooltip-placement="left"
             tooltip-trigger="none" tooltip-is-open="opened" mobile-friendly-tooltip tabindex="0">
+        <span class="oppia-icon-btn-label"><['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]></span>
       </span>
     </li>
     <li class="oppia-progress-arrow" ng-show="dots.length > 1"

--- a/core/templates/dev/head/pages/library/library.html
+++ b/core/templates/dev/head/pages/library/library.html
@@ -109,8 +109,7 @@
                          ng-hide="leftmostCardIndices[$index] == 0">
                 <i class="material-icons">&#xE314;</i>
               </md-button>
-              <div class="oppia-library-carousel-scroller" ng-if="leftmostCardIndices[$index] == 0">
-                <span class="oppia-icon-btn-label">Scroll left</span>
+              <div class="oppia-library-carousel-scroller" ng-if="leftmostCardIndices[$index] == 0" aria-hidden="true">
               </div>
 
               <div class="oppia-library-carousel"
@@ -146,9 +145,9 @@
 
               <md-button class="md-no-ink oppia-library-carousel-scroller"
                          ng-click="scroll($index, false)"
-                         ng-hide="(group.activity_summary_dicts.length - tileDisplayCount) <= leftmostCardIndices[$index]">
+                         ng-hide="(group.activity_summary_dicts.length - tileDisplayCount) <= leftmostCardIndices[$index]"
+                         aria-hidden="true">
                 <i class="material-icons">&#xE315;</i>
-                <span class="oppia-icon-btn-label">Scroll right</span>
               </md-button>
               <div class="oppia-library-carousel-scroller"
                    ng-if="(group.activity_summary_dicts.length - tileDisplayCount) <= leftmostCardIndices[$index]"></div>
@@ -157,7 +156,8 @@
             <div ng-if="libraryWindowIsNarrow && leftmostCardIndices">
               <md-button class="md-no-ink oppia-library-carousel-scroller"
                          ng-click="decrementLeftmostCardIndex($index)"
-                         ng-hide="leftmostCardIndices[$index] == 0">
+                         ng-hide="leftmostCardIndices[$index] == 0"
+                         aria-hidden="true">
                 <i class="material-icons">&#xE314;</i>
               </md-button>
               <div class="oppia-library-carousel-scroller" ng-if="leftmostCardIndices[$index] == 0"></div>

--- a/core/templates/dev/head/pages/library/library.html
+++ b/core/templates/dev/head/pages/library/library.html
@@ -109,7 +109,9 @@
                          ng-hide="leftmostCardIndices[$index] == 0">
                 <i class="material-icons">&#xE314;</i>
               </md-button>
-              <div class="oppia-library-carousel-scroller" ng-if="leftmostCardIndices[$index] == 0"></div>
+              <div class="oppia-library-carousel-scroller" ng-if="leftmostCardIndices[$index] == 0">
+                <span class="oppia-icon-btn-label">Scroll left</span>
+              </div>
 
               <div class="oppia-library-carousel"
                    ng-swipe-right="scroll($index, true)"
@@ -146,6 +148,7 @@
                          ng-click="scroll($index, false)"
                          ng-hide="(group.activity_summary_dicts.length - tileDisplayCount) <= leftmostCardIndices[$index]">
                 <i class="material-icons">&#xE315;</i>
+                <span class="oppia-icon-btn-label">Scroll right</span>
               </md-button>
               <div class="oppia-library-carousel-scroller"
                    ng-if="(group.activity_summary_dicts.length - tileDisplayCount) <= leftmostCardIndices[$index]"></div>

--- a/core/templates/dev/head/pages/library/search_bar_directive.html
+++ b/core/templates/dev/head/pages/library/search_bar_directive.html
@@ -97,6 +97,9 @@
   .oppia-search-bar-input.btn:hover,
   .oppia-search-bar-input.btn:focus {
     color: #fff;
+  }
+
+  .oppia-search-bar-input.btn:focus {
     outline: 1px dotted #fff;
     outline: auto 5px -webkit-focus-ring-color;
   }

--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.html
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.html
@@ -94,7 +94,7 @@
         <div ng-if="displayCheckboxes">
           <label class="item-selection-input-item">
             <md-checkbox class="item-selection-input-checkbox" ng-model="userSelections[choice]" ng-checked="userSelections[choice]"
-              ng-change="onToggleCheckbox()" ng-disabled="preventAdditionalSelections && !userSelections[choice]" aria-label="choice" tabindex="0">
+              ng-change="onToggleCheckbox()" ng-disabled="preventAdditionalSelections && !userSelections[choice]" tabindex="0">
               <span angular-html-bind="choice"></span>
             </md-checkbox>
           </label>


### PR DESCRIPTION
This PR addresses the following issues from #3082:

- Separate out hover and focus styles for the search bar language dropdown and categories dropdown and the language choice select element in the footer. (**Solution:** I did indeed separate the CSS for focus and hover for the search bar dropdown menus. In the case of the language choice element, there was no need.)
- Exploration card metadata (on the library page and the info modal inside of an exploration) is read, but has no context. (**Solution:** I've implemented a specific span element so that icons used in buttons and links have text. [Based off of Nicholas Zakas' blog post.](https://www.nczonline.net/blog/2013/04/01/making-accessible-icon-buttons/))
- The button to scroll through the explorations under a topic heading is just read as "button." There is no context as to what it is meant to do. (**Solution:** After testing this with VO, I've determined that the best solution is to hide these from the screenreader. The screenreader already reads each of the cards in the section; the scroll buttons are superfluous. However, the scroll buttons are still keyboard accessible.)
- Navbar icons, such as the info icon and the report icon as just read as "button" or "link" with no context as to what they are. (**Solution:** I've implemented a specific span element so that icons used in buttons and links have text.)
- When VO is reading the entire page, the embed button is not read. (**Solution:** I've implemented a specific span element so that icons used in buttons and links have text.)
- The Exit button in the info modal is simply read as "button" with no context. (**Solution:** I've implemented a specific span element so that icons used in buttons and links have text.)
- The round buttons that represent each exploration card are just read as "button" with no context as to what they do. (**Solution:** I've implemented a specific span element so that icons used in buttons and links have text. In this case, I used the existing card number tooltip text so that the text is dynamically generated)
- The Flag this Exploration button is not read at all when VO reads the entire page. (**Solution:** I've implemented a specific span element so that icons used in buttons and links have text.)
- The star ratings at the end of an exploration are simply read as "button" with no context. (**Solution:** I've implemented a specific span element so that icons used in buttons and links have text. In this case, the label uses the index to indicate how many stars that rating button represents)
- The delete button for the Add Item interaction is read simply as "button" with no context. (**Solution:** I've implemented a specific span element so that icons used in buttons and links have text.)
-  On the item selection interactive (check boxes) the actual choice text is not read. All I heard was "choice unchecked checkbox," which meant that I didn't know what I was choosing. (**Solution:** I removed the aria label on these elements which was causing them to be read as "choice". Now the text of the actual choice is read.)

## Notes
- Where available, I tried to use the existing i18n translatable text in the new icon label span. I'm not sure if this was necessary, so feedback appreciated!
- There were cases, such as the About link and the profile link in the top navbar, and the Author profile link in the exploration player, where though the text was read, it was not clear that the element was one that a user could or should interact with. I added aria roles similar to the ones used on the search bar categories and language dropdown menus. However, these elements still need to be made keyboard accessible.