### PR TITLE
Fix #3462: Donate page responsiveness hides the paragraph of text

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4522,7 +4522,9 @@ md-card.preview-conversation-skin-supplemental-card {
     margin-bottom: 90px;
   }
   .oppia-donate-info {
-    display: none;
+    display: block;
+    position: inherit;
+    width: 100%;
   }
   .oppia-donate-options {
     float: clear;


### PR DESCRIPTION
#3462
The donation page content is now responsive. 

![screenshot from 2017-05-30 13-54-42](https://cloud.githubusercontent.com/assets/24438869/26574745/20fbbd4e-4540-11e7-8987-be2694c17b0c.png)
