### PR TITLE
Splash page test leg two

### DIFF
--- a/core/controllers/pages.py
+++ b/core/controllers/pages.py
@@ -46,7 +46,7 @@ class SplashPage(base.BaseHandler):
         })
 
         if not c_value:
-            random_number = random.randrange(0, 5)
+            random_number = random.choice([0, 5, 6])
             if random_number == 0:
                 self.render_template('pages/splash/splash.html')
             else:

--- a/core/templates/dev/head/pages/splash/splash_nv5.html
+++ b/core/templates/dev/head/pages/splash/splash_nv5.html
@@ -1,0 +1,260 @@
+{% extends 'pages/base.html' %}
+
+{% block prerender %}
+  <link rel="prerender" href="/library">
+{% endblock prerender %}
+
+{% block maintitle %}
+  I18N_SPLASH_PAGE_TITLE
+{% endblock maintitle %}
+
+{% block header_js %}
+  {{ super() }}
+{% endblock %}
+
+{% block navbar_breadcrumb %}
+{% endblock navbar_breadcrumb %}
+
+{% block content %}
+  <div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
+    <div class="container">
+      <div class="row">
+        <div class="oppia-splash-new-main-cta col-xs-12">
+          <h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
+          <h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
+          <div class="oppia-button-container">
+            <button type="button"
+                    ng-click="onClickBrowseLibraryButton()"
+                    class="btn oppia-transition-200">
+              Start Learning
+            </button>
+            <button type="button"
+                    ng-click="onRedirectToLogin('/creator_dashboard?mode=create')"
+                    class="btn oppia-transition-200">
+              Share Your Knowledge
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="jumbotron">
+        <h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
+        <div class="oppia-splash-new-exploration-summaries">
+          <div ng-repeat="tile in activityList" style="display: inline-block;">
+            <exploration-summary-tile exploration-id="tile.id"
+                                      exploration-title="tile.title"
+                                      last-updated-msec="tile.last_updated_msec"
+                                      objective="tile.objective"
+                                      category="tile.category"
+                                      ratings="tile.ratings"
+                                      num-views="tile.num_views"
+                                      thumbnail-icon-url="tile.thumbnail_icon_url"
+                                      thumbnail-bg-color="tile.thumbnail_bg_color"
+                                      class="protractor-test-exp-summary-tile">
+            </exploration-summary-tile>
+          </div>
+        </div>
+      </div>
+      <div class="jumbotron">
+        <div class="row">
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
+            </div>
+          </div>
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
+            </div>
+          </div>
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/creator_dashboard?mode=create')">share your knowledge</a> today!</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="oppia-splash-new-callout container-fluid">
+      <h2>Share Your Knowledge</h2>
+      <p>Whether you're a K-12 educator, a graduate student, or an individual who's passionate about a specific subject and wants to share your knowledge, Oppia welcomes you. Join the community and start exploring with us.</p>
+      <button type="button"
+              ng-click="onRedirectToLogin('/creator_dashboard?mode=create')"
+              class="btn oppia-transition-200">
+        Get Started
+      </button>
+    </div>
+  </div>
+
+  <style>
+    .oppia-splash-new-main-cta {
+      float: none;
+      margin: 30px auto 20px auto;
+      max-width: 650px;
+    }
+
+    .oppia-splash-new-h1 {
+      color: #024340;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 2.75em;
+      margin: 20px auto 0 auto;
+      text-align: center;
+    }
+
+    .oppia-splash-new-h2 {
+      -webkit-font-smoothing: subpixel-antialiased;
+      color: #04857c;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      font-size: 2em;
+      font-weight: 300;
+      line-height: 1.2;
+      margin: 18px 0;
+      text-align: center;
+      text-rendering: auto;
+    }
+
+    .jumbotron .oppia-splash-new-h2 {
+      margin-top: 0;
+    }
+
+    .oppia-button-container {
+      display: flex;
+      justify-content: center;
+      text-align: center;
+    }
+
+    .oppia-button-container button {
+      background-color: #015c53;
+      border-radius: 0;
+      border: none;
+      color: #ffffff;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 16px;
+      margin: auto 5px;
+      max-width: 300px;
+      padding: 10px;
+      text-transform: uppercase;
+      width: 100%;
+    }
+
+    .oppia-button-container button:hover {
+      background-color: #05beb2;
+      color: #ffffff;
+    }
+
+    .oppia-bullet-holder img {
+      display: block;
+      height: 125px;
+      margin: auto;
+    }
+
+    .oppia-bullet-holder p {
+      color: #333333;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      -webkit-font-smoothing: subpixel-antialiased;
+      font-weight: 300;
+      line-height: 1.45;
+      padding: 5px 15px;
+    }
+
+    .oppia-splash-new-exploration-summaries {
+      font-size: 16px;
+      text-align: center;
+    }
+
+    .oppia-splash-new-callout {
+      background-color: #009788;
+      color: #ffffff;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      text-align: center;
+    }
+
+    .oppia-splash-new-callout h2 {
+      color: #ffffff;
+      font-size: 2em;
+      font-weight: 600;
+      margin: 22px auto 0 auto;
+    }
+
+    .oppia-splash-new-callout p {
+      font-size: 1.3em;
+      line-height: 1.8;
+      margin: 15px auto;
+      max-width: 650px;
+      text-align: center;
+    }
+
+    .oppia-splash-new-callout button {
+      background-color: #00796d;
+      border-radius: 5px;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 1.1em;
+      -webkit-font-smoothing: subpixel-antialiased;
+      margin-bottom: 22px;
+      padding: 10px 20px;
+      text-transform: uppercase;
+      white-space: normal;
+    }
+
+    .oppia-splash-new-callout button:hover {
+      background-color: #05beb2;
+      color: #ffffff;
+    }
+
+    @media (max-width: 768px) {
+      .oppia-display-desktop-only {
+        display: none !important;
+      }
+
+      .oppia-button-container {
+        flex-wrap: wrap;
+      }
+
+      .oppia-button-container button {
+        margin-bottom: 5px;
+      }
+
+      .oppia-splash-new-callout {
+        height: auto;
+        padding: 15px;
+      }
+
+      .oppia-splash-new-callout button {
+        position: auto;
+        top: auto;
+        transform: none;
+      }
+
+      .oppia-splash-new-callout button:first-of-type {
+        margin-top: 15px;
+      }
+    }
+
+    @media (max-width: 500px) {
+      .oppia-activity-summary-tile {
+        margin: 8px 5.5px;
+      }
+    }
+  </style>
+
+  <link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
+{% endblock %}
+
+{% block footer %}
+  {% include 'pages/footer.html' %}
+{% endblock %}
+
+{% block footer_js %}
+  {{ super() }}
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
+{% endblock footer_js %}

