### PR TITLE
Fix  #3537: Handles empty feedbacks for fallback outcomes

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -347,7 +347,8 @@ class FallbackOneOffJob(jobs.BaseMapReduceJobManager):
         if exp_rights.status == rights_manager.ACTIVITY_STATUS_PUBLIC:
             for state_name, state in exploration.states.iteritems():
                 for fallback in state.interaction.fallbacks:
-                    num_submits = fallback.trigger.customization_args['num_submits']
+                    num_submits = (
+                        fallback.trigger.customization_args['num_submits'])
                     feedback = (
                         fallback.outcome.feedback[0]
                         if len(fallback.outcome.feedback) > 0 else 'ERROR')

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -343,17 +343,22 @@ class FallbackOneOffJob(jobs.BaseMapReduceJobManager):
             return
 
         exploration = exp_services.get_exploration_from_model(item)
-        for state_name, state in exploration.states.iteritems():
-            for fallback in state.interaction.fallbacks:
-                num_submits = fallback.trigger.customization_args['num_submits']
-                feedback = fallback.outcome.feedback[0]
-                yield (
-                    '%s: %s' % (
-                        item.id,
-                        state_name.encode('utf-8')),
-                    '%s: %s' % (
-                        num_submits['value'],
-                        feedback.encode('utf-8')))
+        exp_rights = rights_manager.get_exploration_rights(item.id)
+
+        if exp_rights.status == rights_manager.ACTIVITY_STATUS_PUBLIC:
+            for state_name, state in exploration.states.iteritems():
+                for fallback in state.interaction.fallbacks:
+                    num_submits = fallback.trigger.customization_args['num_submits']
+                    feedback = (
+                        fallback.outcome.feedback[0]
+                        if len(fallback.outcome.feedback) > 0 else '')
+                    yield (
+                        '%s: %s' % (
+                            item.id,
+                            state_name.encode('utf-8')),
+                        '%s: %s' % (
+                            num_submits['value'],
+                            feedback.encode('utf-8')))
 
     @staticmethod
     def reduce(key, values):

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -344,7 +344,6 @@ class FallbackOneOffJob(jobs.BaseMapReduceJobManager):
 
         exploration = exp_services.get_exploration_from_model(item)
         exp_rights = rights_manager.get_exploration_rights(item.id)
-
         if exp_rights.status == rights_manager.ACTIVITY_STATUS_PUBLIC:
             for state_name, state in exploration.states.iteritems():
                 for fallback in state.interaction.fallbacks:

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -350,7 +350,7 @@ class FallbackOneOffJob(jobs.BaseMapReduceJobManager):
                     num_submits = fallback.trigger.customization_args['num_submits']
                     feedback = (
                         fallback.outcome.feedback[0]
-                        if len(fallback.outcome.feedback) > 0 else '')
+                        if len(fallback.outcome.feedback) > 0 else 'ERROR')
                     yield (
                         '%s: %s' % (
                             item.id,


### PR DESCRIPTION
This PR handles the case in production where fallback outcomes have empty feedback entries.