### PR TITLE
Fix bugs related to feedback button visibility.

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -833,12 +833,6 @@ oppia.factory('windowDimensionsService', ['$window', function($window) {
     isWindowNarrow: function() {
       var NORMAL_NAVBAR_CUTOFF_WIDTH_PX = 768;
       return this.getWidth() <= NORMAL_NAVBAR_CUTOFF_WIDTH_PX;
-    },
-    isExplorationPlayerNavHidden: function() {
-      // NOTE TO DEVELOPERS: This value should be updated in oppia.css if
-      // changed.
-      var EXPLORATION_PLAYER_NAV_CUTOFF_WIDTH_PX = 768;
-      return this.getWidth() < EXPLORATION_PLAYER_NAV_CUTOFF_WIDTH_PX;
     }
   };
 }]);

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1181,14 +1181,6 @@ textarea {
   }
 }
 
-/* NOTE TO DEVELOPERS: This value should be updated in
-   windowDimensionsService if changed.
- */
-@media(max-width: 768px) {
-  .navbar-nav.oppia-navbar-nav > li > a {
-    display: none;
-  }
-}
 @media(max-width: 600px) {
   .oppia-navbar-breadcrumb {
     margin-top: 3px;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1184,7 +1184,7 @@ textarea {
 /* NOTE TO DEVELOPERS: This value should be updated in
    windowDimensionsService if changed.
  */
-@media(max-width: 651px) {
+@media(max-width: 768px) {
   .navbar-nav.oppia-navbar-nav > li > a {
     display: none;
   }

--- a/core/templates/dev/head/pages/exploration_player/ExplorationFooterDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ExplorationFooterDirective.js
@@ -44,10 +44,10 @@ oppia.directive('explorationFooter', [
           };
 
           $scope.mobileFeedbackIsShown =
-            windowDimensionsService.isExplorationPlayerNavHidden();
+            windowDimensionsService.isWindowNarrow();
           windowDimensionsService.registerOnResizeHook(function() {
             $scope.mobileFeedbackIsShown =
-              windowDimensionsService.isExplorationPlayerNavHidden();
+              windowDimensionsService.isWindowNarrow();
             $scope.$apply();
           });
           

--- a/core/templates/dev/head/pages/exploration_player/FeedbackPopupDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/FeedbackPopupDirective.js
@@ -49,7 +49,7 @@ oppia.directive('feedbackPopup', [
           $scope.feedbackPopoverId = (
             'feedbackPopover' + Math.random().toString(36).slice(2));
 
-          if (windowDimensionsService.isExplorationPlayerNavHidden()) {
+          if (windowDimensionsService.isWindowNarrow()) {
             BackgroundMaskService.activateMask();
           }
 


### PR DESCRIPTION
As mentioned by @Oishikatta, these two bugs have been fixed - 

- The media query in oppia.css should be removed or updated to match (i.e. change 651px to 767px there as well). Since 768px is the default bootstrap collapse value, the learner nav inherits the display:none from .collapse - meaning the media query can be removed if we're keeping the navbar collapse at that width.

- The isExplorationPlayerNavHidden function can also be removed and usages replaced with isWindowNarrow if we're keeping the 768px collapse.