### PR TITLE
Fix #3129: Make navbar text items visible again by changing to rem.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2687,7 +2687,7 @@ div#ng-curtain {
 .oppia-navbar-role-text {
   bottom: 0;
   color: white;
-  font-size: 0.7em;
+  font-size: 1.12rem;
   font-weight: bold;
   position: absolute;
   right: 3px;
@@ -2705,7 +2705,7 @@ div#ng-curtain {
 .oppia-navbar-dashboard-indicator-text {
   bottom: 0;
   color: white;
-  font-size: 0.7em;
+  font-size: 1.12rem;
   font-weight: bold;
   position: absolute;
   right: 4px;


### PR DESCRIPTION
The navbar text items were inheriting the font-size: 0 needed for inline-block to display without extra spacing.

This changes the previous em units to rem units (relative to document root instead of parent).

1.12rem was calculated by taking the previous parent font-size (1.6em) and multiplying by the previous element font size (0.7em).