### PR TITLE
Fix #3688: refactoring ExplorationStatusHandler to remove unpublish and publicize functionality as it is not called from frontend.

### DIFF
--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -366,7 +366,7 @@ class ExplorationStatusHandler(EditorHandler):
     """Handles publishing or publicizing of an exploration."""
 
     def _publish_exploration(self, exploration_id):
-        """Publish an exploration based.
+        """Publish an exploration.
 
         Args:
             exploration_id: str. Id of the exploration.

--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -365,67 +365,52 @@ class ExplorationRightsHandler(EditorHandler):
 class ExplorationStatusHandler(EditorHandler):
     """Handles publishing or publicizing of an exploration."""
 
-    def _publish_exploration(self, exploration_id, make_public):
-        """Publish/Unpublish an exploration based on make_public boolean.
+    def _publish_exploration(self, exploration_id):
+        """Publish an exploration based.
 
         Args:
             exploration_id: str. Id of the exploration.
-            make_public: bool. Whether to publish the exploration or
-                unpublish it.
 
         Raises:
             InvalidInputException: Given exploration is invalid.
         """
         exploration = exp_services.get_exploration_by_id(exploration_id)
-        if make_public:
-            try:
-                exploration.validate(strict=True)
-            except utils.ValidationError as e:
-                raise self.InvalidInputException(e)
+        try:
+            exploration.validate(strict=True)
+        except utils.ValidationError as e:
+            raise self.InvalidInputException(e)
 
-            exp_services.publish_exploration_and_update_user_profiles(
-                self.user_id, exploration_id)
-            exp_services.index_explorations_given_ids([exploration_id])
-        else:
-            rights_manager.unpublish_exploration(
-                self.user_id, exploration_id)
-            exp_services.delete_documents_from_search_index([
-                exploration_id])
+        exp_services.publish_exploration_and_update_user_profiles(
+            self.user_id, exploration_id)
+        exp_services.index_explorations_given_ids([exploration_id])
 
-    def _publicize_exploration(self, exploration_id, make_publicized):
-        """Publicize/Unpublicize and exploration based on make_publicized
-        boolean.
+    def _unpublicize_exploration(self, exploration_id):
+        """Unpublicize an exploration.
 
         Args:
             exploration_id: str. Id of the exploration.
-            make_publicized: bool. Whether to publicize the exploration or
-                unpublicize it.
 
         Raises:
             InvalidInputException: Given exploration is invalid.
         """
         exploration = exp_services.get_exploration_by_id(exploration_id)
-        if make_publicized:
-            try:
-                exploration.validate(strict=True)
-            except utils.ValidationError as e:
-                raise self.InvalidInputException(e)
+        try:
+            exploration.validate(strict=True)
+        except utils.ValidationError as e:
+            raise self.InvalidInputException(e)
 
-            rights_manager.publicize_exploration(
-                self.user_id, exploration_id)
-        else:
-            rights_manager.unpublicize_exploration(
-                self.user_id, exploration_id)
+        rights_manager.unpublicize_exploration(
+            self.user_id, exploration_id)
 
     @acl_decorators.can_publish_exploration
     def put(self, exploration_id):
         make_public = self.payload.get('make_public')
-        make_publicized = self.payload.get('make_publicized')
+        make_unpublicized = self.payload.get('make_unpublicized')
 
         if make_public is not None:
-            self._publish_exploration(exploration_id, make_public)
-        elif make_publicized is not None:
-            self._publicize_exploration(exploration_id, make_publicized)
+            self._publish_exploration(exploration_id)
+        elif make_unpublicized is not None:
+            self._unpublicize_exploration(exploration_id)
 
         self.render_json({
             'rights': rights_manager.get_exploration_rights(

--- a/core/templates/dev/head/pages/exploration_editor/EditorServices.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorServices.js
@@ -609,14 +609,14 @@ oppia.factory('explorationRightsService', [
         });
         return whenRolesSaved.promise;
       },
-      makePublic: function(makePublic) {
+      publish: function() {
         var whenPublishStatusChanged = $q.defer();
         var that = this;
 
         var requestUrl = (
           '/createhandler/status/' + explorationData.explorationId);
         $http.put(requestUrl, {
-          make_public: makePublic
+          make_public: true
         }).then(function(response) {
           var data = response.data;
           alertsService.clearWarnings();
@@ -629,14 +629,14 @@ oppia.factory('explorationRightsService', [
         });
         return whenPublishStatusChanged.promise;
       },
-      makePublicized: function(makePublicized) {
+      unpublicize: function() {
         var whenPublicizedStatusChanged = $q.defer();
         var that = this;
 
         var requestUrl = (
           '/createhandler/status/' + explorationData.explorationId);
         $http.put(requestUrl, {
-          make_publicized: makePublicized
+          make_unpublicized: true
         }).then(function(response) {
           var data = response.data;
           alertsService.clearWarnings();

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
@@ -124,7 +124,7 @@ oppia.factory('explorationSaveService', [
           onStartSaveCallback();
         }
 
-        explorationRightsService.makePublic(true).then(
+        explorationRightsService.publish().then(
           function() {
             if (onSaveDoneCallback) {
               onSaveDoneCallback();

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
@@ -379,7 +379,7 @@ oppia.controller('SettingsTab', [
       // 'moderator action' path, and implement an option for different actions
       // saying whether emails should be sent for these, or not. At present,
       // we don't expect to send an email when an exploration is unpublicized.
-      explorationRightsService.makePublicized(false);
+      explorationRightsService.unpublicize();
     };
 
     $scope.isExplorationLockedForEditing = function() {


### PR DESCRIPTION
#3688 