### PR TITLE
Remove hybrid get_or_create_user() function.

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -184,8 +184,6 @@ class BaseHandler(webapp2.RequestHandler):
         self.user = current_user_services.get_current_user()
         self.user_id = current_user_services.get_user_id(
             self.user) if self.user else None
-        self.role = user_services.get_user_role_from_id(
-            self.user_id) if self.user else feconf.ROLE_GUEST
         self.username = None
         self.has_seen_editor_tutorial = False
         self.partially_logged_in = False

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -193,9 +193,13 @@ class BaseHandler(webapp2.RequestHandler):
         self.preferred_site_language_code = None
 
         if self.user_id:
-            email = current_user_services.get_user_email(self.user)
-            user_settings = user_services.get_or_create_user(
-                self.user_id, email, self.role)
+            user_settings = user_services.get_user_settings(
+                self.user_id, strict=False)
+            if user_settings is None:
+                email = current_user_services.get_user_email(self.user)
+                user_settings = user_services.create_new_user(
+                    self.user_id, email)
+
             self.values['user_email'] = user_settings.email
 
             if (self.REDIRECT_UNFINISHED_SIGNUPS and not

--- a/core/domain/collection_services_test.py
+++ b/core/domain/collection_services_test.py
@@ -55,12 +55,9 @@ class CollectionServicesUnitTests(test_utils.GenericTestBase):
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
         self.viewer_id = self.get_user_id_from_email(self.VIEWER_EMAIL)
 
-        user_services.get_or_create_user(
-            self.owner_id, self.OWNER_EMAIL, feconf.ROLE_COLLECTION_EDITOR)
-        user_services.get_or_create_user(
-            self.editor_id, self.EDITOR_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
-        user_services.get_or_create_user(
-            self.viewer_id, self.VIEWER_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(self.owner_id, self.OWNER_EMAIL)
+        user_services.create_new_user(self.editor_id, self.EDITOR_EMAIL)
+        user_services.create_new_user(self.viewer_id, self.VIEWER_EMAIL)
 
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -1805,8 +1805,7 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
         emails = ('user1@example.com', 'user2@example.com')
 
         for user_id, username, user_email in zip(user_ids, usernames, emails):
-            user_services.get_or_create_user(
-                user_id, user_email, feconf.ROLE_EXPLORATION_EDITOR)
+            user_services.create_new_user(user_id, user_email)
             user_services.set_username(user_id, username)
 
         # Both users can receive all emails in default setting.

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -67,12 +67,9 @@ class ExplorationServicesUnitTests(test_utils.GenericTestBase):
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
         self.viewer_id = self.get_user_id_from_email(self.VIEWER_EMAIL)
 
-        user_services.get_or_create_user(
-            self.owner_id, self.OWNER_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
-        user_services.get_or_create_user(
-            self.editor_id, self.EDITOR_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
-        user_services.get_or_create_user(
-            self.viewer_id, self.VIEWER_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(self.owner_id, self.OWNER_EMAIL)
+        user_services.create_new_user(self.editor_id, self.EDITOR_EMAIL)
+        user_services.create_new_user(self.viewer_id, self.VIEWER_EMAIL)
 
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
@@ -2817,10 +2814,8 @@ class SuggestionActionUnitTests(test_utils.GenericTestBase):
         super(SuggestionActionUnitTests, self).setUp()
         self.user_id = self.get_user_id_from_email(self.USER_EMAIL)
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
-        user_services.get_or_create_user(
-            self.user_id, self.USER_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
-        user_services.get_or_create_user(
-            self.editor_id, self.EDITOR_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(self.user_id, self.USER_EMAIL)
+        user_services.create_new_user(self.editor_id, self.EDITOR_EMAIL)
         self.signup(self.USER_EMAIL, self.USERNAME)
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
         with self.swap(feedback_models.FeedbackThreadModel,

--- a/core/domain/feedback_domain_test.py
+++ b/core/domain/feedback_domain_test.py
@@ -19,7 +19,6 @@ import datetime
 from core.domain import feedback_domain
 from core.domain import user_services
 from core.tests import test_utils
-import feconf
 import utils
 
 
@@ -32,8 +31,7 @@ class FeedbackThreadDomainUnitTests(test_utils.GenericTestBase):
         super(FeedbackThreadDomainUnitTests, self).setUp()
 
         self.viewer_id = self.get_user_id_from_email(self.VIEWER_EMAIL)
-        user_services.get_or_create_user(
-            self.viewer_id, self.VIEWER_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(self.viewer_id, self.VIEWER_EMAIL)
         self.signup(self.VIEWER_EMAIL, self.VIEWER_USERNAME)
 
     def test_to_dict(self):
@@ -78,8 +76,7 @@ class FeedbackMessageDomainUnitTests(test_utils.GenericTestBase):
     def setUp(self):
         super(FeedbackMessageDomainUnitTests, self).setUp()
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
-        user_services.get_or_create_user(
-            self.owner_id, self.OWNER_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(self.owner_id, self.OWNER_EMAIL)
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
 
     def test_to_dict(self):
@@ -123,8 +120,7 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
     def setUp(self):
         super(SuggestionDomainUnitTests, self).setUp()
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
-        user_services.get_or_create_user(
-            self.owner_id, self.OWNER_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(self.owner_id, self.OWNER_EMAIL)
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
 
     def test_to_dict(self):

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -97,8 +97,7 @@ class SuggestionQueriesUnitTests(test_utils.GenericTestBase):
         super(SuggestionQueriesUnitTests, self).setUp()
         # Register users.
         self.user_id = self.get_user_id_from_email(self.USER_EMAIL)
-        user_services.get_or_create_user(
-            self.user_id, self.USER_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(self.user_id, self.USER_EMAIL)
         self.signup(self.USER_EMAIL, self.USERNAME)
         # Open thread with suggestion.
         thread1 = feedback_models.FeedbackThreadModel(
@@ -231,8 +230,7 @@ class FeedbackThreadUnitTests(test_utils.GenericTestBase):
         super(FeedbackThreadUnitTests, self).setUp()
 
         self.viewer_id = self.get_user_id_from_email(self.VIEWER_EMAIL)
-        user_services.get_or_create_user(
-            self.viewer_id, self.VIEWER_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(self.viewer_id, self.VIEWER_EMAIL)
         self.signup(self.VIEWER_EMAIL, self.VIEWER_USERNAME)
 
     def _run_computation(self):

--- a/core/domain/recommendations_services_test.py
+++ b/core/domain/recommendations_services_test.py
@@ -238,8 +238,7 @@ class RecommendationsServicesUnitTests(test_utils.GenericTestBase):
         for name, user in self.USER_DATA.iteritems():
             user['id'] = self.get_user_id_from_email(
                 user['email'])
-            user_services.get_or_create_user(
-                user['id'], user['email'], feconf.ROLE_EXPLORATION_EDITOR)
+            user_services.create_new_user(user['id'], user['email'])
             self.signup(user['email'], name)
             self.USER_DATA[name]['id'] = user['id']
 
@@ -254,8 +253,7 @@ class RecommendationsServicesUnitTests(test_utils.GenericTestBase):
             rights_manager.publish_exploration(exp['owner_id'], exp_id)
 
         self.admin_id = self.get_user_id_from_email(self.ADMIN_EMAIL)
-        user_services.get_or_create_user(
-            self.admin_id, self.ADMIN_EMAIL, feconf.ROLE_ADMIN)
+        user_services.create_new_user(self.admin_id, self.ADMIN_EMAIL)
         self.signup(self.ADMIN_EMAIL, self.ADMIN_USERNAME)
         self.set_admins([self.ADMIN_USERNAME])
 

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -236,8 +236,7 @@ class RecordAnswerTests(test_utils.GenericTestBase):
     def setUp(self):
         super(RecordAnswerTests, self).setUp()
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
-        user_services.get_or_create_user(
-            self.owner_id, self.OWNER_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(self.owner_id, self.OWNER_EMAIL)
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
         self.exploration = self.save_new_valid_exploration(
             self.EXP_ID, self.owner_id, end_state_name='End')

--- a/core/domain/summary_services_test.py
+++ b/core/domain/summary_services_test.py
@@ -423,10 +423,8 @@ class CollectionLearnerDictTests(test_utils.GenericTestBase):
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
 
-        user_services.get_or_create_user(
-            self.owner_id, self.OWNER_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
-        user_services.get_or_create_user(
-            self.editor_id, self.EDITOR_EMAIL, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(self.owner_id, self.OWNER_EMAIL)
+        user_services.create_new_user(self.editor_id, self.EDITOR_EMAIL)
 
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -579,13 +579,12 @@ def has_fully_registered(user_id):
         feconf.REGISTRATION_PAGE_LAST_UPDATED_UTC)
 
 
-def _create_user(user_id, email, role):
+def create_new_user(user_id, email):
     """Creates a new user.
 
     Args:
         user_id: str. The user id.
         email: str. The user email.
-        role: str. The user role.
 
     Returns:
         UserSettings. The newly-created user settings domain object.
@@ -598,29 +597,10 @@ def _create_user(user_id, email, role):
         raise Exception('User %s already exists.' % user_id)
 
     user_settings = UserSettings(
-        user_id, email, role,
+        user_id, email, feconf.ROLE_EXPLORATION_EDITOR,
         preferred_language_codes=[feconf.DEFAULT_LANGUAGE_CODE])
     _save_user_settings(user_settings)
     create_user_contributions(user_id, [], [])
-    return user_settings
-
-
-def get_or_create_user(user_id, email, role):
-    """Returns a UserSettings domain object with given user_id and email.
-    If user does not exist, it creates a new one and returns the new
-    User model.
-
-    Args:
-        user_id: str. The user id.
-        email: str. The user email.
-        role: str. The user role.
-
-    Returns:
-        UserSettings. UserSettings domain object.
-    """
-    user_settings = get_user_settings(user_id, strict=False)
-    if user_settings is None:
-        user_settings = _create_user(user_id, email, role)
     return user_settings
 
 

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -40,8 +40,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(Exception, 'User not found.'):
             user_services.set_username(user_id, username)
 
-        user_services.get_or_create_user(
-            user_id, 'user@example.com', feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(user_id, 'user@example.com')
 
         user_services.set_username(user_id, username)
         self.assertEquals(username, user_services.get_username(user_id))
@@ -51,8 +50,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             user_services.get_username('fakeUser')
 
     def test_get_username_none(self):
-        user_services.get_or_create_user(
-            'fakeUser', 'user@example.com', feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user('fakeUser', 'user@example.com')
         self.assertEquals(None, user_services.get_username('fakeUser'))
 
     def test_is_username_taken_false(self):
@@ -61,23 +59,20 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
     def test_is_username_taken_true(self):
         user_id = 'someUser'
         username = 'newUsername'
-        user_services.get_or_create_user(
-            user_id, 'user@example.com', feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(user_id, 'user@example.com')
         user_services.set_username(user_id, username)
         self.assertTrue(user_services.is_username_taken(username))
 
     def test_is_username_taken_different_case(self):
         user_id = 'someUser'
         username = 'camelCase'
-        user_services.get_or_create_user(
-            user_id, 'user@example.com', feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(user_id, 'user@example.com')
         user_services.set_username(user_id, username)
         self.assertTrue(user_services.is_username_taken('CaMeLcAsE'))
 
     def test_set_invalid_usernames(self):
         user_id = 'someUser'
-        user_services.get_or_create_user(
-            user_id, 'user@example.com', feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(user_id, 'user@example.com')
         bad_usernames = [
             ' bob ', '@', '', 'a' * 100, 'ADMIN', 'admin', 'AdMiN2020']
         for username in bad_usernames:
@@ -88,13 +83,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         bad_email_addresses = ['@', '@@', 'abc', '', None, ['a', '@', 'b.com']]
         for email in bad_email_addresses:
             with self.assertRaises(utils.ValidationError):
-                user_services.get_or_create_user(
-                    'user_id', email, feconf.ROLE_EXPLORATION_EDITOR)
-
-    def test_invalid_roles(self):
-        with self.assertRaises(utils.ValidationError):
-            user_services.get_or_create_user(
-                'test_id', 'test@example.com', 'THIS_ROLE_DOES_NOT_EXIST')
+                user_services.create_new_user('user_id', email)
 
     def test_email_truncation(self):
         email_addresses = [
@@ -105,8 +94,8 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
             ('abcdefgh@efg.h', 'abcde..@efg.h'),
         ]
         for ind, (actual_email, expected_email) in enumerate(email_addresses):
-            user_settings = user_services.get_or_create_user(
-                str(ind), actual_email, feconf.ROLE_EXPLORATION_EDITOR)
+            user_settings = user_services.create_new_user(
+                str(ind), actual_email)
             self.assertEqual(user_settings.truncated_email, expected_email)
 
     def test_get_email_from_username(self):
@@ -114,8 +103,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         username = 'username'
         user_email = 'user@example.com'
 
-        user_services.get_or_create_user(
-            user_id, user_email, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(user_id, user_email)
         user_services.set_username(user_id, username)
         self.assertEquals(user_services.get_username(user_id), username)
 
@@ -136,8 +124,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         username = 'username'
         user_email = 'user@example.com'
 
-        user_services.get_or_create_user(
-            user_id, user_email, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(user_id, user_email)
         user_services.set_username(user_id, username)
         self.assertEquals(user_services.get_username(user_id), username)
 
@@ -224,8 +211,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         username = 'username'
         user_email = 'user@example.com'
 
-        user_services.get_or_create_user(
-            user_id, user_email, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(user_id, user_email)
         user_services.set_username(user_id, username)
 
         # When UserEmailPreferencesModel is yet to be created,
@@ -273,8 +259,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         username = 'username'
         user_email = 'user@example.com'
 
-        user_services.get_or_create_user(
-            user_id, user_email, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(user_id, user_email)
         user_services.set_username(user_id, username)
 
         # When ExplorationUserDataModel is yet to be created, the value
@@ -336,8 +321,7 @@ class UserServicesUnitTests(test_utils.GenericTestBase):
         user_name = 'testname'
         user_email = 'test@email.com'
 
-        user_services.get_or_create_user(
-            user_id, user_email, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(user_id, user_email)
         user_services.set_username(user_id, user_name)
 
         self.assertEqual(user_services.get_user_role_from_id(user_id),
@@ -751,8 +735,7 @@ class SubjectInterestsUnitTests(test_utils.GenericTestBase):
         self.username = 'username'
         self.user_email = 'user@example.com'
 
-        user_services.get_or_create_user(
-            self.user_id, self.user_email, feconf.ROLE_EXPLORATION_EDITOR)
+        user_services.create_new_user(self.user_id, self.user_email)
         user_services.set_username(self.user_id, self.username)
 
     def test_invalid_subject_interests_are_not_accepted(self):


### PR DESCRIPTION
This fixes an error/omission I had made when reviewing #3493. In that PR, I suggested that `role` should not have a default value when the UserSettings constructor is called. That is correct, but propagating `role` throughout the codebase is a code smell and it also violates the semantics of get_or_create_user() -- when getting a user, one shouldn't be able to specify a role, and it's unclear why callers would need to specify it when creating, too.

@wxyxinyu and I discussed this and came to the following recommendations:
- We should split get_or_create_user() into its individual constituents. The different parts need different arguments.
- The 'role' parameter should not be propagated throughout the codebase, but instead should be introduced in the create_new_user() function.

This PR addresses the above. PTAL @1995YogeshSharma @wxyxinyu 