### PR TITLE
Fix #3343: Add trash icon for deleting regions

### DIFF
--- a/extensions/objects/templates/ImageWithRegionsEditor.js
+++ b/extensions/objects/templates/ImageWithRegionsEditor.js
@@ -36,17 +36,30 @@ oppia.directive('imageWithRegionsEditor', [
         '$scope', '$element', '$modal', function($scope, $element, $modal) {
           $scope.alwaysEditable = true;
 
-          $scope.REGION_LABEL_OFFSET_X = 6;
-          $scope.REGION_LABEL_OFFSET_Y = 18;
-          $scope.REGION_LABEL_STYLE = (
-            'fill: white; font-size: large; pointer-events: none;');
-          $scope.SELECTED_REGION_STYLE = 'fill: orange; opacity: 0.5;';
-          $scope.UNSELECTED_REGION_STYLE = 'fill: blue; opacity: 0.5;';
+          // Dynamically defines the CSS style for the region rectangle.
           $scope.getRegionStyle = function(index) {
             if (index === $scope.selectedRegion) {
-              return $scope.SELECTED_REGION_STYLE;
+              return 'fill: blue; opacity: 0.5;';
             } else {
-              return $scope.UNSELECTED_REGION_STYLE;
+              return 'fill: white; opacity: 0.5;';
+            }
+          };
+
+          // Dynamically defines the CSS style for the region rectangle.
+          $scope.getRegionTrashStyle = function(index) {
+            if (index === $scope.selectedRegion) {
+              return 'fill: #eee; opacity: 0.7';
+            } else {
+              return 'fill: #333; opacity: 0.7';
+            }
+          };
+
+          // Dynammically defines the CSS style for the region rectangle.
+          $scope.getRegionLabelStyle = function(index) {
+            if (index === $scope.selectedRegion) {
+              return 'fill: #eee; font-size: 14px; pointer-events: none;';
+            } else {
+              return 'fill: #333; font-size: 14px; pointer-events: none;';
             }
           };
 
@@ -99,6 +112,13 @@ oppia.directive('imageWithRegionsEditor', [
           $scope.hoveredRegion = null;
           // Index of region currently selected.
           $scope.selectedRegion = null;
+
+          // Temporary label list
+          var labelList = $scope.$parent.value.labeledRegions.map(
+            function(region) {
+              return region.label;
+            }
+          );
 
           // Temporary label list
           var labelList = $scope.$parent.value.labeledRegions.map(
@@ -327,8 +347,9 @@ oppia.directive('imageWithRegionsEditor', [
                 // that doesn't overlap with currently existing labels.
                 var newLabel = null;
                 for (var i = 1; i <= labels.length + 1; i++) {
-                  if (labels.indexOf(i.toString()) === -1) {
-                    newLabel = i.toString();
+                  var candidateLabel = 'region ' + i.toString();
+                  if (labels.indexOf(candidateLabel) === -1) {
+                    newLabel = candidateLabel;
                     break;
                   }
                 }

--- a/extensions/objects/templates/ImageWithRegionsEditor.js
+++ b/extensions/objects/templates/ImageWithRegionsEditor.js
@@ -39,13 +39,13 @@ oppia.directive('imageWithRegionsEditor', [
           // Dynamically defines the CSS style for the region rectangle.
           $scope.getRegionStyle = function(index) {
             if (index === $scope.selectedRegion) {
-              return 'fill: blue; opacity: 0.5;';
+              return 'fill: #00f; opacity: 0.5; stroke: #00d';
             } else {
-              return 'fill: white; opacity: 0.5;';
+              return 'fill: white; opacity: 0.5; stroke: #ddd';
             }
           };
 
-          // Dynamically defines the CSS style for the region rectangle.
+          // Dynamically defines the CSS style for the region trash icon.
           $scope.getRegionTrashStyle = function(index) {
             if (index === $scope.selectedRegion) {
               return 'fill: #eee; opacity: 0.7';
@@ -54,7 +54,7 @@ oppia.directive('imageWithRegionsEditor', [
             }
           };
 
-          // Dynammically defines the CSS style for the region rectangle.
+          // Dynamically defines the CSS style for the region label.
           $scope.getRegionLabelStyle = function(index) {
             if (index === $scope.selectedRegion) {
               return 'fill: #eee; font-size: 14px; pointer-events: none;';

--- a/extensions/objects/templates/ImageWithRegionsEditor.js
+++ b/extensions/objects/templates/ImageWithRegionsEditor.js
@@ -120,13 +120,6 @@ oppia.directive('imageWithRegionsEditor', [
             }
           );
 
-          // Temporary label list
-          var labelList = $scope.$parent.value.labeledRegions.map(
-            function(region) {
-              return region.label;
-            }
-          );
-
           // Calculates the dimensions of the image, assuming that the width
           // of the image is scaled down to fit the svg element if necessary.
           var _calculateImageDimensions = function() {

--- a/extensions/objects/templates/ImageWithRegionsEditor.js
+++ b/extensions/objects/templates/ImageWithRegionsEditor.js
@@ -347,7 +347,7 @@ oppia.directive('imageWithRegionsEditor', [
                 // that doesn't overlap with currently existing labels.
                 var newLabel = null;
                 for (var i = 1; i <= labels.length + 1; i++) {
-                  var candidateLabel = 'region ' + i.toString();
+                  var candidateLabel = 'Region ' + i.toString();
                   if (labels.indexOf(candidateLabel) === -1) {
                     newLabel = candidateLabel;
                     break;

--- a/extensions/objects/templates/image_with_regions_editor.html
+++ b/extensions/objects/templates/image_with_regions_editor.html
@@ -36,10 +36,22 @@
         ng-mousemove="onMouseMoveRegion()"
         ng-mousedown="onMousedownRegion($index)">
       </rect>
+      <a ng-repeat="labeledRegion in $parent.$parent.value.labeledRegions" href
+        ng-click="deleteRegion($index)"
+        style=""
+        target="_blank">
+        <text
+          font-family="Material Icons"
+          font-size="20px"
+          text-decoration="none"
+          ng-attr-style="<[getRegionTrashStyle($index)]>"
+          ng-attr-x="<[labeledRegion.region.area[1][0] * getImageWidth() - 25]>"
+          ng-attr-y="<[labeledRegion.region.area[1][1] * getImageHeight() - 5]>">&#xE872;</text>
+      </a>
       <text ng-repeat="labeledRegion in $parent.$parent.value.labeledRegions"
-        ng-attr-style="<[::REGION_LABEL_STYLE]>"
-        ng-attr-x="<[labeledRegion.region.area[0][0] * getImageWidth() + REGION_LABEL_OFFSET_X]>"
-        ng-attr-y="<[labeledRegion.region.area[0][1] * getImageHeight() + REGION_LABEL_OFFSET_Y]>">
+        ng-attr-style="<[getRegionLabelStyle($index)]>"
+        ng-attr-x="<[labeledRegion.region.area[0][0] * getImageWidth() + 6]>"
+        ng-attr-y="<[labeledRegion.region.area[0][1] * getImageHeight() + 18]>">
         <[labeledRegion.label]>
       </text>
     </svg>
@@ -50,7 +62,6 @@
           ng-model="regionLabelGetterSetter(selectedRegion)" 
           ng-model-options="{getterSetter: true}">
         </input>
-        <button style="margin-top: -6px;" type="button" class="btn btn-danger btn-sm" ng-click="deleteRegion(selectedRegion)">Delete Region</button>
       </div>  
 
   </div>

--- a/extensions/objects/templates/image_with_regions_editor.html
+++ b/extensions/objects/templates/image_with_regions_editor.html
@@ -38,7 +38,6 @@
       </rect>
       <a ng-repeat="labeledRegion in $parent.$parent.value.labeledRegions" href
         ng-click="deleteRegion($index)"
-        style=""
         target="_blank">
         <text
           font-family="Material Icons"


### PR DESCRIPTION
Minor changes included in this fix (not originally requested in the bug):
 * Changed the labels of new regions to be "Region {index}" instead of just "{index}"
 * Changed the colors of selected and non-selected regions for a better look-and-feel. Now non-selected regions are white and translucent and selected ones are blue translucent.