### PR TITLE
Fix #2482: Learner's Answers and Oppia's Responses' overflow out of their cards in mobile view 

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1627,6 +1627,7 @@ pre.oppia-pre-wrapped-text {
 
 .oppia-editor-card-section {
   padding: 20px 50px 20px 35px;
+  word-break: break-word;
 }
 
 .oppia-state-content {


### PR DESCRIPTION
#2482
**How to reproduce:**
1) Create a exploration on a mobile or desktop
2) Add any interaction like multiple choice or item selection
3) Add atleast one response of a reasonably long length and save it.
4) Vary width if on desktop

**Observed Behavior:**
The answer in responses overflows out of the cards

**Expected behavior:**
The answer should be wrapped to be fit within the cards.

**In the issue:**
![screenshot from 2017-03-27 08-05-15](https://cloud.githubusercontent.com/assets/24438869/24338584/3039ae1e-12c4-11e7-8acc-9c9d7aa06c02.png)


**This PR's fix**
![screenshot from 2017-03-27 08-04-05](https://cloud.githubusercontent.com/assets/24438869/24338564/08acca20-12c4-11e7-8c98-e5d9edd8f792.png)

