### PR TITLE
Fix #2828: Add IE9 support for sidebar.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -584,6 +584,7 @@ textarea {
   top: 0;
   -webkit-transform: translate3d(-100%, 0, 0);
   transform: translate3d(-100%, 0, 0);
+  -ms-transform: translate(-100%, 0);
   width: 270px;
   z-index: 100;
 }
@@ -688,6 +689,7 @@ textarea {
   overflow-y: scroll;
   -webkit-transform: translate3d(0, 0, 0);
   transform: translate3d(0, 0, 0);
+  -ms-transform: translate(0, 0);
   visibility: visible;
 }
 .oppia-sidebar-menu-open .oppia-sidebar-menu::after {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -582,9 +582,9 @@ textarea {
   left: 0;
   position: fixed;
   top: 0;
+  -ms-transform: translate(-100%, 0);
   -webkit-transform: translate3d(-100%, 0, 0);
   transform: translate3d(-100%, 0, 0);
-  -ms-transform: translate(-100%, 0);
   width: 270px;
   z-index: 100;
 }
@@ -687,9 +687,9 @@ textarea {
 .oppia-sidebar-menu-open .oppia-sidebar-menu {
   box-shadow: 1px 0 3px rgba(0,0,0,0.12), 1px 0 2px rgba(0,0,0,0.24);
   overflow-y: scroll;
+  -ms-transform: translate(0, 0);
   -webkit-transform: translate3d(0, 0, 0);
   transform: translate3d(0, 0, 0);
-  -ms-transform: translate(0, 0);
   visibility: visible;
 }
 .oppia-sidebar-menu-open .oppia-sidebar-menu::after {


### PR DESCRIPTION
IE9 does not support translate3d, so the sidebar was stuck permanently displayed.

This adds a -ms prefixed 2d transform which enables the sidebar to function properly in IE9. In small window sizes, the sidebar is usable; in large window sizes it is not displayed.