### PR TITLE
Fix 'Empty path passed in method' error on the collection page.

### DIFF
--- a/core/templates/dev/head/pages/collection_player/collection_player.html
+++ b/core/templates/dev/head/pages/collection_player/collection_player.html
@@ -322,7 +322,7 @@
 
       </div>
 
-      <div ng-if="collection" class="oppia-card-preview-panel hidden-sm hidden-xs">
+      <div ng-if="collection && collectionSummary" class="oppia-card-preview-panel hidden-sm hidden-xs">
         <md-card class="oppia-activity-summary-tile md-default-theme">
           <div class="title-section" style="background-color: <[collectionSummary.thumbnail_bg_color]>; z-index: 1;">
             <img ng-src="<[getStaticImageUrl(collectionSummary.thumbnail_icon_url)]>" class="thumbnail-image">


### PR DESCRIPTION
Found it! It was due to a race condition between the retrieval of the collection and collectionSummary objects. I'm pretty confident this fixes the issue, because I introduced an artificial delay in the loading of the collectionSummary object from the backend and got the five warnings as expected.