### PR TITLE
Add missing dependency to autosaveInfoModalService.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/EditorServices.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorServices.js
@@ -179,7 +179,7 @@ oppia.factory('angularNameService', [function() {
 
   return {
     getNameOfInteractionRulesService: function(interactionId) {
-      angularName = interactionId.charAt(0).toLowerCase() + 
+      angularName = interactionId.charAt(0).toLowerCase() +
         interactionId.slice(1) + 'RulesService';
       return angularName
     }
@@ -2352,10 +2352,10 @@ oppia.factory('lostChangesService', ['utilsService', function(utilsService) {
 // response received as a result of the autosaving request.
 oppia.factory('autosaveInfoModalsService', [
   '$log', '$modal', '$timeout', '$window', 'lostChangesService',
-  'explorationData',
+  'explorationData', 'UrlInterpolationService',
   function(
       $log, $modal, $timeout, $window, lostChangesService,
-      explorationData) {
+      explorationData, UrlInterpolationService) {
     var _isModalOpen = false;
     var _refreshPage = function(delay) {
       $timeout(function() {


### PR DESCRIPTION
Hi @1995YogeshSharma @vojtechjelinek, I discovered another missing dependency due to the template refactor that caused the frontend to break. PTAL.

Also, since this is the second error I found, I am becoming worried that there are more bugs. Please could you double-check the refactoring PRs that have been submitted?

Thanks!