### PR TITLE
Fix issue with inter-paragraph spacing in content field being unintentionally reduced.

### DIFF
--- a/core/templates/dev/head/pages/collection_player/collection_player.html
+++ b/core/templates/dev/head/pages/collection_player/collection_player.html
@@ -147,7 +147,8 @@
         </svg>
 
         <img ng-src="<[getStaticImageUrl('/general/collection_mascot.svg')]>" class="collection-mascot">
-        <a ng-repeat="node in collection.getCollectionNodes()" href="<[getExplorationUrl(node.getExplorationId())]>"
+        <a ng-repeat="node in collection.getCollectionNodes()"
+           ng-href="<[getExplorationUrl(node.getExplorationId())]>"
            ng-style="{position: 'absolute', left: '<[pathIconParameters[$index].left]>', top: '<[pathIconParameters[$index].top]>'}">
           <svg class="protractor-test-collection-exploration"
                width="100"
@@ -221,7 +222,7 @@
       <div ng-if="collection" class="oppia-collection-table hidden-md hidden-lg hidden-xl">
         <img ng-src="<[getStaticImageUrl('/general/collection_mascot.svg')]>" class="mobile-lesson-icon">
         <div class="mobile-path-segment" ng-repeat="node in collection.getCollectionNodes()" id="mobile-path-anchor-<[$index]>">
-          <a href="<[getExplorationUrl(node.getExplorationId())]>" style="position: absolute; left: 50%; transform: translate(-50%, 195px);">
+          <a href="" style="position: absolute; left: 50%; transform: translate(-50%, 195px); z-index: 1;">
             <svg class="protractor-test-collection-exploration"
                  width="100"
                  height="150"

--- a/core/templates/dev/head/pages/collection_player/collection_player.html
+++ b/core/templates/dev/head/pages/collection_player/collection_player.html
@@ -147,14 +147,14 @@
         </svg>
 
         <img ng-src="<[getStaticImageUrl('/general/collection_mascot.svg')]>" class="collection-mascot">
-        <a ng-repeat="node in collection.getCollectionNodes()" href="<[getExplorationUrl(node.getExplorationId())]>">
+        <a ng-repeat="node in collection.getCollectionNodes()" href="<[getExplorationUrl(node.getExplorationId())]>"
+           ng-style="{position: 'absolute', left: '<[pathIconParameters[$index].left]>', top: '<[pathIconParameters[$index].top]>'}">
           <svg class="protractor-test-collection-exploration"
                width="100"
                height="125"
                xmlns="http://www.w3.org/2000/svg"
                xmlns:xlink="http://www.w3.org/1999/xlink"
                version="1.1"
-               ng-attr-style="position: absolute; left: <[pathIconParameters[$index].left]>; top: <[pathIconParameters[$index].top]>;"
                class="protractor-test-collection-node">
             <defs>
               <pattern id="image<[$index]>" patternUnits="userSpaceOnUse" height="150" width="100">
@@ -221,14 +221,13 @@
       <div ng-if="collection" class="oppia-collection-table hidden-md hidden-lg hidden-xl">
         <img ng-src="<[getStaticImageUrl('/general/collection_mascot.svg')]>" class="mobile-lesson-icon">
         <div class="mobile-path-segment" ng-repeat="node in collection.getCollectionNodes()" id="mobile-path-anchor-<[$index]>">
-          <a href="<[getExplorationUrl(node.getExplorationId())]>">
+          <a href="<[getExplorationUrl(node.getExplorationId())]>" style="position: absolute; left: 50%; transform: translate(-50%, 195px);">
             <svg class="protractor-test-collection-exploration"
                  width="100"
                  height="150"
                  xmlns="http://www.w3.org/2000/svg"
                  xmlns:xlink="http://www.w3.org/1999/xlink"
                  version="1.1"
-                 ng-attr-style="position: absolute; left: 50%; transform: translate(-50%, 195px);"
                  ng-click="scrollToLocation('mobile-path-anchor-' + $index); updateExplorationPreview(node.getExplorationId());">
               <image ng-if="!collectionPlaythrough.hasStartedCollection() && $index===0"
                      x="0"

--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -11,7 +11,7 @@
         <div class="protractor-test-conversation-content"
              angular-html-bind="activeCard.contentHtml">
         </div>
-        <div ng-if="isContentAudioTranslationAvailable()" 
+        <div ng-if="isContentAudioTranslationAvailable()"
              class="conversation-skin-audio-controls">
           <audio-controls audio-translations="contentAudioTranslations">
           </audio-controls>
@@ -177,10 +177,9 @@
     padding: 0 20px;
   }
 
-  .conversation-skin-tutor-card-top-content > p {
+  .conversation-skin-tutor-card-top-content p:not(:last-child) {
     line-height: 28px;
     margin-bottom: 18px;
-    margin-top: 18px;
   }
 
   .conversation-skin-tutor-card-top-content {


### PR DESCRIPTION
PR #3681 added audio translations to the learner view. In order to do this, it created a new div between the existing "top-content" div to hold the content, and another child div to hold the audio translation button. However, this caused the inter-paragraph spacing CSS rule in the content to no longer apply because the CSS had an "immediate descendant" selector.

This PR attempts to fix that.