### PR TITLE
Fix constants XHR in IE9 and IE10.

### DIFF
--- a/core/templates/dev/head/pages/header_js_libs.html
+++ b/core/templates/dev/head/pages/header_js_libs.html
@@ -4,7 +4,7 @@
 <script>
   var constants = (function() {
     var request = new XMLHttpRequest();
-    // The overrideMimeType method was not implemented in IE prior to IE11.
+    /* The overrideMimeType method was not implemented in IE prior to IE11. */
     if (request.overrideMimeType) {
       request.overrideMimeType('application/json');
     }

--- a/core/templates/dev/head/pages/header_js_libs.html
+++ b/core/templates/dev/head/pages/header_js_libs.html
@@ -4,7 +4,9 @@
 <script>
   var constants = (function() {
     var request = new XMLHttpRequest();
-    request.overrideMimeType('application/json');
+    if (request.overrideMimeType) {
+      request.overrideMimeType('application/json');
+    }
     request.open(
       'GET', GLOBALS.ASSET_DIR_PREFIX + '/assets/constants.json', false);
     request.send(null);

--- a/core/templates/dev/head/pages/header_js_libs.html
+++ b/core/templates/dev/head/pages/header_js_libs.html
@@ -4,6 +4,7 @@
 <script>
   var constants = (function() {
     var request = new XMLHttpRequest();
+    // The overrideMimeType method was not implemented in IE prior to IE11.
     if (request.overrideMimeType) {
       request.overrideMimeType('application/json');
     }

--- a/core/tests/karma-constants.js
+++ b/core/tests/karma-constants.js
@@ -19,7 +19,9 @@
 /* This should be kept in parity with how CONSTANTS is set in base.html */
 var constants = (function() {
   var request = new XMLHttpRequest();
-  request.overrideMimeType('application/json');
+  if (request.overrideMimeType) {
+    request.overrideMimeType('application/json');
+  }
   request.open(
    'GET', GLOBALS.ASSET_DIR_PREFIX + '/assets/constants.json', false);
   request.send(null);

--- a/core/tests/karma-constants.js
+++ b/core/tests/karma-constants.js
@@ -19,6 +19,7 @@
 /* This should be kept in parity with how CONSTANTS is set in base.html */
 var constants = (function() {
   var request = new XMLHttpRequest();
+  // The overrideMimeType method was not implemented in IE prior to IE11.
   if (request.overrideMimeType) {
     request.overrideMimeType('application/json');
   }

--- a/core/tests/karma-constants.js
+++ b/core/tests/karma-constants.js
@@ -19,7 +19,7 @@
 /* This should be kept in parity with how CONSTANTS is set in base.html */
 var constants = (function() {
   var request = new XMLHttpRequest();
-  // The overrideMimeType method was not implemented in IE prior to IE11.
+  /* The overrideMimeType method was not implemented in IE prior to IE11. */
   if (request.overrideMimeType) {
     request.overrideMimeType('application/json');
   }


### PR DESCRIPTION
[The overrideMimeType method was not implemented in IE prior to IE11.
](https://msdn.microsoft.com/en-us/library/dn448456(v=vs.85).aspx)

This caused constants not to be loaded in IE9/10.

I've tested this change in Chrome (constants still load, as expected) and IE9 (constants load, instead of being null/undefined).