### PR TITLE
[NOT FOR MERGE] Fix #3467: Introducing re-training function and add_to_training_queue function

### DIFF
--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -127,6 +127,113 @@ def classify_string_classifier_rule(state, normalized_answer):
     return None
 
 
+def add_to_trainining_queue(exploration):
+    """Checks all states of the exploration for re-training conditions and
+    creates ClassifierTrainingJob instances accordingly.
+
+    Args:
+        exploration: Domain object for an exploration.
+
+    Returns:
+        exploration: Domain object for an exploration.
+    """
+    states = exploration.states
+    for state_name in states:
+        state = states[state_name]
+        if state.can_undergo_classification():
+            if state.classifier_model_id is None:
+                training_data = get_training_data_from_state(state)
+                algorithm_id = state.interaction.id
+                exp_id = exploration.id
+                exp_version = exploration.version
+                job_id = save_classifier_training_job(
+                    algorithm_id, exp_id, exp_version, state_name,
+                    training_data)
+                exploration.states[state_name].classifier_model_id = (
+                    job_id)
+            else:
+                classifier_training_job = get_classifier_training_job_by_id(
+                    state.classifier_model_id)
+                if _check_re_training_conditions(state,
+                                                 classifier_training_job):
+                    training_data = get_training_data_from_state(state)
+                    algorithm_id = state.interaction.id
+                    exp_id = exploration.id
+                    exp_version = exploration.version
+                    job_id = save_classifier_training_job(
+                        algorithm_id, exp_id, exp_version, state_name,
+                        training_data)
+                    exploration.states[state_name].classifier_model_id = (
+                        job_id)
+    return exploration
+
+
+def _check_re_training_conditions(state, classifier_training_job):
+    """Checks whether the classifier needs to be trained again.
+
+    Args:
+        state: The current State domain object of the exploration.
+        classifier_training_job: The retrieved ClassifierTrainingJob Domain
+            object.
+
+    Returns: bool. True/False
+    """
+    new_training_data = get_training_data_from_state(state)
+    old_training_data = classifier_training_job.training_data
+
+    # Check for addition/deletion of answer groups.
+    if len(old_training_data) != len(new_training_data):
+        # Check for outcome mismatch.
+        if len(new_training_data) > len(old_training_data):
+            flag = True
+            for (answer_group_index, answer_group) in enumerate(
+                    old_training_data):
+                if answer_group['answer_group_index'] != new_training_data[
+                        answer_group_index]['answer_group_index']:
+                    flag = False
+            if flag:
+                delete_classifier_training_job(state.classifier_model_id)
+                return True
+        return True
+    # Check for change in number of training samples.
+    else:
+        diff = 0
+        for (answer_group_index, answer_group) in enumerate(
+                old_training_data):
+            diff += abs(len(answer_group['answers']) - len(
+                new_training_data[answer_group_index]['answers']))
+        if diff > feconf.MIN_SAMPLE_TO_RETRAIN:
+            return True
+
+        # No re-training condition satisfied.
+        return False
+
+
+def get_training_data_from_state(state):
+    """Retrieves training data from the State domain object.
+
+    Args:
+        state: Domain object for a state.
+
+    Returns:
+        training_data: list. The training data for the job.
+    """
+    training_data = []
+    for (answer_group_index, answer_group) in enumerate(
+            state.interaction.answer_groups):
+        classifier_rule_spec_index = (
+            answer_group.get_classifier_rule_index())
+        if classifier_rule_spec_index is not None:
+            classifier_rule_spec = answer_group.rule_specs[
+                classifier_rule_spec_index]
+            training_data.extend([{
+                'answer_group_index': answer_group_index,
+                'answers': ([doc] for doc in classifier_rule_spec.inputs[
+                    'training_data'])
+            }])
+    return training_data
+
+
 def get_classifier_from_model(classifier_data_model):
     """Gets a classifier domain object from a classifier data model.
 
@@ -306,7 +413,7 @@ def _update_classifier_training_job(classifier_training_job_model, status):
 
 
 def save_classifier_training_job(algorithm_id, exp_id, exp_version,
-                                 state_name, status, training_data,
+                                 state_name, training_data, status="None",
                                  job_id="None"):
     """Checks for the existence of the model.
     If the model exists, it is updated using _update_classifier_training_job

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -185,12 +185,12 @@ def _check_re_training_conditions(state, classifier_training_job):
     if len(old_training_data) != len(new_training_data):
         # Check for outcome mismatch.
         if len(new_training_data) > len(old_training_data):
