### PR TITLE
Fix #3282: Fixes the validate() function for LDAStringClassifier

### DIFF
--- a/extensions/classifiers/LDAStringClassifier/LDAStringClassifier.py
+++ b/extensions/classifiers/LDAStringClassifier/LDAStringClassifier.py
@@ -506,7 +506,6 @@ class LDAStringClassifier(BaseClassifier):
         model['_c_dl'] = copy.deepcopy(self._c_dl)
         model['_c_lw'] = copy.deepcopy(self._c_lw)
         model['_c_l'] = copy.deepcopy(self._c_l)
-        model = self._make_json_serializable(model)
         return model
 
     def from_dict(self, model):
@@ -516,7 +515,6 @@ class LDAStringClassifier(BaseClassifier):
         Args:
             model: A dict representing a StringClassifier.
         """
-        model = self._unpickle_json_serialization(model)
         self._alpha = copy.deepcopy(model['_alpha'])
         self._beta = copy.deepcopy(model['_beta'])
         self._prediction_threshold = copy.deepcopy(
@@ -536,67 +534,6 @@ class LDAStringClassifier(BaseClassifier):
         self._c_dl = copy.deepcopy(model['_c_dl'])
         self._c_lw = copy.deepcopy(model['_c_lw'])
         self._c_l = copy.deepcopy(model['_c_l'])
-
-    def _make_json_serializable(self, model):
-        """Makes the StringClassifier dict JSON serializable by
-        converting numpy data types to Python data types.
-
-        Args:
-            model: A dict representing a StringClassifier.
-
-        Returns:
-            model: A dict representing a StringClassifier
-        """
-        model["_b_dl"] = model["_b_dl"].tolist()
-        for k in range(len(model["_b_dl"])):
-            for i in range(len(model["_b_dl"][k])):
-                if isinstance(model["_b_dl"][k][i], numpy.integer):
-                    model["_b_dl"][k][i] = int(model["_b_dl"][k][i])
-                elif isinstance(model["_b_dl"][k][i], numpy.floating):
-                    model["_b_dl"][k][i] = float(model["_b_dl"][k][i])
-        model["_c_dl"] = model["_c_dl"].tolist()
-        for k in range(len(model["_c_dl"])):
-            for i in range(len(model["_c_dl"][k])):
-                if isinstance(model["_c_dl"][k][i], numpy.integer):
-                    model["_c_dl"][k][i] = int(model["_c_dl"][k][i])
-                elif isinstance(model["_c_dl"][k][i], numpy.floating):
-                    model["_c_dl"][k][i] = float(model["_c_dl"][k][i])
-        model["_c_lw"] = model["_c_lw"].tolist()
-        for k in range(len(model["_c_lw"])):
-            for i in range(len(model["_c_lw"][k])):
-                if isinstance(model["_c_lw"][k][i], numpy.integer):
-                    model["_c_lw"][k][i] = int(model["_c_lw"][k][i])
-                elif isinstance(model["_c_lw"][k][i], numpy.floating):
-                    model["_c_lw"][k][i] = float(model["_c_lw"][k][i])
-        model["_c_l"] = model["_c_l"].tolist()
-        for k in range(len(model["_c_l"])):
-            if isinstance(model["_c_l"][k], numpy.integer):
-                model["_c_lw"][k] = int(model["_c_lw"][k])
-            elif isinstance(model["_c_l"][k], numpy.floating):
-                model["_c_lw"][k] = float(model["_c_lw"][k])
-        model["_l_dp"] = model["_l_dp"]
-        for k in range(len(model["_l_dp"])):
-            for i in range(len(model["_l_dp"][k])):
-                if isinstance(model["_l_dp"][k][i], numpy.integer):
-                    model["_l_dp"][k][i] = int(model["_l_dp"][k][i])
-                elif isinstance(model["_l_dp"][k][i], numpy.floating):
-                    model["_l_dp"][k][i] = float(model["_l_dp"][k][i])
-        return model
-
-    def _unpickle_json_serialization(self, model):
-        """Converts the JSON serialized data back to Numpy format.
-
-        Args:
-            model: A dict representing a StringClassifier.
-
-        Returns:
-            model: A dict representing a StringClassifier
-        """
-        model["_b_dl"] = numpy.array(model["_b_dl"])
-        model["_c_dl"] = numpy.array(model["_c_dl"])
-        model["_c_lw"] = numpy.array(model["_c_lw"])
-        model["_c_l"] = numpy.array(model["_c_l"])
-        return model
 
     def train(self, training_data):
         """Sets the internal state of the classifier, assigns random initial