--- a/core/templates/dev/head/pages/splash/splash_nv6.html
+++ b/core/templates/dev/head/pages/splash/splash_nv6.html
@@ -1,0 +1,260 @@
+{% extends 'pages/base.html' %}
+
+{% block prerender %}
+  <link rel="prerender" href="/library">
+{% endblock prerender %}
+
+{% block maintitle %}
+  I18N_SPLASH_PAGE_TITLE
+{% endblock maintitle %}
+
+{% block header_js %}
+  {{ super() }}
+{% endblock %}
+
+{% block navbar_breadcrumb %}
+{% endblock navbar_breadcrumb %}
+
+{% block content %}
+  <div ng-controller="Splash" style="background-color: #afd2eb; font-size: 14px;">
+    <div class="container">
+      <div class="row">
+        <div class="oppia-splash-new-main-cta col-xs-12">
+          <h1 class="oppia-splash-new-h1">Welcome to Oppia</h1>
+          <h2 class="oppia-splash-new-h2">Oppia's mission is to help anyone learn in an effective and enjoyable way.</h2>
+          <div class="oppia-button-container">
+            <button type="button"
+                    ng-click="onClickBrowseLibraryButton()"
+                    class="btn oppia-transition-200">
+              Start Learning
+            </button>
+            <button type="button"
+                    ng-click="onRedirectToLogin('/creator_dashboard?mode=create')"
+                    class="btn oppia-transition-200">
+              Share Your Knowledge
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="jumbotron">
+        <div class="row">
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet1icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Oppia's lessons are more fun and immersive than static videos or text, helping people learn by doing.</p>
+            </div>
+          </div>
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet2icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Lessons are simple to create and even easier to play. Learners receive tailored feedback based on areas for improvement.</p>
+            </div>
+          </div>
+          <div class="col-sm-4 oppia-bullet-holder">
+            <div class="row">
+              <img ng-src="<[getStaticImageUrl('/splash/bullet3icon.svg')]>" alt="">
+            </div>
+            <div class="row">
+              <p>Join over 250,000 learners and educators from around the world: <a ng-click="onClickBrowseLibraryButton()">start learning</a> or <a ng-click="onRedirectToLogin('/creator_dashboard?mode=create')">share your knowledge</a> today!</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="jumbotron">
+        <h2 class="oppia-splash-new-h2">Start learning with some of our most popular lessons:</h2>
+        <div class="oppia-splash-new-exploration-summaries">
+          <div ng-repeat="tile in activityList" style="display: inline-block;">
+            <exploration-summary-tile exploration-id="tile.id"
+                                      exploration-title="tile.title"
+                                      last-updated-msec="tile.last_updated_msec"
+                                      objective="tile.objective"
+                                      category="tile.category"
+                                      ratings="tile.ratings"
+                                      num-views="tile.num_views"
+                                      thumbnail-icon-url="tile.thumbnail_icon_url"
+                                      thumbnail-bg-color="tile.thumbnail_bg_color"
+                                      class="protractor-test-exp-summary-tile">
+            </exploration-summary-tile>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="oppia-splash-new-callout container-fluid">
+      <h2>Share Your Knowledge</h2>
+      <p>Whether you're a K-12 educator, a graduate student, or an individual who's passionate about a specific subject and wants to share your knowledge, Oppia welcomes you. Join the community and start exploring with us.</p>
+      <button type="button"
+              ng-click="onRedirectToLogin('/creator_dashboard?mode=create')"
+              class="btn oppia-transition-200">
+        Get Started
+      </button>
+    </div>
+  </div>
+
+  <style>
+    .oppia-splash-new-main-cta {
+      float: none;
+      margin: 30px auto 20px auto;
+      max-width: 650px;
+    }
+
+    .oppia-splash-new-h1 {
+      color: #024340;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 2.75em;
+      margin: 20px auto 0 auto;
+      text-align: center;
+    }
+
+    .oppia-splash-new-h2 {
+      -webkit-font-smoothing: subpixel-antialiased;
+      color: #04857c;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      font-size: 2em;
+      font-weight: 300;
+      line-height: 1.2;
+      margin: 18px 0;
+      text-align: center;
+      text-rendering: auto;
+    }
+
+    .jumbotron .oppia-splash-new-h2 {
+      margin-top: 0;
+    }
+
+    .oppia-button-container {
+      display: flex;
+      justify-content: center;
+      text-align: center;
+    }
+
+    .oppia-button-container button {
+      background-color: #015c53;
+      border-radius: 0;
+      border: none;
+      color: #ffffff;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 16px;
+      margin: auto 5px;
+      max-width: 300px;
+      padding: 10px;
+      text-transform: uppercase;
+      width: 100%;
+    }
+
+    .oppia-button-container button:hover {
+      background-color: #05beb2;
+      color: #ffffff;
+    }
+
+    .oppia-bullet-holder img {
+      display: block;
+      height: 125px;
+      margin: auto;
+    }
+
+    .oppia-bullet-holder p {
+      color: #333333;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      -webkit-font-smoothing: subpixel-antialiased;
+      font-weight: 300;
+      line-height: 1.45;
+      padding: 5px 15px;
+    }
+
+    .oppia-splash-new-exploration-summaries {
+      font-size: 16px;
+      text-align: center;
+    }
+
+    .oppia-splash-new-callout {
+      background-color: #009788;
+      color: #ffffff;
+      font-family: 'Rubik', 'Roboto', Arial, sans-serif;
+      text-align: center;
+    }
+
+    .oppia-splash-new-callout h2 {
+      color: #ffffff;
+      font-size: 2em;
+      font-weight: 600;
+      margin: 22px auto 0 auto;
+    }
+
+    .oppia-splash-new-callout p {
+      font-size: 1.3em;
+      line-height: 1.8;
+      margin: 15px auto;
+      max-width: 650px;
+      text-align: center;
+    }
+
+    .oppia-splash-new-callout button {
+      background-color: #00796d;
+      border-radius: 5px;
+      font-family: 'Capriola', 'Roboto', Arial, sans-serif;
+      font-size: 1.1em;
+      -webkit-font-smoothing: subpixel-antialiased;
+      margin-bottom: 22px;
+      padding: 10px 20px;
+      text-transform: uppercase;
+      white-space: normal;
+    }
+
+    .oppia-splash-new-callout button:hover {
+      background-color: #05beb2;
+      color: #ffffff;
+    }
+
+    @media (max-width: 768px) {
+      .oppia-display-desktop-only {
+        display: none !important;
+      }
+
+      .oppia-button-container {
+        flex-wrap: wrap;
+      }
+
+      .oppia-button-container button {
+        margin-bottom: 5px;
+      }
+
+      .oppia-splash-new-callout {
+        height: auto;
+        padding: 15px;
+      }
+
+      .oppia-splash-new-callout button {
+        position: auto;
+        top: auto;
+        transform: none;
+      }
+
+      .oppia-splash-new-callout button:first-of-type {
+        margin-top: 15px;
+      }
+    }
+
+    @media (max-width: 500px) {
+      .oppia-activity-summary-tile {
+        margin: 8px 5.5px;
+      }
+    }
+  </style>
+
+  <link rel="stylesheet" type="text/css" media="screen" href="https://fonts.googleapis.com/css?family=Rubik:300">
+{% endblock %}
+
+{% block footer %}
+  {% include 'pages/footer.html' %}
+{% endblock %}
+
+{% block footer_js %}
+  {{ super() }}
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/splash/Splash.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
+{% endblock footer_js %}