-            flag = True
+            flag = False
             for (answer_group_index, answer_group) in enumerate(
                     old_training_data):
                 if answer_group['answer_group_index'] != new_training_data[
                         answer_group_index]['answer_group_index']:
-                    flag = False
+                    flag = True
             if flag:
                 delete_classifier_training_job(state.classifier_model_id)
                 return True
@@ -226,11 +226,15 @@ def get_training_data_from_state(state):
         if classifier_rule_spec_index is not None:
             classifier_rule_spec = answer_group.rule_specs[
                 classifier_rule_spec_index]
+            answers = []
+            for doc in classifier_rule_spec.inputs['training_data']:
+                answers.extend([doc])
             training_data.extend([{
                 'answer_group_index': answer_group_index,
-                'answers': ([doc] for doc in classifier_rule_spec.inputs[
-                    'training_data'])
+                'answers': answers
             }])
+    for answer_group in training_data:
+        print answer_group['answer_group_index']
     return training_data
 
 
@@ -413,7 +417,7 @@ def _update_classifier_training_job(classifier_training_job_model, status):
 
 
 def save_classifier_training_job(algorithm_id, exp_id, exp_version,
-                                 state_name, training_data, status="None",
+                                 state_name, training_data, status="NEW",
                                  job_id="None"):
     """Checks for the existence of the model.
     If the model exists, it is updated using _update_classifier_training_job

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -152,10 +152,7 @@ def add_to_trainining_queue(exploration):
                 exploration.states[state_name].classifier_model_id = (
                     job_id)
             else:
-                classifier_training_job = get_classifier_training_job_by_id(
-                    state.classifier_model_id)
-                if check_re_training_conditions(state,
-                                                classifier_training_job):
+                if check_re_training_conditions(state):
                     training_data = get_training_data_from_state(state)
                     algorithm_id = state.interaction.id
                     exp_id = exploration.id
@@ -168,16 +165,16 @@ def add_to_trainining_queue(exploration):
     return exploration
 
 
-def check_re_training_conditions(state, classifier_training_job):
+def check_re_training_conditions(state):
     """Checks whether the classifier needs to be trained again.
 
     Args:
         state: The current State domain object of the exploration.
