### PR TITLE
Testing New Splash Page Variants

### DIFF
--- a/core/controllers/dashboard_test.py
+++ b/core/controllers/dashboard_test.py
@@ -42,7 +42,7 @@ class HomePageTest(test_utils.GenericTestBase):
 
         self.assertEqual(response.status_int, 302)
         self.assertIn('splash', response.headers['location'])
-        response.follow().mustcontain(
+        response.follow().follow().mustcontain(
             'I18N_SIDEBAR_ABOUT_LINK', 'I18N_TOPNAV_SIGN_IN')
 
     def test_notifications_dashboard_redirects_for_logged_out_users(self):

--- a/core/controllers/library.py
+++ b/core/controllers/library.py
@@ -206,6 +206,11 @@ class LibraryGroupIndexHandler(base.BaseHandler):
                 activity_list = top_rated_activity_summary_dicts
                 header_i18n_id = feconf.LIBRARY_CATEGORY_TOP_RATED_EXPLORATIONS
 
+        # TODO: create a Splash controller, move this there, and implement it properly.
+        elif group_name == 'splash_page_featured':
+            splash_page_featured_exploration_ids = ['0', 'yvqBFOQNDz5e', 'BvpDpLSmO2Iu', 'gC4_ggkWar-L']
+            activity_list = summary_services.get_displayable_exp_summary_dicts_matching_ids(splash_page_featured_exploration_ids)
+
         else:
             return self.PageNotFoundException
 

--- a/core/controllers/library.py
+++ b/core/controllers/library.py
@@ -207,7 +207,7 @@ class LibraryGroupIndexHandler(base.BaseHandler):
                 header_i18n_id = feconf.LIBRARY_CATEGORY_TOP_RATED_EXPLORATIONS
 
         # TODO: create a Splash controller and implement this properly.
-        elif group_name == feconf.SPLASH_PAGE_FEATURED:
+        elif group_name == feconf.LIBRARY_CATEGORY_SPLASH_PAGE_FEATURED:
             splash_page_featured_exploration_ids = [
                 '0', 'yvqBFOQNDz5e', 'BvpDpLSmO2Iu', 'gC4_ggkWar-L']
             activity_list = (

--- a/core/controllers/library.py
+++ b/core/controllers/library.py
@@ -206,10 +206,15 @@ class LibraryGroupIndexHandler(base.BaseHandler):
                 activity_list = top_rated_activity_summary_dicts
                 header_i18n_id = feconf.LIBRARY_CATEGORY_TOP_RATED_EXPLORATIONS
 
-        # TODO: create a Splash controller, move this there, and implement it properly.
+        # TODO: create a Splash controller and implement this properly.
         elif group_name == 'splash_page_featured':
-            splash_page_featured_exploration_ids = ['0', 'yvqBFOQNDz5e', 'BvpDpLSmO2Iu', 'gC4_ggkWar-L']
-            activity_list = summary_services.get_displayable_exp_summary_dicts_matching_ids(splash_page_featured_exploration_ids)
+            splash_page_featured_exploration_ids = [
+                '0', 'yvqBFOQNDz5e', 'BvpDpLSmO2Iu', 'gC4_ggkWar-L']
+            a = summary_services.get_displayable_exp_summary_dicts_matching_ids(
+                splash_page_featured_exploration_ids)
+            # Really sorry about this -- I'm out of time and need to get the
+            # linter's line length check to pass here. Will fix this later.
+            activity_list = a
 
         else:
             return self.PageNotFoundException

--- a/core/controllers/library.py
+++ b/core/controllers/library.py
@@ -207,14 +207,12 @@ class LibraryGroupIndexHandler(base.BaseHandler):
                 header_i18n_id = feconf.LIBRARY_CATEGORY_TOP_RATED_EXPLORATIONS
 
         # TODO: create a Splash controller and implement this properly.
-        elif group_name == 'splash_page_featured':
+        elif group_name == feconf.SPLASH_PAGE_FEATURED:
             splash_page_featured_exploration_ids = [
                 '0', 'yvqBFOQNDz5e', 'BvpDpLSmO2Iu', 'gC4_ggkWar-L']
-            a = summary_services.get_displayable_exp_summary_dicts_matching_ids(
-                splash_page_featured_exploration_ids)
-            # Really sorry about this -- I'm out of time and need to get the
-            # linter's line length check to pass here. Will fix this later.
-            activity_list = a
+            activity_list = (
+                summary_services.get_displayable_exp_summary_dicts_matching_ids(
+                    splash_page_featured_exploration_ids))
 
         else:
             return self.PageNotFoundException

--- a/core/controllers/pages.py
+++ b/core/controllers/pages.py
@@ -46,7 +46,7 @@ class SplashPage(base.BaseHandler):
         })
 
         if not c_value:
-            random_number = random.randrange(0,5)
+            random_number = random.randrange(0, 5)
             if random_number == 0:
                 self.render_template('pages/splash/splash.html')
             else:

--- a/core/controllers/pages.py
+++ b/core/controllers/pages.py
@@ -14,6 +14,7 @@
 
 """Controllers for simple, mostly-static pages (like About, Forum, etc.)."""
 
+import random
 import urllib
 import urlparse
 
@@ -45,7 +46,11 @@ class SplashPage(base.BaseHandler):
         })
 
         if not c_value:
-            self.render_template('pages/splash/splash.html')
+            random_number = random.randrange(0,5)
+            if random_number == 0:
+                self.render_template('pages/splash/splash.html')
+            else:
+                self.redirect('/splash?c=nv%d' % random_number)
         else:
             try:
                 self.render_template('pages/splash/splash_%s.html' % c_value)

--- a/core/templates/dev/head/pages/splash/Splash.js
+++ b/core/templates/dev/head/pages/splash/Splash.js
@@ -51,5 +51,8 @@ oppia.controller('Splash', [
       }, 150);
       return false;
     };
+
+    $scope.aboutPageMascotImgUrl = UrlInterpolationService.getStaticImageUrl(
+      '/general/about_page_mascot.png');
   }
 ]);

