### PR TITLE
Fix #2042: Fix travis_retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,6 @@ before_install:
 - bash -e /etc/init.d/xvfb start
 
 install:
-- set -e
 - pushd $TRAVIS_BUILD_DIR
 - source scripts/setup.sh || exit 1
 - source scripts/setup_gae.sh || exit 1


### PR DESCRIPTION
This PR attempts to fix travis_retry which does not retry on select tests upon failure. Please do not merge until the test failure [case](https://github.com/kevinlee12/oppia/commit/5e014074216e5b0d796546c557b4f3d17f784fc7) has been rolled back. 

Rationale for change:
`travis_retry` is located at the test level, rather than at the "global" level, so if there is a failure on install, it should exit (with `|| exit 1` within the install section). `set -e` terminates execution of the script completely upon a failure, which interferes with the operation of `travis_retry` which contains tests that will return a non-zero error; thus, terminating the segment before `travis_retry` can retry the test. 