### PR TITLE
Fix #2394: Add useful docstrings to core/storage/job/gae_models.py 

### DIFF
--- a/core/jobs.py
+++ b/core/jobs.py
@@ -1082,7 +1082,7 @@ def get_data_for_recent_jobs(recency_msec=DEFAULT_RECENCY_MSEC):
     returned.
 
     Args:
-        recency_msec: the threshold for a recent job, in seconds.
+        recency_msec: the threshold for a recent job, in milliseconds.
     """
     recent_job_models = job_models.JobModel.get_recent_jobs(
         NUM_JOBS_IN_DASHBOARD_LIMIT, recency_msec)

--- a/core/jobs.py
+++ b/core/jobs.py
@@ -1082,7 +1082,7 @@ def get_data_for_recent_jobs(recency_msec=DEFAULT_RECENCY_MSEC):
     returned.
 
     Args:
-    - recency_secs: the threshold for a recent job, in seconds.
+        recency_msec: the threshold for a recent job, in seconds.
     """
     recent_job_models = job_models.JobModel.get_recent_jobs(
         NUM_JOBS_IN_DASHBOARD_LIMIT, recency_msec)

--- a/core/storage/job/gae_models.py
+++ b/core/storage/job/gae_models.py
@@ -97,11 +97,11 @@ class JobModel(base_models.BaseModel):
 
         Args:
             limit: int. A limit on the number of jobs to return.
-            recency_msec: int. A time in milliseconds. After this time a
-                job is considered recent.
+            recency_msec: int. The number of milliseconds eariler
+                than the current time.
 
         Returns:
