### PR TITLE
Fix #3693: Deprecate ClassifierDataModel and update ClassifierTrainingJobModel

### DIFF
--- a/core/controllers/classifier.py
+++ b/core/controllers/classifier.py
@@ -117,7 +117,7 @@ class TrainedClassifierHandler(base.BaseHandler):
                 'The current status of the job cannot transition to COMPLETE.')
 
         try:
-            classifier_services.create_classifier(job_id, classifier_data)
+            classifier_services.store_classifier_data(job_id, classifier_data)
         except Exception as e:
             raise self.InternalErrorException(e)
 

--- a/core/controllers/classifier.py
+++ b/core/controllers/classifier.py
@@ -115,7 +115,6 @@ class TrainedClassifierHandler(base.BaseHandler):
                 feconf.TRAINING_JOB_STATUS_FAILED):
             raise self.InternalErrorException(
                 'The current status of the job cannot transition to COMPLETE.')
-
         try:
             classifier_services.store_classifier_data(job_id, classifier_data)
         except Exception as e:

--- a/core/controllers/classifier_test.py
+++ b/core/controllers/classifier_test.py
@@ -102,13 +102,11 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
             classifier_services.get_classifier_training_jobs(
                 self.exp_id, self.exploration.version, ['Home']))
         self.assertEqual(len(classifier_training_jobs), 1)
-        classifier_obj = classifier_services.get_classifier_by_id(
-            classifier_training_jobs[0].job_id)
-        self.assertEqual(classifier_obj.id, classifier_training_jobs[0].job_id)
-        self.assertEqual(classifier_obj.exp_id, self.exp_id)
-        self.assertEqual(classifier_obj.state_name, 'Home')
-        self.assertEqual(classifier_obj.algorithm_id, 'LDAStringClassifier')
-        self.assertEqual(classifier_obj.classifier_data, self.classifier_data)
+
+        self.assertEqual(classifier_training_jobs[0].classifier_data,
+                         self.classifier_data)
+        self.assertEqual(classifier_training_jobs[0].status,
+                         feconf.TRAINING_JOB_STATUS_COMPLETE)
 
     def test_error_on_prod_mode_and_default_vm_id(self):
         # Turn off DEV_MODE.
@@ -127,9 +125,3 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
         self.payload['message']['job_id'] = 1
         self.post_json('/ml/trainedclassifierhandler', self.payload,
                        expect_errors=True, expected_status_int=400)
-
-    def test_error_on_existing_classifier(self):
-        # Create ClassifierDataModel before the controller is called.
-        classifier_services.create_classifier(self.job_id, self.classifier_data)
-        self.post_json('/ml/trainedclassifierhandler', self.payload,
-                       expect_errors=True, expected_status_int=500)

--- a/core/domain/classifier_domain_test.py
+++ b/core/domain/classifier_domain_test.py
@@ -22,149 +22,6 @@ from core.tests import test_utils
 import utils
 
 
