### PR TITLE
Remove word-break so that lesson titles don't break unnecessarily across lines.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3924,7 +3924,6 @@ md-card.preview-conversation-skin-supplemental-card {
   margin: 0.3em 0.5em;
   padding: 0.2em;
   position: absolute;
-  word-break: break-all;
 }
 
 .oppia-activity-summary-tile .objective {


### PR DESCRIPTION
Note: Reverts part of #2971. This was supposed to have been fixed in #3067, but for some reason that didn't happen -- apologies!