-            list(Jobs) or None. A list of at most limit jobs
+            list(JobModel) or None. A list of at most limit jobs
             that come after recency_msec time.
         """
         earliest_time_msec = (
@@ -112,13 +112,13 @@ class JobModel(base_models.BaseModel):
 
     @classmethod
     def get_all_unfinished_jobs(cls, limit):
-        """Gets limit number of unfinished jobs.
+        """Gets at most `limit` unfinished jobs.
 
         Args:
             limit: int. A limit on the number of jobs to return.
 
         Returns:
-            list(Jobs) or None. A list of at most limit number
+            list(JobModel) or None. A list of at most limit number
             of unfinished jobs.
         """
         return cls.query().filter(
@@ -133,7 +133,8 @@ class JobModel(base_models.BaseModel):
             job_type: str. The type of jobs that may be unfinished.
 
         Returns:
-            list(Jobs) or None. A list of all jobs that belong to a job_type
+            list(JobModel) or None. A list of all jobs that belong
+            to the given job_type.
         """
         return cls.query().filter(cls.job_type == job_type).filter(
             JobModel.status_code.IN([STATUS_CODE_QUEUED, STATUS_CODE_STARTED]))
@@ -143,7 +144,7 @@ class JobModel(base_models.BaseModel):
         """Checks if unfinished jobs exist.
 
         Returns:
-            bool. True if unfinished jobs exists otherwise false.
+            bool. True if unfinished jobs exist, otherwise false.
         """
         return bool(cls.get_unfinished_jobs(job_type).count(limit=1))
 

--- a/core/storage/job/gae_models.py
+++ b/core/storage/job/gae_models.py
@@ -46,7 +46,7 @@ class JobModel(base_models.BaseModel):
             entity_name: str. The name of the entity to create a new job id for.
 
         Returns:
-            A job id.
+            str. A job id.
         """
         job_type = entity_name
         current_time_str = str(int(utils.get_current_time_in_millisecs()))
@@ -93,14 +93,14 @@ class JobModel(base_models.BaseModel):
 
     @classmethod
     def get_recent_jobs(cls, limit, recency_msec):
-        """Gets no more than a number of jobs within a given recency.
+        """Gets at most limit number of jobs with respect to a time after recency_msec.
 
         Args:
             limit: int. A limit on the number of jobs to return.
-            recency_msec: int. How recent of a job to search for.
+            recency_msec: int. A time in milliseconds. After this time a job is considered recent.
 
         Returns:
-            A list of jobs. Possiably none.
+            list(Jobs) or None. A list of at most limit jobs that come after recency_msec time.
         """
         earliest_time_msec = (
             utils.get_current_time_in_millisecs() - recency_msec)
@@ -110,13 +110,13 @@ class JobModel(base_models.BaseModel):
 
     @classmethod
     def get_all_unfinished_jobs(cls, limit):
-        """Get all jobs that are unfinished.
+        """Get limit number of unfinished jobs.
 
         Args:
             limit: int. A limit on the number of jobs to return.
 
         Returns:
-            A list of jobs. Possiably none.
+            list(Jobs) or None. A list of at most limit number of unfinished jobs.
         """
         return cls.query().filter(
             JobModel.status_code.IN([STATUS_CODE_QUEUED, STATUS_CODE_STARTED])
@@ -130,7 +130,7 @@ class JobModel(base_models.BaseModel):
             job_type: str. The type of jobs that may be unfinished.
 
         Returns:
-            A list of jobs. Possiably none.
+            list(Jobs) or None. A list of all jobs that belong to a job_type
         """
         return cls.query().filter(cls.job_type == job_type).filter(
             JobModel.status_code.IN([STATUS_CODE_QUEUED, STATUS_CODE_STARTED]))
@@ -140,7 +140,7 @@ class JobModel(base_models.BaseModel):
         """Checks if unfinished jobs exist.
 
         Returns:
-            True if unfinished jobs exits otherwise false.
+            bool. True if unfinished jobs exits otherwise false.
         """
         return bool(cls.get_unfinished_jobs(job_type).count(limit=1))
 

--- a/core/storage/job/gae_models.py
+++ b/core/storage/job/gae_models.py
@@ -112,7 +112,7 @@ class JobModel(base_models.BaseModel):
 
     @classmethod
     def get_all_unfinished_jobs(cls, limit):
-        """Get limit number of unfinished jobs.
+        """Gets limit number of unfinished jobs.
 
         Args:
             limit: int. A limit on the number of jobs to return.
@@ -127,7 +127,7 @@ class JobModel(base_models.BaseModel):
 
     @classmethod
     def get_unfinished_jobs(cls, job_type):
-        """Get jobs that are unfinished.
+        """Gets jobs that are unfinished.
 
         Args:
             job_type: str. The type of jobs that may be unfinished.
@@ -143,7 +143,7 @@ class JobModel(base_models.BaseModel):
         """Checks if unfinished jobs exist.
 
         Returns:
-            bool. True if unfinished jobs exits otherwise false.
+            bool. True if unfinished jobs exists otherwise false.
         """
         return bool(cls.get_unfinished_jobs(job_type).count(limit=1))
 

--- a/core/storage/job/gae_models.py
+++ b/core/storage/job/gae_models.py
@@ -93,14 +93,16 @@ class JobModel(base_models.BaseModel):
 
     @classmethod
     def get_recent_jobs(cls, limit, recency_msec):
-        """Gets at most limit number of jobs with respect to a time after recency_msec.
+        """Gets at most limit jobs with respect to a time after recency_msec.
 
         Args:
             limit: int. A limit on the number of jobs to return.
-            recency_msec: int. A time in milliseconds. After this time a job is considered recent.
+            recency_msec: int. A time in milliseconds. After this time a
+                job is considered recent.
 
         Returns:
-            list(Jobs) or None. A list of at most limit jobs that come after recency_msec time.
+            list(Jobs) or None. A list of at most limit jobs
+            that come after recency_msec time.
         """
         earliest_time_msec = (
             utils.get_current_time_in_millisecs() - recency_msec)
@@ -116,7 +118,8 @@ class JobModel(base_models.BaseModel):
             limit: int. A limit on the number of jobs to return.
 
         Returns:
-            list(Jobs) or None. A list of at most limit number of unfinished jobs.
+            list(Jobs) or None. A list of at most limit number
+            of unfinished jobs.
         """
         return cls.query().filter(
             JobModel.status_code.IN([STATUS_CODE_QUEUED, STATUS_CODE_STARTED])

--- a/core/storage/job/gae_models.py
+++ b/core/storage/job/gae_models.py
@@ -40,7 +40,14 @@ class JobModel(base_models.BaseModel):
 
     @classmethod
     def get_new_id(cls, entity_name):
-        """Overwrites superclass method."""
+        """Overwrites superclass method.
+
+        Args:
+            entity_name: str. The name of the entity to create a new job id for.
+
+        Returns:
+            A job id.
+        """
         job_type = entity_name
         current_time_str = str(int(utils.get_current_time_in_millisecs()))
         random_int = random.randint(0, 1000)
@@ -86,6 +93,15 @@ class JobModel(base_models.BaseModel):
 
     @classmethod
     def get_recent_jobs(cls, limit, recency_msec):
+        """Gets no more than a number of jobs within a given recency.
+
+        Args:
+            limit: int. A limit on the number of jobs to return.
+            recency_msec: int. How recent of a job to search for.
+
+        Returns:
+            A list of jobs. Possiably none.
+        """
         earliest_time_msec = (
             utils.get_current_time_in_millisecs() - recency_msec)
         return cls.query().filter(
@@ -94,17 +110,38 @@ class JobModel(base_models.BaseModel):
 
     @classmethod
     def get_all_unfinished_jobs(cls, limit):
+        """Get all jobs that are unfinished.
+
+        Args:
+            limit: int. A limit on the number of jobs to return.
+
+        Returns:
+            A list of jobs. Possiably none.
+        """
         return cls.query().filter(
             JobModel.status_code.IN([STATUS_CODE_QUEUED, STATUS_CODE_STARTED])
         ).order(-cls.time_queued_msec).fetch(limit)
 
     @classmethod
     def get_unfinished_jobs(cls, job_type):
+        """Get jobs that are unfinished.
+
+        Args:
+            job_type: str. The type of jobs that may be unfinished.
+
+        Returns:
+            A list of jobs. Possiably none.
+        """
         return cls.query().filter(cls.job_type == job_type).filter(
             JobModel.status_code.IN([STATUS_CODE_QUEUED, STATUS_CODE_STARTED]))
 
     @classmethod
     def do_unfinished_jobs_exist(cls, job_type):
+        """Checks if unfinished jobs exist.
+
+        Returns:
+            True if unfinished jobs exits otherwise false.
+        """
         return bool(cls.get_unfinished_jobs(job_type).count(limit=1))
 
 

--- a/core/storage/job/gae_models.py
+++ b/core/storage/job/gae_models.py
@@ -97,11 +97,11 @@ class JobModel(base_models.BaseModel):
 
         Args:
             limit: int. A limit on the number of jobs to return.
-            recency_msec: int. The number of milliseconds eariler
+            recency_msec: int. The number of milliseconds earlier
                 than the current time.
 
         Returns:
-            list(JobModel) or None. A list of at most limit jobs
+            list(JobModel) or None. A list of at most `limit` jobs
             that come after recency_msec time.
         """
         earliest_time_msec = (
@@ -118,7 +118,7 @@ class JobModel(base_models.BaseModel):
             limit: int. A limit on the number of jobs to return.
 
         Returns:
-            list(JobModel) or None. A list of at most limit number
+            list(JobModel) or None. A list of at most `limit` number
             of unfinished jobs.
         """
         return cls.query().filter(


### PR DESCRIPTION
Fix #2394: updated docstrings in the the core/storage/job/gae_models.py  file.

Notes:
1.) I wasn't sure to if I should add a docstring for is_cancelable because it was so simple. If you want me to add it I will gladly. 
2.) While looking through the code I noticed that in core/jobs.py the method:
```
def get_data_for_recent_jobs(recency_msec=DEFAULT_RECENCY_MSEC):
    """Get a list containing data about recent jobs.

    This list is arranged in descending order based on the time the job
    was enqueued. At most NUM_JOBS_IN_DASHBOARD_LIMIT job descriptions are
    returned.

    Args:
    - recency_secs: the threshold for a recent job, in seconds.
    """
```
The Args section is spelled differently then the actual argument if this is an error I can change this. Also, it doesn't follow the doc string style guide I don't think.