### PR TITLE
Refactoring : removed 'role' variable from GET request used in editor.py in delete method

### DIFF
--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -352,28 +352,12 @@ class ExplorationHandler(EditorHandler):
     @require_editor
     def delete(self, exploration_id):
         """Deletes the given exploration."""
-        role = self.request.get('role')
-        if not role:
-            role = None
 
-        if role == rights_manager.ROLE_ADMIN:
-            if not self.is_admin:
-                logging.error(
-                    '%s tried to delete an exploration, but is not an admin.'
-                    % self.user_id)
-                raise self.UnauthorizedUserException(
-                    'User %s does not have permissions to delete exploration '
-                    '%s' % (self.user_id, exploration_id))
-        elif role == rights_manager.ROLE_MODERATOR:
-            if not self.is_moderator:
-                logging.error(
-                    '%s tried to delete an exploration, but is not a '
-                    'moderator.' % self.user_id)
-                raise self.UnauthorizedUserException(
-                    'User %s does not have permissions to delete exploration '
-                    '%s' % (self.user_id, exploration_id))
-        elif role is not None:
-            raise self.InvalidInputException('Invalid role: %s' % role)
+        role = ''
+        if self.is_admin:
+            role = 'admin'
+        elif self.is_moderator:
+            role = 'moderator'
 
         logging.info(
             '%s %s tried to delete exploration %s' %

--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -353,15 +353,20 @@ class ExplorationHandler(EditorHandler):
     def delete(self, exploration_id):
         """Deletes the given exploration."""
 
-        role = ''
+        role_description = ''
         if self.is_admin:
-            role = 'admin'
+            role_description = 'admin'
         elif self.is_moderator:
-            role = 'moderator'
+            role_description = 'moderator'
 
-        logging.info(
-            '%s %s tried to delete exploration %s' %
-            (role, self.user_id, exploration_id))
+        log_debug_string = ''
+        if role_description == '':
+            log_debug_string = '%s tried to delete exploration %s' % (
+                self.user_id, exploration_id)
+        else:
+            log_debug_string = '(%s) %s tried to delete exploration %s' % (
+                role_description, self.user_id, exploration_id)
+        logging.debug(log_debug_string)
 
         exploration = exp_services.get_exploration_by_id(exploration_id)
         can_delete = rights_manager.Actor(self.user_id).can_delete(
@@ -376,9 +381,14 @@ class ExplorationHandler(EditorHandler):
         exp_services.delete_exploration(
             self.user_id, exploration_id, force_deletion=is_exploration_cloned)
 
-        logging.info(
-            '%s %s deleted exploration %s' %
-            (role, self.user_id, exploration_id))
+        log_info_string = ''
+        if role_description == '':
+            log_info_string = '%s deleted exploration %s' % (
+                self.user_id, exploration_id)
+        else:
+            log_info_string = '(%s) %s deleted exploration %s' % (
+                role_description, self.user_id, exploration_id)
+        logging.info(log_info_string)
 
 
 class ExplorationRightsHandler(EditorHandler):

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -728,9 +728,9 @@ class ExplorationDeletionRightsTest(BaseEditorControllerTest):
                 '/createhandler/data/%s' % exp_id, expect_errors=True)
 
             # Observed_log_messages[1] is 'Attempting to delete documents
-            # from index %s, ids: %s' % (index.name, ', '.join(doc_ids)) it is
-            # logged by function delete_documents_from_index in
-            # oppia/core/platform/search/gae_search_services.py
+            # from index %s, ids: %s' % (index.name, ', '.join(doc_ids)). It
+            # is logged by function delete_documents_from_index in
+            # oppia/core/platform/search/gae_search_services.py,
             # not to be checked here (same for admin and moderator).
             self.assertEqual(len(observed_log_messages), 3)
             self.assertEqual(observed_log_messages[0],

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -707,7 +707,12 @@ class ExplorationDeletionRightsTest(BaseEditorControllerTest):
         observed_log_messages = []
 
         def add_logging_info(msg, *_):
-            if msg != 'all_pending: clear %s':
+            # Message logged by function clear_all_pending() in
+            # oppia_tools/google_appengine_1.9.19/google_appengine/google/
+            # appengine/ext/ndb/tasklets.py, not to be checked here.
+            log_from_google_app_engine = 'all_pending: clear %s'
+
+            if msg != log_from_google_app_engine:
                 observed_log_messages.append(msg)
 
         with self.swap(logging, 'info', add_logging_info), self.swap(
@@ -721,6 +726,12 @@ class ExplorationDeletionRightsTest(BaseEditorControllerTest):
             self.login(self.OWNER_EMAIL)
             self.testapp.delete(
                 '/createhandler/data/%s' % exp_id, expect_errors=True)
+
+            # Observed_log_messages[1] is 'Attempting to delete documents
+            # from index %s, ids: %s' % (index.name, ', '.join(doc_ids)) it is
+            # logged by function delete_documents_from_index in
+            # oppia/core/platform/search/gae_search_services.py
+            # not to be checked here (same for admin and moderator).
             self.assertEqual(len(observed_log_messages), 3)
             self.assertEqual(observed_log_messages[0],
                              '%s tried to delete exploration %s' %

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
@@ -293,7 +293,7 @@ oppia.controller('SettingsTab', [
       });
     };
 
-    $scope.deleteExploration = function(role) {
+    $scope.deleteExploration = function() {
       alertsService.clearWarnings();
 
       $modal.open({
@@ -311,9 +311,6 @@ oppia.controller('SettingsTab', [
         ]
       }).result.then(function() {
         var deleteUrl = $scope.explorationDataUrl;
-        if (role) {
-          deleteUrl += ('?role=' + role);
-        }
         $http['delete'](deleteUrl).then(function() {
           $window.location = DASHBOARD_PAGE_URL;
         });

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -424,7 +424,7 @@
         {% if can_delete %}
           <p class="oppia-exploration-ctrl">
             <button type="button" ng-if="explorationRightsService.isPrivate()"
-                    class="btn btn-danger" ng-click="deleteExploration('')"
+                    class="btn btn-danger" ng-click="deleteExploration()"
                     title="Delete this exploration">
               Delete Exploration
             </button>
@@ -467,7 +467,7 @@
 
         <p class="oppia-exploration-ctrl oppia-exploration-ctrl-admin" ng-if="explorationRightsService.isPublic() && (currentUserIsAdmin || currentUserIsModerator)">
           <button type="button" class="btn btn-danger"
-                  ng-click="currentUserIsAdmin ? deleteExploration('admin') : deleteExploration('moderator')">
+                  ng-click="deleteExploration()">
             Delete Exploration
             <span ng-if="currentUserIsAdmin">(as admin)</span>
             <span ng-if="!currentUserIsAdmin && currentUserIsModerator">(as moderator)</span>


### PR DESCRIPTION
What was done ?
'role' variable was passed in GET request to use it for logging information in editor.py
- role variable was attached to the GET request in settings_tab.html and SettingsTab.js in deleteExploration function. 
- Then in editor.py it was checked for cases when role passed is 'admin' and user is not admin, similarly for moderator. It is an overkill as we don't need to pass role to do all this for logging.

How I replaced it ?
- I removed the passing 'role' variable from GET request.
- I gave role variable for editor.py using self.is_admin and self.is_moderator. 