### PR TITLE
Fix #3097: Button text does not fit into the buttons in German 

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3441,13 +3441,12 @@ md-card.preview-conversation-skin-supplemental-card {
   border-radius: 0;
   color: #fff;
   font-family: "Capriola", "Roboto", Arial, sans-serif;
-  font-size: 18px;
+  font-size: 14px;
   margin-top: -20px;
-  padding: 10px 0;
+  padding: 10px;
   position: absolute;
   text-transform: uppercase;
   transform: translateX(-50%);
-  width: 360px;
 }
 
 .oppia-splash-button:hover,


### PR DESCRIPTION
**Changelog in PR** #3097
- Changed the button css properties. Width was a constant value, which messed up the responsiveness when **language was changed**/ switch to **mobile view**, hence removed it. 
- Padding was adjusted to set the changed width property.
- Font was reduced to `14px` as `18px`(previous value) was overflowing in mobile view. (It could have been fixed with position and width, but would make things messier. Found this as a solution. If anyone has another better solution. I gladly welcome it

Now everything looks fine.

**How to produce error:**
1.  Visit http://localhost:8181/splash or https://www.oppia.org/splash and change language to German or Dutch.

**Previously:**

![screenshot from 2017-03-11 14-39-22](https://cloud.githubusercontent.com/assets/24438869/23822001/8b22d4e4-0668-11e7-9f6a-75487808f5cc.png)

**Result:** 
![screenshot from 2017-03-11 14-38-22](https://cloud.githubusercontent.com/assets/24438869/23821998/6ca2605c-0668-11e7-9cd9-aa152ab371b3.png)