### PR TITLE
Fix #3295 Add backend support for draft change list id

### DIFF
--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -1980,9 +1980,14 @@ def create_or_update_draft(
         exp_user_data = user_models.ExplorationUserDataModel.create(
             user_id, exp_id)
 
+    draft_id = exp_user_data.draft_change_list_id
+    if draft_id is None:
+        draft_id = 0
+    draft_id += 1
     exp_user_data.draft_change_list = change_list
     exp_user_data.draft_change_list_last_updated = current_datetime
     exp_user_data.draft_change_list_exp_version = exp_version
+    exp_user_data.draft_change_list_id = draft_id
     exp_user_data.put()
 
 

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -3040,7 +3040,7 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
                          self.NEWER_DATETIME)
         self.assertEqual(exp_user_data.draft_change_list_exp_version, 5)
         self.assertEqual(exp_user_data.draft_change_list_id, 1)
-        
+
     def test_get_exp_with_draft_applied_when_draft_exists(self):
         exploration = exp_services.get_exploration_by_id(self.EXP_ID1)
         self.assertEqual(exploration.init_state.param_changes, [])

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -3040,6 +3040,7 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
                          self.NEWER_DATETIME)
         self.assertEqual(exp_user_data.draft_change_list_exp_version, 5)
         self.assertEqual(exp_user_data.draft_change_list_id, 1)
+        
     def test_get_exp_with_draft_applied_when_draft_exists(self):
         exploration = exp_services.get_exploration_by_id(self.EXP_ID1)
         self.assertEqual(exploration.init_state.param_changes, [])

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -2958,13 +2958,15 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
             exploration_id=self.EXP_ID1,
             draft_change_list=self.draft_change_list,
             draft_change_list_last_updated=self.DATETIME,
-            draft_change_list_exp_version=2).put()
+            draft_change_list_exp_version=2,
+            draft_change_list_id=2).put()
         user_models.ExplorationUserDataModel(
             id='%s.%s' % (self.USER_ID, self.EXP_ID2), user_id=self.USER_ID,
             exploration_id=self.EXP_ID2,
             draft_change_list=self.draft_change_list,
             draft_change_list_last_updated=self.DATETIME,
-            draft_change_list_exp_version=4).put()
+            draft_change_list_exp_version=4,
+            draft_change_list_id=10).put()
         # Exploration with no draft.
         user_models.ExplorationUserDataModel(
             id='%s.%s' % (self.USER_ID, self.EXP_ID3), user_id=self.USER_ID,
@@ -3009,6 +3011,7 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
         self.assertEqual(exp_user_data.draft_change_list_last_updated,
                          self.NEWER_DATETIME)
         self.assertEqual(exp_user_data.draft_change_list_exp_version, 5)
+        self.assertEqual(exp_user_data.draft_change_list_id, 3)
 
     def test_create_or_update_draft_when_newer_draft_exists(self):
         exp_services.create_or_update_draft(
@@ -3022,6 +3025,7 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             exp_user_data.draft_change_list_last_updated, self.DATETIME)
         self.assertEqual(exp_user_data.draft_change_list_exp_version, 2)
+        self.assertEqual(exp_user_data.draft_change_list_id, 2)
 
     def test_create_or_update_draft_when_draft_does_not_exist(self):
         exp_services.create_or_update_draft(
@@ -3035,7 +3039,7 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
         self.assertEqual(exp_user_data.draft_change_list_last_updated,
                          self.NEWER_DATETIME)
         self.assertEqual(exp_user_data.draft_change_list_exp_version, 5)
-
+        self.assertEqual(exp_user_data.draft_change_list_id, 1)
     def test_get_exp_with_draft_applied_when_draft_exists(self):
         exploration = exp_services.get_exploration_by_id(self.EXP_ID1)
         self.assertEqual(exploration.init_state.param_changes, [])

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -342,6 +342,8 @@ class ExplorationUserDataModel(base_models.BaseModel):
     draft_change_list_last_updated = ndb.DateTimeProperty(default=None)
     # The exploration version that this change list applied to.
     draft_change_list_exp_version = ndb.IntegerProperty(default=None)
+    #The exploration draft version of this change list.
+    draft_change_list_id = ndb.IntegerProperty(default=None)
     # The user's preference for receiving suggestion emails for this exploration
     mute_suggestion_notifications = ndb.BooleanProperty(
         default=feconf.DEFAULT_SUGGESTION_NOTIFICATIONS_MUTED_PREFERENCE)

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -76,7 +76,8 @@ class ExplorationUserDataModelTest(test_utils.GenericTestBase):
             rated_on=self.DATETIME_OBJECT,
             draft_change_list={'new_content': {}},
             draft_change_list_last_updated=self.DATETIME_OBJECT,
-            draft_change_list_exp_version=3).put()
+            draft_change_list_exp_version=3,
+            draft_change_list_id = 1).put()
 
     def test_create_success(self):
         user_models.ExplorationUserDataModel.create(
@@ -100,6 +101,7 @@ class ExplorationUserDataModelTest(test_utils.GenericTestBase):
         self.assertEqual(retrieved_object.draft_change_list_last_updated,
                          self.DATETIME_OBJECT)
         self.assertEqual(retrieved_object.draft_change_list_exp_version, 3)
+        self.assertEqual(retrieved_object.draft_change_list_id, 1)
 
     def test_get_failure(self):
         retrieved_object = user_models.ExplorationUserDataModel.get(

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -77,7 +77,7 @@ class ExplorationUserDataModelTest(test_utils.GenericTestBase):
             draft_change_list={'new_content': {}},
             draft_change_list_last_updated=self.DATETIME_OBJECT,
             draft_change_list_exp_version=3,
-            draft_change_list_id = 1).put()
+            draft_change_list_id=1).put()
 
     def test_create_success(self):
         user_models.ExplorationUserDataModel.create(


### PR DESCRIPTION
Implements milestone one of extending the exploration editors change list functionality. This commit includes changes to store the id of a change list on the back-end and update this appropriately as the change list is updated.