### PR TITLE
Removes stray tick mark

### DIFF
--- a/core/templates/dev/head/pages/preferences/preferences.html
+++ b/core/templates/dev/head/pages/preferences/preferences.html
@@ -82,7 +82,7 @@
                   <span translate="I18N_TOPNAV_LEARNER_DASHBOARD"></span>
                 </label>
               </div>
-            </div>`
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
I feel like this was already fixed somewhere else, though I might just be misremembering that. In any case, there was a stray tick mark on the preferences page in the RC.