### PR TITLE
Dynamic inclusion of JS files in frontend for prediction.

### DIFF
--- a/core/controllers/reader.py
+++ b/core/controllers/reader.py
@@ -91,6 +91,19 @@ def _get_exploration_player_data(
         interaction_registry.Registry.get_interaction_html(
             interaction_ids))
 
+    interaction_ids_with_prediction_service = []
+    classifier_training_jobs = (
+        classifier_services.get_classifier_training_jobs(
+            exploration_id, exploration.version, exploration.states))
+    for index, state_name in enumerate(exploration.states):
+        if (classifier_training_jobs[index] and
+                classifier_training_jobs[index].classifier_data):
+            interaction_ids_with_prediction_service.append(
+                exploration.states[state_name].interaction.id)
+    prediction_services_html = (
+        interaction_registry.Registry.get_all_html_for_prediction_service(
+            interaction_ids_with_prediction_service))
+
     return {
         'GADGET_SPECS': gadget_registry.Registry.get_all_specs(),
         'INTERACTION_SPECS': interaction_registry.Registry.get_all_specs(),
@@ -105,6 +118,8 @@ def _get_exploration_player_data(
         'collection_id': collection_id,
         'collection_title': collection_title,
         'gadget_templates': jinja2.utils.Markup(gadget_templates),
+        'prediction_services_html': jinja2.utils.Markup(
+            prediction_services_html),
         'interaction_templates': jinja2.utils.Markup(
             interaction_templates),
         'is_private': rights_manager.is_exploration_private(
@@ -220,7 +235,8 @@ class ExplorationHandler(base.BaseHandler):
             classifier_services.get_classifier_training_jobs(
                 exploration_id, exploration.version, exploration.states))
         for index, state_name in enumerate(exploration.states):
-            if classifier_training_jobs[index] is not None:
+            if (classifier_training_jobs[index] and
+                    classifier_training_jobs[index].classifier_data):
                 classifier_data = classifier_training_jobs[
                     index].classifier_data
                 algorithm_id = classifier_training_jobs[index].algorithm_id

--- a/core/domain/interaction_registry.py
+++ b/core/domain/interaction_registry.py
@@ -21,6 +21,7 @@ import os
 import pkgutil
 
 import feconf
+import utils
 
 
 class Registry(object):
@@ -103,3 +104,16 @@ class Registry(object):
             interaction.id: interaction.to_dict()
             for interaction in cls.get_all_interactions()
         }
+
+    @classmethod
+    def get_all_html_for_prediction_service(cls, interaction_ids):
+        """Returns the HTML bodies of the prediction service dependencies of
+        given list of interaction ids."""
+        dependencies = set([])
+        for interaction_id in interaction_ids:
+            interaction = cls.get_interaction_by_id(interaction_id)
+            dependencies.update(interaction.prediction_dependency_ids)
+
+        return '\n'.join([utils.get_file_contents(os.path.join(
+            feconf.PREDICTION_SERVICES_DEPENDENCIES_DIR,
+            '%s.html' % dependency)) for dependency in dependencies])

--- a/core/templates/dev/head/pages/exploration_player/AnswerClassificationService.js
+++ b/core/templates/dev/head/pages/exploration_player/AnswerClassificationService.js
@@ -136,8 +136,8 @@ oppia.factory('AnswerClassificationService', [
             ENABLE_ML_CLASSIFIERS) {
           var classifier = StateClassifierMappingService.getClassifier(
             stateName);
-          if (classifier.classifierData && classifier.algorithmId && (
-            classifier.dataSchemaVersion)) {
+          if (classifier && classifier.classifierData && (
+            classifier.algorithmId && classifier.dataSchemaVersion)) {
             var predictionService = (
               PredictionAlgorithmRegistryService.getPredictionService(
                 classifier.algorithmId, classifier.dataSchemaVersion));

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -227,4 +227,5 @@
 
   {{ interaction_templates }}
   {{ gadget_templates }}
+  {{ prediction_services_html }}
 {% endblock footer_js %}

--- a/extensions/interactions/base.py
+++ b/extensions/interactions/base.py
@@ -89,6 +89,11 @@ class BaseInteraction(object):
     # containing this interaction. These should correspond to names of files in
     # feconf.DEPENDENCIES_TEMPLATES_DIR. Overridden in subclasses.
     _dependency_ids = []
+    # Additional JS library dependencies that should be loaded in pages
+    # if interactions is trainable and prediction service is required in
+    # frontend. These should correspond to names of files in
+    # feconf.PREDICTION_SERVICES_DEPENDENCIES_DIR. Overridden in subclasses.
+    _prediction_dependency_ids = []
     # The type of answer (as a string) accepted by this interaction, e.g.
     # 'CodeEvaluation'. This should be None for linear and terminal
     # interactions.
@@ -148,6 +153,10 @@ class BaseInteraction(object):
     @property
     def dependency_ids(self):
         return copy.deepcopy(self._dependency_ids)
+
+    @property
+    def prediction_dependency_ids(self):
+        return copy.deepcopy(self._prediction_dependency_ids)
 
     def normalize_answer(self, answer):
         """Normalizes a learner's input to this interaction."""

--- a/feconf.py
+++ b/feconf.py
@@ -78,6 +78,9 @@ OBJECT_DEFAULT_VALUES_FILE_PATH = os.path.join(
 RULES_DESCRIPTIONS_FILE_PATH = os.path.join(
     os.getcwd(), 'extensions', 'interactions', 'rule_templates.json')
 
+PREDICTION_SERVICES_DEPENDENCIES_DIR = os.path.join(
+    DEPENDENCIES_TEMPLATES_DIR, 'prediction_service_dependencies')
+
 # A mapping of interaction ids to classifier properties.
 INTERACTION_CLASSIFIER_MAPPING = {
     'TextInput': {


### PR DESCRIPTION
This PR adds feature to dynamically include JS files required for frontend prediction service.

The solution is as follows:
* Add all the required dependency ids in `interaction.py` file in `_prediction_dependency_ids`.
* Create html files for these ids in `extensions/dependencies/prediction_service_dependencies`.
* These html files should contain `<script src='...'></script>` tags. You can include all the scripts required for frontend prediction this way. 