### PR TITLE
Remove extraneous period

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/feedback_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/feedback_tab.html
@@ -133,7 +133,7 @@
             <span>Please specify a reason for setting the status to <[getHumanReadableStatus(tmpMessage.status)]>.</span>
           </div>
 
-.          <div>
+          <div>
             <button class="btn btn-success protractor-test-oppia-feedback-response-send-btn" style="margin-top: 10px;"
                     ng-click="addNewMessage(activeThread.thread_id, tmpMessage.text, tmpMessage.status)"
                     ng-disabled="messageSendingInProgress || (!tmpMessage.text && activeThread.status === tmpMessage.status) || (!tmpMessage.text && (tmpMessage.status === 'ignored' || tmpMessage.status === 'not_actionable'))">


### PR DESCRIPTION
There was an extraneous period here for some reason.