### PR TITLE
Fix #3842: Update the max RAND limit for ID generation to fit within 32 bits.

### DIFF
--- a/core/storage/base_model/gae_models.py
+++ b/core/storage/base_model/gae_models.py
@@ -29,7 +29,7 @@ _VERSION_DELIMITER = '-'
 
 # Constants used for generating ids.
 MAX_RETRIES = 10
-RAND_RANGE = (1 << 60) - 1
+RAND_RANGE = (1 << 30) - 1
 ID_LENGTH = 12
 
 


### PR DESCRIPTION
See #3842 for context.

@seanlip FYI