### PR TITLE
Fix user bios job in the case that user_bio is None

### DIFF
--- a/core/domain/user_jobs_one_off.py
+++ b/core/domain/user_jobs_one_off.py
@@ -100,7 +100,12 @@ class LongUserBiosOneOffJob(jobs.BaseMapReduceJobManager):
 
     @staticmethod
     def map(item):
-        yield (len(item.user_bio), item.username)
+        if item.user_bio is None:
+            user_bio_length = 0
+        else:
+            user_bio_length = len(item.user_bio)
+
+        yield (user_bio_length, item.username)
 
     @staticmethod
     def reduce(userbio_length, stringified_usernames):


### PR DESCRIPTION
We have some legacy data where the user_bio field of the UserSettingsModel for some older users can be None. This PR is to handle that case.