### PR TITLE
Fix #3726: prevent graph SVG from overlapping modal footer buttons.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4955,7 +4955,6 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 .oppia-save-exploration-wide-modal .legend-graph {
   right: -25px;
-  top: 175px;
 }
 
 .oppia-mathexpression-input-mobile-overlay {


### PR DESCRIPTION
Hi @pbhoiwala, thanks so much for noticing this problem! Would you mind reviewing this PR, which aims to fix it? Instructions for reviewers are [here](https://github.com/oppia/oppia/wiki/Instructions-for-Reviewers#doing-the-review), and you can check out the branch via

```
    git pull
    git checkout fix-version-diff-viz
```

Thanks!