### PR TITLE
Convert GLOBALS to AJAX for collection editor permissions

### DIFF
--- a/core/controllers/collection_editor.py
+++ b/core/controllers/collection_editor.py
@@ -105,7 +105,6 @@ class CollectionEditorPage(CollectionEditorHandler):
         self.values.update({
             'collection_id': collection.id,
             'nav_mode': feconf.NAV_MODE_CREATE,
-            'title': collection.title,
             'SHOW_COLLECTION_NAVIGATION_TAB_HISTORY': (
                 feconf.SHOW_COLLECTION_NAVIGATION_TAB_HISTORY),
             'SHOW_COLLECTION_NAVIGATION_TAB_STATS': (
@@ -243,7 +242,6 @@ class CollectionRightsHandler(CollectionEditorHandler):
             'owner_names': rights_manager.get_collection_owner_names(
                 collection_id)
         })
-
 
 
 class ExplorationMetadataSearchHandler(base.BaseHandler):

--- a/core/controllers/collection_editor.py
+++ b/core/controllers/collection_editor.py
@@ -103,15 +103,8 @@ class CollectionEditorPage(CollectionEditorHandler):
             collection_id, strict=False)
 
         self.values.update({
-            'can_edit': True,
-            'can_unpublish': rights_manager.Actor(
-                self.user_id).can_unpublish(
-                    feconf.ACTIVITY_TYPE_COLLECTION, collection_id),
             'collection_id': collection.id,
-            'is_private': rights_manager.is_collection_private(collection_id),
             'nav_mode': feconf.NAV_MODE_CREATE,
-            'owner_names': rights_manager.get_collection_owner_names(
-                collection_id),
             'title': collection.title,
             'SHOW_COLLECTION_NAVIGATION_TAB_HISTORY': (
                 feconf.SHOW_COLLECTION_NAVIGATION_TAB_HISTORY),
@@ -191,6 +184,24 @@ class CollectionRightsHandler(CollectionEditorHandler):
     """Handles management of collection editing rights."""
 
     @require_editor
+    def get(self, collection_id):
+        """Gets the editing rights for the given collection."""
+        collection = collection_services.get_collection_by_id(collection_id)
+
+        self.values.update({
+            'can_edit': True,
+            'can_unpublish': rights_manager.Actor(
+                self.user_id).can_unpublish(
+                    feconf.ACTIVITY_TYPE_COLLECTION, collection_id),
+            'collection_id': collection.id,
+            'is_private': rights_manager.is_collection_private(collection_id),
+            'owner_names': rights_manager.get_collection_owner_names(
+                collection_id)
+        })
+
+        self.render_json(self.values)
+
+    @require_editor
     def put(self, collection_id):
         """Updates the editing rights for the given collection."""
         collection = collection_services.get_collection_by_id(collection_id)
@@ -222,10 +233,17 @@ class CollectionRightsHandler(CollectionEditorHandler):
                 raise self.InvalidInputException(
                     'Cannot unpublish a collection.')
 
-        self.render_json({
-            'rights': rights_manager.get_collection_rights(
-                collection_id).to_dict()
+        self.values.update({
+            'can_edit': True,
+            'can_unpublish': rights_manager.Actor(
+                self.user_id).can_unpublish(
+                    feconf.ACTIVITY_TYPE_COLLECTION, collection_id),
+            'collection_id': collection.id,
+            'is_private': rights_manager.is_collection_private(collection_id),
+            'owner_names': rights_manager.get_collection_owner_names(
+                collection_id)
         })
+
 
 
 class ExplorationMetadataSearchHandler(base.BaseHandler):

--- a/core/controllers/collection_editor_test.py
+++ b/core/controllers/collection_editor_test.py
@@ -24,9 +24,6 @@ import feconf
 
 class BaseCollectionEditorControllerTest(test_utils.GenericTestBase):
 
-    CAN_EDIT_STR = 'GLOBALS.canEdit = JSON.parse(\'true\');'
-    CANNOT_EDIT_STR = 'GLOBALS.canEdit = JSON.parse(\'false\');'
-
     def setUp(self):
         """Completes the sign-up process for self.EDITOR_EMAIL."""
         super(BaseCollectionEditorControllerTest, self).setUp()
@@ -51,21 +48,6 @@ class BaseCollectionEditorControllerTest(test_utils.GenericTestBase):
                 'new_value': 'A new title'
             }]
         }
-
-    def assert_can_edit(self, response_body):
-        """Returns True if the response body indicates that the collection is
-        editable.
-        """
-        self.assertIn(self.CAN_EDIT_STR, response_body)
-        self.assertNotIn(self.CANNOT_EDIT_STR, response_body)
-
-    def assert_cannot_edit(self, response_body):
-        """Returns True if the response body indicates that the collection is
-        not editable.
-        """
-        self.assertIn(self.CANNOT_EDIT_STR, response_body)
-        self.assertNotIn(self.CAN_EDIT_STR, response_body)
-
 
 class CollectionEditorTest(BaseCollectionEditorControllerTest):
     COLLECTION_ID = '0'
@@ -106,7 +88,6 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
                        self.COLLECTION_ID))
         self.assertEqual(response.status_int, 200)
         self.assertIn('Introduction to Collections in Oppia', response.body)
-        self.assert_can_edit(response.body)
         self.logout()
 
     def test_editable_collection_handler_get(self):
@@ -226,3 +207,28 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
         collection_rights = rights_manager.get_collection_rights(collection_id)
         self.assertEqual(collection_rights.status,
                          rights_manager.ACTIVITY_STATUS_PRIVATE)
+
+    def test_get_collection_rights(self):
+        whitelisted_usernames = [self.OWNER_USERNAME]
+        self.set_config_property(
+            config_domain.WHITELISTED_COLLECTION_EDITOR_USERNAMES,
+            whitelisted_usernames)
+
+        self.login(self.OWNER_EMAIL)
+
+        collection_id = 'collection_id'
+        collection = collection_domain.Collection.create_default_collection(
+            collection_id, 'A title', 'A Category', 'An Objective')
+        collection_services.save_new_collection(self.owner_id, collection)
+
+        # Check that collection is published correctly.
+        rights_manager.publish_collection(self.owner_id, collection_id)
+
+        json_response = self.get_json(
+            '%s/%s' % (feconf.COLLECTION_RIGHTS_PREFIX, self.COLLECTION_ID))
+
+        self.assertTrue(json_response['can_edit'])
+        self.assertFalse(json_response['can_unpublish'])
+        self.assertEqual(self.COLLECTION_ID, json_response['collection_id'])
+        self.assertFalse(json_response['is_private'])
+        self.logout()

