### PR TITLE
Fix PipelineSetupError when MR jobs are run on the dev server.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,5 @@
 application: oppiaserver
-version: 2-4-2
+version: default
 runtime: python27
 api_version: 1
 threadsafe: false


### PR DESCRIPTION
This is probably happening due to the recent GAE upgrade. The fix is mentioned [here](https://github.com/GoogleCloudPlatform/appengine-mapreduce/issues/103#issuecomment-293287529).

@wxyxinyu -- please only merge this once you confirm that it doesn't negatively impact the release process? Thanks!