### PR TITLE
Refactor validators (filters) into validator services

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/EditorServices.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorServices.js
@@ -1804,12 +1804,12 @@ oppia.constant('STATE_ERROR_MESSAGES', {
 
 // Service for the list of exploration warnings.
 oppia.factory('explorationWarningsService', [
-  '$filter', 'graphDataService', 'explorationStatesService',
+  '$injector', 'graphDataService', 'explorationStatesService',
   'expressionInterpolationService', 'explorationParamChangesService',
   'parameterMetadataService', 'INTERACTION_SPECS', 'WARNING_TYPES',
   'STATE_ERROR_MESSAGES', 'RULE_TYPE_CLASSIFIER',
   function(
-      $filter, graphDataService, explorationStatesService,
+      $injector, graphDataService, explorationStatesService,
       expressionInterpolationService, explorationParamChangesService,
       parameterMetadataService, INTERACTION_SPECS, WARNING_TYPES,
       STATE_ERROR_MESSAGES, RULE_TYPE_CLASSIFIER) {
@@ -1964,10 +1964,10 @@ oppia.factory('explorationWarningsService', [
       _states.getStateNames().forEach(function(stateName) {
         var interaction = _states.getState(stateName).interaction;
         if (interaction.id) {
-          var validatorName = (
-            'oppiaInteractive' + _states.getState(stateName).interaction.id +
-            'Validator');
-          var interactionWarnings = $filter(validatorName)(
+          var validatorServiceName =
+            _states.getState(stateName).interaction.id + 'ValidationService';
+          var validatorService = $injector.get(validatorServiceName);
+          var interactionWarnings = validatorService.getAllWarnings(
             stateName, interaction.customizationArgs,
             interaction.answerGroups, interaction.defaultOutcome);
 

--- a/extensions/interactions/CodeRepl/validator.js
+++ b/extensions/interactions/CodeRepl/validator.js
@@ -13,17 +13,17 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveCodeReplValidator', [
+oppia.factory('CodeReplValidationService', [
   'baseInteractionValidationService',
   function(baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(stateName, customizationArgs, answerGroups,
-                    defaultOutcome) {
-      return baseInteractionValidationService.getAllOutcomeWarnings(
-        answerGroups, defaultOutcome, stateName);
+    return {
+      getAllWarnings: function(stateName, customizationArgs, answerGroups,
+          defaultOutcome) {
+        return baseInteractionValidationService.getAllOutcomeWarnings(
+          answerGroups, defaultOutcome, stateName);
+      }
     };
   }]);

--- a/extensions/interactions/CodeRepl/validatorSpec.js
+++ b/extensions/interactions/CodeRepl/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveCodeReplValidator', function() {
-  var WARNING_TYPES, validator;
+describe('CodeReplValidationService', function() {
+  var WARNING_TYPES, validatorService;
   var currentState, goodAnswerGroups, goodDefaultOutcome;
 
   beforeEach(function() {
@@ -21,7 +21,7 @@ describe('oppiaInteractiveCodeReplValidator', function() {
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    validator = $injector.get('$filter')('oppiaInteractiveCodeReplValidator');
+    validatorService = $injector.get('CodeReplValidationService');
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
     currentState = 'First State';
@@ -37,7 +37,7 @@ describe('oppiaInteractiveCodeReplValidator', function() {
   }));
 
   it('should be able to perform basic validation', function() {
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, {}, goodAnswerGroups, goodDefaultOutcome);
     expect(warnings).toEqual([]);
   });

--- a/extensions/interactions/Continue/validator.js
+++ b/extensions/interactions/Continue/validator.js
@@ -13,46 +13,46 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveContinueValidator', [
+oppia.factory('ContinueValidationService', [
   '$filter', 'WARNING_TYPES', 'baseInteractionValidationService',
   function($filter, WARNING_TYPES, baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(
-      stateName, customizationArgs, answerGroups, defaultOutcome) {
-      var warningsList = [];
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        var warningsList = [];
 
-      baseInteractionValidationService.requireCustomizationArguments(
-        customizationArgs, ['buttonText']);
+        baseInteractionValidationService.requireCustomizationArguments(
+          customizationArgs, ['buttonText']);
 
-      if (customizationArgs.buttonText.value.length === 0) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: 'The button text should not be empty.'
-        });
+        if (customizationArgs.buttonText.value.length === 0) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: 'The button text should not be empty.'
+          });
+        }
+
+        if (answerGroups.length > 0) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: ('Only the default outcome is necessary for a continue' +
+              ' interaction.')
+          });
+        }
+
+        if (!defaultOutcome ||
+            $filter('isOutcomeConfusing')(defaultOutcome, stateName)) {
+          warningsList.push({
+            type: WARNING_TYPES.ERROR,
+            message: ('Please specify what Oppia should do after the button' +
+              ' is clicked.')
+          });
+        }
+
+        return warningsList;
       }
-
-      if (answerGroups.length > 0) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: (
-            'Only the default outcome is necessary for a continue interaction.')
-        });
-      }
-
-      if (!defaultOutcome ||
-          $filter('isOutcomeConfusing')(defaultOutcome, stateName)) {
-        warningsList.push({
-          type: WARNING_TYPES.ERROR,
-          message: (
-            'Please specify what Oppia should do after the button is clicked.')
-        });
-      }
-
-      return warningsList;
     };
   }
 ]);

--- a/extensions/interactions/Continue/validatorSpec.js
+++ b/extensions/interactions/Continue/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveContinueValidator', function() {
-  var validator, WARNING_TYPES;
+describe('ContinueValidationService', function() {
+  var validatorService, WARNING_TYPES;
 
   var currentState;
   var goodAnswerGroups, goodDefaultOutcome;
@@ -24,7 +24,7 @@ describe('oppiaInteractiveContinueValidator', function() {
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    validator = $injector.get('$filter')('oppiaInteractiveContinueValidator');
+    validatorService = $injector.get('ContinueValidationService');
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
     currentState = 'First State';
@@ -47,12 +47,12 @@ describe('oppiaInteractiveContinueValidator', function() {
 
   it('should expect a non-empty button text customization argument',
     function() {
-      var warnings = validator(
+      var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, [], goodDefaultOutcome);
       expect(warnings).toEqual([]);
 
       customizationArguments.buttonText.value = '';
-      warnings = validator(
+      warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, [], goodDefaultOutcome);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.CRITICAL,
@@ -60,13 +60,14 @@ describe('oppiaInteractiveContinueValidator', function() {
       }]);
 
       expect(function() {
-        validator(currentState, {}, [], goodDefaultOutcome);
+        validatorService.getAllWarnings(
+          currentState, {}, [], goodDefaultOutcome);
       }).toThrow(
         'Expected customization arguments to have property: buttonText');
     });
 
   it('should expect no answer groups', function() {
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, goodAnswerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([{
@@ -78,7 +79,8 @@ describe('oppiaInteractiveContinueValidator', function() {
 
   it('should expect a non-confusing and non-null default outcome',
     function() {
-      var warnings = validator(currentState, customizationArguments, [], null);
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArguments, [], null);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
         message: (

--- a/extensions/interactions/EndExploration/validator.js
+++ b/extensions/interactions/EndExploration/validator.js
@@ -13,37 +13,37 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveEndExplorationValidator', [
+oppia.factory('EndExplorationValidationService', [
   'WARNING_TYPES', 'baseInteractionValidationService',
   function(WARNING_TYPES, baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(
-      stateName, customizationArgs, answerGroups, defaultOutcome) {
-      var warningsList = [];
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        var warningsList = [];
 
-      baseInteractionValidationService.requireCustomizationArguments(
-        customizationArgs, ['recommendedExplorationIds']);
+        baseInteractionValidationService.requireCustomizationArguments(
+          customizationArgs, ['recommendedExplorationIds']);
 
-      if (answerGroups.length !== 0) {
-        warningsList.push({
-          type: WARNING_TYPES.ERROR,
-          message: 'Please make sure end exploration interactions do not ' +
-            'have any answer groups.'
-        });
+        if (answerGroups.length !== 0) {
+          warningsList.push({
+            type: WARNING_TYPES.ERROR,
+            message: 'Please make sure end exploration interactions do not ' +
+              'have any answer groups.'
+          });
+        }
+        if (defaultOutcome) {
+          warningsList.push({
+            type: WARNING_TYPES.ERROR,
+            message: 'Please make sure end exploration interactions do not ' +
+            'have a default outcome.'
+          });
+        }
+
+        return warningsList;
       }
-      if (defaultOutcome) {
-        warningsList.push({
-          type: WARNING_TYPES.ERROR,
-          message: 'Please make sure end exploration interactions do not ' +
-          'have a default outcome.'
-        });
-      }
-
-      return warningsList;
     };
   }
 ]);

--- a/extensions/interactions/EndExploration/validatorSpec.js
+++ b/extensions/interactions/EndExploration/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveEndExplorationValidator', function() {
-  var WARNING_TYPES;
+describe('EndExplorationValidationService', function() {
+  var WARNING_TYPES, validatorService;
 
   var currentState;
   var badOutcome, goodAnswerGroups;
@@ -24,8 +24,7 @@ describe('oppiaInteractiveEndExplorationValidator', function() {
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    var filter = $injector.get('$filter');
-    validator = filter('oppiaInteractiveEndExplorationValidator');
+    validatorService = $injector.get('EndExplorationValidationService');
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
     currentState = 'First State';
@@ -55,13 +54,14 @@ describe('oppiaInteractiveEndExplorationValidator', function() {
 
   it('should not have warnings for no answer groups or no default outcome',
     function() {
-      var warnings = validator(currentState, customizationArguments, [], null);
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArguments, [], null);
       expect(warnings).toEqual([]);
     });
 
   it('should have warnings for any answer groups or default outcome',
     function() {
-      var warnings = validator(
+      var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups, badOutcome);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
@@ -78,7 +78,7 @@ describe('oppiaInteractiveEndExplorationValidator', function() {
 
   it('should throw for missing recommendations argument', function() {
     expect(function() {
-      validator(currentState, {}, [], null);
+      validatorService.getAllWarnings(currentState, {}, [], null);
     }).toThrow(
       'Expected customization arguments to have property: ' +
       'recommendedExplorationIds');
@@ -86,14 +86,16 @@ describe('oppiaInteractiveEndExplorationValidator', function() {
 
   it('should not have warnings for 0 or 8 recommendations', function() {
     customizationArguments.recommendedExplorationIds.value = [];
-    var warnings = validator(currentState, customizationArguments, [], null);
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArguments, [], null);
     expect(warnings).toEqual([]);
 
     customizationArguments.recommendedExplorationIds.value = [
       'ExpID0', 'ExpID1', 'ExpID2', 'ExpID3',
       'ExpID4', 'ExpID5', 'ExpID6', 'ExpID7'
     ];
-    warnings = validator(currentState, customizationArguments, [], null);
+    warnings = validatorService.getAllWarnings(
+      currentState, customizationArguments, [], null);
     expect(warnings).toEqual([]);
   });
 });

--- a/extensions/interactions/GraphInput/validator.js
+++ b/extensions/interactions/GraphInput/validator.js
@@ -22,7 +22,6 @@ oppia.factory('GraphInputValidationService', [
     return {
       getAllWarnings: function(
           stateName, customizationArgs, answerGroups, defaultOutcome) {
-
         baseInteractionValidationService.requireCustomizationArguments(
           customizationArgs,
           ['graph', 'canEditEdgeWeight', 'canEditVertexLabel']);

--- a/extensions/interactions/GraphInput/validator.js
+++ b/extensions/interactions/GraphInput/validator.js
@@ -13,91 +13,93 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveGraphInputValidator', [
+oppia.factory('GraphInputValidationService', [
   'WARNING_TYPES', 'baseInteractionValidationService',
   function(WARNING_TYPES, baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(
-      stateName, customizationArgs, answerGroups, defaultOutcome) {
-      var VERTICES_LIMIT = 50;
-      var ISOMORPHISM_VERTICES_LIMIT = 10;
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
 
-      var warningsList = [];
+        baseInteractionValidationService.requireCustomizationArguments(
+          customizationArgs,
+          ['graph', 'canEditEdgeWeight', 'canEditVertexLabel']);
 
-      baseInteractionValidationService.requireCustomizationArguments(
-        customizationArgs,
-        ['graph', 'canEditEdgeWeight', 'canEditVertexLabel']);
+        var VERTICES_LIMIT = 50;
+        var ISOMORPHISM_VERTICES_LIMIT = 10;
 
-      if (customizationArgs.graph.value.vertices.length > VERTICES_LIMIT) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: (
-            'The graph used in customization exceeds supported ' +
-            'maximum number of vertices of ' + VERTICES_LIMIT + '.')
-        });
-      }
+        var warningsList = [];
+        if (customizationArgs.graph.value.vertices.length > VERTICES_LIMIT) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: (
+              'The graph used in customization exceeds supported ' +
+              'maximum number of vertices of ' + VERTICES_LIMIT + '.')
+          });
+        }
 
-      if (!customizationArgs.graph.value.isWeighted &&
-          customizationArgs.canEditEdgeWeight.value) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: (
-            'The learner cannot edit edge weights for an unweighted graph.')
-        });
-      }
+        if (!customizationArgs.graph.value.isWeighted &&
+            customizationArgs.canEditEdgeWeight.value) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: (
+              'The learner cannot edit edge weights for an unweighted graph.')
+          });
+        }
 
-      if (!customizationArgs.graph.value.isLabeled &&
-          customizationArgs.canEditVertexLabel.value) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: (
-            'The learner cannot edit vertex labels for an unlabeled graph.')
-        });
-      }
+        if (!customizationArgs.graph.value.isLabeled &&
+            customizationArgs.canEditVertexLabel.value) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: (
+              'The learner cannot edit vertex labels for an unlabeled graph.')
+          });
+        }
 
-      warningsList = warningsList.concat(
-        baseInteractionValidationService.getAllOutcomeWarnings(
-          answerGroups, defaultOutcome, stateName));
-      for (var i = 0; i < answerGroups.length; i++) {
-        var rules = answerGroups[i].rules;
-        for (var j = 0; j < rules.length; j++) {
-          var rule = rules[j];
-          try {
-            if (rule.type === 'HasGraphProperty') {
-              continue;
-            } else if (rule.type === 'IsIsomorphicTo' &&
-                rule.inputs.g.vertices.length > ISOMORPHISM_VERTICES_LIMIT) {
+        warningsList = warningsList.concat(
+          baseInteractionValidationService.getAllOutcomeWarnings(
+            answerGroups, defaultOutcome, stateName));
+
+        for (var i = 0; i < answerGroups.length; i++) {
+          var rules = answerGroups[i].rules;
+          for (var j = 0; j < rules.length; j++) {
+            var rule = rules[j];
+            try {
+              if (rule.type === 'HasGraphProperty') {
+                continue;
+              } else if (rule.type === 'IsIsomorphicTo' &&
+                  rule.inputs.g.vertices.length > ISOMORPHISM_VERTICES_LIMIT) {
+                warningsList.push({
+                  type: WARNING_TYPES.CRITICAL,
+                  message: (
+                    'The graph used in the rule ' + (j + 1) + ' in group ' +
+                    (i + 1) + ' exceeds supported maximum number of vertices ' +
+                    'of ' + ISOMORPHISM_VERTICES_LIMIT +
+                    ' for isomorphism check.')
+                });
+              } else if (rule.inputs.g.vertices.length > VERTICES_LIMIT) {
+                warningsList.push({
+                  type: WARNING_TYPES.CRITICAL,
+                  message: (
+                    'The graph used in the rule ' + (j + 1) + ' in group ' +
+                    (i + 1) + ' exceeds supported maximum number of vertices ' +
+                    'of ' + VERTICES_LIMIT + '.')
+                });
+              }
+            }
+            catch (e) {
               warningsList.push({
                 type: WARNING_TYPES.CRITICAL,
                 message: (
-                  'The graph used in the rule ' + (j + 1) + ' in group ' +
-                  (i + 1) + ' exceeds supported maximum number of vertices ' +
-                  'of ' + ISOMORPHISM_VERTICES_LIMIT +
-                  ' for isomorphism check.')
-              });
-            } else if (rule.inputs.g.vertices.length > VERTICES_LIMIT) {
-              warningsList.push({
-                type: WARNING_TYPES.CRITICAL,
-                message: (
-                  'The graph used in the rule ' + (j + 1) + ' in group ' +
-                  (i + 1) + ' exceeds supported maximum number of vertices ' +
-                  'of ' + VERTICES_LIMIT + '.')
+                  'The rule ' + (j + 1) + ' in group ' + (i + 1) +
+                  ' is invalid.')
               });
             }
           }
-          catch (e) {
-            warningsList.push({
-              type: WARNING_TYPES.CRITICAL,
-              message: (
-                'The rule ' + (j + 1) + ' in group ' + (i + 1) + ' is invalid.')
-            });
-          }
         }
+        return warningsList;
       }
-      return warningsList;
-    };
+    }
   }]);

--- a/extensions/interactions/GraphInput/validator.js
+++ b/extensions/interactions/GraphInput/validator.js
@@ -22,14 +22,15 @@ oppia.factory('GraphInputValidationService', [
     return {
       getAllWarnings: function(
           stateName, customizationArgs, answerGroups, defaultOutcome) {
-        baseInteractionValidationService.requireCustomizationArguments(
-          customizationArgs,
-          ['graph', 'canEditEdgeWeight', 'canEditVertexLabel']);
-
         var VERTICES_LIMIT = 50;
         var ISOMORPHISM_VERTICES_LIMIT = 10;
 
         var warningsList = [];
+
+        baseInteractionValidationService.requireCustomizationArguments(
+          customizationArgs,
+          ['graph', 'canEditEdgeWeight', 'canEditVertexLabel']);
+
         if (customizationArgs.graph.value.vertices.length > VERTICES_LIMIT) {
           warningsList.push({
             type: WARNING_TYPES.CRITICAL,

--- a/extensions/interactions/GraphInput/validatorSpec.js
+++ b/extensions/interactions/GraphInput/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveGraphInputValidator', function() {
-  var WARNING_TYPES, validator;
+describe('GraphInputValidationService', function() {
+  var WARNING_TYPES, validatorService;
   var currentState, customizationArguments, answerGroups, goodDefaultOutcome;
 
   beforeEach(function() {
@@ -22,7 +22,7 @@ describe('oppiaInteractiveGraphInputValidator', function() {
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
     WARNING_TYPES = $injector.get('WARNING_TYPES');
-    validator = $injector.get('$filter')('oppiaInteractiveGraphInputValidator');
+    validatorService = $injector.get('GraphInputValidationService');
 
     currentState = 'First State';
     goodDefaultOutcome = {
@@ -69,7 +69,7 @@ describe('oppiaInteractiveGraphInputValidator', function() {
   }));
 
   it('should be able to perform basic validation', function() {
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, answerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([]);
@@ -77,7 +77,8 @@ describe('oppiaInteractiveGraphInputValidator', function() {
 
   it('should expect graph and edit customization arguments', function() {
     expect(function() {
-      validator(currentState, {}, answerGroups, goodDefaultOutcome);
+      validatorService.getAllWarnings(
+        currentState, {}, answerGroups, goodDefaultOutcome);
     }).toThrow('Expected customization arguments to have properties: ' +
       'graph, canEditEdgeWeight, canEditVertexLabel');
   });
@@ -86,7 +87,7 @@ describe('oppiaInteractiveGraphInputValidator', function() {
     'vertices of 50.',
     function() {
       customizationArguments.graph.value.vertices = new Array(51);
-      var warnings = validator(
+      var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, answerGroups,
         goodDefaultOutcome);
       expect(warnings).toEqual([{
@@ -102,7 +103,7 @@ describe('oppiaInteractiveGraphInputValidator', function() {
       answerGroups[0].rules[0].inputs.g.vertices = new Array(11);
       answerGroups[0].rules[1].inputs.g.vertices = new Array(11);
       answerGroups[1].rules[0].inputs.g.vertices = new Array(11);
-      var warnings = validator(
+      var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, answerGroups,
         goodDefaultOutcome);
       expect(warnings).toEqual([{
@@ -123,7 +124,7 @@ describe('oppiaInteractiveGraphInputValidator', function() {
   it('should verify edge weight edit permissions make sense', function() {
     customizationArguments.graph.value.isWeighted = false;
     customizationArguments.canEditEdgeWeight.value = true;
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, answerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([{
@@ -136,7 +137,7 @@ describe('oppiaInteractiveGraphInputValidator', function() {
   it('should verify vertex label edit permissions make sense', function() {
     customizationArguments.graph.value.isLabeled = false;
     customizationArguments.canEditVertexLabel.value = true;
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, answerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([{

--- a/extensions/interactions/ImageClickInput/validator.js
+++ b/extensions/interactions/ImageClickInput/validator.js
@@ -13,106 +13,122 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveImageClickInputValidator', [
+oppia.factory('ImageClickInputValidationService', [
   '$filter', 'WARNING_TYPES', 'baseInteractionValidationService',
   function($filter, WARNING_TYPES, baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(
-      stateName, customizationArgs, answerGroups, defaultOutcome) {
-      var warningsList = [];
+    return {
+      getCustomizationArgsWarnings: function(customizationArgs) {
+        baseInteractionValidationService.requireCustomizationArguments(
+          customizationArgs, ['imageAndRegions']);
 
-      baseInteractionValidationService.requireCustomizationArguments(
-        customizationArgs, ['imageAndRegions']);
+        var warningsList = [];
 
-      if (!customizationArgs.imageAndRegions.value.imagePath) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: 'Please add an image for the learner to click on.'
-        });
-      }
-
-      var areAnyRegionStringsEmpty = false;
-      var areAnyRegionStringsDuplicated = false;
-      var seenRegionStrings = [];
-      if (customizationArgs.imageAndRegions.value.labeledRegions.length === 0) {
-        warningsList.push({
-          type: WARNING_TYPES.ERROR,
-          message: 'Please specify at least one image region to click on.'
-        });
-      }
-
-      for (var i = 0;
-           i < customizationArgs.imageAndRegions.value.labeledRegions.length;
-           i++) {
-        var regionLabel = (
-          customizationArgs.imageAndRegions.value.labeledRegions[i].label);
-
-        var ALPHANUMERIC_REGEX = /^[A-Za-z0-9]+$/;
-        if (regionLabel.trim().length === 0) {
-          areAnyRegionStringsEmpty = true;
-        } else if (!ALPHANUMERIC_REGEX.test(regionLabel)) {
+        var argsValue = customizationArgs.imageAndRegions.value;
+        if (!argsValue.imagePath) {
           warningsList.push({
             type: WARNING_TYPES.CRITICAL,
-            message: (
-              'The image region strings should consist of characters from ' +
-              '[A-Za-z0-9].')
+            message: 'Please add an image for the learner to click on.'
           });
-        } else if (seenRegionStrings.indexOf(regionLabel) !== -1) {
-          areAnyRegionStringsDuplicated = true;
-        } else {
-          seenRegionStrings.push(regionLabel);
         }
-      }
 
-      if (areAnyRegionStringsEmpty) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: 'Please ensure the image region strings are nonempty.'
+        var areAnyRegionStringsEmpty = false;
+        var areAnyRegionStringsDuplicated = false;
+        var seenRegionStrings = [];
+        if (argsValue.labeledRegions.length == 0) {
+          warningsList.push({
+            type: WARNING_TYPES.ERROR,
+            message: 'Please specify at least one image region to click on.'
+          });
+        }
+
+        for (var i = 0; i < argsValue.labeledRegions.length; i++) {
+          var regionLabel = (
+            argsValue.labeledRegions[i].label);
+
+          var ALPHANUMERIC_REGEX = /^[A-Za-z0-9]+$/;
+          if (regionLabel.trim().length === 0) {
+            areAnyRegionStringsEmpty = true;
+          } else if (!ALPHANUMERIC_REGEX.test(regionLabel)) {
+            warningsList.push({
+              type: WARNING_TYPES.CRITICAL,
+              message: (
+                'The image region strings should consist of characters from ' +
+                '[A-Za-z0-9].')
+            });
+          } else if (seenRegionStrings.indexOf(regionLabel) !== -1) {
+            areAnyRegionStringsDuplicated = true;
+          } else {
+            seenRegionStrings.push(regionLabel);
+          }
+        }
+
+        if (areAnyRegionStringsEmpty) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: 'Please ensure the image region strings are nonempty.'
+          });
+        }
+        if (areAnyRegionStringsDuplicated) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: 'Please ensure the image region strings are unique.'
+          });
+        }
+        return warningsList;
+      },
+      getAnswerGroupWarnings: function(
+          customizationArgs, answerGroups, stateName) {
+        var warningsList =
+          baseInteractionValidationService.getAnswerGroupWarnings(
+            answerGroups, stateName);
+
+        var argsValue = customizationArgs.imageAndRegions.value;
+        var seenRegionStrings = argsValue.labeledRegions.map(function(region) {
+          return region.label;
         });
-      }
-      if (areAnyRegionStringsDuplicated) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: 'Please ensure the image region strings are unique.'
-        });
-      }
 
-      warningsList = warningsList.concat(
-        baseInteractionValidationService.getAnswerGroupWarnings(
-          answerGroups, stateName));
-
-      // Check that each rule refers to a valid region string.
-      for (var i = 0; i < answerGroups.length; i++) {
-        var rules = answerGroups[i].rules;
-        for (var j = 0; j < rules.length; j++) {
-          if (rules[j].type === 'IsInRegion') {
-            var label = rules[j].inputs.x;
-            if (seenRegionStrings.indexOf(label) === -1) {
-              warningsList.push({
-                type: WARNING_TYPES.CRITICAL,
-                message: (
-                  'The region label \'' + label + '\' in rule ' +
-                  String(j + 1) + ' in group ' + String(i + 1) + ' is invalid.')
-              });
+        // Check that each rule refers to a valid region string.
+        for (var i = 0; i < answerGroups.length; i++) {
+          var rules = answerGroups[i].rules;
+          for (var j = 0; j < rules.length; j++) {
+            if (rules[j].type === 'IsInRegion') {
+              var label = rules[j].inputs.x;
+              if (seenRegionStrings.indexOf(label) === -1) {
+                warningsList.push({
+                  type: WARNING_TYPES.CRITICAL,
+                  message: (
+                    'The region label \'' + label + '\' in rule ' +
+                    String(j + 1) + ' in group ' + String(i + 1) +
+                    ' is invalid.')
+                });
+              }
             }
           }
         }
+        return warningsList;
+      },
+      getDefaultOutcomeWarnings: function(defaultOutcome, stateName) {
+        var warningsList = [];
+        if (!defaultOutcome ||
+            $filter('isOutcomeConfusing')(defaultOutcome, stateName)) {
+          warningsList.push({
+            type: WARNING_TYPES.ERROR,
+            message: (
+              'Please add a rule to cover what should happen if none of the ' +
+              'given regions are clicked.')
+          });
+        }
+        return warningsList;
+      },
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        return this.getCustomizationArgsWarnings(customizationArgs).concat(
+          this.getAnswerGroupWarnings(
+            customizationArgs, answerGroups, stateName)).concat(
+              this.getDefaultOutcomeWarnings(defaultOutcome, stateName));
       }
-
-      if (!defaultOutcome ||
-          $filter('isOutcomeConfusing')(defaultOutcome, stateName)) {
-        warningsList.push({
-          type: WARNING_TYPES.ERROR,
-          message: (
-            'Please add a rule to cover what should happen if none of the ' +
-            'given regions are clicked.')
-        });
-      }
-
-      return warningsList;
     };
   }]);

--- a/extensions/interactions/ImageClickInput/validator.js
+++ b/extensions/interactions/ImageClickInput/validator.js
@@ -26,8 +26,8 @@ oppia.factory('ImageClickInputValidationService', [
 
         var warningsList = [];
 
-        var argsValue = customizationArgs.imageAndRegions.value;
-        if (!argsValue.imagePath) {
+        var imgAndRegionArgValue = customizationArgs.imageAndRegions.value;
+        if (!imgAndRegionArgValue.imagePath) {
           warningsList.push({
             type: WARNING_TYPES.CRITICAL,
             message: 'Please add an image for the learner to click on.'
@@ -37,16 +37,16 @@ oppia.factory('ImageClickInputValidationService', [
         var areAnyRegionStringsEmpty = false;
         var areAnyRegionStringsDuplicated = false;
         var seenRegionStrings = [];
-        if (argsValue.labeledRegions.length == 0) {
+        if (imgAndRegionArgValue.labeledRegions.length == 0) {
           warningsList.push({
             type: WARNING_TYPES.ERROR,
             message: 'Please specify at least one image region to click on.'
           });
         }
 
-        for (var i = 0; i < argsValue.labeledRegions.length; i++) {
+        for (var i = 0; i < imgAndRegionArgValue.labeledRegions.length; i++) {
           var regionLabel = (
-            argsValue.labeledRegions[i].label);
+            imgAndRegionArgValue.labeledRegions[i].label);
 
           var ALPHANUMERIC_REGEX = /^[A-Za-z0-9]+$/;
           if (regionLabel.trim().length === 0) {
@@ -85,10 +85,11 @@ oppia.factory('ImageClickInputValidationService', [
           baseInteractionValidationService.getAnswerGroupWarnings(
             answerGroups, stateName);
 
-        var argsValue = customizationArgs.imageAndRegions.value;
-        var seenRegionStrings = argsValue.labeledRegions.map(function(region) {
-          return region.label;
-        });
+        var imgAndRegionArgValue = customizationArgs.imageAndRegions.value;
+        var seenRegionStrings = imgAndRegionArgValue.labeledRegions.map(
+          function(region) {
+            return region.label;
+          });
 
         // Check that each rule refers to a valid region string.
         for (var i = 0; i < answerGroups.length; i++) {

--- a/extensions/interactions/ImageClickInput/validatorSpec.js
+++ b/extensions/interactions/ImageClickInput/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveImageClickInputValidator', function() {
-  var WARNING_TYPES, validator;
+describe('ImageClickInputValidationService', function() {
+  var WARNING_TYPES, validatorService;
 
   var currentState;
   var badOutcome, goodAnswerGroups, goodDefaultOutcome;
@@ -25,8 +25,7 @@ describe('oppiaInteractiveImageClickInputValidator', function() {
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
     var filter = $injector.get('$filter');
-    validator = filter('oppiaInteractiveImageClickInputValidator');
-
+    validatorService = $injector.get('ImageClickInputValidationService');
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
     currentState = 'First State';
@@ -68,21 +67,19 @@ describe('oppiaInteractiveImageClickInputValidator', function() {
     function() {
       goodAnswerGroups[0].rules = [];
       expect(function() {
-        validator(currentState, {}, goodAnswerGroups, goodDefaultOutcome);
+        validatorService.getCustomizationArgsWarnings({});
       }).toThrow(
         'Expected customization arguments to have property: imageAndRegions');
     });
 
   it('should expect an image path customization argument', function() {
-    var warnings = validator(
-      currentState, customizationArguments, goodAnswerGroups,
-      goodDefaultOutcome);
+    var warnings = validatorService.getCustomizationArgsWarnings(
+      customizationArguments);
     expect(warnings).toEqual([]);
 
     customizationArguments.imageAndRegions.value.imagePath = '';
-    warnings = validator(
-      currentState, customizationArguments, goodAnswerGroups,
-      goodDefaultOutcome);
+    warnings = validatorService.getCustomizationArgsWarnings(
+      customizationArguments);
     expect(warnings).toEqual([{
       type: WARNING_TYPES.CRITICAL,
       message: 'Please add an image for the learner to click on.'
@@ -94,27 +91,24 @@ describe('oppiaInteractiveImageClickInputValidator', function() {
     function() {
       var regions = customizationArguments.imageAndRegions.value.labeledRegions;
       regions[0].label = '';
-      var warnings = validator(
-        currentState, customizationArguments, goodAnswerGroups,
-        goodDefaultOutcome);
+      var warnings = validatorService.getCustomizationArgsWarnings(
+        customizationArguments);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.CRITICAL,
         message: 'Please ensure the image region strings are nonempty.'
       }]);
 
       regions[0].label = 'SecondLabel';
-      warnings = validator(
-        currentState, customizationArguments, goodAnswerGroups,
-        goodDefaultOutcome);
+      warnings = validatorService.getCustomizationArgsWarnings(
+        customizationArguments);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.CRITICAL,
         message: 'Please ensure the image region strings are unique.'
       }]);
 
       regions[0].label = '@';
-      warnings = validator(
-        currentState, customizationArguments, goodAnswerGroups,
-        goodDefaultOutcome);
+      warnings = validatorService.getCustomizationArgsWarnings(
+        customizationArguments);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.CRITICAL,
         message: 'The image region strings should consist of characters ' +
@@ -123,9 +117,8 @@ describe('oppiaInteractiveImageClickInputValidator', function() {
 
       customizationArguments.imageAndRegions.value.labeledRegions = [];
       goodAnswerGroups[0].rules = [];
-      warnings = validator(
-        currentState, customizationArguments, goodAnswerGroups,
-        goodDefaultOutcome);
+      warnings = validatorService.getCustomizationArgsWarnings(
+        customizationArguments);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
         message: 'Please specify at least one image region to click on.'
@@ -134,9 +127,8 @@ describe('oppiaInteractiveImageClickInputValidator', function() {
 
   it('should expect rule types to reference valid region labels', function() {
     goodAnswerGroups[0].rules[0].inputs.x = 'FakeLabel';
-    var warnings = validator(
-      currentState, customizationArguments, goodAnswerGroups,
-      goodDefaultOutcome);
+    var warnings = validatorService.getAnswerGroupWarnings(
+      customizationArguments, goodAnswerGroups, currentState);
     expect(warnings).toEqual([{
       type: WARNING_TYPES.CRITICAL,
       message: 'The region label \'FakeLabel\' in rule 1 in group 1 is ' +
@@ -146,14 +138,15 @@ describe('oppiaInteractiveImageClickInputValidator', function() {
 
   it('should expect a non-confusing and non-null default outcome',
     function() {
-      var warnings = validator(currentState, customizationArguments, [], null);
+      var warnings = validatorService.getDefaultOutcomeWarnings(
+        null, currentState);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
         message: 'Please add a rule to cover what should happen if none of ' +
           'the given regions are clicked.'
       }]);
-      warnings = validator(
-        currentState, customizationArguments, [], badOutcome);
+      warnings = validatorService.getDefaultOutcomeWarnings(
+        badOutcome, currentState);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
         message: 'Please add a rule to cover what should happen if none of ' +

--- a/extensions/interactions/InteractiveMap/validator.js
+++ b/extensions/interactions/InteractiveMap/validator.js
@@ -13,57 +13,58 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validation service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveInteractiveMapValidator', [
+oppia.factory('InteractiveMapValidationService', [
   'WARNING_TYPES', 'baseInteractionValidationService',
   function(WARNING_TYPES, baseInteractionValidationService) {
-  // Returns a list of warnings.
-    return function(
-      stateName, customizationArgs, answerGroups, defaultOutcome) {
-      var warningsList = [];
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        var warningsList = [];
 
-      baseInteractionValidationService.requireCustomizationArguments(
-        customizationArgs, ['latitude', 'longitude']);
+        baseInteractionValidationService.requireCustomizationArguments(
+          customizationArgs, ['latitude', 'longitude']);
 
-      if (customizationArgs.latitude.value < -90 ||
-          customizationArgs.latitude.value > 90) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: 'Please pick a starting latitude between -90 and 90.'
-        });
-      }
+        if (customizationArgs.latitude.value < -90 ||
+            customizationArgs.latitude.value > 90) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: 'Please pick a starting latitude between -90 and 90.'
+          });
+        }
 
-      if (customizationArgs.longitude.value < -180 ||
-          customizationArgs.longitude.value > 180) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: 'Please pick a starting longitude between -180 and 180.'
-        });
-      }
+        if (customizationArgs.longitude.value < -180 ||
+            customizationArgs.longitude.value > 180) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: 'Please pick a starting longitude between -180 and 180.'
+          });
+        }
 
-      for (var i = 0; i < answerGroups.length; i++) {
-        var rules = answerGroups[i].rules;
-        for (var j = 0; j < rules.length; j++) {
-          if (rules[j].type === 'Within' ||
-              rules[j].type === 'NotWithin') {
-            if (rules[j].inputs.d < 0) {
-              warningsList.push({
-                type: WARNING_TYPES.CRITICAL,
-                message: 'Please ensure that rule ' + String(j + 1) +
-                  ' in group ' + String(i + 1) + ' refers to a valid distance.'
-              });
+        for (var i = 0; i < answerGroups.length; i++) {
+          var rules = answerGroups[i].rules;
+          for (var j = 0; j < rules.length; j++) {
+            if (rules[j].type === 'Within' ||
+                rules[j].type === 'NotWithin') {
+              if (rules[j].inputs.d < 0) {
+                warningsList.push({
+                  type: WARNING_TYPES.CRITICAL,
+                  message: 'Please ensure that rule ' + String(j + 1) +
+                    ' in group ' + String(i + 1) +
+                    ' refers to a valid distance.'
+                });
+              }
             }
           }
         }
+
+        warningsList = warningsList.concat(
+          baseInteractionValidationService.getAllOutcomeWarnings(
+            answerGroups, defaultOutcome, stateName));
+
+        return warningsList;
       }
-
-      warningsList = warningsList.concat(
-        baseInteractionValidationService.getAllOutcomeWarnings(
-          answerGroups, defaultOutcome, stateName));
-
-      return warningsList;
     };
   }]);

--- a/extensions/interactions/InteractiveMap/validatorSpec.js
+++ b/extensions/interactions/InteractiveMap/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveInteractiveMapValidator', function() {
-  var validator, WARNING_TYPES;
+describe('InteractiveMapValidationService', function() {
+  var validatorService, WARNING_TYPES;
 
   var currentState;
   var goodAnswerGroups, goodDefaultOutcome;
@@ -24,8 +24,7 @@ describe('oppiaInteractiveInteractiveMapValidator', function() {
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    var filter = $injector.get('$filter');
-    validator = filter('oppiaInteractiveInteractiveMapValidator');
+    validatorService = $injector.get('InteractiveMapValidationService');
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
     currentState = 'First State';
@@ -60,7 +59,7 @@ describe('oppiaInteractiveInteractiveMapValidator', function() {
   }));
 
   it('should be able to perform basic validation', function() {
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, goodAnswerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([]);
@@ -69,7 +68,8 @@ describe('oppiaInteractiveInteractiveMapValidator', function() {
   it('should expect latitude and longitude customization arguments',
     function() {
       expect(function() {
-        validator(currentState, {}, goodAnswerGroups, goodDefaultOutcome);
+        validatorService.getAllWarnings(
+          currentState, {}, goodAnswerGroups, goodDefaultOutcome);
       }).toThrow('Expected customization arguments to have properties: ' +
         'latitude, longitude');
     }
@@ -80,7 +80,7 @@ describe('oppiaInteractiveInteractiveMapValidator', function() {
     function() {
       customizationArguments.latitude.value = -120;
       customizationArguments.longitude.value = 200;
-      var warnings = validator(
+      var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups,
         goodDefaultOutcome);
       expect(warnings).toEqual([{
@@ -93,7 +93,7 @@ describe('oppiaInteractiveInteractiveMapValidator', function() {
 
       customizationArguments.latitude.value = 120;
       customizationArguments.longitude.value = -200;
-      warnings = validator(
+      warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups,
         goodDefaultOutcome);
       expect(warnings).toEqual([{
@@ -110,7 +110,7 @@ describe('oppiaInteractiveInteractiveMapValidator', function() {
     function() {
       goodAnswerGroups[0].rules[0].inputs.d = -90;
       goodAnswerGroups[0].rules[1].inputs.d = -180;
-      var warnings = validator(
+      var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups,
         goodDefaultOutcome);
       expect(warnings).toEqual([{

--- a/extensions/interactions/ItemSelectionInput/validator.js
+++ b/extensions/interactions/ItemSelectionInput/validator.js
@@ -13,141 +13,143 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveItemSelectionInputValidator', [
+oppia.factory('ItemSelectionInputValidationService', [
   '$filter', 'WARNING_TYPES', 'baseInteractionValidationService',
   function($filter, WARNING_TYPES, baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(
-        stateName, customizationArgs, answerGroups, defaultOutcome) {
-      var warningsList = [];
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        var warningsList = [];
 
-      baseInteractionValidationService.requireCustomizationArguments(
-        customizationArgs, ['choices']);
+        baseInteractionValidationService.requireCustomizationArguments(
+          customizationArgs, ['choices']);
 
-      var areAnyChoicesEmpty = false;
-      var areAnyChoicesDuplicated = false;
-      var seenChoices = [];
-      var handledAnswers = [];
-      var numChoices = customizationArgs.choices.value.length;
-      var areAllChoicesCovered = false;
+        var areAnyChoicesEmpty = false;
+        var areAnyChoicesDuplicated = false;
+        var seenChoices = [];
+        var handledAnswers = [];
+        var numChoices = customizationArgs.choices.value.length;
+        var areAllChoicesCovered = false;
 
-      for (var i = 0; i < numChoices; i++) {
-        var choice = customizationArgs.choices.value[i];
-        if (choice.trim().length === 0) {
-          areAnyChoicesEmpty = true;
+        for (var i = 0; i < numChoices; i++) {
+          var choice = customizationArgs.choices.value[i];
+          if (choice.trim().length === 0) {
+            areAnyChoicesEmpty = true;
+          }
+          if (seenChoices.indexOf(choice) !== -1) {
+            areAnyChoicesDuplicated = true;
+          }
+          seenChoices.push(choice);
+          handledAnswers.push(false);
         }
-        if (seenChoices.indexOf(choice) !== -1) {
-          areAnyChoicesDuplicated = true;
+
+        if (areAnyChoicesEmpty) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: 'Please ensure the choices are nonempty.'
+          });
         }
-        seenChoices.push(choice);
-        handledAnswers.push(false);
-      }
 
-      if (areAnyChoicesEmpty) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: 'Please ensure the choices are nonempty.'
-        });
-      }
+        if (areAnyChoicesDuplicated) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: 'Please ensure the choices are unique.'
+          });
+        }
 
-      if (areAnyChoicesDuplicated) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: 'Please ensure the choices are unique.'
-        });
-      }
+        var minAllowedCount =
+          customizationArgs.minAllowableSelectionCount.value;
+        var maxAllowedCount =
+          customizationArgs.maxAllowableSelectionCount.value;
 
-      var minAllowedCount = customizationArgs.minAllowableSelectionCount.value;
-      var maxAllowedCount = customizationArgs.maxAllowableSelectionCount.value;
+        if (minAllowedCount > maxAllowedCount) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: (
+              'Please ensure that the max allowed count is not less than the ' +
+              'min count.')
+          });
+        }
 
-      if (minAllowedCount > maxAllowedCount) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: (
-            'Please ensure that the max allowed count is not less than the ' +
-            'min count.')
-        });
-      }
+        if (numChoices < minAllowedCount) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: (
+              'Please ensure that you have enough choices to reach the min ' +
+              'count.')
+          });
+        } else if (numChoices < maxAllowedCount) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: (
+              'Please ensure that you have enough choices to reach the max ' +
+              'count.')
+          });
+        }
 
-      if (numChoices < minAllowedCount) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: (
-            'Please ensure that you have enough choices to reach the min ' +
-            'count.')
-        });
-      } else if (numChoices < maxAllowedCount) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: (
-            'Please ensure that you have enough choices to reach the max ' +
-            'count.')
-        });
-      }
+        warningsList = warningsList.concat(
+          baseInteractionValidationService.getAnswerGroupWarnings(
+            answerGroups, stateName));
 
-      warningsList = warningsList.concat(
-        baseInteractionValidationService.getAnswerGroupWarnings(
-          answerGroups, stateName));
+        var selectedChoices = [];
+        if (maxAllowedCount === 1) {
+          var answerChoiceToIndex = {};
+          seenChoices.forEach(function(seenChoice, choiceIndex) {
+            answerChoiceToIndex[seenChoice] = choiceIndex;
+          });
 
-      var selectedChoices = [];
-      if (maxAllowedCount === 1) {
-        var answerChoiceToIndex = {};
-        seenChoices.forEach(function(seenChoice, choiceIndex) {
-          answerChoiceToIndex[seenChoice] = choiceIndex;
-        });
-
-        answerGroups.forEach(function(answerGroup, answerIndex) {
-          var rules = answerGroup.rules;
-          rules.forEach(function(rule, ruleIndex) {
-            var ruleInputs = rule.inputs.x;
-            ruleInputs.forEach(function(ruleInput) {
-              var choiceIndex = answerChoiceToIndex[ruleInput];
-              if (rule.type === 'Equals') {
-                handledAnswers[choiceIndex] = true;
-                if (ruleInputs.length > 1) {
-                  warningsList.push({
-                    type: WARNING_TYPES.ERROR,
-                    message: (
-                      'In answer group ' + (answerIndex + 1) + ', ' +
-                      'rule ' + (ruleIndex + 1) + ', ' +
-                      'please select only one answer choice.')
-                  });
-                }
-              } else if (rule.type === 'ContainsAtLeastOneOf') {
-                handledAnswers[choiceIndex] = true;
-              } else if (rule.type ===
-                'DoesNotContainAtLeastOneOf') {
-                for (var i = 0; i < handledAnswers.length; i++) {
-                  if (i !== choiceIndex) {
-                    handledAnswers[i] = true;
+          answerGroups.forEach(function(answerGroup, answerIndex) {
+            var rules = answerGroup.rules;
+            rules.forEach(function(rule, ruleIndex) {
+              var ruleInputs = rule.inputs.x;
+              ruleInputs.forEach(function(ruleInput) {
+                var choiceIndex = answerChoiceToIndex[ruleInput];
+                if (rule.type === 'Equals') {
+                  handledAnswers[choiceIndex] = true;
+                  if (ruleInputs.length > 1) {
+                    warningsList.push({
+                      type: WARNING_TYPES.ERROR,
+                      message: (
+                        'In answer group ' + (answerIndex + 1) + ', ' +
+                        'rule ' + (ruleIndex + 1) + ', ' +
+                        'please select only one answer choice.')
+                    });
+                  }
+                } else if (rule.type === 'ContainsAtLeastOneOf') {
+                  handledAnswers[choiceIndex] = true;
+                } else if (rule.type ===
+                  'DoesNotContainAtLeastOneOf') {
+                  for (var i = 0; i < handledAnswers.length; i++) {
+                    if (i !== choiceIndex) {
+                      handledAnswers[i] = true;
+                    }
                   }
                 }
-              }
+              });
             });
           });
-        });
-        areAllChoicesCovered = handledAnswers.every(function(handledAnswer) {
-          return handledAnswer;
-        });
-      }
-
-      if (!areAllChoicesCovered) {
-        if (!defaultOutcome ||
-            $filter('isOutcomeConfusing')(defaultOutcome, stateName)) {
-          warningsList.push({
-            type: WARNING_TYPES.ERROR,
-            message: (
-              'Please add something for Oppia to say in the ' +
-              '\"All other answers\" response.')
+          areAllChoicesCovered = handledAnswers.every(function(handledAnswer) {
+            return handledAnswer;
           });
         }
-      }
 
-      return warningsList;
+        if (!areAllChoicesCovered) {
+          if (!defaultOutcome ||
+              $filter('isOutcomeConfusing')(defaultOutcome, stateName)) {
+            warningsList.push({
+              type: WARNING_TYPES.ERROR,
+              message: (
+                'Please add something for Oppia to say in the ' +
+                '\"All other answers\" response.')
+            });
+          }
+        }
+
+        return warningsList;
+      }
     };
   }
 ]);

--- a/extensions/interactions/ItemSelectionInput/validatorSpec.js
+++ b/extensions/interactions/ItemSelectionInput/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveItemSelectionInputValidator', function() {
-  var WARNING_TYPES, validator;
+describe('ItemSelectionInputValidationService', function() {
+  var WARNING_TYPES, validatorService;
 
   var currentState;
   var goodAnswerGroups, goodDefaultOutcome;
@@ -24,8 +24,7 @@ describe('oppiaInteractiveItemSelectionInputValidator', function() {
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    var filter = $injector.get('$filter');
-    validator = filter('oppiaInteractiveItemSelectionInputValidator');
+    validatorService = $injector.get('ItemSelectionInputValidationService');
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
     currentState = 'First State';
@@ -59,7 +58,7 @@ describe('oppiaInteractiveItemSelectionInputValidator', function() {
   }));
 
   it('should be able to perform basic validation', function() {
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, goodAnswerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([]);
@@ -67,7 +66,8 @@ describe('oppiaInteractiveItemSelectionInputValidator', function() {
 
   it('should expect a choices customization argument', function() {
     expect(function() {
-      validator(currentState, {}, goodAnswerGroups, goodDefaultOutcome);
+      validatorService.getAllWarnings(
+        currentState, {}, goodAnswerGroups, goodDefaultOutcome);
     }).toThrow('Expected customization arguments to have property: choices');
   });
 
@@ -76,7 +76,7 @@ describe('oppiaInteractiveItemSelectionInputValidator', function() {
     function() {
       customizationArguments.minAllowableSelectionCount.value = 3;
 
-      var warnings = validator(
+      var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups,
         goodDefaultOutcome);
       expect(warnings).toEqual([{
@@ -95,7 +95,7 @@ describe('oppiaInteractiveItemSelectionInputValidator', function() {
       // Remove the last choice.
       customizationArguments.choices.value.splice(2, 1);
 
-      var warnings = validator(
+      var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups,
         goodDefaultOutcome);
       expect(warnings).toEqual([{
@@ -114,7 +114,7 @@ describe('oppiaInteractiveItemSelectionInputValidator', function() {
       customizationArguments.minAllowableSelectionCount.value = 3;
       customizationArguments.maxAllowableSelectionCount.value = 3;
 
-      var warnings = validator(
+      var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups,
         goodDefaultOutcome);
       expect(warnings).toEqual([{
@@ -128,7 +128,7 @@ describe('oppiaInteractiveItemSelectionInputValidator', function() {
     // Set the first choice to empty.
     customizationArguments.choices.value[0] = '';
 
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, goodAnswerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([{
@@ -141,7 +141,7 @@ describe('oppiaInteractiveItemSelectionInputValidator', function() {
     // Repeat the last choice.
     customizationArguments.choices.value.push('Selection 3');
 
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, goodAnswerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([{

--- a/extensions/interactions/LogicProof/validator.js
+++ b/extensions/interactions/LogicProof/validator.js
@@ -13,25 +13,26 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveLogicProofValidator', [
+oppia.factory('LogicProofValidationService', [
   'baseInteractionValidationService',
   function(baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(stateName, customizationArgs, answerGroups) {
-      var warningsList = [];
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        var warningsList = [];
 
-      warningsList = warningsList.concat(
-        baseInteractionValidationService.getAnswerGroupWarnings(
-          answerGroups, stateName));
+        warningsList = warningsList.concat(
+          baseInteractionValidationService.getAnswerGroupWarnings(
+            answerGroups, stateName));
 
-      // We do not require a default rule for this interaction, since the
-      // feedback is mostly provided from within the interaction itself.
+        // We do not require a default rule for this interaction, since the
+        // feedback is mostly provided from within the interaction itself.
 
-      return warningsList;
+        return warningsList;
+      }
     };
   }
 ]);

--- a/extensions/interactions/LogicProof/validatorSpec.js
+++ b/extensions/interactions/LogicProof/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveLogicProofValidator', function() {
-  var validator, WARNING_TYPES;
+describe('LogicProofValidationService', function() {
+  var validatorService, WARNING_TYPES;
 
   var currentState;
   var badOutcome, goodAnswerGroups, goodDefaultOutcome;
@@ -23,8 +23,7 @@ describe('oppiaInteractiveLogicProofValidator', function() {
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    var filter = $injector.get('$filter');
-    validator = filter('oppiaInteractiveLogicProofValidator');
+    validatorService = $injector.get('LogicProofValidationService');
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
     currentState = 'First State';
@@ -47,13 +46,14 @@ describe('oppiaInteractiveLogicProofValidator', function() {
   }));
 
   it('should be able to perform basic validation', function() {
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, {}, goodAnswerGroups, goodDefaultOutcome);
     expect(warnings).toEqual([]);
   });
 
   it('should not have warnings for a confusing default outcome', function() {
-    var warnings = validator(currentState, {}, [], badOutcome);
+    var warnings = validatorService.getAllWarnings(
+      currentState, {}, [], badOutcome);
     expect(warnings).toEqual([]);
   });
 });

--- a/extensions/interactions/MathExpressionInput/validator.js
+++ b/extensions/interactions/MathExpressionInput/validator.js
@@ -13,35 +13,36 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveMathExpressionInputValidator', [
+oppia.factory('MathExpressionInputValidationService', [
   'baseInteractionValidationService', 'WARNING_TYPES',
   function(baseInteractionValidationService, WARNING_TYPES) {
-    // Returns a list of warnings.
-    return function(
-      stateName, customizationArgs, answerGroups, defaultOutcome) {
-      var warningsList = baseInteractionValidationService.getAllOutcomeWarnings(
-        answerGroups, defaultOutcome, stateName);
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        var warningsList =
+          baseInteractionValidationService.getAllOutcomeWarnings(
+            answerGroups, defaultOutcome, stateName);
 
-      // Check that each rule has a valid math expression.
-      for (var i = 0; i < answerGroups.length; i++) {
-        var rules = answerGroups[i].rules;
-        for (var j = 0; j < rules.length; j++) {
-          try {
-            MathExpression.fromLatex(rules[j].inputs.x);
-          } catch (e) {
-            warningsList.push({
-              type: WARNING_TYPES.CRITICAL,
-              message: (
-                'The math expression used in rule ' + String(j + 1) +
-                ' in group ' + String(i + 1) + ' is invalid.')
-            });
+        // Check that each rule has a valid math expression.
+        for (var i = 0; i < answerGroups.length; i++) {
+          var rules = answerGroups[i].rules;
+          for (var j = 0; j < rules.length; j++) {
+            try {
+              MathExpression.fromLatex(rules[j].inputs.x);
+            } catch (e) {
+              warningsList.push({
+                type: WARNING_TYPES.CRITICAL,
+                message: (
+                  'The math expression used in rule ' + String(j + 1) +
+                  ' in group ' + String(i + 1) + ' is invalid.')
+              });
+            }
           }
         }
+        return warningsList;
       }
-      return warningsList;
     };
   }]);

--- a/extensions/interactions/MultipleChoiceInput/validator.js
+++ b/extensions/interactions/MultipleChoiceInput/validator.js
@@ -13,96 +13,95 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveMultipleChoiceInputValidator', [
+oppia.factory('MultipleChoiceInputValidationService', [
   '$filter', 'WARNING_TYPES', 'baseInteractionValidationService',
   function($filter, WARNING_TYPES, baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(
-      stateName, customizationArgs, answerGroups, defaultOutcome) {
-      var warningsList = [];
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        var warningsList = [];
 
-      baseInteractionValidationService.requireCustomizationArguments(
-        customizationArgs, ['choices']);
+        baseInteractionValidationService.requireCustomizationArguments(
+          customizationArgs, ['choices']);
 
-      var areAnyChoicesEmpty = false;
-      var areAnyChoicesDuplicated = false;
-      var seenChoices = [];
-      var numChoices = customizationArgs.choices.value.length;
-      for (var i = 0; i < customizationArgs.choices.value.length; i++) {
-        var choice = customizationArgs.choices.value[i];
-        if (choice.trim().length === 0) {
-          areAnyChoicesEmpty = true;
+        var areAnyChoicesEmpty = false;
+        var areAnyChoicesDuplicated = false;
+        var seenChoices = [];
+        var numChoices = customizationArgs.choices.value.length;
+        for (var i = 0; i < customizationArgs.choices.value.length; i++) {
+          var choice = customizationArgs.choices.value[i];
+          if (choice.trim().length === 0) {
+            areAnyChoicesEmpty = true;
+          }
+          if (seenChoices.indexOf(choice) !== -1) {
+            areAnyChoicesDuplicated = true;
+          }
+          seenChoices.push(choice);
         }
-        if (seenChoices.indexOf(choice) !== -1) {
-          areAnyChoicesDuplicated = true;
+
+        if (areAnyChoicesEmpty) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: 'Please ensure the choices are nonempty.'
+          });
         }
-        seenChoices.push(choice);
-      }
+        if (areAnyChoicesDuplicated) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: 'Please ensure the choices are unique.'
+          });
+        }
 
-      if (areAnyChoicesEmpty) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: 'Please ensure the choices are nonempty.'
-        });
-      }
-      if (areAnyChoicesDuplicated) {
-        warningsList.push({
-          type: WARNING_TYPES.CRITICAL,
-          message: 'Please ensure the choices are unique.'
-        });
-      }
-
-      var selectedEqualsChoices = [];
-      for (var i = 0; i < answerGroups.length; i++) {
-        var rules = answerGroups[i].rules;
-        for (var j = 0; j < rules.length; j++) {
-          if (rules[j].type === 'Equals') {
-            var choicePreviouslySelected = (
-              selectedEqualsChoices.indexOf(rules[j].inputs.x) !== -1);
-            if (!choicePreviouslySelected) {
-              selectedEqualsChoices.push(rules[j].inputs.x);
-            } else {
-              warningsList.push({
-                type: WARNING_TYPES.CRITICAL,
-                message: 'Please ensure rule ' + String(j + 1) + ' in group ' +
-                  String(i + 1) + ' is not equaling the same multiple choice ' +
-                  'option as another rule.'
-              });
-            }
-            if (rules[j].inputs.x >= numChoices) {
-              warningsList.push({
-                type: WARNING_TYPES.CRITICAL,
-                message: 'Please ensure rule ' + String(j + 1) + ' in group ' +
-                  String(i + 1) + ' refers to a valid choice.'
-              });
+        var selectedEqualsChoices = [];
+        for (var i = 0; i < answerGroups.length; i++) {
+          var rules = answerGroups[i].rules;
+          for (var j = 0; j < rules.length; j++) {
+            if (rules[j].type === 'Equals') {
+              var choicePreviouslySelected = (
+                selectedEqualsChoices.indexOf(rules[j].inputs.x) !== -1);
+              if (!choicePreviouslySelected) {
+                selectedEqualsChoices.push(rules[j].inputs.x);
+              } else {
+                warningsList.push({
+                  type: WARNING_TYPES.CRITICAL,
+                  message: 'Please ensure rule ' + String(j + 1) +
+                    ' in group ' + String(i + 1) + ' is not equaling the ' +
+                    'same multiple choice option as another rule.'
+                });
+              }
+              if (rules[j].inputs.x >= numChoices) {
+                warningsList.push({
+                  type: WARNING_TYPES.CRITICAL,
+                  message: 'Please ensure rule ' + String(j + 1) +
+                    ' in group ' + String(i + 1) + ' refers to a valid choice.'
+                });
+              }
             }
           }
         }
-      }
 
-      warningsList = warningsList.concat(
-        baseInteractionValidationService.getAnswerGroupWarnings(
-          answerGroups, stateName));
+        warningsList = warningsList.concat(
+          baseInteractionValidationService.getAnswerGroupWarnings(
+            answerGroups, stateName));
 
-      // Only require a default rule if some choices have not been taken care of
-      // by rules.
-      if (selectedEqualsChoices.length < numChoices) {
-        if (!defaultOutcome ||
-            $filter('isOutcomeConfusing')(defaultOutcome, stateName)) {
-          warningsList.push({
-            type: WARNING_TYPES.ERROR,
-            message: (
-              'Please add something for Oppia to say in the ' +
-              '\"All other answers\" response.')
-          });
+        // Only require a default rule if some choices have not been taken care
+        // of by rules.
+        if (selectedEqualsChoices.length < numChoices) {
+          if (!defaultOutcome ||
+              $filter('isOutcomeConfusing')(defaultOutcome, stateName)) {
+            warningsList.push({
+              type: WARNING_TYPES.ERROR,
+              message: 'Please add something for Oppia to say in the ' +
+                '\"All other answers\" response.'
+            });
+          }
         }
-      }
 
-      return warningsList;
+        return warningsList;
+      }
     };
   }
 ]);

--- a/extensions/interactions/MultipleChoiceInput/validatorSpec.js
+++ b/extensions/interactions/MultipleChoiceInput/validatorSpec.js
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveMultipleChoiceInputValidator', function() {
+describe('MultipleChoiceInputValidationService', function() {
   var WARNING_TYPES;
 
   var currentState, goodOutcomeDest;
   var badOutcome, goodAnswerGroups, goodDefaultOutcome;
-  var validator, customizationArguments;
+  var validatorService, customizationArguments;
 
   beforeEach(function() {
     module('oppia');
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    var filter = $injector.get('$filter');
-    validator = filter('oppiaInteractiveMultipleChoiceInputValidator');
+    validatorService = $injector.get('MultipleChoiceInputValidationService');
 
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
@@ -65,7 +64,7 @@ describe('oppiaInteractiveMultipleChoiceInputValidator', function() {
   }));
 
   it('should be able to perform basic validation', function() {
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, goodAnswerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([]);
@@ -73,13 +72,14 @@ describe('oppiaInteractiveMultipleChoiceInputValidator', function() {
 
   it('should expect a choices customization argument', function() {
     expect(function() {
-      validator(currentState, {}, goodAnswerGroups, goodDefaultOutcome);
+      validatorService.getAllWarnings(
+        currentState, {}, goodAnswerGroups, goodDefaultOutcome);
     }).toThrow('Expected customization arguments to have property: choices');
   });
 
   it('should expect non-empty and unique choices', function() {
     customizationArguments.choices.value[0] = '';
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, goodAnswerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([{
@@ -88,7 +88,7 @@ describe('oppiaInteractiveMultipleChoiceInputValidator', function() {
     }]);
 
     customizationArguments.choices.value[0] = 'Option 2';
-    warnings = validator(
+    warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, goodAnswerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([{
@@ -100,7 +100,7 @@ describe('oppiaInteractiveMultipleChoiceInputValidator', function() {
   it('should validate answer group rules refer to valid choices only once',
     function() {
       goodAnswerGroups[0].rules[0].inputs.x = 2;
-      var warnings = validator(
+      var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups,
         goodDefaultOutcome);
       expect(warnings).toEqual([{
@@ -109,7 +109,7 @@ describe('oppiaInteractiveMultipleChoiceInputValidator', function() {
       }]);
 
       goodAnswerGroups[0].rules[0].inputs.x = 1;
-      warnings = validator(
+      warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups,
         goodDefaultOutcome);
       // Rule 2 will be caught when trying to verify whether any rules are
@@ -125,7 +125,7 @@ describe('oppiaInteractiveMultipleChoiceInputValidator', function() {
   it('should expect a non-confusing and non-null default outcome only when ' +
     'not all choices are covered by rules',
     function() {
-      var warnings = validator(
+      var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups, badOutcome);
       // All of the multiple choice options are targeted by rules, therefore no
       // warning should be issued for a bad default outcome.
@@ -134,7 +134,7 @@ describe('oppiaInteractiveMultipleChoiceInputValidator', function() {
       // Taking away 1 rule reverts back to the expect validation behavior with
       // default outcome.
       goodAnswerGroups[0].rules.splice(1, 1);
-      warnings = validator(
+      warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups, null);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
@@ -142,7 +142,7 @@ describe('oppiaInteractiveMultipleChoiceInputValidator', function() {
           'Please add something for Oppia to say in the ' +
           '\"All other answers\" response.')
       }]);
-      warnings = validator(
+      warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups, badOutcome);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,

--- a/extensions/interactions/MusicNotesInput/validator.js
+++ b/extensions/interactions/MusicNotesInput/validator.js
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveMusicNotesInputValidator', [
+oppia.factory('MusicNotesInputValidationService', [
   'baseInteractionValidationService',
   function(baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(
-        stateName, customizationArgs, answerGroups, defaultOutcome) {
-      return baseInteractionValidationService.getAllOutcomeWarnings(
-        answerGroups, defaultOutcome, stateName);
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        return baseInteractionValidationService.getAllOutcomeWarnings(
+          answerGroups, defaultOutcome, stateName);
+      }
     };
   }
 ]);

--- a/extensions/interactions/MusicNotesInput/validatorSpec.js
+++ b/extensions/interactions/MusicNotesInput/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveMusicNotesInputValidator', function() {
-  var validator, WARNING_TYPES;
+describe('MusicNotesInputValidationService', function() {
+  var validatorService, WARNING_TYPES;
 
   var currentState;
   var goodAnswerGroups, goodDefaultOutcome;
@@ -23,8 +23,7 @@ describe('oppiaInteractiveMusicNotesInputValidator', function() {
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    var filter = $injector.get('$filter');
-    validator = filter('oppiaInteractiveMusicNotesInputValidator');
+    validatorService = $injector.get('MusicNotesInputValidationService');
 
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
@@ -41,7 +40,7 @@ describe('oppiaInteractiveMusicNotesInputValidator', function() {
   }));
 
   it('should be able to perform basic validation', function() {
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, {}, goodAnswerGroups, goodDefaultOutcome);
     expect(warnings).toEqual([]);
   });

--- a/extensions/interactions/NumericInput/validator.js
+++ b/extensions/interactions/NumericInput/validator.js
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveNumericInputValidator', [
+oppia.factory('NumericInputValidationService', [
   'baseInteractionValidationService',
   function(baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(
-        stateName, customizationArgs, answerGroups, defaultOutcome) {
-      return baseInteractionValidationService.getAllOutcomeWarnings(
-        answerGroups, defaultOutcome, stateName);
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        return baseInteractionValidationService.getAllOutcomeWarnings(
+          answerGroups, defaultOutcome, stateName);
+      }
     };
   }
 ]);

--- a/extensions/interactions/NumericInput/validatorSpec.js
+++ b/extensions/interactions/NumericInput/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveNumericInputValidator', function() {
-  var validator, WARNING_TYPES;
+describe('NumericInputValidationService', function() {
+  var validatorService, WARNING_TYPES;
 
   var currentState;
   var goodAnswerGroups, goodDefaultOutcome;
@@ -23,8 +23,7 @@ describe('oppiaInteractiveNumericInputValidator', function() {
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    var filter = $injector.get('$filter');
-    validator = filter('oppiaInteractiveNumericInputValidator');
+    validatorService = $injector.get('NumericInputValidationService');
 
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
@@ -41,7 +40,7 @@ describe('oppiaInteractiveNumericInputValidator', function() {
   }));
 
   it('should be able to perform basic validation', function() {
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, {}, goodAnswerGroups, goodDefaultOutcome);
     expect(warnings).toEqual([]);
   });

--- a/extensions/interactions/PencilCodeEditor/validator.js
+++ b/extensions/interactions/PencilCodeEditor/validator.js
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractivePencilCodeEditorValidator', [
+oppia.factory('PencilCodeEditorValidationService', [
   'baseInteractionValidationService',
   function(baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(
-        stateName, customizationArgs, answerGroups, defaultOutcome) {
-      return baseInteractionValidationService.getAllOutcomeWarnings(
-        answerGroups, defaultOutcome, stateName);
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        return baseInteractionValidationService.getAllOutcomeWarnings(
+          answerGroups, defaultOutcome, stateName);
+      }
     };
   }
 ]);

--- a/extensions/interactions/SetInput/validator.js
+++ b/extensions/interactions/SetInput/validator.js
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveSetInputValidator', [
+oppia.factory('SetInputValidationService', [
   'baseInteractionValidationService',
   function(baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(
-        stateName, customizationArgs, answerGroups, defaultOutcome) {
-      return baseInteractionValidationService.getAllOutcomeWarnings(
-        answerGroups, defaultOutcome, stateName);
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        return baseInteractionValidationService.getAllOutcomeWarnings(
+          answerGroups, defaultOutcome, stateName);
+      }
     };
   }
 ]);

--- a/extensions/interactions/SetInput/validatorSpec.js
+++ b/extensions/interactions/SetInput/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveSetInputValidator', function() {
-  var validator, WARNING_TYPES;
+describe('SetInputValidationService', function() {
+  var validatorService, WARNING_TYPES;
 
   var currentState;
   var goodAnswerGroups, goodDefaultOutcome;
@@ -23,8 +23,7 @@ describe('oppiaInteractiveSetInputValidator', function() {
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    var filter = $injector.get('$filter');
-    validator = filter('oppiaInteractiveSetInputValidator');
+    validatorService = $injector.get('SetInputValidationService');
 
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
@@ -43,7 +42,7 @@ describe('oppiaInteractiveSetInputValidator', function() {
   }));
 
   it('should be able to perform basic validation', function() {
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, {}, goodAnswerGroups, goodDefaultOutcome);
     expect(warnings).toEqual([]);
   });

--- a/extensions/interactions/TextInput/validator.js
+++ b/extensions/interactions/TextInput/validator.js
@@ -13,18 +13,18 @@
 // limitations under the License.
 
 /**
- * @fileoverview Frontend validator for customization args and rules of
- * the interaction.
+ * @fileoverview Validator service for the interaction.
  */
 
-oppia.filter('oppiaInteractiveTextInputValidator', [
+oppia.factory('TextInputValidationService', [
   'baseInteractionValidationService',
   function(baseInteractionValidationService) {
-    // Returns a list of warnings.
-    return function(
-        stateName, customizationArgs, answerGroups, defaultOutcome) {
-      return baseInteractionValidationService.getAllOutcomeWarnings(
-        answerGroups, defaultOutcome, stateName);
+    return {
+      getAllWarnings: function(
+          stateName, customizationArgs, answerGroups, defaultOutcome) {
+        return baseInteractionValidationService.getAllOutcomeWarnings(
+          answerGroups, defaultOutcome, stateName);
+      }
     };
   }
 ]);

--- a/extensions/interactions/TextInput/validatorSpec.js
+++ b/extensions/interactions/TextInput/validatorSpec.js
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-describe('oppiaInteractiveTextInputValidator', function() {
-  var validator, WARNING_TYPES;
+describe('TextInputValidationService', function() {
+  var validatorService, WARNING_TYPES;
 
   var currentState;
   var goodAnswerGroups, goodDefaultOutcome;
@@ -23,8 +23,7 @@ describe('oppiaInteractiveTextInputValidator', function() {
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    var filter = $injector.get('$filter');
-    validator = filter('oppiaInteractiveTextInputValidator');
+    validatorService = $injector.get('TextInputValidationService');
 
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 
@@ -42,7 +41,7 @@ describe('oppiaInteractiveTextInputValidator', function() {
   }));
 
   it('should be able to perform basic validation', function() {
-    var warnings = validator(
+    var warnings = validatorService.getAllWarnings(
       currentState, {}, goodAnswerGroups, goodDefaultOutcome);
     expect(warnings).toEqual([]);
   });


### PR DESCRIPTION
**Context**

This is the first of a series of changes. The ultimate goal is to be able to control whether the "Save" button on the interaction editor is enabled or not, based on the warnings returned by the validator, but only for the customization arguments (not all warnings are relevant).

So the steps to achieve this are:

1. Refactor all validators (filters) into validator services, exposing getAllWarnings()
2. Make these services expose getCustomizationArgsWarnings() which will only return warnings relevant to the customization args.
3. Tie the "Save" button to just the output of getCustomizationArgsWarnings()

This PR addresses step #1.