### PR TITLE
Remove generic error message when trying to publish a collection cont…

### DIFF
--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
@@ -75,9 +75,6 @@ oppia.directive('collectionEditorNavbar', [function() {
               $scope.collectionRights.setPublic();
               CollectionEditorStateService.setCollectionRights(
                 $scope.collectionRights);
-            }, function() {
-              alertsService.addWarning(
-                'There was an error when publishing the collection.');
             });
         };
 


### PR DESCRIPTION
Remove generic error message "There was an error publishing this collection" which appears when we try to publish a collection containing a private exploration. The error message which actually describes the problem only appears now.