### PR TITLE
Fix #3502: Extract components from HTML string

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -80,6 +80,7 @@ THIRD_PARTY_LIBS = [
     os.path.join(ROOT_PATH, 'third_party', 'graphy-1.0.0'),
     os.path.join(ROOT_PATH, 'third_party', 'requests-2.10.0'),
     os.path.join(ROOT_PATH, 'third_party', 'simplejson-3.7.1'),
+    os.path.join(ROOT_PATH, 'third_party', 'beautifulsoup4-4.6.0'),
 ]
 
 # In the GAE production environment, numpy is automatically provided, and

--- a/core/domain/html_cleaner.py
+++ b/core/domain/html_cleaner.py
@@ -16,14 +16,14 @@
 
 """HTML sanitizing service."""
 
+import HTMLParser
+import json
 import logging
 import urlparse
-from HTMLParser import HTMLParser
-import json
 
 import bleach
+import bs4
 
-from bs4 import BeautifulSoup
 from core.domain import rte_component_registry
 
 
@@ -124,17 +124,17 @@ def get_rte_components(html_string):
         - id: str. The name of the component, i.e. 'oppia-noninteractive-link'.
         - customization_args: dict. Customization arg specs for the component.
     """
-    parser = HTMLParser()
+    parser = HTMLParser.HTMLParser()
     components = []
-    soup = BeautifulSoup(html_string, 'html.parser')
-    oppia_custom_tags = (
+    soup = bs4.BeautifulSoup(html_string, 'html.parser')
+    oppia_custom_tag_attrs = (
         rte_component_registry.Registry.get_tag_list_with_attrs())
-    for tag_name in oppia_custom_tags:
+    for tag_name in oppia_custom_tag_attrs:
         component_tags = soup.find_all(tag_name)
         for component_tag in component_tags:
             component = {'id': tag_name}
             customization_args = {}
-            for attr in oppia_custom_tags[tag_name]:
+            for attr in oppia_custom_tag_attrs[tag_name]:
                 # Unescape special HTML characters such as '&quot;'
                 attr_val = parser.unescape(component_tag[attr])
                 # Adds escapes so that things like '\frac' aren't

--- a/core/domain/html_cleaner.py
+++ b/core/domain/html_cleaner.py
@@ -21,6 +21,7 @@ import urlparse
 
 import bleach
 
+from bs4 import BeautifulSoup
 from core.domain import rte_component_registry
 
 
@@ -107,3 +108,29 @@ def strip_html_tags(html):
         stripped out.
     """
     return bleach.clean(html, tags=[], attributes={}, strip=True)
+
+
+def get_rte_components(html_string):
+    """Extracts the RTE components from an HTML string.
+
+    Args:
+        html: str. An HTML string.
+
+    Returns:
+        list. A list of dictionaries, each representing an RTE component.
+        Each dict contains component 'id' and 'customization_args'.
+    """
+    components = []
+    soup = BeautifulSoup(html_string, 'html.parser')
+    oppia_custom_tags = (
+        rte_component_registry.Registry.get_tag_list_with_attrs())
+    for tag_name in oppia_custom_tags:
+        component_tags = soup.find_all(tag_name)
+        for component_tag in component_tags:
+            component = {'id': tag_name}
+            customization_args = {}
+            for attr in oppia_custom_tags[tag_name]:
+                customization_args[attr] = component_tag[attr]
+            component['customization_args'] = customization_args
+            components.append(component)
+    return components

--- a/core/domain/html_cleaner_test.py
+++ b/core/domain/html_cleaner_test.py
@@ -126,3 +126,57 @@ class HtmlStripperUnitTests(test_utils.GenericTestBase):
 
         for datum in test_data:
             self.assertEqual(html_cleaner.strip_html_tags(datum[0]), datum[1])
