### PR TITLE
Fix: Fixed splash button for small screen mobile devices

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3557,6 +3557,23 @@ md-card.preview-conversation-skin-supplemental-card {
   width: 10%;
 }
 
+.oppia-splash-button-container button {
+  bottom: 210px;
+  left: -webkit-calc(130px + 15%);
+  left: -moz-calc(130px + 15%);
+  left: -o-calc(130px + 15%);
+  left: calc(130px + 15%);
+  z-index: 10;
+}
+
+@media (max-width: 380px) {
+  .oppia-splash-button-container button {
+    left: 50%;
+    width: 90%;
+    font-size: 14px;
+  }
+}
+
 .oppia-splash-books {
   left: 50%;
   position: absolute;

--- a/core/templates/dev/head/pages/splash/splash.html
+++ b/core/templates/dev/head/pages/splash/splash.html
@@ -126,21 +126,19 @@
             <button type="button"
                     ng-click="onRedirectToLogin('/dashboard?mode=create')"
                     class="btn oppia-splash-button oppia-splash-button-create oppia-transition-200"
-                    style="left: -webkit-calc(130px + 15%); left: -moz-calc(130px + 15%); left: -o-calc(130px + 15%); left: calc(130px + 15%); bottom: 210px; z-index: 10;"
                     translate="I18N_ACTION_CREATE_LESSON">
             </button>
           {% else %}
             <button type="button"
                     ng-click="onClickCreateExplorationButton()"
                     class="btn oppia-splash-button oppia-splash-button-create oppia-transition-200"
-                    style="left: -webkit-calc(130px + 15%); left: -moz-calc(130px + 15%); left: -o-calc(130px + 15%); left: calc(130px + 15%); bottom: 210px; z-index: 10;"
                     translate="I18N_ACTION_CREATE_LESSON">
             </button>
           {% endif %}
 
           <button type="button" ng-click="onClickBrowseLibraryButton()"
                   class="btn oppia-splash-button oppia-splash-button-browse oppia-transition-200"
-                  style="left: -webkit-calc(130px + 15%); left: -moz-calc(130px + 15%); left: -o-calc(130px + 15%); left: calc(130px + 15%); bottom: 150px; z-index: 10;"
+                  style="bottom: 150px;"
                   translate="I18N_ACTION_BROWSE_LESSONS">
           </button>
         </div>


### PR DESCRIPTION
The splash page's button overflow for small screen devices. The following fix makes the buttons responsive. 