### PR TITLE
Allow list type schema value to be empty

### DIFF
--- a/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
+++ b/core/templates/dev/head/components/forms/schema_editors/schema_based_list_editor_directive.html
@@ -25,7 +25,7 @@
                            on-input-focus="($last ? hideAddItemButton : showAddItemButton)">
       </schema-based-editor>
     </td>
-    <td ng-if="!len && (!minListLength || localValue.length > minListLength) && localValue.length > 1" style="vertical-align: top;">
+    <td ng-if="!len && (!minListLength || localValue.length > minListLength) && localValue.length > 0" style="vertical-align: top;">
       <button class="oppia-delete-list-entry-button oppia-transition-200 protractor-test-delete-list-entry" type="button"
               ng-click="deleteElement($index)"
               ng-disabled="isDisabled()">


### PR DESCRIPTION
List type schema editor enforced that list should have at least one element present in it. This PR modifies condition for 'X' button so that lists can be empty.