### PR TITLE
Change error message in editor

### DIFF
--- a/extensions/interactions/baseValidator.js
+++ b/extensions/interactions/baseValidator.js
@@ -64,8 +64,8 @@ oppia.factory('baseInteractionValidationService', [
           partialWarningsList.push({
             type: WARNING_TYPES.ERROR,
             message: (
-              'Please add feedback for the user if they are to return to the ' +
-              'same state again.')
+              'Please add feedback for the user in the [All other answers] ' +
+              'rule if they are to return to the same state again.')
           });
         }
         return partialWarningsList;

--- a/extensions/interactions/baseValidator.js
+++ b/extensions/interactions/baseValidator.js
@@ -65,7 +65,7 @@ oppia.factory('baseInteractionValidationService', [
             type: WARNING_TYPES.ERROR,
             message: (
               'Please add feedback for the user in the [All other answers] ' +
-              'rule if they are to return to the same state again.')
+              'rule.')
           });
         }
         return partialWarningsList;

--- a/extensions/interactions/baseValidatorSpec.js
+++ b/extensions/interactions/baseValidatorSpec.js
@@ -103,7 +103,7 @@ describe('Interaction validator', function() {
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
         message: 'Please add feedback for the user in the [All other ' +
-          'answers] rule if they are to return to the same state again.'
+          'answers] rule.'
       }]);
     });
 
@@ -131,8 +131,7 @@ describe('Interaction validator', function() {
       }, {
         type: WARNING_TYPES.ERROR,
         message: (
-          'Please add feedback for the user in the [All other answers] rule ' +
-          'if they are to return to the same state again.')
+          'Please add feedback for the user in the [All other answers] rule.')
       }
       ]);
     });

--- a/extensions/interactions/baseValidatorSpec.js
+++ b/extensions/interactions/baseValidatorSpec.js
@@ -102,8 +102,8 @@ describe('Interaction validator', function() {
       var warnings = bivs.getDefaultOutcomeWarnings(badOutcome, currentState);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
-        message: 'Please add feedback for the user if they are to return ' +
-          'to the same state again.'
+        message: 'Please add feedback for the user in the [All other ' +
+          'answers] rule if they are to return to the same state again.'
       }]);
     });
 
@@ -131,8 +131,8 @@ describe('Interaction validator', function() {
       }, {
         type: WARNING_TYPES.ERROR,
         message: (
-          'Please add feedback for the user if they are to return ' +
-          'to the same state again.')
+          'Please add feedback for the user in the [All other answers] rule ' +
+          'if they are to return to the same state again.')
       }
       ]);
     });


### PR DESCRIPTION
This changes the error message in the editor to clarify where the author should add feedback in the case where the default rule has no feedback.