### PR TITLE
Fix #3093: Popover of Userhelp button remains constant when the user creates the exploration for the first time.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
@@ -41,11 +41,10 @@ oppia.directive('editorNavigation', [function() {
           if ($scope.isLargeScreen) {
             $scope.postTutorialHelpPopoverIsShown = true;
             $timeout(function() {
-            $scope.postTutorialHelpPopoverIsShown = false;
+              $scope.postTutorialHelpPopoverIsShown = false;
             }, 5000);
-          }
-          else {
-          $scope.postTutorialHelpPopoverIsShown = false;
+          } else {
+            $scope.postTutorialHelpPopoverIsShown = false;
           }
         });
 

--- a/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
@@ -38,10 +38,15 @@ oppia.directive('editorNavigation', [function() {
         $scope.postTutorialHelpPopoverIsShown = false;
 
         $scope.$on('openPostTutorialHelpPopover', function() {
-          $scope.postTutorialHelpPopoverIsShown = true;
-          $timeout(function() {
+          if ($scope.isLargeScreen) {
+            $scope.postTutorialHelpPopoverIsShown = true;
+            $timeout(function() {
             $scope.postTutorialHelpPopoverIsShown = false;
-          }, 5000);
+              }, 5000);
+          }
+          else {
+          $scope.postTutorialHelpPopoverIsShown = false;
+          }
         });
 
         $scope.showUserHelpModal = function() {

--- a/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
@@ -42,7 +42,7 @@ oppia.directive('editorNavigation', [function() {
             $scope.postTutorialHelpPopoverIsShown = true;
             $timeout(function() {
             $scope.postTutorialHelpPopoverIsShown = false;
-              }, 5000);
+            }, 5000);
           }
           else {
           $scope.postTutorialHelpPopoverIsShown = false;

--- a/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
@@ -36,6 +36,7 @@ oppia.directive('editorNavigation', [function() {
           threadDataService, siteAnalyticsService,
           explorationContextService, windowDimensionsService) {
         $scope.postTutorialHelpPopoverIsShown = false;
+        $scope.isLargeScreen = (windowDimensionsService.getWidth() >= 1024);
 
         $scope.$on('openPostTutorialHelpPopover', function() {
           if ($scope.isLargeScreen) {
@@ -100,7 +101,6 @@ oppia.directive('editorNavigation', [function() {
         $scope.selectHistoryTab = routerService.navigateToHistoryTab;
         $scope.selectFeedbackTab = routerService.navigateToFeedbackTab;
         $scope.getOpenThreadsCount = threadDataService.getOpenThreadsCount;
-        $scope.isLargeScreen = (windowDimensionsService.getWidth() >= 1024);
 
         windowDimensionsService.registerOnResizeHook(function() {
           $scope.isLargeScreen = (windowDimensionsService.getWidth() >= 1024);

--- a/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
@@ -70,7 +70,7 @@
     </li>
 
     {% if username %}
-      <li ng-if="isLargeScreen" class="dropdown" popover-is-open="postTutorialHelpPopoverIsShown"
+      <li class="dropdown" popover-is-open="postTutorialHelpPopoverIsShown"
           popover-placement="bottom" popover-trigger="none"
           popover="To get help in the future, click here!">
         <a href="#" tooltip="Help" tooltip-placement="bottom"

--- a/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
@@ -81,3 +81,11 @@
     {% endif %}
   </ul>
 </script>
+<style type="text/css">
+  .popover {
+    font-size: 13px;
+    max-width: 200px;
+    text-align: center;
+    z-index: -1;
+  }
+</style>

--- a/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
@@ -70,7 +70,7 @@
     </li>
 
     {% if username %}
-    <div class="oppia-help-dropdown nav navbar-nav oppia-navbar-nav pull-right ng-cloak">
+    <div class="nav navbar-nav oppia-navbar-nav oppia-help-dropdown pull-right ng-cloak">
       <li class="dropdown" popover-is-open="postTutorialHelpPopoverIsShown"
           popover-placement="bottom" popover-trigger="none"
           popover="To get help in the future, click here!">

--- a/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
@@ -82,7 +82,7 @@
   </ul>
 </script>
 <style type="text/css">
-  .popover {
+  ul .popover.bottom {
     font-size: 13px;
     max-width: 200px;
     text-align: center;

--- a/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
@@ -70,6 +70,7 @@
     </li>
 
     {% if username %}
+    <div class="oppia-help-dropdown nav navbar-nav oppia-navbar-nav pull-right ng-cloak">
       <li class="dropdown" popover-is-open="postTutorialHelpPopoverIsShown"
           popover-placement="bottom" popover-trigger="none"
           popover="To get help in the future, click here!">
@@ -78,11 +79,12 @@
           <i class="material-icons">&#xE887;</i>
         </a>
       </li>
+    </div>
     {% endif %}
   </ul>
 </script>
 <style type="text/css">
-  ul .popover.bottom {
+  .oppia-help-dropdown .popover {
     font-size: 13px;
     max-width: 200px;
     text-align: center;


### PR DESCRIPTION
#3093
The tooltip "To get help in future click here" doesn't disappear on the click and  causes unintended behavior with profile menu.

**How to produce error?**
1. Login in locally with a new username or just use the test user name with admin panel.
2. Create an exploration. This should pop up the tooltip _"To get help in future click here"_ 
3. Now, click on the profile icon and try to go to any nav element.

**Error**
1. The menu simply disappears and user can't navigate to any page from menu

**Expected behavior**
1. The tooltip must be not cut off. 
2. It should not block user from accessing menu.

![screenshot from 2017-04-01 09-16-05](https://cloud.githubusercontent.com/assets/24438869/24575213/e5343194-16bc-11e7-9631-1cdb12dcb709.png)

**This PR's fix**

![screenshot from 2017-04-01 22-28-42](https://cloud.githubusercontent.com/assets/24438869/24580740/e07da928-172a-11e7-91b8-a11289d416a8.png)
![screenshot from 2017-04-01 22-28-46](https://cloud.githubusercontent.com/assets/24438869/24580741/e07e38fc-172a-11e7-93bd-a62a78643231.png)
