### PR TITLE
Fix #3269: Use responsive min-width in exploration player, add viewport styles to CSS

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -60,6 +60,12 @@
   100% { opacity: 1; }
 }
 
+@-webkit-viewport{width:device-width}
+@-moz-viewport{width:device-width}
+@-ms-viewport{width:device-width}
+@-o-viewport{width:device-width}
+@viewport{width:device-width}
+
 /* Angular material overrides. */
 md-input-group.long > input {
   width: 100%;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -60,11 +60,25 @@
   100% { opacity: 1; }
 }
 
-@-webkit-viewport{width:device-width}
-@-moz-viewport{width:device-width}
-@-ms-viewport{width:device-width}
-@-o-viewport{width:device-width}
-@viewport{width:device-width}
+@-webkit-viewport {
+  width: device-width;
+}
+
+@-moz-viewport {
+  width: device-width;
+}
+
+@-ms-viewport {
+  width: device-width;
+}
+
+@-o-viewport {
+  width: device-width;
+}
+
+@viewport {
+  width: device-width;
+}
 
 /* Angular material overrides. */
 md-input-group.long > input {

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -193,11 +193,15 @@ otherwise they will interfere with the iframed conversation skin directive.
   .conversation-skin-tutor-card-container {
     flex-shrink: 10000;
     max-width: 560px;
+    /* NOTE TO DEVELOPERS: If min-width is changed, max-width in media query
+       below should be changed to match. */
     min-width: 360px;
     width: 100%;
     z-index: 1;
   }
 
+  /* Some mobile devices have CSS width below 360px, use a responsive min-width
+     when under 360px to prevent pushing things offscreen. */
   @media(max-width: 360px) {
     .conversation-skin-tutor-card-container {
       min-width: 100vw;

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -198,6 +198,12 @@ otherwise they will interfere with the iframed conversation skin directive.
     z-index: 1;
   }
 
+  @media(max-width: 360px) {
+    .conversation-skin-tutor-card-container {
+      min-width: 100vw;
+    }
+  }
+
   .conversation-skin-future-tutor-card {
     left: -30000px;
     max-width: 560px;


### PR DESCRIPTION
This fixes the navbars being partly off screen in exploration player for devices with small screen widths like iPhone 5.

Adding the viewport styles is not strictly necessary, but [could lead to wider browser support in some cases.](http://trentwalton.com/2013/01/16/windows-phone-8-viewport-fix/)

Before/After images here: https://github.com/oppia/oppia/issues/1081#issuecomment-305060618