### PR TITLE
Convert state dictionary data in FeedbackTab to State objects

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
@@ -20,12 +20,12 @@ oppia.controller('FeedbackTab', [
   '$scope', '$http', '$modal', '$timeout', '$rootScope', 'alertsService',
   'oppiaDatetimeFormatter', 'threadStatusDisplayService',
   'threadDataService', 'explorationStatesService', 'explorationData',
-  'changeListService',
+  'changeListService', 'StateObjectFactory',
   function(
     $scope, $http, $modal, $timeout, $rootScope, alertsService,
     oppiaDatetimeFormatter, threadStatusDisplayService,
     threadDataService, explorationStatesService, explorationData,
-    changeListService) {
+    changeListService, StateObjectFactory) {
     var ACTION_ACCEPT_SUGGESTION = 'accept';
     var ACTION_REJECT_SUGGESTION = 'reject';
     $scope.STATUS_CHOICES = threadStatusDisplayService.STATUS_CHOICES;
@@ -211,7 +211,8 @@ oppia.controller('FeedbackTab', [
             if (result.action === ACTION_ACCEPT_SUGGESTION) {
               var suggestion = $scope.activeThread.suggestion;
               var stateName = suggestion.state_name;
-              var state = explorationData.data.states[stateName];
+              var stateDict = explorationData.data.states[stateName];
+              var state = StateObjectFactory.create(stateName, stateDict); 
               state.content[0].value = suggestion.state_content.value;
               explorationData.data.version += 1;
               explorationStatesService.setState(stateName, state);

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
@@ -212,7 +212,7 @@ oppia.controller('FeedbackTab', [
               var suggestion = $scope.activeThread.suggestion;
               var stateName = suggestion.state_name;
               var stateDict = explorationData.data.states[stateName];
-              var state = StateObjectFactory.create(stateName, stateDict); 
+              var state = StateObjectFactory.create(stateName, stateDict);
               state.content[0].value = suggestion.state_content.value;
               explorationData.data.version += 1;
               explorationStatesService.setState(stateName, state);


### PR DESCRIPTION
Fix a bug where some state data in the feedback data isn't converted into State objects, causing features in the feedback tab to break. This should allow @arun1595 to continue with #3050 .
