### PR TITLE
Simple fix to prevent the last updated field on running the count job.

### DIFF
--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -45,7 +45,7 @@ class FeedbackThreadMessagesCountOneOffJob(jobs.BaseMapReduceOneOffJobManager):
         thread_model = feedback_models.FeedbackThreadModel.get(key)
         next_message_id = max(message_ids) + 1
         thread_model.message_count = next_message_id
-        thread_model.put()
+        thread_model.put(False)
 
         if next_message_id != len(message_ids):
             exploration_and_thread_id = key.split('.')

--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -45,7 +45,7 @@ class FeedbackThreadMessagesCountOneOffJob(jobs.BaseMapReduceOneOffJobManager):
         thread_model = feedback_models.FeedbackThreadModel.get(key)
         next_message_id = max(message_ids) + 1
         thread_model.message_count = next_message_id
-        thread_model.put(False)
+        thread_model.put(update_last_updated_time=False)
 
         if next_message_id != len(message_ids):
             exploration_and_thread_id = key.split('.')

--- a/core/domain/feedback_services.py
+++ b/core/domain/feedback_services.py
@@ -521,9 +521,6 @@ def get_thread_summaries(user_id, full_thread_ids):
         author_last_message = user_services.get_username(
             last_two_messages[index][0].author_id)
 
-        thread_last_updated_time = (
-            utils.get_time_in_millisecs(last_two_messages[index][0].created_on))
-
         second_last_message_read = None
         author_second_last_message = None
 
@@ -552,7 +549,7 @@ def get_thread_summaries(user_id, full_thread_ids):
         thread_summary = {
             'status': thread.status,
             'original_author_id': thread.original_author_id,
-            'last_updated': thread_last_updated_time,
+            'last_updated': utils.get_time_in_millisecs(thread.last_updated),
             'last_message_text': last_two_messages[index][0].text,
             'total_message_count': total_message_count,
             'last_message_read': last_message_read,

--- a/core/domain/feedback_services.py
+++ b/core/domain/feedback_services.py
@@ -521,6 +521,9 @@ def get_thread_summaries(user_id, full_thread_ids):
         author_last_message = user_services.get_username(
             last_two_messages[index][0].author_id)
 
+        thread_last_updated_time = (
+            utils.get_time_in_millisecs(last_two_messages[index][0].created_on))
+
         second_last_message_read = None
         author_second_last_message = None
 
@@ -549,7 +552,7 @@ def get_thread_summaries(user_id, full_thread_ids):
         thread_summary = {
             'status': thread.status,
             'original_author_id': thread.original_author_id,
-            'last_updated': utils.get_time_in_millisecs(thread.last_updated),
+            'last_updated': thread_last_updated_time,
             'last_message_text': last_two_messages[index][0].text,
             'total_message_count': total_message_count,
             'last_message_read': last_message_read,

--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -16,8 +16,9 @@
 
 """Models for Oppia feedback threads and messages."""
 
-from core.platform import models
 import datetime
+
+from core.platform import models
 import feconf
 import utils
 

--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -17,6 +17,7 @@
 """Models for Oppia feedback threads and messages."""
 
 from core.platform import models
+import datetime
 import feconf
 import utils
 
@@ -72,6 +73,20 @@ class FeedbackThreadModel(base_models.BaseModel):
     has_suggestion = ndb.BooleanProperty(indexed=True, default=False)
     # The number of messages in the thread.
     message_count = ndb.IntegerProperty(indexed=True)
+    # When this thread was last updated.
+    last_updated = ndb.DateTimeProperty(indexed=True)
+
+    def put(self, update_last_updated_time=True):
+        """Writes the given thread instance to the datastore.
+
+        Args:
+            update_last_updated_time: bool. Whether to update the
+                last_updated_field of the thread.
+        """
+        if update_last_updated_time:
+            self.last_updated = datetime.datetime.utcnow()
+
+        return super(FeedbackThreadModel, self).put()
 
     @classmethod
     def generate_new_thread_id(cls, exploration_id):

--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -74,7 +74,12 @@ class FeedbackThreadModel(base_models.BaseModel):
     has_suggestion = ndb.BooleanProperty(indexed=True, default=False)
     # The number of messages in the thread.
     message_count = ndb.IntegerProperty(indexed=True)
-    # When this thread was last updated.
+    # When this thread was last updated. This overrides the field in
+    # BaseModel. We are overriding it because we do not want the last_updated
+    # field to be updated everytime the feedback thread is changed. For example,
+    # on running the job for calculating the number of messages in a thread
+    # and updating the message_count field we do not wish the last_updated field
+    # to be updated.
     last_updated = ndb.DateTimeProperty(indexed=True)
 
     def put(self, update_last_updated_time=True):

--- a/core/storage/feedback/gae_models_test.py
+++ b/core/storage/feedback/gae_models_test.py
@@ -28,6 +28,23 @@ FIELDS_NOT_REQUIRED = [CREATED_ON_FIELD, LAST_UPDATED_FIELD, DELETED_FIELD]
 class FeedbackThreadModelTest(test_utils.GenericTestBase):
     """Tests for the FeedbackThreadModel class."""
 
+    def test_put_function(self):
+        feedback_thread_model = feedback_models.FeedbackThreadModel(
+            exploration_id='exp_id_1')
+        feedback_thread_model.put()
+
+        last_updated = feedback_thread_model.last_updated
+
+        # If we do not wish to update the last_updated time, we should set
+        # the update_last_updated_time argument to False in the put function.
+        feedback_thread_model.put(False)
+        self.assertEqual(feedback_thread_model.last_updated, last_updated)
+
+        # If we do wish to change it however, we can simply use the put function
+        # as the default value of update_last_updated_time is True.
+        feedback_thread_model.put()
+        self.assertNotEqual(feedback_thread_model.last_updated, last_updated)
+
     def test_get_exploration_and_thread_ids(self):
         # Generate some full thread ids.
         full_thread_id_1 = (

--- a/core/storage/feedback/gae_models_test.py
+++ b/core/storage/feedback/gae_models_test.py
@@ -37,7 +37,7 @@ class FeedbackThreadModelTest(test_utils.GenericTestBase):
 
         # If we do not wish to update the last_updated time, we should set
         # the update_last_updated_time argument to False in the put function.
-        feedback_thread_model.put(False)
+        feedback_thread_model.put(update_last_updated_time=False)
         self.assertEqual(feedback_thread_model.last_updated, last_updated)
 
         # If we do wish to change it however, we can simply use the put function


### PR DESCRIPTION
The last updated of the thread is nothing but when the last message is created - and this is not changed on running the job.