### PR TITLE
Fix #3789 :Space out the profile drop down icons (#3789).

### DIFF
--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -66,11 +66,12 @@
          aria-haspopup="true"
          aria-expanded="false"
          aria-label="User Menu"
-         tabindex="0">
+         tabindex="0"
+         style="padding:10px 5px;">
         <div class="oppia-navbar-profile-picture-container">
           <span ng-if="profilePictureDataUrl">
             <img ng-src="<[profilePictureDataUrl]>" class="oppia-navbar-profile-picture img-circle" alt="User Avatar">
-            <span class="caret" style="margin-top: 10px;"></span>
+            <span class="caret" style="margin: 4px;margin-left: 10px;"></span>
           </span>
           <span ng-if="!profilePictureDataUrl">
             <i class="material-icons md-40" style="margin-top: -1px;">&#xE853;</i>


### PR DESCRIPTION
 The Screenshot of the page after changes:
Mobile View:
![screen shot 2017-08-26 at 6 55 28 pm](https://user-images.githubusercontent.com/19726282/29741806-2a60fd72-8a91-11e7-8a44-dcf7dc5e2c20.png)

Web -View:
![screen shot 2017-08-26 at 6 56 20 pm](https://user-images.githubusercontent.com/19726282/29741810-503f6e0c-8a91-11e7-8569-78fcd379bc3f.png)

