### PR TITLE
Fix create exploration button terminology in collection editor.

### DIFF
--- a/core/templates/dev/head/pages/collection_editor/editor_tab/collection_node_creator_directive.html
+++ b/core/templates/dev/head/pages/collection_editor/editor_tab/collection_node_creator_directive.html
@@ -2,7 +2,7 @@
   <h2>Add Exploration</h2>
   <form class="form-inline" ng-submit="createNewExploration()">
     <input class="form-control" ng-model="newExplorationTitle" type="text" placeholder="New exploration title">
-    <button class="btn btn-success" type="submit" ng-disabled="!newExplorationTitle">Add New Exploration</button>
+    <button class="btn btn-success" type="submit" ng-disabled="!newExplorationTitle">Create New Exploration</button>
   </form>
   or
   <form ng-submit="addExploration()">


### PR DESCRIPTION
Change "Add new exploration" to "Create new exploration" to make the distinction with "Add existing exploration" clearer and match our terminology in the NavBar.
