### PR TITLE
Fix #3427: social icons aligned flush left with row above.

### DIFF
--- a/core/templates/dev/head/components/share/sharing_links_directive.html
+++ b/core/templates/dev/head/components/share/sharing_links_directive.html
@@ -26,6 +26,13 @@
 </ul>
 
 <style>
+  .oppia-sharing-links {
+    margin-left: -webkit-calc(4%);
+    margin-left: -moz-calc(4%);
+    margin-left: -o-calc(4%);
+    margin-left: calc(4%);
+  }
+
   .oppia-sharing-links .embed-link {
     color: white;
     background: #009688;

--- a/core/templates/dev/head/components/share/sharing_links_directive.html
+++ b/core/templates/dev/head/components/share/sharing_links_directive.html
@@ -26,13 +26,6 @@
 </ul>
 
 <style>
-  .oppia-sharing-links {
-    margin-left: -webkit-calc(4%);
-    margin-left: -moz-calc(4%);
-    margin-left: -o-calc(4%);
-    margin-left: calc(4%);
-  }
-
   .oppia-sharing-links .embed-link {
     color: white;
     background: #009688;

--- a/core/templates/dev/head/pages/dashboard/dashboard.html
+++ b/core/templates/dev/head/pages/dashboard/dashboard.html
@@ -294,7 +294,7 @@
               </li>
               <sharing-links ng-if="exploration.status !== 'private'"
                              ng-click="$event.stopPropagation()"
-                             style="position: relative; right: 8px; bottom: 2px;"
+                             style="position: relative; right: 1px; bottom: 2px;"
                              flex="100"
                              class="dashboard-hide-mobile"
                              layout-type="row"


### PR DESCRIPTION
Fixed #3427 to allow social icons to align flush left with row above them. 
