### PR TITLE
Fix a bug in the LogicProof interaction.

### DIFF
--- a/extensions/interactions/LogicProof/LogicProof.js
+++ b/extensions/interactions/LogicProof/LogicProof.js
@@ -51,22 +51,25 @@ oppia.directive('oppiaInteractiveLogicProof', [
             ['variable', 'constant', 'prefix_function']
           );
 
-          var operators = $scope.typing[0].operators;
+          $scope.questionData.language.operators = $scope.typing[0].operators;
 
           if ($scope.questionData.assumptions.length <= 1) {
             $scope.assumptionsString = logicProofShared.displayExpressionArray(
-              $scope.questionData.assumptions, operators);
+              $scope.questionData.assumptions,
+              $scope.questionData.language.operators);
           } else {
             $scope.assumptionsString = logicProofShared.displayExpressionArray(
               $scope.questionData.assumptions.slice(
                 0, $scope.questionData.assumptions.length - 1
-              ), operators
+              ), $scope.questionData.language.operators
             ) + ' and ' + logicProofShared.displayExpression(
               $scope.questionData.assumptions[
-                $scope.questionData.assumptions.length - 1], operators);
+                $scope.questionData.assumptions.length - 1],
+                $scope.questionData.language.operators);
           }
           $scope.targetString = logicProofShared.displayExpression(
-            $scope.questionData.results[0], operators);
+            $scope.questionData.results[0],
+            $scope.questionData.language.operators);
           $scope.questionString = (
             $scope.assumptionsString === '' ?
             'I18N_INTERACTIONS_LOGIC_PROOF_QUESTION_STR_NO_ASSUMPTION' :


### PR DESCRIPTION
Previously operators were not being included in the student language, causing operators like 'A(x)' to be rejected even if they occur in the question.