### PR TITLE
Fix a few bugs in image region interaction.

### DIFF
--- a/core/templates/dev/head/components/forms/HtmlSelectDirective.js
+++ b/core/templates/dev/head/components/forms/HtmlSelectDirective.js
@@ -36,7 +36,8 @@ oppia.directive('htmlSelect', [function() {
 
       $scope.getSelectionIndex = function() {
         for (var i = 0; i < $scope.options.length; i++) {
-          if (($scope.options[i].val === $scope.selection) || ($scope.options[i].id === $scope.selection)) {
+          if (($scope.options[i].val === $scope.selection) ||
+            ($scope.options[i].id === $scope.selection)) {
             return i;
           }
         }

--- a/core/templates/dev/head/components/forms/HtmlSelectDirective.js
+++ b/core/templates/dev/head/components/forms/HtmlSelectDirective.js
@@ -33,6 +33,14 @@ oppia.directive('htmlSelect', [function() {
       $scope.select = function(id) {
         $scope.selection = id;
       };
+
+      $scope.getSelectionIndex = function() {
+        for (var i = 0; i < $scope.options.length; i++) {
+          if (($scope.options[i].val === $scope.selection) || ($scope.options[i].id === $scope.selection)) {
+            return i;
+          }
+        }
+      };
     }
     ]
   };

--- a/core/templates/dev/head/components/forms/HtmlSelectDirective.js
+++ b/core/templates/dev/head/components/forms/HtmlSelectDirective.js
@@ -35,10 +35,9 @@ oppia.directive('htmlSelect', [function() {
       };
 
       $scope.getSelectionIndex = function() {
-        for (var i = 0; i < $scope.options.length; i++) {
-          if (($scope.options[i].val === $scope.selection) ||
-            ($scope.options[i].id === $scope.selection)) {
-            return i;
+        for (var index = 0; index < $scope.options.length; index++) {
+          if ($scope.options[index].id === $scope.selection) {
+            return index;
           }
         }
       };

--- a/core/templates/dev/head/components/forms/html_select_directive.html
+++ b/core/templates/dev/head/components/forms/html_select_directive.html
@@ -1,7 +1,7 @@
 <script type="text/ng-template" id="components/htmlSelect">
   <div class="oppia-html-select">
     <button class="btn btn-default dropdown-toggle oppia-html-select-selection" type="button" aria-expanded="false" data-toggle="dropdown">
-      <div class="oppia-html-select-selection-element" angular-html-bind="options[selection].val"></div>
+      <div class="oppia-html-select-selection-element" angular-html-bind="options[getSelectionIndex()].val"></div>
       <span class="caret oppia-html-select-selection-caret"></span>
     </button>
     <ul class="dropdown-menu" style="width: inherit;">

--- a/core/templates/dev/head/components/forms/html_select_directive.html
+++ b/core/templates/dev/head/components/forms/html_select_directive.html
@@ -1,7 +1,7 @@
 <script type="text/ng-template" id="components/htmlSelect">
   <div class="oppia-html-select">
     <button class="btn btn-default dropdown-toggle oppia-html-select-selection" type="button" aria-expanded="false" data-toggle="dropdown">
-      <div class="oppia-html-select-selection-element" angular-html-bind="selection"></div>
+      <div class="oppia-html-select-selection-element" angular-html-bind="options[selection].val"></div>
       <span class="caret oppia-html-select-selection-caret"></span>
     </button>
     <ul class="dropdown-menu" style="width: inherit;">

--- a/core/templates/dev/head/components/forms/html_select_directive.html
+++ b/core/templates/dev/head/components/forms/html_select_directive.html
@@ -1,7 +1,7 @@
 <script type="text/ng-template" id="components/htmlSelect">
   <div class="oppia-html-select">
     <button class="btn btn-default dropdown-toggle oppia-html-select-selection" type="button" aria-expanded="false" data-toggle="dropdown">
-      <div class="oppia-html-select-selection-element" angular-html-bind="options[selection].val"></div>
+      <div class="oppia-html-select-selection-element" angular-html-bind="selection"></div>
       <span class="caret oppia-html-select-selection-caret"></span>
     </button>
     <ul class="dropdown-menu" style="width: inherit;">

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
@@ -362,7 +362,7 @@ oppia.controller('StateInteraction', [
         var imageWithRegions = currentCustomizationArgs.imageAndRegions.value;
         for (var j = 0; j < imageWithRegions.labeledRegions.length; j++) {
           _answerChoices.push({
-            val: j,
+            val: imageWithRegions.labeledRegions[j].label,
             label: imageWithRegions.labeledRegions[j].label
           });
         }

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
@@ -362,7 +362,7 @@ oppia.controller('StateInteraction', [
         var imageWithRegions = currentCustomizationArgs.imageAndRegions.value;
         for (var j = 0; j < imageWithRegions.labeledRegions.length; j++) {
           _answerChoices.push({
-            val: imageWithRegions.labeledRegions[j].label,
+            val: j,
             label: imageWithRegions.labeledRegions[j].label
           });
         }

--- a/extensions/objects/templates/ImageWithRegionsEditor.js
+++ b/extensions/objects/templates/ImageWithRegionsEditor.js
@@ -340,7 +340,7 @@ oppia.directive('imageWithRegionsEditor', [
                 // that doesn't overlap with currently existing labels.
                 var newLabel = null;
                 for (var i = 1; i <= labels.length + 1; i++) {
-                  var candidateLabel = 'Region ' + i.toString();
+                  var candidateLabel = 'Region' + i.toString();
                   if (labels.indexOf(candidateLabel) === -1) {
                     newLabel = candidateLabel;
                     break;


### PR DESCRIPTION
This PR fixes the display issue - the option selected in the image region customization is displayed correctly.

Also since the default names of the regions were set to be of the form 'Region 1' - the space between Region and the number resulted in a critical error and it would be quite hard for the creator to fix this since normally we expect that the default option is correct.