### PR TITLE
Fix #3612: In embedded explorations, the learner avatars are too large.

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -221,7 +221,7 @@ directive. -->
   }
 
   .conversation-skin-oppia-avatar,
-  .conversation-skin-user-avatar {
+  .conversation-skin-learner-answer-container .conversation-skin-user-avatar {
     height: 36px;
     position: absolute;
     top: 0;

--- a/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
@@ -45,7 +45,7 @@
     text-align: right;
   }
 
-  .conversation-skin-learner-answer-container .conversation-skin-user-avatar {
+  .conversation-skin-user-avatar {
     border: 2px solid #094142;
     height: 100px;
     right: -88px;


### PR DESCRIPTION
<img width="1001" alt="resizedavatar" src="https://user-images.githubusercontent.com/16796008/28379096-2975b3a0-6cd0-11e7-8e3e-f5c7d46373fc.png">
