### PR TITLE
Fix #3698:   Exception handling shifted for NotLoggedInException so that it does not generate log errors.

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -434,6 +434,11 @@ class BaseHandler(webapp2.RequestHandler):
             unused_debug_mode: bool. True if the web application is running
                 in debug mode.
         """
+        if isinstance(exception, self.NotLoggedInException):
+            self.redirect(
+                current_user_services.create_login_url(self.request.uri))
+            return
+
         logging.info(''.join(traceback.format_exception(*sys.exc_info())))
         logging.error('Exception raised: %s', exception)
 
@@ -442,11 +447,6 @@ class BaseHandler(webapp2.RequestHandler):
             self.error(404)
             self._render_exception(404, {
                 'error': 'Could not find the page %s.' % self.request.uri})
-            return
-
-        if isinstance(exception, self.NotLoggedInException):
-            self.redirect(
-                current_user_services.create_login_url(self.request.uri))
             return
 
         if isinstance(exception, self.UnauthorizedUserException):


### PR DESCRIPTION
#3698 

Exception handling shifted for NotLoggedInException so that it does not generate log errors.