### PR TITLE
Fix #3355: Change of Font Awesome Icons for relevancy

### DIFF
--- a/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
@@ -78,7 +78,7 @@
       padding-top: 6px;
     }
     .oppia-sidebar-menu-icon.fa {
-      font-size: 22px;
+      font-size: 24px;
     }
 
   </style>

--- a/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
@@ -105,7 +105,7 @@
 
       <li ng-class="{'active': NAV_MODE === 'get_started'}">
         <a href="/get_started">
-          <i class="material-icons oppia-sidebar-menu-icon fa">&#xf135;</i>
+          <i class="oppia-sidebar-menu-icon fa">&#xf135;</i>
           <span translate="I18N_SIDEBAR_GET_STARTED"></span>
         </a>
       </li>

--- a/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
@@ -77,6 +77,9 @@
       height: 56px;
       padding-top: 6px;
     }
+    .oppia-sidebar-menu-icon.fa {
+      font-size: 22px;
+    }
 
   </style>
   <nav class="oppia-sidebar-menu oppia-sidebar-menu-transition">
@@ -102,7 +105,7 @@
 
       <li ng-class="{'active': NAV_MODE === 'get_started'}">
         <a href="/get_started">
-          <i class="material-icons oppia-sidebar-menu-icon">&#xE869;</i>
+          <i class="material-icons oppia-sidebar-menu-icon fa">&#xf135;</i>
           <span translate="I18N_SIDEBAR_GET_STARTED"></span>
         </a>
       </li>
@@ -130,7 +133,7 @@
 
       <li ng-class="{'active': NAV_MODE === 'contact'}">
         <a href="/contact">
-          <i class="material-icons oppia-sidebar-menu-icon">&#xE87F;</i>
+          <i class="material-icons oppia-sidebar-menu-icon">&#xE0BE;</i>
           <span translate="I18N_SIDEBAR_CONTACT_US"></span>
         </a>
       </li>

--- a/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
@@ -77,7 +77,7 @@
       height: 56px;
       padding-top: 6px;
     }
-    .oppia-sidebar-menu-icon.fa {
+    side-navigation-bar .oppia-sidebar-menu-icon.fa {
       font-size: 24px;
     }
 


### PR DESCRIPTION
#3355
Modified necessary icons as stated in the issue. 

**PR's commit:**

![screenshot from 2017-04-25 15-23-12](https://cloud.githubusercontent.com/assets/24438869/25379587/2846cc64-29cb-11e7-8ecf-556c145630a1.png)


**Note on Code:**
1. For the contact icon found the relevant icon from the [material icons itself.  ](https://material.io/icons/#ic_mail)
2. The Get started icon (rocket) was not present in the Material icon set as it is very limited. Adopted the font awesome icons, hence added the required `fa` class and font size for it. 