-class ClassifierDataDomainTests(test_utils.GenericTestBase):
-    """Test the classifier domain."""
-
-    def test_to_dict(self):
-        expected_classifier_dict = {
-            'classifier_id': 'job_request_id1',
-            'exp_id': 'exp_id1',
-            'exp_version_when_created': 1,
-            'state_name': 'a state name',
-            'algorithm_id': "LDAStringClassifier",
-            'classifier_data': {'alpha': 1.0},
-            'data_schema_version': 1
-        }
-        observed_classifier = classifier_domain.ClassifierData(
-            expected_classifier_dict['classifier_id'],
-            expected_classifier_dict['exp_id'],
-            expected_classifier_dict['exp_version_when_created'],
-            expected_classifier_dict['state_name'],
-            expected_classifier_dict['algorithm_id'],
-            expected_classifier_dict['classifier_data'],
-            expected_classifier_dict['data_schema_version'])
-        self.assertDictEqual(expected_classifier_dict,
-                             observed_classifier.to_dict())
-
-    def test_validation(self):
-        """Tests to verify validate method of classifier domain."""
-
-        # Verify no errors are raised for correct data.
-        classifier_data = {
-            '_alpha': 0.1,
-            '_beta': 0.001,
-            '_prediction_threshold': 0.5,
-            '_training_iterations': 25,
-            '_prediction_iterations': 5,
-            '_num_labels': 10,
-            '_num_docs': 12,
-            '_num_words': 20,
-            '_label_to_id': {'text': 1},
-            '_word_to_id': {'hello': 2},
-            '_w_dp': [],
-            '_b_dl': [],
-            '_l_dp': [],
-            '_c_dl': [],
-            '_c_lw': [],
-            '_c_l': []
-        }
-        classifier_dict = {
-            'classifier_id': 'job_request_id1',
-            'exp_id': 'exp_id1',
-            'exp_version_when_created': 1,
-            'state_name': 'a state name',
-            'algorithm_id': "LDAStringClassifier",
-            'classifier_data': classifier_data,
-            'data_schema_version': 1
-        }
-        classifier = classifier_domain.ClassifierData(
-            classifier_dict['classifier_id'],
-            classifier_dict['exp_id'],
-            classifier_dict['exp_version_when_created'],
-            classifier_dict['state_name'],
-            classifier_dict['algorithm_id'],
-            classifier_dict['classifier_data'],
-            classifier_dict['data_schema_version'])
-        classifier.validate()
-
-        # Verify validation error is raised when int is provided instead of
-        # string.
-        classifier_dict['classifier_id'] = 1
-        classifier = classifier_domain.ClassifierData(
-            classifier_dict['classifier_id'],
-            classifier_dict['exp_id'],
-            classifier_dict['exp_version_when_created'],
-            classifier_dict['state_name'],
-            classifier_dict['algorithm_id'],
-            classifier_dict['classifier_data'],
-            classifier_dict['data_schema_version'])
-        with self.assertRaisesRegexp(utils.ValidationError, (
-            'Expected id to be a string')):
-            classifier.validate()
-
-        # Verify validation error is raised when string is provided instead of
-        # int.
-        classifier_dict['classifier_id'] = 'job_request_id1'
-        classifier_dict['exp_version_when_created'] = 'abc'
-        classifier = classifier_domain.ClassifierData(
-            classifier_dict['classifier_id'],
-            classifier_dict['exp_id'],
-            classifier_dict['exp_version_when_created'],
-            classifier_dict['state_name'],
-            classifier_dict['algorithm_id'],
-            classifier_dict['classifier_data'],
-            classifier_dict['data_schema_version'])
-        with self.assertRaisesRegexp(utils.ValidationError, (
-            'Expected exp_version_when_created to be an int')):
-            classifier.validate()
-
-        # Verify valdation error is raised when invalid state_name is provided.
-        classifier_dict['exp_version_when_created'] = 1
-        classifier_dict['state_name'] = 'A string #'
-        classifier = classifier_domain.ClassifierData(
-            classifier_dict['classifier_id'],
-            classifier_dict['exp_id'],
-            classifier_dict['exp_version_when_created'],
-            classifier_dict['state_name'],
-            classifier_dict['algorithm_id'],
-            classifier_dict['classifier_data'],
-            classifier_dict['data_schema_version'])
-        with self.assertRaisesRegexp(utils.ValidationError, (
-            'Invalid character # in the state name')):
-            classifier.validate()
-
-        # Verify validation error is raised when invalid algorithm_id is
-        # provided.
-        classifier_dict['state_name'] = 'a state name'
-        classifier_dict['algorithm_id'] = 'abc'
-        classifier = classifier_domain.ClassifierData(
-            classifier_dict['classifier_id'],
-            classifier_dict['exp_id'],
-            classifier_dict['exp_version_when_created'],
-            classifier_dict['state_name'],
-            classifier_dict['algorithm_id'],
-            classifier_dict['classifier_data'],
-            classifier_dict['data_schema_version'])
-        with self.assertRaisesRegexp(utils.ValidationError, (
-            'Invalid algorithm id')):
-            classifier.validate()
-
-        # Verify validation error is raised when list is provided for dict.
-        classifier_dict['algorithm_id'] = "LDAStringClassifier"
-        classifier_dict['classifier_data'] = []
-        classifier = classifier_domain.ClassifierData(
-            classifier_dict['classifier_id'],
-            classifier_dict['exp_id'],
-            classifier_dict['exp_version_when_created'],
-            classifier_dict['state_name'],
-            classifier_dict['algorithm_id'],
-            classifier_dict['classifier_data'],
-            classifier_dict['data_schema_version'])
-        with self.assertRaisesRegexp(utils.ValidationError, (
-            'Expected classifier_data to be a dict')):
-            classifier.validate()
-
-
 class ClassifierTrainingJobDomainTests(test_utils.GenericTestBase):
     """Test the ClassifierTrainingJob domain."""
 
