### PR TITLE
Fix #1251, correct border color when math input is empty.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -408,6 +408,11 @@ input.ng-dirty.ng-invalid, md-input-group.md-default-theme input.ng-dirty.ng-inv
   border-color: #F44336;
 }
 
+/* Input border should go back to default state when input is empty. */
+input.ng-dirty.ng-invalid, input.ng-dirty.ng-invalid.ng-empty {
+  border-color: #66afe9; 
+}
+
 ::-webkit-input-placeholder {
   font-style: italic;
 }


### PR DESCRIPTION
Fix #1251 MathExpressionInput.

Able to pass all tests but somehow Git tells me ```error: failed to push some refs to 'https://github.com/jlin95/oppia.git'```.

I have installed all recommended linters, ran the tests, but I couldnt push to origin. 
