### PR TITLE
Fix #3329: 'Error 404: Page not found' has broken footer

### DIFF
--- a/core/templates/dev/head/pages/error/error.html
+++ b/core/templates/dev/head/pages/error/error.html
@@ -65,11 +65,11 @@
       font-weight: 700;
     }
     .oppia-footer {
-    position: absolute;
+      position: absolute;
     }
     @media (max-width: 768px) {
       .oppia-footer {
-      position: relative;
+        position: relative;
       }
     }
   </style>

--- a/core/templates/dev/head/pages/error/error.html
+++ b/core/templates/dev/head/pages/error/error.html
@@ -64,6 +64,9 @@
       font-size: 1.17em;
       font-weight: 700;
     }
+    .oppia-footer {
+    position: absolute;
+    }
   </style>
 {% endblock %}
 

--- a/core/templates/dev/head/pages/error/error.html
+++ b/core/templates/dev/head/pages/error/error.html
@@ -67,6 +67,11 @@
     .oppia-footer {
     position: absolute;
     }
+    @media (max-width: 768px) {
+      .oppia-footer {
+      position: relative;
+      }
+    }
   </style>
 {% endblock %}
 


### PR DESCRIPTION
#3329
The Error 404: Page not found has broken footer, 

**How to produce**
1. Go to any address which is not a page at Oppia, Eg http://localhost:8181/ighiu 

![screenshot from 2017-04-12 21-05-21](https://cloud.githubusercontent.com/assets/24438869/24966237/03312732-1fc4-11e7-9da4-79aecca881e4.png)

This PR's **commit**

![screenshot from 2017-04-22 14-32-38](https://cloud.githubusercontent.com/assets/24438869/25303013/94138082-2768-11e7-96b8-1ceb9f2f3f41.png)
