### PR TITLE
Fix #3456 : Full exploration title on mobile visible as info icon

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -746,6 +746,12 @@ textarea {
   content: ">";
 }
 
+.oppia-navbar-breadcrumb-icon {
+  height: 20px;
+  margin: 0 12px 4px 12px;
+  width: 20px;
+}
+
 .navbar-default .navbar-nav > li > a:hover,
 .navbar-default .navbar-nav > li > a:focus {
   color: #fff;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2878,6 +2878,7 @@ md-card.preview-conversation-skin-supplemental-card {
 
 .oppia-modal-information-card .modal-dialog {
   margin: 100px auto;
+  max-width: 98vw;
   width: 400px;
 }
 

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -746,12 +746,6 @@ textarea {
   content: ">";
 }
 
-.oppia-navbar-breadcrumb-icon {
-  height: 20px;
-  margin: 0 12px 4px 12px;
-  width: 20px;
-}
-
 .navbar-default .navbar-nav > li > a:hover,
 .navbar-default .navbar-nav > li > a:focus {
   color: #fff;

--- a/core/templates/dev/head/pages/exploration_player/LearnerViewInfo.js
+++ b/core/templates/dev/head/pages/exploration_player/LearnerViewInfo.js
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 /**
- * @fileoverview Controllers for the learner view breadcrumb section of the
- * navbar.
+ * @fileoverview Controllers for the learner view info section of the
+ * footer.
  */
 
-oppia.controller('LearnerViewBreadcrumb', [
+oppia.controller('LearnerViewInfo', [
   '$scope', '$modal', '$http', '$log', 'explorationContextService',
   'EXPLORATION_SUMMARY_DATA_URL_TEMPLATE',
   function($scope, $modal, $http, $log, explorationContextService,

--- a/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
@@ -114,6 +114,18 @@
     float: left;
   }
 
+  .oppia-navbar-footer-info-icon {
+    height: 56px;
+    padding: 12px;
+  }
+
+  .oppia-navbar-footer-info-icon:hover {
+    background: #fff;
+    color: #009688;
+    height: 56px;
+    padding: 12px;
+  }
+
   @media (max-width: 475px) {
     .oppia-exploration-footer-sharing-links {
       display: none;
@@ -123,6 +135,12 @@
   @media (max-width: 658px) {
     .oppia-share-exploration-footer {
       display: none;
+    }
+    .oppia-navbar-footer-info-icon {
+      margin-top: -11px;
+    }
+    .oppia-navbar-footer-info-icon:hover {
+      margin-top: -11px;
     }
   }
 </style>
@@ -164,7 +182,11 @@
     </div>
     <div class="col-sm-7">
       <div class="pull-right">
-        <ul class="author-profile">
+        <ul class="author-profile" ng-controller="LearnerViewInfo">
+          <li ng-click="showInformationCard()" style="cursor: pointer;" class="oppia-exploration-info-icon protractor-test-exploration-info-icon" tabindex="0">
+            <i class="material-icons oppia-navbar-footer-info-icon" style="font-size: 20px;">&#xE88E;</i>
+            <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_INFO_TOOLTIP' | translate]></span>
+          </li>
           <li>
             <h4 translate="I18N_PLAYER_SHARE_THIS_EXPLORATION" class="oppia-share-exploration-footer"></h4>
           </li>

--- a/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
@@ -126,6 +126,10 @@
     padding: 12px;
   }
 
+  .modal-dialog {
+    max-width: 98vw;
+  }
+
   @media (max-width: 475px) {
     .oppia-exploration-footer-sharing-links {
       display: none;
@@ -141,6 +145,12 @@
     }
     .oppia-navbar-footer-info-icon:hover {
       margin-top: -11px;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .oppia-exploration-footer-info-icon {
+      display: none;
     }
   }
 </style>
@@ -183,7 +193,7 @@
     <div class="col-sm-7">
       <div class="pull-right">
         <ul class="author-profile" ng-controller="LearnerViewInfo">
-          <li ng-click="showInformationCard()" style="cursor: pointer;" class="oppia-exploration-info-icon protractor-test-exploration-info-icon" tabindex="0">
+          <li ng-click="showInformationCard()" style="cursor: pointer;" class="oppia-exploration-footer-info-icon protractor-test-exploration-info-icon" tabindex="0">
             <i class="material-icons oppia-navbar-footer-info-icon" style="font-size: 20px;">&#xE88E;</i>
             <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_INFO_TOOLTIP' | translate]></span>
           </li>

--- a/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
@@ -193,7 +193,7 @@
     <div class="col-sm-7">
       <div class="pull-right">
         <ul class="author-profile" ng-controller="LearnerViewInfo">
-          <li ng-click="showInformationCard()" style="cursor: pointer;" class="oppia-exploration-footer-info-icon protractor-test-exploration-info-icon" tabindex="0">
+          <li ng-click="showInformationCard()" style="cursor: pointer;" class="oppia-exploration-footer-info-icon" tabindex="0">
             <i class="material-icons oppia-navbar-footer-info-icon" style="font-size: 20px;">&#xE88E;</i>
             <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_INFO_TOOLTIP' | translate]></span>
           </li>

--- a/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
@@ -126,10 +126,6 @@
     padding: 12px;
   }
 
-  .oppia-exploration-footer .modal-dialog {
-    max-width: 98vw;
-  }
-
   @media (max-width: 475px) {
     .oppia-exploration-footer-sharing-links {
       display: none;

--- a/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
@@ -114,19 +114,19 @@
     float: left;
   }
 
-  .oppia-navbar-footer-info-icon {
+  .oppia-exploration-footer .oppia-navbar-footer-info-icon {
     height: 56px;
     padding: 12px;
   }
 
-  .oppia-navbar-footer-info-icon:hover {
+  .oppia-exploration-footer .oppia-navbar-footer-info-icon:hover {
     background: #fff;
     color: #009688;
     height: 56px;
     padding: 12px;
   }
 
-  .modal-dialog {
+  .oppia-exploration-footer .modal-dialog {
     max-width: 98vw;
   }
 
@@ -137,19 +137,19 @@
   }
 
   @media (max-width: 658px) {
-    .oppia-share-exploration-footer {
+    .oppia-exploration-footer .oppia-share-exploration-footer {
       display: none;
     }
-    .oppia-navbar-footer-info-icon {
+    .oppia-exploration-footer .oppia-navbar-footer-info-icon {
       margin-top: -11px;
     }
-    .oppia-navbar-footer-info-icon:hover {
+    .oppia-exploration-footer .oppia-navbar-footer-info-icon:hover {
       margin-top: -11px;
     }
   }
 
   @media (min-width: 768px) {
-    .oppia-exploration-footer-info-icon {
+    .oppia-exploration-footer .oppia-exploration-footer-info-icon {
       display: none;
     }
   }

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -48,10 +48,14 @@
 {% endblock header_js %}
 
 {% block navbar_breadcrumb %}
-  <ul class="nav navbar-nav oppia-navbar-breadcrumb">
+  <ul class="nav navbar-nav oppia-navbar-breadcrumb" ng-controller="LearnerViewInfo">
     <li>
       <span class="oppia-navbar-breadcrumb-separator"></span>
       <h1 class="oppia-exploration-h1"><span class="protractor-test-exploration-header oppia-exploration-header" itemprop="description">{{exploration_title}}</span></h1>
+    </li>
+    <li ng-click="showInformationCard()" tooltip="<['I18N_PLAYER_INFO_TOOLTIP' | translate]>" tooltip-placement="bottom" style="cursor: pointer;" class="oppia-exploration-info-icon protractor-test-exploration-info-icon" tabindex="0">
+      <i class="material-icons oppia-navbar-breadcrumb-icon" style="font-size: 20px;">&#xE88E;</i>
+      <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_INFO_TOOLTIP' | translate]></span>
     </li>
   </ul>
 {% endblock navbar_breadcrumb %}
@@ -108,6 +112,13 @@
       display: inline;
       font-size: 1em;
       font-weight: normal;
+    }
+    .oppia-exploration-info-icon:hover {
+      background: #fff;
+      color: #009688;
+      margin-top: -13px;
+      height: 56px;
+      padding-top: 12px;
     }
   </style>
 

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -23,21 +23,6 @@
 
   {{dependencies_html}}
   <style>
-    @media(max-width: 768px) {
-      /* This prevents the navbar from collapsing in the exploration page,
-      so that the exploration title can be shown. */
-      .oppia-exploration-header {
-        display: block;
-        float: right;
-        max-width: 240px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-      .oppia-navbar-collapse.collapse {
-        display: block;
-      }
-    }
     @media(max-width: 500px) {
       img.oppia-logo {
         height: 48px;
@@ -53,9 +38,6 @@
         max-width: 35px;
         overflow: hidden;
       }
-      .oppia-navbar-breadcrumb-icon {
-        display: none;
-      }
     }
     @media(max-width: 400px) {
       .oppia-exploration-header {
@@ -66,14 +48,10 @@
 {% endblock header_js %}
 
 {% block navbar_breadcrumb %}
-  <ul class="nav navbar-nav oppia-navbar-breadcrumb" ng-controller="LearnerViewBreadcrumb">
+  <ul class="nav navbar-nav oppia-navbar-breadcrumb">
     <li>
       <span class="oppia-navbar-breadcrumb-separator"></span>
       <h1 class="oppia-exploration-h1"><span class="protractor-test-exploration-header oppia-exploration-header" itemprop="description">{{exploration_title}}</span></h1>
-    </li>
-    <li ng-click="showInformationCard()" tooltip="<['I18N_PLAYER_INFO_TOOLTIP' | translate]>" tooltip-placement="bottom" style="cursor: pointer;" class="oppia-exploration-info-icon protractor-test-exploration-info-icon" tabindex="0">
-      <i class="material-icons oppia-navbar-breadcrumb-icon" style="font-size: 20px;">&#xE88E;</i>
-      <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_INFO_TOOLTIP' | translate]></span>
     </li>
   </ul>
 {% endblock navbar_breadcrumb %}
@@ -130,13 +108,6 @@
       display: inline;
       font-size: 1em;
       font-weight: normal;
-    }
-    .oppia-exploration-info-icon:focus {
-      background: #fff;
-      color: #009688;
-      margin-top: -13px;
-      height: 56px;
-      padding-top: 12px;
     }
   </style>
 
@@ -198,7 +169,7 @@
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/FeedbackPopupDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/LearnerLocalNav.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/LearnerParamsService.js"></script>
-  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/LearnerViewBreadcrumb.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/LearnerViewInfo.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/LearnerViewRatingService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/PlayerPositionService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/PlayerServices.js"></script>

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -24,19 +24,8 @@
   {{dependencies_html}}
   <style>
     @media(max-width: 500px) {
-      img.oppia-logo {
-        height: 48px;
-        margin-left: 0;
-        margin-top: 8px;
-        max-width: none;
-        width: auto;
-      }
       .oppia-exploration-header {
         max-width: 180px;
-      }
-      .oppia-navbar-brand-name {
-        max-width: 35px;
-        overflow: hidden;
       }
     }
     @media(max-width: 400px) {


### PR DESCRIPTION
Fixes #3456
The info icon is now visible on the footer and removes exploration titles from the top of the page for mobile devices.