--- a/extensions/classifiers/LDAStringClassifier/LDAStringClassifier.py
+++ b/extensions/classifiers/LDAStringClassifier/LDAStringClassifier.py
@@ -506,6 +506,7 @@ class LDAStringClassifier(BaseClassifier):
         model['_c_dl'] = copy.deepcopy(self._c_dl)
         model['_c_lw'] = copy.deepcopy(self._c_lw)
         model['_c_l'] = copy.deepcopy(self._c_l)
+        model = self._make_json_serializable(model)
         return model
 
     def from_dict(self, model):
@@ -515,6 +516,7 @@ class LDAStringClassifier(BaseClassifier):
         Args:
             model: A dict representing a StringClassifier.
         """
+        model = self._unpickle_json_serialization(model)
         self._alpha = copy.deepcopy(model['_alpha'])
         self._beta = copy.deepcopy(model['_beta'])
         self._prediction_threshold = copy.deepcopy(
@@ -534,6 +536,67 @@ class LDAStringClassifier(BaseClassifier):
         self._c_dl = copy.deepcopy(model['_c_dl'])
         self._c_lw = copy.deepcopy(model['_c_lw'])
         self._c_l = copy.deepcopy(model['_c_l'])
+
+    def _make_json_serializable(self, model):
+        """Makes the StringClassifier dict JSON serializable by
+        converting numpy data types to Python data types.
+
+        Args:
+            model: A dict representing a StringClassifier.
+
+        Returns:
+            model: A dict representing a StringClassifier
+        """
+        model["_b_dl"] = model["_b_dl"].tolist()
+        for k in range(len(model["_b_dl"])):
+            for i in range(len(model["_b_dl"][k])):
+                if isinstance(model["_b_dl"][k][i], numpy.integer):
+                    model["_b_dl"][k][i] = int(model["_b_dl"][k][i])
+                elif isinstance(model["_b_dl"][k][i], numpy.floating):
+                    model["_b_dl"][k][i] = float(model["_b_dl"][k][i])
+        model["_c_dl"] = model["_c_dl"].tolist()
+        for k in range(len(model["_c_dl"])):
+            for i in range(len(model["_c_dl"][k])):
+                if isinstance(model["_c_dl"][k][i], numpy.integer):
+                    model["_c_dl"][k][i] = int(model["_c_dl"][k][i])
+                elif isinstance(model["_c_dl"][k][i], numpy.floating):
+                    model["_c_dl"][k][i] = float(model["_c_dl"][k][i])
+        model["_c_lw"] = model["_c_lw"].tolist()
+        for k in range(len(model["_c_lw"])):
+            for i in range(len(model["_c_lw"][k])):
+                if isinstance(model["_c_lw"][k][i], numpy.integer):
+                    model["_c_lw"][k][i] = int(model["_c_lw"][k][i])
+                elif isinstance(model["_c_lw"][k][i], numpy.floating):
+                    model["_c_lw"][k][i] = float(model["_c_lw"][k][i])
+        model["_c_l"] = model["_c_l"].tolist()
+        for k in range(len(model["_c_l"])):
+            if isinstance(model["_c_l"][k], numpy.integer):
+                model["_c_lw"][k] = int(model["_c_lw"][k])
+            elif isinstance(model["_c_l"][k], numpy.floating):
+                model["_c_lw"][k] = float(model["_c_lw"][k])
+        model["_l_dp"] = model["_l_dp"]
+        for k in range(len(model["_l_dp"])):
+            for i in range(len(model["_l_dp"][k])):
+                if isinstance(model["_l_dp"][k][i], numpy.integer):
+                    model["_l_dp"][k][i] = int(model["_l_dp"][k][i])
+                elif isinstance(model["_l_dp"][k][i], numpy.floating):
+                    model["_l_dp"][k][i] = float(model["_l_dp"][k][i])
+        return model
+
+    def _unpickle_json_serialization(self, model):
+        """Converts the JSON serialized data back to Numpy format.
+
+        Args:
+            model: A dict representing a StringClassifier.
+
+        Returns:
+            model: A dict representing a StringClassifier
+        """
+        model["_b_dl"] = numpy.array(model["_b_dl"])
+        model["_c_dl"] = numpy.array(model["_c_dl"])
+        model["_c_lw"] = numpy.array(model["_c_lw"])
+        model["_c_l"] = numpy.array(model["_c_l"])
+        return model
 
     def train(self, training_data):
         """Sets the internal state of the classifier, assigns random initial
@@ -623,12 +686,14 @@ class LDAStringClassifier(BaseClassifier):
             '_label_to_id',
             '_word_to_id'
         ]
