### PR TITLE
Remove unresolved answers from the creator dashboard

### DIFF
--- a/core/controllers/dashboard.py
+++ b/core/controllers/dashboard.py
@@ -23,7 +23,6 @@ from core.domain import config_domain
 from core.domain import exp_domain
 from core.domain import exp_services
 from core.domain import feedback_services
-from core.domain import stats_services
 from core.domain import subscription_services
 from core.domain import summary_services
 from core.domain import user_jobs_continuous
@@ -154,49 +153,40 @@ class DashboardHandler(base.BaseHandler):
         def _round_average_ratings(rating):
             return round(rating, feconf.AVERAGE_RATINGS_DASHBOARD_PRECISION)
 
-        exploration_ids_subscribed_to = (
-            subscription_services.get_exploration_ids_subscribed_to(
-                self.user_id))
-
-        subscribed_exploration_summaries = filter(None, (
+        # We need to do the filtering because some activities that were
+        # originally subscribed to may have been deleted since.
+        subscribed_exploration_summaries = [
+            summary for summary in
             exp_services.get_exploration_summaries_matching_ids(
-                exploration_ids_subscribed_to)))
-        subscribed_collection_summaries = filter(None, (
+                subscription_services.get_exploration_ids_subscribed_to(
+                    self.user_id))
+            if summary is not None]
+        subscribed_collection_summaries = [
+            summary for summary in
             collection_services.get_collection_summaries_matching_ids(
                 subscription_services.get_collection_ids_subscribed_to(
-                    self.user_id))))
+                    self.user_id))
+            if summary is not None]
 
