### PR TITLE
Fix collection migration job to use non-strict validation

### DIFF
--- a/core/domain/collection_jobs_one_off.py
+++ b/core/domain/collection_jobs_one_off.py
@@ -55,7 +55,7 @@ class CollectionMigrationJob(jobs.BaseMapReduceJobManager):
         # Note: the read will bring the collection up to the newest version.
         collection = collection_services.get_collection_by_id(item.id)
         try:
-            collection.validate()
+            collection.validate(strict=False)
         except Exception as e:
             logging.error(
                 'Collection %s failed validation: %s' % (item.id, e))

--- a/core/domain/collection_jobs_one_off_test.py
+++ b/core/domain/collection_jobs_one_off_test.py
@@ -112,11 +112,7 @@ class CollectionMigrationJobTest(test_utils.GenericTestBase):
         """Tests that the collection migration job migrates collections which
         do not pass strict validation.
         """
-        # Create an exploration to put in the collection.
-        self.save_new_default_exploration(self.EXP_ID, self.albert_id)
-        node = collection_domain.CollectionNode.create_default_node(self.EXP_ID)
-
-        # Save a collection without an objective in version 1.
+        # Save a collection without an objective or explorations in version 1.
         collection_title = 'A title'
         collection_category = 'A category'
         rights_manager.create_new_collection_rights(
@@ -128,7 +124,6 @@ class CollectionMigrationJobTest(test_utils.GenericTestBase):
             objective='',
             tags=[],
             schema_version=1,
-            nodes=[node.to_dict()],
         )
         model.commit(self.albert_id, 'Made a new collection!', [{
             'cmd': collection_services.CMD_CREATE_NEW,

--- a/core/domain/collection_jobs_one_off_test.py
+++ b/core/domain/collection_jobs_one_off_test.py
@@ -95,7 +95,7 @@ class CollectionMigrationJobTest(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(Exception, 'Entity .* not found'):
             collection_services.get_collection_by_id(self.COLLECTION_ID)
 
-        # Start migration job on sample exploration.
+        # Start migration job on sample collection.
         job_id = (
             collection_jobs_one_off.CollectionMigrationJob.create_new())
         collection_jobs_one_off.CollectionMigrationJob.enqueue(job_id)
@@ -107,6 +107,47 @@ class CollectionMigrationJobTest(test_utils.GenericTestBase):
         # Ensure the exploration is still deleted.
         with self.assertRaisesRegexp(Exception, 'Entity .* not found'):
             collection_services.get_collection_by_id(self.COLLECTION_ID)
+
+    def test_migrate_colections_failing_strict_validation(self):
+        """Tests that the collection migration job migrates collections which
+        do not pass strict validation.
+        """
+        # Create an exploration to put in the collection.
+        self.save_new_default_exploration(self.EXP_ID, self.albert_id)
+        node = collection_domain.CollectionNode.create_default_node(self.EXP_ID)
+
+        # Save a collection without an objective in version 1.
+        collection_title = 'A title'
+        collection_category = 'A category'
+        rights_manager.create_new_collection_rights(
+            self.COLLECTION_ID, self.albert_id)
+        model = collection_models.CollectionModel(
+            id=self.COLLECTION_ID,
+            category=collection_title,
+            title=collection_category,
+            objective='',
+            tags=[],
+            schema_version=1,
+            nodes=[node.to_dict()],
+        )
+        model.commit(self.albert_id, 'Made a new collection!', [{
+            'cmd': collection_services.CMD_CREATE_NEW,
+            'title': collection_title,
+            'category': collection_category,
+        }])
+
+        # Start migration job on sample collection.
+        job_id = (
+            collection_jobs_one_off.CollectionMigrationJob.create_new())
+        collection_jobs_one_off.CollectionMigrationJob.enqueue(job_id)
+
+        # This running without errors indicates the collection is migrated.
+        self.process_and_flush_pending_tasks()
+
+        # Check the version number of the new model
+        new_model = collection_models.CollectionModel.get(self.COLLECTION_ID)
+        self.assertEqual(
+            new_model.schema_version, feconf.CURRENT_COLLECTION_SCHEMA_VERSION)
 
     def test_migration_job_migrates_collection_nodes(self):
         """Tests that the collection migration job migrates content from


### PR DESCRIPTION
The strict migration would fail to migrate collections that e.g. didn't have an objective.