### PR TITLE
Fix #3557: make http://localhost:8181 open in default browser

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -83,18 +83,18 @@ sed -i.bak -e s/"MINIFICATION: .*"/"$yaml_env_variable"/ app.yaml
 rm app.yaml.bak
 
 # Launch a browser window.
-if [ $(uname) = "Linux" ]; then
+if [ ${OS} == "Linux" ]; then
   echo ""
   echo "  INFORMATION"
   echo "  Setting up a local development server at localhost:8181. Opening a"
-  echo "  Default Browser window pointing to this server."
+  echo "  default browser window pointing to this server."
   echo ""
   (sleep 5; xdg-open http://localhost:8181/ )&
-elif [ $(uname) = "Darwin" ]; then
+elif [ ${OS} == "Darwin" ]; then
   echo ""
   echo "  INFORMATION"
   echo "  Setting up a local development server at localhost:8181. Opening a"
-  echo "  Default Browser window pointing to this server."
+  echo "  default browser window pointing to this server."
   echo ""
   (sleep 5; open http://localhost:8181/ )&
 else

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -83,13 +83,13 @@ sed -i.bak -e s/"MINIFICATION: .*"/"$yaml_env_variable"/ app.yaml
 rm app.yaml.bak
 
 # Launch a browser window.
-if [ -f "/usr/bin/google-chrome" ]; then
+if [ $(uname) = "Linux" ]; then
   echo ""
   echo "  INFORMATION"
   echo "  Setting up a local development server at localhost:8181. Opening a"
-  echo "  Chrome browser window pointing to this server."
+  echo "  Default Browser window pointing to this server."
   echo ""
-  (sleep 5; /usr/bin/google-chrome http://localhost:8181/ )&
+  (sleep 5; xdg-open http://localhost:8181/ )&
 elif [ -e /Applications/Google\ Chrome.app ]; then
   echo ""
   echo "  INFORMATION"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -90,13 +90,13 @@ if [ $(uname) = "Linux" ]; then
   echo "  Default Browser window pointing to this server."
   echo ""
   (sleep 5; xdg-open http://localhost:8181/ )&
-elif [ -e /Applications/Google\ Chrome.app ]; then
+elif [ $(uname) = "Darwin" ]; then
   echo ""
   echo "  INFORMATION"
   echo "  Setting up a local development server at localhost:8181. Opening a"
-  echo "  Chrome browser window pointing to this server."
+  echo "  Default Browser window pointing to this server."
   echo ""
-  (sleep 5; open /Applications/Google\ Chrome.app http://localhost:8181/ )&
+  (sleep 5; open http://localhost:8181/ )&
 else
   echo ""
   echo "  INFORMATION"


### PR DESCRIPTION
Fix for #3557 
Check for OS, 
If OS is "Linux" using "xdg-open" command opens http://localhost:8181
if OS is "Darwin" using "open" command opens http://localhost:8181
