### PR TITLE
Fix #3750: open user-profile dropdown menu with 1 click

### DIFF
--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -59,7 +59,7 @@
   </ul>
   <ul class="nav oppia-navbar-nav oppia-navbar-profile">
     <li ng-if="username" class="dropdown protractor-test-profile-dropdown">
-      <a class="dropdown-toggle oppia-navbar-dropdown-toggle" data-toggle="dropdown"
+      <a class="dropdown-toggle oppia-navbar-dropdown-toggle"
          ng-mouseover="onMouseoverProfilePictureOrDropdown($event)"
          ng-mouseleave="onMouseoutProfilePictureOrDropdown($event)"
          role="menuitem"


### PR DESCRIPTION
**Fix #3750: open user-profile dropdown menu with 1 click**

the issue seemed to be a fairly common one.
see : https://stackoverflow.com/questions/24218663/avoid-having-to-double-click-to-toggle-bootstrap-dropdown
