### PR TITLE
updated I18_PREFERENCES_EMAIL_EXPLAIN for clarity 

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -315,7 +315,7 @@
     "I18N_PREFERENCES_CANCEL_BUTTON": "Cancel",
     "I18N_PREFERENCES_CHANGE_PICTURE": "Change profile picture",
     "I18N_PREFERENCES_EMAIL": "Email",
-    "I18N_PREFERENCES_EMAIL_EXPLAIN": "Only moderators and site admins can see this.",
+    "I18N_PREFERENCES_EMAIL_EXPLAIN": "Only moderators and site admins can see your email.",
     "I18N_PREFERENCES_EMAIL_RECEIVE_EDIT_RIGHTS_NEWS": "Receive emails when someone gives you edit rights to an exploration",
     "I18N_PREFERENCES_EMAIL_RECEIVE_FEEDBACK_NEWS": "Receive emails when someone sends you feedback on an exploration",
     "I18N_PREFERENCES_EMAIL_RECEIVE_NEWS": "Receive news and updates about the site",

--- a/assets/i18n/hi.json
+++ b/assets/i18n/hi.json
@@ -315,7 +315,7 @@
 	"I18N_PREFERENCES_CANCEL_BUTTON": "रद्द करे",
 	"I18N_PREFERENCES_CHANGE_PICTURE": "प्रोफ़ाइल चित्र बदलें",
 	"I18N_PREFERENCES_EMAIL": "ईमेल",
-	"I18N_PREFERENCES_EMAIL_EXPLAIN": "केवल मध्यस्थों और साइट व्यवस्थापक यह देख सकते हैं ।",
+	"I18N_PREFERENCES_EMAIL_EXPLAIN": "केवल मध्यस्थों और साइट व्यवस्थापक आपका ईमेल देख सकते हैं ।",
 	"I18N_PREFERENCES_EMAIL_RECEIVE_EDIT_RIGHTS_NEWS": "यदि कोई आपको लिखने का अधिकार देता है, तो ईमेल द्वारा सूचना प्राप्त करें।",
 	"I18N_PREFERENCES_EMAIL_RECEIVE_FEEDBACK_NEWS": "यदि कोई व्यक्ति आपको अन्वेषण पर प्रतिक्रिया दे तब जानकारी प्राप्त करें।",
 	"I18N_PREFERENCES_EMAIL_RECEIVE_NEWS": "साइट के बारे में समाचार प्राप्त करे।",


### PR DESCRIPTION
Updated the I18_PREFERENCES_EMAIL_EXPLAIN from "Only moderators and site admins can see this."  to "Only moderators and site admins can see your email" for more clarity.