### PR TITLE
Fix a couple of UI issues in the collection editor.

### DIFF
--- a/core/templates/dev/head/pages/collection_editor/editor_tab/CollectionNodeCreatorDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/editor_tab/CollectionNodeCreatorDirective.js
@@ -57,7 +57,7 @@ oppia.directive('collectionNodeCreator', [
                 explorationMetadataBackendDict.collection_node_metadata_list.
                   map(function(item) {
                     if (!$scope.collection.containsCollectionNode(item.id)) {
-                      options.push('(#' + item.id + ') ' + item.title);
+                      options.push(item.title + ' (#' + item.id + ')');
                     }
                   });
                 return options;
@@ -115,7 +115,7 @@ oppia.directive('collectionNodeCreator', [
           };
 
           var convertTypeaheadToExplorationId = function(typeaheadOption) {
-            var matchResults = typeaheadOption.match(/\(#(.*?)\)/);
+            var matchResults = typeaheadOption.match(/\(#(.*?)\)$/);
             if (matchResults == null) {
               return typeaheadOption;
             }
@@ -143,6 +143,16 @@ oppia.directive('collectionNodeCreator', [
                   newExplorationId);
               addExplorationToCollection(newExplorationId);
             });
+          };
+
+          // Checks whether the user has left a '#' at the end of their ID
+          // by accident (which can happen if it's being copy/pasted from the
+          // editor page.
+          $scope.isMalformedId = function(typedExplorationId) {
+            return (
+              typedExplorationId &&
+              typedExplorationId.lastIndexOf('#') ===
+              typedExplorationId.length - 1);
           };
 
           $scope.addExploration = function() {

--- a/core/templates/dev/head/pages/collection_editor/editor_tab/collection_node_creator_directive.html
+++ b/core/templates/dev/head/pages/collection_editor/editor_tab/collection_node_creator_directive.html
@@ -7,4 +7,7 @@ or
 <form class="form-inline" ng-class="{'has-error': searchQueryHasError}" ng-submit="addExploration()">
   <input class="form-control protractor-test-add-exploration-input" style="width: 430px" ng-model="newExplorationId" type="text" placeholder="Enter exploration id to be added, or search explorations by name" typeahead="exploration for exploration in fetchTypeaheadResults($viewValue)" ng-model-options="{ debounce: 300 }">
   <button class="btn btn-success protractor-test-add-exploration-button" type="submit" ng-disabled="!newExplorationId">Add Existing Exploration</button>
+  <span class="help-block" style="font-size: smaller" ng-if="isMalformedId(newExplorationId)">
+    <em>IDs should not end with '#'.</em>
+  </span>
 </form>

--- a/core/templates/dev/head/pages/collection_editor/editor_tab/collection_node_creator_directive.html
+++ b/core/templates/dev/head/pages/collection_editor/editor_tab/collection_node_creator_directive.html
@@ -8,6 +8,6 @@ or
   <input class="form-control protractor-test-add-exploration-input" style="width: 430px" ng-model="newExplorationId" type="text" placeholder="Enter exploration id to be added, or search explorations by name" typeahead="exploration for exploration in fetchTypeaheadResults($viewValue)" ng-model-options="{ debounce: 300 }">
   <button class="btn btn-success protractor-test-add-exploration-button" type="submit" ng-disabled="!newExplorationId">Add Existing Exploration</button>
   <span class="help-block" style="font-size: smaller" ng-if="isMalformedId(newExplorationId)">
-    <em>IDs should not end with '#'.</em>
+    <em>The trailing '#' is not part of the ID.</em>
   </span>
 </form>


### PR DESCRIPTION
(NB: This is a release fix, but is being made into develop per @wxyxinyu's instructions for the new release process.)

During release testing, @jacobdavis11 reported the following:
- The collection editor does not explain what an "exploration id" is. It would be nice if it accepted ids with a trailing #, since it's not obvious from the url that that is not part of the id.
- In the collection editor, when searching for explorations by name it would be more user friendly to show the results as "name (id)" rather than "(id) name" since the name is the main thing the user is interested in.

This PR makes the following changes:
- Shows an error message explaining that IDs should not end with a '#', if there is a trailing '#' in the field. (I think this is better than just accepting entries with trailing '#'s since we are also teaching the user what an exploration ID is in the process.)
- Switches the order to "name (id)".

PTAL. This needs to be merged before Sunday.