### PR TITLE
Add a check that user contributions for logged in users exist 

### DIFF
--- a/main.py
+++ b/main.py
@@ -76,8 +76,9 @@ class HomePageRedirectHandler(base.BaseHandler):
 
             # 'Creator' is a user who has created or edited an exploration.
             user_is_creator = (
-                len(user_contributions.created_exploration_ids) > 0 or
-                len(user_contributions.edited_exploration_ids) > 0)
+                user_contributions is not None and
+                (len(user_contributions.created_exploration_ids) > 0 or
+                 len(user_contributions.edited_exploration_ids) > 0))
             if user_is_creator:
                 self.redirect(feconf.DASHBOARD_URL)
             else:


### PR DESCRIPTION
This was causing a bug in production -- somehow I had no user contribution model even though I was logged in, and this caused a 500 error on accessing oppia.org.