### PR TITLE
Fix #2936: Limit the length of goal description in explorations.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -11,6 +11,8 @@
                 <input id="explorationTitle" type="text" class="form-control protractor-test-exploration-title-input" ng-model="explorationTitleService.displayed" ng-blur="saveExplorationTitle()" placeholder="Choose a title for your exploration." focus-on="<[::EXPLORATION_TITLE_INPUT_FOCUS_LABEL]>" maxlength="40">
                 <span class="help-block" style="font-size: smaller">
                   <em>Please use at most 40 characters, so that this fits in the summary card.</em>
+                  <span ng-if="explorationTitleService.displayed.length > 0"><[ "Characters used: " +  (explorationTitleService.displayed.length) + "/40" ]>
+                  </span>
                 </span>
               </div>
             </div>
@@ -20,11 +22,11 @@
                 <input id="explorationObjective" type="text"
                        class="form-control protractor-test-exploration-objective-input"
                        ng-model="explorationObjectiveService.displayed"
-                       ng-blur="saveExplorationObjective()" placeholder="What does this exploration help people to do? " data-ng-trim="false">
+                       ng-blur="saveExplorationObjective()" placeholder="Learn how to..." data-ng-trim="false">
                 <span class="help-block" style="font-size: smaller">
-                    <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length">Please provide a complete, descriptive sentence.
+                    <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length"> In a complete sentence, tell people what they'll learn from this exploration.
                     </span>
-                    <span ng-if="explorationObjectiveService.displayed.length > 0"><[ "Characters remaining: " +  (explorationObjectiveService.displayed.length) + "/100" ]>
+                    <span ng-if="explorationObjectiveService.displayed.length > 0"><[ "Characters used: " +  (explorationObjectiveService.displayed.length) + "/100" ]>
                     </span>
                 </span>
               </div>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -8,7 +8,7 @@
             <div class="form-group" ng-class="{'has-error': !explorationTitleService.displayed}">
               <label for="explorationTitle" class="col-lg-2 col-md-2 col-sm-2">Title</label>
               <div class="col-lg-10 col-md-10 col-sm-10">
-                <input id="explorationTitle" type="text" class="form-control protractor-test-exploration-title-input" ng-model="explorationTitleService.displayed" ng-blur="saveExplorationTitle()" placeholder="Choose a title for your exploration." focus-on="<[::EXPLORATION_TITLE_INPUT_FOCUS_LABEL]>" maxlength="40">
+                <input id="explorationTitle" type="text" class="form-control protractor-test-exploration-title-input" ng-model="explorationTitleService.displayed" ng-blur="saveExplorationTitle()" placeholder="Choose a title for your exploration." focus-on="<[::EXPLORATION_TITLE_INPUT_FOCUS_LABEL]>" maxlength="40" data-ng-trim="false">
                 <span class="help-block" style="font-size: smaller">
                   <em>Please use at most 40 characters, so that this fits in the summary card.</em>
                   <span ng-if="explorationTitleService.displayed.length > 0">
@@ -24,10 +24,8 @@
                        class="form-control protractor-test-exploration-objective-input"
                        ng-model="explorationObjectiveService.displayed"
                        ng-blur="saveExplorationObjective()" placeholder="Learn how to..." data-ng-trim="false">
-                <span class="help-block" style="font-size: smaller">
-                    <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length">
+                <span class="help-block" style="font-size: smaller"> 
                     <em>In a complete sentence, tell people what they'll learn from this exploration.</em>
-                    </span>
                     <span ng-if="explorationObjectiveService.displayed.length > 0">
                     <em><[ "Characters used: " +  (explorationObjectiveService.displayed.length) + "/100" ]></em>
                     </span>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -618,4 +618,3 @@
     <button class="btn btn-default protractor-test-close-preview-summary-modal" ng-click="close()">Return to editor</button>
   </div>
 </script>
-

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -17,13 +17,16 @@
             <div class="form-group" ng-class="{'has-error': !explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15}">
               <label for="explorationObjective" class="col-lg-2 col-md-2 col-sm-2">Goal</label>
               <div class="col-lg-10 col-md-10 col-sm-10">
-                <input id="explorationObjective" type="text" onkeyup="counter(this);"
+                <input id="explorationObjective" type="text"
                        class="form-control protractor-test-exploration-objective-input"
                        ng-model="explorationObjectiveService.displayed"
                        ng-blur="saveExplorationObjective()" placeholder="Learn how to ..." maxlength="100">
                 <span class="help-block" style="font-size: smaller">
-                  What does this exploration help people to do? <span ng-if="explorationObjectiveService.displayed.length > 15" id="counter"></span>
-                  <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15">Please provide a complete, descriptive sentence.</span>
+                  What does this exploration help people to do? 
+                    <span ng-if="explorationObjectiveService.displayed.length > 15"><[ "Characters remaining: " +  (explorationObjectiveService.displayed.length) + "/100" ]>
+                    </span>
+                    <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15">Please provide a complete, descriptive sentence.
+                    </span>
                 </span>
               </div>
             </div>
