### PR TITLE
Fix #3490: Update ui-bootstrap to 2.5.0

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -72,11 +72,11 @@ oppia.constant(
 // Add RTE extensions to textAngular toolbar options.
 oppia.config(['$provide', function($provide) {
   $provide.decorator('taOptions', [
-    '$delegate', '$document', '$modal', '$timeout', 'focusService',
+    '$delegate', '$document', '$uibModal', '$timeout', 'focusService',
     'taRegisterTool', 'rteHelperService', 'alertsService',
     'explorationContextService', 'PAGE_CONTEXT',
     function(
-      taOptions, $document, $modal, $timeout, focusService,
+      taOptions, $document, $uibModal, $timeout, focusService,
       taRegisterTool, rteHelperService, alertsService,
       explorationContextService, PAGE_CONTEXT) {
       taOptions.disableSanitizer = true;
@@ -95,13 +95,13 @@ oppia.config(['$provide', function($provide) {
         customizationArgSpecs, attrsCustomizationArgsDict, onSubmitCallback,
         onDismissCallback, refocusFn) {
         $document[0].execCommand('enableObjectResizing', false, false);
-        var modalDialog = $modal.open({
+        var modalDialog = $uibModal.open({
           templateUrl: 'modals/customizeRteComponent',
           backdrop: 'static',
           resolve: {},
           controller: [
-            '$scope', '$modalInstance', '$timeout',
-            function($scope, $modalInstance, $timeout) {
+            '$scope', '$uibModalInstance', '$timeout',
+            function($scope, $uibModalInstance, $timeout) {
               $scope.customizationArgSpecs = customizationArgSpecs;
 
               // Without this code, the focus will remain in the background RTE
@@ -129,7 +129,7 @@ oppia.config(['$provide', function($provide) {
               }
 
               $scope.cancel = function() {
-                $modalInstance.dismiss('cancel');
+                $uibModalInstance.dismiss('cancel');
               };
 
               $scope.save = function() {
@@ -142,7 +142,7 @@ oppia.config(['$provide', function($provide) {
                     $scope.tmpCustomizationArgs[i].value);
                 }
 
-                $modalInstance.close(customizationArgsDict);
+                $uibModalInstance.close(customizationArgsDict);
               };
             }
           ]

--- a/core/templates/dev/head/components/ClassifierRulePanelDirective.js
+++ b/core/templates/dev/head/components/ClassifierRulePanelDirective.js
@@ -28,10 +28,10 @@ oppia.directive('classifierRulePanel', [
         '/components/' +
         'classifier_panel_directive.html'),
       controller: [
-        '$scope', '$modal', 'oppiaExplorationHtmlFormatterService',
+        '$scope', '$uibModal', 'oppiaExplorationHtmlFormatterService',
         'stateInteractionIdService', 'stateCustomizationArgsService',
         'trainingModalService',
-        function($scope, $modal, oppiaExplorationHtmlFormatterService,
+        function($scope, $uibModal, oppiaExplorationHtmlFormatterService,
             stateInteractionIdService, stateCustomizationArgsService,
             trainingModalService) {
           $scope.trainingDataHtmlList = [];

--- a/core/templates/dev/head/components/ExplorationCreationService.js
+++ b/core/templates/dev/head/components/ExplorationCreationService.js
@@ -18,10 +18,10 @@
  */
 
 oppia.factory('ExplorationCreationService', [
-  '$http', '$modal', '$timeout', '$rootScope', '$window',
+  '$http', '$uibModal', '$timeout', '$rootScope', '$window',
   'alertsService', 'siteAnalyticsService', 'UrlInterpolationService',
   function(
-      $http, $modal, $timeout, $rootScope, $window,
+      $http, $uibModal, $timeout, $rootScope, $window,
       alertsService, siteAnalyticsService, UrlInterpolationService) {
     var CREATE_NEW_EXPLORATION_URL_TEMPLATE = '/create/<exploration_id>';
 
@@ -57,13 +57,13 @@ oppia.factory('ExplorationCreationService', [
       showUploadExplorationModal: function() {
         alertsService.clearWarnings();
 
-        $modal.open({
+        $uibModal.open({
           backdrop: true,
           templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
             '/pages/creator_dashboard/' +
             'upload_activity_modal_directive.html'),
           controller: [
-            '$scope', '$modalInstance', function($scope, $modalInstance) {
+            '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
               $scope.save = function() {
                 var returnObj = {};
                 var file = document.getElementById('newFileInput').files[0];
@@ -73,11 +73,11 @@ oppia.factory('ExplorationCreationService', [
                 }
                 returnObj.yamlFile = file;
 
-                $modalInstance.close(returnObj);
+                $uibModalInstance.close(returnObj);
               };
 
               $scope.cancel = function() {
-                $modalInstance.dismiss('cancel');
+                $uibModalInstance.dismiss('cancel');
                 alertsService.clearWarnings();
               };
             }

--- a/core/templates/dev/head/components/VersionDiffVisualizationDirective.js
+++ b/core/templates/dev/head/components/VersionDiffVisualizationDirective.js
@@ -249,10 +249,10 @@ oppia.directive('versionDiffVisualization', [
               }
             },
             controller: [
-              '$scope', '$http', '$uibModalInstance', '$timeout', 'newStateName',
-              'oldStateName', 'newState', 'oldState', 'headers',
+              '$scope', '$http', '$timeout', '$uibModalInstance',
+              'newStateName', 'oldStateName', 'newState', 'oldState', 'headers',
               function(
-                  $scope, $http, $uibModalInstance, $timeout, newStateName,
+                  $scope, $http, $timeout, $uibModalInstance, newStateName,
                   oldStateName, newState, oldState, headers) {
                 var STATE_YAML_URL = '/createhandler/state_yaml';
 

--- a/core/templates/dev/head/components/VersionDiffVisualizationDirective.js
+++ b/core/templates/dev/head/components/VersionDiffVisualizationDirective.js
@@ -51,7 +51,7 @@ oppia.directive('versionDiffVisualization', [
       templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
         '/components/' +
         'version_diff_visualization_directive.html'),
-      controller: ['$scope', '$modal', function($scope, $modal) {
+      controller: ['$scope', '$uibModal', function($scope, $uibModal) {
         // Constants for color of nodes in diff graph
         var COLOR_ADDED = '#4EA24E';
         var COLOR_DELETED = '#DC143C';
@@ -209,7 +209,7 @@ oppia.directive('versionDiffVisualization', [
         //     deleted.
         $scope.showStateDiffModal = function(
             newStateName, oldStateName, stateProperty) {
-          $modal.open({
+          $uibModal.open({
             templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
               '/pages/exploration_editor/' +
               'state_diff_modal_directive.html'),
@@ -249,10 +249,10 @@ oppia.directive('versionDiffVisualization', [
               }
             },
             controller: [
-              '$scope', '$http', '$modalInstance', '$timeout', 'newStateName',
+              '$scope', '$http', '$uibModalInstance', '$timeout', 'newStateName',
               'oldStateName', 'newState', 'oldState', 'headers',
               function(
-                  $scope, $http, $modalInstance, $timeout, newStateName,
+                  $scope, $http, $uibModalInstance, $timeout, newStateName,
                   oldStateName, newState, oldState, headers) {
                 var STATE_YAML_URL = '/createhandler/state_yaml';
 
@@ -299,7 +299,7 @@ oppia.directive('versionDiffVisualization', [
                 }
 
                 $scope.cancel = function() {
-                  $modalInstance.dismiss('cancel');
+                  $uibModalInstance.dismiss('cancel');
                 };
 
                 // Options for the codemirror mergeview.

--- a/core/templates/dev/head/components/create_button/CreateActivityButtonDirective.js
+++ b/core/templates/dev/head/components/create_button/CreateActivityButtonDirective.js
@@ -22,10 +22,11 @@ oppia.directive('createActivityButton', [
       restrict: 'E',
       templateUrl: 'components/createActivityButton',
       controller: [
-        '$scope', '$timeout', '$window', '$uibModal', 'ExplorationCreationService',
-        'CollectionCreationService', 'siteAnalyticsService', 'urlService',
+        '$scope', '$timeout', '$uibModal', '$window',
+        'ExplorationCreationService', 'CollectionCreationService',
+        'siteAnalyticsService', 'urlService',
         function(
-            $scope, $timeout, $window, $uibModal, ExplorationCreationService,
+            $scope, $timeout, $uibModal, $window, ExplorationCreationService,
             CollectionCreationService, siteAnalyticsService, urlService) {
           $scope.creationInProgress = false;
 

--- a/core/templates/dev/head/components/create_button/CreateActivityButtonDirective.js
+++ b/core/templates/dev/head/components/create_button/CreateActivityButtonDirective.js
@@ -22,10 +22,10 @@ oppia.directive('createActivityButton', [
       restrict: 'E',
       templateUrl: 'components/createActivityButton',
       controller: [
-        '$scope', '$timeout', '$window', '$modal', 'ExplorationCreationService',
+        '$scope', '$timeout', '$window', '$uibModal', 'ExplorationCreationService',
         'CollectionCreationService', 'siteAnalyticsService', 'urlService',
         function(
-            $scope, $timeout, $window, $modal, ExplorationCreationService,
+            $scope, $timeout, $window, $uibModal, ExplorationCreationService,
             CollectionCreationService, siteAnalyticsService, urlService) {
           $scope.creationInProgress = false;
 
@@ -55,24 +55,24 @@ oppia.directive('createActivityButton', [
             } else if (urlService.getPathname() !== '/creator_dashboard') {
               $window.location.replace('/creator_dashboard?mode=create');
             } else {
-              $modal.open({
+              $uibModal.open({
                 templateUrl: 'modals/createActivity',
                 backdrop: true,
                 controller: [
-                  '$scope', '$modalInstance',
-                  function($scope, $modalInstance) {
+                  '$scope', '$uibModalInstance',
+                  function($scope, $uibModalInstance) {
                     $scope.chooseExploration = function() {
                       ExplorationCreationService.createNewExploration();
-                      $modalInstance.close();
+                      $uibModalInstance.close();
                     };
 
                     $scope.chooseCollection = function() {
                       CollectionCreationService.createNewCollection();
-                      $modalInstance.close();
+                      $uibModalInstance.close();
                     };
 
                     $scope.cancel = function() {
-                      $modalInstance.dismiss('cancel');
+                      $uibModalInstance.dismiss('cancel');
                     };
 
                     $scope.explorationImgUrl = (

--- a/core/templates/dev/head/components/embed_modal/ExplorationEmbedButtonService.js
+++ b/core/templates/dev/head/components/embed_modal/ExplorationEmbedButtonService.js
@@ -17,11 +17,11 @@
  */
 
 oppia.factory('ExplorationEmbedButtonService', [
-  '$modal', 'siteAnalyticsService', 'UrlInterpolationService',
-  function($modal, siteAnalyticsService, UrlInterpolationService) {
+  '$uibModal', 'siteAnalyticsService', 'UrlInterpolationService',
+  function($uibModal, siteAnalyticsService, UrlInterpolationService) {
     return {
       showModal: function(explorationId) {
-        $modal.open({
+        $uibModal.open({
           backdrop: true,
           templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
             '/components/embed_modal/' +
@@ -32,14 +32,14 @@ oppia.factory('ExplorationEmbedButtonService', [
             }
           },
           controller: [
-            '$scope', '$modalInstance', '$window', 'explorationId',
-            function($scope, $modalInstance, $window, explorationId) {
+            '$scope', '$uibModalInstance', '$window', 'explorationId',
+            function($scope, $uibModalInstance, $window, explorationId) {
               $scope.explorationId = explorationId;
               $scope.serverName = (
                 $window.location.protocol + '//' + $window.location.host);
 
               $scope.close = function() {
-                $modalInstance.dismiss('close');
+                $uibModalInstance.dismiss('close');
               };
 
               $scope.selectText = function($event) {

--- a/core/templates/dev/head/components/share/sharing_links_directive.html
+++ b/core/templates/dev/head/components/share/sharing_links_directive.html
@@ -18,7 +18,7 @@
   </li>
 
   <li ng-if="shareType === 'exploration'">
-    <a ng-click="showEmbedExplorationModal(explorationId)" tooltip="Embed" tooltip-placement="top" tabindex="0">
+    <a ng-click="showEmbedExplorationModal(explorationId)" uib-tooltip="Embed" tooltip-placement="top" tabindex="0">
       <i class="material-icons md-48 embed-link">&#xE86F;</i>
       <span class="oppia-icon-accessibility-label">Embed this Exploration</span>
     </a>

--- a/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
@@ -13,7 +13,7 @@
           <circular-image ng-if="avatarsList.length > 0"
                           src="avatarsList[0].image"
                           link="avatarsList[0].link"
-                          tooltip="<[avatarsList[0].tooltipText | truncate:14]>"
+                          uib-tooltip="<[avatarsList[0].tooltipText | truncate:14]>"
                           tooltip-placement="right">
           </circular-image>
         </div>
@@ -31,7 +31,7 @@
       <ul ng-if="!isCollectionPreviewTile" layout="row" class="metrics" layout-align="space-between center">
         <li>
           <span class="protractor-test-exp-summary-tile-rating" ng-class="{'rating-disabled': !getAverageRating()}">
-            <span class="fa fa-star fa-lg" tooltip="<['I18N_LIBRARY_RATINGS_TOOLTIP' | translate]>" tooltip-placement="top">
+            <span class="fa fa-star fa-lg" uib-tooltip="<['I18N_LIBRARY_RATINGS_TOOLTIP' | translate]>" tooltip-placement="top">
               <span class="oppia-icon-accessibility-label"><['I18N_LIBRARY_RATINGS_TOOLTIP' | translate]></span>
             </span>
             <span ng-if="getAverageRating()">
@@ -42,7 +42,7 @@
           </span>
         </li>
         <li>
-          <span class="fa fa-eye fa-lg" tooltip="<['I18N_LIBRARY_VIEWS_TOOLTIP' | translate]>" tooltip-placement="top">
+          <span class="fa fa-eye fa-lg" uib-tooltip="<['I18N_LIBRARY_VIEWS_TOOLTIP' | translate]>" tooltip-placement="top">
             <span class="oppia-icon-accessibility-label"><['I18N_LIBRARY_VIEWS_TOOLTIP' | translate]></span>
           </span>
           <span ng-if="getNumViews()">

--- a/core/templates/dev/head/pages/admin/admin_navbar_directive.html
+++ b/core/templates/dev/head/pages/admin/admin_navbar_directive.html
@@ -110,7 +110,7 @@
             <a class="oppia-navbar-tab"
                ng-click="showTab(ADMIN_TAB_URLS.MISC)"
                ng-href="<[::ADMIN_TAB_URLS.MISC]>"
-               tooltip="Miscellaneous"
+               uib-tooltip="Miscellaneous"
                tooltip-placement="bottom">
               Misc
             </a>
@@ -119,7 +119,7 @@
             <a class="oppia-navbar-tab protractor-test-admin-roles-tab"
                ng-click="showTab(ADMIN_TAB_URLS.ROLES)"
                ng-href="<[::ADMIN_TAB_URLS.ROLES]>"
-               tooltip="Roles"
+               uib-tooltip="Roles"
                tooltip-placemnt="bottom">
               Roles
             </a>
@@ -128,7 +128,7 @@
             <a class="oppia-navbar-tab protractor-test-admin-config-tab"
                ng-click="showTab(ADMIN_TAB_URLS.CONFIG)"
                ng-href="<[::ADMIN_TAB_URLS.CONFIG]>"
-               tooltip="Config"
+               uib-tooltip="Config"
                tooltip-placement="bottom">
               Config
             </a>
@@ -137,7 +137,7 @@
             <a class="oppia-navbar-tab"
                ng-click="showTab(ADMIN_TAB_URLS.JOBS)"
                ng-href="<[::ADMIN_TAB_URLS.JOBS]>"
-               tooltip="Jobs"
+               uib-tooltip="Jobs"
                tooltip-placement="bottom">
               Jobs
             </a>
@@ -146,7 +146,7 @@
             <a class="oppia-navbar-tab"
                ng-click="showTab(ADMIN_TAB_URLS.ACTIVITIES)"
                ng-href="<[::ADMIN_TAB_URLS.ACTIVITIES]>"
-               tooltip="Activities"
+               uib-tooltip="Activities"
                tooltip-placement="bottom">
               Activities
             </a>

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
@@ -22,9 +22,9 @@ oppia.directive('collectionEditorNavbar', [
       restrict: 'E',
       templateUrl: 'inline/collection_editor_navbar_directive',
       controller: [
-        '$scope', '$uibModal', 'alertsService', 'routerService', 'UndoRedoService',
-        'CollectionEditorStateService', 'CollectionValidationService',
-        'CollectionRightsBackendApiService',
+        '$scope', '$uibModal', 'alertsService', 'routerService',
+        'UndoRedoService', 'CollectionEditorStateService',
+        'CollectionValidationService', 'CollectionRightsBackendApiService',
         'EditableCollectionBackendApiService',
         'EVENT_COLLECTION_INITIALIZED', 'EVENT_COLLECTION_REINITIALIZED',
         'EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED',
@@ -114,7 +114,8 @@ oppia.directive('collectionEditorNavbar', [
                 'collection_editor_save_modal_directive.html'),
               backdrop: true,
               controller: [
-                '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
+                '$scope', '$uibModalInstance',
+                function($scope, $uibModalInstance) {
                   $scope.isCollectionPrivate = isPrivate;
 
                   $scope.save = function(commitMessage) {

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
@@ -22,14 +22,14 @@ oppia.directive('collectionEditorNavbar', [
       restrict: 'E',
       templateUrl: 'inline/collection_editor_navbar_directive',
       controller: [
-        '$scope', '$modal', 'alertsService', 'routerService', 'UndoRedoService',
+        '$scope', '$uibModal', 'alertsService', 'routerService', 'UndoRedoService',
         'CollectionEditorStateService', 'CollectionValidationService',
         'CollectionRightsBackendApiService',
         'EditableCollectionBackendApiService',
         'EVENT_COLLECTION_INITIALIZED', 'EVENT_COLLECTION_REINITIALIZED',
         'EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED',
         function(
-            $scope, $modal, alertsService, routerService, UndoRedoService,
+            $scope, $uibModal, alertsService, routerService, UndoRedoService,
             CollectionEditorStateService, CollectionValidationService,
             CollectionRightsBackendApiService,
             EditableCollectionBackendApiService,
@@ -108,20 +108,20 @@ oppia.directive('collectionEditorNavbar', [
 
           $scope.saveChanges = function() {
             var isPrivate = $scope.collectionRights.isPrivate();
-            var modalInstance = $modal.open({
+            var modalInstance = $uibModal.open({
               templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
                 '/pages/collection_editor/' +
                 'collection_editor_save_modal_directive.html'),
               backdrop: true,
               controller: [
-                '$scope', '$modalInstance', function($scope, $modalInstance) {
+                '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
                   $scope.isCollectionPrivate = isPrivate;
 
                   $scope.save = function(commitMessage) {
-                    $modalInstance.close(commitMessage);
+                    $uibModalInstance.close(commitMessage);
                   };
                   $scope.cancel = function() {
-                    $modalInstance.dismiss('cancel');
+                    $uibModalInstance.dismiss('cancel');
                   };
                 }
               ]
@@ -139,16 +139,16 @@ oppia.directive('collectionEditorNavbar', [
               !$scope.collection.getCategory());
 
             if (additionalMetadataNeeded) {
-              $modal.open({
+              $uibModal.open({
                 templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
                   '/pages/collection_editor/' +
                   'collection_editor_pre_publish_modal_directive.html'),
                 backdrop: true,
                 controller: [
-                  '$scope', '$modalInstance', 'CollectionEditorStateService',
+                  '$scope', '$uibModalInstance', 'CollectionEditorStateService',
                   'CollectionUpdateService', 'ALL_CATEGORIES',
                   function(
-                      $scope, $modalInstance, CollectionEditorStatesService,
+                      $scope, $uibModalInstance, CollectionEditorStatesService,
                       CollectionUpdateService, ALL_CATEGORIES) {
                     var collection = (
                       CollectionEditorStateService.getCollection());
@@ -209,11 +209,11 @@ oppia.directive('collectionEditorNavbar', [
                           collection, $scope.newCategory);
                       }
 
-                      $modalInstance.close(metadataList);
+                      $uibModalInstance.close(metadataList);
                     };
 
                     $scope.cancel = function() {
-                      $modalInstance.dismiss('cancel');
+                      $uibModalInstance.dismiss('cancel');
                     };
                   }
                 ]

--- a/core/templates/dev/head/pages/collection_editor/collection_editor_navbar_directive.html
+++ b/core/templates/dev/head/pages/collection_editor/collection_editor_navbar_directive.html
@@ -2,7 +2,7 @@
   <ul class="nav navbar-nav oppia-navbar-nav navbar-right ng-cloak" style="margin-left: 20px;">
     <!-- Editor -->
     <li ng-class="{'active': getTabStatuses().active === 'main', 'dropdown': getWarningsCount()}">
-      <a href="#" tooltip="Editor" ng-click="selectMainTab()" class="protractor-test-main-tab">
+      <a href="#" uib-tooltip="Editor" ng-click="selectMainTab()" class="protractor-test-main-tab">
         <i class="material-icons">&#xE254;</i>
       </a>
       <div ng-show="getWarningsCount()"
@@ -24,7 +24,7 @@
 
     <!-- Settings -->
     <li ng-class="{'active': getTabStatuses().active === 'settings'}">
-      <a href="#" tooltip="Settings" tooltip-placement="bottom" ng-click="selectSettingsTab()" class="protractor-test-settings-tab">
+      <a href="#" uib-tooltip="Settings" tooltip-placement="bottom" ng-click="selectSettingsTab()" class="protractor-test-settings-tab">
         <i class="material-icons">&#xE8B8;</i>
       </a>
     </li>
@@ -32,7 +32,7 @@
     <!-- History -->
     {% if SHOW_COLLECTION_NAVIGATION_TAB_HISTORY %}
     <li ng-class="{'active': getTabStatuses().active === 'history'}">
-      <a href="#" tooltip="History" tooltip-placement="bottom" ng-click="selectHistoryTab()" class="protractor-test-history-tab">
+      <a href="#" uib-tooltip="History" tooltip-placement="bottom" ng-click="selectHistoryTab()" class="protractor-test-history-tab">
         <i class="material-icons">&#xE192;</i>
       </a>
     </li>
@@ -41,7 +41,7 @@
     <!-- Stats -->
     {% if SHOW_COLLECTION_NAVIGATION_TAB_STATS and username %}
       <li ng-class="{'active': getTabStatuses().active === 'stats'}">
-        <a href="#" tooltip="Statistics" tooltip-placement="bottom" ng-click="selectStatsTab()">
+        <a href="#" uib-tooltip="Statistics" tooltip-placement="bottom" ng-click="selectStatsTab()">
           <i class="material-icons">&#xE24B;</i>
         </a>
       </li>
@@ -49,7 +49,7 @@
 
     <!-- Player -->
     <li>
-      <a ng-href="/collection/<[collectionId]>" target="_blank" tooltip="Player (new tab)" tooltip-placement="bottom">
+      <a ng-href="/collection/<[collectionId]>" target="_blank" uib-tooltip="Player (new tab)" tooltip-placement="bottom">
         <i class="material-icons">&#xE037;</i>
       </a>
     </li>

--- a/core/templates/dev/head/pages/collection_editor/editor_tab/collection_node_creator_directive.html
+++ b/core/templates/dev/head/pages/collection_editor/editor_tab/collection_node_creator_directive.html
@@ -5,7 +5,7 @@
 </form>
 or
 <form class="form-inline" ng-class="{'has-error': searchQueryHasError}" ng-submit="addExploration()">
-  <input class="form-control protractor-test-add-exploration-input" style="width: 430px" ng-model="newExplorationId" type="text" placeholder="Enter exploration id to be added, or search explorations by name" typeahead="exploration for exploration in fetchTypeaheadResults($viewValue)" ng-model-options="{ debounce: 300 }">
+  <input class="form-control protractor-test-add-exploration-input" style="width: 430px" ng-model="newExplorationId" type="text" placeholder="Enter exploration id to be added, or search explorations by name" uib-typeahead="exploration for exploration in fetchTypeaheadResults($viewValue)" ng-model-options="{ debounce: 300 }">
   <button class="btn btn-success protractor-test-add-exploration-button" type="submit" ng-disabled="!newExplorationId">Add Existing Exploration</button>
   <span class="help-block" style="font-size: smaller" ng-if="isMalformedId(newExplorationId)">
     <em>The trailing '#' is not part of the ID.</em>

--- a/core/templates/dev/head/pages/collection_player/collection_player.html
+++ b/core/templates/dev/head/pages/collection_player/collection_player.html
@@ -93,7 +93,7 @@
   <ul class="nav navbar-nav oppia-navbar-nav navbar-right" style="margin-right: 0px;">
     {% if can_edit %}
       <li>
-        <a ng-href="/collection_editor/create/{{collection_id}}" tooltip="Edit" tooltip-placement="bottom" target="_blank">
+        <a ng-href="/collection_editor/create/{{collection_id}}" uib-tooltip="Edit" tooltip-placement="bottom" target="_blank">
           <i class="material-icons">&#xE254;</i>
           <span class="oppia-icon-accessibility-label">Edit</span>
         </a>

--- a/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
+++ b/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
@@ -249,7 +249,7 @@
               <li flex="50">
                 <span class="protractor-test-exp-summary-tile-rating">
                   <span class="fa fa-star fa-lg oppia-dashboard-card-statistic-icon"
-                        tooltip="<['I18N_LIBRARY_RATINGS_TOOLTIP' | translate]>"
+                        uib-tooltip="<['I18N_LIBRARY_RATINGS_TOOLTIP' | translate]>"
                         tooltip-placement="top">
                   </span>
                   <span class="oppia-dashboard-card-statistic-value">
@@ -260,7 +260,7 @@
 
               <li flex="50" style="padding-left: 8px;" class="protractor-test-exploration-feedback-count">
                 <span class="fa fa-comments fa-lg oppia-dashboard-card-statistic-icon"
-                      tooltip="<['I18N_DASHBOARD_OPEN_FEEDBACK' | translate]>"
+                      uib-tooltip="<['I18N_DASHBOARD_OPEN_FEEDBACK' | translate]>"
                       tooltip-placement="top">
                 </span>
                 <a ng-if="exploration.num_open_threads != 0" ng-href="/create/<[exploration.id]>#/feedback"
@@ -275,7 +275,7 @@
 
               <li flex="50">
                 <span class="fa fa-eye fa-lg oppia-dashboard-card-statistic-icon"
-                      tooltip="<['I18N_LIBRARY_VIEWS_TOOLTIP' | translate]>"
+                      uib-tooltip="<['I18N_LIBRARY_VIEWS_TOOLTIP' | translate]>"
                       tooltip-placement="top">
                 </span>
                 <span class="oppia-dashboard-card-statistic-value">
@@ -285,7 +285,7 @@
 
               <li flex="50">
                 <span class="fa fa-clock-o fa-lg oppia-dashboard-card-statistic-icon"
-                      tooltip="<['I18N_LIBRARY_LAST_UPDATED' | translate]>"
+                      uib-tooltip="<['I18N_LIBRARY_LAST_UPDATED' | translate]>"
                       tooltip-placement="top">
                 </span>
                 <span class="oppia-dashboard-card-statistic-value">
@@ -346,7 +346,7 @@
               <strong class="protractor-test-subscription-name"
                       popover-append-to-body
                       popover-trigger="<[showUsernamePopover(subscriber.subscriber_username)]>"
-                      ng-attr-popover="<[subscriber.subscriber_username]>">
+                      ng-attr-uib-popover="<[subscriber.subscriber_username]>">
                 <[subscriber.subscriber_username| truncate:10]>
               </strong>
             </div>

--- a/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
@@ -23,14 +23,14 @@ oppia.directive('editorNavigation', [
       restrict: 'E',
       templateUrl: 'inline/editor_navigation_directive',
       controller: [
-        '$scope', '$rootScope', '$timeout', '$modal',
+        '$scope', '$rootScope', '$timeout', '$uibModal',
         'routerService', 'explorationRightsService',
         'explorationWarningsService',
         'stateEditorTutorialFirstTimeService',
         'threadDataService', 'siteAnalyticsService',
         'explorationContextService', 'windowDimensionsService',
         function(
-            $scope, $rootScope, $timeout, $modal,
+            $scope, $rootScope, $timeout, $uibModal,
             routerService, explorationRightsService,
             explorationWarningsService,
             stateEditorTutorialFirstTimeService,
@@ -53,16 +53,16 @@ oppia.directive('editorNavigation', [
           $scope.showUserHelpModal = function() {
             var explorationId = explorationContextService.getExplorationId();
             siteAnalyticsService.registerClickHelpButtonEvent(explorationId);
-            var modalInstance = $modal.open({
+            var modalInstance = $uibModal.open({
               templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
                 '/pages/exploration_editor/' +
                 'help_modal_directive.html'),
               backdrop: true,
               controller: [
-                '$scope', '$modalInstance',
+                '$scope', '$uibModalInstance',
                 'siteAnalyticsService', 'explorationContextService',
                 function(
-                  $scope, $modalInstance,
+                  $scope, $uibModalInstance,
                   siteAnalyticsService, explorationContextService) {
                   var explorationId = (
                     explorationContextService.getExplorationId());
@@ -71,13 +71,13 @@ oppia.directive('editorNavigation', [
                     siteAnalyticsService
                       .registerOpenTutorialFromHelpCenterEvent(
                         explorationId);
-                    $modalInstance.close();
+                    $uibModalInstance.close();
                   };
 
                   $scope.goToHelpCenter = function() {
                     siteAnalyticsService.registerVisitHelpCenterEvent(
                       explorationId);
-                    $modalInstance.dismiss('cancel');
+                    $uibModalInstance.dismiss('cancel');
                   };
                 }
               ],

--- a/core/templates/dev/head/pages/exploration_editor/EditorServices.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorServices.js
@@ -822,12 +822,12 @@ oppia.factory('explorationParamChangesService', [
 // is unlike the other exploration property services, in that it keeps no
 // mementos.
 oppia.factory('explorationStatesService', [
-  '$log', '$modal', '$filter', '$location', '$rootScope',
+  '$log', '$uibModal', '$filter', '$location', '$rootScope',
   'explorationInitStateNameService', 'alertsService', 'changeListService',
   'editorContextService', 'validatorsService', 'explorationGadgetsService',
   'StatesObjectFactory',
   function(
-      $log, $modal, $filter, $location, $rootScope,
+      $log, $uibModal, $filter, $location, $rootScope,
       explorationInitStateNameService, alertsService, changeListService,
       editorContextService, validatorsService, explorationGadgetsService,
       StatesObjectFactory) {
@@ -1062,7 +1062,7 @@ oppia.factory('explorationStatesService', [
           return;
         }
 
-        $modal.open({
+        $uibModal.open({
           templateUrl: 'modals/deleteState',
           backdrop: true,
           resolve: {
@@ -1071,10 +1071,10 @@ oppia.factory('explorationStatesService', [
             }
           },
           controller: [
-            '$scope', '$modalInstance', 'explorationGadgetsService',
+            '$scope', '$uibModalInstance', 'explorationGadgetsService',
             'deleteStateName',
             function(
-                $scope, $modalInstance, explorationGadgetsService,
+                $scope, $uibModalInstance, explorationGadgetsService,
                 deleteStateName) {
               $scope.deleteStateWarningText = (
                 'Are you sure you want to delete the card "' +
@@ -1094,7 +1094,7 @@ oppia.factory('explorationStatesService', [
               }
 
               $scope.reallyDelete = function() {
-                $modalInstance.close(deleteStateName);
+                $uibModalInstance.close(deleteStateName);
                 // Delete the gadgets without additional dialog when confirmed.
                 for (var i = 0; i < gadgetNamesUniqueToThisState.length; i++) {
                   // Note that explorationGadgetsService will update the data
@@ -1106,7 +1106,7 @@ oppia.factory('explorationStatesService', [
               };
 
               $scope.cancel = function() {
-                $modalInstance.dismiss('cancel');
+                $uibModalInstance.dismiss('cancel');
                 alertsService.clearWarnings();
               };
             }
@@ -1293,10 +1293,10 @@ oppia.factory('stateHintsService', [
 
 // Data service for keeping track of gadget data and location across panels.
 oppia.factory('explorationGadgetsService', [
-  '$log', '$modal', '$filter', '$location', '$rootScope',
+  '$log', '$uibModal', '$filter', '$location', '$rootScope',
   'changeListService', 'editorContextService', 'alertsService',
   'gadgetValidationService', 'GADGET_SPECS',
-  function($log, $modal, $filter, $location, $rootScope,
+  function($log, $uibModal, $filter, $location, $rootScope,
            changeListService, editorContextService, alertsService,
            gadgetValidationService, GADGET_SPECS) {
     // _gadgets is a JS object with gadget_instance.name strings as keys
@@ -1626,7 +1626,7 @@ oppia.factory('explorationGadgetsService', [
           return;
         }
 
-        $modal.open({
+        $uibModal.open({
           templateUrl: 'modals/deleteGadget',
           backdrop: true,
           resolve: {
@@ -1635,16 +1635,16 @@ oppia.factory('explorationGadgetsService', [
             }
           },
           controller: [
-            '$scope', '$modalInstance', 'deleteGadgetName',
-            function($scope, $modalInstance, deleteGadgetName) {
+            '$scope', '$uibModalInstance', 'deleteGadgetName',
+            function($scope, $uibModalInstance, deleteGadgetName) {
               $scope.deleteGadgetName = deleteGadgetName;
 
               $scope.reallyDelete = function() {
-                $modalInstance.close(deleteGadgetName);
+                $uibModalInstance.close(deleteGadgetName);
               };
 
               $scope.cancel = function() {
-                $modalInstance.dismiss('cancel');
+                $uibModalInstance.dismiss('cancel');
                 alertsService.clearWarnings();
               };
             }
@@ -2378,10 +2378,10 @@ oppia.factory('lostChangesService', ['utilsService', function(utilsService) {
 // Service for displaying different types of modals depending on the type of
 // response received as a result of the autosaving request.
 oppia.factory('autosaveInfoModalsService', [
-  '$log', '$modal', '$timeout', '$window', 'lostChangesService',
+  '$log', '$uibModal', '$timeout', '$window', 'lostChangesService',
   'explorationData', 'UrlInterpolationService',
   function(
-      $log, $modal, $timeout, $window, lostChangesService,
+      $log, $uibModal, $timeout, $window, lostChangesService,
       explorationData, UrlInterpolationService) {
     var _isModalOpen = false;
     var _refreshPage = function(delay) {
@@ -2392,16 +2392,16 @@ oppia.factory('autosaveInfoModalsService', [
 
     return {
       showNonStrictValidationFailModal: function() {
-        $modal.open({
+        $uibModal.open({
           templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
             '/pages/exploration_editor/' +
             'save_validation_fail_modal.html'),
           // Prevent modal from closing when the user clicks outside it.
           backdrop: 'static',
           controller: [
-            '$scope', '$modalInstance', function($scope, $modalInstance) {
+            '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
               $scope.closeAndRefresh = function() {
-                $modalInstance.dismiss('cancel');
+                $uibModalInstance.dismiss('cancel');
                 _refreshPage(20);
               };
             }
@@ -2418,7 +2418,7 @@ oppia.factory('autosaveInfoModalsService', [
         return _isModalOpen;
       },
       showVersionMismatchModal: function(lostChanges) {
-        $modal.open({
+        $uibModal.open({
           templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
             '/pages/exploration_editor/' +
             'save_version_mismatch_modal.html'),

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
@@ -46,7 +46,7 @@ oppia.controller('ExplorationEditor', [
   'routerService', 'graphDataService', 'stateEditorTutorialFirstTimeService',
   'explorationParamSpecsService', 'explorationParamChangesService',
   'explorationWarningsService', '$templateCache', 'explorationContextService',
-  'explorationAdvancedFeaturesService', '$modal', 'changeListService',
+  'explorationAdvancedFeaturesService', '$uibModal', 'changeListService',
   'autosaveInfoModalsService', 'siteAnalyticsService',
   'UserEmailPreferencesService', 'ParamChangesObjectFactory',
   'UrlInterpolationService',
@@ -60,7 +60,7 @@ oppia.controller('ExplorationEditor', [
       routerService, graphDataService, stateEditorTutorialFirstTimeService,
       explorationParamSpecsService, explorationParamChangesService,
       explorationWarningsService, $templateCache, explorationContextService,
-      explorationAdvancedFeaturesService, $modal, changeListService,
+      explorationAdvancedFeaturesService, $uibModal, changeListService,
       autosaveInfoModalsService, siteAnalyticsService,
       UserEmailPreferencesService, ParamChangesObjectFactory,
       UrlInterpolationService) {
@@ -370,15 +370,15 @@ oppia.controller('ExplorationEditor', [
     };
 
     $scope.showWelcomeExplorationModal = function() {
-      var modalInstance = $modal.open({
+      var modalInstance = $uibModal.open({
         templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
           '/pages/exploration_editor/' +
           'welcome_modal_directive.html'),
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', 'siteAnalyticsService',
+          '$scope', '$uibModalInstance', 'siteAnalyticsService',
           'explorationContextService',
-          function($scope, $modalInstance, siteAnalyticsService,
+          function($scope, $uibModalInstance, siteAnalyticsService,
           explorationContextService) {
             var explorationId = explorationContextService.getExplorationId();
 
@@ -387,13 +387,13 @@ oppia.controller('ExplorationEditor', [
             $scope.beginTutorial = function() {
               siteAnalyticsService.registerAcceptTutorialModalEvent(
                 explorationId);
-              $modalInstance.close();
+              $uibModalInstance.close();
             };
 
             $scope.cancel = function() {
               siteAnalyticsService.registerDeclineTutorialModalEvent(
                 explorationId);
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
             };
 
             $scope.editorWelcomeImgUrl = (

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
@@ -17,7 +17,7 @@
  */
 
 oppia.factory('explorationSaveService', [
-  '$modal', '$timeout', '$rootScope', '$log', '$q',
+  '$uibModal', '$timeout', '$rootScope', '$log', '$q',
   'alertsService', 'explorationData', 'explorationStatesService',
   'explorationTagsService', 'explorationTitleService',
   'explorationObjectiveService', 'explorationCategoryService',
@@ -27,7 +27,7 @@ oppia.factory('explorationSaveService', [
   'focusService', 'changeListService', 'siteAnalyticsService',
   'StatesObjectFactory', 'UrlInterpolationService',
   function(
-      $modal, $timeout, $rootScope, $log, $q,
+      $uibModal, $timeout, $rootScope, $log, $q,
       alertsService, explorationData, explorationStatesService,
       explorationTagsService, explorationTitleService,
       explorationObjectiveService, explorationCategoryService,
@@ -74,20 +74,20 @@ oppia.factory('explorationSaveService', [
     };
 
     var showCongratulatorySharingModal = function() {
-      return $modal.open({
+      return $uibModal.open({
         templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
           '/pages/exploration_editor/' +
           'post_publish_modal_directive.html'),
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', 'explorationContextService',
-          function($scope, $modalInstance, explorationContextService) {
+          '$scope', '$uibModalInstance', 'explorationContextService',
+          function($scope, $uibModalInstance, explorationContextService) {
             $scope.congratsImgUrl = UrlInterpolationService.getStaticImageUrl(
               '/general/congrats.svg');
             $scope.DEFAULT_TWITTER_SHARE_MESSAGE_EDITOR = (
               GLOBALS.DEFAULT_TWITTER_SHARE_MESSAGE_EDITOR);
             $scope.close = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
             };
             $scope.explorationId = (
               explorationContextService.getExplorationId());
@@ -101,17 +101,17 @@ oppia.factory('explorationSaveService', [
       // This is resolved when modal is closed.
       var whenModalClosed = $q.defer();
 
-      var publishModalInstance = $modal.open({
+      var publishModalInstance = $uibModal.open({
         templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
           '/pages/exploration_editor/' +
           'exploration_publish_modal_directive.html'),
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', function($scope, $modalInstance) {
-            $scope.publish = $modalInstance.close;
+          '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
+            $scope.publish = $uibModalInstance.close;
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               alertsService.clearWarnings();
               whenModalClosed.resolve();
             };
@@ -202,17 +202,17 @@ oppia.factory('explorationSaveService', [
       },
 
       discardChanges: function() {
-        $modal.open({
+        $uibModal.open({
           templateUrl: 'modals/confirmDiscardChanges',
           backdrop: 'static',
           keyboard: false,
           controller: [
-            '$scope', '$modalInstance', function($scope, $modalInstance) {
+            '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
               $scope.cancel = function() {
-                $modalInstance.dismiss();
+                $uibModalInstance.dismiss();
               };
               $scope.confirmDiscard = function() {
-                $modalInstance.close();
+                $uibModalInstance.close();
               };
             }
           ]
@@ -220,16 +220,16 @@ oppia.factory('explorationSaveService', [
           alertsService.clearWarnings();
           $rootScope.$broadcast('externalSave');
 
-          $modal.open({
+          $uibModal.open({
             templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
               '/pages/exploration_editor/' +
               'editor_reloading_modal_directive.html'),
             backdrop: 'static',
             keyboard: false,
             controller: [
-              '$scope', '$modalInstance', function($scope, $modalInstance) {
+              '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
                 $timeout(function() {
-                  $modalInstance.dismiss('cancel');
+                  $uibModalInstance.dismiss('cancel');
                 }, 2500);
               }
             ],
@@ -260,17 +260,17 @@ oppia.factory('explorationSaveService', [
         // If the metadata has not yet been specified, open the pre-publication
         // 'add exploration metadata' modal.
         if (isAdditionalMetadataNeeded()) {
-          var modalInstance = $modal.open({
+          var modalInstance = $uibModal.open({
             templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
               '/pages/exploration_editor/' +
               'exploration_metadata_modal_directive.html'),
             backdrop: 'static',
             controller: [
-              '$scope', '$modalInstance', 'explorationObjectiveService',
+              '$scope', '$uibModalInstance', 'explorationObjectiveService',
               'explorationTitleService', 'explorationCategoryService',
               'explorationStatesService', 'ALL_CATEGORIES',
               'explorationLanguageCodeService', 'explorationTagsService',
-              function($scope, $modalInstance, explorationObjectiveService,
+              function($scope, $uibModalInstance, explorationObjectiveService,
               explorationTitleService, explorationCategoryService,
               explorationStatesService, ALL_CATEGORIES,
               explorationLanguageCodeService, explorationTagsService) {
@@ -375,7 +375,7 @@ oppia.factory('explorationSaveService', [
                   // will be called when the draft changes entered here
                   // are properly saved to the backend.
                   $timeout(function() {
-                    $modalInstance.close(metadataList);
+                    $uibModalInstance.close(metadataList);
                   }, 500);
                 };
 
@@ -387,7 +387,7 @@ oppia.factory('explorationSaveService', [
                   explorationLanguageCodeService.restoreFromMemento();
                   explorationTagsService.restoreFromMemento();
 
-                  $modalInstance.dismiss('cancel');
+                  $uibModalInstance.dismiss('cancel');
                   alertsService.clearWarnings();
                 };
               }
@@ -485,7 +485,7 @@ oppia.factory('explorationSaveService', [
             return;
           }
 
-          var modalInstance = $modal.open({
+          var modalInstance = $uibModal.open({
             templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
               '/pages/exploration_editor/' +
               'exploration_save_modal_directive.html'),
@@ -500,8 +500,8 @@ oppia.factory('explorationSaveService', [
             },
             windowClass: 'oppia-save-exploration-modal',
             controller: [
-              '$scope', '$modalInstance', 'isExplorationPrivate',
-              function($scope, $modalInstance, isExplorationPrivate) {
+              '$scope', '$uibModalInstance', 'isExplorationPrivate',
+              function($scope, $uibModalInstance, isExplorationPrivate) {
                 $scope.showDiff = false;
                 $scope.onClickToggleDiffButton = function() {
                   $scope.showDiff = !$scope.showDiff;
@@ -521,10 +521,10 @@ oppia.factory('explorationSaveService', [
                 $scope.laterVersionHeader = 'New changes';
 
                 $scope.save = function(commitMessage) {
-                  $modalInstance.close(commitMessage);
+                  $uibModalInstance.close(commitMessage);
                 };
                 $scope.cancel = function() {
-                  $modalInstance.dismiss('cancel');
+                  $uibModalInstance.dismiss('cancel');
                   alertsService.clearWarnings();
                 };
               }

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
@@ -227,7 +227,8 @@ oppia.factory('explorationSaveService', [
             backdrop: 'static',
             keyboard: false,
             controller: [
-              '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
+              '$scope', '$uibModalInstance',
+              function($scope, $uibModalInstance) {
                 $timeout(function() {
                   $uibModalInstance.dismiss('cancel');
                 }, 2500);

--- a/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
@@ -26,7 +26,7 @@
   </style>
   <ul class="nav navbar-nav oppia-navbar-nav pull-right ng-cloak" style="margin-left: 20px;">
     <li ng-class="{'active': getTabStatuses().active === 'main', 'dropdown': countWarnings()}">
-      <a href="#" tooltip="Editor" tooltip-placement="<[countWarnings() ? 'left' : 'bottom']>" ng-click="selectMainTab()"
+      <a href="#" uib-tooltip="Editor" tooltip-placement="<[countWarnings() ? 'left' : 'bottom']>" ng-click="selectMainTab()"
          class="oppia-editor-navbar-tab-anchor protractor-test-main-tab">
         <i class="material-icons">&#xE254;</i>
       </a>
@@ -51,7 +51,7 @@
 
     {% if username %}
       <li id="tutorialPreviewTab" ng-class="{'active': getTabStatuses().active === 'preview'}">
-        <a href="#" tooltip="Preview" tooltip-placement="bottom" ng-click="selectPreviewTab()"
+        <a href="#" uib-tooltip="Preview" tooltip-placement="bottom" ng-click="selectPreviewTab()"
            class="oppia-editor-navbar-tab-anchor protractor-test-preview-tab">
           <i class="material-icons">&#xE037;</i>
         </a>
@@ -59,7 +59,7 @@
     {% endif %}
 
     <li ng-if="isLargeScreen" ng-class="{'active': getTabStatuses().active === 'settings'}">
-      <a href="#" tooltip="Settings" tooltip-placement="bottom" ng-click="selectSettingsTab()"
+      <a href="#" uib-tooltip="Settings" tooltip-placement="bottom" ng-click="selectSettingsTab()"
          class="oppia-editor-navbar-tab-anchor protractor-test-settings-tab">
         <i class="material-icons">&#xE8B8;</i>
       </a>
@@ -67,7 +67,7 @@
 
     {% if username %}
       <li ng-if="isLargeScreen" ng-class="{'active': getTabStatuses().active === 'stats'}">
-        <a href="#" tooltip="Statistics" tooltip-placement="bottom" ng-click="selectStatsTab()"
+        <a href="#" uib-tooltip="Statistics" tooltip-placement="bottom" ng-click="selectStatsTab()"
            class="oppia-editor-navbar-tab-anchor">
           <i class="material-icons">&#xE24B;</i>
         </a>
@@ -75,7 +75,7 @@
     {% endif %}
 
     <li ng-if="isLargeScreen" ng-class="{'active': getTabStatuses().active === 'history'}">
-      <a href="#" tooltip="History" tooltip-placement="bottom" ng-click="selectHistoryTab()"
+      <a href="#" uib-tooltip="History" tooltip-placement="bottom" ng-click="selectHistoryTab()"
          disabled="explorationRightsService.isCloned()"
          class="oppia-editor-navbar-tab-anchor protractor-test-history-tab">
         <i class="material-icons">&#xE192;</i>
@@ -83,7 +83,7 @@
     </li>
 
     <li ng-if="isLargeScreen" ng-class="{'active': getTabStatuses().active === 'feedback'}" ng-click="selectFeedbackTab()">
-      <a href="#" tooltip="Feedback" tooltip-placement="bottom"
+      <a href="#" uib-tooltip="Feedback" tooltip-placement="bottom"
          class="oppia-editor-navbar-tab-anchor protractor-test-feedback-tab">
         <i class="material-icons">&#xE87F;</i>
       </a>
@@ -99,7 +99,7 @@
       <li class="dropdown" popover-is-open="postTutorialHelpPopoverIsShown"
           popover-placement="bottom" popover-trigger="none"
           popover="To get help in the future, click here!">
-        <a href="#" tooltip="Help" tooltip-placement="bottom"
+        <a href="#" uib-tooltip="Help" tooltip-placement="bottom"
            class="oppia-editor-navbar-tab-anchor" ng-click="showUserHelpModal()">
           <i class="material-icons">&#xE887;</i>
         </a>

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/ExplorationGraph.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/ExplorationGraph.js
@@ -17,11 +17,11 @@
  */
 
 oppia.controller('ExplorationGraph', [
-  '$scope', '$modal', 'editorContextService', 'alertsService',
+  '$scope', '$uibModal', 'editorContextService', 'alertsService',
   'explorationStatesService', 'editabilityService', 'routerService',
   'graphDataService',
   function(
-      $scope, $modal, editorContextService, alertsService,
+      $scope, $uibModal, editorContextService, alertsService,
       explorationStatesService, editabilityService, routerService,
       graphDataService) {
     $scope.getGraphData = graphDataService.getGraphData;
@@ -49,7 +49,7 @@ oppia.controller('ExplorationGraph', [
     $scope.openStateGraphModal = function() {
       alertsService.clearWarnings();
 
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/stateGraph',
         backdrop: true,
         resolve: {
@@ -59,30 +59,30 @@ oppia.controller('ExplorationGraph', [
         },
         windowClass: 'oppia-large-modal-window',
         controller: [
-          '$scope', '$modalInstance', 'editorContextService',
+          '$scope', '$uibModalInstance', 'editorContextService',
           'graphDataService', 'isEditable',
-          function($scope, $modalInstance, editorContextService,
+          function($scope, $uibModalInstance, editorContextService,
                    graphDataService, isEditable) {
             $scope.currentStateName = editorContextService.getActiveStateName();
             $scope.graphData = graphDataService.getGraphData();
             $scope.isEditable = isEditable;
 
             $scope.deleteState = function(stateName) {
-              $modalInstance.close({
+              $uibModalInstance.close({
                 action: 'delete',
                 stateName: stateName
               });
             };
 
             $scope.selectState = function(stateName) {
-              $modalInstance.close({
+              $uibModalInstance.close({
                 action: 'navigate',
                 stateName: stateName
               });
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               alertsService.clearWarnings();
             };
           }

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/GadgetEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/GadgetEditor.js
@@ -18,10 +18,10 @@
 
 // Controls adding, deleting and updating gadgets.
 oppia.controller('GadgetEditor', [
-  '$scope', '$modal', '$log', 'editorContextService',
+  '$scope', '$uibModal', '$log', 'editorContextService',
   'explorationGadgetsService', 'GADGET_SPECS',
   function(
-      $scope, $modal, $log, editorContextService,
+      $scope, $uibModal, $log, editorContextService,
       explorationGadgetsService, GADGET_SPECS) {
     $scope.GADGET_SPECS = GADGET_SPECS;
 
@@ -81,7 +81,7 @@ oppia.controller('GadgetEditor', [
      *   dismissed.
      */
     var _openCustomizeGadgetModal = function(gadgetDict, successCallback) {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/customizeGadget',
         // Clicking outside this modal should not dismiss it.
         backdrop: 'static',
@@ -91,11 +91,11 @@ oppia.controller('GadgetEditor', [
           }
         },
         controller: [
-          '$scope', '$modalInstance', 'explorationStatesService',
+          '$scope', '$uibModalInstance', 'explorationStatesService',
           'explorationGadgetsService', 'gadgetDict', 'GADGET_SPECS',
           'UrlInterpolationService',
           function(
-              $scope, $modalInstance, explorationStatesService,
+              $scope, $uibModalInstance, explorationStatesService,
               explorationGadgetsService, gadgetDict, GADGET_SPECS,
               UrlInterpolationService) {
             $scope.getGadgetImgUrl = UrlInterpolationService.getGadgetImgUrl;
@@ -188,7 +188,7 @@ oppia.controller('GadgetEditor', [
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
             };
 
             $scope.save = function() {
@@ -202,7 +202,7 @@ oppia.controller('GadgetEditor', [
                     $scope.gadgetDict)) {
                 return;
               }
-              $modalInstance.close($scope.gadgetDict);
+              $uibModalInstance.close($scope.gadgetDict);
             };
           }
         ]

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateEditor.js
@@ -131,8 +131,8 @@ oppia.controller('StateEditor', [
 // A service which handles opening and closing the training modal used for both
 // unresolved answers and answers within the training data of a classifier.
 oppia.factory('trainingModalService', [
-  '$rootScope', '$modal', 'alertsService',
-  function($rootScope, $modal, alertsService) {
+  '$rootScope', '$uibModal', 'alertsService',
+  function($rootScope, $uibModal, alertsService) {
     return {
       openTrainUnresolvedAnswerModal: function(unhandledAnswer, externalSave) {
         alertsService.clearWarnings();
@@ -140,15 +140,15 @@ oppia.factory('trainingModalService', [
           $rootScope.$broadcast('externalSave');
         }
 
-        $modal.open({
+        $uibModal.open({
           templateUrl: 'modals/trainUnresolvedAnswer',
           backdrop: true,
           controller: [
-            '$scope', '$injector', '$modalInstance',
+            '$scope', '$injector', '$uibModalInstance',
             'explorationStatesService', 'editorContextService',
             'AnswerClassificationService', 'explorationContextService',
             'stateInteractionIdService', 'angularNameService',
-            function($scope, $injector, $modalInstance,
+            function($scope, $injector, $uibModalInstance,
                 explorationStatesService, editorContextService,
                 AnswerClassificationService, explorationContextService,
                 stateInteractionIdService, angularNameService) {
@@ -164,7 +164,7 @@ oppia.factory('trainingModalService', [
               };
 
               $scope.finishTraining = function() {
-                $modalInstance.close();
+                $uibModalInstance.close();
               };
 
               $scope.init = function() {

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateFallbacks.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateFallbacks.js
@@ -17,12 +17,12 @@
  */
 
 oppia.controller('StateFallbacks', [
-  '$scope', '$rootScope', '$modal', '$filter', 'editorContextService',
+  '$scope', '$rootScope', '$uibModal', '$filter', 'editorContextService',
   'alertsService', 'INTERACTION_SPECS', 'stateFallbacksService',
   'explorationStatesService', 'stateInteractionIdService',
   'UrlInterpolationService', 'FallbackObjectFactory',
   function(
-      $scope, $rootScope, $modal, $filter, editorContextService,
+      $scope, $rootScope, $uibModal, $filter, editorContextService,
       alertsService, INTERACTION_SPECS, stateFallbacksService,
       explorationStatesService, stateInteractionIdService,
       UrlInterpolationService, FallbackObjectFactory) {
@@ -72,12 +72,12 @@ oppia.controller('StateFallbacks', [
       alertsService.clearWarnings();
       $rootScope.$broadcast('externalSave');
 
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/addFallback',
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', 'editorContextService',
-          function($scope, $modalInstance, editorContextService) {
+          '$scope', '$uibModalInstance', 'editorContextService',
+          function($scope, $uibModalInstance, editorContextService) {
             $scope.INT_FORM_SCHEMA = {
               type: 'int',
               ui_config: {},
@@ -106,13 +106,13 @@ oppia.controller('StateFallbacks', [
               $scope.$broadcast('saveOutcomeFeedbackDetails');
               $scope.$broadcast('saveOutcomeDestDetails');
               // Close the modal and save it afterwards.
-              $modalInstance.close({
+              $uibModalInstance.close({
                 fallback: angular.copy($scope.tmpFallback)
               });
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               alertsService.clearWarnings();
             };
           }
@@ -150,17 +150,17 @@ oppia.controller('StateFallbacks', [
       evt.stopPropagation();
 
       alertsService.clearWarnings();
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/deleteFallback',
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', function($scope, $modalInstance) {
+          '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
             $scope.reallyDelete = function() {
-              $modalInstance.close();
+              $uibModalInstance.close();
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               alertsService.clearWarnings();
             };
           }

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateHints.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateHints.js
@@ -17,12 +17,12 @@
  */
 
 oppia.controller('StateHints', [
-  '$scope', '$rootScope', '$modal', '$filter', 'editorContextService',
+  '$scope', '$rootScope', '$uibModal', '$filter', 'editorContextService',
   'ENABLE_HINT_EDITOR', 'alertsService', 'INTERACTION_SPECS',
   'stateHintsService', 'explorationStatesService', 'stateInteractionIdService',
   'UrlInterpolationService', 'HintObjectFactory',
   function(
-    $scope, $rootScope, $modal, $filter, editorContextService,
+    $scope, $rootScope, $uibModal, $filter, editorContextService,
     ENABLE_HINT_EDITOR, alertsService, INTERACTION_SPECS,
     stateHintsService, explorationStatesService, stateInteractionIdService,
     UrlInterpolationService, HintObjectFactory) {
@@ -69,12 +69,12 @@ oppia.controller('StateHints', [
       alertsService.clearWarnings();
       $rootScope.$broadcast('externalSave');
 
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/addHint',
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', 'editorContextService',
-          function($scope, $modalInstance, editorContextService) {
+          '$scope', '$uibModalInstance', 'editorContextService',
+          function($scope, $uibModalInstance, editorContextService) {
             $scope.HINT_FORM_SCHEMA = {
               type: 'html',
               ui_config: {}
@@ -88,14 +88,14 @@ oppia.controller('StateHints', [
 
             $scope.saveHint = function() {
               // Close the modal and save it afterwards.
-              $modalInstance.close({
+              $uibModalInstance.close({
                 hint: angular.copy(
                   HintObjectFactory.createNew($scope.tmpHint))
               });
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               alertsService.clearWarnings();
             };
           }
@@ -133,17 +133,17 @@ oppia.controller('StateHints', [
       evt.stopPropagation();
 
       alertsService.clearWarnings();
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/deleteHint',
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', function($scope, $modalInstance) {
+          '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
             $scope.reallyDelete = function() {
-              $modalInstance.close();
+              $uibModalInstance.close();
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               alertsService.clearWarnings();
             };
           }

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
@@ -44,14 +44,14 @@ oppia.factory('interactionDetailsCache', [function() {
 }]);
 
 oppia.controller('StateInteraction', [
-  '$scope', '$http', '$rootScope', '$modal', '$injector', '$filter',
+  '$scope', '$http', '$rootScope', '$uibModal', '$injector', '$filter',
   'alertsService', 'editorContextService', 'oppiaHtmlEscaper',
   'INTERACTION_SPECS', 'stateInteractionIdService',
   'stateCustomizationArgsService', 'editabilityService',
   'explorationStatesService', 'graphDataService', 'interactionDetailsCache',
   'oppiaExplorationHtmlFormatterService', 'UrlInterpolationService',
   'SubtitledHtmlObjectFactory',
-  function($scope, $http, $rootScope, $modal, $injector, $filter,
+  function($scope, $http, $rootScope, $uibModal, $injector, $filter,
       alertsService, editorContextService, oppiaHtmlEscaper,
       INTERACTION_SPECS, stateInteractionIdService,
       stateCustomizationArgsService, editabilityService,
@@ -181,18 +181,18 @@ oppia.controller('StateInteraction', [
       if (editabilityService.isEditable()) {
         alertsService.clearWarnings();
 
-        $modal.open({
+        $uibModal.open({
           templateUrl: 'modals/customizeInteraction',
           // Clicking outside this modal should not dismiss it.
           backdrop: 'static',
           resolve: {},
           controller: [
-            '$scope', '$modalInstance', '$injector',
+            '$scope', '$uibModalInstance', '$injector',
             'stateInteractionIdService', 'stateCustomizationArgsService',
             'interactionDetailsCache', 'INTERACTION_SPECS',
             'UrlInterpolationService', 'editorFirstTimeEventsService',
             function(
-                $scope, $modalInstance, $injector,
+                $scope, $uibModalInstance, $injector,
                 stateInteractionIdService, stateCustomizationArgsService,
                 interactionDetailsCache, INTERACTION_SPECS,
                 UrlInterpolationService, editorFirstTimeEventsService) {
@@ -334,15 +334,15 @@ oppia.controller('StateInteraction', [
               $scope.save = function() {
                 editorFirstTimeEventsService
                   .registerFirstSaveInteractionEvent();
-                $modalInstance.close();
+                $uibModalInstance.close();
               };
 
               $scope.okay = function() {
-                $modalInstance.close('okay');
+                $uibModalInstance.close('okay');
               };
 
               $scope.cancel = function() {
-                $modalInstance.dismiss('cancel');
+                $uibModalInstance.dismiss('cancel');
               };
             }
           ]
@@ -355,17 +355,17 @@ oppia.controller('StateInteraction', [
 
     $scope.deleteInteraction = function() {
       alertsService.clearWarnings();
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/deleteInteraction',
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', function($scope, $modalInstance) {
+          '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
             $scope.reallyDelete = function() {
-              $modalInstance.close();
+              $uibModalInstance.close();
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               alertsService.clearWarnings();
             };
           }

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
@@ -326,13 +326,13 @@ oppia.factory('responsesService', [
 ]);
 
 oppia.controller('StateResponses', [
-  '$scope', '$rootScope', '$modal', '$filter', 'stateInteractionIdService',
+  '$scope', '$rootScope', '$uibModal', '$filter', 'stateInteractionIdService',
   'editorContextService', 'alertsService', 'responsesService', 'routerService',
   'explorationContextService', 'trainingDataService',
   'stateCustomizationArgsService', 'PLACEHOLDER_OUTCOME_DEST',
   'INTERACTION_SPECS', 'UrlInterpolationService', 'AnswerGroupObjectFactory',
   function(
-      $scope, $rootScope, $modal, $filter, stateInteractionIdService,
+      $scope, $rootScope, $uibModal, $filter, stateInteractionIdService,
       editorContextService, alertsService, responsesService, routerService,
       explorationContextService, trainingDataService,
       stateCustomizationArgsService, PLACEHOLDER_OUTCOME_DEST,
@@ -554,11 +554,11 @@ oppia.controller('StateResponses', [
       alertsService.clearWarnings();
       $rootScope.$broadcast('externalSave');
 
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/teachOppia',
         backdrop: false,
         controller: [
-          '$scope', '$injector', '$modalInstance',
+          '$scope', '$injector', '$uibModalInstance',
           'oppiaExplorationHtmlFormatterService',
           'stateInteractionIdService', 'stateCustomizationArgsService',
           'explorationContextService', 'editorContextService',
@@ -566,7 +566,7 @@ oppia.controller('StateResponses', [
           'AnswerClassificationService', 'focusService',
           'angularNameService', 'RULE_TYPE_CLASSIFIER',
           function(
-              $scope, $injector, $modalInstance,
+              $scope, $injector, $uibModalInstance,
               oppiaExplorationHtmlFormatterService,
               stateInteractionIdService, stateCustomizationArgsService,
               explorationContextService, editorContextService,
@@ -610,7 +610,7 @@ oppia.controller('StateResponses', [
             focusService.setFocus('testInteractionInput');
 
             $scope.finishTeaching = function(reopen) {
-              $modalInstance.close({
+              $uibModalInstance.close({
                 reopen: reopen
               });
             };
@@ -664,16 +664,16 @@ oppia.controller('StateResponses', [
       alertsService.clearWarnings();
       $rootScope.$broadcast('externalSave');
 
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/addAnswerGroup',
         // Clicking outside this modal should not dismiss it.
         backdrop: 'static',
         controller: [
-          '$scope', '$modalInstance', 'responsesService',
+          '$scope', '$uibModalInstance', 'responsesService',
           'editorContextService', 'editorFirstTimeEventsService',
           'RuleObjectFactory', 'OutcomeObjectFactory',
           function(
-              $scope, $modalInstance, responsesService,
+              $scope, $uibModalInstance, responsesService,
               editorContextService, editorFirstTimeEventsService,
               RuleObjectFactory, OutcomeObjectFactory) {
             $scope.feedbackEditorIsOpen = false;
@@ -714,7 +714,7 @@ oppia.controller('StateResponses', [
               editorFirstTimeEventsService.registerFirstSaveRuleEvent();
 
               // Close the modal and save it afterwards.
-              $modalInstance.close({
+              $uibModalInstance.close({
                 tmpRule: angular.copy($scope.tmpRule),
                 tmpOutcome: angular.copy($scope.tmpOutcome),
                 reopen: reopen
@@ -722,7 +722,7 @@ oppia.controller('StateResponses', [
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               alertsService.clearWarnings();
             };
           }
@@ -768,17 +768,17 @@ oppia.controller('StateResponses', [
       evt.stopPropagation();
 
       alertsService.clearWarnings();
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/deleteAnswerGroup',
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', function($scope, $modalInstance) {
+          '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
             $scope.reallyDelete = function() {
-              $modalInstance.close();
+              $uibModalInstance.close();
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               alertsService.clearWarnings();
             };
           }

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateStatistics.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateStatistics.js
@@ -18,12 +18,12 @@
  */
 
 oppia.controller('StateStatistics', [
-  '$rootScope', '$scope', '$modal', 'explorationData', 'editorContextService',
+  '$rootScope', '$scope', '$uibModal', 'explorationData', 'editorContextService',
   'explorationStatesService', 'trainingDataService',
   'stateCustomizationArgsService', 'oppiaExplorationHtmlFormatterService',
   'trainingModalService', 'INTERACTION_SPECS',
   function(
-      $rootScope, $scope, $modal, explorationData, editorContextService,
+      $rootScope, $scope, $uibModal, explorationData, editorContextService,
       explorationStatesService, trainingDataService,
       stateCustomizationArgsService, oppiaExplorationHtmlFormatterService,
       trainingModalService, INTERACTION_SPECS) {

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateStatistics.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateStatistics.js
@@ -18,8 +18,8 @@
  */
 
 oppia.controller('StateStatistics', [
-  '$rootScope', '$scope', '$uibModal', 'explorationData', 'editorContextService',
-  'explorationStatesService', 'trainingDataService',
+  '$rootScope', '$scope', '$uibModal', 'explorationData',
+  'editorContextService', 'explorationStatesService', 'trainingDataService',
   'stateCustomizationArgsService', 'oppiaExplorationHtmlFormatterService',
   'trainingModalService', 'INTERACTION_SPECS',
   function(

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/gadget_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/gadget_editor.html
@@ -2,7 +2,7 @@
   <span style="font-size: 14px;">
     <strong>Gadgets</strong>
   </span>
-  <i class="material-icons md-18" tooltip="These can be reused throughout an exploration." tooltip-placement="bottom" 
+  <i class="material-icons md-18" uib-tooltip="These can be reused throughout an exploration." tooltip-placement="bottom" 
      style="padding-left: 4px; vertical-align: text-top;">&#xE88E;</i>
 
   <md-card style="background-color: white; margin: 20px 0px; padding: 10px 10px;" class="md-default-theme">

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_interaction.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_interaction.html
@@ -43,8 +43,8 @@
 
   <div class="modal-body">
     <div ng-if="!stateInteractionIdService.displayed" ng-cloak>
-      <tabset>
-        <tab ng-repeat="category in ALLOWED_INTERACTION_CATEGORIES"
+      <uib-tabset>
+        <uib-tab ng-repeat="category in ALLOWED_INTERACTION_CATEGORIES"
              heading="<[category.name]>" active="category.active"
              class="protractor-test-interaction-tab-<[category.name]>">
           <br>
@@ -56,8 +56,8 @@
               <[INTERACTION_SPECS[interactionId].name]>
             </div>
           </div>
-        </tab>
-      </tabset>
+        </uib-tab>
+      </uib-tabset>
     </div>
 
     <form ng-if="stateInteractionIdService.displayed && hasCustomizationArgs" name="form.schemaForm" class="protractor-test-interaction-editor">
@@ -87,7 +87,7 @@
          popover-append-to-body
          popover-placement="bottom"
          popover-trigger="<[isSaveInteractionButtonEnabled() ? 'none' : 'mouseenter']>"
-         ng-attr-popover="<[getSaveInteractionButtonTooltip()]>">
+         ng-attr-uib-popover="<[getSaveInteractionButtonTooltip()]>">
       <button class="btn btn-success protractor-test-save-interaction"
               ng-click="save()"
               ng-disabled="!isSaveInteractionButtonEnabled()">

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
@@ -17,7 +17,7 @@
               <img ng-if="editabilityService.isEditable()" ng-src="<[dragDotsImgUrl]>" width="10">
             </span>
             <div class="oppia-rule-header-warning-placement" ng-if="isSelfLoopWithNoFeedback(answerGroup.outcome)" ng-click="changeActiveAnswerGroupIndex($index)"
-                 tooltip="<[getOutcomeTooltip(answerGroup.outcome)]>" tooltip-placement="bottom">
+                 uib-tooltip="<[getOutcomeTooltip(answerGroup.outcome)]>" tooltip-placement="bottom">
               <div class="oppia-rule-header-warning-style" >
                 ⚠
               </div>
@@ -56,7 +56,7 @@
         <ul class="nav oppia-option-list nav-stacked nav-pills" role="tablist">
           <li ng-class="{'active': activeAnswerGroupIndex === answerGroups.length}" class="oppia-rule-block">
             <div class="oppia-rule-header-warning-placement" ng-if="isSelfLoopWithNoFeedback(defaultOutcome) && !suppressDefaultAnswerGroupWarnings()" ng-click="changeActiveAnswerGroupIndex(answerGroups.length)"
-                 tooltip="<[getOutcomeTooltip(defaultOutcome)]>" tooltip-placement="bottom">
+                 uib-tooltip="<[getOutcomeTooltip(defaultOutcome)]>" tooltip-placement="bottom">
               <div class="oppia-rule-header-warning-style" >
                 ⚠
               </div>

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_graph_visualization_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_graph_visualization_directive.html
@@ -103,7 +103,7 @@ with the same id on the page. -->
                       style="fill: yellow;" width="22" height="22"
                       ng-attr-x="<[node.x0]>" ng-attr-y="<[node.y0 - 8]>"
                       ng-attr-transform="<[getHighlightTransform(node.x0, node.y0)]>"
-                      tooltip="<[getNodeErrorMessage(node.label)]>"
+                      uib-tooltip="<[getNodeErrorMessage(node.label)]>"
                       tooltip-placement="bottom" tooltip-animation="true"
                       tooltip-append-to-body="true">
                 </rect>

--- a/core/templates/dev/head/pages/exploration_editor/exploration_save_and_publish_buttons_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_save_and_publish_buttons_directive.html
@@ -26,7 +26,7 @@
   </li>
 
   <li ng-if="isEditableOutsideTutorialMode()">
-    <div dropdown class="btn-group" style="margin-right: 10px; margin-top: 8px;"
+    <div uib-dropdown class="btn-group" style="margin-right: 10px; margin-top: 8px;"
          title="<[getSaveButtonTooltip()]>">
       <button id="tutorialSaveButton" class="btn btn-default oppia-save-draft-button protractor-test-save-changes" ng-class="{'btn-success': isExplorationSaveable(), 'oppia-save-draft-button-padding': getChangeListLength() && !isPrivate()}" ng-click="saveChanges()" ng-disabled="!isExplorationSaveable()">
         <span ng-if="!saveIsInProcess">

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
@@ -143,9 +143,9 @@ oppia.controller('FeedbackTab', [
           }
         },
         controller: [
-          '$scope', '$uibModalInstance', 'suggestionIsOpen', 'suggestionIsValid',
-          'unsavedChangesExist', 'suggestionStatus', 'description',
-          'currentContent', 'newContent', 'editabilityService',
+          '$scope', '$uibModalInstance', 'suggestionIsOpen',
+          'suggestionIsValid', 'unsavedChangesExist', 'suggestionStatus',
+          'description', 'currentContent', 'newContent', 'editabilityService',
           function(
             $scope, $uibModalInstance, suggestionIsOpen, suggestionIsValid,
             unsavedChangesExist, suggestionStatus, description,

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
@@ -17,12 +17,12 @@
  */
 
 oppia.controller('FeedbackTab', [
-  '$scope', '$http', '$modal', '$timeout', '$rootScope', 'alertsService',
+  '$scope', '$http', '$uibModal', '$timeout', '$rootScope', 'alertsService',
   'oppiaDatetimeFormatter', 'threadStatusDisplayService',
   'threadDataService', 'explorationStatesService', 'explorationData',
   'changeListService', 'StateObjectFactory',
   function(
-    $scope, $http, $modal, $timeout, $rootScope, alertsService,
+    $scope, $http, $uibModal, $timeout, $rootScope, alertsService,
     oppiaDatetimeFormatter, threadStatusDisplayService,
     threadDataService, explorationStatesService, explorationData,
     changeListService, StateObjectFactory) {
@@ -55,12 +55,12 @@ oppia.controller('FeedbackTab', [
     };
 
     $scope.showCreateThreadModal = function() {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/editorFeedbackCreateThread',
         backdrop: true,
         resolve: {},
-        controller: ['$scope', '$modalInstance', function(
-          $scope, $modalInstance) {
+        controller: ['$scope', '$uibModalInstance', function(
+          $scope, $uibModalInstance) {
           $scope.newThreadSubject = '';
           $scope.newThreadText = '';
 
@@ -74,14 +74,14 @@ oppia.controller('FeedbackTab', [
               return;
             }
 
-            $modalInstance.close({
+            $uibModalInstance.close({
               newThreadSubject: newThreadSubject,
               newThreadText: newThreadText
             });
           };
 
           $scope.cancel = function() {
-            $modalInstance.dismiss('cancel');
+            $uibModalInstance.dismiss('cancel');
           };
         }]
       }).result.then(function(result) {
@@ -113,7 +113,7 @@ oppia.controller('FeedbackTab', [
 
     // TODO(Allan): Implement ability to edit suggestions before applying.
     $scope.showSuggestionModal = function() {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/editorViewSuggestion',
         backdrop: true,
         size: 'lg',
@@ -143,11 +143,11 @@ oppia.controller('FeedbackTab', [
           }
         },
         controller: [
-          '$scope', '$modalInstance', 'suggestionIsOpen', 'suggestionIsValid',
+          '$scope', '$uibModalInstance', 'suggestionIsOpen', 'suggestionIsValid',
           'unsavedChangesExist', 'suggestionStatus', 'description',
           'currentContent', 'newContent', 'editabilityService',
           function(
-            $scope, $modalInstance, suggestionIsOpen, suggestionIsValid,
+            $scope, $uibModalInstance, suggestionIsOpen, suggestionIsValid,
             unsavedChangesExist, suggestionStatus, description,
             currentContent, newContent, editabilityService) {
             var SUGGESTION_ACCEPTED_MSG = 'This suggestion has already been ' +
@@ -183,20 +183,20 @@ oppia.controller('FeedbackTab', [
             $scope.commitMessage = description;
 
             $scope.acceptSuggestion = function() {
-              $modalInstance.close({
+              $uibModalInstance.close({
                 action: ACTION_ACCEPT_SUGGESTION,
                 commitMessage: $scope.commitMessage
               });
             };
 
             $scope.rejectSuggestion = function() {
-              $modalInstance.close({
+              $uibModalInstance.close({
                 action: ACTION_REJECT_SUGGESTION
               });
             };
 
             $scope.cancelReview = function() {
-              $modalInstance.dismiss();
+              $uibModalInstance.dismiss();
             };
           }
         ]

--- a/core/templates/dev/head/pages/exploration_editor/history_tab/HistoryTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/history_tab/HistoryTab.js
@@ -17,11 +17,11 @@
  */
 
 oppia.controller('HistoryTab', [
-  '$scope', '$http', '$rootScope', '$log', '$modal', 'explorationData',
+  '$scope', '$http', '$rootScope', '$log', '$uibModal', 'explorationData',
   'versionsTreeService', 'compareVersionsService', 'graphDataService',
   'oppiaDatetimeFormatter',
   function(
-      $scope, $http, $rootScope, $log, $modal, explorationData,
+      $scope, $http, $rootScope, $log, $uibModal, explorationData,
       versionsTreeService, compareVersionsService, graphDataService,
       oppiaDatetimeFormatter) {
     $scope.explorationId = explorationData.explorationId;
@@ -218,7 +218,7 @@ oppia.controller('HistoryTab', [
     };
 
     $scope.showRevertExplorationModal = function(version) {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/revertExploration',
         backdrop: true,
         resolve: {
@@ -227,8 +227,8 @@ oppia.controller('HistoryTab', [
           }
         },
         controller: [
-          '$scope', '$modalInstance', 'version', 'explorationData',
-          function($scope, $modalInstance, version, explorationData) {
+          '$scope', '$uibModalInstance', 'version', 'explorationData',
+          function($scope, $uibModalInstance, version, explorationData) {
             $scope.version = version;
 
             $scope.getExplorationUrl = function(version) {
@@ -237,11 +237,11 @@ oppia.controller('HistoryTab', [
             };
 
             $scope.revert = function() {
-              $modalInstance.close(version);
+              $uibModalInstance.close(version);
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
             };
           }
         ]

--- a/core/templates/dev/head/pages/exploration_editor/preview_tab/PreviewTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/preview_tab/PreviewTab.js
@@ -18,7 +18,7 @@
  */
 
 oppia.controller('PreviewTab', [
-  '$scope', '$modal', '$q', '$timeout', 'LearnerParamsService',
+  '$scope', '$uibModal', '$q', '$timeout', 'LearnerParamsService',
   'explorationData', 'explorationAdvancedFeaturesService',
   'explorationCategoryService', 'editorContextService',
   'explorationGadgetsService', 'explorationInitStateNameService',
@@ -27,7 +27,7 @@ oppia.controller('PreviewTab', [
   'oppiaPlayerService', 'parameterMetadataService',
   'ParamChangeObjectFactory', 'UrlInterpolationService',
   function(
-      $scope, $modal, $q, $timeout, LearnerParamsService,
+      $scope, $uibModal, $q, $timeout, LearnerParamsService,
       explorationData, explorationAdvancedFeaturesService,
       explorationCategoryService, editorContextService,
       explorationGadgetsService, explorationInitStateNameService,
@@ -89,19 +89,19 @@ oppia.controller('PreviewTab', [
     };
 
     $scope.showSetParamsModal = function(manualParamChanges, callback) {
-      var modalInstance = $modal.open({
+      var modalInstance = $uibModal.open({
         templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
           '/pages/exploration_editor/preview_tab/' +
           'preview_set_parameters_modal_directive.html'),
         backdrop: 'static',
         windowClass: 'oppia-preview-set-params-modal',
         controller: [
-          '$scope', '$modalInstance', 'routerService',
-          function($scope, $modalInstance, routerService) {
+          '$scope', '$uibModalInstance', 'routerService',
+          function($scope, $uibModalInstance, routerService) {
             $scope.manualParamChanges = manualParamChanges;
-            $scope.previewParamModalOk = $modalInstance.close;
+            $scope.previewParamModalOk = $uibModalInstance.close;
             $scope.previewParamModalCancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               routerService.navigateToMainTab();
             };
           }

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
@@ -17,7 +17,7 @@
  */
 
 oppia.controller('SettingsTab', [
-  '$scope', '$http', '$window', '$modal', '$rootScope',
+  '$scope', '$http', '$window', '$uibModal', '$rootScope',
   'explorationData', 'explorationTitleService', 'explorationCategoryService',
   'explorationObjectiveService', 'explorationLanguageCodeService',
   'explorationTagsService', 'explorationRightsService',
@@ -29,7 +29,7 @@ oppia.controller('SettingsTab', [
   'EditableExplorationBackendApiService', 'UrlInterpolationService',
   'ENABLE_FALLBACK_EDITOR',
   function(
-      $scope, $http, $window, $modal, $rootScope,
+      $scope, $http, $window, $uibModal, $rootScope,
       explorationData, explorationTitleService, explorationCategoryService,
       explorationObjectiveService, explorationLanguageCodeService,
       explorationTagsService, explorationRightsService,
@@ -232,11 +232,11 @@ oppia.controller('SettingsTab', [
     ********************************************/
     $scope.previewSummaryTile = function() {
       alertsService.clearWarnings();
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/previewSummaryTile',
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', function($scope, $modalInstance) {
+          '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
             $scope.getExplorationTitle = function() {
               return explorationTitleService.displayed;
             };
@@ -265,7 +265,7 @@ oppia.controller('SettingsTab', [
             };
 
             $scope.close = function() {
-              $modalInstance.dismiss();
+              $uibModalInstance.dismiss();
               alertsService.clearWarnings();
             };
           }
@@ -275,15 +275,15 @@ oppia.controller('SettingsTab', [
 
     $scope.showTransferExplorationOwnershipModal = function() {
       alertsService.clearWarnings();
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/transferExplorationOwnership',
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', function($scope, $modalInstance) {
-            $scope.transfer = $modalInstance.close;
+          '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
+            $scope.transfer = $uibModalInstance.close;
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               alertsService.clearWarnings();
             };
           }
@@ -298,15 +298,15 @@ oppia.controller('SettingsTab', [
     $scope.deleteExploration = function() {
       alertsService.clearWarnings();
 
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/deleteExploration',
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', function($scope, $modalInstance) {
-            $scope.reallyDelete = $modalInstance.close;
+          '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
+            $scope.reallyDelete = $uibModalInstance.close;
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
               alertsService.clearWarnings();
             };
           }
@@ -329,7 +329,7 @@ oppia.controller('SettingsTab', [
         // exposed to the mdoerator.
         var draftEmailBody = response.data.draft_email_body;
 
-        $modal.open({
+        $uibModal.open({
           templateUrl: 'modals/takeModeratorAction',
           backdrop: true,
           resolve: {
@@ -338,8 +338,8 @@ oppia.controller('SettingsTab', [
             }
           },
           controller: [
-            '$scope', '$modalInstance', 'draftEmailBody',
-            function($scope, $modalInstance, draftEmailBody) {
+            '$scope', '$uibModalInstance', 'draftEmailBody',
+            function($scope, $uibModalInstance, draftEmailBody) {
               $scope.action = action;
               $scope.willEmailBeSent = Boolean(draftEmailBody);
               $scope.emailBody = draftEmailBody;
@@ -354,13 +354,13 @@ oppia.controller('SettingsTab', [
               }
 
               $scope.reallyTakeAction = function() {
-                $modalInstance.close({
+                $uibModalInstance.close({
                   emailBody: $scope.emailBody
                 });
               };
 
               $scope.cancel = function() {
-                $modalInstance.dismiss('cancel');
+                $uibModalInstance.dismiss('cancel');
                 alertsService.clearWarnings();
               };
             }

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -500,7 +500,7 @@
 
     <h3>
       Initial parameter changes
-      <i class="material-icons md-18" tooltip="These changes are applied before the learner begins the exploration."
+      <i class="material-icons md-18" uib-tooltip="These changes are applied before the learner begins the exploration."
          tooltip-placement="right" style="padding-left: 4px; vertical-align: text-top;">&#xE88E;</i>
     </h3>
 

--- a/core/templates/dev/head/pages/exploration_editor/statistics_tab/StatisticsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/statistics_tab/StatisticsTab.js
@@ -20,12 +20,12 @@
 oppia.constant('IMPROVE_TYPE_INCOMPLETE', 'incomplete');
 
 oppia.controller('StatisticsTab', [
-  '$scope', '$http', '$modal', 'alertsService', 'explorationStatesService',
+  '$scope', '$http', '$uibModal', 'alertsService', 'explorationStatesService',
   'explorationData', 'computeGraphService', 'oppiaDatetimeFormatter',
   'StatesObjectFactory', 'StateImprovementSuggestionService',
   'ReadOnlyExplorationBackendApiService', 'IMPROVE_TYPE_INCOMPLETE',
   function(
-      $scope, $http, $modal, alertsService, explorationStatesService,
+      $scope, $http, $uibModal, alertsService, explorationStatesService,
       explorationData, computeGraphService, oppiaDatetimeFormatter,
       StatesObjectFactory, StateImprovementSuggestionService,
       ReadOnlyExplorationBackendApiService, IMPROVE_TYPE_INCOMPLETE) {
@@ -131,7 +131,7 @@ oppia.controller('StatisticsTab', [
         '/createhandler/state_rules_stats/' + $scope.explorationId + '/' +
         encodeURIComponent(stateName)
       ).then(function(response) {
-        $modal.open({
+        $uibModal.open({
           templateUrl: 'modals/stateStats',
           backdrop: true,
           resolve: {
@@ -149,9 +149,9 @@ oppia.controller('StatisticsTab', [
             }
           },
           controller: [
-            '$scope', '$modalInstance', '$filter', 'stateName', 'stateStats',
+            '$scope', '$uibModalInstance', '$filter', 'stateName', 'stateStats',
             'improvementType', 'visualizationsInfo', 'oppiaHtmlEscaper',
-            function($scope, $modalInstance, $filter, stateName, stateStats,
+            function($scope, $uibModalInstance, $filter, stateName, stateStats,
                 improvementType, visualizationsInfo, oppiaHtmlEscaper) {
               $scope.stateName = stateName;
               $scope.stateStats = stateStats;
@@ -177,7 +177,7 @@ oppia.controller('StatisticsTab', [
               $scope.visualizationsHtml = _getVisualizationsHtml();
 
               $scope.cancel = function() {
-                $modalInstance.dismiss('cancel');
+                $uibModalInstance.dismiss('cancel');
                 alertsService.clearWarnings();
               };
             }

--- a/core/templates/dev/head/pages/exploration_player/FatigueDetectionService.js
+++ b/core/templates/dev/head/pages/exploration_player/FatigueDetectionService.js
@@ -17,7 +17,7 @@
  */
 
 oppia.factory('FatigueDetectionService', 
-  ['$modal', function($modal) {
+  ['$uibModal', function($uibModal) {
     // 4 submissions in under 10 seconds triggers modal.
     var SPAM_COUNT_THRESHOLD = 4;
     var SPAM_WINDOW_MSEC = 10000;
@@ -39,15 +39,15 @@ oppia.factory('FatigueDetectionService',
         return false;
       },
       displayTakeBreakMessage: function() {
-        $modal.open({
+        $uibModal.open({
           templateUrl: 'modals/takeBreak',
           backdrop: 'static',
           resolve: {},
           controller: [
-            '$scope', '$modalInstance',
-            function($scope, $modalInstance) {
+            '$scope', '$uibModalInstance',
+            function($scope, $uibModalInstance) {
               $scope.okay = function() {
-                $modalInstance.close('okay');
+                $uibModalInstance.close('okay');
               };
             }]
         });

--- a/core/templates/dev/head/pages/exploration_player/FeedbackPopupDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/FeedbackPopupDirective.js
@@ -60,12 +60,12 @@ oppia.directive('feedbackPopup', [
             oppiaPlayerService.getExplorationId());
 
           var getTriggerElt = function() {
-            // Find the popover trigger node (the one with a uib-popover-template
-            // attribute). This is also the DOM node that contains the state
-            // name. Since the popover DOM node is inserted as a sibling to the
-            // node, we therefore climb up the DOM tree until we find the
-            // top-level popover element. The trigger will be one of its
-            // siblings.
+            // Find the popover trigger node (the one with a
+            // uib-popover-template attribute). This is also the DOM node that
+            // contains the state name. Since the popover DOM node is inserted
+            // as a sibling to the node, we therefore climb up the DOM tree
+            // until we find the top-level popover element. The trigger will be
+            // one of its siblings.
             //
             // If the trigger element cannot be found, a value of undefined is
             // returned. This could happen if the trigger is clicked while the
@@ -74,7 +74,8 @@ oppia.directive('feedbackPopup', [
             var popoverChildElt = null;
             for (var i = 0; i < 10; i++) {
               elt = elt.parent();
-              if (!angular.isUndefined(elt.attr('uib-popover-template-popup'))) {
+              if (!angular.isUndefined(
+                elt.attr('uib-popover-template-popup'))) {
                 popoverChildElt = elt;
                 break;
               }

--- a/core/templates/dev/head/pages/exploration_player/FeedbackPopupDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/FeedbackPopupDirective.js
@@ -20,7 +20,7 @@
 // follows:
 //
 // <some-html-element popover-placement="bottom"
-//                    popover-template="popover/feedback"
+//                    uib-popover-template="popover/feedback"
 //                    popover-trigger="click" state-name="<[STATE_NAME]>">
 // </some-html-element>
 //
@@ -60,7 +60,7 @@ oppia.directive('feedbackPopup', [
             oppiaPlayerService.getExplorationId());
 
           var getTriggerElt = function() {
-            // Find the popover trigger node (the one with a popover-template
+            // Find the popover trigger node (the one with a uib-popover-template
             // attribute). This is also the DOM node that contains the state
             // name. Since the popover DOM node is inserted as a sibling to the
             // node, we therefore climb up the DOM tree until we find the
@@ -74,7 +74,7 @@ oppia.directive('feedbackPopup', [
             var popoverChildElt = null;
             for (var i = 0; i < 10; i++) {
               elt = elt.parent();
-              if (!angular.isUndefined(elt.attr('popover-template-popup'))) {
+              if (!angular.isUndefined(elt.attr('uib-popover-template-popup'))) {
                 popoverChildElt = elt;
                 break;
               }
@@ -89,7 +89,7 @@ oppia.directive('feedbackPopup', [
             var childElts = popoverElt.children();
             for (var i = 0; i < childElts.length; i++) {
               var childElt = $(childElts[i]);
-              if (childElt.attr('popover-template')) {
+              if (childElt.attr('uib-popover-template')) {
                 triggerElt = childElt;
                 break;
               }

--- a/core/templates/dev/head/pages/exploration_player/LearnerLocalNav.js
+++ b/core/templates/dev/head/pages/exploration_player/LearnerLocalNav.js
@@ -19,21 +19,21 @@ oppia.constant(
   'FLAG_EXPLORATION_URL_TEMPLATE', '/flagexplorationhandler/<exploration_id>');
 
 oppia.controller('LearnerLocalNav', [
-  '$scope', '$modal', '$http', 'oppiaPlayerService', 'alertsService',
+  '$scope', '$uibModal', '$http', 'oppiaPlayerService', 'alertsService',
   'UrlInterpolationService', 'focusService', 'FLAG_EXPLORATION_URL_TEMPLATE',
-  function($scope, $modal, $http, oppiaPlayerService, alertsService,
+  function($scope, $uibModal, $http, oppiaPlayerService, alertsService,
     UrlInterpolationService, focusService, FLAG_EXPLORATION_URL_TEMPLATE) {
     $scope.explorationId = oppiaPlayerService.getExplorationId();
     $scope.showLearnerSuggestionModal = function() {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/learnerViewSuggestion',
         backdrop: 'static',
         resolve: {},
         controller: [
-          '$scope', '$modalInstance', '$timeout', 'playerPositionService',
+          '$scope', '$uibModalInstance', '$timeout', 'playerPositionService',
           'oppiaPlayerService',
           function(
-              $scope, $modalInstance, $timeout, playerPositionService,
+              $scope, $uibModalInstance, $timeout, playerPositionService,
               oppiaPlayerService) {
             var stateName = playerPositionService.getCurrentStateName();
             $scope.originalHtml = oppiaPlayerService.getStateContentHtml(
@@ -47,11 +47,11 @@ oppia.controller('LearnerLocalNav', [
             }, 500);
 
             $scope.cancelSuggestion = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
             };
 
             $scope.submitSuggestion = function() {
-              $modalInstance.close({
+              $uibModalInstance.close({
                 id: oppiaPlayerService.getExplorationId(),
                 version: oppiaPlayerService.getExplorationVersion(),
                 stateName: stateName,
@@ -69,15 +69,15 @@ oppia.controller('LearnerLocalNav', [
         }).error(function(res) {
           alertsService.addWarning(res);
         });
-        $modal.open({
+        $uibModal.open({
           templateUrl: 'modals/learnerSuggestionSubmitted',
           backdrop: true,
           resolve: {},
           controller: [
-            '$scope', '$modalInstance',
-            function($scope, $modalInstance) {
+            '$scope', '$uibModalInstance',
+            function($scope, $uibModalInstance) {
               $scope.close = function() {
-                $modalInstance.dismiss();
+                $uibModalInstance.dismiss();
               };
             }
           ]
@@ -86,12 +86,12 @@ oppia.controller('LearnerLocalNav', [
     };
 
     $scope.showFlagExplorationModal = function() {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/flagExploration',
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', 'playerPositionService',
-          function($scope, $modalInstance, playerPositionService) {
+          '$scope', '$uibModalInstance', 'playerPositionService',
+          function($scope, $uibModalInstance, playerPositionService) {
             $scope.flagMessageTextareaIsShown = false;
             var stateName = playerPositionService.getCurrentStateName();
 
@@ -104,7 +104,7 @@ oppia.controller('LearnerLocalNav', [
 
             $scope.submitReport = function() {
               if ($scope.flagMessage) {
-                $modalInstance.close({
+                $uibModalInstance.close({
                   report_type: $scope.flag,
                   report_text: $scope.flagMessage,
                   state: stateName
@@ -113,7 +113,7 @@ oppia.controller('LearnerLocalNav', [
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
             };
           }
         ]
@@ -131,14 +131,14 @@ oppia.controller('LearnerLocalNav', [
         }).error(function(error) {
           alertsService.addWarning(error);
         });
-        $modal.open({
+        $uibModal.open({
           templateUrl: 'modals/explorationSuccessfullyFlagged',
           backdrop: true,
           controller: [
-            '$scope', '$modalInstance',
-            function($scope, $modalInstance) {
+            '$scope', '$uibModalInstance',
+            function($scope, $uibModalInstance) {
               $scope.close = function() {
-                $modalInstance.dismiss('cancel');
+                $uibModalInstance.dismiss('cancel');
               };
             }
           ]

--- a/core/templates/dev/head/pages/exploration_player/LearnerViewInfo.js
+++ b/core/templates/dev/head/pages/exploration_player/LearnerViewInfo.js
@@ -18,9 +18,9 @@
  */
 
 oppia.controller('LearnerViewInfo', [
-  '$scope', '$modal', '$http', '$log', 'explorationContextService',
+  '$scope', '$uibModal', '$http', '$log', 'explorationContextService',
   'EXPLORATION_SUMMARY_DATA_URL_TEMPLATE',
-  function($scope, $modal, $http, $log, explorationContextService,
+  function($scope, $uibModal, $http, $log, explorationContextService,
     EXPLORATION_SUMMARY_DATA_URL_TEMPLATE) {
     var explorationId = explorationContextService.getExplorationId();
     var expInfo = null;
@@ -44,7 +44,7 @@ oppia.controller('LearnerViewInfo', [
     };
 
     var openInformationCardModal = function() {
-      $modal.open({
+      $uibModal.open({
         animation: true,
         templateUrl: 'modal/informationCard',
         windowClass: 'oppia-modal-information-card',
@@ -54,9 +54,9 @@ oppia.controller('LearnerViewInfo', [
           }
         },
         controller: [
-          '$scope', '$window', '$modalInstance', 'oppiaDatetimeFormatter',
+          '$scope', '$window', '$uibModalInstance', 'oppiaDatetimeFormatter',
           'RatingComputationService', 'expInfo',
-          function($scope, $window, $modalInstance, oppiaDatetimeFormatter,
+          function($scope, $window, $uibModalInstance, oppiaDatetimeFormatter,
                    RatingComputationService, expInfo) {
             var getExplorationTagsSummary = function(arrayOfTags) {
               var tagsToShow = [];
@@ -113,7 +113,7 @@ oppia.controller('LearnerViewInfo', [
             $scope.objective = expInfo.objective;
 
             $scope.cancel = function() {
-              $modalInstance.dismiss();
+              $uibModalInstance.dismiss();
             };
           }
         ]

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -75,7 +75,7 @@
   <div ng-if="isLoggedIn && !isInPreviewMode" class="conversation-skin-final-ratings">
     <div class="conversation-skin-final-ratings-header" translate="I18N_PLAYER_RATE_EXPLORATION">
     </div>
-    <div popover-placement="bottom" popover-template="'popover/feedback'" popover-trigger="click">
+    <div popover-placement="bottom" uib-popover-template="'popover/feedback'" popover-trigger="click">
       <rating-display rating-value="userRating" is-editable="true" on-edit="submitUserRating"
                       class="conversation-skin-final-ratings-display">
       </rating-display>

--- a/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
@@ -216,7 +216,7 @@
         </li>
       </ul>
       <ul class="mobile-feedback" ng-if="mobileFeedbackIsShown">
-        <li popover-placement="top-left" popover-template="'popover/feedback'" popover-trigger="click">
+        <li popover-placement="top-left" uib-popover-template="'popover/feedback'" popover-trigger="click">
           <a href="" class="btn oppia-navbar-button">
             <i class="material-icons">&#xE87F;</i>
             <span translate="I18N_PLAYER_FEEDBACK_TOOLTIP"></span>

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -42,7 +42,7 @@
       <span class="oppia-navbar-breadcrumb-separator"></span>
       <h1 class="oppia-exploration-h1"><span class="protractor-test-exploration-header oppia-exploration-header" itemprop="description">{{exploration_title}}</span></h1>
     </li>
-    <li ng-click="showInformationCard()" tooltip="<['I18N_PLAYER_INFO_TOOLTIP' | translate]>" tooltip-placement="bottom" style="cursor: pointer;" class="oppia-exploration-info-icon protractor-test-exploration-info-icon" tabindex="0">
+    <li ng-click="showInformationCard()" uib-tooltip="<['I18N_PLAYER_INFO_TOOLTIP' | translate]>" tooltip-placement="bottom" style="cursor: pointer;" class="oppia-exploration-info-icon protractor-test-exploration-info-icon" tabindex="0">
       <i class="material-icons oppia-navbar-breadcrumb-icon" style="font-size: 20px;">&#xE88E;</i>
       <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_INFO_TOOLTIP' | translate]></span>
     </li>

--- a/core/templates/dev/head/pages/exploration_player/hint_button_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/hint_button_directive.html
@@ -1,4 +1,4 @@
-<span ng-if="allHintsAreExhausted()" tooltip="<['I18N_PLAYER_HINTS_EXHAUSTED' | translate]>">
+<span ng-if="allHintsAreExhausted()" uib-tooltip="<['I18N_PLAYER_HINTS_EXHAUSTED' | translate]>">
   <md-button class="hint-button"
              ng-click="onClickHintButton()"
              ng-disabled="!currentHintIsAvailable()"
@@ -8,7 +8,7 @@
   </md-button>
 </span>
 <span ng-if="!allHintsAreExhausted()">
-  <span ng-if="currentHintIsAvailable()" tooltip="<['I18N_PLAYER_HINT_IS_AVAILABLE' | translate]>">
+  <span ng-if="currentHintIsAvailable()" uib-tooltip="<['I18N_PLAYER_HINT_IS_AVAILABLE' | translate]>">
     <md-button class="hint-button"
                ng-click="onClickHintButton()"
                ng-disabled="!currentHintIsAvailable()"
@@ -17,7 +17,7 @@
       <i class="fa fa-lightbulb-o"></i>
     </md-button>
   </span>
-  <span ng-if="!currentHintIsAvailable()" tooltip="<['I18N_PLAYER_HINT_NOT_AVAILABLE' | translate]>">
+  <span ng-if="!currentHintIsAvailable()" uib-tooltip="<['I18N_PLAYER_HINT_NOT_AVAILABLE' | translate]>">
     <md-button class="hint-button"
                ng-click="onClickHintButton()"
                ng-disabled="!currentHintIsAvailable()"

--- a/core/templates/dev/head/pages/exploration_player/information_card_modal.html
+++ b/core/templates/dev/head/pages/exploration_player/information_card_modal.html
@@ -13,7 +13,7 @@
 
       <ul layout="row" class="card-metrics" layout-align="space-between center">
         <li class="protractor-test-info-card-rating">
-          <span class="fa fa-star fa-lg" tooltip="<['I18N_PLAYER_RATINGS_TOOLTIP' | translate]>" tooltip-placement="top">
+          <span class="fa fa-star fa-lg" uib-tooltip="<['I18N_PLAYER_RATINGS_TOOLTIP' | translate]>" tooltip-placement="top">
             <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_RATINGS_TOOLTIP' | translate]></span>
           </span>
           <span ng-if="!averageRating" translate="I18N_PLAYER_UNRATED">Unrated</span>
@@ -21,34 +21,34 @@
         </li>
 
         <li>
-          <span class="fa fa-eye fa-lg" tooltip="<['I18N_PLAYER_VIEWS_TOOLTIP' | translate]>" tooltip-placement="top">
+          <span class="fa fa-eye fa-lg" uib-tooltip="<['I18N_PLAYER_VIEWS_TOOLTIP' | translate]>" tooltip-placement="top">
             <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_VIEWS_TOOLTIP' | translate]></span>
           </span>
           <[numViews | summarizeNonnegativeNumber]>
         </li>
 
         <li>
-          <span class="fa fa-clock-o fa-lg" tooltip="<['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]>" tooltip-placement="top">
+          <span class="fa fa-clock-o fa-lg" uib-tooltip="<['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]>" tooltip-placement="top">
             <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_LAST_UPDATED_TOOLTIP' | translate]></span>
           </span>
           <[lastUpdatedString]>
         </li>
 
         <ul layout="row" layout-align="space-between center" class="oppia-info-card-exploration-contributors-profile">
-          <i class="material-icons" tooltip="<['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]>" tooltip-placement="top" style="cursor: default; margin-right: 5px;">&#xE7EF;</i>
+          <i class="material-icons" uib-tooltip="<['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]>" tooltip-placement="top" style="cursor: default; margin-right: 5px;">&#xE7EF;</i>
           <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_CONTRIBUTORS_TOOLTIP' | translate]></span>
           <li ng-repeat="name in contributorNames| limitTo: 2"
-            tooltip="<[name]>" tooltip-placement="top">
+            uib-tooltip="<[name]>" tooltip-placement="top">
             <profile-link-image username="name">
             </profile-link-image>
           </li>
 
           <li ng-if="contributorNames.length > 2" class="oppia-contributors-more-circle"
-            tooltip-append-to-body="true" tooltip="<[contributorNames.slice(2).join(',')]>"
+            tooltip-append-to-body="true" uib-tooltip="<[contributorNames.slice(2).join(',')]>"
             tooltip-placement="top">+<[contributorNames.length - 2]>
           </li>
           <li ng-if="contributorNames.length === 0"
-              tooltip="<['I18N_PLAYER_COMMUNITY_EDITABLE_TOOLTIP' | translate]>"
+              uib-tooltip="<['I18N_PLAYER_COMMUNITY_EDITABLE_TOOLTIP' | translate]>"
               tooltip-placement="top">
             <span class="fa fa-globe fa-lg oppia-info-card-community-editable-icon"></span>
           </li>
@@ -60,14 +60,14 @@
           <md-content layout="row">
             <div class="oppia-info-card-tag-icon">
               <span class="fa fa-tags fa-lg" tooltip-append-to-body="true"
-                    tooltip="<['I18N_PLAYER_TAGS_TOOLTIP' | translate]>"
+                    uib-tooltip="<['I18N_PLAYER_TAGS_TOOLTIP' | translate]>"
                     tooltip-placement="top">
                 <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_TAGS_TOOLTIP' | translate]></span>
               </span>
             </div>
             <md-chips layout-align="center center">
               <md-chip ng-if="explorationTags.tagsInTooltip.length > 0" class="oppia-info-card-tooltip-more"
-                tooltip-append-to-body="true" tooltip="<[explorationTags.tagsInTooltip.join(', ')]>"
+                tooltip-append-to-body="true" uib-tooltip="<[explorationTags.tagsInTooltip.join(', ')]>"
                 tooltip-placement="right"
                 translate="I18N_PLAYER_PLUS_TAGS"
                 translate-values="{additionalTagNumber: <[explorationTags.tagsInTooltip.length]>}">

--- a/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
@@ -2,7 +2,7 @@
   <img class="conversation-skin-user-avatar img-circle" ng-src="<[profilePicture()]>" alt="">
   <div ng-if="!data.isHint">
     <div ng-if="getShortAnswerHtml()" class="conversation-skin-learner-answer-content"
-         popover-placement="bottom" popover-template="'popover/answer'"
+         popover-placement="bottom" uib-popover-template="'popover/answer'"
          popover-trigger="click" style="cursor: pointer;">
       <div class="conversation-skin-learner-answer" angular-html-bind="getShortAnswerHtml()">
       </div>

--- a/core/templates/dev/head/pages/exploration_player/learner_local_nav.html
+++ b/core/templates/dev/head/pages/exploration_player/learner_local_nav.html
@@ -1,19 +1,19 @@
 <ul class="nav navbar-nav oppia-navbar-nav navbar-right"
     ng-controller="LearnerLocalNav" style="margin-right: 0px;">
-  <li popover-placement="bottom" popover-template="'popover/feedback'" popover-trigger="click">
-    <a href="" class="protractor-test-exploration-feedback-popup-link" tooltip="<['I18N_PLAYER_FEEDBACK_TOOLTIP' | translate]>" tooltip-placement="bottom">
+  <li popover-placement="bottom" uib-popover-template="'popover/feedback'" popover-trigger="click">
+    <a href="" class="protractor-test-exploration-feedback-popup-link" uib-tooltip="<['I18N_PLAYER_FEEDBACK_TOOLTIP' | translate]>" tooltip-placement="bottom">
       <i class="material-icons">&#xE87F;</i>
       <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_FEEDBACK_TOOLTIP' | translate]></span>
     </a>
   </li>
   <li>
     {% if can_edit %}
-      <a ng-href="/create/<[explorationId]>" tooltip="<['I18N_PLAYER_EDIT_TOOLTIP' | translate]>" tooltip-placement="bottom" target="_blank">
+      <a ng-href="/create/<[explorationId]>" uib-tooltip="<['I18N_PLAYER_EDIT_TOOLTIP' | translate]>" tooltip-placement="bottom" target="_blank">
         <i class="material-icons">&#xE254;</i>
         <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_EDIT_TOOLTIP' | translate]></span>
       </a>
     {% elif username %}
-      <a class="protractor-test-exploration-suggestion-popup-link" ng-click="showLearnerSuggestionModal()" tooltip="Suggest Changes" tooltip-placement="bottom" target="_blank">
+      <a class="protractor-test-exploration-suggestion-popup-link" ng-click="showLearnerSuggestionModal()" uib-tooltip="Suggest Changes" tooltip-placement="bottom" target="_blank">
         <i class="material-icons">&#xE254;</i>
         <span class="oppia-icon-accessibility-label">Suggest Changes</span>
       </a>
@@ -21,7 +21,7 @@
   </li>
   <li>
     {% if username %}
-      <a ng-click="showFlagExplorationModal()" tooltip="<['I18N_PLAYER_REPORT_TOOLTIP' | translate]>" tooltip-placement="bottom" tabindex="0">
+      <a ng-click="showFlagExplorationModal()" uib-tooltip="<['I18N_PLAYER_REPORT_TOOLTIP' | translate]>" tooltip-placement="bottom" tabindex="0">
         <i class="material-icons">&#xE153;</i>
         <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_REPORT_TOOLTIP' | translate]></span>
       </a>

--- a/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/progress_dots_directive.html
@@ -102,7 +102,7 @@
     <!-- TODO (mili) include card number in the translation -->
     <span class="oppia-progress-dot oppia-progress-dot-active"
           ng-if="$index === currentDotIndex" ng-show="dots.length > 1"
-          tooltip="<['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]>" tooltip-placement="left"
+          uib-tooltip="<['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]>" tooltip-placement="left"
           tooltip-trigger="none" tooltip-is-open="opened" mobile-friendly-tooltip tabindex="0">
       <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]></span>
     </span>
@@ -112,7 +112,7 @@
                     'oppia-progress-dot-gradient-right' :''"
           ng-if="$index !== currentDotIndex"
           ng-click="changeActiveDot($index)"
-          tooltip="<['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]>" tooltip-placement="left"
+          uib-tooltip="<['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]>" tooltip-placement="left"
           tooltip-trigger="none" tooltip-is-open="opened" mobile-friendly-tooltip tabindex="0">
       <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_CARD_NUMBER_TOOLTIP' | translate]><[$index +1]></span>
     </span>

--- a/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
+++ b/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
@@ -50,14 +50,14 @@ oppia.constant('HUMAN_READABLE_SUBSCRIPTION_SORT_BY_KEYS', {
 });
 
 oppia.controller('LearnerDashboard', [
-  '$scope', '$rootScope', '$window', '$http', '$modal',
+  '$scope', '$rootScope', '$window', '$http', '$uibModal',
   'EXPLORATIONS_SORT_BY_KEYS', 'SUBSCRIPTION_SORT_BY_KEYS',
   'HUMAN_READABLE_EXPLORATIONS_SORT_BY_KEYS', 'FATAL_ERROR_CODES',
   'HUMAN_READABLE_SUBSCRIPTION_SORT_BY_KEYS',
   'LearnerDashboardBackendApiService', 'UrlInterpolationService',
   'LEARNER_DASHBOARD_SECTIONS', 'LEARNER_DASHBOARD_SUBSECTIONS',
   function(
-      $scope, $rootScope, $window, $http, $modal, EXPLORATIONS_SORT_BY_KEYS,
+      $scope, $rootScope, $window, $http, $uibModal, EXPLORATIONS_SORT_BY_KEYS,
       SUBSCRIPTION_SORT_BY_KEYS, HUMAN_READABLE_EXPLORATIONS_SORT_BY_KEYS, 
       FATAL_ERROR_CODES, HUMAN_READABLE_SUBSCRIPTION_SORT_BY_KEYS,
       LearnerDashboardBackendApiService, UrlInterpolationService,
@@ -193,7 +193,7 @@ oppia.controller('LearnerDashboard', [
 
     $scope.openRemoveEntityModal = function(
       sectionName, subSectionName, entity) {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/removeEntity',
         backdrop: true,
         resolve: {
@@ -208,8 +208,8 @@ oppia.controller('LearnerDashboard', [
           }
         },
         controller: [
-          '$scope', '$modalInstance', '$http', 'sectionName', 'subSectionName',
-          function($scope, $modalInstance, $http, sectionName, subSectionName) {
+          '$scope', '$uibModalInstance', '$http', 'sectionName', 'subSectionName',
+          function($scope, $uibModalInstance, $http, sectionName, subSectionName) {
             $scope.sectionName = sectionName;
             $scope.subSectionName = subSectionName;
             $scope.entityTitle = entity.title;
@@ -228,11 +228,11 @@ oppia.controller('LearnerDashboard', [
                   collection_id: entity.id
                 });
               }
-              $modalInstance.close();
+              $uibModalInstance.close();
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
             };
           }
         ]

--- a/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
+++ b/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
@@ -208,8 +208,10 @@ oppia.controller('LearnerDashboard', [
           }
         },
         controller: [
-          '$scope', '$uibModalInstance', '$http', 'sectionName', 'subSectionName',
-          function($scope, $uibModalInstance, $http, sectionName, subSectionName) {
+          '$scope', '$uibModalInstance', '$http', 'sectionName',
+          'subSectionName',
+          function($scope, $uibModalInstance, $http, sectionName,
+                   subSectionName) {
             $scope.sectionName = sectionName;
             $scope.subSectionName = subSectionName;
             $scope.entityTitle = entity.title;

--- a/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
+++ b/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
@@ -211,7 +211,7 @@
                  ng-show="showRemoveIcon"
                  aria-hidden="true"
                  ng-click="openRemoveEntityModal(activeSection, activeSubSection, tile)"
-                 tooltip="Remove"
+                 uib-tooltip="Remove"
                  tooltip-placement="top"></i>
               <exploration-summary-tile
                                       exploration-id="tile.id"
@@ -320,7 +320,7 @@
                  ng-show="showRemoveIcon"
                  aria-hidden="true"
                  ng-click="openRemoveEntityModal(activeSection, activeSubSection, tile)"
-                 tooltip="Remove"
+                 uib-tooltip="Remove"
                  tooltip-placement="top"></i>
               <collection-summary-tile
                                        collection-id="tile.id"
@@ -428,7 +428,7 @@
                     <strong class="protractor-test-subscription-name"
                             popover-append-to-body
                             popover-trigger="<[showUsernamePopover(subscription.creator_username)]>"
-                            ng-attr-popover="<[subscription.creator_username]>">
+                            ng-attr-uib-popover="<[subscription.creator_username]>">
                       <[subscription.creator_username| truncate:10]>
                     </strong>
                   </div>

--- a/core/templates/dev/head/pages/library/search_bar_directive.html
+++ b/core/templates/dev/head/pages/library/search_bar_directive.html
@@ -14,15 +14,15 @@
   </div>
 </form>
 
-<div dropdown class="dropdown navbar-left oppia-navbar-button-container oppia-search-bar-category-selector protractor-test-search-bar-category-selector">
-  <button dropdown-toggle type="button" class="btn dropdown-toggle oppia-search-bar-input ng-cloak"
+<div uib-dropdown class="dropdown navbar-left oppia-navbar-button-container oppia-search-bar-category-selector protractor-test-search-bar-category-selector">
+  <button uib-dropdown-toggle type="button" class="btn dropdown-toggle oppia-search-bar-input ng-cloak"
           title="<[selectionDetails.categories.description | translate]>"
           style="max-width: 130px;">
     <[categoryButtonText|truncate:14]>
     <span class="caret"></span>
   </button>
   <!-- The $event.stopPropagation() prevents the dropdown from closing after an option is selected. -->
-  <ul class="dropdown-menu" role="menu" style="max-height: 400px; overflow: auto;" ng-click="$event.stopPropagation()">
+  <ul uib-dropdown-menu class="dropdown-menu" role="menu" style="max-height: 400px; overflow: auto;" ng-click="$event.stopPropagation()">
     <li ng-repeat="item in selectionDetails.categories.masterList track by $index"
         ng-if="selectionDetails.categories.selections[item.id]">
       <a href ng-click="toggleSelection('categories', item.id)">
@@ -44,15 +44,15 @@
   </ul>
 </div>
 
-<div dropdown class="dropdown navbar-left oppia-navbar-button-container oppia-search-bar-language-selector protractor-test-search-bar-language-selector">
-  <button dropdown-toggle type="button" class="btn dropdown-toggle oppia-search-bar-input ng-cloak"
+<div uib-dropdown class="dropdown navbar-left oppia-navbar-button-container oppia-search-bar-language-selector protractor-test-search-bar-language-selector">
+  <button uib-dropdown-toggle type="button" class="btn dropdown-toggle oppia-search-bar-input ng-cloak"
           style="border-bottom-right-radius: 4px; border-top-right-radius: 4px; max-width: 130px;"
           title="<[selectionDetails.languageCodes.description | translate]>">
     <[languageButtonText|truncate:14]>
     <span class="caret"></span>
   </button>
   <!-- The $event.stopPropagation() prevents the dropdown from closing after an option is selected. -->
-  <ul class="dropdown-menu" role="menu" style="max-height: 400px; overflow: auto;" ng-click="$event.stopPropagation()">
+  <ul uib-dropdown-menu class="dropdown-menu" role="menu" style="max-height: 400px; overflow: auto;" ng-click="$event.stopPropagation()">
     <li ng-repeat="item in selectionDetails.languageCodes.masterList track by $index"
         ng-if="selectionDetails.languageCodes.selections[item.id]">
       <a href ng-click="toggleSelection('languageCodes', item.id)">

--- a/core/templates/dev/head/pages/moderator/moderator.html
+++ b/core/templates/dev/head/pages/moderator/moderator.html
@@ -17,8 +17,8 @@
   <div ng-controller="Moderator">
     <div class="oppia-content">
       <br>
-      <tabset>
-        <tab heading="Recent Commits" active>
+      <uib-tabset>
+        <uib-tab heading="Recent Commits" active>
           <h3>Recent Commits (all non-private explorations)</h3>
           <div ng-show="allCommits.length">
             <table class="oppia-padded-table">
@@ -46,9 +46,9 @@
               </tr>
             </table>
           </div>
-        </tab>
+        </uib-tab>
 
-        <tab heading="Recent Feedback Messages">
+        <uib-tab heading="Recent Feedback Messages">
           <h3>Recent Feedback Messages</h3>
           (Note that some of these links may be to private explorations, and thus result in authorization errors.)
           <br><br>
@@ -70,9 +70,9 @@
               </tr>
             </table>
           </div>
-        </tab>
+        </uib-tab>
 
-        <tab heading="Featured Activities">
+        <uib-tab heading="Featured Activities">
           <h3>Activities to feature in the library</h3>
           <br><br>
 
@@ -85,8 +85,8 @@
                   ng-disabled="isSaveFeaturedActivitiesButtonDisabled()">
             Save Featured Activities
           </button>
-        </tab>
-      </tabset>
+        </uib-tab>
+      </uib-tabset>
     </div>
   </div>
 {% endblock %}

--- a/core/templates/dev/head/pages/preferences/Preferences.js
+++ b/core/templates/dev/head/pages/preferences/Preferences.js
@@ -17,10 +17,10 @@
  */
 
 oppia.controller('Preferences', [
-  '$scope', '$http', '$rootScope', '$modal', '$timeout', '$translate',
+  '$scope', '$http', '$rootScope', '$uibModal', '$timeout', '$translate',
   'alertsService', 'UrlInterpolationService', 'utilsService',
   function(
-      $scope, $http, $rootScope, $modal, $timeout, $translate, alertsService,
+      $scope, $http, $rootScope, $uibModal, $timeout, $translate, alertsService,
       UrlInterpolationService, utilsService) {
     var _PREFERENCES_DATA_URL = '/preferenceshandler/data';
     $rootScope.loadingMessage = 'Loading';
@@ -125,11 +125,11 @@ oppia.controller('Preferences', [
     };
 
     $scope.showEditProfilePictureModal = function() {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/editProfilePicture',
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', function($scope, $modalInstance) {
+          '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
             $scope.uploadedImage = null;
             $scope.croppedImageDataUrl = '';
             $scope.invalidImageWarningIsShown = false;
@@ -164,11 +164,11 @@ oppia.controller('Preferences', [
             };
 
             $scope.confirm = function() {
-              $modalInstance.close($scope.croppedImageDataUrl);
+              $uibModalInstance.close($scope.croppedImageDataUrl);
             };
 
             $scope.cancel = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
             };
           }
         ]

--- a/core/templates/dev/head/pages/preferences/preferences.html
+++ b/core/templates/dev/head/pages/preferences/preferences.html
@@ -108,7 +108,7 @@
                       <strong class="protractor-test-subscription-name"
                               popover-append-to-body
                               popover-trigger="<[showUsernamePopover(subscription.creator_username)]>"
-                              ng-attr-popover="<[subscription.creator_username]>">
+                              ng-attr-uib-popover="<[subscription.creator_username]>">
                         <[subscription.creator_username| truncate:10]>
                       </strong>
                     </div>

--- a/core/templates/dev/head/pages/profile/profile.html
+++ b/core/templates/dev/head/pages/profile/profile.html
@@ -45,13 +45,13 @@
       </div>
 
       <h2 class="oppia-profile-username-large-screen">
-        <span popover-placement="right" ng-attr-popover="<[usernameIsLong ? username.helpText : undefined]>"
+        <span popover-placement="right" ng-attr-uib-popover="<[usernameIsLong ? username.helpText : undefined]>"
             popover-append-to-body popover-trigger="mouseenter">
           <strong><[username.value| truncate:16]></strong>
         </span>
       </h2>
       <h2 class="oppia-profile-username-small-screen">
-        <span popover-placement="right" ng-attr-popover="<[username.helpText]>" popover-append-to-body popover-trigger="mouseenter">
+        <span popover-placement="right" ng-attr-uib-popover="<[username.helpText]>" popover-append-to-body popover-trigger="mouseenter">
           <strong><[username.value| truncate:11]></strong>
         </span>
       </h2>
@@ -62,7 +62,7 @@
 
       <div class="oppia-profile-user-stat-container-large-screen">
         <div ng-repeat="stat in userDisplayedStatistics" class="oppia-profile-user-stat">
-          <div popover-placement="right" ng-attr-popover="<[stat.helpText]>" popover-append-to-body popover-trigger="mouseenter">
+          <div popover-placement="right" ng-attr-uib-popover="<[stat.helpText]>" popover-append-to-body popover-trigger="mouseenter">
             <span style="font-size: 16px"><strong><[stat.value || 0]></strong></span>
             <span><[stat.title]></span>
           </div>
@@ -91,7 +91,7 @@
       <hr class="oppia-profile-stat-container-line-small-screen">
       <div class="oppia-profile-user-stat-container-small-screen">
         <div ng-repeat="stat in userDisplayedStatistics" class="oppia-profile-user-stat">
-          <div popover-placement="right" ng-attr-popover="<[stat.helpText]>" popover-append-to-body popover-trigger="mouseenter">
+          <div popover-placement="right" ng-attr-uib-popover="<[stat.helpText]>" popover-append-to-body popover-trigger="mouseenter">
             <span style="font-size: 16px"><strong><[stat.value || 0]></strong></span>
             <span><[stat.title]></span>
           </div>
@@ -133,7 +133,7 @@
       <button class="btn oppia-subscription-button oppia-transition-200 protractor-test-subscription-button"
               ng-click="changeSubscriptionStatus()"
               popover-placement="right"
-              ng-attr-popover="<[subscriptionButtonPopoverText]>"
+              ng-attr-uib-popover="<[subscriptionButtonPopoverText]>"
               popover-append-to-body
               popover-trigger="mouseenter">
               <span translate="I18N_SUBSCRIBE_BUTTON_TEXT" ng-if="!isAlreadySubscribed"></span>

--- a/core/templates/dev/head/pages/signup/Signup.js
+++ b/core/templates/dev/head/pages/signup/Signup.js
@@ -17,10 +17,10 @@
  */
 
 oppia.controller('Signup', [
-  '$scope', '$http', '$rootScope', '$modal', 'alertsService', 'urlService',
+  '$scope', '$http', '$rootScope', '$uibModal', 'alertsService', 'urlService',
   'focusService', 'siteAnalyticsService',
   function(
-      $scope, $http, $rootScope, $modal, alertsService, urlService,
+      $scope, $http, $rootScope, $uibModal, alertsService, urlService,
       focusService, siteAnalyticsService) {
     var _SIGNUP_DATA_URL = '/signuphandler/data';
     $rootScope.loadingMessage = 'I18N_SIGNUP_LOADING';
@@ -49,14 +49,14 @@ oppia.controller('Signup', [
     };
 
     $scope.showLicenseExplanationModal = function() {
-      $modal.open({
+      $uibModal.open({
         templateUrl: 'modals/licenseExplanation',
         backdrop: true,
         resolve: {},
         controller: [
-          '$scope', '$modalInstance', function($scope, $modalInstance) {
+          '$scope', '$uibModalInstance', function($scope, $uibModalInstance) {
             $scope.close = function() {
-              $modalInstance.dismiss('cancel');
+              $uibModalInstance.dismiss('cancel');
             };
           }
         ]

--- a/extensions/rich_text_components/Collapsible/Collapsible.html
+++ b/extensions/rich_text_components/Collapsible/Collapsible.html
@@ -2,13 +2,13 @@
 
 <script type="text/ng-template" id="richTextComponent/Collapsible">
   <uib-accordion>
-    <uib-accordion-group is-open="isOpen">
+    <div uib-accordion-group is-open="isOpen">
       <uib-accordion-heading>
         <i class="material-icons pull-right md-18" ng-hide="isOpen">&#xE147;</i>
         <i class="material-icons pull-right md-18" ng-show="isOpen">&#xE15C;</i>
         <div class="protractor-test-collapsible-heading"><[heading]></div>
       </uib-accordion-heading>
       <div angular-html-bind="content"></div>
-    </uib-accordion-group>
+    </div>
   </uib-accordion>
 </script>

--- a/extensions/rich_text_components/Collapsible/Collapsible.html
+++ b/extensions/rich_text_components/Collapsible/Collapsible.html
@@ -1,14 +1,14 @@
 <script src="{{cache_slug}}/extensions/rich_text_components/Collapsible/Collapsible.js"></script>
 
 <script type="text/ng-template" id="richTextComponent/Collapsible">
-  <accordion>
-    <accordion-group is-open="isOpen">
-      <accordion-heading>
+  <uib-accordion>
+    <uib-accordion-group is-open="isOpen">
+      <uib-accordion-heading>
         <i class="material-icons pull-right md-18" ng-hide="isOpen">&#xE147;</i>
         <i class="material-icons pull-right md-18" ng-show="isOpen">&#xE15C;</i>
         <div class="protractor-test-collapsible-heading"><[heading]></div>
-      </accordion-heading>
+      </uib-accordion-heading>
       <div angular-html-bind="content"></div>
-    </accordion-group>
-  </accordion>
+    </uib-accordion-group>
+  </uib-accordion>
 </script>

--- a/manifest.json
+++ b/manifest.json
@@ -379,14 +379,14 @@
         }
       },
       "uiBootstrap": {
-        "version": "0.13.4",
+        "version": "2.5.0",
         "downloadFormat": "files",
         "url": "https://raw.githubusercontent.com/angular-ui/bootstrap/gh-pages",
         "rootDirPrefix": "ui-bootstrap-",
         "targetDirPrefix": "ui-bootstrap-",
-        "files": ["ui-bootstrap-tpls-0.13.4.js", "ui-bootstrap-tpls-0.13.4.min.js"],
+        "files": ["ui-bootstrap-tpls-2.5.0.js", "ui-bootstrap-tpls-2.5.0.min.js"],
         "bundle": {
-          "js": ["ui-bootstrap-tpls-0.13.4.js"]
+          "js": ["ui-bootstrap-tpls-2.5.0.js"]
         }
       },
       "uiCodemirror": {


### PR DESCRIPTION
Updates ui-bootstrap from 0.13.4 to 2.5.0 and changes prefixes as required by the updated library.

I'm not ready yet to say there are definitely no bugs introduced, but haven't noticed any yet in the testing I've done.