### PR TITLE
Add installation of peer dependency: jasmine-core.

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,6 +59,7 @@ function maybeInstallDependencies {
 
     $NODE_PATH/bin/node $NODE_MODULE_DIR/gulp/bin/gulp.js build
 
+    install_node_module jasmine-core 2.5.2
     install_node_module karma 1.5.0
     install_node_module karma-jasmine 1.1.0
     install_node_module karma-jasmine-jquery 0.1.1


### PR DESCRIPTION
When running frontend tests I get this error:

```
npm ERR! peer dep missing: jasmine-core@*, required by karma-jasmine@1.1.0
```

This PR fixes it.