### PR DESCRIPTION
This is the second leg of our splash page test (first one here: #3396). So far, the data have been mostly inconclusive. However, splash variant nv4 did recently pull ahead and demonstrate a statistically significant improvement over the original splash page in terms of learner conversions (~21% improvement; p = 0.036; [data here](https://docs.google.com/spreadsheets/d/1gYx3j-UEoFtHapDh3ZvIYtDnzhoIEAfUZ92vjziZTp0/edit#gid=0)).

Creator conversions are a bit fuzzier because there are just so few of them. Using creator CTA CTR as a proxy, all of the new splash variants demonstrated significant drops. However, using the real creator conversion metric we decided on before the test began (a user beginning the exploration creator tutorial), most demonstrated gains (but not at a significant level).

This update takes the most successful variant in terms of learner conversions and pairs it with the creator-targeted footer of the least unsuccessful variant in terms of creator conversions (using creator CTA CTR as a proxy).

It includes two variants: one with the explanatory box on top and one with the explorations on top. (The second most successful variant was the one with the explanatory box on top.)

Hopefully, this will further prove the increase in learner conversions while also mitigating the decrease in creator conversions by our proxy. Ideally, it will also demonstrate improvement in creator conversions by our primary creator conversion criteria (though, we'll likely again not have enough data to make that call).

We'll plan to run this leg of the test for about a month. Then, we should decide whether it makes sense to invest time and energy into optimizing one of these new variants or just abandon this experiment in favor of the old splash.