@@ -177,7 +34,9 @@ class ClassifierTrainingJobDomainTests(test_utils.GenericTestBase):
             training_job_dict['exp_version'],
             training_job_dict['state_name'],
             training_job_dict['status'],
-            training_job_dict['training_data'])
+            training_job_dict['training_data'],
+            training_job_dict['classifier_data'],
+            training_job_dict['data_schema_version'])
 
         return training_job
 
@@ -199,7 +58,9 @@ class ClassifierTrainingJobDomainTests(test_utils.GenericTestBase):
                     'answer_group_index': 2,
                     'answers': ['a2', 'a3']
                 }
-            ]
+            ],
+            'classifier_data': {},
+            'data_schema_version': 1
         }
         observed_training_job = self._get_training_job_from_dict(
             expected_training_job_dict)
@@ -228,7 +89,9 @@ class ClassifierTrainingJobDomainTests(test_utils.GenericTestBase):
             'algorithm_id': 'LDAStringClassifier',
             'interaction_id': 'TextInput',
             'training_data': training_data,
-            'status': 'NEW'
+            'status': 'NEW',
+            'classifier_data': None,
+            'data_schema_version': 1
         }
         training_job = self._get_training_job_from_dict(training_job_dict)
         training_job.validate()

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -344,7 +344,7 @@ def store_classifier_data(job_id, classifier_data):
 
     Args:
         job_id: str. ID of the ClassifierTrainingJob domain object.
-        classifier_data: str. The classification model which needs to be stored
+        classifier_data: dict. The classification model which needs to be stored
             in the job.
 
     Raises:
@@ -358,7 +358,7 @@ def store_classifier_data(job_id, classifier_data):
             'The ClassifierTrainingJobModel corresponding to the job_id of the'
             'ClassifierTrainingJob does not exist.')
 
-    classifier_training_job = get_classifier_training_job_by_id(job_id)
+    classifier_training_job = get_classifier_training_job_from_model(job_id)
     classifier_training_job.update_classifier_data(classifier_data)
     classifier_training_job.validate()
 

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -358,7 +358,8 @@ def store_classifier_data(job_id, classifier_data):
             'The ClassifierTrainingJobModel corresponding to the job_id of the'
             'ClassifierTrainingJob does not exist.')
 
-    classifier_training_job = get_classifier_training_job_from_model(job_id)
+    classifier_training_job = get_classifier_training_job_from_model(
+        classifier_training_job_model)
     classifier_training_job.update_classifier_data(classifier_data)
     classifier_training_job.validate()
 

--- a/core/storage/classifier/gae_models_test.py
+++ b/core/storage/classifier/gae_models_test.py
@@ -23,39 +23,6 @@ import feconf
     [models.NAMES.classifier])
 
 
-class ClassifierDataModelUnitTests(test_utils.GenericTestBase):
-    """Test the ClassifierDataModel class."""
-
-    def setUp(self):
-        super(ClassifierDataModelUnitTests, self).setUp()
-        classifier_models.ClassifierDataModel.create(
-            'job_request_id1', 'exp_id1', 1, 'state_name1',
-            'LDAStringClassifier', {'alpha': 1.0}, 1)
-        classifier_models.ClassifierDataModel.create(
-            'job_request_id2', 'exp_id1', 1, 'state_name2',
-            'LDAStringClassifier', {'alpha': 1.0}, 1)
-        classifier_models.ClassifierDataModel.create(
-            'job_request_id3', 'exp_id2', 1, 'state_name3',
-            'LDAStringClassifier', {'alpha': 1.0}, 1)
-
-    def test_create_new_classifier_runs_successfully(self):
-        classifier_id = classifier_models.ClassifierDataModel.create(
-            'job_request_id4', 'exp_id3', 1, 'state_name1',
-            'LDAStringClassifier', {'alpha': 1.0},
-            1)
-
-        classifier = (
-            classifier_models.ClassifierDataModel.get(classifier_id))
-
-        self.assertEqual(classifier.id, 'job_request_id4')
-        self.assertEqual(classifier.exp_id, 'exp_id3')
-        self.assertEqual(classifier.exp_version_when_created, 1)
-        self.assertEqual(classifier.state_name, 'state_name1')
-        self.assertEqual(classifier.algorithm_id, 'LDAStringClassifier')
-        self.assertEqual(classifier.classifier_data, {'alpha': 1.0})
-        self.assertEqual(classifier.data_schema_version, 1)
-
-
 class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
     """Test the ClassifierTrainingJobModel class."""
 
