### PR TITLE
Add a one-off job to list which explorations use gadgets; remove old fallbacks job.

### DIFF
--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -780,7 +780,8 @@ class GadgetsOneOffJobTest(test_utils.GenericTestBase):
 
         actual_values = [
             value.encode('ascii')
-            for value in exp_jobs_one_off.GadgetsOneOffJob.get_output(job_id)]
+            for value in exp_jobs_one_off.GadgetsOneOffJob.get_output(job_id)
+        ]
         expected_values = [
             str([u'1', [u'bottom']]),
         ]

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -739,80 +739,50 @@ class ExplorationMigrationJobTest(test_utils.GenericTestBase):
             exp_services.get_exploration_by_id(self.NEW_EXP_ID)
 
 
-class FallbackOneOffJobTest(test_utils.GenericTestBase):
+class GadgetsOneOffJobTest(test_utils.GenericTestBase):
 
-    EXP_IDS = ['exp_id0', 'exp_id1']
-    FALLBACK = [{
-        'trigger': {
-            'customization_args': {
-                'num_submits': {
-                    'value': i + 3
-                }
-            },
-            'trigger_type': 'NthResubmission'
-        },
-        'outcome': {
-            'feedback': [
-                '<p>feedback %d</p>' % i
-            ],
-            'param_changes': [],
-            'dest': 'Introduction'
-        }
-    } for i in xrange(3)]
-    STATE_NAMES = ['Introduction', 'state 1']
+    REGULAR_EXP_ID = '0'
+    GADGET_EXP_ID = '1'
 
     def setUp(self):
-        super(FallbackOneOffJobTest, self).setUp()
+        super(GadgetsOneOffJobTest, self).setUp()
 
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
 
-    def test_fallbacks_are_listed(self):
-        """Tests that fallbacks are listed."""
-        explorations = [self.save_new_valid_exploration(
-            EXP_ID, self.owner_id, objective='The objective',
-            end_state_name='end') for EXP_ID in self.EXP_IDS]
-        for exploration in explorations:
-            init_state = exploration.states[exploration.init_state_name]
-            init_interaction = init_state.interaction
-            init_interaction.default_outcome.dest = 'state 1'
-            init_state.update_interaction_fallbacks(self.FALLBACK)
-            exploration.add_states(['state 1'])
-            new_state = exploration.states['state 1']
-            new_state.interaction.default_outcome.dest = 'end'
-            new_state.update_interaction_fallbacks(self.FALLBACK)
-            exploration.states['end'].update_interaction_id('EndExploration')
+        exp_services.load_demo(self.REGULAR_EXP_ID)
 
-            exp_services._save_exploration(self.owner_id, exploration, '', []) # pylint: disable=protected-access
-            rights_manager.publish_exploration(self.owner_id, exploration.id)
+        exp_services.load_demo(self.GADGET_EXP_ID)
+        exploration = exp_services.get_exploration_by_id(self.GADGET_EXP_ID)
+        exp_services.update_exploration(self.owner_id, self.GADGET_EXP_ID, [{
+            'cmd': exp_domain.CMD_ADD_GADGET,
+            'panel': 'bottom',
+            'gadget_dict' : {
+                'gadget_type': 'ScoreBar',
+                'gadget_name': 'NewGadget',
+                'customization_args': {
+                    'adviceObjects': {
+                        'value': [{
+                            'adviceTitle': 'b',
+                            'adviceHtml': '<p>c</p>'
+                        }]
+                    }
+                },
+                'visible_in_states': [exploration.init_state_name]
+            }
+        }], 'add a new gadget')
 
-        job_id = exp_jobs_one_off.FallbackOneOffJob.create_new()
-        exp_jobs_one_off.FallbackOneOffJob.enqueue(job_id)
+    def test_explorations_with_gadgets_are_listed(self):
+        """Tests that explorations with gadgets are listed."""
+        job_id = exp_jobs_one_off.GadgetsOneOffJob.create_new()
+        exp_jobs_one_off.GadgetsOneOffJob.enqueue(job_id)
         self.process_and_flush_pending_tasks()
 
-        actual_values = exp_jobs_one_off.FallbackOneOffJob.get_output(job_id)
+        actual_values = [
+            value.encode('ascii')
+            for value in exp_jobs_one_off.GadgetsOneOffJob.get_output(job_id)]
+        expected_values = [
+            str([u'1', [u'bottom']]),
+        ]
 
-        expected_values = [[
-            u'exp_id0: Introduction',
-            [u'3: <p>feedback 0</p>',
-             u'4: <p>feedback 1</p>',
-             u'5: <p>feedback 2</p>']
-        ], [
-            u'exp_id0: state 1',
-            [u'3: <p>feedback 0</p>',
-             u'4: <p>feedback 1</p>',
-             u'5: <p>feedback 2</p>']
-        ], [
-            u'exp_id1: Introduction',
-            [u'3: <p>feedback 0</p>',
-             u'4: <p>feedback 1</p>',
-             u'5: <p>feedback 2</p>']
-        ], [u'exp_id1: state 1',
-            [u'3: <p>feedback 0</p>',
-             u'4: <p>feedback 1</p>',
-             u'5: <p>feedback 2</p>']]]
-
-        actual_values.sort()
-        for index, actual_value in enumerate(actual_values):
-            self.assertEqual(actual_value.encode('ascii'),
-                             str(expected_values[index]))
+        self.assertEqual(actual_values, expected_values)

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -52,7 +52,7 @@ ONE_OFF_JOB_MANAGERS = [
     user_jobs_one_off.UserLastExplorationActivityOneOffJob,
     recommendations_jobs_one_off.ExplorationRecommendationsOneOffJob,
     collection_jobs_one_off.CollectionMigrationJob,
-    exp_jobs_one_off.FallbackOneOffJob]
+    exp_jobs_one_off.GadgetsOneOffJob]
 
 # List of all ContinuousComputation managers to show controls for on the
 # admin dashboard.


### PR DESCRIPTION
@wxyxinyu -- could we cherrypick this into the release? It should have no user-visible impact except for the name of the job in the admin view. Getting this data will help us figure out how gadgets are being used so that we can deprecate them safely.

Thanks!