### PR TITLE
Fixes: 1782 - tooltip placement issues

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4558,9 +4558,3 @@ md-card.preview-conversation-skin-supplemental-card {
   padding: 0;
   width: 1px;
 }
-
-
-.popover.bottom.fade.in {
-  height: 56px !important;
-  width: 200px !important;
-}

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4558,3 +4558,9 @@ md-card.preview-conversation-skin-supplemental-card {
   padding: 0;
   width: 1px;
 }
+
+
+.popover.bottom.fade.in {
+  height: 56px !important;
+  width: 200px !important;
+}

--- a/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
@@ -97,7 +97,7 @@
     {% if username %}
     <div class="nav navbar-nav oppia-navbar-nav oppia-help-dropdown pull-right ng-cloak">
       <li class="dropdown" popover-is-open="postTutorialHelpPopoverIsShown"
-          popover-placement="bottom" popover-trigger="none"
+          popover-placement="bottom" popover-trigger="click"
           popover="To get help in the future, click here!">
         <a href="#" tooltip="Help" tooltip-placement="bottom"
            class="oppia-editor-navbar-tab-anchor" ng-click="showUserHelpModal()">
@@ -111,8 +111,8 @@
     .oppia-help-dropdown .popover{
       background-color: black;
       color: white;
-      font-size: 13px;
-      max-width: 300px;
+      font-size: 14px;
+      max-width: 200px;
       text-align: center;
       z-index: -1;
     }

--- a/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
@@ -97,7 +97,7 @@
     {% if username %}
     <div class="nav navbar-nav oppia-navbar-nav oppia-help-dropdown pull-right ng-cloak">
       <li class="dropdown" popover-is-open="postTutorialHelpPopoverIsShown"
-          popover-placement="bottom" popover-trigger="click"
+          popover-placement="bottom" popover-trigger="none"
           popover="To get help in the future, click here!">
         <a href="#" tooltip="Help" tooltip-placement="bottom"
            class="oppia-editor-navbar-tab-anchor" ng-click="showUserHelpModal()">


### PR DESCRIPTION
#1782 

This PR fixes the tooltip button that looks a bit off screen by overriding dynamic CSS styling. PTAL @seanlip . Would this be an issue in screens of varying sizes?
![tooltip](https://cloud.githubusercontent.com/assets/15828797/25874437/30f01a94-3530-11e7-8a90-dd7dffc33eea.png)