--- a/core/controllers/collection_editor_test.py
+++ b/core/controllers/collection_editor_test.py
@@ -86,6 +86,10 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
             '%s/%s' % (feconf.COLLECTION_EDITOR_URL_PREFIX,
                        self.COLLECTION_ID))
         self.assertEqual(response.status_int, 200)
+
+        json_response = self.get_json(
+            '%s/%s' % (feconf.COLLECTION_RIGHTS_PREFIX, self.COLLECTION_ID))
+        self.assertTrue(json_response['can_edit'])
         self.logout()
 
     def test_editable_collection_handler_get(self):

--- a/core/controllers/collection_editor_test.py
+++ b/core/controllers/collection_editor_test.py
@@ -72,7 +72,6 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
             '%s/%s?v=1' % (feconf.COLLECTION_DATA_URL_PREFIX,
                            self.COLLECTION_ID))
         self.assertEqual(response.status_int, 200)
-        self.assertIn('Introduction to Collections in Oppia', response.body)
 
         # Check that non-editors cannot access the editor page. This is due
         # to them not being whitelisted.
@@ -87,7 +86,6 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
             '%s/%s' % (feconf.COLLECTION_EDITOR_URL_PREFIX,
                        self.COLLECTION_ID))
         self.assertEqual(response.status_int, 200)
-        self.assertIn('Introduction to Collections in Oppia', response.body)
         self.logout()
 
     def test_editable_collection_handler_get(self):
@@ -111,9 +109,6 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
             '%s/%s' % (feconf.EDITABLE_COLLECTION_DATA_URL_PREFIX,
                        self.COLLECTION_ID))
         self.assertEqual(self.COLLECTION_ID, json_response['collection']['id'])
-        self.assertEqual(
-            'Introduction to Collections in Oppia',
-            json_response['collection']['title'])
         self.logout()
 
     def test_editable_collection_handler_put_cannot_access(self):
@@ -178,8 +173,6 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
 
         self.assertEqual(self.COLLECTION_ID, json_response['collection']['id'])
         self.assertEqual(2, json_response['collection']['version'])
-        self.assertEqual(
-            'A new title', json_response['collection']['title'])
         self.logout()
 
     def test_collection_rights_handler(self):

