### PR TITLE
Fix #3615: Hint Editor should not allow blank hints.

### DIFF
--- a/core/templates/dev/head/components/hint_editor_directive.html
+++ b/core/templates/dev/head/components/hint_editor_directive.html
@@ -41,7 +41,7 @@
         </button>
         <button type="button"
                 class="btn btn-success"
-                ng-disabled="editHintForm.$invalid"
+                ng-disabled="!hint.hintText || editHintForm.$invalid"
                 ng-click="saveThisHint()">
           Save
         </button>

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateHints.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateHints.js
@@ -71,7 +71,7 @@ oppia.controller('StateHints', [
 
       $modal.open({
         templateUrl: 'modals/addHint',
-        backdrop: true,
+        backdrop: 'static',
         controller: [
           '$scope', '$modalInstance', 'editorContextService',
           function($scope, $modalInstance, editorContextService) {

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_hints.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_hints.html
@@ -77,7 +77,7 @@
 
   <div class="modal-footer">
     <button class="btn btn-default" ng-click="cancel()">Cancel</button>
-    <button class="btn btn-success" ng-click="saveHint()">Save Hint</button>
+    <button class="btn btn-success" ng-click="saveHint()" ng-disabled="!tmpHint">Save Hint</button>
   </div>
 </script>
 


### PR DESCRIPTION
Hint Editor should not allow blank hints to be specified. This PR grays out the "save" button when no hint is specified (Linking #3615).