### PR TITLE
Make the representation of the learner's 'Continue' answer more conversational.

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -110,6 +110,7 @@
 <style>
   .conversation-skin-tutor-card {
     max-width: 100vw;
+    padding-bottom: 18px;
   }
 
   .conversation-skin-tutor-card-top-section .conversation-skin-oppia-avatar {
@@ -229,7 +230,7 @@
   .conversation-skin-inline-interaction {
     border-bottom-left-radius: 2px;
     border-bottom-right-radius: 2px;
-    padding: 8px 20px 16px;
+    padding: 8px 20px 0;
     position: relative;
   }
 

--- a/extensions/interactions/Continue/Continue.js
+++ b/extensions/interactions/Continue/Continue.js
@@ -32,9 +32,22 @@ oppia.directive('oppiaInteractiveContinue', [
         $scope.buttonText = oppiaHtmlEscaper.escapedJsonToObj(
           $attrs.buttonTextWithValue);
 
+        var DEFAULT_BUTTON_TEXT = 'Continue';
+        var DEFAULT_HUMAN_READABLE_ANSWER = 'Please continue.';
+
         $scope.submitAnswer = function() {
+          // We used to show "(Continue)" to indicate a 'continue' action when
+          // the learner browses through the history of the exploration, but
+          // this apparently can be mistaken for a button/control. The
+          // following makes the learner's "answer" a bit more conversational,
+          // as if they were chatting with Oppia.
+          var humanReadableAnswer = DEFAULT_HUMAN_READABLE_ANSWER;
+          if ($scope.buttonText !== DEFAULT_BUTTON_TEXT) {
+            humanReadableAnswer = $scope.buttonText;
+          }
+
           $scope.onSubmit({
-            answer: '(' + $scope.buttonText + ')',
+            answer: humanReadableAnswer,
             rulesService: continueRulesService
           });
         };


### PR DESCRIPTION
This PR is meant to address some feedback from a user study review a few days ago. On navigating through the exploration history, the "(Continue)" button looked like something that was clickable:

![old-one](https://user-images.githubusercontent.com/10575562/28508697-6a9e9d46-6ff1-11e7-878e-639de1f02098.png)

and this PR changes the text representing the learner's answer so that it now looks like this:

![snaphost](https://user-images.githubusercontent.com/10575562/28508525-681fc7da-6ff0-11e7-9267-eb3d3706205e.png)

The PR also adjusts the bottom padding a bit -- the aim was to try and make it look like the learner's answer is part of the conversation rather than a control at the bottom, but I'm not sure whether that's a good change or not.

I'd be grateful for feedback on both changes in isolation -- happy to make any adjustments needed. Thanks!