### PR TITLE
Fix #3017 : [NOT FOR MERGE] Adds functionality for moving questions in sidebar

### DIFF
--- a/core/templates/dev/head/domain/exploration/QuestionListObjectFactory.js
+++ b/core/templates/dev/head/domain/exploration/QuestionListObjectFactory.js
@@ -90,6 +90,10 @@ oppia.factory('QuestionListObjectFactory', [function() {
       'Cannot find question corresponding to state named: ' + stateName);
   };
 
+  QuestionList.prototype.getBindableQuestions = function() {
+    return this._questions;
+  };
+
   // Returns a copy of the last question in the list.
   QuestionList.prototype.getLastQuestion = function() {
     return angular.copy(this._questions[this._questions.length - 1]);

--- a/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/SimpleEditorManagerService.js
+++ b/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/SimpleEditorManagerService.js
@@ -21,13 +21,15 @@
  */
 
 oppia.factory('SimpleEditorManagerService', [
-  'explorationInitStateNameService', 'OutcomeObjectFactory',
-  'QuestionListObjectFactory', 'QuestionObjectFactory',
-  'SimpleEditorShimService', 'StatesToQuestionsService',
+  'AnswerGroupObjectFactory', 'explorationInitStateNameService',
+  'OutcomeObjectFactory', 'QuestionListObjectFactory',
+  'QuestionObjectFactory', 'RuleObjectFactory', 'SimpleEditorShimService',
+  'StatesToQuestionsService',
   function(
-    explorationInitStateNameService, OutcomeObjectFactory,
-    QuestionListObjectFactory, QuestionObjectFactory,
-    SimpleEditorShimService, StatesToQuestionsService) {
+    AnswerGroupObjectFactory, explorationInitStateNameService,
+    OutcomeObjectFactory, QuestionListObjectFactory,
+    QuestionObjectFactory, RuleObjectFactory, SimpleEditorShimService,
+    StatesToQuestionsService) {
     var data = {
       title: null,
       introductionHtml: null,
@@ -210,9 +212,28 @@ oppia.factory('SimpleEditorManagerService', [
         var stateNamesInOrder = data.questionList.getAllStateNames();
         var sStateName = stateNamesInOrder[sIndex];
         var sState = SimpleEditorShimService.getState(sStateName);
-        var sDestName = sState.interaction.answerGroups[0].outcome.dest;
         var dStateName = stateNamesInOrder[dIndex];
         var dState = SimpleEditorShimService.getState(dStateName);
+        if (dState.interaction.answerGroups.length === 0 ||
+          sState.interaction.answerGroups.length === 0) {
+          var newStateName = this.addState();
+          var newAnswerGroups = [];
+          newAnswerGroups.push(AnswerGroupObjectFactory.createNew([
+            RuleObjectFactory.createNew('Equals', {
+              x: 0
+            })
+          ], OutcomeObjectFactory.createEmpty(newStateName), false));
+          if (dState.interaction.answerGroups.length === 0) {
+            SimpleEditorShimService.saveAnswerGroups(dStateName,
+              newAnswerGroups);
+            dState.interaction.answerGroups = newAnswerGroups;
+          } else {
+            SimpleEditorShimService.saveAnswerGroups(sStateName,
+              newAnswerGroups);
+            sState.interaction.answerGroups = newAnswerGroups;
+          }
+        }
+        var sDestName = sState.interaction.answerGroups[0].outcome.dest;
         var dDestName = dState.interaction.answerGroups[0].outcome.dest;
 
         redirectAllIncomingNodes(sStateName, sDestName);

--- a/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/SimpleEditorSidebarDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/SimpleEditorSidebarDirective.js
@@ -17,7 +17,8 @@
  */
 
 oppia.directive('simpleEditorSidebar', [
-  'UrlInterpolationService', function(UrlInterpolationService) {
+  '$document', 'QuestionIdService', 'UrlInterpolationService',
+  function($document, QuestionIdService, UrlInterpolationService) {
     return {
       restrict: 'E',
       templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
@@ -72,6 +73,23 @@ oppia.directive('simpleEditorSidebar', [
                 'intro' : $scope.questionList.getLastQuestion().getId();
               ScrollSyncService.scrollTo(end);
             }
+          };
+
+          $scope.dragQuestionStart = function(question) {
+            console.log('down');
+            var DOMElem = angular
+              .element($document[0].getElementById(
+                $scope.ID_PREFIX + question.getId()));
+            console.log(DOMElem);
+            DOMElem.addClass('selected');
+          };
+          $scope.dragQuestionEnd = function(question) {
+            console.log('up');
+            var DOMElem = angular
+              .element($document[0].getElementById(
+                $scope.ID_PREFIX + question.getId()));
+            console.log(DOMElem);
+            DOMElem.removeClass('selected');
           };
         }
       ]

--- a/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/SimpleEditorSidebarDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/SimpleEditorSidebarDirective.js
@@ -46,6 +46,26 @@ oppia.directive('simpleEditorSidebar', [
               question.getId(), subfieldLabel
             );
           };
+          $scope._questions = $scope.questionList.getBindableQuestions();
+          $scope.SIDEBAR_SORTABLE_OPTIONS = {
+            axis: 'y',
+            cursor: 'move',
+            containment: 'parent',
+            tolerance: 'pointer',
+            revert: 100,
+            start: function(e, ui) {
+              ui.placeholder.height(ui.item.height());
+              // This class is to be added, but it is giving strange behaviour.
+              // ui.item.addClass('selected');
+            },
+            update: function(e, ui) {
+              SimpleEditorManagerService.sortQuestions(
+                ui.item.sortable.index, ui.item.sortable.dropindex);
+            },
+            stop: function() {
+              // ui.item.removeClass('selected');
+            }
+          };
 
           $scope.scrollToField = function(question, subfieldLabel) {
             ScrollSyncService.scrollTo(
@@ -73,23 +93,6 @@ oppia.directive('simpleEditorSidebar', [
                 'intro' : $scope.questionList.getLastQuestion().getId();
               ScrollSyncService.scrollTo(end);
             }
-          };
-
-          $scope.dragQuestionStart = function(question) {
-            console.log('down');
-            var DOMElem = angular
-              .element($document[0].getElementById(
-                $scope.ID_PREFIX + question.getId()));
-            console.log(DOMElem);
-            DOMElem.addClass('selected');
-          };
-          $scope.dragQuestionEnd = function(question) {
-            console.log('up');
-            var DOMElem = angular
-              .element($document[0].getElementById(
-                $scope.ID_PREFIX + question.getId()));
-            console.log(DOMElem);
-            DOMElem.removeClass('selected');
           };
         }
       ]

--- a/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/simple_editor_sidebar_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/simple_editor_sidebar_directive.html
@@ -15,6 +15,7 @@
     </li>
   </ul>
   <ul ui-sortable="SIDEBAR_SORTABLE_OPTIONS" ng-model="answerGroups">
+  <ul>
     <li class="sidebar-item" ng-repeat="question in questionList.getQuestions() track by $index" class="oppia-rule-block oppia-sortable-rule-block oppia-prevent-selection">
       <div id="<[ID_PREFIX + question.getId()]>" class="sidebar-item-header">
         <i ng-click="question.toggleCollapse()" class="collapse-icon material-icons" ng-hide="sidebarModeService.isSidebarInEditMode()">

--- a/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/simple_editor_sidebar_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/simple_editor_sidebar_directive.html
@@ -14,37 +14,37 @@
       <strong>Introduction</strong>
     </li>
   </ul>
-  <ul ui-sortable="SIDEBAR_SORTABLE_OPTIONS" ng-model="answerGroups">
-  <ul>
-    <li class="sidebar-item" ng-repeat="question in questionList.getQuestions() track by $index" class="oppia-rule-block oppia-sortable-rule-block oppia-prevent-selection">
-      <div id="<[ID_PREFIX + question.getId()]>" class="sidebar-item-header">
-        <i ng-click="question.toggleCollapse()" class="collapse-icon material-icons" ng-hide="sidebarModeService.isSidebarInEditMode()">
+  <div id="sidebar-question-container">
+    <ul ui-sortable="SIDEBAR_SORTABLE_OPTIONS" ng-model="_questions">
+      <li class="sidebar-item" ng-repeat="question in questionList.getQuestions() track by $index" class="oppia-rule-block oppia-sortable-rule-block oppia-prevent-selection">
+        <div id="<[ID_PREFIX + question.getId()]>" class="sidebar-item-header">
+          <i ng-click="question.toggleCollapse()" class="collapse-icon material-icons" ng-hide="sidebarModeService.isSidebarInEditMode()">
           <[isCollapsed(question) ? '&#xE5C7;' : '&#xE5C5;']>
-        </i>
-        <i ng-click="deleteQuestion(question)" class="delete-icon material-icons" ng-hide="sidebarModeService.isSidebarInReadonlyMode()">
+          </i>
+          <i ng-click="deleteQuestion(question)" class="delete-icon material-icons" ng-hide="sidebarModeService.isSidebarInReadonlyMode()">
           <['&#xE872;']>
-        </i>
-        <strong ng-click="scrollToQuestion(question)">Question <[$index + 1]></strong>
-        <span class="right-edge"><a>
-          <i ng-mousedown="dragQuestionStart(question)" ng-mouseup = "dragQuestionEnd(question)" class="oppia-rule-sort-handle drag-handle material-icons" ng-hide="sidebarModeService.isSidebarInReadonlyMode()"></a>
+          </i>
+          <strong ng-click="scrollToQuestion(question)">Question <[$index + 1]></strong>
+          <span class="right-edge"><a>
+          <i class="oppia-rule-sort-handle drag-handle material-icons" ng-hide="sidebarModeService.isSidebarInReadonlyMode()"></a>
           <['&#xE25D;']>
-        </i>
-        </span>
-      </div>
+          </i>
+          </span>
+        </div>
 
-      <ul ng-show="question.isCollapsed() && sidebarModeService.isSidebarInReadonlyMode()">
-        <li class="sidebar-item sidebar-item-indented"
+        <ul ng-show="question.isCollapsed() && sidebarModeService.isSidebarInReadonlyMode()">
+          <li class="sidebar-item sidebar-item-indented"
             ng-repeat="subfieldLabel in SUBFIELD_LABELS track by $index"
             ng-click="scrollToField(question, subfieldLabel)"
             id="<[getSidebarItemId(question, subfieldLabel)]>">
-          <span>
-            <a><[subfieldLabel]></a>
-          </span>
-        </li>
-      </ul>
-    </li>
-  </ul>
-
+            <span>
+              <a><[subfieldLabel]></a>
+            </span>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </div>
 </div>
 
 <style>

--- a/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/simple_editor_sidebar_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/simple_editor_tab/simple_editor_sidebar_directive.html
@@ -13,8 +13,9 @@
         ng-click="scrollToHeader('intro')" class="sidebar-item sidebar-header">
       <strong>Introduction</strong>
     </li>
-
-    <li class="sidebar-item" ng-repeat="question in questionList.getQuestions() track by $index">
+  </ul>
+  <ul ui-sortable="SIDEBAR_SORTABLE_OPTIONS" ng-model="answerGroups">
+    <li class="sidebar-item" ng-repeat="question in questionList.getQuestions() track by $index" class="oppia-rule-block oppia-sortable-rule-block oppia-prevent-selection">
       <div id="<[ID_PREFIX + question.getId()]>" class="sidebar-item-header">
         <i ng-click="question.toggleCollapse()" class="collapse-icon material-icons" ng-hide="sidebarModeService.isSidebarInEditMode()">
           <[isCollapsed(question) ? '&#xE5C7;' : '&#xE5C5;']>
@@ -23,6 +24,11 @@
           <['&#xE872;']>
         </i>
         <strong ng-click="scrollToQuestion(question)">Question <[$index + 1]></strong>
+        <span class="right-edge"><a>
+          <i ng-mousedown="dragQuestionStart(question)" ng-mouseup = "dragQuestionEnd(question)" class="oppia-rule-sort-handle drag-handle material-icons" ng-hide="sidebarModeService.isSidebarInReadonlyMode()"></a>
+          <['&#xE25D;']>
+        </i>
+        </span>
       </div>
 
       <ul ng-show="question.isCollapsed() && sidebarModeService.isSidebarInReadonlyMode()">
@@ -136,5 +142,25 @@
   simple-editor-sidebar .edit-mode-button {
     position: absolute;
     right: 0;
+  }
+
+  simple-editor-sidebar .right-edge{
+    vertical-align: middle;
+  }
+
+  simple-editor-sidebar .selected{
+    box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  }
+
+  simple-editor-sidebar .oppia-rule-sort-handle{
+    cursor: move;
+    right: 5px;
+    left: auto;
+    margin-left: 5px;
+    opacity: 0.3;
+    position: absolute;
+    top: 8px;
+    width: 25px;
+    z-index: 1;
   }
 </style>


### PR DESCRIPTION
This PR addresses issue #3017 . It adds moving functionality i.e. sorting questions through sidebar in simple editor.

It uses [ui-sortable](https://github.com/angular-ui/ui-sortable). It has some UI bugs similar to #1252 . I am looking forward to fix these in next few commits but any help will be much appreciated.

Tests are remaining too.
.