-        list_of_list_properties = [
+        list_of_list_int_properties = [
             '_w_dp',
-            '_b_dl',
             '_l_dp',
             '_c_dl',
             '_c_lw'
+        ]
+        list_of_list_bool_properties = [
+            '_b_dl'
         ]
         list_properties = [
             '_c_l'
@@ -688,7 +753,7 @@ class LDAStringClassifier(BaseClassifier):
                         'Expected values of %s to be a int, received %s' % (
                             list_property, value))
 
-        for list_of_list_property in list_of_list_properties:
+        for list_of_list_property in list_of_list_int_properties:
             if list_of_list_property not in classifier_data:
                 raise utils.ValidationError(
                     'Expected %s to be a key in classifier_data' %
@@ -696,11 +761,26 @@ class LDAStringClassifier(BaseClassifier):
             if not isinstance(classifier_data[list_of_list_property], list):
                 raise utils.ValidationError(
                     'Expected %s to be a list, received %s' % (
-                        list_of_list_property,
-                        classifier_data[list_of_list_property]))
+                        list_of_list_property, classifier_data[list_of_list_property]))
             for inner_list in classifier_data[list_of_list_property]:
                 for value in inner_list:
                     if not isinstance(value, int):
                         raise utils.ValidationError(
                             'Expected values of %s to be a int, received %s' % (
+                                list_of_list_property, value))
+
+        for list_of_list_property in list_of_list_bool_properties:
+            if list_of_list_property not in classifier_data:
+                raise utils.ValidationError(
+                    'Expected %s to be a key in classifier_data' %
+                    list_of_list_property)
+            if not isinstance(classifier_data[list_of_list_property], list):
+                raise utils.ValidationError(
+                    'Expected %s to be a list, received %s' % (
+                        list_of_list_property, classifier_data[list_of_list_property]))
+            for inner_list in classifier_data[list_of_list_property]:
+                for value in inner_list:
+                    if not isinstance(value, bool):
+                        raise utils.ValidationError(
+                            'Expected values of %s to be a bool, received %s' % (
                                 list_of_list_property, value))

--- a/extensions/classifiers/LDAStringClassifier/LDAStringClassifier.py
+++ b/extensions/classifiers/LDAStringClassifier/LDAStringClassifier.py
@@ -698,7 +698,8 @@ class LDAStringClassifier(BaseClassifier):
             if not isinstance(classifier_data[list_of_list_property], list):
                 raise utils.ValidationError(
                     'Expected %s to be a list, received %s' % (
-                        list_of_list_property, classifier_data[list_of_list_property]))
+                        list_of_list_property,
+                        classifier_data[list_of_list_property]))
             for inner_list in classifier_data[list_of_list_property]:
                 for value in inner_list:
                     if not isinstance(value, int):
@@ -714,10 +715,11 @@ class LDAStringClassifier(BaseClassifier):
             if not isinstance(classifier_data[list_of_list_property], list):
                 raise utils.ValidationError(
                     'Expected %s to be a list, received %s' % (
-                        list_of_list_property, classifier_data[list_of_list_property]))
+                        list_of_list_property,
+                        classifier_data[list_of_list_property]))
             for inner_list in classifier_data[list_of_list_property]:
                 for value in inner_list:
                     if not isinstance(value, bool):
                         raise utils.ValidationError(
-                            'Expected values of %s to be a bool, received %s' % (
+                            'Expected values of %s to be bool, received %s' % (
                                 list_of_list_property, value))

--- a/extensions/classifiers/LDAStringClassifier/LDAStringClassifier.py
+++ b/extensions/classifiers/LDAStringClassifier/LDAStringClassifier.py
@@ -704,4 +704,3 @@ class LDAStringClassifier(BaseClassifier):
                         raise utils.ValidationError(
                             'Expected values of %s to be a int, received %s' % (
                                 list_of_list_property, value))
-

--- a/extensions/classifiers/LDAStringClassifier/LDAStringClassifierTest.py
+++ b/extensions/classifiers/LDAStringClassifier/LDAStringClassifierTest.py
@@ -310,7 +310,7 @@ class LDAStringClassifierTest(test_utils.GenericTestBase):
 
         # Verify validation error is raised when the list values are string
         # instead of int.
-        classifier_data['_w_dp'] = ['abc']
+        classifier_data['_w_dp'] = [['abc']]
         with self.assertRaisesRegexp(utils.ValidationError, (
             'Expected values of _w_dp to be a int')):
             self.classifier.validate(classifier_data)


### PR DESCRIPTION
#3282 

This PR rectifies the validate() function for LDAStringClassifier and also modifies the tests accordingly. 
Since we will be serializing the dict data, we don't need to handle numpy arrays in validate(). There were a couple of issues which had confusions between list_properties and list_of_list_properties. I fixed these issues. 
PTAL @anmolshkl 
Thanks. 