### PR TITLE
Adding back the warning about license terms of images

### DIFF
--- a/core/templates/dev/head/components/forms/image_uploader_directive.html
+++ b/core/templates/dev/head/components/forms/image_uploader_directive.html
@@ -4,11 +4,28 @@
     <i class="material-icons">&#xE002;</i>
     <[errorMessage]>
   </span>
+  <span class="image-uploader-license-warning">
+    Before uploading images, please ensure that they are<br>
+    compatible with the <a href="/about#license" target="_blank">license terms</a> of the site.
+  </span>
   <label for="image-file-input" translate="I18N_DIRECTIVES_UPLOAD_A_FILE" class="image-uploader-upload-label-button"></label>
   <input type="file" id='image-file-input' class="image-uploader-file-input" ng-class="fileInputClassName">
 </div>
 
 <style>
+  .image-uploader-license-warning {
+    background-color: rgba(225, 250, 89, 0.41);
+    border: 1px solid rgba(200, 230, 59, 0.41);
+    border-radius: 6px;
+    bottom: 8px;
+    font-size: 12px;
+    font-style: italic;
+    left: 8px;
+    position: absolute;
+    text-align: left;
+    padding: 4px 6px;
+  }
+
   .image-uploader-drop-area {
     background: #eee;
     color: black;


### PR DESCRIPTION
Recently during the redesign of the image-uploader we got rid of the warning about license terms on uploaded images. I'm putting it back in this PR.

This is what it looks like if we approve this PR:

<img width="554" alt="screen shot 2017-07-03 at 7 00 20 pm" src="https://user-images.githubusercontent.com/4760286/27812217-0f7e3cb6-6022-11e7-8c5a-3207b4701fbb.png">

We can further improve it (with input from a designer maybe), but this should do for now, just to make sure that the warning is there on the next release.