### PR TITLE
Fix #2400: Oppia-donation card margin corrections

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3592,10 +3592,11 @@ md-card.preview-conversation-skin-supplemental-card {
   font-family: "Capriola", "Roboto", Arial, sans-serif;
   font-size: 18px;
   margin-top: -20px;
-  padding: 10px;
+  padding: 10px 0;
   position: absolute;
   text-transform: uppercase;
   transform: translateX(-50%);
+  width: 360px;
 }
 
 .oppia-splash-button:hover,

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4587,7 +4587,8 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 
 .oppia-donation-card-content-wide {
-  margin: 0 auto;
+  margin: 40px  auto;
+  margin-bottom: 80px;
   min-height: 670px;
   overflow: auto;
 }
@@ -4642,7 +4643,7 @@ md-card.preview-conversation-skin-supplemental-card {
 
 @media only screen and (max-width: 1140px) {
   .oppia-donation-card-content-wide {
-    margin-bottom: 30px;
+    margin-bottom: 90px;
   }
   .oppia-donate-info {
     display: none;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3592,11 +3592,10 @@ md-card.preview-conversation-skin-supplemental-card {
   font-family: "Capriola", "Roboto", Arial, sans-serif;
   font-size: 18px;
   margin-top: -20px;
-  padding: 10px 0;
+  padding: 10px;
   position: absolute;
   text-transform: uppercase;
   transform: translateX(-50%);
-  width: 360px;
 }
 
 .oppia-splash-button:hover,


### PR DESCRIPTION
The donation card lacks the background banner alike other pages but the css style properties are inherited from the same causing the top-bottom margin errors in both **desktop** and **mobile** views. 
#2400
**How to Produce Error:**

- In development mode at http://localhost:8181/donate

- You can also view it on web https://www.oppia.org/donate

**Code corrections requested**
`.oppia-donation-card-content-wide {`  
`  margin: 40px  auto;`
`  margin-bottom: 80px;`
`  min-height: 670px;`
  `overflow: auto;`
`}`

`@media only screen and (max-width: 1140px) {`
`  .oppia-donation-card-content-wide {`
  `  margin-bottom: 90px;`
`  }`





