### PR TITLE
Fix #3304: Better account for overflowing text on summary cards

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3697,10 +3697,16 @@ md-card.preview-conversation-skin-supplemental-card {
   font-family: "Capriola", "Roboto", Arial, sans-serif;
   font-size: 1em;
   font-weight: normal;
+  hyphens: auto;
   line-height: 1.2em;
   margin: 0.3em 0.5em;
+  -ms-hyphens: auto;
+  -moz-hyphens: auto;
+  overflow-wrap: break-word;
   padding: 0.2em;
   position: absolute;
+  word-break: break-word;
+  -webkit-hyphens: auto;
 }
 .oppia-activity-summary-tile .objective {
   display: -webkit-box;


### PR DESCRIPTION
Made a PR as suggested CSS fix from the issue #3304 

**PR's commit**

![screenshot from 2017-05-01 21-44-40](https://cloud.githubusercontent.com/assets/24438869/25585332/99447c22-2eb7-11e7-9db1-b84f4a69f0d7.png)