+
+
+class RteComponentExtractorUnitTests(test_utils.GenericTestBase):
+    '''Test the RTE component extractor.'''
+
+    def test_get_rte_components(self):
+        test_data = (
+            '<p>Test text&nbsp;'
+            '<oppia-noninteractive-math '
+            'raw_latex-with-value="&amp;quot;\\frac{x}{y}&amp;quot;">'
+            '</oppia-noninteractive-math></p><p>&nbsp;'
+            '<oppia-noninteractive-link '
+            'text-with-value="&amp;quot;Link&amp;quot;" '
+            'url-with-value="&amp;quot;https://www.example.com&amp;quot;">'
+            '</oppia-noninteractive-link>.</p>'
+            '<p>Video</p>'
+            '<p><oppia-noninteractive-video autoplay-with-value="false" '
+            'end-with-value="0" start-with-value="0" '
+            'video_id-with-value="&amp;quot;'
+            'https://www.youtube.com/watch?v=Ntcw0H0hwPU&amp;quot;">'
+            '</oppia-noninteractive-video><br></p>'
+        )
+
+        expected_components = [
+            {
+                'customization_args': {
+                    'text-with-value': u'&quot;Link&quot;',
+                    'url-with-value': u'&quot;https://www.example.com&quot;'},
+                'id': 'oppia-noninteractive-link'
+            },
+            {
+                'customization_args': {
+                    'start-with-value': u'0',
+                    'end-with-value': u'0',
+                    'video_id-with-value': (
+                        u'&quot;https://www.youtube.com/watch?'
+                        u'v=Ntcw0H0hwPU&quot;'),
+                    'autoplay-with-value': u'false'
+                },
+                'id': 'oppia-noninteractive-video'
+            },
+            {
+                'customization_args': {
+                    'raw_latex-with-value': u'&quot;\\frac{x}{y}&quot;'
+                },
+                'id': 'oppia-noninteractive-math'
+            }
+        ]
+
+        components = html_cleaner.get_rte_components(test_data)
+
+        self.assertEqual(len(components), len(expected_components))
+        for component in components:
+            self.assertIn(component, expected_components)

--- a/core/domain/html_cleaner_test.py
+++ b/core/domain/html_cleaner_test.py
@@ -152,24 +152,24 @@ class RteComponentExtractorUnitTests(test_utils.GenericTestBase):
         expected_components = [
             {
                 'customization_args': {
-                    'text-with-value': u'&quot;Link&quot;',
-                    'url-with-value': u'&quot;https://www.example.com&quot;'},
+                    'text-with-value': u'Link',
+                    'url-with-value': u'https://www.example.com'},
                 'id': 'oppia-noninteractive-link'
             },
             {
                 'customization_args': {
-                    'start-with-value': u'0',
-                    'end-with-value': u'0',
+                    'start-with-value': 0,
+                    'end-with-value': 0,
                     'video_id-with-value': (
-                        u'&quot;https://www.youtube.com/watch?'
-                        u'v=Ntcw0H0hwPU&quot;'),
-                    'autoplay-with-value': u'false'
+                        u'https://www.youtube.com/watch?'
+                        u'v=Ntcw0H0hwPU'),
+                    'autoplay-with-value': False
                 },
                 'id': 'oppia-noninteractive-video'
             },
             {
                 'customization_args': {
-                    'raw_latex-with-value': u'&quot;\\frac{x}{y}&quot;'
+                    'raw_latex-with-value': u'\\frac{x}{y}'
                 },
                 'id': 'oppia-noninteractive-math'
             }

--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -55,6 +55,7 @@ DIRS_TO_ADD_TO_SYS_PATH = [
     os.path.join(THIRD_PARTY_DIR, 'html5lib-python-0.95'),
     os.path.join(THIRD_PARTY_DIR, 'requests-2.10.0'),
     os.path.join(THIRD_PARTY_DIR, 'simplejson-3.7.1'),
+    os.path.join(THIRD_PARTY_DIR, 'beautifulsoup4-4.6.0'),
 ]
 
 _PARSER = argparse.ArgumentParser()

--- a/manifest.json
+++ b/manifest.json
@@ -62,6 +62,14 @@
         "tarRootDirPrefix": "simplejson-",
         "rootDirPrefix": "simplejson-",
         "targetDirPrefix": "simplejson-"
+      },
+      "beautifulSoup": {
+        "version": "4.6.0",
+        "downloadFormat": "tar",
+        "url": "https://pypi.python.org/packages/fa/8d/1d14391fdaed5abada4e0f63543fef49b8331a34ca60c88bd521bcf7f782/beautifulsoup4-4.6.0.tar.gz#md5=c17714d0f91a23b708a592cb3c697728",
+        "tarRootDirPrefix": "beautifulsoup4-",
+        "rootDirPrefix": "beautifulsoup4-",
+        "targetDirPrefix": "beautifulsoup4-"
       }
     },
     "frontend": {

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -157,6 +157,7 @@ _PATHS_TO_INSERT = [
     os.path.join(_PARENT_DIR, 'oppia_tools', 'selenium-2.53.2'),
     os.path.join('third_party', 'gae-pipeline-1.9.17.0'),
     os.path.join('third_party', 'bleach-1.2.2'),
+    os.path.join('third_party', 'beautifulsoup4-4.6.0'),
     os.path.join('third_party', 'gae-mapreduce-1.9.17.0'),
 ]
 for path in _PATHS_TO_INSERT:


### PR DESCRIPTION
Per #3502, implement `get_rte_components` in `html_cleaner.py` which extracts the rte components from an html string.

Adds BeautifulSoup4 as a dependency.