### PR TITLE
Fix #3459: Create captions for Oppia Contributor Video

### DIFF
--- a/core/templates/dev/head/pages/donate/donate.html
+++ b/core/templates/dev/head/pages/donate/donate.html
@@ -59,7 +59,7 @@
       <div class="oppia-donate-info">
         <div style="height: 0; margin: 60px auto 0px auto; width: 70%; padding-bottom: 56.25%; position: relative;">
           <iframe title="Meet Oppia's Contributors" width="100%"
-                  height="100%" src="https://www.youtube.com/embed/OConyxG7HaM?rel=0"
+                  height="100%" src="https://www.youtube.com/embed/OConyxG7HaM?rel=0&cc_lang_pref=en&cc_load_policy=1"
                   frameborder="0" allowfullscreen
                   style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
           </iframe>


### PR DESCRIPTION
This PR updates the link for the embed code of the Meet Oppia's Contributors video to force English captions to show initially.

Of course, no difference is visible because the captions have not been uploaded.

Timed captions can be viewed here: https://amara.org/en/videos/g0XMqKKhW4ym/en/1873618/ and can be downloaded as SRT or VTT, as YouTube requires.

@bching When you have a moment, would you please take a look at the captioned video at the link above to double check their correctness?

Also, @seanlip Who would be the appropriate person to ping about actually getting these in YouTube?