### PR TITLE
Fix overflowing of names in the subscription card.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4009,7 +4009,8 @@ md-card.preview-conversation-skin-supplemental-card {
   display: inline-block;
   height: 90px;
   padding: 0;
-  width: 184px;
+  margin: 8px 4px;
+  width: 191px;
 }
 
 .oppia-dashboard-tab-panel {
@@ -4037,7 +4038,7 @@ md-card.preview-conversation-skin-supplemental-card {
 
 .oppia-subscription-card-summary {
   float: left;
-  margin-left: 14px;
+  margin-left: 11px;
   margin-top: 19.5px;
 }
 

--- a/core/templates/dev/head/pages/dashboard/Dashboard.js
+++ b/core/templates/dev/head/pages/dashboard/Dashboard.js
@@ -113,6 +113,17 @@ oppia.controller('Dashboard', [
       return ($window.innerWidth < 500);
     };
 
+    $scope.showUsernamePopover = function(subscriberUsername) {
+      // The popover on the subscription card is only shown if the length of
+      // the subscriber username is greater than 10 and the user hovers over
+      // the truncated username.
+      if (subscriberUsername.length > 10) {
+        return 'mouseenter';
+      } else {
+        return 'none';
+      }
+    };
+
     $scope.updatesGivenScreenWidth = function() {
       if ($scope.checkMobileView()) {
         $scope.myExplorationsView = 'card';

--- a/core/templates/dev/head/pages/dashboard/dashboard.html
+++ b/core/templates/dev/head/pages/dashboard/dashboard.html
@@ -356,7 +356,11 @@
           <img ng-src="<[subscriber.subscriber_picture_data_url]>" class="oppia-subscription-card-profile-picture img-circle">
           <span class="oppia-subscription-card-summary">
             <div style="margin-bottom: 5px; font-size: 17.5px;">
-              <strong class="protractor-test-subscription-name"><[subscriber.subscriber_username| truncate:9]></strong>
+              <strong class="protractor-test-subscription-name" 
+                      popover-append-to-body
+                      popover-trigger="<[subscriber.subscriber_username.length > 10 ? 'mouseenter' : 'none']>"
+                      ng-attr-popover="<[subscriber.subscriber_username]>">
+                      <[subscriber.subscriber_username| truncate:10]></strong>
             </div>
             <div style="font-size: 14.5px;">
               <span>Impact</span>

--- a/core/templates/dev/head/pages/dashboard/dashboard.html
+++ b/core/templates/dev/head/pages/dashboard/dashboard.html
@@ -356,7 +356,7 @@
           <img ng-src="<[subscriber.subscriber_picture_data_url]>" class="oppia-subscription-card-profile-picture img-circle">
           <span class="oppia-subscription-card-summary">
             <div style="margin-bottom: 5px; font-size: 17.5px;">
-              <strong class="protractor-test-subscription-name"><[subscriber.subscriber_username| truncate:11]></strong>
+              <strong class="protractor-test-subscription-name"><[subscriber.subscriber_username| truncate:9]></strong>
             </div>
             <div style="font-size: 14.5px;">
               <span>Impact</span>

--- a/core/templates/dev/head/pages/dashboard/dashboard.html
+++ b/core/templates/dev/head/pages/dashboard/dashboard.html
@@ -356,11 +356,12 @@
           <img ng-src="<[subscriber.subscriber_picture_data_url]>" class="oppia-subscription-card-profile-picture img-circle">
           <span class="oppia-subscription-card-summary">
             <div style="margin-bottom: 5px; font-size: 17.5px;">
-              <strong class="protractor-test-subscription-name" 
+              <strong class="protractor-test-subscription-name"
                       popover-append-to-body
-                      popover-trigger="<[subscriber.subscriber_username.length > 10 ? 'mouseenter' : 'none']>"
+                      popover-trigger="<[showUsernamePopover(subscriber.subscriber_username)]>"
                       ng-attr-popover="<[subscriber.subscriber_username]>">
-                      <[subscriber.subscriber_username| truncate:10]></strong>
+                <[subscriber.subscriber_username| truncate:10]>
+              </strong>
             </div>
             <div style="font-size: 14.5px;">
               <span>Impact</span>

--- a/core/templates/dev/head/pages/preferences/Preferences.js
+++ b/core/templates/dev/head/pages/preferences/Preferences.js
@@ -97,6 +97,17 @@ oppia.controller('Preferences', [
         'preferred_site_language_code', preferredSiteLanguageCode);
     };
 
+    $scope.showUsernamePopover = function(creatorUsername) {
+      // The popover on the subscription card is only shown if the length of
+      // the creator username is greater than 10 and the user hovers over
+      // the truncated username.
+      if (creatorUsername.length > 10) {
+        return 'mouseenter';
+      } else {
+        return 'none';
+      }
+    };
+
     $scope.saveEmailPreferences = function(
       canReceiveEmailUpdates, canReceiveEditorRoleEmail,
       canReceiveFeedbackMessageEmail, canReceiveSubscriptionEmail) {

--- a/core/templates/dev/head/pages/preferences/preferences.html
+++ b/core/templates/dev/head/pages/preferences/preferences.html
@@ -105,7 +105,12 @@
                   <img ng-src="<[subscription.creator_picture_data_url]>" class="oppia-subscription-card-profile-picture img-circle">
                   <span class="oppia-subscription-card-summary">
                     <div style="margin-bottom: 5px; font-size: 17.5px;">
-                      <strong class="protractor-test-subscription-name"><[subscription.creator_username| truncate:10]></strong>
+                      <strong class="protractor-test-subscription-name"
+                              popover-append-to-body
+                              popover-trigger="<[showUsernamePopover(subscription.creator_username)]>"
+                              ng-attr-popover="<[subscription.creator_username]>">
+                        <[subscription.creator_username| truncate:10]>
+                      </strong>
                     </div>
                     <div style="font-size: 14.5px;">
                       <span>Impact</span>

--- a/core/templates/dev/head/pages/preferences/preferences.html
+++ b/core/templates/dev/head/pages/preferences/preferences.html
@@ -105,7 +105,7 @@
                   <img ng-src="<[subscription.creator_picture_data_url]>" class="oppia-subscription-card-profile-picture img-circle">
                   <span class="oppia-subscription-card-summary">
                     <div style="margin-bottom: 5px; font-size: 17.5px;">
-                      <strong class="protractor-test-subscription-name"><[subscription.creator_username| truncate:11]></strong>
+                      <strong class="protractor-test-subscription-name"><[subscription.creator_username| truncate:9]></strong>
                     </div>
                     <div style="font-size: 14.5px;">
                       <span>Impact</span>

--- a/core/templates/dev/head/pages/preferences/preferences.html
+++ b/core/templates/dev/head/pages/preferences/preferences.html
@@ -100,12 +100,12 @@
               <md-card class="oppia-subscription-card"
                        ng-if="subscriptionList.length > 0"
                        ng-repeat="subscription in subscriptionList"
-                       style="margin: 0 16px 0 0;">
+                       style="margin: 0 8px 0 0;">
                 <a class="oppia-subscription-profile-link" href="/profile/<[subscription.creator_username]>" target="_blank">
                   <img ng-src="<[subscription.creator_picture_data_url]>" class="oppia-subscription-card-profile-picture img-circle">
                   <span class="oppia-subscription-card-summary">
                     <div style="margin-bottom: 5px; font-size: 17.5px;">
-                      <strong class="protractor-test-subscription-name"><[subscription.creator_username| truncate:9]></strong>
+                      <strong class="protractor-test-subscription-name"><[subscription.creator_username| truncate:10]></strong>
                     </div>
                     <div style="font-size: 14.5px;">
                       <span>Impact</span>

--- a/core/tests/protractor/subscriptions.js
+++ b/core/tests/protractor/subscriptions.js
@@ -45,10 +45,10 @@ describe('Subscriptions functionality', function() {
     browser.get(general.USER_PREFERENCES_URL);
     expect(element.all(by.css(
       '.protractor-test-subscription-name')).first().getText()).toMatch(
-      'creator1...');
+      'creator...');
     expect(element.all(by.css(
       '.protractor-test-subscription-name')).last().getText()).toMatch(
-      'creator2...');
+      'creator...');
     users.logout();
 
     // Create a learner who subscribes to one creator and unsubscribes from the
@@ -69,7 +69,7 @@ describe('Subscriptions functionality', function() {
       '.protractor-test-subscription-name')).count()).toEqual(1);
     expect(element.all(by.css(
       '.protractor-test-subscription-name')).first().getText()).toMatch(
-      'creator1...');
+      'creator...');
     users.logout();
 
     users.login('creator1@subscriptions.com');
@@ -78,10 +78,10 @@ describe('Subscriptions functionality', function() {
     element(by.css('.protractor-test-subscription-tab')).click();
     expect(element.all(by.css(
       '.protractor-test-subscription-name')).first().getText()).toMatch(
-      'learner2...');
+      'learner...');
     expect(element.all(by.css(
       '.protractor-test-subscription-name')).last().getText()).toMatch(
-      'learner1...');
+      'learner...');
     users.logout();
 
     users.login('creator2@subscriptions.com');
@@ -92,7 +92,7 @@ describe('Subscriptions functionality', function() {
       '.protractor-test-subscription-name')).count()).toEqual(1);
     expect(element.all(by.css(
       '.protractor-test-subscription-name')).last().getText()).toMatch(
-      'learner1...');
+      'learner...');
     users.logout();
   });
 


### PR DESCRIPTION
Due to wrong truncation limit, names overflowed out of the subscription card like this -
![image](https://cloud.githubusercontent.com/assets/13691317/24590758/7e61bf0a-17e2-11e7-93f2-168d54ebe4fd.png)

The truncation limit has been reduced so that names fit on the card.
![image](https://cloud.githubusercontent.com/assets/13691317/24590779/d86166b8-17e2-11e7-89f7-68d81d1b4d3f.png)
