### PR TITLE
Fix #3318: Style fixes for collection card in creator dashboard 

### DIFF
--- a/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
@@ -10,8 +10,8 @@
       <div> 
         <div class="objective">
           <[getObjective() | truncateAndCapitalize: 95]>
+          <span ng-if="!getObjective()">No objective specified.</span>
         </div>
-        <span ng-if="!getObjective()">No objective specified.</span>
         <ul layout="row" class="metrics" layout-align="space-between center">
           <li>
             <span>


### PR DESCRIPTION
This the fix, for issue #3318. It was simple to fix, the span was not inherited by the class objective which caused alien behavior. Hence repositioned the `span`

**PR's fix:** 

![shot 05](https://cloud.githubusercontent.com/assets/24438869/24969550/c79d1f54-1fce-11e7-8d43-48827054cebc.jpg)
