### PR TITLE
Fix #3162: set expiration explicitly for files in the build directory.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -32,6 +32,7 @@ handlers:
 - url: /build
   static_dir: build
   secure: always
+  expiration: 30d
   http_headers:
     Cache-Control: 'public, max-age=2592000'
 - url: /assets/common


### PR DESCRIPTION
I have tested this on a production server, and it works! It follows the guidelines in https://cloud.google.com/appengine/docs/standard/python/config/appref .

Note that we need to be very careful to ensure that build files always have slugs, due to the longer cache expiration time.