### PR TITLE
Fix #3120: Buttons on About page have text overflow on mobile.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4522,11 +4522,11 @@ md-card.preview-conversation-skin-supplemental-card {
   font-size: 18px;
   margin: 0 15px 15px 15px;
   max-width: 90%;
+  min-width: 200px;
   padding: 15px;
   text-transform: uppercase;
   white-space: normal;
   width: 366px;
-  min-width: 200px;
 }
 
 .oppia-about-button:hover,

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4526,6 +4526,7 @@ md-card.preview-conversation-skin-supplemental-card {
   text-transform: uppercase;
   white-space: normal;
   width: 366px;
+  min-width: 200px;
 }
 
 .oppia-about-button:hover,


### PR DESCRIPTION
fixed bug 3120. 
now ui view in mobile screen size:
![after_patch](https://cloud.githubusercontent.com/assets/11019397/23357623/a6e9ba5c-fd04-11e6-993c-05bcfec95bd5.png)