@@ -64,21 +31,25 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
         classifier_models.ClassifierTrainingJobModel.create(
             'LDAStringClassifier', 'TextInput', 'exp_id1', 1,
             [{'answer_group_index': 1, 'answers': ['a1', 'a2']}],
-            'state_name1', feconf.TRAINING_JOB_STATUS_NEW)
+            'state_name1', feconf.TRAINING_JOB_STATUS_NEW,
+            None, 1)
         classifier_models.ClassifierTrainingJobModel.create(
             'LDAStringClassifier', 'TextInput', 'exp_id2', 2,
             [{'answer_group_index': 1, 'answers': ['a1', 'a2']}],
-            'state_name1', feconf.TRAINING_JOB_STATUS_NEW)
+            'state_name1', feconf.TRAINING_JOB_STATUS_NEW,
+            None, 1)
         classifier_models.ClassifierTrainingJobModel.create(
             'LDAStringClassifier', 'TextInput', 'exp_id3', 3,
             [{'answer_group_index': 1, 'answers': ['a1', 'a2']}],
-            'state_name1', feconf.TRAINING_JOB_STATUS_NEW)
+            'state_name1', feconf.TRAINING_JOB_STATUS_NEW,
+            None, 1)
 
     def test_create_and_get_new_training_job_runs_successfully(self):
         job_id = classifier_models.ClassifierTrainingJobModel.create(
             'LDAStringClassifier', 'TextInput', 'exp_id1', 1,
             [{'answer_group_index': 1, 'answers': ['a1', 'a2']}],
-            'state_name2', feconf.TRAINING_JOB_STATUS_NEW)
+            'state_name2', feconf.TRAINING_JOB_STATUS_NEW,
+            None, 1)
 
         training_job = (
             classifier_models.ClassifierTrainingJobModel.get(job_id))
@@ -92,6 +63,8 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
                          feconf.TRAINING_JOB_STATUS_NEW)
         self.assertEqual(training_job.training_data,
                          [{'answer_group_index': 1, 'answers': ['a1', 'a2']}])
+        self.assertEqual(training_job.classifier_data, None)
+        self.assertEqual(training_job.data_schema_version, 1)
 
     def test_create_multi_jobs(self):
         job_dicts_list = []
@@ -103,7 +76,9 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
             'algorithm_id': feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput'][
                 'algorithm_id'],
             'training_data': [],
-            'status': feconf.TRAINING_JOB_STATUS_NEW
+            'status': feconf.TRAINING_JOB_STATUS_NEW,
+            'classifier_data': None,
+            'data_schema_version': 1
         })
         job_dicts_list.append({
             'exp_id': u'1',
@@ -113,7 +88,9 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
             'algorithm_id': feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput'][
                 'algorithm_id'],
             'training_data': [],
-            'status': feconf.TRAINING_JOB_STATUS_NEW
+            'status': feconf.TRAINING_JOB_STATUS_NEW,
+            'classifier_data': None,
+            'data_schema_version': 1
         })
 
         job_ids = classifier_models.ClassifierTrainingJobModel.create_multi(
@@ -133,6 +110,8 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(training_job1.state_name, 'Home')
         self.assertEqual(training_job1.status,
                          feconf.TRAINING_JOB_STATUS_NEW)
+        self.assertEqual(training_job1.classifier_data, None)
+        self.assertEqual(training_job1.data_schema_version, 1)
 
         training_job2 = (
             classifier_models.ClassifierTrainingJobModel.get(job_ids[1]))
@@ -147,6 +126,8 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(training_job2.state_name, 'Home')
         self.assertEqual(training_job2.status,
                          feconf.TRAINING_JOB_STATUS_NEW)
+        self.assertEqual(training_job2.classifier_data, None)
+        self.assertEqual(training_job2.data_schema_version, 1)
 
 
 class TrainingJobExplorationMappingModelUnitTests(test_utils.GenericTestBase):


### PR DESCRIPTION
#3693 

This PR deprecates the ClassifierDataModel and its domain layer. It also updates the ClassifierTrainingJobModel with two additional fields (classifier_data, data_schema_version) and modifies domain layer accordingly.

All usage of the ClassifierData class throughout the code base has been fixed and changed to fit in the new structure.

@prasanna08 @anmolshkl @seanlip PTAL.