### PR TITLE
Feedback button at the bottom appears as soon as the one in the top dissapears.

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -837,7 +837,7 @@ oppia.factory('windowDimensionsService', ['$window', function($window) {
     isExplorationPlayerNavHidden: function() {
       // NOTE TO DEVELOPERS: This value should be updated in oppia.css if
       // changed.
-      var EXPLORATION_PLAYER_NAV_CUTOFF_WIDTH_PX = 651;
+      var EXPLORATION_PLAYER_NAV_CUTOFF_WIDTH_PX = 768;
       return this.getWidth() < EXPLORATION_PLAYER_NAV_CUTOFF_WIDTH_PX;
     }
   };


### PR DESCRIPTION
As @jacobdavis11 pointed out, if we reduce the screen width gradually, the feedback button in the navbar disappears sometime before the feedback button at the bottom appears. This issue is fixed.