### PR TITLE
Fix: #3297 . Renaming Classifier Registry method

### DIFF
--- a/core/domain/classifier_domain.py
+++ b/core/domain/classifier_domain.py
@@ -162,5 +162,7 @@ class Classifier(object):
             raise utils.ValidationError(
                 'Expected cached_classifier_data to be a dict, received %s' %(
                     self.cached_classifier_data))
-        classifier_class = classifier_registry.Registry.get_classifier_by_algorithm_id(self.algorithm_id) # pylint: disable=line-too-long
+        classifier_class = (
+            classifier_registry.Registry.get_classifier_by_algorithm_id(
+                self.algorithm_id))
         classifier_class.validate(self.cached_classifier_data)

--- a/core/domain/classifier_domain.py
+++ b/core/domain/classifier_domain.py
@@ -162,6 +162,5 @@ class Classifier(object):
             raise utils.ValidationError(
                 'Expected cached_classifier_data to be a dict, received %s' %(
                     self.cached_classifier_data))
-        classifier_class = classifier_registry.Registry.get_classifier_by_id(
-            self.algorithm_id)
+        classifier_class = classifier_registry.Registry.get_classifier_by_algorithm_id(self.algorithm_id) # pylint: disable=line-too-long
         classifier_class.validate(self.cached_classifier_data)

--- a/core/domain/classifier_registry.py
+++ b/core/domain/classifier_registry.py
@@ -29,11 +29,11 @@ class Registry(object):
     _classifier_instances = {}
 
     @classmethod
-    def get_all_classifier_ids(cls):
-        """Retrieves a list of all classifier IDs.
+    def get_all_classifier_algorithm_ids(cls):
+        """Retrieves a list of all classifier algorithm IDs.
 
         Returns:
-            A list containing all the classifier IDs.
+            A list containing all the classifier algorithm IDs.
         """
         return [classifier_id
                 for classifier_id in feconf.ANSWER_CLASSIFIER_CLASS_IDS]
@@ -45,7 +45,7 @@ class Registry(object):
         """
         cls._classifier_instances.clear()
 
-        all_classifier_ids = cls.get_all_classifier_ids()
+        all_classifier_ids = cls.get_all_classifier_algorithm_ids()
 
         # Assemble all paths to the classifiers.
         extension_paths = [
@@ -75,14 +75,14 @@ class Registry(object):
         return cls._classifier_instances.values()
 
     @classmethod
-    def get_classifier_by_id(cls, classifier_id):
-        """Retrieves a classifier instance by its id.
+    def get_classifier_by_algorithm_id(cls, classifier_algorithm_id):
+        """Retrieves a classifier instance by its algorithm id.
 
         Refreshes once if the classifier is not found; subsequently, throws a
         KeyError.
 
         Args:
-            classifier_id: str. The ID of the classifier.
+            classifier_algorithm_id: str. The ID of the classifier algorithm.
 
         Raises:
             KeyError: If the classifier is not found the first time.
@@ -90,6 +90,6 @@ class Registry(object):
         Returns:
             An instance of the classifier.
         """
-        if classifier_id not in cls._classifier_instances:
+        if classifier_algorithm_id not in cls._classifier_instances:
             cls._refresh()
-        return cls._classifier_instances[classifier_id]
+        return cls._classifier_instances[classifier_algorithm_id]

--- a/core/domain/classifier_registry_test.py
+++ b/core/domain/classifier_registry_test.py
@@ -21,12 +21,12 @@ from core.tests import test_utils
 class ClassifierRegistryTest(test_utils.GenericTestBase):
     """Test the classifier registry class."""
 
-    def test_get_all_classifier_ids(self):
+    def test_get_all_classifier_algorithm_ids(self):
         expected_algorithm_ids = [
             'LDAStringClassifier'
         ]
         algorithm_ids = (
-            classifier_registry.Registry.get_all_classifier_ids())
+            classifier_registry.Registry.get_all_classifier_algorithm_ids())
         self.assertItemsEqual(expected_algorithm_ids, algorithm_ids)
 
     def test_get_all_classifiers(self):

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -83,7 +83,7 @@ def classify_string_classifier_rule(state, normalized_answer):
     best_matched_answer_group_index = len(state.interaction.answer_groups)
     best_matched_rule_spec_index = None
 
-    sc = classifier_registry.Registry.get_classifier_by_id(
+    sc = classifier_registry.Registry.get_classifier_by_algorithm_id(
         feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput'])
 
     training_examples = [

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -52,7 +52,7 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
             exp_services.get_exploration_by_id(exploration_id).states['Home'])
 
     def _is_string_classifier_called(self, answer):
-        sc = classifier_registry.Registry.get_classifier_by_id(
+        sc = classifier_registry.Registry.get_classifier_by_algorithm_id(
             feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput'])
         string_classifier_predict = (
             sc.__class__.predict)

--- a/core/tests/performance_tests/lda_string_classifier_performance_test.py
+++ b/core/tests/performance_tests/lda_string_classifier_performance_test.py
@@ -106,7 +106,7 @@ class LDAStringClassifierBenchmarker(object):
             dict. The dict representing the resulting classifier model.
         """
         classifier = (
-            classifier_registry.Registry.get_classifier_by_id(
+            classifier_registry.Registry.get_classifier_by_algorithm_id(
                 feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput']))
         classifier.train(self.examples[:num])
         classifier_dict = classifier.to_dict()
@@ -129,7 +129,7 @@ class LDAStringClassifierBenchmarker(object):
         if not self.classifier_model_dict:
             raise Exception('No classifier found')
         classifier = (
-            classifier_registry.Registry.get_classifier_by_id(
+            classifier_registry.Registry.get_classifier_by_algorithm_id(
                 feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput']))
         classifier.from_dict(self.classifier_model_dict)
         classifier.predict(self.docs_to_classify[:num])

--- a/extensions/classifiers/LDAStringClassifier/LDAStringClassifierTest.py
+++ b/extensions/classifiers/LDAStringClassifier/LDAStringClassifierTest.py
@@ -42,7 +42,7 @@ class LDAStringClassifierTest(test_utils.GenericTestBase):
     def setUp(self):
         super(LDAStringClassifierTest, self).setUp()
         self.classifier = (
-            classifier_registry.Registry.get_classifier_by_id(
+            classifier_registry.Registry.get_classifier_by_algorithm_id(
                 feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput']))
         self.classifier.train(self._EXAMPLES_TRAIN)
 


### PR DESCRIPTION
#3297

This PR renames every occurrence of:
 - get_all_classifier_ids() to get_all_classifier_algorithm_ids()
 - get_classifier_by_id() to get_classifier_by_algorithm_id

PTAL @seanlip @anmolshkl 
Please tell me if I missed something. 
Thanks