@@ -615,8 +618,4 @@
     <button class="btn btn-default protractor-test-close-preview-summary-modal" ng-click="close()">Return to editor</button>
   </div>
 </script>
-<script>
-  function counter(msg){
-   document.getElementById('counter').innerHTML = "Characters remaining: " + "<b>" +msg.value.length+'/100' +"</b>" ;
-  }
-</script>
+

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -20,7 +20,7 @@
                 <input id="explorationObjective" type="text"
                        class="form-control protractor-test-exploration-objective-input"
                        ng-model="explorationObjectiveService.displayed"
-                       ng-blur="saveExplorationObjective()" placeholder="Learn how to ...">
+                       ng-blur="saveExplorationObjective()" placeholder="Learn how to ... (in about 100 characters)" maxlength="100">
                 <span class="help-block" style="font-size: smaller">
                   What does this exploration help people to do?
                   <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15">Please provide a complete, descriptive sentence.</span>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -11,7 +11,8 @@
                 <input id="explorationTitle" type="text" class="form-control protractor-test-exploration-title-input" ng-model="explorationTitleService.displayed" ng-blur="saveExplorationTitle()" placeholder="Choose a title for your exploration." focus-on="<[::EXPLORATION_TITLE_INPUT_FOCUS_LABEL]>" maxlength="40">
                 <span class="help-block" style="font-size: smaller">
                   <em>Please use at most 40 characters, so that this fits in the summary card.</em>
-                  <span ng-if="explorationTitleService.displayed.length > 0"><[ "Characters used: " +  (explorationTitleService.displayed.length) + "/40" ]>
+                  <span ng-if="explorationTitleService.displayed.length > 0">
+                  <em><[ "Characters used: " +  (explorationTitleService.displayed.length) + "/40" ]></em>
                   </span>
                 </span>
               </div>
@@ -24,9 +25,11 @@
                        ng-model="explorationObjectiveService.displayed"
                        ng-blur="saveExplorationObjective()" placeholder="Learn how to..." data-ng-trim="false">
                 <span class="help-block" style="font-size: smaller">
-                    <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length"> In a complete sentence, tell people what they'll learn from this exploration.
+                    <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length">
+                    <em>In a complete sentence, tell people what they'll learn from this exploration.</em>
                     </span>
-                    <span ng-if="explorationObjectiveService.displayed.length > 0"><[ "Characters used: " +  (explorationObjectiveService.displayed.length) + "/100" ]>
+                    <span ng-if="explorationObjectiveService.displayed.length > 0">
+                    <em><[ "Characters used: " +  (explorationObjectiveService.displayed.length) + "/100" ]></em>
                     </span>
                 </span>
               </div>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -12,7 +12,7 @@
                 <span class="help-block" style="font-size: smaller">
                   <em>Please use at most 40 characters, so that this fits in the summary card.</em>
                   <span ng-if="explorationTitleService.displayed.length > 0">
-                    <em>Characters used: <[(explorationTitleService.displayed.length) + "/40" ]></em>
+                    <em>Characters used: <[(explorationTitleService.displayed.length)]>/40</em>
                   </span>
                 </span>
               </div>
@@ -27,7 +27,7 @@
                 <span class="help-block" style="font-size: smaller"> 
                   <em>In a complete sentence, tell people what they'll learn from this exploration.</em>
                   <span ng-if="explorationObjectiveService.displayed.length > 0">
-                    <em>Characters used: <[(explorationObjectiveService.displayed.length) + "/100" ]></em>
+                    <em>Characters used: <[(explorationObjectiveService.displayed.length)]>/100</em>
                   </span>
                 </span>
               </div>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -14,18 +14,17 @@
                 </span>
               </div>
             </div>
-            <div class="form-group" ng-class="{'has-error': !explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15}">
+            <div class="form-group" ng-class="{'has-error': !explorationObjectiveService.displayed || ((explorationObjectiveService.displayed.length < 15) || (explorationObjectiveService.displayed.length > 100))}">
               <label for="explorationObjective" class="col-lg-2 col-md-2 col-sm-2">Goal</label>
               <div class="col-lg-10 col-md-10 col-sm-10">
                 <input id="explorationObjective" type="text"
                        class="form-control protractor-test-exploration-objective-input"
                        ng-model="explorationObjectiveService.displayed"
-                       ng-blur="saveExplorationObjective()" placeholder="Learn how to ..." maxlength="100">
+                       ng-blur="saveExplorationObjective()" placeholder="What does this exploration help people to do? " data-ng-trim="false">
                 <span class="help-block" style="font-size: smaller">