-        classifier_training_job: The retrieved ClassifierTrainingJob Domain
-            object.
 
     Returns: bool. True/False
     """
+    classifier_training_job = get_classifier_training_job_by_id(
+        state.classifier_model_id)
     new_training_data = get_training_data_from_state(state)
     old_training_data = classifier_training_job.training_data
 
@@ -190,7 +187,6 @@ def check_re_training_conditions(state, classifier_training_job):
     # Check for outcome mismatch.
     if flag and (len(new_training_data) > len(old_training_data)):
         delete_classifier_training_job(state.classifier_model_id)
-        state.classifier_model_id = None
         return True
 
     # Check for addition/deletion of answer groups (without Outcome mismatch).

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -219,7 +219,6 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
 
         exp_id = u'1'
         state_name = 'Home'
-        status = 'NEW'
         test_status = 'PENDING'
         training_data = [
             {
@@ -234,11 +233,11 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         # Job does not exist yet.
         job_id = classifier_services.save_classifier_training_job(
             feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput']['algorithm_id'],
-            exp_id, 1, state_name, status, training_data)
+            exp_id, 1, state_name, training_data)
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
         self.assertEqual(classifier_training_job.exp_id, exp_id)
-        self.assertEqual(classifier_training_job.status, status)
+        self.assertEqual(classifier_training_job.status, 'NEW')
         classifier_training_job.update_status(test_status)
         # Updating existing job.
         classifier_services.save_classifier_training_job(
@@ -246,8 +245,8 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
             classifier_training_job.exp_id,
             classifier_training_job.exp_version,
             classifier_training_job.state_name,
-            classifier_training_job.status,
             classifier_training_job.training_data,
+            classifier_training_job.status,
             classifier_training_job.job_id)
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -19,7 +19,6 @@ import os
 from core.domain import classifier_domain
 from core.domain import classifier_registry
 from core.domain import classifier_services
-from core.domain import exp_domain
 from core.domain import exp_services
 from core.platform import models
 from core.tests import test_utils
@@ -75,21 +74,21 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         return (answer_group.get_classifier_rule_index() == rule_spec_index and
                 predict_counter.times_called == 1)
 
-    def test_string_classifier_classification(self):
-        """All these responses trigger the string classifier."""
-
-        with self.swap(feconf, 'ENABLE_STRING_CLASSIFIER', True):
-            self.assertTrue(
-                self._is_string_classifier_called(
-                    'it\'s a permutation of 3 elements'))
-            self.assertTrue(
-                self._is_string_classifier_called(
-                    'There are 3 options for the first ball, and 2 for the '
-                    'remaining two. So 3*2=6.'))
-            self.assertTrue(
-                self._is_string_classifier_called('abc acb bac bca cbb cba'))
-            self.assertTrue(
-                self._is_string_classifier_called('dunno, just guessed'))
+    # def test_string_classifier_classification(self):
+    #     """All these responses trigger the string classifier."""
+    #
+    #     with self.swap(feconf, 'ENABLE_STRING_CLASSIFIER', True):
+    #         self.assertTrue(
+    #             self._is_string_classifier_called(
+    #                 'it\'s a permutation of 3 elements'))
+    #         self.assertTrue(
+    #             self._is_string_classifier_called(
+    #                 'There are 3 options for the first ball, and 2 for the '
+    #                 'remaining two. So 3*2=6.'))
+    #         self.assertTrue(
+    #             self._is_string_classifier_called('abc acb bac bca cbb cba'))
+    #         self.assertTrue(
+    #             self._is_string_classifier_called('dunno, just guessed'))
 
     def test_check_re_training_conditions(self):
         """Test the _check_re_training_conditions method."""
@@ -102,12 +101,13 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
             'Home', classifier_services.get_training_data_from_state(state))
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
+        state.classifier_model_id = job_id
 
         # Test outcome mismatch condition.
-        state.interaction.answer_groups.insert(3,
-            state.interaction.answer_groups[1])
-        self.assertTrue(classifier_services._check_re_training_conditions(state,
-            classifier_training_job))
+        state.interaction.answer_groups.insert(
+            3, state.interaction.answer_groups[1])
+        self.assertTrue(classifier_services.check_re_training_conditions(
+            state, classifier_training_job))
         self.assertFalse(state.classifier_model_id)
 
     def test_retrieval_of_classifiers(self):

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -75,21 +75,21 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         return (answer_group.get_classifier_rule_index() == rule_spec_index and
                 predict_counter.times_called == 1)
 
-    # def test_string_classifier_classification(self):
-    #     """All these responses trigger the string classifier."""
-    #
-    #     with self.swap(feconf, 'ENABLE_STRING_CLASSIFIER', True):
-    #         self.assertTrue(
-    #             self._is_string_classifier_called(
-    #                 'it\'s a permutation of 3 elements'))
-    #         self.assertTrue(
-    #             self._is_string_classifier_called(
-    #                 'There are 3 options for the first ball, and 2 for the '
-    #                 'remaining two. So 3*2=6.'))
-    #         self.assertTrue(
-    #             self._is_string_classifier_called('abc acb bac bca cbb cba'))
-    #         self.assertTrue(
-    #             self._is_string_classifier_called('dunno, just guessed'))
+    def test_string_classifier_classification(self):
+        """All these responses trigger the string classifier."""
+
+        with self.swap(feconf, 'ENABLE_STRING_CLASSIFIER', True):
+            self.assertTrue(
+                self._is_string_classifier_called(
+                    'it\'s a permutation of 3 elements'))
+            self.assertTrue(
+                self._is_string_classifier_called(
+                    'There are 3 options for the first ball, and 2 for the '
+                    'remaining two. So 3*2=6.'))
+            self.assertTrue(
+                self._is_string_classifier_called('abc acb bac bca cbb cba'))
+            self.assertTrue(
+                self._is_string_classifier_called('dunno, just guessed'))
 
     def test_check_re_training_conditions(self):
         """Test the _check_re_training_conditions method."""

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -74,21 +74,21 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         return (answer_group.get_classifier_rule_index() == rule_spec_index and
                 predict_counter.times_called == 1)
 
-    # def test_string_classifier_classification(self):
-    #     """All these responses trigger the string classifier."""
-    #
-    #     with self.swap(feconf, 'ENABLE_STRING_CLASSIFIER', True):
-    #         self.assertTrue(
-    #             self._is_string_classifier_called(
-    #                 'it\'s a permutation of 3 elements'))
-    #         self.assertTrue(
-    #             self._is_string_classifier_called(
-    #                 'There are 3 options for the first ball, and 2 for the '
-    #                 'remaining two. So 3*2=6.'))
-    #         self.assertTrue(
-    #             self._is_string_classifier_called('abc acb bac bca cbb cba'))
-    #         self.assertTrue(
-    #             self._is_string_classifier_called('dunno, just guessed'))
+    def test_string_classifier_classification(self):
+        """All these responses trigger the string classifier."""
+
+        with self.swap(feconf, 'ENABLE_STRING_CLASSIFIER', True):
+            self.assertTrue(
+                self._is_string_classifier_called(
+                    'it\'s a permutation of 3 elements'))
+            self.assertTrue(
+                self._is_string_classifier_called(
+                    'There are 3 options for the first ball, and 2 for the '
+                    'remaining two. So 3*2=6.'))
+            self.assertTrue(
+                self._is_string_classifier_called('abc acb bac bca cbb cba'))
+            self.assertTrue(
+                self._is_string_classifier_called('dunno, just guessed'))
 
     def test_check_re_training_conditions(self):
         """Test the _check_re_training_conditions method."""
@@ -99,16 +99,18 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         job_id = classifier_services.save_classifier_training_job(
             algorithm_id, exploration.id, exploration.version,
             'Home', classifier_services.get_training_data_from_state(state))
-        classifier_training_job = (
-            classifier_services.get_classifier_training_job_by_id(job_id))
         state.classifier_model_id = job_id
 
         # Test outcome mismatch condition.
         state.interaction.answer_groups.insert(
             3, state.interaction.answer_groups[1])
         self.assertTrue(classifier_services.check_re_training_conditions(
-            state, classifier_training_job))
-        self.assertFalse(state.classifier_model_id)
+            state))
+        with self.assertRaisesRegexp(Exception, (
+            'Entity for class ClassifierTrainingJobModel '
+            'with id %s not found' %(
+                job_id))):
+            classifier_services.get_classifier_training_job_by_id(job_id)
 
     def test_retrieval_of_classifiers(self):
         """Test the get_classifier_by_id method."""

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -32,6 +32,7 @@ import StringIO
 import zipfile
 
 from core.domain import activity_services
+from core.domain import classifier_services
 from core.domain import email_subscription_services
 from core.domain import exp_domain
 from core.domain import feedback_services
@@ -806,6 +807,8 @@ def _save_exploration(committer_id, exploration, commit_message, change_list):
                 'Trying to update version %s of exploration from version %s, '
                 'which is too old. Please reload the page and try again.'
                 % (exploration_model.version, exploration.version))
+
+    exploration = classifier_services.add_to_trainining_queue(exploration)
 
     exploration_model.category = exploration.category
     exploration_model.title = exploration.title

--- a/feconf.py
+++ b/feconf.py
@@ -90,6 +90,9 @@ ALLOWED_TRAINING_JOB_STATUSES = [
     TRAINING_JOB_STATUS_PENDING
 ]
 
+# The minimum number of modified samples to re-train a classifier.
+MIN_SAMPLE_TO_RETRAIN = 10
+
 # The minimum number of training samples required for training a classifier.
 MIN_TOTAL_TRAINING_EXAMPLES = 50
 


### PR DESCRIPTION
#3467

This PR implements the checks for re-training and also the function that creates training job instances on update_exploration(). There's a small issue with checking for Outcome mismatch (@seanlip). We can't really uniquely identify an answer group. So, I'm not sure how we can check if ordering of answer groups remain the same as this is how we check for outcome mismatch. There is also the case where we add one answer group and remove another. I'm not completely sure how we can handle that.

@anmolshkl @prasanna08 . It would be great if you could provide some suggestions.