### PR TITLE
Modify styles on new splash pages to better handle certain viewport widths

### DIFF
--- a/core/templates/dev/head/pages/splash/splash_nv1.html
+++ b/core/templates/dev/head/pages/splash/splash_nv1.html
@@ -28,12 +28,12 @@
           <div class="oppia-button-container">
             <button type="button"
                     ng-click="onClickBrowseLibraryButton()"
-                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    class="btn oppia-transition-200">
               Start Learning
             </button>
             <button type="button"
                     ng-click="onRedirectToLogin('/dashboard?mode=create')"
-                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    class="btn oppia-transition-200">
               Share Your Knowledge
             </button>
           </div>
@@ -147,7 +147,7 @@
       font-size: 16px;
       margin: auto 5px;
       max-width: 300px;
-      padding: 10px 0;
+      padding: 10px;
       text-transform: uppercase;
       width: 100%;
     }
@@ -173,6 +173,7 @@
     }
 
     .oppia-splash-new-exploration-summaries {
+      font-size: 16px;
       text-align: center;
     }
 
@@ -242,6 +243,11 @@
       }
     }
 
+    @media (max-width: 500px) {
+      .oppia-activity-summary-tile {
+        margin: 8px 5.5px;
+      }
+    }
   </style>
 
   <link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">

--- a/core/templates/dev/head/pages/splash/splash_nv1.html
+++ b/core/templates/dev/head/pages/splash/splash_nv1.html
@@ -244,6 +244,10 @@
     }
 
     @media (max-width: 500px) {
+      .oppia-splash-new-h1 {
+        margin-top: 10px;
+      }
+      
       .oppia-activity-summary-tile {
         margin: 8px 5.5px;
       }

--- a/core/templates/dev/head/pages/splash/splash_nv2.html
+++ b/core/templates/dev/head/pages/splash/splash_nv2.html
@@ -28,12 +28,12 @@
           <div class="oppia-button-container">
             <button type="button"
                     ng-click="onClickBrowseLibraryButton()"
-                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    class="btn oppia-transition-200">
               Start Learning
             </button>
             <button type="button"
                     ng-click="onRedirectToLogin('/dashboard?mode=create')"
-                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    class="btn oppia-transition-200">
               Share Your Knowledge
             </button>
           </div>
@@ -147,7 +147,7 @@
       font-size: 16px;
       margin: auto 5px;
       max-width: 300px;
-      padding: 10px 0;
+      padding: 10px;
       text-transform: uppercase;
       width: 100%;
     }
@@ -173,6 +173,7 @@
     }
 
     .oppia-splash-new-exploration-summaries {
+      font-size: 16px;
       text-align: center;
     }
 
@@ -239,6 +240,12 @@
       #oppia-splash-new-otter {
         bottom: -85px;
         width: 175px;
+      }
+    }
+
+    @media (max-width: 500px) {
+      .oppia-activity-summary-tile {
+        margin: 8px 5.5px;
       }
     }
   </style>

--- a/core/templates/dev/head/pages/splash/splash_nv2.html
+++ b/core/templates/dev/head/pages/splash/splash_nv2.html
@@ -244,6 +244,10 @@
     }
 
     @media (max-width: 500px) {
+      .oppia-splash-new-h1 {
+        margin-top: 10px;
+      }
+      
       .oppia-activity-summary-tile {
         margin: 8px 5.5px;
       }

--- a/core/templates/dev/head/pages/splash/splash_nv3.html
+++ b/core/templates/dev/head/pages/splash/splash_nv3.html
@@ -260,6 +260,10 @@
         margin-top: 10px;
       }
       
+      .oppia-splash-new-h3 {
+        text-align: center;
+      }
+      
       .oppia-activity-summary-tile {
         margin: 8px 5.5px;
       }

--- a/core/templates/dev/head/pages/splash/splash_nv3.html
+++ b/core/templates/dev/head/pages/splash/splash_nv3.html
@@ -28,12 +28,12 @@
           <div class="oppia-button-container">
             <button type="button"
                     ng-click="onClickBrowseLibraryButton()"