-                  What does this exploration help people to do? 
-                    <span ng-if="explorationObjectiveService.displayed.length > 15"><[ "Characters remaining: " +  (explorationObjectiveService.displayed.length) + "/100" ]>
+                    <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length">Please provide a complete, descriptive sentence.
                     </span>
-                    <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15">Please provide a complete, descriptive sentence.
+                    <span ng-if="explorationObjectiveService.displayed.length > 0"><[ "Characters remaining: " +  (explorationObjectiveService.displayed.length) + "/100" ]>
                     </span>
                 </span>
               </div>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -17,12 +17,12 @@
             <div class="form-group" ng-class="{'has-error': !explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15}">
               <label for="explorationObjective" class="col-lg-2 col-md-2 col-sm-2">Goal</label>
               <div class="col-lg-10 col-md-10 col-sm-10">
-                <input id="explorationObjective" type="text"
+                <input id="explorationObjective" type="text" onkeyup="counter(this);"
                        class="form-control protractor-test-exploration-objective-input"
                        ng-model="explorationObjectiveService.displayed"
-                       ng-blur="saveExplorationObjective()" placeholder="Learn how to ... (in about 100 characters)" maxlength="100">
+                       ng-blur="saveExplorationObjective()" placeholder="Learn how to ..." maxlength="100">
                 <span class="help-block" style="font-size: smaller">
-                  What does this exploration help people to do?
+                  What does this exploration help people to do? <span ng-if="explorationObjectiveService.displayed.length > 15" id="counter"></span>
                   <span ng-if="!explorationObjectiveService.displayed || explorationObjectiveService.displayed.length < 15">Please provide a complete, descriptive sentence.</span>
                 </span>
               </div>
@@ -614,4 +614,9 @@
   <div class="modal-footer">
     <button class="btn btn-default protractor-test-close-preview-summary-modal" ng-click="close()">Return to editor</button>
   </div>
+</script>
+<script>
+  function counter(msg){
+   document.getElementById('counter').innerHTML = "Characters remaining: " + "<b>" +msg.value.length+'/100' +"</b>" ;
+  }
 </script>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -8,11 +8,11 @@
             <div class="form-group" ng-class="{'has-error': !explorationTitleService.displayed}">
               <label for="explorationTitle" class="col-lg-2 col-md-2 col-sm-2">Title</label>
               <div class="col-lg-10 col-md-10 col-sm-10">
-                <input id="explorationTitle" type="text" class="form-control protractor-test-exploration-title-input" ng-model="explorationTitleService.displayed" ng-blur="saveExplorationTitle()" placeholder="Choose a title for your exploration." focus-on="<[::EXPLORATION_TITLE_INPUT_FOCUS_LABEL]>" maxlength="40" data-ng-trim="false">
+                <input id="explorationTitle" type="text" class="form-control protractor-test-exploration-title-input" ng-model="explorationTitleService.displayed" ng-blur="saveExplorationTitle()" placeholder="Choose a title for your exploration." focus-on="<[::EXPLORATION_TITLE_INPUT_FOCUS_LABEL]>" maxlength="40" ng-trim="false">
                 <span class="help-block" style="font-size: smaller">
                   <em>Please use at most 40 characters, so that this fits in the summary card.</em>
                   <span ng-if="explorationTitleService.displayed.length > 0">
-                  <em><[ "Characters used: " +  (explorationTitleService.displayed.length) + "/40" ]></em>
+                    <em>Characters used: <[(explorationTitleService.displayed.length) + "/40" ]></em>
                   </span>
                 </span>
               </div>
@@ -23,12 +23,12 @@
                 <input id="explorationObjective" type="text"
                        class="form-control protractor-test-exploration-objective-input"
                        ng-model="explorationObjectiveService.displayed"
-                       ng-blur="saveExplorationObjective()" placeholder="Learn how to..." data-ng-trim="false">
+                       ng-blur="saveExplorationObjective()" placeholder="Learn how to..." ng-trim="false">
                 <span class="help-block" style="font-size: smaller"> 
-                    <em>In a complete sentence, tell people what they'll learn from this exploration.</em>
-                    <span ng-if="explorationObjectiveService.displayed.length > 0">
-                    <em><[ "Characters used: " +  (explorationObjectiveService.displayed.length) + "/100" ]></em>
-                    </span>
+                  <em>In a complete sentence, tell people what they'll learn from this exploration.</em>
+                  <span ng-if="explorationObjectiveService.displayed.length > 0">
+                    <em>Characters used: <[(explorationObjectiveService.displayed.length) + "/100" ]></em>
+                  </span>
                 </span>
               </div>
             </div>


### PR DESCRIPTION
#2936
This PR is a suggested fix in the issue above. The exploration description is limited to 100 charaters