--- a/core/templates/dev/head/domain/collection/CollectionRightsBackendApiService.js
+++ b/core/templates/dev/head/domain/collection/CollectionRightsBackendApiService.js
@@ -17,9 +17,31 @@
  */
 
 oppia.factory('CollectionRightsBackendApiService', [
-    '$http', '$q', 'COLLECTION_RIGHTS_URL_TEMPLATE', 'UrlInterpolationService',
-    function($http, $q, COLLECTION_RIGHTS_URL_TEMPLATE,
+    '$http', '$log', '$q', 'COLLECTION_RIGHTS_URL_TEMPLATE',
+    'UrlInterpolationService',
+    function($http, $log, $q, COLLECTION_RIGHTS_URL_TEMPLATE,
       UrlInterpolationService) {
+      // Maps previously loaded collection rights to their IDs.
+      var collectionRightsCache = {};
+
+      var _fetchCollectionRights = function(collectionId, successCallback,
+        errorCallback) {
+        var collectionRightsUrl = UrlInterpolationService.interpolateUrl(
+          COLLECTION_RIGHTS_URL_TEMPLATE, {
+            collection_id: collectionId
+          });
+
+        $http.get(collectionRightsUrl).then(function(response) {
+          if (successCallback) {
+            successCallback(response.data);
+          }
+        }, function(errorResponse) {
+          if (errorCallback) {
+            errorCallback(errorResponse.data);
+          }
+        });
+      };
+
       var _setCollectionStatus = function(
           collectionId, collectionVersion, isPublic, successCallback,
           errorCallback) {
@@ -32,12 +54,18 @@ oppia.factory('CollectionRightsBackendApiService', [
           version: collectionVersion,
           is_public: isPublic
         };
-        $http.put(collectionRightsUrl, putParams).then(function() {
-          // TODO(bhenning): Consolidate the backend rights domain objects and
-          // implement a frontend activity rights domain object. The rights
-          // being passed in here should be used to create one of those objects.
-          if (successCallback) {
-            successCallback();
+        $http.put(collectionRightsUrl, putParams).then(function(response) {
+          // Check if the response from the backend does not contradict
+          // putParams.
+          if (response.data.is_private === isPublic) {
+            if (errorCallback) {
+              errorCallback(response.data);
+            }
+          } else {
+            collectionRightsCache[collectionId] = response.data;
+            if (successCallback) {
+              successCallback(collectionRightsCache[collectionId]);
+            }
           }
         }, function(errorResponse) {
           if (errorCallback) {
@@ -46,7 +74,64 @@ oppia.factory('CollectionRightsBackendApiService', [
         });
       };
 
+      var _isCached = function(collectionId) {
+        return collectionId in collectionRightsCache;
+      };
+
       return {
+        /**
+         * Gets a collection's rights, given its ID.
+         */
+        fetchCollectionRights: function(collectionId) {
+          return $q(function(resolve, reject) {
+            _fetchCollectionRights(collectionId, resolve, reject);
+          });
+        },
+
+        /**
+         * Behaves in the exactly as fetchCollectionRights (including callback
+         * behavior and returning a promise object), except this function will
+         * attempt to see whether the given collection rights has already been
+         * loaded. If it has not yet been loaded, it will fetch the collection
+         * rights from the backend. If it successfully retrieves the collection
+         * rights from the backend, it will store it in the cache to avoid
+         * requests from the backend in further function calls.
+         */
+        loadCollectionRights: function(collectionId) {
+          return $q(function(resolve, reject) {
+            if (_isCached(collectionId)) {
+              if (resolve) {
+                resolve(collectionRightsCache[collectionId]);
+              }
+            } else {
+              _fetchCollectionRights(collectionId, function(collectionRights) {
+                // Save the fetched collection rights to avoid future fetches.
+                collectionRightsCache[collectionId] = collectionRights;
+                if (resolve) {
+                  resolve(collectionRightsCache[collectionId]);
+                }
+              }, reject);
+            }
+          });
+        },
+
+        /**
+         * Returns whether the given collection rights is stored within the
+         * local data cache or if it needs to be retrieved from the backend
+         * upon a laod.
+         */
+        isCached: function(collectionId) {
+          return _isCached(collectionId);
+        },
+
+        /**
+         * Replaces the current collection rights in the cache given by the
+         * specified collection ID with a new collection rights object.
+         */
+        cacheCollectionRights: function(collectionId, collectionRights) {
+          collectionRightsCache[collectionId] = angular.copy(collectionRights);
+        },
+
         /**
          * Updates a collection's rights to be have public learner access, given
          * its ID and version.

--- a/core/templates/dev/head/domain/collection/CollectionRightsBackendApiService.js
+++ b/core/templates/dev/head/domain/collection/CollectionRightsBackendApiService.js
@@ -89,10 +89,10 @@ oppia.factory('CollectionRightsBackendApiService', [
         },
 
         /**
-         * Behaves in the exactly as fetchCollectionRights (including callback
+         * Behaves exactly as fetchCollectionRights (including callback
          * behavior and returning a promise object), except this function will
-         * attempt to see whether the given collection rights has already been
-         * loaded. If it has not yet been loaded, it will fetch the collection
+         * attempt to see whether the given collection rights has been
+         * cached. If it has not yet been cached, it will fetch the collection
          * rights from the backend. If it successfully retrieves the collection
          * rights from the backend, it will store it in the cache to avoid
          * requests from the backend in further function calls.

--- a/core/templates/dev/head/domain/collection/CollectionRightsBackendApiServiceSpec.js
+++ b/core/templates/dev/head/domain/collection/CollectionRightsBackendApiServiceSpec.js
@@ -47,8 +47,11 @@ describe('Collection rights backend API service', function() {
     // PUT request. The typical expect() syntax with a passed-in object payload
     // does not seem to be working correctly.
     $httpBackend.expect(
-      'PUT', '/collection_editor_handler/rights/0').respond(
-      200);
+      'PUT', '/collection_editor_handler/rights/0').respond(200, {
+        data: {
+          is_private: false
+        }
+      });
     CollectionRightsBackendApiService.setCollectionPublic('0', 1).then(
       successHandler, failHandler);
     $httpBackend.flush();
@@ -72,5 +75,61 @@ describe('Collection rights backend API service', function() {
 
     expect(successHandler).not.toHaveBeenCalled();
     expect(failHandler).toHaveBeenCalled();
+  });
+
+  it('should call the provided fail handler if isPrivate response is false ' +
+     'when setting collection public', function() {
+    var successHandler = jasmine.createSpy('success');
+    var failHandler = jasmine.createSpy('fail');
+
+    $httpBackend.expect(
+      'PUT', '/collection_editor_handler/rights/0').respond(200, {
+        is_private: true
+      });
+    CollectionRightsBackendApiService.setCollectionPublic('0', 1).then(
+      successHandler, failHandler);
+    $httpBackend.flush();
+    $rootScope.$digest();
+
+    expect(successHandler).not.toHaveBeenCalled();
+    expect(failHandler).toHaveBeenCalled();
+  });
+
+  it('should report a cached collection rights after caching it', function() {
+    var successHandler = jasmine.createSpy('success');
+    var failHandler = jasmine.createSpy('fail');
+
+    // The collection should not currently be cached.
+    expect(CollectionRightsBackendApiService.isCached('0')).toBeFalsy();
+
+    // Cache a collection.
+    CollectionRightsBackendApiService.cacheCollectionRights('0', {
+      collection_id: 0,
+      can_edit: true,
+      can_unpublish: false,
+      is_private: true,
+      owner_names: ['A']
+    });
+
+    // It should now be cached.
+    expect(CollectionRightsBackendApiService.isCached('0')).toBeTruthy();
+
+    // A new collection should not have been fetched from the backend. Also,
+    // the returned collection should match the expected collection object.
+    CollectionRightsBackendApiService.loadCollectionRights('0').then(
+      successHandler, failHandler);
+
+    // http://brianmcd.com/2014/03/27/
+    // a-tip-for-angular-unit-tests-with-promises.html
+    $rootScope.$digest();
+
+    expect(successHandler).toHaveBeenCalledWith({
+      collection_id: 0,
+      can_edit: true,
+      can_unpublish: false,
+      is_private: true,
+      owner_names: ['A']
+    });
+    expect(failHandler).not.toHaveBeenCalled();
   });
 });

--- a/core/templates/dev/head/domain/collection/CollectionRightsBackendApiServiceSpec.js
+++ b/core/templates/dev/head/domain/collection/CollectionRightsBackendApiServiceSpec.js
@@ -100,7 +100,7 @@ describe('Collection rights backend API service', function() {
     var failHandler = jasmine.createSpy('fail');
 
     // The collection should not currently be cached.
-    expect(CollectionRightsBackendApiService.isCached('0')).toBeFalsy();
+    expect(CollectionRightsBackendApiService.isCached('0')).toBe(false);
 
     // Cache a collection.
     CollectionRightsBackendApiService.cacheCollectionRights('0', {
@@ -112,7 +112,7 @@ describe('Collection rights backend API service', function() {
     });
 
     // It should now be cached.
-    expect(CollectionRightsBackendApiService.isCached('0')).toBeTruthy();
+    expect(CollectionRightsBackendApiService.isCached('0')).toBe(true);
 
     // A new collection should not have been fetched from the backend. Also,
     // the returned collection should match the expected collection object.

--- a/core/templates/dev/head/domain/collection/CollectionRightsObjectFactory.js
+++ b/core/templates/dev/head/domain/collection/CollectionRightsObjectFactory.js
@@ -1,0 +1,110 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Factory for creating and mutating instances of frontend
+ * collection rights domain objects.
+ */
+
+oppia.factory('CollectionRightsObjectFactory', [
+    function() {
+    var CollectionRights = function(collectionRightsObject) {
+      this._collectionId = collectionRightsObject.collection_id;
+      this._canEdit = collectionRightsObject.can_edit;
+      this._canUnpublish = collectionRightsObject.can_unpublish;
+      this._isPrivate = collectionRightsObject.is_private;
+      this._ownerNames = collectionRightsObject.owner_names;
+    };
+
+    // Instance methods
+
+    CollectionRights.prototype.getCollectionId = function() {
+      return this._collectionId;
+    };
+
+    // Returns true if the the user can edit the collection. This property is
+    // immutable.
+    CollectionRights.prototype.canEdit = function() {
+      return this._canEdit;
+    };
+
+    // Returns true if the user can unpublish the collection.
+    CollectionRights.prototype.canUnpublish = function() {
+      return this._canUnpublish;
+    };
+
+    // Returns true if the collection is private.
+    CollectionRights.prototype.isPrivate = function() {
+      return this._isPrivate;
+    };
+
+    // Returns true if the collection is public.
+    CollectionRights.prototype.isPublic = function() {
+      return !this._isPrivate;
+    };
+
+    CollectionRights.prototype.setPublic = function() {
+      if (this._canEdit) {
+        this._isPrivate = false;
+      } else {
+        throw new Error('User is not allowed to edit this collection.');
+      }
+    };
+
+    // Sets isPrivate to true only if canUnpublish in is true.
+    CollectionRights.prototype.setPrivate = function() {
+      if (this.canUnpublish()) {
+        this._isPrivate = true;
+      } else {
+        throw new Error('User is not allowed to unpublish this collection.');
+      }
+    };
+
+    // Returns the owner names of the collection. This property is immutable.
+    CollectionRights.prototype.getOwnerNames = function() {
+      return angular.copy(this._ownerNames);
+    };
+
+    // Static class methods. Note that "this" is not available in static
+    // contexts. This function takes a JSON object which represents a backend
+    // collection python dict.
+    CollectionRights.create = function(collectionRightsBackendObject) {
+      return new CollectionRights(angular.copy(collectionRightsBackendObject));
+    };
+
+    // Reassigns all values within this collection to match the existing
+    // collection rights. This is performed as a deep copy such that none of the
+    // internal, bindable objects are changed within this collection rights.
+    // Note that the collection nodes within this collection will be completely
+    // redefined as copies from the specified collection rights
+    CollectionRights.prototype.copyFromCollectionRights = function(
+      otherCollectionRights) {
+      this._collectionId = otherCollectionRights.getCollectionId();
+      this._canEdit = otherCollectionRights.canEdit();
+      this._isPrivate = otherCollectionRights.isPrivate();
+      this._canUnpublish = otherCollectionRights.canUnpublish();
+      this._ownerNames = otherCollectionRights.getOwnerNames();
+    };
+
+    // Create a new, empty collection rights. This is not guaranteed to pass
+    // validation tests.
+    CollectionRights.createEmptyCollectionRights = function() {
+      return new CollectionRights({
+        owner_names: []
+      });
+    };
+
+    return CollectionRights;
+  }
+]);

--- a/core/templates/dev/head/domain/collection/CollectionRightsObjectFactory.js
+++ b/core/templates/dev/head/domain/collection/CollectionRightsObjectFactory.js
@@ -54,7 +54,8 @@ oppia.factory('CollectionRightsObjectFactory', [
       return !this._isPrivate;
     };
 
-    // Sets isPrivate to false only if canEdit in is true.
+    // Sets isPrivate to false only if the user can edit the corresponding
+    // collection.
     CollectionRights.prototype.setPublic = function() {
       if (this.canEdit()) {
         this._isPrivate = false;

--- a/core/templates/dev/head/domain/collection/CollectionRightsObjectFactory.js
+++ b/core/templates/dev/head/domain/collection/CollectionRightsObjectFactory.js
@@ -54,17 +54,18 @@ oppia.factory('CollectionRightsObjectFactory', [
       return !this._isPrivate;
     };
 
+    // Sets isPrivate to false only if canEdit in is true.
     CollectionRights.prototype.setPublic = function() {
-      if (this._canEdit) {
+      if (this.canEdit()) {
         this._isPrivate = false;
       } else {
         throw new Error('User is not allowed to edit this collection.');
       }
     };
 
-    // Sets isPrivate to true only if canUnpublish in is true.
+    // Sets isPrivate to true only if canUnpublish and canEdit are both true.
     CollectionRights.prototype.setPrivate = function() {
-      if (this.canUnpublish()) {
+      if (this.canEdit() && this.canUnpublish()) {
         this._isPrivate = true;
       } else {
         throw new Error('User is not allowed to unpublish this collection.');
@@ -74,6 +75,16 @@ oppia.factory('CollectionRightsObjectFactory', [
     // Returns the owner names of the collection. This property is immutable.
     CollectionRights.prototype.getOwnerNames = function() {
       return angular.copy(this._ownerNames);
+    };
+
+    // Returns the reference to the internal ownerNames array; this function is
+    // only meant to be used for Angular bindings and should never be used in
+    // code. Please use getOwnerNames() and related functions, instead. Please
+    // also be aware this exposes internal state of the collection rights domain
+    // object, so changes to the array itself may internally break the domain
+    // object.
+    CollectionRights.prototype.getBindableOwnerNames = function() {
+      return this._ownerNames;
     };
 
     // Static class methods. Note that "this" is not available in static
@@ -97,8 +108,8 @@ oppia.factory('CollectionRightsObjectFactory', [
       this._ownerNames = otherCollectionRights.getOwnerNames();
     };
 
-    // Create a new, empty collection rights. This is not guaranteed to pass
-    // validation tests.
+    // Create a new, empty collection rights object. This is not guaranteed to
+    // pass validation tests.
     CollectionRights.createEmptyCollectionRights = function() {
       return new CollectionRights({
         owner_names: []

--- a/core/templates/dev/head/domain/collection/CollectionRightsObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/collection/CollectionRightsObjectFactorySpec.js
@@ -1,0 +1,165 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Tests for CollectionRightsObjectFactory.
+ */
+
+describe('Collection rights object factory', function() {
+  var CollectionRightsObjectFactory = null;
+
+  beforeEach(module('oppia'));
+
+  beforeEach(inject(function($injector) {
+    CollectionRightsObjectFactory = $injector.get(
+      'CollectionRightsObjectFactory');
+  }));
+
+  it('should not be able to modify owner names', function() {
+    var initialCollectionRightsBackendObject = {
+      collection_id: 0,
+      can_edit: true,
+      can_unpublish: false,
+      is_private: true,
+      owner_names: ['A']
+    };
+
+    sampleCollectionRights = CollectionRightsObjectFactory.create(
+      initialCollectionRightsBackendObject);
+    var ownerNames = sampleCollectionRights.getOwnerNames();
+    ownerNames.push('B');
+
+    expect(sampleCollectionRights.getOwnerNames()).toEqual(['A']);
+  });
+
+  it('should be able to set public when canEdit is true', function() {
+    var initialCollectionRightsBackendObject = {
+      collection_id: 0,
+      can_edit: true,
+      can_unpublish: false,
+      is_private: true,
+      owner_names: ['A']
+    };
+
+    sampleCollectionRights = CollectionRightsObjectFactory.create(
+      initialCollectionRightsBackendObject);
+    expect(sampleCollectionRights.isPrivate()).toBe(true);
+    expect(sampleCollectionRights.isPublic()).toBe(false);
+
+    sampleCollectionRights.setPublic();
+    expect(sampleCollectionRights.isPrivate()).toBe(false);
+    expect(sampleCollectionRights.isPublic()).toBe(true);
+  });
+
+  it('should throw error and not be able to set public when canEdit is false',
+     function() {
+    var initialCollectionRightsBackendObject = {
+      collection_id: 0,
+      can_edit: false,
+      can_unpublish: false,
+      is_private: true,
+      owner_names: ['A']
+    };
+
+    sampleCollectionRights = CollectionRightsObjectFactory.create(
+      initialCollectionRightsBackendObject);
+    expect(sampleCollectionRights.isPrivate()).toBe(true);
+    expect(sampleCollectionRights.isPublic()).toBe(false);
+
+    expect(function() {
+      sampleCollectionRights.setPublic();
+    }).toThrow(new Error('User is not allowed to edit this collection.'));
+    expect(sampleCollectionRights.isPrivate()).toBe(true);
+    expect(sampleCollectionRights.isPublic()).toBe(false);
+  });
+
+  it('should be able to set private when canUnpublish is true', function() {
+    var initialCollectionRightsBackendObject = {
+      collection_id: 0,
+      can_edit: true,
+      can_unpublish: true,
+      is_private: false,
+      owner_names: ['A']
+    };
+
+    sampleCollectionRights = CollectionRightsObjectFactory.create(
+      initialCollectionRightsBackendObject);
+    expect(sampleCollectionRights.isPrivate()).toBe(false);
+    expect(sampleCollectionRights.isPublic()).toBe(true);
+
+    sampleCollectionRights.setPrivate();
+    expect(sampleCollectionRights.isPrivate()).toBe(true);
+    expect(sampleCollectionRights.isPublic()).toBe(false);
+  });
+
+  it('should throw error when when canUnpublish is false during unpublishing',
+     function() {
+    var noUnpublishCollectionRightsBackendObject = {
+      collection_id: 0,
+      can_edit: true,
+      can_unpublish: false,
+      is_private: false,
+      owner_names: ['A']
+    };
+
+    sampleCollectionRights = CollectionRightsObjectFactory.create(
+      noUnpublishCollectionRightsBackendObject);
+    expect(sampleCollectionRights.isPrivate()).toBe(false);
+    expect(sampleCollectionRights.isPublic()).toBe(true);
+
+    expect(function() {
+      sampleCollectionRights.setPrivate();
+    }).toThrow(new Error('User is not allowed to unpublish this collection.'));
+
+    // Verify that the status remains unchanged.
+    expect(sampleCollectionRights.isPrivate()).toBe(false);
+    expect(sampleCollectionRights.isPublic()).toBe(true);
+  });
+
+  it('should create an empty collection rights object', function() {
+    var emptyCollectionRightsBackendObject = (
+      CollectionRightsObjectFactory.createEmptyCollectionRights());
+
+    expect(
+      emptyCollectionRightsBackendObject.getCollectionId()).toBeUndefined();
+    expect(emptyCollectionRightsBackendObject.canEdit()).toBeUndefined();
+    expect(emptyCollectionRightsBackendObject.canUnpublish()).toBeUndefined();
+    expect(emptyCollectionRightsBackendObject.isPrivate()).toBeUndefined();
+    expect(emptyCollectionRightsBackendObject.getOwnerNames()).toEqual([]);
+  });
+
+  it('should make a copy from another collection rights', function() {
+    var noUnpublishCollectionRightsBackendObject = {
+      collection_id: 0,
+      can_edit: true,
+      can_unpublish: false,
+      is_private: false,
+      owner_names: ['A']
+    };
+
+    sampleCollectionRights = CollectionRightsObjectFactory.create(
+      noUnpublishCollectionRightsBackendObject);
+
+    var emptyCollectionRightsBackendObject = (
+      CollectionRightsObjectFactory.createEmptyCollectionRights());
+
+    emptyCollectionRightsBackendObject.copyFromCollectionRights(
+      sampleCollectionRights);
+    expect(emptyCollectionRightsBackendObject.getCollectionId()).toEqual(0);
+    expect(emptyCollectionRightsBackendObject.canEdit()).toBe(true);
+    expect(emptyCollectionRightsBackendObject.canUnpublish()).toBe(false);
+    expect(emptyCollectionRightsBackendObject.isPrivate()).toBe(false);
+    expect(emptyCollectionRightsBackendObject.getOwnerNames()).toEqual(['A']);
+  });
+});

--- a/core/templates/dev/head/domain/collection/CollectionRightsObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/collection/CollectionRightsObjectFactorySpec.js
@@ -43,6 +43,24 @@ describe('Collection rights object factory', function() {
     expect(sampleCollectionRights.getOwnerNames()).toEqual(['A']);
   });
 
+  it('should accept accept changes to the bindable list of collection nodes',
+     function() {
+    var initialCollectionRightsBackendObject = {
+      collection_id: 0,
+      can_edit: true,
+      can_unpublish: false,
+      is_private: true,
+      owner_names: ['A']
+    };
+
+    sampleCollectionRights = CollectionRightsObjectFactory.create(
+      initialCollectionRightsBackendObject);
+    var ownerNames = sampleCollectionRights.getBindableOwnerNames();
+    ownerNames.push('B');
+
+    expect(sampleCollectionRights.getOwnerNames()).toEqual(['A', 'B']);
+  });
+
   it('should be able to set public when canEdit is true', function() {
     var initialCollectionRightsBackendObject = {
       collection_id: 0,

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
@@ -39,7 +39,7 @@ oppia.directive('collectionEditorNavbar', [function() {
         $scope.collectionRights = (
           CollectionEditorStateService.getCollectionRights());
 
-        $scope.isCollectionLoading = (
+        $scope.isLoadingCollection = (
           CollectionEditorStateService.isLoadingCollection);
         $scope.validationIssues = [];
         $scope.isSaveInProgress = (

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
@@ -36,8 +36,10 @@ oppia.directive('collectionEditorNavbar', [function() {
           EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED) {
         $scope.collectionId = GLOBALS.collectionId;
         $scope.collection = CollectionEditorStateService.getCollection();
-        $scope.isPrivate = GLOBALS.isPrivate;
-        $scope.canUnpublish = GLOBALS.canUnpublish;
+        $scope.collectionRights = (
+          CollectionEditorStateService.getCollectionRights());
+
+        $scope.isPageLoading = CollectionEditorStateService.isLoadingCollection;
         $scope.validationIssues = [];
         $scope.isSaveInProgress = (
           CollectionEditorStateService.isSavingCollection);
@@ -50,7 +52,7 @@ oppia.directive('collectionEditorNavbar', [function() {
         $scope.selectHistoryTab = routerService.navigateToHistoryTab;
 
         var _validateCollection = function() {
-          if ($scope.isPrivate) {
+          if ($scope.collectionRights.isPrivate()) {
             $scope.validationIssues = (
               CollectionValidationService
                 .findValidationIssuesForPrivateCollection(
@@ -72,7 +74,9 @@ oppia.directive('collectionEditorNavbar', [function() {
               // TODO(bhenning): There should be a scope-level rights object
               // used, instead. The rights object should be loaded with the
               // collection.
-              $scope.isPrivate = false;
+              $scope.collectionRights.setPublic();
+              CollectionEditorStateService.setCollectionRights(
+                $scope.collectionRights);
             }, function() {
               alertsService.addWarning(
                 'There was an error when publishing the collection.');
@@ -100,13 +104,13 @@ oppia.directive('collectionEditorNavbar', [function() {
 
         $scope.isCollectionPublishable = function() {
           return (
-            $scope.isPrivate &&
+            $scope.collectionRights.isPrivate() &&
             $scope.getChangeListCount() === 0 &&
             $scope.validationIssues.length === 0);
         };
 
         $scope.saveChanges = function() {
-          var isPrivate = $scope.isPrivate;
+          var isPrivate = $scope.collectionRights.isPrivate();
           var modalInstance = $modal.open({
             templateUrl: 'modals/saveCollection',
             backdrop: true,
@@ -229,7 +233,9 @@ oppia.directive('collectionEditorNavbar', [function() {
           CollectionRightsBackendApiService.setCollectionPrivate(
             $scope.collectionId, $scope.collection.getVersion()).then(
             function() {
-              $scope.isPrivate = true;
+              $scope.collectionRights.setPrivate();
+              CollectionEditorStateService.setCollectionRights(
+                $scope.collectionRights);
             }, function() {
               alertsService.addWarning(
                 'There was an error when unpublishing the collection.');

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
@@ -39,7 +39,8 @@ oppia.directive('collectionEditorNavbar', [function() {
         $scope.collectionRights = (
           CollectionEditorStateService.getCollectionRights());
 
-        $scope.isPageLoading = CollectionEditorStateService.isLoadingCollection;
+        $scope.isCollectionLoading = (
+          CollectionEditorStateService.isLoadingCollection);
         $scope.validationIssues = [];
         $scope.isSaveInProgress = (
           CollectionEditorStateService.isSavingCollection);
@@ -71,9 +72,6 @@ oppia.directive('collectionEditorNavbar', [function() {
           CollectionRightsBackendApiService.setCollectionPublic(
             $scope.collectionId, $scope.collection.getVersion()).then(
             function() {
-              // TODO(bhenning): There should be a scope-level rights object
-              // used, instead. The rights object should be loaded with the
-              // collection.
               $scope.collectionRights.setPublic();
               CollectionEditorStateService.setCollectionRights(
                 $scope.collectionRights);

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorStateService.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorStateService.js
@@ -24,15 +24,19 @@ oppia.constant('EVENT_COLLECTION_REINITIALIZED', 'collectionReinitialized');
 
 oppia.factory('CollectionEditorStateService', [
   '$rootScope', 'alertsService', 'CollectionObjectFactory',
+  'CollectionRightsBackendApiService', 'CollectionRightsObjectFactory',
   'SkillListObjectFactory', 'UndoRedoService',
   'EditableCollectionBackendApiService', 'EVENT_COLLECTION_INITIALIZED',
   'EVENT_COLLECTION_REINITIALIZED', 'EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED',
   function(
       $rootScope, alertsService, CollectionObjectFactory,
+      CollectionRightsBackendApiService, CollectionRightsObjectFactory,
       SkillListObjectFactory, UndoRedoService,
       EditableCollectionBackendApiService, EVENT_COLLECTION_INITIALIZED,
       EVENT_COLLECTION_REINITIALIZED, EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED) {
     var _collection = CollectionObjectFactory.createEmptyCollection();
+    var _collectionRights = (
+      CollectionRightsObjectFactory.createEmptyCollectionRights());
     var _collectionSkillList = SkillListObjectFactory.create([]);
     var _collectionIsInitialized = false;
     var _isLoadingCollection = false;
@@ -57,6 +61,19 @@ oppia.factory('CollectionEditorStateService', [
       _setCollection(CollectionObjectFactory.create(
         newBackendCollectionObject));
     };
+    var _setCollectionRights = function(collectionRights) {
+      _collectionRights.copyFromCollectionRights(collectionRights);
+      if (_collectionIsInitialized) {
+        $rootScope.$broadcast(EVENT_COLLECTION_REINITIALIZED);
+      } else {
+        $rootScope.$broadcast(EVENT_COLLECTION_INITIALIZED);
+        _collectionIsInitialized = true;
+      }
+    };
+    var _updateCollectionRights = function(newBackendCollectionRightsObject) {
+      _setCollectionRights(CollectionRightsObjectFactory.create(
+        newBackendCollectionRightsObject));
+    };
 
     // TODO(bhenning): Do this more efficiently by passing the change object
     // and whether it was a forward change from the UndoRedoService through the
@@ -76,12 +93,20 @@ oppia.factory('CollectionEditorStateService', [
           collectionId).then(
           function(newBackendCollectionObject) {
             _updateCollection(newBackendCollectionObject);
-            _isLoadingCollection = false;
           },
           function(error) {
             alertsService.addWarning(
               error || 'There was an error when loading the collection.');
             _isLoadingCollection = false;
+          });
+        CollectionRightsBackendApiService.fetchCollectionRights(
+          collectionId).then(function(newBackendCollectionRightsObject) {
+            _updateCollectionRights(newBackendCollectionRightsObject);
+            _isLoadingCollection = false;
+          }, function(error) {
+            alertsService.addWarning(
+              error ||
+              'There was an error when loading the collection rights.');
           });
       },
 
@@ -114,6 +139,18 @@ oppia.factory('CollectionEditorStateService', [
       },
 
       /**
+       * Returns the current collection rights to be shared among the collection
+       * editor. Please note any changes to this collection rights will be
+       * propogated to all bindings to it. This collection rights object will
+       * be retained for the lifetime of the editor. This function never returns
+       * null, though it may return an empty collection rights object if the
+       * collection rights has not yet been loaded for this editor instance.
+       */
+      getCollectionRights: function() {
+        return _collectionRights;
+      },
+
+      /**
        * Sets the collection stored within this service, propogating changes to
        * all bindings to the collection returned by getCollection(). The first
        * time this is called it will fire a global event based on the
@@ -122,6 +159,18 @@ oppia.factory('CollectionEditorStateService', [
        */
       setCollection: function(collection) {
         _setCollection(collection);
+      },
+
+      /**
+       * Sets the collection rights stored within this service, propogating
+       * changes to all bindings to the collection returned by
+       * getCollectionRights(). The first time this is called it will fire a
+       * global event based on the EVENT_COLLECTION_INITIALIZED constant. All
+       * subsequent calls will similarly fire a EVENT_COLLECTION_REINITIALIZED
+       * event.
+       */
+      setCollectionRights: function(collectionRights) {
+        _setCollectionRights(collectionRights);
       },
 
       /**

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorStateService.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorStateService.js
@@ -63,12 +63,6 @@ oppia.factory('CollectionEditorStateService', [
     };
     var _setCollectionRights = function(collectionRights) {
       _collectionRights.copyFromCollectionRights(collectionRights);
-      if (_collectionIsInitialized) {
-        $rootScope.$broadcast(EVENT_COLLECTION_REINITIALIZED);
-      } else {
-        $rootScope.$broadcast(EVENT_COLLECTION_INITIALIZED);
-        _collectionIsInitialized = true;
-      }
     };
     var _updateCollectionRights = function(newBackendCollectionRightsObject) {
       _setCollectionRights(CollectionRightsObjectFactory.create(
@@ -107,6 +101,7 @@ oppia.factory('CollectionEditorStateService', [
             alertsService.addWarning(
               error ||
               'There was an error when loading the collection rights.');
+            _isLoadingCollection = false;
           });
       },
 

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorStateServiceSpec.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorStateServiceSpec.js
@@ -52,14 +52,14 @@ describe('Collection editor state service', function() {
     var _fetchCollectionRights = function() {
       return $q(function(resolve, reject) {
         if (!self.failure) {
-          resolve(self.newBackendCollectionRightsObject);
+          resolve(self.backendCollectionRightsObject);
         } else {
           reject();
         }
       });
     };
 
-    self.newBackendCollectionRightsObject = {};
+    self.backendCollectionRightsObject = {};
     self.failure = null;
     self.fetchCollectionRights = _fetchCollectionRights;
 
@@ -126,16 +126,19 @@ describe('Collection editor state service', function() {
       }]
     };
 
-    fakeCollectionRightsBackendApiService.newBackendCollectionRightsObject = {
+    privateCollectionRightsObject = {
       collection_id: '5',
       can_edit: 'true',
       can_unpublish: 'false',
       is_private: 'true',
       owner_names: ['A']
     };
-    secondBackendCollectionRightsObject = {
+    fakeCollectionRightsBackendApiService.backendCollectionRightsObject = (
+      privateCollectionRightsObject);
+
+    unpublishablePublicCollectionRightsObject = {
       collection_id: '5',
-      can_edit: 'false',
+      can_edit: 'true',
       can_unpublish: 'true',
       is_private: 'false',
       owner_names: ['A']
@@ -153,7 +156,7 @@ describe('Collection editor state service', function() {
   });
 
   it('should request to load the collection rights from the backend',
-    function() {
+      function() {
     spyOn(
       fakeCollectionRightsBackendApiService,
       'fetchCollectionRights').andCallThrough();
@@ -274,7 +277,7 @@ describe('Collection editor state service', function() {
     var previousCollectionRights = (
       CollectionEditorStateService.getCollectionRights());
     var expectedCollectionRights = CollectionRightsObjectFactory.create(
-      fakeCollectionRightsBackendApiService.newBackendCollectionRightsObject);
+      fakeCollectionRightsBackendApiService.backendCollectionRightsObject);
     expect(previousCollectionRights).not.toEqual(expectedCollectionRights);
 
     CollectionEditorStateService.loadCollection(5);
@@ -315,7 +318,7 @@ describe('Collection editor state service', function() {
     var previousCollectionRights = (
       CollectionEditorStateService.getCollectionRights());
     var expectedCollectionRights = CollectionRightsObjectFactory.create(
-      secondBackendCollectionRightsObject);
+      unpublishablePublicCollectionRightsObject);
     expect(previousCollectionRights).not.toEqual(expectedCollectionRights);
 
     CollectionEditorStateService.setCollectionRights(expectedCollectionRights);
@@ -342,22 +345,6 @@ describe('Collection editor state service', function() {
     var newCollection = CollectionObjectFactory.create(
       secondBackendCollectionObject);
     CollectionEditorStateService.setCollection(newCollection);
-
-    expect($rootScope.$broadcast).toHaveBeenCalledWith(
-      'collectionReinitialized');
-  });
-
-  it('should fire an update event after setting the new collection rights',
-      function() {
-    // Load initial collection.
-    CollectionEditorStateService.loadCollection(5);
-    $rootScope.$apply();
-
-    spyOn($rootScope, '$broadcast').andCallThrough();
-
-    var newCollectionRights = CollectionRightsObjectFactory.create(
-      secondBackendCollectionRightsObject);
-    CollectionEditorStateService.setCollectionRights(newCollectionRights);
 
     expect($rootScope.$broadcast).toHaveBeenCalledWith(
       'collectionReinitialized');

--- a/core/templates/dev/head/pages/collection_editor/collection_editor.html
+++ b/core/templates/dev/head/pages/collection_editor/collection_editor.html
@@ -11,12 +11,7 @@
 {% block header_js %}
   {{ super() }}
   <script type="text/javascript">
-    GLOBALS.canEdit = JSON.parse('{{can_edit|js_string}}');
-    GLOBALS.canUnpublish = JSON.parse('{{can_unpublish|js_string}}');
     GLOBALS.collectionId = JSON.parse('{{collection_id|js_string}}');
-    GLOBALS.collectionTitle = JSON.parse('{{title|js_string}}');
-    GLOBALS.ownerNames = JSON.parse('{{owner_names|js_string}}');
-    GLOBALS.isPrivate = JSON.parse('{{is_private|js_string}}');
     GLOBALS.TAG_REGEX = JSON.parse('{{TAG_REGEX|js_string}}');
   </script>
 {% endblock header_js %}
@@ -90,6 +85,7 @@
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/collection/CollectionNodeObjectFactory.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/collection/CollectionObjectFactory.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/collection/CollectionRightsBackendApiService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/domain/collection/CollectionRightsObjectFactory.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/collection/CollectionUpdateService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/collection/CollectionValidationService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/collection/EditableCollectionBackendApiService.js"></script>

--- a/core/templates/dev/head/pages/collection_editor/collection_editor_navbar_directive.html
+++ b/core/templates/dev/head/pages/collection_editor/collection_editor_navbar_directive.html
@@ -55,14 +55,14 @@
     </li>
   </ul>
 
-  <ul class="nav navbar-nav oppia-navbar-nav navbar-right">
+  <ul class="nav navbar-nav oppia-navbar-nav navbar-right" ng-if="!isPageLoading()">
     <li style="margin-right: 10px; margin-top: 8px;">
       <button class="btn btn-default oppia-save-draft-button"
               ng-class="{'btn-success': isCollectionSaveable()}"
               ng-click="saveChanges()"
               ng-disabled="!isCollectionSaveable()">
         <span ng-if="!isSaveInProgress()">
-          <span ng-if="isPrivate">
+          <span ng-if="collectionRights.isPrivate()">
             <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
                alt="Save Collection">&#xE161;</i>
             <span class="oppia-save-publish-button-label">Save Draft</span>
@@ -71,7 +71,7 @@
               (<[getChangeListCount()]>)
             </span>
           </span>
-          <span ng-if="!isPrivate" title="Publish Changes">
+          <span ng-if="!collectionRights.isPrivate()" title="Publish Changes">
             <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
                alt="Publish Changes">&#xE2C3;</i>
             <span class="oppia-save-publish-button-label">Publish Changes</span>
@@ -79,13 +79,13 @@
         </span>
 
         <span ng-if="isSaveInProgress()">
-          <span ng-if="isPrivate" class="oppia-save-publish-button-label">Saving</span>
-          <span ng-if="!isPrivate" class="oppia-save-publish-button-label">Publishing</span>
+          <span ng-if="collectionRights.isPrivate()" class="oppia-save-publish-button-label">Saving</span>
+          <span ng-if="!collectionRights.isPrivate()" class="oppia-save-publish-button-label">Publishing</span>
           <loading-dots></loading-dots>
         </span>
       </button>
 
-      <button type="button" ng-if="isPrivate"
+      <button type="button" ng-if="collectionRights.isPrivate()"
               class="btn btn-default oppia-editor-publish-button"
               ng-class="{'btn-success': isCollectionPublishable()}"
               ng-click="publishCollection()"
@@ -96,7 +96,7 @@
       </button>
 
       <button type="button" ng-click="unpublishCollection()"
-              ng-if="!isPrivate && canUnpublish"
+              ng-if="!collectionRights.isPrivate() && collectionRights.canUnpublish()"
               class="btn btn-default">
         Unpublish (as moderator)
       </button>

--- a/core/templates/dev/head/pages/collection_editor/collection_editor_navbar_directive.html
+++ b/core/templates/dev/head/pages/collection_editor/collection_editor_navbar_directive.html
@@ -55,7 +55,7 @@
     </li>
   </ul>
 
-  <ul class="nav navbar-nav oppia-navbar-nav navbar-right" ng-if="!isCollectionLoading()">
+  <ul class="nav navbar-nav oppia-navbar-nav navbar-right" ng-if="!isLoadingCollection()">
     <li style="margin-right: 10px; margin-top: 8px;">
       <button class="btn btn-default oppia-save-draft-button"
               ng-class="{'btn-success': isCollectionSaveable()}"

--- a/core/templates/dev/head/pages/collection_editor/collection_editor_navbar_directive.html
+++ b/core/templates/dev/head/pages/collection_editor/collection_editor_navbar_directive.html
@@ -55,7 +55,7 @@
     </li>
   </ul>
 
-  <ul class="nav navbar-nav oppia-navbar-nav navbar-right" ng-if="!isPageLoading()">
+  <ul class="nav navbar-nav oppia-navbar-nav navbar-right" ng-if="!isCollectionLoading()">
     <li style="margin-right: 10px; margin-top: 8px;">
       <button class="btn btn-default oppia-save-draft-button"
               ng-class="{'btn-success': isCollectionSaveable()}"
@@ -71,7 +71,7 @@
               (<[getChangeListCount()]>)
             </span>
           </span>
-          <span ng-if="!collectionRights.isPrivate()" title="Publish Changes">
+          <span ng-if="collectionRights.isPublic()" title="Publish Changes">
             <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
                alt="Publish Changes">&#xE2C3;</i>
             <span class="oppia-save-publish-button-label">Publish Changes</span>
@@ -80,7 +80,7 @@
 
         <span ng-if="isSaveInProgress()">
           <span ng-if="collectionRights.isPrivate()" class="oppia-save-publish-button-label">Saving</span>
-          <span ng-if="!collectionRights.isPrivate()" class="oppia-save-publish-button-label">Publishing</span>
+          <span ng-if="collectionRights.isPublic()" class="oppia-save-publish-button-label">Publishing</span>
           <loading-dots></loading-dots>
         </span>
       </button>
@@ -96,7 +96,7 @@
       </button>
 
       <button type="button" ng-click="unpublishCollection()"
-              ng-if="!collectionRights.isPrivate() && collectionRights.canUnpublish()"
+              ng-if="collectionRights.isPublic() && collectionRights.canUnpublish()"
               class="btn btn-default">
         Unpublish (as moderator)
       </button>

--- a/core/templates/dev/head/pages/collection_editor/settings_tab/CollectionPermissionsCardDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/settings_tab/CollectionPermissionsCardDirective.js
@@ -22,10 +22,11 @@ oppia.directive('collectionPermissionsCard', [function() {
     restrict: 'E',
     templateUrl: 'inline/collection_permissions_card_directive',
     controller: [
-      '$scope',
-      function($scope) {
-        $scope.ownerNames = GLOBALS.ownerNames;
-        $scope.isPrivate = GLOBALS.isPrivate;
+      '$scope', 'CollectionEditorStateService',
+      function($scope, CollectionEditorStateService) {
+        $scope.collectionRights =
+          CollectionEditorStateService.getCollectionRights();
+        $scope.hasPageLoaded = CollectionEditorStateService.hasLoadedCollection;
       }
     ]
   };

--- a/core/templates/dev/head/pages/collection_editor/settings_tab/collection_permissions_card_directive.html
+++ b/core/templates/dev/head/pages/collection_editor/settings_tab/collection_permissions_card_directive.html
@@ -1,11 +1,11 @@
 <script type="text/ng-template" id="inline/collection_permissions_card_directive">
-  <md-card class="oppia-page-card oppia-long-text">
+  <md-card class="oppia-page-card oppia-long-text" ng-if="hasPageLoaded()">
     <h2>Collection Permissions</h2>
     <div class="row">
       <div class="col-lg-5 col-md-5 col-sm-5">
         <h3>Managers</h3>
         <ul>
-          <li ng-repeat="ownerName in ownerNames track by $index">
+          <li ng-repeat="ownerName in collectionRights.getOwnerNames() track by $index">
             <[ownerName]>
           </li>
         </ul>
@@ -13,13 +13,13 @@
 
       <div class="col-lg-7 col-md-7 col-sm-7">
         <h3>Permissions</h3>
-        <div ng-if="isPrivate">
+        <div ng-if="collectionRights.isPrivate()">
           This collection is <strong>private</strong>.
           <br>
           <br>
           It is <strong>not shown</strong> in the Oppia library.
         </div>
-        <div ng-if="!isPrivate">
+        <div ng-if="!collectionRights.isPrivate()">
           This collection is <strong>public</strong>: anyone can access it.
           <br>
           <br>

--- a/core/templates/dev/head/pages/collection_editor/settings_tab/collection_permissions_card_directive.html
+++ b/core/templates/dev/head/pages/collection_editor/settings_tab/collection_permissions_card_directive.html
@@ -19,7 +19,7 @@
           <br>
           It is <strong>not shown</strong> in the Oppia library.
         </div>
-        <div ng-if="!collectionRights.isPrivate()">
+        <div ng-if="collectionRights.isPublic()">
           This collection is <strong>public</strong>: anyone can access it.
           <br>
           <br>


### PR DESCRIPTION
Convert collections GLOBALS to AJAX calls. 