### PR TITLE
Fix #2400: Oppia-donation card margin corrections

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4452,7 +4452,7 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 
 .oppia-donation-card-content-wide {
-  margin: 40px auto;
+  margin: 40px auto 80px;
   min-height: 670px;
   overflow: auto;
 }

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4452,7 +4452,7 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 
 .oppia-donation-card-content-wide {
-  margin: 0 auto;
+  margin: 40px auto;
   min-height: 670px;
   overflow: auto;
 }
@@ -4507,7 +4507,7 @@ md-card.preview-conversation-skin-supplemental-card {
 
 @media only screen and (max-width: 1140px) {
   .oppia-donation-card-content-wide {
-    margin-bottom: 30px;
+    margin-bottom: 90px;
   }
   .oppia-donate-info {
     display: none;


### PR DESCRIPTION
**NEW PR**
The donation card lacks the background banner alike other pages but the css style properties are inherited from the same causing the top-bottom margin errors in both **desktop** and **mobile** views. 
#2400

**How to Produce Error:**

- In development mode at http://localhost:8181/donate

- You can also view it on web https://www.oppia.org/donate

**Code corrections requested**
`.oppia-donation-card-content-wide {`  
`  margin: 40px  auto 80px;`
`  min-height: 670px;`
  `overflow: auto;`
`}`

`@media only screen and (max-width: 1140px) {`
`  .oppia-donation-card-content-wide {`
  `  margin-bottom: 90px;`
`  }`
