### PR TITLE
[NOT FOR MERGE] Issue 2700 : changes for left out directives (those without 'directive' in name)

### DIFF
--- a/core/templates/dev/head/components/RatingDisplayDirective.js
+++ b/core/templates/dev/head/components/RatingDisplayDirective.js
@@ -23,7 +23,8 @@ oppia.directive('ratingDisplay', [
       // passed in are as follows:
       //  - isEditable: true or false; whether the rating is user-editable.
       //  - onEdit: should be supplied iff isEditable is true, and be a function
-      //    that will be supplied with the new rating when the rating is changed.
+      //    that will be supplied with the new rating when the rating is
+      //    changed.
       //  - ratingValue: an integer 1-5 giving the rating
       restrict: 'E',
       scope: {

--- a/core/templates/dev/head/components/RatingDisplayDirective.js
+++ b/core/templates/dev/head/components/RatingDisplayDirective.js
@@ -16,88 +16,90 @@
  * @fileoverview Directive for displaying summary rating information.
  */
 
-oppia.directive('ratingDisplay', [function() {
-  return {
-    // This will display a star-rating based on the given data. The attributes
-    // passed in are as follows:
-    //  - isEditable: true or false; whether the rating is user-editable.
-    //  - onEdit: should be supplied iff isEditable is true, and be a function
-    //    that will be supplied with the new rating when the rating is changed.
-    //  - ratingValue: an integer 1-5 giving the rating
-    restrict: 'E',
-    scope: {
-      isEditable: '=',
-      onEdit: '=',
-      ratingValue: '='
-    },
-    templateUrl: 'components/ratingSummary',
-    link: function(scope, element) {
-      // This is needed in order for the scope to be retrievable during Karma
-      // unit testing. See http://stackoverflow.com/a/29833832 for more
-      // details.
-      element[0].isolateScope = function() {
-        return scope;
-      };
-    },
-    controller: ['$scope', function($scope) {
-      var POSSIBLE_RATINGS = [1, 2, 3, 4, 5];
-      $scope.stars = POSSIBLE_RATINGS.map(function(starValue) {
-        return {
-          cssClass: 'fa-star-o',
-          value: starValue
+oppia.directive('ratingDisplay', [
+  'UrlInterpolationService', function(UrlInterpolationService) {
+    return {
+      // This will display a star-rating based on the given data. The attributes
+      // passed in are as follows:
+      //  - isEditable: true or false; whether the rating is user-editable.
+      //  - onEdit: should be supplied iff isEditable is true, and be a function
+      //    that will be supplied with the new rating when the rating is changed.
+      //  - ratingValue: an integer 1-5 giving the rating
+      restrict: 'E',
+      scope: {
+        isEditable: '=',
+        onEdit: '=',
+        ratingValue: '='
+      },
+      templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
+        '/components/rating_display.html'),
+      link: function(scope, element) {
+        // This is needed in order for the scope to be retrievable during Karma
+        // unit testing. See http://stackoverflow.com/a/29833832 for more
+        // details.
+        element[0].isolateScope = function() {
+          return scope;
         };
-      });
+      },
+      controller: ['$scope', function($scope) {
+        var POSSIBLE_RATINGS = [1, 2, 3, 4, 5];
+        $scope.stars = POSSIBLE_RATINGS.map(function(starValue) {
+          return {
+            cssClass: 'fa-star-o',
+            value: starValue
+          };
+        });
 
-      var STATUS_ACTIVE = 'active';
-      var STATUS_INACTIVE = 'inactive';
-      var STATUS_RATING_SET = 'rating_set';
-      $scope.status = STATUS_INACTIVE;
-
-      var displayValue = function(ratingValue) {
-        for (var i = 0; i < $scope.stars.length; i++) {
-          $scope.stars[i].cssClass = (
-            ratingValue === undefined ? 'fa-star-o' :
-            ratingValue < $scope.stars[i].value - 0.75 ? 'fa-star-o' :
-            ratingValue < $scope.stars[i].value - 0.25 ? 'fa-star-half-o' :
-            'fa-star');
-
-          if ($scope.status === STATUS_ACTIVE &&
-              ratingValue >= $scope.stars[i].value) {
-            $scope.stars[i].cssClass += ' oppia-rating-star-active';
-          }
-        }
-      };
-
-      displayValue($scope.ratingValue);
-      $scope.$watch('ratingValue', function() {
-        displayValue($scope.ratingValue);
-      });
-
-      $scope.clickStar = function(starValue) {
-        if ($scope.isEditable && $scope.status === STATUS_ACTIVE) {
-          $scope.status = STATUS_RATING_SET;
-          $scope.ratingValue = starValue;
-          displayValue(starValue);
-          $scope.onEdit(starValue);
-        }
-      };
-      $scope.enterStar = function(starValue) {
-        if (
-            $scope.isEditable &&
-            ($scope.status === STATUS_ACTIVE ||
-              $scope.status === STATUS_INACTIVE)) {
-          $scope.status = STATUS_ACTIVE;
-          displayValue(starValue);
-        }
-      };
-      $scope.leaveArea = function() {
+        var STATUS_ACTIVE = 'active';
+        var STATUS_INACTIVE = 'inactive';
+        var STATUS_RATING_SET = 'rating_set';
         $scope.status = STATUS_INACTIVE;
-        displayValue($scope.ratingValue);
-      };
 
-      $scope.getCursorStyle = function() {
-        return 'cursor: ' + ($scope.isEditable ? 'pointer' : 'auto');
-      };
-    }]
-  };
-}]);
+        var displayValue = function(ratingValue) {
+          for (var i = 0; i < $scope.stars.length; i++) {
+            $scope.stars[i].cssClass = (
+              ratingValue === undefined ? 'fa-star-o' :
+              ratingValue < $scope.stars[i].value - 0.75 ? 'fa-star-o' :
+              ratingValue < $scope.stars[i].value - 0.25 ? 'fa-star-half-o' :
+              'fa-star');
+
+            if ($scope.status === STATUS_ACTIVE &&
+                ratingValue >= $scope.stars[i].value) {
+              $scope.stars[i].cssClass += ' oppia-rating-star-active';
+            }
+          }
+        };
+
+        displayValue($scope.ratingValue);
+        $scope.$watch('ratingValue', function() {
+          displayValue($scope.ratingValue);
+        });
+
+        $scope.clickStar = function(starValue) {
+          if ($scope.isEditable && $scope.status === STATUS_ACTIVE) {
+            $scope.status = STATUS_RATING_SET;
+            $scope.ratingValue = starValue;
+            displayValue(starValue);
+            $scope.onEdit(starValue);
+          }
+        };
+        $scope.enterStar = function(starValue) {
+          if (
+              $scope.isEditable &&
+              ($scope.status === STATUS_ACTIVE ||
+                $scope.status === STATUS_INACTIVE)) {
+            $scope.status = STATUS_ACTIVE;
+            displayValue(starValue);
+          }
+        };
+        $scope.leaveArea = function() {
+          $scope.status = STATUS_INACTIVE;
+          displayValue($scope.ratingValue);
+        };
+
+        $scope.getCursorStyle = function() {
+          return 'cursor: ' + ($scope.isEditable ? 'pointer' : 'auto');
+        };
+      }]
+    };
+  }]);

--- a/core/templates/dev/head/components/rating_display.html
+++ b/core/templates/dev/head/components/rating_display.html
@@ -1,5 +1,5 @@
 <span style="<[getCursorStyle()]>" ng-mouseleave="leaveArea()">
-	<span ng-if="ratingValue || isEditable" ng-repeat="star in stars" class="fa <[star.cssClass]> oppia-rating-star protractor-test-rating-star" ng-click="clickStar(star.value)" ng-mouseenter="enterStar(star.value)">
-		<span class="oppia-icon-accessibility-label">Rate this <[$index + 1]> stars</span>
-	</span>
+    <span ng-if="ratingValue || isEditable" ng-repeat="star in stars" class="fa <[star.cssClass]> oppia-rating-star protractor-test-rating-star" ng-click="clickStar(star.value)" ng-mouseenter="enterStar(star.value)">
+        <span class="oppia-icon-accessibility-label">Rate this <[$index + 1]> stars</span>
+    </span>
 </span>

--- a/core/templates/dev/head/components/rating_display.html
+++ b/core/templates/dev/head/components/rating_display.html
@@ -1,7 +1,5 @@
-<script type="text/ng-template" id="components/ratingSummary">
-  <span style="<[getCursorStyle()]>" ng-mouseleave="leaveArea()">
-    <span ng-if="ratingValue || isEditable" ng-repeat="star in stars" class="fa <[star.cssClass]> oppia-rating-star protractor-test-rating-star" ng-click="clickStar(star.value)" ng-mouseenter="enterStar(star.value)">
-      <span class="oppia-icon-accessibility-label">Rate this <[$index + 1]> stars</span>
-    </span>
-  </span>
-</script>
+<span style="<[getCursorStyle()]>" ng-mouseleave="leaveArea()">
+	<span ng-if="ratingValue || isEditable" ng-repeat="star in stars" class="fa <[star.cssClass]> oppia-rating-star protractor-test-rating-star" ng-click="clickStar(star.value)" ng-mouseenter="enterStar(star.value)">
+		<span class="oppia-icon-accessibility-label">Rate this <[$index + 1]> stars</span>
+	</span>
+</span>

--- a/core/templates/dev/head/pages/base.html
+++ b/core/templates/dev/head/pages/base.html
@@ -212,8 +212,6 @@
     {% include 'components/forms/form_builder_templates.html' %}
     {% include 'components/create_button/create_activity_button_directive.html' %}
 
-    {% include 'components/rating_display.html' %}
-
     <script src="{{TEMPLATE_DIR_PREFIX}}/app.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/directives.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/filters.js"></script>

--- a/core/templates/dev/head/pages/exploration_player/FatigueDetectionService.js
+++ b/core/templates/dev/head/pages/exploration_player/FatigueDetectionService.js
@@ -16,8 +16,9 @@
  * @fileoverview Service for detecting spamming behavior from the learner.
  */
 
-oppia.factory('FatigueDetectionService', 
-  ['$modal', function($modal) {
+oppia.factory('FatigueDetectionService', [
+  '$modal', 'UrlInterpolationService',
+  function($modal, UrlInterpolationService) {
     // 4 submissions in under 10 seconds triggers modal.
     var SPAM_COUNT_THRESHOLD = 4;
     var SPAM_WINDOW_MSEC = 10000;
@@ -40,7 +41,8 @@ oppia.factory('FatigueDetectionService',
       },
       displayTakeBreakMessage: function() {
         $modal.open({
-          templateUrl: 'modals/takeBreak',
+          templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
+            '/pages/exploration_player/take_break_modal.html'),
           backdrop: 'static',
           resolve: {},
           controller: [

--- a/core/templates/dev/head/pages/exploration_player/LearnerLocalNav.js
+++ b/core/templates/dev/head/pages/exploration_player/LearnerLocalNav.js
@@ -90,7 +90,8 @@ oppia.controller('LearnerLocalNav', [
 
     $scope.showFlagExplorationModal = function() {
       $modal.open({
-        templateUrl: 'modals/flagExploration',
+        templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
+          '/pages/exploration_player/flag_exploration_modal.html'),
         backdrop: true,
         controller: [
           '$scope', '$modalInstance', 'playerPositionService',
@@ -135,7 +136,9 @@ oppia.controller('LearnerLocalNav', [
           alertsService.addWarning(error);
         });
         $modal.open({
-          templateUrl: 'modals/explorationSuccessfullyFlagged',
+          templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
+            '/pages/exploration_player/' +
+            'exploration_successfully_flagged_modal.html'),
           backdrop: true,
           controller: [
             '$scope', '$modalInstance',

--- a/core/templates/dev/head/pages/exploration_player/LearnerViewInfo.js
+++ b/core/templates/dev/head/pages/exploration_player/LearnerViewInfo.js
@@ -19,9 +19,9 @@
 
 oppia.controller('LearnerViewInfo', [
   '$scope', '$modal', '$http', '$log', 'explorationContextService',
-  'EXPLORATION_SUMMARY_DATA_URL_TEMPLATE',
+  'EXPLORATION_SUMMARY_DATA_URL_TEMPLATE', 'UrlInterploationService',
   function($scope, $modal, $http, $log, explorationContextService,
-    EXPLORATION_SUMMARY_DATA_URL_TEMPLATE) {
+    EXPLORATION_SUMMARY_DATA_URL_TEMPLATE, UrlInterploationService) {
     var explorationId = explorationContextService.getExplorationId();
     var expInfo = null;
 
@@ -46,7 +46,8 @@ oppia.controller('LearnerViewInfo', [
     var openInformationCardModal = function() {
       $modal.open({
         animation: true,
-        templateUrl: 'modal/informationCard',
+        templateUrl: UrlInterploationService.getDirectiveTemplateUrl(
+          '/pages/exploration_player/information_card_modal.html'),
         windowClass: 'oppia-modal-information-card',
         resolve: {
           expInfo: function() {

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -111,11 +111,7 @@
     }
   </style>
 
-  {% include 'pages/exploration_player/exploration_successfully_flagged_modal.html' %}
   {% include 'pages/exploration_player/feedback_popup_directive.html' %}
-  {% include 'pages/exploration_player/flag_exploration_modal.html' %}
-  {% include 'pages/exploration_player/information_card_modal.html' %}
-  {% include 'pages/exploration_player/take_break_modal.html' %}
 
 {% endblock %}
 

--- a/core/templates/dev/head/pages/exploration_player/exploration_successfully_flagged_modal.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_successfully_flagged_modal.html
@@ -1,15 +1,13 @@
-<script type="text/ng-template" id="modals/explorationSuccessfullyFlagged">
-  <div class="modal-header">
-    <h3><['I18N_PLAYER_REPORT_SUCCESS_MODAL_HEADER' | translate]></h3>
-  </div>
+<div class="modal-header">
+  <h3><['I18N_PLAYER_REPORT_SUCCESS_MODAL_HEADER' | translate]></h3>
+</div>
 
-  <div class="modal-body">
-    <p>
-      <['I18N_PLAYER_REPORT_SUCCESS_MODAL_BODY' | translate]>
-    </p>
-  </div>
+<div class="modal-body">
+  <p>
+    <['I18N_PLAYER_REPORT_SUCCESS_MODAL_BODY' | translate]>
+  </p>
+</div>
 
-  <div class="modal-footer">
-    <button class="btn btn-default" ng-click="close()"><['I18N_PLAYER_REPORT_SUCCESS_MODAL_CLOSE' | translate]></button>
- </div>
-</script>
+<div class="modal-footer">
+  <button class="btn btn-default" ng-click="close()"><['I18N_PLAYER_REPORT_SUCCESS_MODAL_CLOSE' | translate]></button>
+</div>

--- a/core/templates/dev/head/pages/exploration_player/flag_exploration_modal.html
+++ b/core/templates/dev/head/pages/exploration_player/flag_exploration_modal.html
@@ -1,45 +1,43 @@
-<script type="text/ng-template" id="modals/flagExploration">
-  <div class="modal-header">
-    <h3>
-      <span><['I18N_PLAYER_REPORT_MODAL_HEADER' | translate]></span>
-    </h3>
-  </div>
-  <div class="modal-body oppia-long-text">
-    <h4>
-      <span><b><['I18N_PLAYER_REPORT_MODAL_BODY_HEADER' | translate]></b></span>
-    </h4>  
-    <form>
-      <div class="radio">
-        <label>
-          <input type="radio" value="ad" ng-model="flag" ng-change="showFlagMessageTextarea(flag)">
-          <['I18N_PLAYER_REPORT_MODAL_BODY_AD' | translate]>
-        </label>
-      </div>
-      <div class="radio">
-        <label>
-          <input type="radio" value="poor_experience" ng-model="flag" ng-change="showFlagMessageTextarea(flag)">
-          <['I18N_PLAYER_REPORT_MODAL_BODY_POOR_EXPERIENCE' | translate]>
-        </label>
-      </div>
-      <div class="radio">
-        <label>
-          <input type="radio" value="other" ng-model="flag" ng-change="showFlagMessageTextarea(flag)">
-          <['I18N_PLAYER_REPORT_MODAL_BODY_OTHER' | translate]>
-        </label>
-        <p ng-show="flagMessageTextareaIsShown">
-          <['I18N_PLAYER_REPORT_MODAL_BODY_ADDITIONAL_DETAILS' | translate]>
-          <textarea rows="3" cols="50" ng-model="flagMessage" class="form-control" focus-on="flagMessageTextarea">
-          </textarea>
-        </p>
-      </div>
-    </form>
-  </div>
-  <div class="modal-footer">
-    <button class="btn btn-default" ng-click="cancel()">
-      <['I18N_PLAYER_REPORT_MODAL_FOOTER_CANCEL' | translate]>
-    </button>
-    <button class="btn btn-success" ng-click="submitReport()" ng-disabled="!flagMessage">
-      <['I18N_PLAYER_REPORT_MODAL_FOOTER_SUBMIT' | translate]>
-    </button>
-  </div>
-</script>
+<div class="modal-header">
+  <h3>
+    <span><['I18N_PLAYER_REPORT_MODAL_HEADER' | translate]></span>
+  </h3>
+</div>
+<div class="modal-body oppia-long-text">
+  <h4>
+    <span><b><['I18N_PLAYER_REPORT_MODAL_BODY_HEADER' | translate]></b></span>
+  </h4>  
+  <form>
+    <div class="radio">
+      <label>
+        <input type="radio" value="ad" ng-model="flag" ng-change="showFlagMessageTextarea(flag)">
+        <['I18N_PLAYER_REPORT_MODAL_BODY_AD' | translate]>
+      </label>
+    </div>
+    <div class="radio">
+      <label>
+        <input type="radio" value="poor_experience" ng-model="flag" ng-change="showFlagMessageTextarea(flag)">
+        <['I18N_PLAYER_REPORT_MODAL_BODY_POOR_EXPERIENCE' | translate]>
+      </label>
+    </div>
+    <div class="radio">
+      <label>
+        <input type="radio" value="other" ng-model="flag" ng-change="showFlagMessageTextarea(flag)">
+        <['I18N_PLAYER_REPORT_MODAL_BODY_OTHER' | translate]>
+      </label>
+      <p ng-show="flagMessageTextareaIsShown">
+        <['I18N_PLAYER_REPORT_MODAL_BODY_ADDITIONAL_DETAILS' | translate]>
+        <textarea rows="3" cols="50" ng-model="flagMessage" class="form-control" focus-on="flagMessageTextarea">
+        </textarea>
+      </p>
+    </div>
+  </form>
+</div>
+<div class="modal-footer">
+  <button class="btn btn-default" ng-click="cancel()">
+    <['I18N_PLAYER_REPORT_MODAL_FOOTER_CANCEL' | translate]>
+  </button>
+  <button class="btn btn-success" ng-click="submitReport()" ng-disabled="!flagMessage">
+    <['I18N_PLAYER_REPORT_MODAL_FOOTER_SUBMIT' | translate]>
+  </button>
+</div>

--- a/core/templates/dev/head/pages/exploration_player/information_card_modal.html
+++ b/core/templates/dev/head/pages/exploration_player/information_card_modal.html
@@ -1,99 +1,97 @@
-<script type="text/ng-template" id="modal/informationCard">
-  <md-card class="md-padding">
-    <div ng-style="infoCardBackgroundCss" class="oppia-info-card-logo-thumbnail">
-      <img ng-src="<[infoCardBackgroundImageUrl]>" class="oppia-info-card-bg-image">
-      <h2 class="oppia-info-card-title"><[explorationTitle]></h2>
-    </div>
+<md-card class="md-padding">
+  <div ng-style="infoCardBackgroundCss" class="oppia-info-card-logo-thumbnail">
+    <img ng-src="<[infoCardBackgroundImageUrl]>" class="oppia-info-card-bg-image">
+    <h2 class="oppia-info-card-title"><[explorationTitle]></h2>
+  </div>
 
-    <div class="oppia-info-card-content">
-      <p ng-if="objective">
-        <[objective | truncateAndCapitalize: 95]>
-      </p>
-      <p ng-if="!objective" translate="I18N_PLAYER_NO_OBJECTIVE">No objective specified.</p>
+  <div class="oppia-info-card-content">
+    <p ng-if="objective">
+      <[objective | truncateAndCapitalize: 95]>
+    </p>
+    <p ng-if="!objective" translate="I18N_PLAYER_NO_OBJECTIVE">No objective specified.</p>
 
-      <ul layout="row" class="card-metrics" layout-align="space-between center">
-        <li class="protractor-test-info-card-rating">
-          <span class="fa fa-star fa-lg" tooltip="<['I18N_PLAYER_RATINGS_TOOLTIP' | translate]>" tooltip-placement="top">
-            <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_RATINGS_TOOLTIP' | translate]></span>
-          </span>
-          <span ng-if="!averageRating" translate="I18N_PLAYER_UNRATED">Unrated</span>
-          <span ng-if="averageRating"><[averageRating | number:1]></span>
+    <ul layout="row" class="card-metrics" layout-align="space-between center">
+      <li class="protractor-test-info-card-rating">
+        <span class="fa fa-star fa-lg" tooltip="<['I18N_PLAYER_RATINGS_TOOLTIP' | translate]>" tooltip-placement="top">
+          <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_RATINGS_TOOLTIP' | translate]></span>
+        </span>
+        <span ng-if="!averageRating" translate="I18N_PLAYER_UNRATED">Unrated</span>
+        <span ng-if="averageRating"><[averageRating | number:1]></span>
+      </li>
+
+      <li>
+        <span class="fa fa-eye fa-lg" tooltip="<['I18N_PLAYER_VIEWS_TOOLTIP' | translate]>" tooltip-placement="top">
+          <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_VIEWS_TOOLTIP' | translate]></span>
+        </span>
+        <[numViews | summarizeNonnegativeNumber]>
+      </li>
+
+      <li>
+        <span class="fa fa-clock-o fa-lg" tooltip="<['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]>" tooltip-placement="top">
+          <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]></span>
+        </span>
+        <[lastUpdatedString]>
+      </li>
+
+      <ul layout="row" layout-align="space-between center" class="oppia-info-card-exploration-contributors-profile">
+        <i class="material-icons" tooltip="<['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]>" tooltip-placement="top" style="cursor: default; margin-right: 5px;">&#xE7EF;</i>
+        <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]></span>
+        <li ng-repeat="name in contributorNames| limitTo: 2"
+          tooltip="<[name]>" tooltip-placement="top">
+          <profile-link-image username="name">
+          </profile-link-image>
         </li>
 
-        <li>
-          <span class="fa fa-eye fa-lg" tooltip="<['I18N_PLAYER_VIEWS_TOOLTIP' | translate]>" tooltip-placement="top">
-            <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_VIEWS_TOOLTIP' | translate]></span>
-          </span>
-          <[numViews | summarizeNonnegativeNumber]>
+        <li ng-if="contributorNames.length > 2" class="oppia-contributors-more-circle"
+          tooltip-append-to-body="true" tooltip="<[contributorNames.slice(2).join(',')]>"
+          tooltip-placement="top">+<[contributorNames.length - 2]>
         </li>
-
-        <li>
-          <span class="fa fa-clock-o fa-lg" tooltip="<['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]>" tooltip-placement="top">
-            <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]></span>
-          </span>
-          <[lastUpdatedString]>
+        <li ng-if="contributorNames.length === 0"
+            tooltip="<['I18N_PLAYER_COMMUNITY_EDITABLE_TOOLTIP' | translate]>"
+            tooltip-placement="top">
+          <span class="fa fa-globe fa-lg oppia-info-card-community-editable-icon"></span>
         </li>
-
-        <ul layout="row" layout-align="space-between center" class="oppia-info-card-exploration-contributors-profile">
-          <i class="material-icons" tooltip="<['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]>" tooltip-placement="top" style="cursor: default; margin-right: 5px;">&#xE7EF;</i>
-          <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]></span>
-          <li ng-repeat="name in contributorNames| limitTo: 2"
-            tooltip="<[name]>" tooltip-placement="top">
-            <profile-link-image username="name">
-            </profile-link-image>
-          </li>
-
-          <li ng-if="contributorNames.length > 2" class="oppia-contributors-more-circle"
-            tooltip-append-to-body="true" tooltip="<[contributorNames.slice(2).join(',')]>"
-            tooltip-placement="top">+<[contributorNames.length - 2]>
-          </li>
-          <li ng-if="contributorNames.length === 0"
-              tooltip="<['I18N_PLAYER_COMMUNITY_EDITABLE_TOOLTIP' | translate]>"
-              tooltip-placement="top">
-            <span class="fa fa-globe fa-lg oppia-info-card-community-editable-icon"></span>
-          </li>
-        </ul>
       </ul>
+    </ul>
 
-      <div class="oppia-info-card-bottom-row" layout="row">
-        <div flex="40">
-          <md-content layout="row">
-            <div class="oppia-info-card-tag-icon">
-              <span class="fa fa-tags fa-lg" tooltip-append-to-body="true"
-                    tooltip="<['I18N_PLAYER_TAGS_TOOLTIP' | translate]>"
-                    tooltip-placement="top">
-                <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_TAGS_TOOLTIP' | translate]></span>
-              </span>
-            </div>
-            <md-chips layout-align="center center">
-              <md-chip ng-if="explorationTags.tagsInTooltip.length > 0" class="oppia-info-card-tooltip-more"
-                tooltip-append-to-body="true" tooltip="<[explorationTags.tagsInTooltip.join(', ')]>"
-                tooltip-placement="right"
-                translate="I18N_PLAYER_PLUS_TAGS"
-                translate-values="{additionalTagNumber: <[explorationTags.tagsInTooltip.length]>}">
-              </md-chip>
-              <md-chip ng-if="explorationTags.tagsToShow.length > 0">
-                <[explorationTags.tagsToShow.join(", ")]>
-              </md-chip>
-              <md-chip ng-if="explorationTags.tagsToShow.length === 0 &&
-                explorationTags.tagsInTooltip.length === 0">
-                <span><em translate="I18N_PLAYER_NO_TAGS"></em></span>
-              <md-chip>
-            </md-chips>
-          </md-content>
-        </div>
-        <div flex="60">
-          <sharing-links flex="45" layout-type="row" layout-align-type="end center"
-                         twitter-text="DEFAULT_TWITTER_SHARE_MESSAGE_PLAYER"
-                         share-type="exploration"
-                         exploration-id="explorationId">
-          </sharing-links>
-        </div>
+    <div class="oppia-info-card-bottom-row" layout="row">
+      <div flex="40">
+        <md-content layout="row">
+          <div class="oppia-info-card-tag-icon">
+            <span class="fa fa-tags fa-lg" tooltip-append-to-body="true"
+                  tooltip="<['I18N_PLAYER_TAGS_TOOLTIP' | translate]>"
+                  tooltip-placement="top">
+              <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_TAGS_TOOLTIP' | translate]></span>
+            </span>
+          </div>
+          <md-chips layout-align="center center">
+            <md-chip ng-if="explorationTags.tagsInTooltip.length > 0" class="oppia-info-card-tooltip-more"
+              tooltip-append-to-body="true" tooltip="<[explorationTags.tagsInTooltip.join(', ')]>"
+              tooltip-placement="right"
+              translate="I18N_PLAYER_PLUS_TAGS"
+              translate-values="{additionalTagNumber: <[explorationTags.tagsInTooltip.length]>}">
+            </md-chip>
+            <md-chip ng-if="explorationTags.tagsToShow.length > 0">
+              <[explorationTags.tagsToShow.join(", ")]>
+            </md-chip>
+            <md-chip ng-if="explorationTags.tagsToShow.length === 0 &&
+              explorationTags.tagsInTooltip.length === 0">
+              <span><em translate="I18N_PLAYER_NO_TAGS"></em></span>
+            <md-chip>
+          </md-chips>
+        </md-content>
+      </div>
+      <div flex="60">
+        <sharing-links flex="45" layout-type="row" layout-align-type="end center"
+                       twitter-text="DEFAULT_TWITTER_SHARE_MESSAGE_PLAYER"
+                       share-type="exploration"
+                       exploration-id="explorationId">
+        </sharing-links>
       </div>
     </div>
-    <button type="button" class="oppia-close-popover-button" ng-click="cancel()">
-      <i class="material-icons md-18" style="color: white;">&#xE5CD;</i>
-      <span class="oppia-icon-accessibility-label">Close</span>
-    </button>
-  </md-card>
-</script>
+  </div>
+  <button type="button" class="oppia-close-popover-button" ng-click="cancel()">
+    <i class="material-icons md-18" style="color: white;">&#xE5CD;</i>
+    <span class="oppia-icon-accessibility-label">Close</span>
+  </button>
+</md-card>

--- a/core/templates/dev/head/pages/exploration_player/take_break_modal.html
+++ b/core/templates/dev/head/pages/exploration_player/take_break_modal.html
@@ -1,21 +1,19 @@
-<script type="text/ng-template" id="modals/takeBreak">
-  <div class="modal-header">
-    <h3>
-      Time for a break?
-    </h3>
-  </div>
+<div class="modal-header">
+  <h3>
+    Time for a break?
+  </h3>
+</div>
 
-  <div class="modal-body">
-    <p>
-      You seem to be submitting answers very quickly. Are you starting to get tired?
-    </p>
-    <br>
-    <p>
-      If so, consider taking a break! You can come back later.
-    </p>
-  </div>
+<div class="modal-body">
+  <p>
+    You seem to be submitting answers very quickly. Are you starting to get tired?
+  </p>
+  <br>
+  <p>
+    If so, consider taking a break! You can come back later.
+  </p>
+</div>
 
-  <div class="modal-footer">
-    <button class="btn btn-success" ng-click="okay()">I'm ready to continue the lesson</button>
-  </div>  
-</script>
+<div class="modal-footer">
+  <button class="btn btn-success" ng-click="okay()">I'm ready to continue the lesson</button>
+</div>  


### PR DESCRIPTION
This is in regard of #2700.

_form_builder_templates.html_ -> It is not used anywhere (I searched for the id "modals/editParamName" but it was not referenced anywhere.)

_feedback_popover_directive_ -> It is used in many places in HTML as well eg. [here](https://github.com/oppia/oppia/blob/develop/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html#L78) and [here](https://github.com/oppia/oppia/blob/develop/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html#L219)

take_break_model was also left -> done.

In pre_push_hook in karma tests, I am having this error
![image](https://cloud.githubusercontent.com/assets/9693472/26753954/e51d1910-488e-11e7-8beb-b87dc97c84af.png)

I can't think of any change that would cause this. @vojtechjelinek please take a look.

