### PR TITLE
Fix #2870: Limit exploration cards to screen width to maintain centering

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -102,6 +102,10 @@
   </div>
 
   <style>
+    .conversation-skin-tutor-card {
+      max-width: 100vw;
+    }
+
     .conversation-skin-tutor-card-top-section .conversation-skin-oppia-avatar {
       height: 48px;
       left: -28px;


### PR DESCRIPTION
This change was much simpler than my initial expectation.

While this seems to fix the issue, I think the underlying cause needs more investigation. The cause _may_ be that the exploration player page can be wider than the available screen width (see partly off-screen user icon in screenshot below). However, I haven't been able to replicate that outside of Chrome's devtools. I'll open a new issue and set aside some time for testing later this week.

![Preview](https://i.imgur.com/UQrhTdC.png)