### PR TITLE
Fix #2639: Updated Google chart/visualization Library loader code and use async to load the library

### DIFF
--- a/core/domain/visualization_registry.py
+++ b/core/domain/visualization_registry.py
@@ -53,7 +53,7 @@ class Registry(object):
             feconf.VISUALIZATIONS_DIR, 'visualizations.js'))
         html_templates = utils.get_file_contents(os.path.join(
             feconf.VISUALIZATIONS_DIR, 'visualizations.html'))
-        return '<script>%s</script>\n%s' % (js_directives, html_templates)
+        return '<script defer>%s</script>\n%s' % (js_directives, html_templates)
 
     @classmethod
     def get_visualization_class(cls, visualization_id):

--- a/core/domain/visualization_registry.py
+++ b/core/domain/visualization_registry.py
@@ -53,7 +53,7 @@ class Registry(object):
             feconf.VISUALIZATIONS_DIR, 'visualizations.js'))
         html_templates = utils.get_file_contents(os.path.join(
             feconf.VISUALIZATIONS_DIR, 'visualizations.html'))
-        return '<script defer>%s</script>\n%s' % (js_directives, html_templates)
+        return '<script>%s</script>\n%s' % (js_directives, html_templates)
 
     @classmethod
     def get_visualization_class(cls, visualization_id):

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -35,16 +35,15 @@
   https://developers.google.com/chart/interactive/docs/basic_load_libs#update-library-loader-code -->
   <script type="text/javascript" async src="https://www.gstatic.com/charts/loader.js"></script>
   <script type="text/javascript">
-    function onloadChartLoadHandler() {
+    // Since we are using async to load the library wait until entire page is loaded to call google.load().
+    // That should allow the initial page load to complete before starting the chart rendering.
+    window.addEventListener('load', function() {
       if (window.google && window.google.charts) {
         google.charts.load('current', {packages: ['corechart']});
       } else {
         throw 'error: Could not load google visualization library. Are you offline?';
       }
-    }
-    // Since we are using async to load the library wait until entire page is loaded to call google.load().
-    // That should allow the initial page load to complete before starting the chart rendering.
-    window.onload = onloadChartLoadHandler;
+    });
   </script>
 
   <style>

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -31,13 +31,21 @@
     GLOBALS.TAG_REGEX = JSON.parse('{{TAG_REGEX|js_string}}');
   </script>
 
-  <script type="text/javascript" src="https://www.google.com/jsapi"></script>
+  <!-- Updated previous version to current version of google charts
+  https://developers.google.com/chart/interactive/docs/basic_load_libs#update-library-loader-code -->
+  <script type="text/javascript" async src="https://www.gstatic.com/charts/loader.js"></script>
   <script type="text/javascript">
-    if (window.google && window.google.load) {
-      google.load('visualization', '1', {packages: ['corechart']});
-    } else {
-      throw 'error: Could not load google visualization library. Are you offline?';
-    }
+    function onloadChartLoadHandler() {
+      if (window.google && window.google.charts) {
+        google.charts.load('current', {packages: ['corechart']});
+        console.log(google);
+      }else {
+          throw 'error: Could not load google visualization library. Are you offline?';
+        }
+      }
+    // Since we are using async to load the library wait until entire page is loaded to call google.load().
+    // That should allow the initial page load to complete before starting the chart rendering.
+    window.onload = onloadChartLoadHandler;
   </script>
 
   <style>

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -38,7 +38,6 @@
     function onloadChartLoadHandler() {
       if (window.google && window.google.charts) {
         google.charts.load('current', {packages: ['corechart']});
-        console.log(google);
       } else {
         throw 'error: Could not load google visualization library. Are you offline?';
       }

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -33,7 +33,7 @@
 
   <!-- Updated previous version to current version of google charts
   https://developers.google.com/chart/interactive/docs/basic_load_libs#update-library-loader-code -->
-  <script type="text/javascript" async src="https://www.gstatic.com/charts/loader.js"></script>
+  <script type="text/javascript"  src="https://www.gstatic.com/charts/loader.js"></script>
   <script type="text/javascript">
     // Since we are using async to load the library wait until entire page is loaded to call google.load().
     // That should allow the initial page load to complete before starting the chart rendering.
@@ -242,7 +242,7 @@
 
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_editor/statistics_tab/StateImprovementSuggestionService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_editor/statistics_tab/StatisticsTab.js"></script>
-  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_editor/statistics_tab/BarChartDirective.js"></script>
+  <script defer src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_editor/statistics_tab/BarChartDirective.js"></script>
 
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_editor/settings_tab/SettingsTab.js"></script>
 

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -38,10 +38,11 @@
     function onloadChartLoadHandler() {
       if (window.google && window.google.charts) {
         google.charts.load('current', {packages: ['corechart']});
-      }else {
-          throw 'error: Could not load google visualization library. Are you offline?';
-        }
+        console.log(google);
+      } else {
+        throw 'error: Could not load google visualization library. Are you offline?';
       }
+    }
     // Since we are using async to load the library wait until entire page is loaded to call google.load().
     // That should allow the initial page load to complete before starting the chart rendering.
     window.onload = onloadChartLoadHandler;

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -38,7 +38,6 @@
     function onloadChartLoadHandler() {
       if (window.google && window.google.charts) {
         google.charts.load('current', {packages: ['corechart']});
-        console.log(google);
       }else {
           throw 'error: Could not load google visualization library. Are you offline?';
         }

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -35,15 +35,11 @@
   https://developers.google.com/chart/interactive/docs/basic_load_libs#update-library-loader-code -->
   <script type="text/javascript"  src="https://www.gstatic.com/charts/loader.js"></script>
   <script type="text/javascript">
-    // Since we are using async to load the library wait until entire page is loaded to call google.load().
-    // That should allow the initial page load to complete before starting the chart rendering.
-    window.addEventListener('load', function() {
-      if (window.google && window.google.charts) {
-        google.charts.load('current', {packages: ['corechart']});
-      } else {
-        throw 'error: Could not load google visualization library. Are you offline?';
-      }
-    });
+    if (window.google && window.google.charts) {
+      google.charts.load('current', {packages: ['corechart']});
+    } else {
+      throw 'error: Could not load google visualization library. Are you offline?';
+    }
   </script>
 
   <style>
@@ -242,7 +238,7 @@
 
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_editor/statistics_tab/StateImprovementSuggestionService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_editor/statistics_tab/StatisticsTab.js"></script>
-  <script defer src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_editor/statistics_tab/BarChartDirective.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_editor/statistics_tab/BarChartDirective.js"></script>
 
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_editor/settings_tab/SettingsTab.js"></script>
 


### PR DESCRIPTION
I tried to use async  in script to load the the visualization library but then google.load was never called because google was not added to the $window. I have to wait until the library is fully loaded to google.load the visualization library into the $window. with old library this raised more problems because it used document.write so other js files like jquery, mathJax could not append to the body. So I changed to new way to load library(new library) which suppress the warning. look [here](https://developers.google.com/chart/interactive/docs/basic_load_libs#update-library-loader-code)