### PR TITLE
Fixes #3192: shifted back css of oppia-sidebar-menu-open back to oppi…

### DIFF
--- a/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
@@ -78,21 +78,6 @@
       padding-top: 6px;
     }
 
-    side-navigation-bar .oppia-sidebar-menu-open .oppia-sidebar-menu {
-      box-shadow: 1px 0 3px rgba(0,0,0,0.12), 1px 0 2px rgba(0,0,0,0.24);
-      overflow-y: scroll;
-      -webkit-transform: translate3d(0, 0, 0);
-      transform: translate3d(0, 0, 0);
-      visibility: visible;
-    }
-    side-navigation-bar .oppia-sidebar-menu-open .oppia-sidebar-menu::after {
-      height: 0;
-      opacity: 0;
-      -webkit-transition: opacity 0.5s, width 0.1s 0.5s, height 0.1s 0.5s;
-      transition: opacity 0.5s, width 0.1s 0.5s, height 0.1s 0.5s;
-      width: 0;
-    }
-
   </style>
   <nav class="oppia-sidebar-menu oppia-sidebar-menu-transition">
     <div class="oppia-sidebar-header">

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -559,6 +559,21 @@ textarea {
   -webkit-transition: -webkit-transform 0.5s;
 }
 
+.oppia-sidebar-menu-open .oppia-sidebar-menu {
+  box-shadow: 1px 0 3px rgba(0,0,0,0.12), 1px 0 2px rgba(0,0,0,0.24);
+  overflow-y: scroll;
+  -webkit-transform: translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
+  visibility: visible;
+}
+.oppia-sidebar-menu-open .oppia-sidebar-menu::after {
+  height: 0;
+  opacity: 0;
+  -webkit-transition: opacity 0.5s, width 0.1s 0.5s, height 0.1s 0.5s;
+  transition: opacity 0.5s, width 0.1s 0.5s, height 0.1s 0.5s;
+  width: 0;
+}
+
 .oppia-sidebar-menu-open .oppia-content-container::after {
   height: 100%;
   opacity: 1;


### PR DESCRIPTION
This is in regard of the issue #3192.

some css related to 'oppia-sidebar-menu-open' class had to be shifted back to the oppia.css. It was shifted to the directive in regard of the issue #3064. But, @Oishikatta pointed out it was also used in base.html.

before, 
![before_shifting_back](https://cloud.githubusercontent.com/assets/9693472/23992545/4ca719ba-0a63-11e7-8828-e25291b9fc55.png)

after, 
![after_shifting_back](https://cloud.githubusercontent.com/assets/9693472/23992559/57d1756a-0a63-11e7-945c-02b2d6460bc9.png)


