### PR TITLE
Fix #3480: Added config property for adding VMID and shared keys in Oppia.

### DIFF
--- a/core/domain/config_domain.py
+++ b/core/domain/config_domain.py
@@ -18,6 +18,8 @@
 
 from core.domain import user_services
 from core.platform import models
+
+import feconf
 import schema_utils
 
 (config_models,) = models.Registry.import_models([models.NAMES.config])
@@ -33,6 +35,24 @@ SET_OF_STRINGS_SCHEMA = {
     'validators': [{
         'id': 'is_uniquified',
     }],
+}
+
+VMID_SHARED_SECRET_KEY_SCHEMA = {
+    'type': 'list',
+    'items': {
+        'type': 'dict',
+        'properties': [{
+            'name': 'vm_id',
+            'schema': {
+                'type': 'unicode'
+            }
+        }, {
+            'name': 'shared_secret_key',
+            'schema': {
+                'type': 'unicode'
+            }
+        }]
+    }
 }
 
 BOOL_SCHEMA = {
@@ -257,3 +277,11 @@ PROMO_BAR_ENABLED = ConfigProperty(
 PROMO_BAR_MESSAGE = ConfigProperty(
     'promo_bar_message', UNICODE_SCHEMA,
     'The message to show to all users if the promo bar is enabled', '')
+
+VMID_SHARED_SECRET_KEY_MAPPING = ConfigProperty(
+    'vmid_shared_secret_key_mapping', VMID_SHARED_SECRET_KEY_SCHEMA,
+    'VMID and shared secret key corresponding to that VM',
+    [{
+        'vm_id': feconf.DEFAULT_VM_ID,
+        'shared_secret_key': feconf.DEFAULT_VM_SHARED_SECRET
+    }])

--- a/feconf.py
+++ b/feconf.py
@@ -155,6 +155,11 @@ DEFAULT_COLLECTION_CATEGORY = ''
 # Default objective for a newly-minted collection.
 DEFAULT_COLLECTION_OBJECTIVE = ''
 
+# Default ID of VM which is used for training classifier.
+DEFAULT_VM_ID = 'vm_default'
+# Shared secret key for default VM.
+DEFAULT_VM_SHARED_SECRET = '1a2b3c4e'
+
 # A dict containing the accepted image formats (as determined by the imghdr
 # module) and the corresponding allowed extensions in the filenames of uploaded
 # files.


### PR DESCRIPTION
This PR adds config property for VMID and shared key so that admin can add VMID and shared key corresponsing to that VM from "/admin" page directly.