### PR TITLE
Fix #3342: Close modal window if clicked outside

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
@@ -183,8 +183,7 @@ oppia.controller('StateInteraction', [
 
         $modal.open({
           templateUrl: 'modals/customizeInteraction',
-          // Clicking outside this modal should not dismiss it.
-          backdrop: 'static',
+          backdrop: true,
           resolve: {},
           controller: [
             '$scope', '$modalInstance', '$injector',


### PR DESCRIPTION
- [x] Add a "Cancel" button at the bottom.  
- [x] Also close if you click outside the area of the model window.