### PR TITLE
Fix #3828: Show warning only on button click and not on form submit

### DIFF
--- a/core/templates/dev/head/pages/signup/signup.html
+++ b/core/templates/dev/head/pages/signup/signup.html
@@ -28,7 +28,7 @@
     <md-card class="oppia-page-card">
       <h2 class="oppia-signup-page-title" translate="I18N_SIGNUP_COMPLETE_REGISTRATION"></h2>
 
-      <form ng-submit="submitPrerequisitesForm(hasAgreedToLatestTerms, username, canReceiveEmailUpdates)">
+      <form>
         <div ng-show="!hasUsername" role="form" class="form-horizontal">
           <div class="form-group">
             <label for="username" class="col-lg-3 col-md-3 col-sm-3" translate="I18N_SIGNUP_USERNAME"></label>
@@ -100,6 +100,7 @@
 
         <button type="submit" class="btn btn-success protractor-test-register-user"
                 ng-disabled="warningI18nCode || !hasAgreedToLatestTerms || submissionInProcess"
+                ng-click="submitPrerequisitesForm(hasAgreedToLatestTerms, username, canReceiveEmailUpdates)"
                 translate="I18N_SIGNUP_BUTTON_SUBMIT">
         </button>
       </form>


### PR DESCRIPTION
#3828 

This PR fixes the Safari issue where the warning was showing up when the button was ng-disabled.