--- a/core/templates/dev/head/pages/splash/Splash.js
+++ b/core/templates/dev/head/pages/splash/Splash.js
@@ -17,15 +17,13 @@
  */
 
 oppia.controller('Splash', [
-  '$scope', '$timeout', '$window', 'siteAnalyticsService',
+  '$http', '$scope', '$timeout', '$window', 'siteAnalyticsService',
   'UrlInterpolationService',
-  function($scope, $timeout, $window, siteAnalyticsService,
+  function($http, $scope, $timeout, $window, siteAnalyticsService,
     UrlInterpolationService) {
     $scope.getStaticImageUrl = UrlInterpolationService.getStaticImageUrl;
-    $scope.getStaticSubjectImageUrl = function(subjectName) {
-      return UrlInterpolationService.getStaticImageUrl('/subjects/' +
-        subjectName + '.svg');
-    };
+    $scope.aboutPageMascotImgUrl = UrlInterpolationService.getStaticImageUrl(
+      '/general/about_page_mascot.png');
 
     $scope.onRedirectToLogin = function(destinationUrl) {
       siteAnalyticsService.registerStartLoginEvent(
@@ -52,7 +50,13 @@ oppia.controller('Splash', [
       return false;
     };
 
-    $scope.aboutPageMascotImgUrl = UrlInterpolationService.getStaticImageUrl(
-      '/general/about_page_mascot.png');
+    $http.get('/librarygrouphandler', {
+      params: {
+        group_name: 'splash_page_featured'
+      }
+    }).success(
+    function(data) {
+      $scope.activityList = data.activity_list;
+    });
   }
 ]);

--- a/core/templates/dev/head/pages/splash/Splash.js
+++ b/core/templates/dev/head/pages/splash/Splash.js
@@ -22,6 +22,10 @@ oppia.controller('Splash', [
   function($http, $scope, $timeout, $window, siteAnalyticsService,
     UrlInterpolationService) {
     $scope.getStaticImageUrl = UrlInterpolationService.getStaticImageUrl;
+    $scope.getStaticSubjectImageUrl = function(subjectName) {
+      return UrlInterpolationService.getStaticImageUrl('/subjects/' +
+        subjectName + '.svg');
+    };
     $scope.aboutPageMascotImgUrl = UrlInterpolationService.getStaticImageUrl(
       '/general/about_page_mascot.png');
 

--- a/core/templates/dev/head/pages/splash/Splash.js
+++ b/core/templates/dev/head/pages/splash/Splash.js
@@ -54,8 +54,7 @@ oppia.controller('Splash', [
       params: {
         group_name: 'splash_page_featured'
       }
-    }).success(
-    function(data) {
+    }).success(function(data) {
       $scope.activityList = data.activity_list;
     });
   }

--- a/core/templates/dev/head/pages/splash/splash_nv1.html
+++ b/core/templates/dev/head/pages/splash/splash_nv1.html
@@ -1,35 +1,240 @@
 {% extends 'pages/base.html' %}
 
 {% block prerender %}
-  <link rel="prerender" href="/library">
+	<link rel="prerender" href="/library">
 {% endblock prerender %}
 
 {% block maintitle %}
-  I18N_SPLASH_PAGE_TITLE
+	I18N_SPLASH_PAGE_TITLE
 {% endblock maintitle %}
 
 {% block header_js %}
-  {{ super() }}
+	{{ super() }}
 {% endblock %}
 
 {% block navbar_breadcrumb %}
 {% endblock navbar_breadcrumb %}
 
 {% block content %}
-  <div ng-controller="Splash">
-    1
-  </div>
+	<div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
+		<div class="container">
+			<div class="row">
+				<div class="col-md-4 oppia-display-desktop-only col-sm-3">
+					<img src="https://www.oppia.org/build/bcbnbz/assets/images/general/about_page_mascot.png" id="oppia-splash-new-otter" />
+				</div>
+				<div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
+					<h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
+					<h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
+					<div class="oppia-button-container">
+						<button type="button"
+										ng-click="onClickBrowseLibraryButton()"
+	                  class="btn oppia-transition-200 oppia-splash-new-cta-button">
+										Start Learning
+						</button>
+						<button type="button"
+										ng-click="onRedirectToLogin('/dashboard?mode=create')"
+										class="btn oppia-transition-200 oppia-splash-new-cta-button">
+										Share Your Knowledge
+						</button>
+					</div>
+				</div>
+			</div>
+			<div class="jumbotron">
+				<h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
+				<!-- TODO: put carousel here -->
+			</div>
+			<div class="jumbotron">
+				<div class="row">
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
+						</div>
+					</div>
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
+						</div>
+					</div>
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/dashboard?mode=create')">share your knowledge</a> today!</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="oppia-about-extra-info">
+			<button type="button"
+							ng-click="onClickBrowseLibraryButton()"
+							class="btn oppia-transition-200">
+							Start Learning
+			</button>
+			<button type="button"
+							ng-click="onRedirectToLogin('/dashboard?mode=create')"
+							class="btn oppia-transition-200">
+							Share Your Knowledge
+			</button>
+    </div>
+	</div>
 
-  <style>
-    /* styles that apply to just this page */
-  </style>
+	<style>
+		.oppia-splash-new-h1 {
+			font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+			color: #024340;
+			font-size: 2.75em;
+			margin: 20px auto 0 auto;
+			text-align: center;
+		}
+
+		.oppia-splash-new-h2 {
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      font-size: 2em;
+      font-weight: 300;
+      color: #04857c;
+      text-align: center;
+      margin: 18px 0;
+      line-height: 1.2;
+			-webkit-font-smoothing: subpixel-antialiased;
+			text-rendering: auto;
+    }
+
+    .jumbotron .oppia-splash-new-h2 {
+      margin-top: 0;
+    }
+
+		#oppia-splash-new-otter {
+			position: relative;
+			width: 250px;
+			bottom: -35px;
+			left: 10px;
+		}
+
+    .oppia-button-container {
+      text-align: center;
+			display: flex;
+			justify-content: center;
+    }
+
+		.oppia-button-container button {
+      background-color: #015c53;
+      border-radius: 0;
+      color: #ffffff;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 16px;
+      padding: 10px 0;
+      text-transform: uppercase;
+			width: 100%;
+      max-width: 300px;
+      border: none;
+			margin: auto 5px;
+    }
+
+    .oppia-button-container button:hover {
+      background-color: #05beb2;
+			color: #ffffff;
+    }
+
+		.oppia-bullet-holder img {
+      height: 125px;
+			display: block;
+			margin: auto;
+    }
+
+    .oppia-bullet-holder p {
+      padding: 5px 15px;
+			font-weight: 300;
+			line-height: 1.45;
+			font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+			color: #333333;
+			-webkit-font-smoothing: subpixel-antialiased;
+    }
+
+		.oppia-about-extra-info {
+      background-color: #009788;
+      color: #ffffff;
+      height: 150px;
+      text-align: center;
+    }
+
+    .oppia-about-extra-info button {
+      background-color: #00796d;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 18px;
+      margin: 0 15px 15px 15px;
+      max-width: 90%;
+      padding: 15px;
+      text-transform: uppercase;
+      white-space: normal;
+      width: 352px;
+      border-radius: 5px;
+      position: relative;
+      top: 50%;
+      transform: translateY(-50%);
+			-webkit-font-smoothing: subpixel-antialiased;
+    }
+
+    .oppia-about-extra-info button:hover {
+      background-color: #05beb2;
+			color: #ffffff;
+    }
+
+		@media (max-width: 768px) {
+			.oppia-display-desktop-only {
+				display: none !important;
+			}
+
+			.oppia-button-container {
+				flex-wrap: wrap;
+				margin-bottom: 10px;
+			}
+
+			.oppia-button-container button {
+				margin-bottom: 5px;
+			}
+
+			.oppia-about-extra-info {
+        padding: 15px 0;
+        height: auto;
+      }
+
+      .oppia-about-extra-info button {
+        position: auto;
+        top: auto;
+        transform: none;
+      }
+
+      .oppia-about-extra-info button:first-of-type {
+        margin-top: 15px;
+      }
+		}
+
+		@media (max-width: 992px) {
+      #oppia-splash-new-otter {
+        width: 175px;
+        bottom: -85px;
+      }
+    }
+
+
+	</style>
+
+	<link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
 {% endblock %}
 
 {% block footer %}
-  {% include 'pages/footer.html' %}
+	{% include 'pages/footer.html' %}
 {% endblock %}
 
 {% block footer_js %}
-  {{ super() }}
-  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+	{{ super() }}
+	<script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv1.html
+++ b/core/templates/dev/head/pages/splash/splash_nv1.html
@@ -41,8 +41,22 @@
 			</div>
 			<div class="jumbotron">
 				<h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
-				<!-- TODO: put carousel here -->
-			</div>
+				<div class="oppia-splash-new-exploration-summaries">
+        	<div ng-repeat="tile in activityList" style="display: inline-block;">
+          	<exploration-summary-tile exploration-id="tile.id"
+                                    	exploration-title="tile.title"
+                                    	last-updated-msec="tile.last_updated_msec"
+	                                    objective="tile.objective"
+	                                    category="tile.category"
+	                                    ratings="tile.ratings"
+	                                    num-views="tile.num_views"
+	                                    thumbnail-icon-url="tile.thumbnail_icon_url"
+	                                    thumbnail-bg-color="tile.thumbnail_bg_color"
+	                                    class="protractor-test-exp-summary-tile">
+          	</exploration-summary-tile>
+					</div>
+        </div>
+      </div>
 			<div class="jumbotron">
 				<div class="row">
 					<div class="col-sm-4 oppia-bullet-holder">
@@ -158,6 +172,10 @@
 			-webkit-font-smoothing: subpixel-antialiased;
     }
 
+		.oppia-splash-new-exploration-summaries {
+      text-align: center;
+    }
+
 		.oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
@@ -237,4 +255,6 @@
 {% block footer_js %}
 	{{ super() }}
 	<script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+	<script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
+	<script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv1.html
+++ b/core/templates/dev/head/pages/splash/splash_nv1.html
@@ -20,7 +20,7 @@
 		<div class="container">
 			<div class="row">
 				<div class="col-md-4 oppia-display-desktop-only col-sm-3">
-					<img src="https://www.oppia.org/build/bcbnbz/assets/images/general/about_page_mascot.png" id="oppia-splash-new-otter" />
+					<img ng-src="<[aboutPageMascotImgUrl]>" id="oppia-splash-new-otter" />
 				</div>
 				<div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
 					<h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
@@ -72,7 +72,7 @@
 				</div>
 			</div>
 		</div>
-		<div class="oppia-about-extra-info">
+		<div class="oppia-splash-new-callout">
 			<button type="button"
 							ng-click="onClickBrowseLibraryButton()"
 							class="btn oppia-transition-200">
@@ -158,14 +158,14 @@
 			-webkit-font-smoothing: subpixel-antialiased;
     }
 
-		.oppia-about-extra-info {
+		.oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
       height: 150px;
       text-align: center;
     }
 
-    .oppia-about-extra-info button {
+    .oppia-splash-new-callout button {
       background-color: #00796d;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 18px;
@@ -182,7 +182,7 @@
 			-webkit-font-smoothing: subpixel-antialiased;
     }
 
-    .oppia-about-extra-info button:hover {
+    .oppia-splash-new-callout button:hover {
       background-color: #05beb2;
 			color: #ffffff;
     }
@@ -201,18 +201,18 @@
 				margin-bottom: 5px;
 			}
 
-			.oppia-about-extra-info {
+			.oppia-splash-new-callout {
         padding: 15px 0;
         height: auto;
       }
 
-      .oppia-about-extra-info button {
+      .oppia-splash-new-callout button {
         position: auto;
         top: auto;
         transform: none;
       }
 
-      .oppia-about-extra-info button:first-of-type {
+      .oppia-splash-new-callout button:first-of-type {
         margin-top: 15px;
       }
 		}

--- a/core/templates/dev/head/pages/splash/splash_nv1.html
+++ b/core/templates/dev/head/pages/splash/splash_nv1.html
@@ -29,12 +29,12 @@
             <button type="button"
                     ng-click="onClickBrowseLibraryButton()"
                     class="btn oppia-transition-200 oppia-splash-new-cta-button">
-                    Start Learning
+              Start Learning
             </button>
             <button type="button"
                     ng-click="onRedirectToLogin('/dashboard?mode=create')"
                     class="btn oppia-transition-200 oppia-splash-new-cta-button">
-                    Share Your Knowledge
+              Share Your Knowledge
             </button>
           </div>
         </div>
@@ -90,34 +90,34 @@
       <button type="button"
               ng-click="onClickBrowseLibraryButton()"
               class="btn oppia-transition-200">
-              Start Learning
+        Start Learning
       </button>
       <button type="button"
               ng-click="onRedirectToLogin('/dashboard?mode=create')"
               class="btn oppia-transition-200">
-              Share Your Knowledge
+        Share Your Knowledge
       </button>
     </div>
   </div>
 
   <style>
     .oppia-splash-new-h1 {
-      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       color: #024340;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 2.75em;
       margin: 20px auto 0 auto;
       text-align: center;
     }
 
     .oppia-splash-new-h2 {
+      color: #04857c;
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
       font-size: 2em;
-      font-weight: 300;
-      color: #04857c;
-      text-align: center;
-      margin: 18px 0;
-      line-height: 1.2;
       -webkit-font-smoothing: subpixel-antialiased;
+      font-weight: 300;
+      line-height: 1.2;
+      margin: 18px 0;
+      text-align: center;
       text-rendering: auto;
     }
 
@@ -126,30 +126,30 @@
     }
 
     #oppia-splash-new-otter {
-      position: relative;
-      width: 250px;
       bottom: -35px;
       left: 10px;
+      position: relative;
+      width: 250px;
     }
 
     .oppia-button-container {
-      text-align: center;
       display: flex;
       justify-content: center;
+      text-align: center;
     }
 
     .oppia-button-container button {
       background-color: #015c53;
       border-radius: 0;
+      border: none;
       color: #ffffff;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 16px;
+      margin: auto 5px;
+      max-width: 300px;
       padding: 10px 0;
       text-transform: uppercase;
       width: 100%;
-      max-width: 300px;
-      border: none;
-      margin: auto 5px;
     }
 
     .oppia-button-container button:hover {
@@ -158,18 +158,18 @@
     }
 
     .oppia-bullet-holder img {
-      height: 125px;
       display: block;
+      height: 125px;
       margin: auto;
     }
 
     .oppia-bullet-holder p {
-      padding: 5px 15px;
+      color: #333333;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      -webkit-font-smoothing: subpixel-antialiased;
       font-weight: 300;
       line-height: 1.45;
-      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
-      color: #333333;
-      -webkit-font-smoothing: subpixel-antialiased;
+      padding: 5px 15px;
     }
 
     .oppia-splash-new-exploration-summaries {
@@ -185,19 +185,19 @@
 
     .oppia-splash-new-callout button {
       background-color: #00796d;
+      border-radius: 5px;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 18px;
+      -webkit-font-smoothing: subpixel-antialiased;
       margin: 0 15px 15px 15px;
       max-width: 90%;
       padding: 15px;
-      text-transform: uppercase;
-      white-space: normal;
-      width: 352px;
-      border-radius: 5px;
       position: relative;
+      text-transform: uppercase;
       top: 50%;
       transform: translateY(-50%);
-      -webkit-font-smoothing: subpixel-antialiased;
+      white-space: normal;
+      width: 352px;
     }
 
     .oppia-splash-new-callout button:hover {
@@ -220,8 +220,8 @@
       }
 
       .oppia-splash-new-callout {
-        padding: 15px 0;
         height: auto;
+        padding: 15px 0;
       }
 
       .oppia-splash-new-callout button {
@@ -237,11 +237,10 @@
 
     @media (max-width: 992px) {
       #oppia-splash-new-otter {
-        width: 175px;
         bottom: -85px;
+        width: 175px;
       }
     }
-
 
   </style>
 

--- a/core/templates/dev/head/pages/splash/splash_nv1.html
+++ b/core/templates/dev/head/pages/splash/splash_nv1.html
@@ -1,0 +1,35 @@
+{% extends 'pages/base.html' %}
+
+{% block prerender %}
+  <link rel="prerender" href="/library">
+{% endblock prerender %}
+
+{% block maintitle %}
+  I18N_SPLASH_PAGE_TITLE
+{% endblock maintitle %}
+
+{% block header_js %}
+  {{ super() }}
+{% endblock %}
+
+{% block navbar_breadcrumb %}
+{% endblock navbar_breadcrumb %}
+
+{% block content %}
+  <div ng-controller="Splash">
+    1
+  </div>
+
+  <style>
+    /* styles that apply to just this page */
+  </style>
+{% endblock %}
+
+{% block footer %}
+  {% include 'pages/footer.html' %}
+{% endblock %}
+
+{% block footer_js %}
+  {{ super() }}
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+{% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv1.html
+++ b/core/templates/dev/head/pages/splash/splash_nv1.html
@@ -1,115 +1,115 @@
 {% extends 'pages/base.html' %}
 
 {% block prerender %}
-	<link rel="prerender" href="/library">
+  <link rel="prerender" href="/library">
 {% endblock prerender %}
 
 {% block maintitle %}
-	I18N_SPLASH_PAGE_TITLE
+  I18N_SPLASH_PAGE_TITLE
 {% endblock maintitle %}
 
 {% block header_js %}
-	{{ super() }}
+  {{ super() }}
 {% endblock %}
 
 {% block navbar_breadcrumb %}
 {% endblock navbar_breadcrumb %}
 
 {% block content %}
-	<div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
-		<div class="container">
-			<div class="row">
-				<div class="col-md-4 oppia-display-desktop-only col-sm-3">
-					<img ng-src="<[aboutPageMascotImgUrl]>" id="oppia-splash-new-otter" />
-				</div>
-				<div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
-					<h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
-					<h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
-					<div class="oppia-button-container">
-						<button type="button"
-										ng-click="onClickBrowseLibraryButton()"
-	                  class="btn oppia-transition-200 oppia-splash-new-cta-button">
-										Start Learning
-						</button>
-						<button type="button"
-										ng-click="onRedirectToLogin('/dashboard?mode=create')"
-										class="btn oppia-transition-200 oppia-splash-new-cta-button">
-										Share Your Knowledge
-						</button>
-					</div>
-				</div>
-			</div>
-			<div class="jumbotron">
-				<h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
-				<div class="oppia-splash-new-exploration-summaries">
-        	<div ng-repeat="tile in activityList" style="display: inline-block;">
-          	<exploration-summary-tile exploration-id="tile.id"
-                                    	exploration-title="tile.title"
-                                    	last-updated-msec="tile.last_updated_msec"
-	                                    objective="tile.objective"
-	                                    category="tile.category"
-	                                    ratings="tile.ratings"
-	                                    num-views="tile.num_views"
-	                                    thumbnail-icon-url="tile.thumbnail_icon_url"
-	                                    thumbnail-bg-color="tile.thumbnail_bg_color"
-	                                    class="protractor-test-exp-summary-tile">
-          	</exploration-summary-tile>
-					</div>
+  <div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-4 oppia-display-desktop-only col-sm-3">
+          <img ng-src="<[aboutPageMascotImgUrl]>" id="oppia-splash-new-otter" />
+        </div>
+        <div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
+          <h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
+          <h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
+          <div class="oppia-button-container">
+            <button type="button"
+                    ng-click="onClickBrowseLibraryButton()"
+                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    Start Learning
+            </button>
+            <button type="button"
+                    ng-click="onRedirectToLogin('/dashboard?mode=create')"
+                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    Share Your Knowledge
+            </button>
+          </div>
         </div>
       </div>
-			<div class="jumbotron">
-				<div class="row">
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
-						</div>
-					</div>
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
-						</div>
-					</div>
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/dashboard?mode=create')">share your knowledge</a> today!</p>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-		<div class="oppia-splash-new-callout">
-			<button type="button"
-							ng-click="onClickBrowseLibraryButton()"
-							class="btn oppia-transition-200">
-							Start Learning
-			</button>
-			<button type="button"
-							ng-click="onRedirectToLogin('/dashboard?mode=create')"
-							class="btn oppia-transition-200">
-							Share Your Knowledge
-			</button>
+      <div class="jumbotron">
+        <h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
+        <div class="oppia-splash-new-exploration-summaries">
+          <div ng-repeat="tile in activityList" style="display: inline-block;">
+            <exploration-summary-tile exploration-id="tile.id"
+                                      exploration-title="tile.title"
+                                      last-updated-msec="tile.last_updated_msec"
+                                      objective="tile.objective"
+                                      category="tile.category"
+                                      ratings="tile.ratings"
+                                      num-views="tile.num_views"
+                                      thumbnail-icon-url="tile.thumbnail_icon_url"
+                                      thumbnail-bg-color="tile.thumbnail_bg_color"
+                                      class="protractor-test-exp-summary-tile">
+            </exploration-summary-tile>
+          </div>
+        </div>
+      </div>
+      <div class="jumbotron">
+        <div class="row">
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
+            </div>
+          </div>
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
+            </div>
+          </div>
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/dashboard?mode=create')">share your knowledge</a> today!</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-	</div>
+    <div class="oppia-splash-new-callout">
+      <button type="button"
+              ng-click="onClickBrowseLibraryButton()"
+              class="btn oppia-transition-200">
+              Start Learning
+      </button>
+      <button type="button"
+              ng-click="onRedirectToLogin('/dashboard?mode=create')"
+              class="btn oppia-transition-200">
+              Share Your Knowledge
+      </button>
+    </div>
+  </div>
 
-	<style>
-		.oppia-splash-new-h1 {
-			font-family: 'Capriola', 'Roboto', Arial, sans-serif;
-			color: #024340;
-			font-size: 2.75em;
-			margin: 20px auto 0 auto;
-			text-align: center;
-		}
+  <style>
+    .oppia-splash-new-h1 {
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      color: #024340;
+      font-size: 2.75em;
+      margin: 20px auto 0 auto;
+      text-align: center;
+    }
 
-		.oppia-splash-new-h2 {
+    .oppia-splash-new-h2 {
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
       font-size: 2em;
       font-weight: 300;
@@ -117,28 +117,28 @@
       text-align: center;
       margin: 18px 0;
       line-height: 1.2;
-			-webkit-font-smoothing: subpixel-antialiased;
-			text-rendering: auto;
+      -webkit-font-smoothing: subpixel-antialiased;
+      text-rendering: auto;
     }
 
     .jumbotron .oppia-splash-new-h2 {
       margin-top: 0;
     }
 
-		#oppia-splash-new-otter {
-			position: relative;
-			width: 250px;
-			bottom: -35px;
-			left: 10px;
-		}
+    #oppia-splash-new-otter {
+      position: relative;
+      width: 250px;
+      bottom: -35px;
+      left: 10px;
+    }
 
     .oppia-button-container {
       text-align: center;
-			display: flex;
-			justify-content: center;
+      display: flex;
+      justify-content: center;
     }
 
-		.oppia-button-container button {
+    .oppia-button-container button {
       background-color: #015c53;
       border-radius: 0;
       color: #ffffff;
@@ -146,37 +146,37 @@
       font-size: 16px;
       padding: 10px 0;
       text-transform: uppercase;
-			width: 100%;
+      width: 100%;
       max-width: 300px;
       border: none;
-			margin: auto 5px;
+      margin: auto 5px;
     }
 
     .oppia-button-container button:hover {
       background-color: #05beb2;
-			color: #ffffff;
+      color: #ffffff;
     }
 
-		.oppia-bullet-holder img {
+    .oppia-bullet-holder img {
       height: 125px;
-			display: block;
-			margin: auto;
+      display: block;
+      margin: auto;
     }
 
     .oppia-bullet-holder p {
       padding: 5px 15px;
-			font-weight: 300;
-			line-height: 1.45;
-			font-family: 'Rubik', 'Roboto', Arial, sans-serif;
-			color: #333333;
-			-webkit-font-smoothing: subpixel-antialiased;
+      font-weight: 300;
+      line-height: 1.45;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      color: #333333;
+      -webkit-font-smoothing: subpixel-antialiased;
     }
 
-		.oppia-splash-new-exploration-summaries {
+    .oppia-splash-new-exploration-summaries {
       text-align: center;
     }
 
-		.oppia-splash-new-callout {
+    .oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
       height: 150px;
@@ -197,29 +197,29 @@
       position: relative;
       top: 50%;
       transform: translateY(-50%);
-			-webkit-font-smoothing: subpixel-antialiased;
+      -webkit-font-smoothing: subpixel-antialiased;
     }
 
     .oppia-splash-new-callout button:hover {
       background-color: #05beb2;
-			color: #ffffff;
+      color: #ffffff;
     }
 
-		@media (max-width: 768px) {
-			.oppia-display-desktop-only {
-				display: none !important;
-			}
+    @media (max-width: 768px) {
+      .oppia-display-desktop-only {
+        display: none !important;
+      }
 
-			.oppia-button-container {
-				flex-wrap: wrap;
-				margin-bottom: 10px;
-			}
+      .oppia-button-container {
+        flex-wrap: wrap;
+        margin-bottom: 10px;
+      }
 
-			.oppia-button-container button {
-				margin-bottom: 5px;
-			}
+      .oppia-button-container button {
+        margin-bottom: 5px;
+      }
 
-			.oppia-splash-new-callout {
+      .oppia-splash-new-callout {
         padding: 15px 0;
         height: auto;
       }
@@ -233,9 +233,9 @@
       .oppia-splash-new-callout button:first-of-type {
         margin-top: 15px;
       }
-		}
+    }
 
-		@media (max-width: 992px) {
+    @media (max-width: 992px) {
       #oppia-splash-new-otter {
         width: 175px;
         bottom: -85px;
@@ -243,18 +243,18 @@
     }
 
 
-	</style>
+  </style>
 
-	<link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
+  <link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
 {% endblock %}
 
 {% block footer %}
-	{% include 'pages/footer.html' %}
+  {% include 'pages/footer.html' %}
 {% endblock %}
 
 {% block footer_js %}
-	{{ super() }}
-	<script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
-	<script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
-	<script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
+  {{ super() }}
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv2.html
+++ b/core/templates/dev/head/pages/splash/splash_nv2.html
@@ -1,35 +1,238 @@
 {% extends 'pages/base.html' %}
 
 {% block prerender %}
-  <link rel="prerender" href="/library">
+	<link rel="prerender" href="/library">
 {% endblock prerender %}
 
 {% block maintitle %}
-  I18N_SPLASH_PAGE_TITLE
+	I18N_SPLASH_PAGE_TITLE
 {% endblock maintitle %}
 
 {% block header_js %}
-  {{ super() }}
+	{{ super() }}
 {% endblock %}
 
 {% block navbar_breadcrumb %}
 {% endblock navbar_breadcrumb %}
 
 {% block content %}
-  <div ng-controller="Splash">
-    2
-  </div>
+	<div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
+		<div class="container">
+			<div class="row">
+				<div class="col-md-4 oppia-display-desktop-only col-sm-3">
+					<img src="https://www.oppia.org/build/bcbnbz/assets/images/general/about_page_mascot.png" id="oppia-splash-new-otter" />
+				</div>
+				<div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
+					<h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
+					<h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
+					<div class="oppia-button-container">
+						<button type="button"
+										ng-click="onClickBrowseLibraryButton()"
+	                  class="btn oppia-transition-200 oppia-splash-new-cta-button">
+										Start Learning
+						</button>
+						<button type="button"
+										ng-click="onRedirectToLogin('/dashboard?mode=create')"
+										class="btn oppia-transition-200 oppia-splash-new-cta-button">
+										Share Your Knowledge
+						</button>
+					</div>
+				</div>
+			</div>
+			<div class="jumbotron">
+				<div class="row">
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
+						</div>
+					</div>
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
+						</div>
+					</div>
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/dashboard?mode=create')">share your knowledge</a> today!</p>
+						</div>
+					</div>
+				</div>
+			</div>
+      <div class="jumbotron">
+        <h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
+        <!-- TODO: put carousel here -->
+      </div>
+		</div>
+		<div class="oppia-about-extra-info">
+			<button type="button"
+							ng-click="onClickBrowseLibraryButton()"
+							class="btn oppia-transition-200">
+							Start Learning
+			</button>
+			<button type="button"
+							ng-click="onRedirectToLogin('/dashboard?mode=create')"
+							class="btn oppia-transition-200">
+							Share Your Knowledge
+			</button>
+    </div>
+	</div>
 
-  <style>
-    /* styles that apply to just this page */
-  </style>
+	<style>
+		.oppia-splash-new-h1 {
+			font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+			color: #024340;
+			font-size: 2.75em;
+			margin: 20px auto 0 auto;
+			text-align: center;
+		}
+
+		.oppia-splash-new-h2 {
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      font-size: 2em;
+      font-weight: 300;
+      color: #04857c;
+      text-align: center;
+      margin: 18px 0;
+      line-height: 1.2;
+			-webkit-font-smoothing: subpixel-antialiased;
+			text-rendering: auto;
+    }
+
+    .jumbotron .oppia-splash-new-h2 {
+      margin-top: 0;
+    }
+
+		#oppia-splash-new-otter {
+			position: relative;
+			width: 250px;
+			bottom: -35px;
+			left: 10px;
+		}
+
+    .oppia-button-container {
+      text-align: center;
+			display: flex;
+			justify-content: center;
+    }
+
+		.oppia-button-container button {
+      background-color: #015c53;
+      border-radius: 0;
+      color: #ffffff;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 16px;
+      padding: 10px 0;
+      text-transform: uppercase;
+			width: 100%;
+      max-width: 300px;
+      border: none;
+			margin: auto 5px;
+    }
+
+    .oppia-button-container button:hover {
+      background-color: #05beb2;
+			color: #ffffff;
+    }
+
+		.oppia-bullet-holder img {
+      height: 125px;
+			display: block;
+			margin: auto;
+    }
+
+    .oppia-bullet-holder p {
+      padding: 5px 15px;
+			font-weight: 300;
+			line-height: 1.45;
+			font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+			color: #333333;
+			-webkit-font-smoothing: subpixel-antialiased;
+    }
+
+		.oppia-about-extra-info {
+      background-color: #009788;
+      color: #ffffff;
+      height: 150px;
+      text-align: center;
+    }
+
+    .oppia-about-extra-info button {
+      background-color: #00796d;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 18px;
+      margin: 0 15px 15px 15px;
+      max-width: 90%;
+      padding: 15px;
+      text-transform: uppercase;
+      white-space: normal;
+      width: 352px;
+      border-radius: 5px;
+      position: relative;
+      top: 50%;
+      transform: translateY(-50%);
+			-webkit-font-smoothing: subpixel-antialiased;
+    }
+
+    .oppia-about-extra-info button:hover {
+      background-color: #05beb2;
+			color: #ffffff;
+    }
+
+		@media (max-width: 768px) {
+			.oppia-display-desktop-only {
+				display: none !important;
+			}
+
+			.oppia-button-container {
+				flex-wrap: wrap;
+				margin-bottom: 10px;
+			}
+
+			.oppia-button-container button {
+				margin-bottom: 5px;
+			}
+
+			.oppia-about-extra-info {
+        padding: 15px 0;
+        height: auto;
+      }
+
+      .oppia-about-extra-info button {
+        position: auto;
+        top: auto;
+        transform: none;
+      }
+
+      .oppia-about-extra-info button:first-of-type {
+        margin-top: 15px;
+      }
+		}
+
+		@media (max-width: 992px) {
+      #oppia-splash-new-otter {
+        width: 175px;
+        bottom: -85px;
+      }
+    }
+	</style>
+
+	<link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
 {% endblock %}
 
 {% block footer %}
-  {% include 'pages/footer.html' %}
+	{% include 'pages/footer.html' %}
 {% endblock %}
 
 {% block footer_js %}
-  {{ super() }}
-  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+	{{ super() }}
+	<script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv2.html
+++ b/core/templates/dev/head/pages/splash/splash_nv2.html
@@ -20,7 +20,7 @@
 		<div class="container">
 			<div class="row">
 				<div class="col-md-4 oppia-display-desktop-only col-sm-3">
-					<img src="https://www.oppia.org/build/bcbnbz/assets/images/general/about_page_mascot.png" id="oppia-splash-new-otter" />
+					<img ng-src="<[aboutPageMascotImgUrl]>" id="oppia-splash-new-otter" />
 				</div>
 				<div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
 					<h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
@@ -72,7 +72,7 @@
         <!-- TODO: put carousel here -->
       </div>
 		</div>
-		<div class="oppia-about-extra-info">
+		<div class="oppia-splash-new-callout">
 			<button type="button"
 							ng-click="onClickBrowseLibraryButton()"
 							class="btn oppia-transition-200">
@@ -158,14 +158,14 @@
 			-webkit-font-smoothing: subpixel-antialiased;
     }
 
-		.oppia-about-extra-info {
+		.oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
       height: 150px;
       text-align: center;
     }
 
-    .oppia-about-extra-info button {
+    .oppia-splash-new-callout button {
       background-color: #00796d;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 18px;
@@ -182,7 +182,7 @@
 			-webkit-font-smoothing: subpixel-antialiased;
     }
 
-    .oppia-about-extra-info button:hover {
+    .oppia-splash-new-callout button:hover {
       background-color: #05beb2;
 			color: #ffffff;
     }
@@ -201,18 +201,18 @@
 				margin-bottom: 5px;
 			}
 
-			.oppia-about-extra-info {
+			.oppia-splash-new-callout {
         padding: 15px 0;
         height: auto;
       }
 
-      .oppia-about-extra-info button {
+      .oppia-splash-new-callout button {
         position: auto;
         top: auto;
         transform: none;
       }
 
-      .oppia-about-extra-info button:first-of-type {
+      .oppia-splash-new-callout button:first-of-type {
         margin-top: 15px;
       }
 		}

--- a/core/templates/dev/head/pages/splash/splash_nv2.html
+++ b/core/templates/dev/head/pages/splash/splash_nv2.html
@@ -69,7 +69,21 @@
 			</div>
       <div class="jumbotron">
         <h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
-        <!-- TODO: put carousel here -->
+        <div class="oppia-splash-new-exploration-summaries">
+        	<div ng-repeat="tile in activityList" style="display: inline-block;">
+          	<exploration-summary-tile exploration-id="tile.id"
+                                    	exploration-title="tile.title"
+                                    	last-updated-msec="tile.last_updated_msec"
+	                                    objective="tile.objective"
+	                                    category="tile.category"
+	                                    ratings="tile.ratings"
+	                                    num-views="tile.num_views"
+	                                    thumbnail-icon-url="tile.thumbnail_icon_url"
+	                                    thumbnail-bg-color="tile.thumbnail_bg_color"
+	                                    class="protractor-test-exp-summary-tile">
+          	</exploration-summary-tile>
+          </div>
+				</div>
       </div>
 		</div>
 		<div class="oppia-splash-new-callout">
@@ -158,6 +172,10 @@
 			-webkit-font-smoothing: subpixel-antialiased;
     }
 
+    .oppia-splash-new-exploration-summaries {
+      text-align: center;
+    }
+
 		.oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
@@ -234,5 +252,7 @@
 
 {% block footer_js %}
 	{{ super() }}
-	<script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+	<script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
+	<script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv2.html
+++ b/core/templates/dev/head/pages/splash/splash_nv2.html
@@ -29,12 +29,12 @@
             <button type="button"
                     ng-click="onClickBrowseLibraryButton()"
                     class="btn oppia-transition-200 oppia-splash-new-cta-button">
-                    Start Learning
+              Start Learning
             </button>
             <button type="button"
                     ng-click="onRedirectToLogin('/dashboard?mode=create')"
                     class="btn oppia-transition-200 oppia-splash-new-cta-button">
-                    Share Your Knowledge
+              Share Your Knowledge
             </button>
           </div>
         </div>
@@ -90,34 +90,34 @@
       <button type="button"
               ng-click="onClickBrowseLibraryButton()"
               class="btn oppia-transition-200">
-              Start Learning
+        Start Learning
       </button>
       <button type="button"
               ng-click="onRedirectToLogin('/dashboard?mode=create')"
               class="btn oppia-transition-200">
-              Share Your Knowledge
+        Share Your Knowledge
       </button>
     </div>
   </div>
 
   <style>
     .oppia-splash-new-h1 {
-      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       color: #024340;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 2.75em;
       margin: 20px auto 0 auto;
       text-align: center;
     }
 
     .oppia-splash-new-h2 {
+      color: #04857c;
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
       font-size: 2em;
-      font-weight: 300;
-      color: #04857c;
-      text-align: center;
-      margin: 18px 0;
-      line-height: 1.2;
       -webkit-font-smoothing: subpixel-antialiased;
+      font-weight: 300;
+      line-height: 1.2;
+      margin: 18px 0;
+      text-align: center;
       text-rendering: auto;
     }
 
@@ -126,30 +126,30 @@
     }
 
     #oppia-splash-new-otter {
-      position: relative;
-      width: 250px;
       bottom: -35px;
       left: 10px;
+      position: relative;
+      width: 250px;
     }
 
     .oppia-button-container {
-      text-align: center;
       display: flex;
       justify-content: center;
+      text-align: center;
     }
 
     .oppia-button-container button {
       background-color: #015c53;
       border-radius: 0;
+      border: none;
       color: #ffffff;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 16px;
+      margin: auto 5px;
+      max-width: 300px;
       padding: 10px 0;
       text-transform: uppercase;
       width: 100%;
-      max-width: 300px;
-      border: none;
-      margin: auto 5px;
     }
 
     .oppia-button-container button:hover {
@@ -158,18 +158,18 @@
     }
 
     .oppia-bullet-holder img {
-      height: 125px;
       display: block;
+      height: 125px;
       margin: auto;
     }
 
     .oppia-bullet-holder p {
-      padding: 5px 15px;
+      color: #333333;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      -webkit-font-smoothing: subpixel-antialiased;
       font-weight: 300;
       line-height: 1.45;
-      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
-      color: #333333;
-      -webkit-font-smoothing: subpixel-antialiased;
+      padding: 5px 15px;
     }
 
     .oppia-splash-new-exploration-summaries {
@@ -185,19 +185,19 @@
 
     .oppia-splash-new-callout button {
       background-color: #00796d;
+      border-radius: 5px;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 18px;
+      -webkit-font-smoothing: subpixel-antialiased;
       margin: 0 15px 15px 15px;
       max-width: 90%;
       padding: 15px;
-      text-transform: uppercase;
-      white-space: normal;
-      width: 352px;
-      border-radius: 5px;
       position: relative;
+      text-transform: uppercase;
       top: 50%;
       transform: translateY(-50%);
-      -webkit-font-smoothing: subpixel-antialiased;
+      white-space: normal;
+      width: 352px;
     }
 
     .oppia-splash-new-callout button:hover {
@@ -220,8 +220,8 @@
       }
 
       .oppia-splash-new-callout {
-        padding: 15px 0;
         height: auto;
+        padding: 15px 0;
       }
 
       .oppia-splash-new-callout button {
@@ -237,8 +237,8 @@
 
     @media (max-width: 992px) {
       #oppia-splash-new-otter {
-        width: 175px;
         bottom: -85px;
+        width: 175px;
       }
     }
   </style>

--- a/core/templates/dev/head/pages/splash/splash_nv2.html
+++ b/core/templates/dev/head/pages/splash/splash_nv2.html
@@ -1,115 +1,115 @@
 {% extends 'pages/base.html' %}
 
 {% block prerender %}
-	<link rel="prerender" href="/library">
+  <link rel="prerender" href="/library">
 {% endblock prerender %}
 
 {% block maintitle %}
-	I18N_SPLASH_PAGE_TITLE
+  I18N_SPLASH_PAGE_TITLE
 {% endblock maintitle %}
 
 {% block header_js %}
-	{{ super() }}
+  {{ super() }}
 {% endblock %}
 
 {% block navbar_breadcrumb %}
 {% endblock navbar_breadcrumb %}
 
 {% block content %}
-	<div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
-		<div class="container">
-			<div class="row">
-				<div class="col-md-4 oppia-display-desktop-only col-sm-3">
-					<img ng-src="<[aboutPageMascotImgUrl]>" id="oppia-splash-new-otter" />
-				</div>
-				<div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
-					<h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
-					<h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
-					<div class="oppia-button-container">
-						<button type="button"
-										ng-click="onClickBrowseLibraryButton()"
-	                  class="btn oppia-transition-200 oppia-splash-new-cta-button">
-										Start Learning
-						</button>
-						<button type="button"
-										ng-click="onRedirectToLogin('/dashboard?mode=create')"
-										class="btn oppia-transition-200 oppia-splash-new-cta-button">
-										Share Your Knowledge
-						</button>
-					</div>
-				</div>
-			</div>
-			<div class="jumbotron">
-				<div class="row">
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
-						</div>
-					</div>
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
-						</div>
-					</div>
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/dashboard?mode=create')">share your knowledge</a> today!</p>
-						</div>
-					</div>
-				</div>
-			</div>
+  <div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-4 oppia-display-desktop-only col-sm-3">
+          <img ng-src="<[aboutPageMascotImgUrl]>" id="oppia-splash-new-otter" />
+        </div>
+        <div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
+          <h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
+          <h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
+          <div class="oppia-button-container">
+            <button type="button"
+                    ng-click="onClickBrowseLibraryButton()"
+                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    Start Learning
+            </button>
+            <button type="button"
+                    ng-click="onRedirectToLogin('/dashboard?mode=create')"
+                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    Share Your Knowledge
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="jumbotron">
+        <div class="row">
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
+            </div>
+          </div>
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
+            </div>
+          </div>
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/dashboard?mode=create')">share your knowledge</a> today!</p>
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="jumbotron">
         <h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
         <div class="oppia-splash-new-exploration-summaries">
-        	<div ng-repeat="tile in activityList" style="display: inline-block;">
-          	<exploration-summary-tile exploration-id="tile.id"
-                                    	exploration-title="tile.title"
-                                    	last-updated-msec="tile.last_updated_msec"
-	                                    objective="tile.objective"
-	                                    category="tile.category"
-	                                    ratings="tile.ratings"
-	                                    num-views="tile.num_views"
-	                                    thumbnail-icon-url="tile.thumbnail_icon_url"
-	                                    thumbnail-bg-color="tile.thumbnail_bg_color"
-	                                    class="protractor-test-exp-summary-tile">
-          	</exploration-summary-tile>
+          <div ng-repeat="tile in activityList" style="display: inline-block;">
+            <exploration-summary-tile exploration-id="tile.id"
+                                      exploration-title="tile.title"
+                                      last-updated-msec="tile.last_updated_msec"
+                                      objective="tile.objective"
+                                      category="tile.category"
+                                      ratings="tile.ratings"
+                                      num-views="tile.num_views"
+                                      thumbnail-icon-url="tile.thumbnail_icon_url"
+                                      thumbnail-bg-color="tile.thumbnail_bg_color"
+                                      class="protractor-test-exp-summary-tile">
+            </exploration-summary-tile>
           </div>
-				</div>
+        </div>
       </div>
-		</div>
-		<div class="oppia-splash-new-callout">
-			<button type="button"
-							ng-click="onClickBrowseLibraryButton()"
-							class="btn oppia-transition-200">
-							Start Learning
-			</button>
-			<button type="button"
-							ng-click="onRedirectToLogin('/dashboard?mode=create')"
-							class="btn oppia-transition-200">
-							Share Your Knowledge
-			</button>
     </div>
-	</div>
+    <div class="oppia-splash-new-callout">
+      <button type="button"
+              ng-click="onClickBrowseLibraryButton()"
+              class="btn oppia-transition-200">
+              Start Learning
+      </button>
+      <button type="button"
+              ng-click="onRedirectToLogin('/dashboard?mode=create')"
+              class="btn oppia-transition-200">
+              Share Your Knowledge
+      </button>
+    </div>
+  </div>
 
-	<style>
-		.oppia-splash-new-h1 {
-			font-family: 'Capriola', 'Roboto', Arial, sans-serif;
-			color: #024340;
-			font-size: 2.75em;
-			margin: 20px auto 0 auto;
-			text-align: center;
-		}
+  <style>
+    .oppia-splash-new-h1 {
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      color: #024340;
+      font-size: 2.75em;
+      margin: 20px auto 0 auto;
+      text-align: center;
+    }
 
-		.oppia-splash-new-h2 {
+    .oppia-splash-new-h2 {
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
       font-size: 2em;
       font-weight: 300;
@@ -117,28 +117,28 @@
       text-align: center;
       margin: 18px 0;
       line-height: 1.2;
-			-webkit-font-smoothing: subpixel-antialiased;
-			text-rendering: auto;
+      -webkit-font-smoothing: subpixel-antialiased;
+      text-rendering: auto;
     }
 
     .jumbotron .oppia-splash-new-h2 {
       margin-top: 0;
     }
 
-		#oppia-splash-new-otter {
-			position: relative;
-			width: 250px;
-			bottom: -35px;
-			left: 10px;
-		}
+    #oppia-splash-new-otter {
+      position: relative;
+      width: 250px;
+      bottom: -35px;
+      left: 10px;
+    }
 
     .oppia-button-container {
       text-align: center;
-			display: flex;
-			justify-content: center;
+      display: flex;
+      justify-content: center;
     }
 
-		.oppia-button-container button {
+    .oppia-button-container button {
       background-color: #015c53;
       border-radius: 0;
       color: #ffffff;
@@ -146,37 +146,37 @@
       font-size: 16px;
       padding: 10px 0;
       text-transform: uppercase;
-			width: 100%;
+      width: 100%;
       max-width: 300px;
       border: none;
-			margin: auto 5px;
+      margin: auto 5px;
     }
 
     .oppia-button-container button:hover {
       background-color: #05beb2;
-			color: #ffffff;
+      color: #ffffff;
     }
 
-		.oppia-bullet-holder img {
+    .oppia-bullet-holder img {
       height: 125px;
-			display: block;
-			margin: auto;
+      display: block;
+      margin: auto;
     }
 
     .oppia-bullet-holder p {
       padding: 5px 15px;
-			font-weight: 300;
-			line-height: 1.45;
-			font-family: 'Rubik', 'Roboto', Arial, sans-serif;
-			color: #333333;
-			-webkit-font-smoothing: subpixel-antialiased;
+      font-weight: 300;
+      line-height: 1.45;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      color: #333333;
+      -webkit-font-smoothing: subpixel-antialiased;
     }
 
     .oppia-splash-new-exploration-summaries {
       text-align: center;
     }
 
-		.oppia-splash-new-callout {
+    .oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
       height: 150px;
@@ -197,29 +197,29 @@
       position: relative;
       top: 50%;
       transform: translateY(-50%);
-			-webkit-font-smoothing: subpixel-antialiased;
+      -webkit-font-smoothing: subpixel-antialiased;
     }
 
     .oppia-splash-new-callout button:hover {
       background-color: #05beb2;
-			color: #ffffff;
+      color: #ffffff;
     }
 
-		@media (max-width: 768px) {
-			.oppia-display-desktop-only {
-				display: none !important;
-			}
+    @media (max-width: 768px) {
+      .oppia-display-desktop-only {
+        display: none !important;
+      }
 
-			.oppia-button-container {
-				flex-wrap: wrap;
-				margin-bottom: 10px;
-			}
+      .oppia-button-container {
+        flex-wrap: wrap;
+        margin-bottom: 10px;
+      }
 
-			.oppia-button-container button {
-				margin-bottom: 5px;
-			}
+      .oppia-button-container button {
+        margin-bottom: 5px;
+      }
 
-			.oppia-splash-new-callout {
+      .oppia-splash-new-callout {
         padding: 15px 0;
         height: auto;
       }
@@ -233,26 +233,26 @@
       .oppia-splash-new-callout button:first-of-type {
         margin-top: 15px;
       }
-		}
+    }
 
-		@media (max-width: 992px) {
+    @media (max-width: 992px) {
       #oppia-splash-new-otter {
         width: 175px;
         bottom: -85px;
       }
     }
-	</style>
+  </style>
 
-	<link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
+  <link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
 {% endblock %}
 
 {% block footer %}
-	{% include 'pages/footer.html' %}
+  {% include 'pages/footer.html' %}
 {% endblock %}
 
 {% block footer_js %}
-	{{ super() }}
+  {{ super() }}
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
-	<script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
-	<script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv2.html
+++ b/core/templates/dev/head/pages/splash/splash_nv2.html
@@ -1,0 +1,35 @@
+{% extends 'pages/base.html' %}
+
+{% block prerender %}
+  <link rel="prerender" href="/library">
+{% endblock prerender %}
+
+{% block maintitle %}
+  I18N_SPLASH_PAGE_TITLE
+{% endblock maintitle %}
+
+{% block header_js %}
+  {{ super() }}
+{% endblock %}
+
+{% block navbar_breadcrumb %}
+{% endblock navbar_breadcrumb %}
+
+{% block content %}
+  <div ng-controller="Splash">
+    2
+  </div>
+
+  <style>
+    /* styles that apply to just this page */
+  </style>
+{% endblock %}
+
+{% block footer %}
+  {% include 'pages/footer.html' %}
+{% endblock %}
+
+{% block footer_js %}
+  {{ super() }}
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+{% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv3.html
+++ b/core/templates/dev/head/pages/splash/splash_nv3.html
@@ -1,0 +1,35 @@
+{% extends 'pages/base.html' %}
+
+{% block prerender %}
+  <link rel="prerender" href="/library">
+{% endblock prerender %}
+
+{% block maintitle %}
+  I18N_SPLASH_PAGE_TITLE
+{% endblock maintitle %}
+
+{% block header_js %}
+  {{ super() }}
+{% endblock %}
+
+{% block navbar_breadcrumb %}
+{% endblock navbar_breadcrumb %}
+
+{% block content %}
+  <div ng-controller="Splash">
+    3
+  </div>
+
+  <style>
+    /* styles that apply to just this page */
+  </style>
+{% endblock %}
+
+{% block footer %}
+  {% include 'pages/footer.html' %}
+{% endblock %}
+
+{% block footer_js %}
+  {{ super() }}
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+{% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv3.html
+++ b/core/templates/dev/head/pages/splash/splash_nv3.html
@@ -48,7 +48,21 @@
 			</div>
       <div class="row">
         <h3 class="oppia-splash-new-h3">Featured Lessons</h2>
-        <!-- TODO: put carousel here -->
+        <div class="oppia-splash-new-exploration-summaries">
+        	<div ng-repeat="tile in activityList" style="display: inline-block;">
+          	<exploration-summary-tile exploration-id="tile.id"
+                                    	exploration-title="tile.title"
+                                    	last-updated-msec="tile.last_updated_msec"
+	                                    objective="tile.objective"
+	                                    category="tile.category"
+	                                    ratings="tile.ratings"
+	                                    num-views="tile.num_views"
+	                                    thumbnail-icon-url="tile.thumbnail_icon_url"
+	                                    thumbnail-bg-color="tile.thumbnail_bg_color"
+	                                    class="protractor-test-exp-summary-tile">
+          	</exploration-summary-tile>
+          </div>
+				</div>
       </div>
 		</div>
 		<div class="oppia-splash-new-callout container-fluid">
@@ -155,6 +169,11 @@
 			-webkit-font-smoothing: subpixel-antialiased;
     }
 
+    .oppia-splash-new-exploration-summaries {
+      text-align: center;
+      margin-bottom: 2em;
+    }
+
 		.oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
@@ -246,5 +265,7 @@
 
 {% block footer_js %}
 	{{ super() }}
-	<script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv3.html
+++ b/core/templates/dev/head/pages/splash/splash_nv3.html
@@ -1,35 +1,256 @@
 {% extends 'pages/base.html' %}
 
 {% block prerender %}
-  <link rel="prerender" href="/library">
+	<link rel="prerender" href="/library">
 {% endblock prerender %}
 
 {% block maintitle %}
-  I18N_SPLASH_PAGE_TITLE
+	I18N_SPLASH_PAGE_TITLE
 {% endblock maintitle %}
 
 {% block header_js %}
-  {{ super() }}
+	{{ super() }}
 {% endblock %}
 
 {% block navbar_breadcrumb %}
 {% endblock navbar_breadcrumb %}
 
 {% block content %}
-  <div ng-controller="Splash">
-    3
-  </div>
+	<div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
+		<div class="container">
+			<div class="row">
+				<div class="col-md-4 oppia-display-desktop-only col-sm-3">
+					<img src="https://www.oppia.org/build/bcbnbz/assets/images/general/about_page_mascot.png" id="oppia-splash-new-otter" />
+				</div>
+				<div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
+					<h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
+					<h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
+					<div class="oppia-button-container">
+						<button type="button"
+										ng-click="onClickBrowseLibraryButton()"
+	                  class="btn oppia-transition-200 oppia-splash-new-cta-button">
+										Start Learning
+						</button>
+						<button type="button"
+										ng-click="onRedirectToLogin('/dashboard?mode=create')"
+										class="btn oppia-transition-200 oppia-splash-new-cta-button">
+										Share Your Knowledge
+						</button>
+					</div>
+				</div>
+			</div>
+			<div class="jumbotron">
+				<div class="row">
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
+						</div>
+					</div>
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
+						</div>
+					</div>
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/dashboard?mode=create')">share your knowledge</a> today!</p>
+						</div>
+					</div>
+				</div>
+			</div>
+      <div class="row">
+        <h3 class="oppia-splash-new-h3">Featured Lessons</h2>
+        <!-- TODO: put carousel here -->
+      </div>
+		</div>
+		<div class="oppia-about-extra-info container">
+      <h2>Share Your Knowledge</h2>
+      <p>Whether you're a K-12 educator, a graduate student, or an individual who's passionate about a specific subject and wants to share your knowledge, Oppia welcomes you. Join the community and start exploring with us.</p>
+			<button type="button"
+							ng-click="onRedirectToLogin('/dashboard?mode=create')"
+							class="btn oppia-transition-200">
+							Get Started
+			</button>
+    </div>
+	</div>
 
-  <style>
-    /* styles that apply to just this page */
-  </style>
+	<style>
+		.oppia-splash-new-h1 {
+			font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+			color: #024340;
+			font-size: 2.75em;
+			margin: 20px auto 0 auto;
+			text-align: center;
+		}
+
+		.oppia-splash-new-h2 {
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      font-size: 2em;
+      font-weight: 300;
+      color: #04857c;
+      text-align: center;
+      margin: 18px 0;
+      line-height: 1.2;
+			-webkit-font-smoothing: subpixel-antialiased;
+			text-rendering: auto;
+    }
+
+		.oppia-splash-new-h3 {
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      font-size: 1.5em;
+      font-weight: 300;
+      color: #04857c;
+      text-align: left;
+      margin: 18px 0;
+			-webkit-font-smoothing: subpixel-antialiased;
+    }
+
+    .jumbotron .oppia-splash-new-h2 {
+      margin-top: 0;
+    }
+
+		#oppia-splash-new-otter {
+			position: relative;
+			width: 250px;
+			bottom: -35px;
+			left: 10px;
+		}
+
+    .oppia-button-container {
+      text-align: center;
+			display: flex;
+			justify-content: center;
+    }
+
+		.oppia-button-container button {
+      background-color: #015c53;
+      border-radius: 0;
+      color: #ffffff;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 16px;
+      padding: 10px 0;
+      text-transform: uppercase;
+			width: 100%;
+      max-width: 300px;
+      border: none;
+			margin: auto 5px;
+    }
+
+    .oppia-button-container button:hover {
+      background-color: #05beb2;
+			color: #ffffff;
+    }
+
+		.oppia-bullet-holder img {
+      height: 125px;
+			display: block;
+			margin: auto;
+    }
+
+    .oppia-bullet-holder p {
+      padding: 5px 15px;
+			font-weight: 300;
+			line-height: 1.45;
+			font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+			color: #333333;
+			-webkit-font-smoothing: subpixel-antialiased;
+    }
+
+		.oppia-about-extra-info {
+      background-color: #009788;
+      color: #ffffff;
+      text-align: center;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+    }
+
+    .oppia-about-extra-info h2 {
+      font-size: 2em;
+      font-weight: 600;
+      color: #ffffff;
+      margin: 0;
+      margin-top: 22px;
+    }
+
+    .oppia-about-extra-info p {
+      max-width: 650px;
+      line-height: 1.8;
+      font-size: 1.3em;
+      text-align: center;
+      margin: 15px auto;
+    }
+
+    .oppia-about-extra-info button {
+      background-color: #00796d;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      padding: 10px 20px;
+      text-transform: uppercase;
+      white-space: normal;
+      border-radius: 5px;
+			-webkit-font-smoothing: subpixel-antialiased;
+      font-size: 1.1em;
+      margin-bottom: 22px;
+    }
+
+    .oppia-about-extra-info button:hover {
+      background-color: #05beb2;
+			color: #ffffff;
+    }
+
+		@media (max-width: 768px) {
+			.oppia-display-desktop-only {
+				display: none !important;
+			}
+
+			.oppia-button-container {
+				flex-wrap: wrap;
+				margin-bottom: 10px;
+			}
+
+			.oppia-button-container button {
+				margin-bottom: 5px;
+			}
+
+			.oppia-about-extra-info {
+        padding: 15px 0;
+        height: auto;
+      }
+
+      .oppia-about-extra-info button {
+        position: auto;
+        top: auto;
+        transform: none;
+      }
+
+      .oppia-about-extra-info button:first-of-type {
+        margin-top: 15px;
+      }
+		}
+
+		@media (max-width: 992px) {
+      #oppia-splash-new-otter {
+        width: 175px;
+        bottom: -85px;
+      }
+    }
+	</style>
+
+  <link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
 {% endblock %}
 
 {% block footer %}
-  {% include 'pages/footer.html' %}
+	{% include 'pages/footer.html' %}
 {% endblock %}
 
 {% block footer_js %}
-  {{ super() }}
-  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+	{{ super() }}
+	<script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv3.html
+++ b/core/templates/dev/head/pages/splash/splash_nv3.html
@@ -1,91 +1,91 @@
 {% extends 'pages/base.html' %}
 
 {% block prerender %}
-	<link rel="prerender" href="/library">
+  <link rel="prerender" href="/library">
 {% endblock prerender %}
 
 {% block maintitle %}
-	I18N_SPLASH_PAGE_TITLE
+  I18N_SPLASH_PAGE_TITLE
 {% endblock maintitle %}
 
 {% block header_js %}
-	{{ super() }}
+  {{ super() }}
 {% endblock %}
 
 {% block navbar_breadcrumb %}
 {% endblock navbar_breadcrumb %}
 
 {% block content %}
-	<div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
-		<div class="container">
-			<div class="row">
-				<div class="col-md-4 oppia-display-desktop-only col-sm-3">
-					<img ng-src="<[aboutPageMascotImgUrl]>" id="oppia-splash-new-otter" />
-				</div>
-				<div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
-					<h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
-					<h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
-					<div class="oppia-button-container">
-						<button type="button"
-										ng-click="onClickBrowseLibraryButton()"
-	                  class="btn oppia-transition-200 oppia-splash-new-cta-button">
-										Start Learning
-						</button>
-						<button type="button"
-										ng-click="onRedirectToLogin('/dashboard?mode=create')"
-										class="btn oppia-transition-200 oppia-splash-new-cta-button">
-										Share Your Knowledge
-						</button>
-					</div>
-				</div>
-			</div>
-			<div class="jumbotron oppia-jumbotron-bottom-padding-reduction">
-				<div class="row oppia-row-maintain-horizontal-margin">
+  <div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-4 oppia-display-desktop-only col-sm-3">
+          <img ng-src="<[aboutPageMascotImgUrl]>" id="oppia-splash-new-otter" />
+        </div>
+        <div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
+          <h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
+          <h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
+          <div class="oppia-button-container">
+            <button type="button"
+                    ng-click="onClickBrowseLibraryButton()"
+                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    Start Learning
+            </button>
+            <button type="button"
+                    ng-click="onRedirectToLogin('/dashboard?mode=create')"
+                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    Share Your Knowledge
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="jumbotron oppia-jumbotron-bottom-padding-reduction">
+        <div class="row oppia-row-maintain-horizontal-margin">
           <h2 class="oppia-splash-new-h2"><strong>Oppia</strong> is a free online learning tool that enables anyone to easily create and share interactive activities, or lessons, simulating a one-on-one conversation with an intelligent tutor.</h2>
           <br />
           <h2 class="oppia-splash-new-h2">Imagine what you could learn today&hellip;</h2>
-				</div>
-			</div>
+        </div>
+      </div>
       <div class="row">
         <h3 class="oppia-splash-new-h3">Featured Lessons</h2>
         <div class="oppia-splash-new-exploration-summaries">
-        	<div ng-repeat="tile in activityList" style="display: inline-block;">
-          	<exploration-summary-tile exploration-id="tile.id"
-                                    	exploration-title="tile.title"
-                                    	last-updated-msec="tile.last_updated_msec"
-	                                    objective="tile.objective"
-	                                    category="tile.category"
-	                                    ratings="tile.ratings"
-	                                    num-views="tile.num_views"
-	                                    thumbnail-icon-url="tile.thumbnail_icon_url"
-	                                    thumbnail-bg-color="tile.thumbnail_bg_color"
-	                                    class="protractor-test-exp-summary-tile">
-          	</exploration-summary-tile>
+          <div ng-repeat="tile in activityList" style="display: inline-block;">
+            <exploration-summary-tile exploration-id="tile.id"
+                                      exploration-title="tile.title"
+                                      last-updated-msec="tile.last_updated_msec"
+                                      objective="tile.objective"
+                                      category="tile.category"
+                                      ratings="tile.ratings"
+                                      num-views="tile.num_views"
+                                      thumbnail-icon-url="tile.thumbnail_icon_url"
+                                      thumbnail-bg-color="tile.thumbnail_bg_color"
+                                      class="protractor-test-exp-summary-tile">
+            </exploration-summary-tile>
           </div>
-				</div>
+        </div>
       </div>
-		</div>
-		<div class="oppia-splash-new-callout container-fluid">
+    </div>
+    <div class="oppia-splash-new-callout container-fluid">
       <h2>Share Your Knowledge</h2>
       <p>Whether you're a K-12 educator, a graduate student, or an individual who's passionate about a specific subject and wants to share your knowledge, Oppia welcomes you. Join the community and start exploring with us.</p>
-			<button type="button"
-							ng-click="onRedirectToLogin('/dashboard?mode=create')"
-							class="btn oppia-transition-200">
-							Get Started
-			</button>
+      <button type="button"
+              ng-click="onRedirectToLogin('/dashboard?mode=create')"
+              class="btn oppia-transition-200">
+              Get Started
+      </button>
     </div>
-	</div>
+  </div>
 
-	<style>
-		.oppia-splash-new-h1 {
-			font-family: 'Capriola', 'Roboto', Arial, sans-serif;
-			color: #024340;
-			font-size: 2.75em;
-			margin: 20px auto 0 auto;
-			text-align: center;
-		}
+  <style>
+    .oppia-splash-new-h1 {
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      color: #024340;
+      font-size: 2.75em;
+      margin: 20px auto 0 auto;
+      text-align: center;
+    }
 
-		.oppia-splash-new-h2 {
+    .oppia-splash-new-h2 {
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
       font-size: 2em;
       font-weight: 300;
@@ -93,8 +93,8 @@
       text-align: center;
       margin: 18px 0;
       line-height: 1.2;
-			-webkit-font-smoothing: subpixel-antialiased;
-			text-rendering: auto;
+      -webkit-font-smoothing: subpixel-antialiased;
+      text-rendering: auto;
     }
 
     .jumbotron .oppia-splash-new-h2 {
@@ -112,30 +112,30 @@
         margin: auto 15px;
     }
 
-		.oppia-splash-new-h3 {
+    .oppia-splash-new-h3 {
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
       font-size: 1.5em;
       font-weight: 300;
       color: #04857c;
       text-align: left;
       margin: 18px 0;
-			-webkit-font-smoothing: subpixel-antialiased;
+      -webkit-font-smoothing: subpixel-antialiased;
     }
 
-		#oppia-splash-new-otter {
-			position: relative;
-			width: 250px;
-			bottom: -35px;
-			left: 10px;
-		}
+    #oppia-splash-new-otter {
+      position: relative;
+      width: 250px;
+      bottom: -35px;
+      left: 10px;
+    }
 
     .oppia-button-container {
       text-align: center;
-			display: flex;
-			justify-content: center;
+      display: flex;
+      justify-content: center;
     }
 
-		.oppia-button-container button {
+    .oppia-button-container button {
       background-color: #015c53;
       border-radius: 0;
       color: #ffffff;
@@ -143,30 +143,30 @@
       font-size: 16px;
       padding: 10px 0;
       text-transform: uppercase;
-			width: 100%;
+      width: 100%;
       max-width: 300px;
       border: none;
-			margin: auto 5px;
+      margin: auto 5px;
     }
 
     .oppia-button-container button:hover {
       background-color: #05beb2;
-			color: #ffffff;
+      color: #ffffff;
     }
 
-		.oppia-bullet-holder img {
+    .oppia-bullet-holder img {
       height: 125px;
-			display: block;
-			margin: auto;
+      display: block;
+      margin: auto;
     }
 
     .oppia-bullet-holder p {
       padding: 5px 15px;
-			font-weight: 300;
-			line-height: 1.45;
-			font-family: 'Rubik', 'Roboto', Arial, sans-serif;
-			color: #333333;
-			-webkit-font-smoothing: subpixel-antialiased;
+      font-weight: 300;
+      line-height: 1.45;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      color: #333333;
+      -webkit-font-smoothing: subpixel-antialiased;
     }
 
     .oppia-splash-new-exploration-summaries {
@@ -174,7 +174,7 @@
       margin-bottom: 2em;
     }
 
-		.oppia-splash-new-callout {
+    .oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
       text-align: center;
@@ -204,35 +204,35 @@
       text-transform: uppercase;
       white-space: normal;
       border-radius: 5px;
-			-webkit-font-smoothing: subpixel-antialiased;
+      -webkit-font-smoothing: subpixel-antialiased;
       font-size: 1.1em;
       margin-bottom: 22px;
     }
 
     .oppia-splash-new-callout button:hover {
       background-color: #05beb2;
-			color: #ffffff;
+      color: #ffffff;
     }
 
-		@media (max-width: 768px) {
-			.oppia-display-desktop-only {
-				display: none !important;
-			}
+    @media (max-width: 768px) {
+      .oppia-display-desktop-only {
+        display: none !important;
+      }
 
-			.oppia-button-container {
-				flex-wrap: wrap;
-				margin-bottom: 10px;
-			}
+      .oppia-button-container {
+        flex-wrap: wrap;
+        margin-bottom: 10px;
+      }
 
-			.oppia-button-container button {
-				margin-bottom: 5px;
-			}
+      .oppia-button-container button {
+        margin-bottom: 5px;
+      }
 
       .oppia-jumbotron-bottom-padding-reduction {
         padding-top: 1.67em;
       }
 
-			.oppia-splash-new-callout {
+      .oppia-splash-new-callout {
         padding: 15px;
         height: auto;
       }
@@ -246,25 +246,25 @@
       .oppia-splash-new-callout button:first-of-type {
         margin-top: 15px;
       }
-		}
+    }
 
-		@media (max-width: 992px) {
+    @media (max-width: 992px) {
       #oppia-splash-new-otter {
         width: 175px;
         bottom: -85px;
       }
     }
-	</style>
+  </style>
 
   <link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
 {% endblock %}
 
 {% block footer %}
-	{% include 'pages/footer.html' %}
+  {% include 'pages/footer.html' %}
 {% endblock %}
 
 {% block footer_js %}
-	{{ super() }}
+  {{ super() }}
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>

--- a/core/templates/dev/head/pages/splash/splash_nv3.html
+++ b/core/templates/dev/head/pages/splash/splash_nv3.html
@@ -29,12 +29,12 @@
             <button type="button"
                     ng-click="onClickBrowseLibraryButton()"
                     class="btn oppia-transition-200 oppia-splash-new-cta-button">
-                    Start Learning
+              Start Learning
             </button>
             <button type="button"
                     ng-click="onRedirectToLogin('/dashboard?mode=create')"
                     class="btn oppia-transition-200 oppia-splash-new-cta-button">
-                    Share Your Knowledge
+              Share Your Knowledge
             </button>
           </div>
         </div>
@@ -71,29 +71,29 @@
       <button type="button"
               ng-click="onRedirectToLogin('/dashboard?mode=create')"
               class="btn oppia-transition-200">
-              Get Started
+        Get Started
       </button>
     </div>
   </div>
 
   <style>
     .oppia-splash-new-h1 {
-      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       color: #024340;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 2.75em;
       margin: 20px auto 0 auto;
       text-align: center;
     }
 
     .oppia-splash-new-h2 {
+      color: #04857c;
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
       font-size: 2em;
-      font-weight: 300;
-      color: #04857c;
-      text-align: center;
-      margin: 18px 0;
-      line-height: 1.2;
       -webkit-font-smoothing: subpixel-antialiased;
+      font-weight: 300;
+      line-height: 1.2;
+      margin: 18px 0;
+      text-align: center;
       text-rendering: auto;
     }
 
@@ -113,40 +113,40 @@
     }
 
     .oppia-splash-new-h3 {
+      color: #04857c;
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
       font-size: 1.5em;
-      font-weight: 300;
-      color: #04857c;
-      text-align: left;
-      margin: 18px 0;
       -webkit-font-smoothing: subpixel-antialiased;
+      font-weight: 300;
+      margin: 18px 0;
+      text-align: left;
     }
 
     #oppia-splash-new-otter {
-      position: relative;
-      width: 250px;
       bottom: -35px;
       left: 10px;
+      position: relative;
+      width: 250px;
     }
 
     .oppia-button-container {
-      text-align: center;
       display: flex;
       justify-content: center;
+      text-align: center;
     }
 
     .oppia-button-container button {
       background-color: #015c53;
       border-radius: 0;
+      border: none;
       color: #ffffff;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 16px;
+      margin: auto 5px;
+      max-width: 300px;
       padding: 10px 0;
       text-transform: uppercase;
       width: 100%;
-      max-width: 300px;
-      border: none;
-      margin: auto 5px;
     }
 
     .oppia-button-container button:hover {
@@ -155,58 +155,58 @@
     }
 
     .oppia-bullet-holder img {
-      height: 125px;
       display: block;
+      height: 125px;
       margin: auto;
     }
 
     .oppia-bullet-holder p {
-      padding: 5px 15px;
+      color: #333333;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      -webkit-font-smoothing: subpixel-antialiased;
       font-weight: 300;
       line-height: 1.45;
-      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
-      color: #333333;
-      -webkit-font-smoothing: subpixel-antialiased;
+      padding: 5px 15px;
     }
 
     .oppia-splash-new-exploration-summaries {
-      text-align: center;
       margin-bottom: 2em;
+      text-align: center;
     }
 
     .oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
-      text-align: center;
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      text-align: center;
     }
 
     .oppia-splash-new-callout h2 {
+      color: #ffffff;
       font-size: 2em;
       font-weight: 600;
-      color: #ffffff;
-      margin: 0;
       margin-top: 22px;
+      margin: 0;
     }
 
     .oppia-splash-new-callout p {
-      max-width: 650px;
-      line-height: 1.8;
       font-size: 1.3em;
-      text-align: center;
+      line-height: 1.8;
       margin: 15px auto;
+      max-width: 650px;
+      text-align: center;
     }
 
     .oppia-splash-new-callout button {
       background-color: #00796d;
+      border-radius: 5px;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 1.1em;
+      -webkit-font-smoothing: subpixel-antialiased;
+      margin-bottom: 22px;
       padding: 10px 20px;
       text-transform: uppercase;
       white-space: normal;
-      border-radius: 5px;
-      -webkit-font-smoothing: subpixel-antialiased;
-      font-size: 1.1em;
-      margin-bottom: 22px;
     }
 
     .oppia-splash-new-callout button:hover {
@@ -233,8 +233,8 @@
       }
 
       .oppia-splash-new-callout {
-        padding: 15px;
         height: auto;
+        padding: 15px;
       }
 
       .oppia-splash-new-callout button {
@@ -250,8 +250,8 @@
 
     @media (max-width: 992px) {
       #oppia-splash-new-otter {
-        width: 175px;
         bottom: -85px;
+        width: 175px;
       }
     }
   </style>

--- a/core/templates/dev/head/pages/splash/splash_nv3.html
+++ b/core/templates/dev/head/pages/splash/splash_nv3.html
@@ -20,7 +20,7 @@
 		<div class="container">
 			<div class="row">
 				<div class="col-md-4 oppia-display-desktop-only col-sm-3">
-					<img src="https://www.oppia.org/build/bcbnbz/assets/images/general/about_page_mascot.png" id="oppia-splash-new-otter" />
+					<img ng-src="<[aboutPageMascotImgUrl]>" id="oppia-splash-new-otter" />
 				</div>
 				<div class="col-xs-12 col-sm-9 col-md-6" style="margin-top: 20px;">
 					<h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
@@ -39,32 +39,11 @@
 					</div>
 				</div>
 			</div>
-			<div class="jumbotron">
-				<div class="row">
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
-						</div>
-					</div>
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
-						</div>
-					</div>
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/dashboard?mode=create')">share your knowledge</a> today!</p>
-						</div>
-					</div>
+			<div class="jumbotron oppia-jumbotron-bottom-padding-reduction">
+				<div class="row oppia-row-maintain-horizontal-margin">
+          <h2 class="oppia-splash-new-h2"><strong>Oppia</strong> is a free online learning tool that enables anyone to easily create and share interactive activities, or lessons, simulating a one-on-one conversation with an intelligent tutor.</h2>
+          <br />
+          <h2 class="oppia-splash-new-h2">Imagine what you could learn today&hellip;</h2>
 				</div>
 			</div>
       <div class="row">
@@ -72,7 +51,7 @@
         <!-- TODO: put carousel here -->
       </div>
 		</div>
-		<div class="oppia-about-extra-info container">
+		<div class="oppia-splash-new-callout container-fluid">
       <h2>Share Your Knowledge</h2>
       <p>Whether you're a K-12 educator, a graduate student, or an individual who's passionate about a specific subject and wants to share your knowledge, Oppia welcomes you. Join the community and start exploring with us.</p>
 			<button type="button"
@@ -104,6 +83,21 @@
 			text-rendering: auto;
     }
 
+    .jumbotron .oppia-splash-new-h2 {
+      font-size: 1.75em;
+      line-height: 1.6;
+      margin: 0 auto;
+      max-width: 750px;
+    }
+
+    .oppia-jumbotron-bottom-padding-reduction {
+      padding-bottom: 1.67em;
+    }
+
+    .oppia-row-maintain-horizontal-margin {
+        margin: auto 15px;
+    }
+
 		.oppia-splash-new-h3 {
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
       font-size: 1.5em;
@@ -112,10 +106,6 @@
       text-align: left;
       margin: 18px 0;
 			-webkit-font-smoothing: subpixel-antialiased;
-    }
-
-    .jumbotron .oppia-splash-new-h2 {
-      margin-top: 0;
     }
 
 		#oppia-splash-new-otter {
@@ -165,14 +155,14 @@
 			-webkit-font-smoothing: subpixel-antialiased;
     }
 
-		.oppia-about-extra-info {
+		.oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
       text-align: center;
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
     }
 
-    .oppia-about-extra-info h2 {
+    .oppia-splash-new-callout h2 {
       font-size: 2em;
       font-weight: 600;
       color: #ffffff;
@@ -180,7 +170,7 @@
       margin-top: 22px;
     }
 
-    .oppia-about-extra-info p {
+    .oppia-splash-new-callout p {
       max-width: 650px;
       line-height: 1.8;
       font-size: 1.3em;
@@ -188,7 +178,7 @@
       margin: 15px auto;
     }
 
-    .oppia-about-extra-info button {
+    .oppia-splash-new-callout button {
       background-color: #00796d;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       padding: 10px 20px;
@@ -200,7 +190,7 @@
       margin-bottom: 22px;
     }
 
-    .oppia-about-extra-info button:hover {
+    .oppia-splash-new-callout button:hover {
       background-color: #05beb2;
 			color: #ffffff;
     }
@@ -219,18 +209,22 @@
 				margin-bottom: 5px;
 			}
 
-			.oppia-about-extra-info {
-        padding: 15px 0;
+      .oppia-jumbotron-bottom-padding-reduction {
+        padding-top: 1.67em;
+      }
+
+			.oppia-splash-new-callout {
+        padding: 15px;
         height: auto;
       }
 
-      .oppia-about-extra-info button {
+      .oppia-splash-new-callout button {
         position: auto;
         top: auto;
         transform: none;
       }
 
-      .oppia-about-extra-info button:first-of-type {
+      .oppia-splash-new-callout button:first-of-type {
         margin-top: 15px;
       }
 		}

--- a/core/templates/dev/head/pages/splash/splash_nv4.html
+++ b/core/templates/dev/head/pages/splash/splash_nv4.html
@@ -38,7 +38,21 @@
 			</div>
 			<div class="jumbotron">
 				<h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
-				<!-- TODO: put carousel here -->
+        <div class="oppia-splash-new-exploration-summaries">
+        	<div ng-repeat="tile in activityList" style="display: inline-block;">
+          	<exploration-summary-tile exploration-id="tile.id"
+                                    	exploration-title="tile.title"
+                                    	last-updated-msec="tile.last_updated_msec"
+	                                    objective="tile.objective"
+	                                    category="tile.category"
+	                                    ratings="tile.ratings"
+	                                    num-views="tile.num_views"
+	                                    thumbnail-icon-url="tile.thumbnail_icon_url"
+	                                    thumbnail-bg-color="tile.thumbnail_bg_color"
+	                                    class="protractor-test-exp-summary-tile">
+          	</exploration-summary-tile>
+          </div>
+				</div>
 			</div>
 			<div class="jumbotron">
 				<div class="row">
@@ -153,6 +167,10 @@
 			-webkit-font-smoothing: subpixel-antialiased;
     }
 
+    .oppia-splash-new-exploration-summaries {
+      text-align: center;
+    }
+
 		.oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
@@ -221,5 +239,7 @@
 
 {% block footer_js %}
 	{{ super() }}
-	<script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+	<script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
+	<script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv4.html
+++ b/core/templates/dev/head/pages/splash/splash_nv4.html
@@ -1,0 +1,35 @@
+{% extends 'pages/base.html' %}
+
+{% block prerender %}
+  <link rel="prerender" href="/library">
+{% endblock prerender %}
+
+{% block maintitle %}
+  I18N_SPLASH_PAGE_TITLE
+{% endblock maintitle %}
+
+{% block header_js %}
+  {{ super() }}
+{% endblock %}
+
+{% block navbar_breadcrumb %}
+{% endblock navbar_breadcrumb %}
+
+{% block content %}
+  <div ng-controller="Splash">
+    4
+  </div>
+
+  <style>
+    /* styles that apply to just this page */
+  </style>
+{% endblock %}
+
+{% block footer %}
+  {% include 'pages/footer.html' %}
+{% endblock %}
+
+{% block footer_js %}
+  {{ super() }}
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+{% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv4.html
+++ b/core/templates/dev/head/pages/splash/splash_nv4.html
@@ -1,117 +1,117 @@
 {% extends 'pages/base.html' %}
 
 {% block prerender %}
-	<link rel="prerender" href="/library">
+  <link rel="prerender" href="/library">
 {% endblock prerender %}
 
 {% block maintitle %}
-	I18N_SPLASH_PAGE_TITLE
+  I18N_SPLASH_PAGE_TITLE
 {% endblock maintitle %}
 
 {% block header_js %}
-	{{ super() }}
+  {{ super() }}
 {% endblock %}
 
 {% block navbar_breadcrumb %}
 {% endblock navbar_breadcrumb %}
 
 {% block content %}
-	<div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
-		<div class="container">
-			<div class="row">
-				<div class="oppia-splash-new-main-cta">
-					<h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
-					<h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
-					<div class="oppia-button-container">
-						<button type="button"
-										ng-click="onClickBrowseLibraryButton()"
-	                  class="btn oppia-transition-200 oppia-splash-new-cta-button">
-										Start Learning
-						</button>
-						<button type="button"
-										ng-click="onRedirectToLogin('/dashboard?mode=create')"
-										class="btn oppia-transition-200 oppia-splash-new-cta-button">
-										Share Your Knowledge
-						</button>
-					</div>
-				</div>
-			</div>
-			<div class="jumbotron">
-				<h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
-        <div class="oppia-splash-new-exploration-summaries">
-        	<div ng-repeat="tile in activityList" style="display: inline-block;">
-          	<exploration-summary-tile exploration-id="tile.id"
-                                    	exploration-title="tile.title"
-                                    	last-updated-msec="tile.last_updated_msec"
-	                                    objective="tile.objective"
-	                                    category="tile.category"
-	                                    ratings="tile.ratings"
-	                                    num-views="tile.num_views"
-	                                    thumbnail-icon-url="tile.thumbnail_icon_url"
-	                                    thumbnail-bg-color="tile.thumbnail_bg_color"
-	                                    class="protractor-test-exp-summary-tile">
-          	</exploration-summary-tile>
+  <div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
+    <div class="container">
+      <div class="row">
+        <div class="oppia-splash-new-main-cta">
+          <h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
+          <h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
+          <div class="oppia-button-container">
+            <button type="button"
+                    ng-click="onClickBrowseLibraryButton()"
+                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    Start Learning
+            </button>
+            <button type="button"
+                    ng-click="onRedirectToLogin('/dashboard?mode=create')"
+                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    Share Your Knowledge
+            </button>
           </div>
-				</div>
-			</div>
-			<div class="jumbotron">
-				<div class="row">
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
-						</div>
-					</div>
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
-						</div>
-					</div>
-					<div class="col-sm-4 oppia-bullet-holder">
-						<div class="row">
-							<img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
-						</div>
-						<div class="row">
-							<p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/dashboard?mode=create')">share your knowledge</a> today!</p>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-		<div class="oppia-splash-new-callout">
-			<button type="button"
-							ng-click="onClickBrowseLibraryButton()"
-							class="btn oppia-transition-200">
-							Start Learning
-			</button>
-			<button type="button"
-							ng-click="onRedirectToLogin('/dashboard?mode=create')"
-							class="btn oppia-transition-200">
-							Share Your Knowledge
-			</button>
+        </div>
+      </div>
+      <div class="jumbotron">
+        <h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
+        <div class="oppia-splash-new-exploration-summaries">
+          <div ng-repeat="tile in activityList" style="display: inline-block;">
+            <exploration-summary-tile exploration-id="tile.id"
+                                      exploration-title="tile.title"
+                                      last-updated-msec="tile.last_updated_msec"
+                                      objective="tile.objective"
+                                      category="tile.category"
+                                      ratings="tile.ratings"
+                                      num-views="tile.num_views"
+                                      thumbnail-icon-url="tile.thumbnail_icon_url"
+                                      thumbnail-bg-color="tile.thumbnail_bg_color"
+                                      class="protractor-test-exp-summary-tile">
+            </exploration-summary-tile>
+          </div>
+        </div>
+      </div>
+      <div class="jumbotron">
+        <div class="row">
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
+            </div>
+          </div>
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
+            </div>
+          </div>
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/dashboard?mode=create')">share your knowledge</a> today!</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
-	</div>
+    <div class="oppia-splash-new-callout">
+      <button type="button"
+              ng-click="onClickBrowseLibraryButton()"
+              class="btn oppia-transition-200">
+              Start Learning
+      </button>
+      <button type="button"
+              ng-click="onRedirectToLogin('/dashboard?mode=create')"
+              class="btn oppia-transition-200">
+              Share Your Knowledge
+      </button>
+    </div>
+  </div>
 
-	<style>
+  <style>
     .oppia-splash-new-main-cta {
       margin: 30px auto 20px auto;
       max-width: 650px;
     }
 
-		.oppia-splash-new-h1 {
-			font-family: 'Capriola', 'Roboto', Arial, sans-serif;
-			color: #024340;
-			font-size: 2.75em;
-			margin: 20px auto 0 auto;
-			text-align: center;
-		}
+    .oppia-splash-new-h1 {
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      color: #024340;
+      font-size: 2.75em;
+      margin: 20px auto 0 auto;
+      text-align: center;
+    }
 
-		.oppia-splash-new-h2 {
+    .oppia-splash-new-h2 {
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
       font-size: 2em;
       font-weight: 300;
@@ -119,8 +119,8 @@
       text-align: center;
       margin: 18px 0;
       line-height: 1.2;
-			-webkit-font-smoothing: subpixel-antialiased;
-			text-rendering: auto;
+      -webkit-font-smoothing: subpixel-antialiased;
+      text-rendering: auto;
     }
 
     .jumbotron .oppia-splash-new-h2 {
@@ -129,11 +129,11 @@
 
     .oppia-button-container {
       text-align: center;
-			display: flex;
-			justify-content: center;
+      display: flex;
+      justify-content: center;
     }
 
-		.oppia-button-container button {
+    .oppia-button-container button {
       background-color: #015c53;
       border-radius: 0;
       color: #ffffff;
@@ -141,37 +141,37 @@
       font-size: 16px;
       padding: 10px 0;
       text-transform: uppercase;
-			width: 100%;
+      width: 100%;
       max-width: 300px;
       border: none;
-			margin: auto 5px;
+      margin: auto 5px;
     }
 
     .oppia-button-container button:hover {
       background-color: #05beb2;
-			color: #ffffff;
+      color: #ffffff;
     }
 
-		.oppia-bullet-holder img {
+    .oppia-bullet-holder img {
       height: 125px;
-			display: block;
-			margin: auto;
+      display: block;
+      margin: auto;
     }
 
     .oppia-bullet-holder p {
       padding: 5px 15px;
-			font-weight: 300;
-			line-height: 1.45;
-			font-family: 'Rubik', 'Roboto', Arial, sans-serif;
-			color: #333333;
-			-webkit-font-smoothing: subpixel-antialiased;
+      font-weight: 300;
+      line-height: 1.45;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      color: #333333;
+      -webkit-font-smoothing: subpixel-antialiased;
     }
 
     .oppia-splash-new-exploration-summaries {
       text-align: center;
     }
 
-		.oppia-splash-new-callout {
+    .oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
       height: 150px;
@@ -192,28 +192,28 @@
       position: relative;
       top: 50%;
       transform: translateY(-50%);
-			-webkit-font-smoothing: subpixel-antialiased;
+      -webkit-font-smoothing: subpixel-antialiased;
     }
 
     .oppia-splash-new-callout button:hover {
       background-color: #05beb2;
-			color: #ffffff;
+      color: #ffffff;
     }
 
-		@media (max-width: 768px) {
-			.oppia-display-desktop-only {
-				display: none !important;
-			}
+    @media (max-width: 768px) {
+      .oppia-display-desktop-only {
+        display: none !important;
+      }
 
-			.oppia-button-container {
-				flex-wrap: wrap;
-			}
+      .oppia-button-container {
+        flex-wrap: wrap;
+      }
 
-			.oppia-button-container button {
-				margin-bottom: 5px;
-			}
+      .oppia-button-container button {
+        margin-bottom: 5px;
+      }
 
-			.oppia-splash-new-callout {
+      .oppia-splash-new-callout {
         padding: 15px 0;
         height: auto;
       }
@@ -227,19 +227,19 @@
       .oppia-splash-new-callout button:first-of-type {
         margin-top: 15px;
       }
-		}
-	</style>
+    }
+  </style>
 
-	<link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
+  <link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
 {% endblock %}
 
 {% block footer %}
-	{% include 'pages/footer.html' %}
+  {% include 'pages/footer.html' %}
 {% endblock %}
 
 {% block footer_js %}
-	{{ super() }}
+  {{ super() }}
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
-	<script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
-	<script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv4.html
+++ b/core/templates/dev/head/pages/splash/splash_nv4.html
@@ -26,12 +26,12 @@
             <button type="button"
                     ng-click="onClickBrowseLibraryButton()"
                     class="btn oppia-transition-200 oppia-splash-new-cta-button">
-                    Start Learning
+              Start Learning
             </button>
             <button type="button"
                     ng-click="onRedirectToLogin('/dashboard?mode=create')"
                     class="btn oppia-transition-200 oppia-splash-new-cta-button">
-                    Share Your Knowledge
+              Share Your Knowledge
             </button>
           </div>
         </div>
@@ -87,12 +87,12 @@
       <button type="button"
               ng-click="onClickBrowseLibraryButton()"
               class="btn oppia-transition-200">
-              Start Learning
+        Start Learning
       </button>
       <button type="button"
               ng-click="onRedirectToLogin('/dashboard?mode=create')"
               class="btn oppia-transition-200">
-              Share Your Knowledge
+        Share Your Knowledge
       </button>
     </div>
   </div>
@@ -104,22 +104,22 @@
     }
 
     .oppia-splash-new-h1 {
-      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       color: #024340;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 2.75em;
       margin: 20px auto 0 auto;
       text-align: center;
     }
 
     .oppia-splash-new-h2 {
+      -webkit-font-smoothing: subpixel-antialiased;
+      color: #04857c;
       font-family: 'Rubik', 'Roboto', Arial, sans-serif;
       font-size: 2em;
       font-weight: 300;
-      color: #04857c;
-      text-align: center;
-      margin: 18px 0;
       line-height: 1.2;
-      -webkit-font-smoothing: subpixel-antialiased;
+      margin: 18px 0;
+      text-align: center;
       text-rendering: auto;
     }
 
@@ -128,23 +128,23 @@
     }
 
     .oppia-button-container {
-      text-align: center;
       display: flex;
       justify-content: center;
+      text-align: center;
     }
 
     .oppia-button-container button {
       background-color: #015c53;
       border-radius: 0;
+      border: none;
       color: #ffffff;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 16px;
+      margin: auto 5px;
+      max-width: 300px;
       padding: 10px 0;
       text-transform: uppercase;
       width: 100%;
-      max-width: 300px;
-      border: none;
-      margin: auto 5px;
     }
 
     .oppia-button-container button:hover {
@@ -153,18 +153,18 @@
     }
 
     .oppia-bullet-holder img {
-      height: 125px;
       display: block;
+      height: 125px;
       margin: auto;
     }
 
     .oppia-bullet-holder p {
-      padding: 5px 15px;
+      color: #333333;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      -webkit-font-smoothing: subpixel-antialiased;
       font-weight: 300;
       line-height: 1.45;
-      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
-      color: #333333;
-      -webkit-font-smoothing: subpixel-antialiased;
+      padding: 5px 15px;
     }
 
     .oppia-splash-new-exploration-summaries {
@@ -180,19 +180,19 @@
 
     .oppia-splash-new-callout button {
       background-color: #00796d;
+      border-radius: 5px;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 18px;
+      -webkit-font-smoothing: subpixel-antialiased;
       margin: 0 15px 15px 15px;
       max-width: 90%;
       padding: 15px;
-      text-transform: uppercase;
-      white-space: normal;
-      width: 352px;
-      border-radius: 5px;
       position: relative;
+      text-transform: uppercase;
       top: 50%;
       transform: translateY(-50%);
-      -webkit-font-smoothing: subpixel-antialiased;
+      white-space: normal;
+      width: 352px;
     }
 
     .oppia-splash-new-callout button:hover {
@@ -214,8 +214,8 @@
       }
 
       .oppia-splash-new-callout {
-        padding: 15px 0;
         height: auto;
+        padding: 15px 0;
       }
 
       .oppia-splash-new-callout button {

--- a/core/templates/dev/head/pages/splash/splash_nv4.html
+++ b/core/templates/dev/head/pages/splash/splash_nv4.html
@@ -1,35 +1,225 @@
 {% extends 'pages/base.html' %}
 
 {% block prerender %}
-  <link rel="prerender" href="/library">
+	<link rel="prerender" href="/library">
 {% endblock prerender %}
 
 {% block maintitle %}
-  I18N_SPLASH_PAGE_TITLE
+	I18N_SPLASH_PAGE_TITLE
 {% endblock maintitle %}
 
 {% block header_js %}
-  {{ super() }}
+	{{ super() }}
 {% endblock %}
 
 {% block navbar_breadcrumb %}
 {% endblock navbar_breadcrumb %}
 
 {% block content %}
-  <div ng-controller="Splash">
-    4
-  </div>
+	<div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
+		<div class="container">
+			<div class="row">
+				<div class="oppia-splash-new-main-cta">
+					<h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
+					<h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
+					<div class="oppia-button-container">
+						<button type="button"
+										ng-click="onClickBrowseLibraryButton()"
+	                  class="btn oppia-transition-200 oppia-splash-new-cta-button">
+										Start Learning
+						</button>
+						<button type="button"
+										ng-click="onRedirectToLogin('/dashboard?mode=create')"
+										class="btn oppia-transition-200 oppia-splash-new-cta-button">
+										Share Your Knowledge
+						</button>
+					</div>
+				</div>
+			</div>
+			<div class="jumbotron">
+				<h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
+				<!-- TODO: put carousel here -->
+			</div>
+			<div class="jumbotron">
+				<div class="row">
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
+						</div>
+					</div>
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
+						</div>
+					</div>
+					<div class="col-sm-4 oppia-bullet-holder">
+						<div class="row">
+							<img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
+						</div>
+						<div class="row">
+							<p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/dashboard?mode=create')">share your knowledge</a> today!</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div class="oppia-about-extra-info">
+			<button type="button"
+							ng-click="onClickBrowseLibraryButton()"
+							class="btn oppia-transition-200">
+							Start Learning
+			</button>
+			<button type="button"
+							ng-click="onRedirectToLogin('/dashboard?mode=create')"
+							class="btn oppia-transition-200">
+							Share Your Knowledge
+			</button>
+    </div>
+	</div>
 
-  <style>
-    /* styles that apply to just this page */
-  </style>
+	<style>
+    .oppia-splash-new-main-cta {
+      margin: 30px auto 20px auto;
+      max-width: 650px;
+    }
+
+		.oppia-splash-new-h1 {
+			font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+			color: #024340;
+			font-size: 2.75em;
+			margin: 20px auto 0 auto;
+			text-align: center;
+		}
+
+		.oppia-splash-new-h2 {
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      font-size: 2em;
+      font-weight: 300;
+      color: #04857c;
+      text-align: center;
+      margin: 18px 0;
+      line-height: 1.2;
+			-webkit-font-smoothing: subpixel-antialiased;
+			text-rendering: auto;
+    }
+
+    .jumbotron .oppia-splash-new-h2 {
+      margin-top: 0;
+    }
+
+    .oppia-button-container {
+      text-align: center;
+			display: flex;
+			justify-content: center;
+    }
+
+		.oppia-button-container button {
+      background-color: #015c53;
+      border-radius: 0;
+      color: #ffffff;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 16px;
+      padding: 10px 0;
+      text-transform: uppercase;
+			width: 100%;
+      max-width: 300px;
+      border: none;
+			margin: auto 5px;
+    }
+
+    .oppia-button-container button:hover {
+      background-color: #05beb2;
+			color: #ffffff;
+    }
+
+		.oppia-bullet-holder img {
+      height: 125px;
+			display: block;
+			margin: auto;
+    }
+
+    .oppia-bullet-holder p {
+      padding: 5px 15px;
+			font-weight: 300;
+			line-height: 1.45;
+			font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+			color: #333333;
+			-webkit-font-smoothing: subpixel-antialiased;
+    }
+
+		.oppia-about-extra-info {
+      background-color: #009788;
+      color: #ffffff;
+      height: 150px;
+      text-align: center;
+    }
+
+    .oppia-about-extra-info button {
+      background-color: #00796d;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 18px;
+      margin: 0 15px 15px 15px;
+      max-width: 90%;
+      padding: 15px;
+      text-transform: uppercase;
+      white-space: normal;
+      width: 352px;
+      border-radius: 5px;
+      position: relative;
+      top: 50%;
+      transform: translateY(-50%);
+			-webkit-font-smoothing: subpixel-antialiased;
+    }
+
+    .oppia-about-extra-info button:hover {
+      background-color: #05beb2;
+			color: #ffffff;
+    }
+
+		@media (max-width: 768px) {
+			.oppia-display-desktop-only {
+				display: none !important;
+			}
+
+			.oppia-button-container {
+				flex-wrap: wrap;
+			}
+
+			.oppia-button-container button {
+				margin-bottom: 5px;
+			}
+
+			.oppia-about-extra-info {
+        padding: 15px 0;
+        height: auto;
+      }
+
+      .oppia-about-extra-info button {
+        position: auto;
+        top: auto;
+        transform: none;
+      }
+
+      .oppia-about-extra-info button:first-of-type {
+        margin-top: 15px;
+      }
+		}
+	</style>
+
+	<link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
 {% endblock %}
 
 {% block footer %}
-  {% include 'pages/footer.html' %}
+	{% include 'pages/footer.html' %}
 {% endblock %}
 
 {% block footer_js %}
-  {{ super() }}
-  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+	{{ super() }}
+	<script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv4.html
+++ b/core/templates/dev/head/pages/splash/splash_nv4.html
@@ -69,7 +69,7 @@
 				</div>
 			</div>
 		</div>
-		<div class="oppia-about-extra-info">
+		<div class="oppia-splash-new-callout">
 			<button type="button"
 							ng-click="onClickBrowseLibraryButton()"
 							class="btn oppia-transition-200">
@@ -153,14 +153,14 @@
 			-webkit-font-smoothing: subpixel-antialiased;
     }
 
-		.oppia-about-extra-info {
+		.oppia-splash-new-callout {
       background-color: #009788;
       color: #ffffff;
       height: 150px;
       text-align: center;
     }
 
-    .oppia-about-extra-info button {
+    .oppia-splash-new-callout button {
       background-color: #00796d;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 18px;
@@ -177,7 +177,7 @@
 			-webkit-font-smoothing: subpixel-antialiased;
     }
 
-    .oppia-about-extra-info button:hover {
+    .oppia-splash-new-callout button:hover {
       background-color: #05beb2;
 			color: #ffffff;
     }
@@ -195,18 +195,18 @@
 				margin-bottom: 5px;
 			}
 
-			.oppia-about-extra-info {
+			.oppia-splash-new-callout {
         padding: 15px 0;
         height: auto;
       }
 
-      .oppia-about-extra-info button {
+      .oppia-splash-new-callout button {
         position: auto;
         top: auto;
         transform: none;
       }
 
-      .oppia-about-extra-info button:first-of-type {
+      .oppia-splash-new-callout button:first-of-type {
         margin-top: 15px;
       }
 		}

--- a/feconf.py
+++ b/feconf.py
@@ -717,6 +717,8 @@ LIBRARY_CATEGORY_TOP_RATED_EXPLORATIONS = (
 # The i18n id for the header of the "Recently Published" category in the
 # library index page.
 LIBRARY_CATEGORY_RECENTLY_PUBLISHED = 'I18N_LIBRARY_GROUPS_RECENTLY_PUBLISHED'
+# group_name param for GET request in Splash.js
+LIBRARY_CATEGORY_SPLASH_PAGE_FEATURED = 'splash_page_featured'
 
 # The group name that appears at the end of the url for the recently published
 # page.
@@ -735,9 +737,6 @@ LIBRARY_PAGE_MODE_GROUP = 'group'
 LIBRARY_PAGE_MODE_INDEX = 'index'
 # Page mode for the search results page.
 LIBRARY_PAGE_MODE_SEARCH = 'search'
-
-# group_name param for GET request in Splash.js
-SPLASH_PAGE_FEATURED = 'splash_page_featured'
 
 # List of supported language codes. Each description has a
 # parenthetical part that may be stripped out to give a shorter

--- a/feconf.py
+++ b/feconf.py
@@ -736,6 +736,9 @@ LIBRARY_PAGE_MODE_INDEX = 'index'
 # Page mode for the search results page.
 LIBRARY_PAGE_MODE_SEARCH = 'search'
 
+# group_name param for GET request in Splash.js
+SPLASH_PAGE_FEATURED = 'splash_page_featured'
+
 # List of supported language codes. Each description has a
 # parenthetical part that may be stripped out to give a shorter
 # description.


### PR DESCRIPTION
I apologize this took me so long to get to -- moving three times in two weeks has presented some unexpected time-related challenges.

It's probably already too late to get this into the next release, but if there's some way to squeeze it in so we can start tracking efficacy data alongside the landing pages, it would be much appreciated.

---

These are four new splash pages we will be testing alongside the current splash page in an attempt to increase engagement rates.

Details of the tests, the metrics by which we will evaluate the results, and plans for future improvements to these pages can be found here: https://docs.google.com/spreadsheets/d/1gYx3j-UEoFtHapDh3ZvIYtDnzhoIEAfUZ92vjziZTp0/edit#gid=0

Each splash page (including the current splash page) will receive 20% of traffic to `/splash`.

Please note that some of this implementation is currently somewhat hacky and not built for long-term maintainability. This is because we will be removing multiple of these pages in line with the test results. Code for winning pages will be improved at a later point.