### PR TITLE
Fix #3259: the number of feedback items in the dashboard is incorrect.

### DIFF
--- a/core/controllers/dashboard.py
+++ b/core/controllers/dashboard.py
@@ -154,21 +154,29 @@ class DashboardHandler(base.BaseHandler):
         def _round_average_ratings(rating):
             return round(rating, feconf.AVERAGE_RATINGS_DASHBOARD_PRECISION)
 
-        exploration_ids_subscribed_to = (
-            subscription_services.get_exploration_ids_subscribed_to(
-                self.user_id))
-
-        subscribed_exploration_summaries = filter(None, (
+        # We need to do the filtering because some activities that were
+        # originally subscribed to may have been deleted since.
+        subscribed_exploration_summaries = [
+            summary for summary in
             exp_services.get_exploration_summaries_matching_ids(
-                exploration_ids_subscribed_to)))
-        subscribed_collection_summaries = filter(None, (
+                subscription_services.get_exploration_ids_subscribed_to(
+                    self.user_id))
+            if summary is not None]
+        subscribed_collection_summaries = [
+            summary for summary in
             collection_services.get_collection_summaries_matching_ids(
                 subscription_services.get_collection_ids_subscribed_to(
-                    self.user_id))))
+                    self.user_id))
+            if summary is not None]
 
-        exp_summary_list = summary_services.get_displayable_exp_summary_dicts(
+        exploration_ids_subscribed_to = [
+            summary.id for summary in subscribed_exploration_summaries]
+        collection_ids_subscribed_to = [
+            summary.id for summary in subscribed_collection_summaries]
+
+        exp_summary_dicts = summary_services.get_displayable_exp_summary_dicts(
             subscribed_exploration_summaries)
-        collection_summary_list = []
+        collection_summary_dicts = []
 
         feedback_thread_analytics = (
             feedback_services.get_thread_analytics_multi(
@@ -180,7 +188,7 @@ class DashboardHandler(base.BaseHandler):
 
         total_unresolved_answers = 0
 
-        for ind, exploration in enumerate(exp_summary_list):
+        for ind, exploration in enumerate(exp_summary_dicts):
             exploration.update(feedback_thread_analytics[ind].to_dict())
             exploration.update({
                 'num_unresolved_answers': (
@@ -195,8 +203,8 @@ class DashboardHandler(base.BaseHandler):
             })
             total_unresolved_answers += exploration['num_unresolved_answers']
 
-        exp_summary_list = sorted(
-            exp_summary_list,
+        exp_summary_dicts = sorted(
+            exp_summary_dicts,
             key=lambda x: (x['num_open_threads'], x['last_updated_msec']),
             reverse=True)
 
@@ -205,7 +213,7 @@ class DashboardHandler(base.BaseHandler):
             for collection_summary in subscribed_collection_summaries:
                 # TODO(sll): Reuse _get_displayable_collection_summary_dicts()
                 # in summary_services, instead of replicating it like this.
-                collection_summary_list.append({
+                collection_summary_dicts.append({
                     'id': collection_summary.id,
                     'title': collection_summary.title,
                     'category': collection_summary.category,
@@ -259,8 +267,8 @@ class DashboardHandler(base.BaseHandler):
             subscribers_list.append(subscriber_summary)
 
         self.values.update({
-            'explorations_list': exp_summary_list,
-            'collections_list': collection_summary_list,
+            'explorations_list': exp_summary_dicts,
+            'collections_list': collection_summary_dicts,
             'dashboard_stats': dashboard_stats,
             'last_week_stats': last_week_stats,
             'subscribers_list': subscribers_list

--- a/core/controllers/dashboard.py
+++ b/core/controllers/dashboard.py
@@ -171,8 +171,6 @@ class DashboardHandler(base.BaseHandler):
 
         exploration_ids_subscribed_to = [
             summary.id for summary in subscribed_exploration_summaries]
-        collection_ids_subscribed_to = [
-            summary.id for summary in subscribed_collection_summaries]
 
         exp_summary_dicts = summary_services.get_displayable_exp_summary_dicts(
             subscribed_exploration_summaries)


### PR DESCRIPTION
PTAL. It turns out that, if explorations subscribed to are later deleted, then there is a mismatch between the list of non-None exploration summaries that are generated and the list of feedback messages returned (which includes exploration summaries that might be None). These two lists were zipped together, causing feedback information to be matched incorrectly to the exploration information.