### PR TITLE
Add exception for updating user first contribution time for migration bot

### DIFF
--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -1046,7 +1046,8 @@ def update_exploration(
     user_services.add_edited_exploration_id(committer_id, exploration.id)
     user_services.record_user_edited_an_exploration(committer_id)
 
-    if not rights_manager.is_exploration_private(exploration.id):
+    if (not rights_manager.is_exploration_private(exploration.id) and
+            committer_id != feconf.MIGRATION_BOT_USER_ID):
         user_services.update_first_contribution_msec_if_not_set(
             committer_id, utils.get_current_time_in_millisecs())
 

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -514,6 +514,18 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
         self.assertEqual(retrieved_exp_summary.category, 'A new category')
         self.assertEqual(retrieved_exp_summary.contributor_ids, [self.owner_id])
 
+    def test_update_exploration_by_migration_bot(self):
+        self.save_new_valid_exploration(
+            self.EXP_ID, self.owner_id, end_state_name='end')
+        rights_manager.publish_exploration(self.owner_id, self.EXP_ID)
+
+        exp_services.update_exploration(
+            feconf.MIGRATION_BOT_USER_ID, self.EXP_ID, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'title',
+                'new_value': 'New title'
+            }], 'Did migration.')
+
 
 class LoadingAndDeletionOfExplorationDemosTest(ExplorationServicesUnitTests):
 


### PR DESCRIPTION
This currently causes an error with the migration job.