### PR TITLE
Handle audio files with MPEG container with mutagen

### DIFF
--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -23,8 +23,7 @@ import StringIO
 
 import jinja2
 import mutagen
-
-from mutagen.mp3 import MP3
+from mutagen import mp3
 
 from constants import constants
 from core.controllers import base
@@ -886,7 +885,7 @@ class AudioUploadHandler(EditorHandler):
         tempbuffer.seek(0)
         try:
             if extension == 'mp3':
-                audio = MP3(tempbuffer)
+                audio = mp3.MP3(tempbuffer)
             else:
                 audio = mutagen.File(tempbuffer)
         except mutagen.MutagenError:

--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -24,6 +24,8 @@ import StringIO
 import jinja2
 import mutagen
 
+from mutagen.mp3 import MP3
+
 from constants import constants
 from core.controllers import base
 from core.domain import acl_decorators
@@ -883,7 +885,10 @@ class AudioUploadHandler(EditorHandler):
         tempbuffer.write(raw_audio_file)
         tempbuffer.seek(0)
         try:
-            audio = mutagen.File(tempbuffer)
+            if extension == 'mp3':
+                audio = MP3(tempbuffer)
+            else:
+                audio = mutagen.File(tempbuffer)
         except mutagen.MutagenError:
             # Mutagen occasionally has problems with certain files
             # for unknown reasons.

--- a/core/controllers/resources_test.py
+++ b/core/controllers/resources_test.py
@@ -397,6 +397,5 @@ class AudioHandlerTest(test_utils.GenericTestBase):
         )
         self.logout()
         self.assertEqual(response_dict['code'], 400)
-        self.assertIn(
-            'Although the filename extension indicates the file',
-            response_dict['error'])
+        self.assertEqual(response_dict['error'], 'Audio not recognized as '
+                         'a mp3 file')


### PR DESCRIPTION
It seems like currently audio files with MPEG containers aren't handled by mutagen. It seems like you have to use mutagen's mp3 package specifically to handle these files.