### PR TITLE
Fix#3094: License terms link in image insert does not work

### DIFF
--- a/core/templates/dev/head/pages/about/about.html
+++ b/core/templates/dev/head/pages/about/about.html
@@ -139,7 +139,7 @@
                 <a href="/donate">donating to the Oppia Foundation</a> or
                 <a href="/contact">getting involved in other ways</a>.
               </p>
-              <h3>Directors</h3>
+              <h3 id="directors">Directors</h3>
               <p>
                 The directors of the Foundation are Amit Deutsch, Jacob Davis, and Sean Lip.
                 The Foundation's
@@ -481,7 +481,7 @@
           visibleContent);
       }
 
-      if (hash === 'foundation') {
+      if (hash === 'foundation' || 'directors') {
         activateTab('foundation');
       }
 

--- a/core/templates/dev/head/pages/about/about.html
+++ b/core/templates/dev/head/pages/about/about.html
@@ -139,7 +139,7 @@
                 <a href="/donate">donating to the Oppia Foundation</a> or
                 <a href="/contact">getting involved in other ways</a>.
               </p>
-              <h3 id="directors">Directors</h3>
+              <h3>Directors</h3>
               <p>
                 The directors of the Foundation are Amit Deutsch, Jacob Davis, and Sean Lip.
                 The Foundation's
@@ -148,7 +148,7 @@
                 are available to read. If you wish to contact the Foundation, please email:
                 <a href="mailto:admin@oppia.org" class="inline-links">admin@oppia.org</a>.
               </p>
-              <h3>License</h3>
+              <h3 id="license">License</h3>
               <p>
                 All content in Oppia's explorations is licensed under
                 <a href="https://creativecommons.org/licenses/by-sa/4.0/legalcode" class="inline-links">CC-BY-SA 4.0</a>
@@ -481,7 +481,7 @@
           visibleContent);
       }
 
-      if (hash === 'foundation' || 'directors') {
+      if (hash === 'foundation' || 'license') {
         activateTab('foundation');
       }
 

--- a/core/templates/dev/head/pages/about/about.html
+++ b/core/templates/dev/head/pages/about/about.html
@@ -148,7 +148,10 @@
                 are available to read. If you wish to contact the Foundation, please email:
                 <a href="mailto:admin@oppia.org" class="inline-links">admin@oppia.org</a>.
               </p>
-              <h3 id="license">License</h3>
+              <a name="license">
+                <h1 style="padding-top: 70px; margin-top: -80px;"></h1>
+              </a>
+              <h3>License</h3>
               <p>
                 All content in Oppia's explorations is licensed under
                 <a href="https://creativecommons.org/licenses/by-sa/4.0/legalcode" class="inline-links">CC-BY-SA 4.0</a>

--- a/extensions/objects/templates/filepath_editor.html
+++ b/extensions/objects/templates/filepath_editor.html
@@ -30,7 +30,7 @@
 
   <div ng-if="imageUploaderIsActive" style="border: 1px solid black; padding: 5px;">
     <div class="oppia-warning">
-      Before uploading any images, please ensure that they are compatible with the <a href="/about#foundation" target="_blank">license terms</a> of this site (the link opens in a new window).
+      Before uploading any images, please ensure that they are compatible with the <a href="/about#directors" target="_blank">license terms</a> of this site (the link opens in a new window).
     </div>
 
     <br>

--- a/extensions/objects/templates/filepath_editor.html
+++ b/extensions/objects/templates/filepath_editor.html
@@ -30,7 +30,7 @@
 
   <div ng-if="imageUploaderIsActive" style="border: 1px solid black; padding: 5px;">
     <div class="oppia-warning">
-      Before uploading any images, please ensure that they are compatible with the <a href="/about#directors" target="_blank">license terms</a> of this site (the link opens in a new window).
+      Before uploading any images, please ensure that they are compatible with the <a href="/about#license" target="_blank">license terms</a> of this site (the link opens in a new window).
     </div>
 
     <br>


### PR DESCRIPTION
#3094

**How to produce error**
1. Go to the creator dashboard and edit an exploration.
2. Edit content, and click on the image insert button.
3 Click on "upload a new image"
4. In the "license terms" link (shown below), the link goes to the about page, but not straight to the license terms. The license terms are on the "Foundation" tab.

![image](https://cloud.githubusercontent.com/assets/5061134/23279934/37b2b688-f9e5-11e6-97bd-6499af39ae80.png)

**Rationale behind the PR code**
Tried anchor tags, alike `ahref="#license" `to the header `<h2 id="license">`. It simply doesn't work as a javascript in [about.html dynamically activates](https://github.com/oppia/oppia/blob/develop/core/templates/dev/head/pages/about/about.html#L492) the tab. Hence modified the Javascript with `||` relation.

Note: This PR points to the **directors** because if **license** is being hyperlinked, the heading is cut off, as the main oppia navigation bar overlays the text. (occurs in mobile as well as desktop)