-        exp_summary_list = summary_services.get_displayable_exp_summary_dicts(
+        exploration_ids_subscribed_to = [
+            summary.id for summary in subscribed_exploration_summaries]
+
+        exp_summary_dicts = summary_services.get_displayable_exp_summary_dicts(
             subscribed_exploration_summaries)
-        collection_summary_list = []
+        collection_summary_dicts = []
 
         feedback_thread_analytics = (
             feedback_services.get_thread_analytics_multi(
                 exploration_ids_subscribed_to))
 
-        unresolved_answers_dict = (
-            stats_services.get_exps_unresolved_answers_for_default_rule(
-                exploration_ids_subscribed_to))
-
-        total_unresolved_answers = 0
-
-        for ind, exploration in enumerate(exp_summary_list):
+        # TODO(bhenning): Update this to use unresovled answers from
+        # stats_services once the training interface is enabled and it's cheaper
+        # to retrieve top answers from stats_services.
+        for ind, exploration in enumerate(exp_summary_dicts):
             exploration.update(feedback_thread_analytics[ind].to_dict())
-            exploration.update({
-                'num_unresolved_answers': (
-                    unresolved_answers_dict[exploration['id']]['frequency']
-                    if exploration['id'] in unresolved_answers_dict else 0
-                ),
-                'top_unresolved_answers': (
-                    unresolved_answers_dict[exploration['id']]
-                    ['unresolved_answers']
-                    [:feconf.TOP_UNRESOLVED_ANSWERS_COUNT_DASHBOARD]
-                )
-            })
-            total_unresolved_answers += exploration['num_unresolved_answers']
 
-        exp_summary_list = sorted(
-            exp_summary_list,
+        exp_summary_dicts = sorted(
+            exp_summary_dicts,
             key=lambda x: (x['num_open_threads'], x['last_updated_msec']),
             reverse=True)
 
@@ -205,7 +195,7 @@ class DashboardHandler(base.BaseHandler):
             for collection_summary in subscribed_collection_summaries:
                 # TODO(sll): Reuse _get_displayable_collection_summary_dicts()
                 # in summary_services, instead of replicating it like this.
-                collection_summary_list.append({
+                collection_summary_dicts.append({
                     'id': collection_summary.id,
                     'title': collection_summary.title,
                     'category': collection_summary.category,
@@ -230,8 +220,7 @@ class DashboardHandler(base.BaseHandler):
                 self.user_id))
         dashboard_stats.update({
             'total_open_feedback': feedback_services.get_total_open_threads(
-                feedback_thread_analytics),
-            'total_unresolved_answers': total_unresolved_answers
+                feedback_thread_analytics)
         })
         if dashboard_stats and dashboard_stats.get('average_ratings'):
             dashboard_stats['average_ratings'] = (
@@ -259,8 +248,8 @@ class DashboardHandler(base.BaseHandler):
             subscribers_list.append(subscriber_summary)
 
         self.values.update({
-            'explorations_list': exp_summary_list,
-            'collections_list': collection_summary_list,
+            'explorations_list': exp_summary_dicts,
+            'collections_list': collection_summary_dicts,
             'dashboard_stats': dashboard_stats,
             'last_week_stats': last_week_stats,
             'subscribers_list': subscribers_list

--- a/core/controllers/dashboard.py
+++ b/core/controllers/dashboard.py
@@ -179,7 +179,7 @@ class DashboardHandler(base.BaseHandler):
             feedback_services.get_thread_analytics_multi(
                 exploration_ids_subscribed_to))
 
-        # TODO(bhenning): Update this to use unresovled answers from
+        # TODO(bhenning): Update this to use unresolved answers from
         # stats_services once the training interface is enabled and it's cheaper
         # to retrieve top answers from stats_services.
         for ind, exploration in enumerate(exp_summary_dicts):

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -28,6 +28,8 @@ from core.platform import models
 (stats_models,) = models.Registry.import_models([models.NAMES.statistics])
 
 
+# TODO(bhenning): Update this to work correctly & efficiently with the new
+# storage model.
 def get_exps_unresolved_answers_for_default_rule(exp_ids):
     """Gets unresolved answers per exploration for default rule across all
     states for explorations with ids in exp_ids. The value of total count should

--- a/core/templates/dev/head/domain/dashboard/DashboardBackendApiServiceSpec.js
+++ b/core/templates/dev/head/domain/dashboard/DashboardBackendApiServiceSpec.js
@@ -45,20 +45,7 @@ describe('Dashboard backend API service', function() {
       thumbnail_bg_color: '#bb8b2f',
       num_views: 2,
       num_open_threads: 0,
-      num_total_threads: 0,
-      num_unresolved_answers: 2,
-      top_unresolved_answers: [
-        {
-          state: 'Introduction',
-          answer: '40',
-          frequency: 2
-        },
-        {
-          state: 'Introduction',
-          answer: '20',
-          frequency: 1
-        }
-      ]
+      num_total_threads: 0
     }],
     collections_list: [],
     dashboard_stats: {

--- a/core/templates/dev/head/pages/dashboard/Dashboard.js
+++ b/core/templates/dev/head/pages/dashboard/Dashboard.js
@@ -17,8 +17,7 @@
  */
 
 oppia.constant('EXPLORATION_DROPDOWN_STATS', {
-  OPEN_FEEDBACK: 'open_feedback',
-  TOP_UNRESOLVED_ANSWERS: 'top_unresolved_answers'
+  OPEN_FEEDBACK: 'open_feedback'
 });
 
 oppia.constant('EXPLORATIONS_SORT_BY_KEYS', {
@@ -26,7 +25,6 @@ oppia.constant('EXPLORATIONS_SORT_BY_KEYS', {
   RATING: 'ratings',
   NUM_VIEWS: 'num_views',
   OPEN_FEEDBACK: 'num_open_threads',
-  UNRESOLVED_ANSWERS: 'num_unresolved_answers',
   LAST_UPDATED: 'last_updated_msec'
 });
 
@@ -35,7 +33,6 @@ oppia.constant('HUMAN_READABLE_EXPLORATIONS_SORT_BY_KEYS', {
   RATING: 'I18N_DASHBOARD_EXPLORATIONS_SORT_BY_AVERAGE_RATING',
   NUM_VIEWS: 'I18N_DASHBOARD_EXPLORATIONS_SORT_BY_TOTAL_PLAYS',
   OPEN_FEEDBACK: 'I18N_DASHBOARD_EXPLORATIONS_SORT_BY_OPEN_FEEDBACK',
-  UNRESOLVED_ANSWERS: 'I18N_DASHBOARD_EXPLORATIONS_SORT_BY_UNRESOLVED_ANSWERS',
   LAST_UPDATED: 'I18N_DASHBOARD_EXPLORATIONS_SORT_BY_LAST_UPDATED'
 });
 
@@ -182,14 +179,6 @@ oppia.controller('Dashboard', [
         value = (averageRating || 0);
       }
       return value;
-    };
-
-    $scope.topUnresolvedAnswersCount = function(exploration) {
-      var topUnresolvedAnswersCount = 0;
-      exploration.top_unresolved_answers.forEach(function(answer) {
-        topUnresolvedAnswersCount += answer.frequency;
-      });
-      return topUnresolvedAnswersCount;
     };
 
     $rootScope.loadingMessage = 'Loading';

--- a/core/templates/dev/head/pages/dashboard/Dashboard.js
+++ b/core/templates/dev/head/pages/dashboard/Dashboard.js
@@ -86,9 +86,6 @@ oppia.controller('Dashboard', [
     $scope.emptyDashboardImgUrl = UrlInterpolationService.getStaticImageUrl(
       '/general/empty_dashboard.svg');
 
-    $scope.unresolvedAnswersIconUrl = UrlInterpolationService.getStaticImageUrl(
-      '/icons/unresolved_answers.svg');
-
     $scope.setActiveTab = function(newActiveTabName) {
       $scope.activeTab = newActiveTabName;
     };

--- a/core/templates/dev/head/pages/dashboard/dashboard.html
+++ b/core/templates/dev/head/pages/dashboard/dashboard.html
@@ -167,7 +167,6 @@
                 <p ng-if="key === 'NUM_VIEWS'" translate="I18N_DASHBOARD_TABLE_HEADING_PLAYS"></p>
                 <p ng-if="key === 'OPEN_FEEDBACK'" translate="I18N_DASHBOARD_TABLE_HEADING_OPEN_THREADS"></p>
                 <p ng-if="key === 'LAST_UPDATED'" translate="I18N_DASHBOARD_TABLE_HEADING_LAST_UPDATED"></p>
-                <p ng-if="key === 'UNRESOLVED_ANSWERS'" translate="I18N_DASHBOARD_TABLE_HEADING_UNRESOLVED_ANSWERS"></p>
                 <span class="fa"
                       ng-if="currentSortType === value"
                       ng-class="isCurrentSortDescending ? 'fa-caret-up': 'fa-caret-down'">

--- a/core/templates/dev/head/pages/dashboard/dashboard.html
+++ b/core/templates/dev/head/pages/dashboard/dashboard.html
@@ -208,11 +208,6 @@
                   <[exploration.num_open_threads]>
                 </a>
               </td>
-              <td ng-if="exploration.status !== 'private'">
-                <a ng-href="<[getExplorationUrl(exploration.id)]>" class="oppia-dashboard-list-summary">
-                  <[exploration.num_unresolved_answers]>
-                </a>
-              </td>
               <td>
                 <a ng-href="<[getExplorationUrl(exploration.id)]>" class="oppia-dashboard-list-summary">
                   <[getLocaleAbbreviatedDatetimeString(exploration.last_updated_msec)]>
@@ -286,13 +281,6 @@
                 </span>
                 <span class="oppia-dashboard-card-statistic-value">
                   <[exploration.num_views]>
-                </span>
-              </li>
-
-              <li flex="50" style="padding-left: 8px;">
-                <img ng-src="<[unresolvedAnswersIconUrl]>" style="width: 15px; padding-top: 1px;" tooltip="Unresolved Answers" tooltip-placement="top" class="oppia-dashboard-card-statistic-icon" alt="Unresolved Answers">
-                <span class="oppia-dashboard-card-statistic-value">
-                  <[exploration.num_unresolved_answers]>
                 </span>
               </li>
 


### PR DESCRIPTION
Remove unresolved answers from the creator dashboard since:

1. It's too expensive to retrieve a lot of top answers from a list of explorations (known issue with the new storage model)

2. Unresolved answers have a different meaning now, which means they can't be addressed (the unresolved answers section of the exploration editor has been completely removed). We need to enable the training interface before this can happen.