### PR TITLE
Fix #3694: Move hint button to left corner for supplemental cards

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
@@ -21,7 +21,7 @@
   <div class="protractor-test-conversation-input"
        angular-html-bind="activeCard.interactionHtml">
   </div>
-  <div ng-if="hintsExist" style="text-align: right; padding: 8px">
+  <div ng-if="hintsExist" style="text-align: left; padding: 8px">
     <hint-button on-click-hint-button="consumeHint()"
                  current-hint-is-available="isHintAvailable()"
                  all-hints-are-exhausted="areAllHintsExhausted()">


### PR DESCRIPTION
This PR fixes #3694 by moving the hint button to left corner for interactions that use the supplemental card interface.