-                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    class="btn oppia-transition-200">
               Start Learning
             </button>
             <button type="button"
                     ng-click="onRedirectToLogin('/dashboard?mode=create')"
-                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    class="btn oppia-transition-200">
               Share Your Knowledge
             </button>
           </div>
@@ -144,7 +144,7 @@
       font-size: 16px;
       margin: auto 5px;
       max-width: 300px;
-      padding: 10px 0;
+      padding: 10px;
       text-transform: uppercase;
       width: 100%;
     }
@@ -170,6 +170,7 @@
     }
 
     .oppia-splash-new-exploration-summaries {
+      font-size: 16px;
       margin-bottom: 2em;
       text-align: center;
     }
@@ -185,8 +186,7 @@
       color: #ffffff;
       font-size: 2em;
       font-weight: 600;
-      margin-top: 22px;
-      margin: 0;
+      margin: 22px auto 0 auto;
     }
 
     .oppia-splash-new-callout p {
@@ -252,6 +252,12 @@
       #oppia-splash-new-otter {
         bottom: -85px;
         width: 175px;
+      }
+    }
+
+    @media (max-width: 500px) {
+      .oppia-activity-summary-tile {
+        margin: 8px 5.5px;
       }
     }
   </style>

--- a/core/templates/dev/head/pages/splash/splash_nv3.html
+++ b/core/templates/dev/head/pages/splash/splash_nv3.html
@@ -256,6 +256,10 @@
     }
 
     @media (max-width: 500px) {
+      .oppia-splash-new-h1 {
+        margin-top: 10px;
+      }
+      
       .oppia-activity-summary-tile {
         margin: 8px 5.5px;
       }

--- a/core/templates/dev/head/pages/splash/splash_nv4.html
+++ b/core/templates/dev/head/pages/splash/splash_nv4.html
@@ -19,7 +19,7 @@
   <div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
     <div class="container">
       <div class="row">
-        <div class="oppia-splash-new-main-cta">
+        <div class="oppia-splash-new-main-cta col-xs-12">
           <h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
           <h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
           <div class="oppia-button-container">
@@ -99,6 +99,7 @@
 
   <style>
     .oppia-splash-new-main-cta {
+      float: none;
       margin: 30px auto 20px auto;
       max-width: 650px;
     }

--- a/core/templates/dev/head/pages/splash/splash_nv4.html
+++ b/core/templates/dev/head/pages/splash/splash_nv4.html
@@ -25,12 +25,12 @@
           <div class="oppia-button-container">
             <button type="button"
                     ng-click="onClickBrowseLibraryButton()"
-                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    class="btn oppia-transition-200">
               Start Learning
             </button>
             <button type="button"
                     ng-click="onRedirectToLogin('/dashboard?mode=create')"
-                    class="btn oppia-transition-200 oppia-splash-new-cta-button">
+                    class="btn oppia-transition-200">
               Share Your Knowledge
             </button>
           </div>
@@ -142,7 +142,7 @@
       font-size: 16px;
       margin: auto 5px;
       max-width: 300px;
-      padding: 10px 0;
+      padding: 10px;
       text-transform: uppercase;
       width: 100%;
     }
@@ -168,6 +168,7 @@
     }
 
     .oppia-splash-new-exploration-summaries {
+      font-size: 16px;
       text-align: center;
     }
 
@@ -226,6 +227,12 @@
 
       .oppia-splash-new-callout button:first-of-type {
         margin-top: 15px;
+      }
+    }
+
+    @media (max-width: 500px) {
+      .oppia-activity-summary-tile {
+        margin: 8px 5.5px;
       }
     }
   </style>


### PR DESCRIPTION
~~Note: just found one more oddity -- do not merge yet.~~ Update: this oddity only occurs when a user is on mobile _and_ is signed in _and_ is on a splash page. Probably fine launching with it for now. (Evidently, there's some width difference between the mobile top bar with the sign in button as compared to with the logged-in dropdown, and this results in some weirdness around page width.)