### PR TITLE
Fix #3677 Select2 tags not refreshing sometimes

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/RouterServices.js
+++ b/core/templates/dev/head/pages/exploration_editor/RouterServices.js
@@ -85,6 +85,17 @@ oppia.factory('routerService', [
       }
     });
 
+    // Select2 dropdowns does not automatically get populated
+    // when the tab is loaded, so we have to force it to refresh.
+    // Similar issue happened in Preferences.js and the same bug
+    // fix was made.
+    var _forceSelect2Refresh = function() {
+      $rootScope.select2DropdownIsShown = false;
+      $timeout(function() {
+        $rootScope.select2DropdownIsShown = true;
+      }, 100);
+    };
+
     var _doNavigationWithState = function(path, pathType) {
       var pathBase = '/' + pathType + '/';
       var putativeStateName = path.substring(pathBase.length);
@@ -195,6 +206,7 @@ oppia.factory('routerService', [
       navigateToSettingsTab: function() {
         _savePendingChanges();
         $location.path('/settings');
+        _forceSelect2Refresh();
       },
       navigateToHistoryTab: function() {
         _savePendingChanges();

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -36,7 +36,7 @@
             <div class="form-group" ng-class="{'has-error': !explorationCategoryService.displayed}">
               <label for="explorationCategory" class="col-lg-2 col-md-2 col-sm-2">Category</label>
               <div class="col-lg-10 col-md-10 col-sm-10">
-                <div ng-if="hasPageLoaded">
+                <div ng-if="hasPageLoaded && select2DropdownIsShown">
                   <select2-dropdown id="explorationCategory"
                                     class="protractor-test-exploration-category-input"
                                     item="explorationCategoryService.displayed"
@@ -76,7 +76,7 @@
             <div class="form-group">
               <label for="explorationTags" class="col-lg-2 col-md-2 col-sm-2">Tags</label>
               <div class="col-lg-10 col-md-10 col-sm-10">
-                <div ng-if="hasPageLoaded">
+                <div ng-if="hasPageLoaded && select2DropdownIsShown">
                   <select2-dropdown
                     item="$parent.explorationTagsService.displayed"
                     choices="$parent.explorationTagsService.displayed"


### PR DESCRIPTION
A very similar issue happened on Preferences page and in Preferences.js file, this method "forceSelect2Refresh" was created to force the select2 elements to refresh on page load. I implemented the same method for RouterService which loads the settings tab and now the "tags" and "category" drop-downs are both getting populated without needing to reload the page. 
