### PR TITLE
Fix #3319: Oppia video at the donation page shows "Related videos" after the video finishes

### DIFF
--- a/core/templates/dev/head/pages/donate/donate.html
+++ b/core/templates/dev/head/pages/donate/donate.html
@@ -59,7 +59,7 @@
       <div class="oppia-donate-info">
         <div style="height: 0; margin: 60px auto 0px auto; width: 70%; padding-bottom: 56.25%; position: relative;">
           <iframe title="Meet Oppia's Contributors" width="100%"
-                  height="100%" src="https://www.youtube.com/embed/OConyxG7HaM"
+                  height="100%" src="https://www.youtube.com/embed/OConyxG7HaM?rel=0"
                   frameborder="0" allowfullscreen
                   style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
           </iframe>


### PR DESCRIPTION
#3319 
Added ?rel=0 to the video url to avoid related vidoes.