### PR TITLE
Fix #2018: make toast z-index lower than navbar z-index

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1401,7 +1401,7 @@ md-card.oppia-dashboard-tile {
 
 .oppia-toast-container {
   position: fixed;
-  z-index: 999999;
+  z-index: 1000;
 }
 
 .oppia-toast-container * {


### PR DESCRIPTION
This makes the navbar usable even when there is an alert box.