### PR TITLE
Show feedback thread in the learner dashboard only opened by the learner.

### DIFF
--- a/core/domain/feedback_services.py
+++ b/core/domain/feedback_services.py
@@ -510,66 +510,67 @@ def get_thread_summaries(user_id, full_thread_ids):
     thread_summaries = []
     number_of_unread_threads = 0
     for index, thread in enumerate(threads):
-        feedback_thread_user_model_exists = (
-            feedback_thread_user_models[index] is not None)
-        if feedback_thread_user_model_exists:
-            last_message_read = (
-                last_two_messages[index][0].message_id
-                in feedback_thread_user_models[index].message_ids_read_by_user)
-        else:
-            last_message_read = False
-
-        if last_two_messages[index][0].author_id is None:
-            author_last_message = None
-        else:
-            author_last_message = user_services.get_username(
-                last_two_messages[index][0].author_id)
-
-        second_last_message_read = None
-        author_second_last_message = None
-
-        does_second_message_exist = (last_two_messages[index][1] is not None)
-        if does_second_message_exist:
+        if thread.original_author_id == user_id:
+            feedback_thread_user_model_exists = (
+                feedback_thread_user_models[index] is not None)
             if feedback_thread_user_model_exists:
-                second_last_message_read = (
-                    last_two_messages[index][1].message_id
-                    in feedback_thread_user_models[index].message_ids_read_by_user) # pylint: disable=line-too-long
+                last_message_read = (
+                    last_two_messages[index][0].message_id
+                    in feedback_thread_user_models[index].message_ids_read_by_user)
             else:
-                second_last_message_read = False
+                last_message_read = False
 
-            if last_two_messages[index][1].author_id is None:
-                author_second_last_message = None
+            if last_two_messages[index][0].author_id is None:
+                author_last_message = None
             else:
-                author_second_last_message = user_services.get_username(
-                    last_two_messages[index][1].author_id)
-        if not last_message_read:
-            number_of_unread_threads += 1
+                author_last_message = user_services.get_username(
+                    last_two_messages[index][0].author_id)
 
-        if thread.message_count:
-            total_message_count = thread.message_count
-        # TODO(Arunabh): Remove else clause after each thread has a message
-        # count.
-        else:
-            total_message_count = (
-                feedback_models.FeedbackMessageModel.get_message_count(
-                    thread.exploration_id, thread.get_thread_id()))
+            second_last_message_read = None
+            author_second_last_message = None
 
-        thread_summary = {
-            'status': thread.status,
-            'original_author_id': thread.original_author_id,
-            'last_updated': utils.get_time_in_millisecs(thread.last_updated),
-            'last_message_text': last_two_messages[index][0].text,
-            'total_message_count': total_message_count,
-            'last_message_read': last_message_read,
-            'second_last_message_read': second_last_message_read,
-            'author_last_message': author_last_message,
-            'author_second_last_message': author_second_last_message,
-            'exploration_title': explorations[index].title,
-            'exploration_id': exploration_ids[index],
-            'thread_id': thread_ids[index]
-        }
+            does_second_message_exist = (last_two_messages[index][1] is not None)
+            if does_second_message_exist:
+                if feedback_thread_user_model_exists:
+                    second_last_message_read = (
+                        last_two_messages[index][1].message_id
+                        in feedback_thread_user_models[index].message_ids_read_by_user) # pylint: disable=line-too-long
+                else:
+                    second_last_message_read = False
 
-        thread_summaries.append(thread_summary)
+                if last_two_messages[index][1].author_id is None:
+                    author_second_last_message = None
+                else:
+                    author_second_last_message = user_services.get_username(
+                        last_two_messages[index][1].author_id)
+            if not last_message_read:
+                number_of_unread_threads += 1
+
+            if thread.message_count:
+                total_message_count = thread.message_count
+            # TODO(Arunabh): Remove else clause after each thread has a message
+            # count.
+            else:
+                total_message_count = (
+                    feedback_models.FeedbackMessageModel.get_message_count(
+                        thread.exploration_id, thread.get_thread_id()))
+
+            thread_summary = {
+                'status': thread.status,
+                'original_author_id': thread.original_author_id,
+                'last_updated': utils.get_time_in_millisecs(thread.last_updated),
+                'last_message_text': last_two_messages[index][0].text,
+                'total_message_count': total_message_count,
+                'last_message_read': last_message_read,
+                'second_last_message_read': second_last_message_read,
+                'author_last_message': author_last_message,
+                'author_second_last_message': author_second_last_message,
+                'exploration_title': explorations[index].title,
+                'exploration_id': exploration_ids[index],
+                'thread_id': thread_ids[index]
+            }
+
+            thread_summaries.append(thread_summary)
 
     return thread_summaries, number_of_unread_threads
 

--- a/core/domain/feedback_services.py
+++ b/core/domain/feedback_services.py
@@ -515,8 +515,8 @@ def get_thread_summaries(user_id, full_thread_ids):
                 feedback_thread_user_models[index] is not None)
             if feedback_thread_user_model_exists:
                 last_message_read = (
-                    last_two_messages[index][0].message_id
-                    in feedback_thread_user_models[index].message_ids_read_by_user)
+                    last_two_messages[index][0].message_id in
+                    feedback_thread_user_models[index].message_ids_read_by_user)
             else:
                 last_message_read = False
 
@@ -529,7 +529,8 @@ def get_thread_summaries(user_id, full_thread_ids):
             second_last_message_read = None
             author_second_last_message = None
 
-            does_second_message_exist = (last_two_messages[index][1] is not None)
+            does_second_message_exist = (
+                last_two_messages[index][1] is not None)
             if does_second_message_exist:
                 if feedback_thread_user_model_exists:
                     second_last_message_read = (
@@ -558,7 +559,8 @@ def get_thread_summaries(user_id, full_thread_ids):
             thread_summary = {
                 'status': thread.status,
                 'original_author_id': thread.original_author_id,
-                'last_updated': utils.get_time_in_millisecs(thread.last_updated),
+                'last_updated': (
+                    utils.get_time_in_millisecs(thread.last_updated)),
                 'last_message_text': last_two_messages[index][0].text,
                 'total_message_count': total_message_count,
                 'last_message_read': last_message_read,

--- a/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
+++ b/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
@@ -268,10 +268,10 @@ oppia.controller('LearnerDashboard', [
             $scope.threadSummaries[index].threadId === threadId) {
           threadIndex = index;
           var threadSummary = $scope.threadSummaries[index];
-          threadSummary.markTheLastTwoMessagesAsRead();
           if (!threadSummary.lastMessageRead) {
             $scope.numberOfUnreadThreads -= 1;
           }
+          threadSummary.markTheLastTwoMessagesAsRead();
         }
       }
 


### PR DESCRIPTION
As mentioned in the list of bugs, I have now displayed only the threads opened by the learners themselves thus avoiding the confusion for users that are learners and creators.

Also, I've fixed another bug regarding, updating of the number of unread threads.