### PR TITLE
Add user default dashboards job to job registry

### DIFF
--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -48,6 +48,7 @@ ONE_OFF_JOB_MANAGERS = [
     user_jobs_one_off.DashboardSubscriptionsOneOffJob,
     user_jobs_one_off.LongUserBiosOneOffJob,
     user_jobs_one_off.UserContributionsOneOffJob,
+    user_jobs_one_off.UserDefaultDashboardOneOffJob,
     user_jobs_one_off.UserFirstContributionMsecOneOffJob,
     user_jobs_one_off.UserLastExplorationActivityOneOffJob,
     user_jobs_one_off.UserProfilePictureOneOffJob,


### PR DESCRIPTION
This is so the job is shown on the admin page.