### PR TITLE
Remove warning sign in interaction save button; make some warnings more user-friendly.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
@@ -328,7 +328,7 @@ oppia.controller('StateInteraction', [
                 } else if (warningMessages.length === 1) {
                   return warningMessages[0];
                 } else {
-                  return '• ' + warningMessages.join('\n• ');
+                  return warningMessages.join(' ');
                 }
               }
 

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
@@ -325,12 +325,10 @@ oppia.controller('StateInteraction', [
                   } else {
                     return '';
                   }
-                } else if (warningMessages.length === 1) {
-                  return warningMessages[0];
                 } else {
                   return warningMessages.join(' ');
                 }
-              }
+              };
 
               $scope.save = function() {
                 editorFirstTimeEventsService

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_interaction.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_interaction.html
@@ -84,13 +84,13 @@
     <button class="btn btn-default" ng-click="cancel()" ng-if="hasCustomizationArgs">Cancel</button>
     <div class="btn-group"
          ng-if="hasCustomizationArgs"
-         title="<[getSaveInteractionButtonTooltip()]>">
+         popover-append-to-body
+         popover-placement="bottom"
+         popover-trigger="<[isSaveInteractionButtonEnabled() ? 'none' : 'mouseenter']>"
+         ng-attr-popover="<[getSaveInteractionButtonTooltip()]>">
       <button class="btn btn-success protractor-test-save-interaction"
               ng-click="save()"
               ng-disabled="!isSaveInteractionButtonEnabled()">
-        <i class="material-icons"
-           style="margin-right: 2px; font-size: 22px;"
-           ng-if="!isSaveInteractionButtonEnabled()">&#xE002;</i>
         Save Interaction
       </button>
     </div>

--- a/extensions/interactions/ImageClickInput/ImageClickInputValidationService.js
+++ b/extensions/interactions/ImageClickInput/ImageClickInputValidationService.js
@@ -32,6 +32,9 @@ oppia.factory('ImageClickInputValidationService', [
             type: WARNING_TYPES.CRITICAL,
             message: 'Please add an image for the learner to click on.'
           });
+          // If there is no image specified, further warnings don't really
+          // apply.
+          return warningsList;
         }
 
         var areAnyRegionStringsEmpty = false;
@@ -40,7 +43,7 @@ oppia.factory('ImageClickInputValidationService', [
         if (imgAndRegionArgValue.labeledRegions.length == 0) {
           warningsList.push({
             type: WARNING_TYPES.ERROR,
-            message: 'Please specify at least one image region to click on.'
+            message: 'Please specify at least one region in the image.'
           });
         }
 
@@ -55,8 +58,7 @@ oppia.factory('ImageClickInputValidationService', [
             warningsList.push({
               type: WARNING_TYPES.CRITICAL,
               message: (
-                'The image region strings should consist of characters from ' +
-                '[A-Za-z0-9].')
+                'The region labels should consist of alphanumeric characters.')
             });
           } else if (seenRegionStrings.indexOf(regionLabel) !== -1) {
             areAnyRegionStringsDuplicated = true;
@@ -68,13 +70,13 @@ oppia.factory('ImageClickInputValidationService', [
         if (areAnyRegionStringsEmpty) {
           warningsList.push({
             type: WARNING_TYPES.CRITICAL,
-            message: 'Please ensure the image region strings are nonempty.'
+            message: 'Please ensure the region labels are nonempty.'
           });
         }
         if (areAnyRegionStringsDuplicated) {
           warningsList.push({
             type: WARNING_TYPES.CRITICAL,
-            message: 'Please ensure the image region strings are unique.'
+            message: 'Please ensure the region labels are unique.'
           });
         }
         return warningsList;

--- a/extensions/interactions/ImageClickInput/ImageClickInputValidationServiceSpec.js
+++ b/extensions/interactions/ImageClickInput/ImageClickInputValidationServiceSpec.js
@@ -99,7 +99,7 @@ describe('ImageClickInputValidationService', function() {
         goodDefaultOutcome);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.CRITICAL,
-        message: 'Please ensure the image region strings are nonempty.'
+        message: 'Please ensure the region labels are nonempty.'
       }]);
 
       regions[0].label = 'SecondLabel';
@@ -108,7 +108,7 @@ describe('ImageClickInputValidationService', function() {
         goodDefaultOutcome);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.CRITICAL,
-        message: 'Please ensure the image region strings are unique.'
+        message: 'Please ensure the region labels are unique.'
       }]);
 
       regions[0].label = '@';
@@ -117,8 +117,7 @@ describe('ImageClickInputValidationService', function() {
         goodDefaultOutcome);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.CRITICAL,
-        message: 'The image region strings should consist of characters ' +
-          'from [A-Za-z0-9].'
+        message: 'The region labels should consist of alphanumeric characters.'
       }]);
 
       customizationArguments.imageAndRegions.value.labeledRegions = [];
@@ -128,7 +127,7 @@ describe('ImageClickInputValidationService', function() {
         goodDefaultOutcome);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
-        message: 'Please specify at least one image region to click on.'
+        message: 'Please specify at least one region in the image.'
       }]);
     });
 


### PR DESCRIPTION
This is a release fix and needs to go in before Sunday.

Note that the current tooltip only displays after a brief delay, so I used a popover instead, which shows up faster (and looks better IMO). I can't seem to put HTML in the popover though (probably for good reason), so I removed the bullet points from the warning message. I also tidied up some of the existing warning messages to remove jargon and make them more user-friendly.

/cc @juansaba 