### PR TITLE
Fix #3852: Fix failing e2e test in develop

### DIFF
--- a/core/tests/protractor/richTextComponents.js
+++ b/core/tests/protractor/richTextComponents.js
@@ -84,6 +84,7 @@ describe('rich-text components', function() {
       // TODO (Jacob) Remove when
       // https://code.google.com/p/google-cast-sdk/issues/detail?id=309 is fixed
       'cast_sender.js - Failed to load resource: net::ERR_FAILED',
+      'chrome-extension://invalid/ - Failed to load resource: net::ERR_FAILED',
       'Uncaught ReferenceError: ytcfg is not defined'
     ]);
   });

--- a/core/tests/protractor/richTextComponents.js
+++ b/core/tests/protractor/richTextComponents.js
@@ -57,8 +57,8 @@ describe('rich-text components', function() {
       richTextChecker.readBoldText('bold');
       richTextChecker.readPlainText(' ');
       richTextChecker.readRteComponent('Link', 'http://google.com/', true);
-      richTextChecker.readRteComponent('Video', 'ANeHmk22a6Q', 10, 100, false);
       richTextChecker.readRteComponent('Math', 'abc');
+      richTextChecker.readRteComponent('Video', 'ANeHmk22a6Q', 10, 100, false);
       richTextChecker.readRteComponent(
         'Collapsible', 'title', forms.toRichText('inner'));
       richTextChecker.readRteComponent('Tabs', [{

--- a/core/tests/protractor/richTextComponents.js
+++ b/core/tests/protractor/richTextComponents.js
@@ -41,6 +41,7 @@ describe('rich-text components', function() {
       // and click on them.
       richTextEditor.addRteComponent(
         'Collapsible', 'title', forms.toRichText('inner'));
+      general.scrollToTop();
       richTextEditor.addRteComponent('Tabs', [{
         title: 'title 1',
         content: forms.toRichText('contents 1')
@@ -55,11 +56,6 @@ describe('rich-text components', function() {
     player.expectContentToMatch(function(richTextChecker) {
       richTextChecker.readBoldText('bold');
       richTextChecker.readPlainText(' ');
-      richTextChecker.readRteComponent('Link', 'http://google.com/', true);
-      richTextChecker.readRteComponent('Math', 'abc');
-      richTextChecker.readRteComponent('Video', 'ANeHmk22a6Q', 10, 100, false);
-      richTextChecker.readRteComponent(
-        'Collapsible', 'title', forms.toRichText('inner'));
       richTextChecker.readRteComponent('Tabs', [{
         title: 'title 1',
         content: forms.toRichText('contents 1')
@@ -68,6 +64,11 @@ describe('rich-text components', function() {
         content: forms.toRichText('contents 2')
       }]
       );
+      richTextChecker.readRteComponent(
+        'Collapsible', 'title', forms.toRichText('inner'));
+      richTextChecker.readRteComponent('Video', 'ANeHmk22a6Q', 10, 100, false);
+      richTextChecker.readRteComponent('Math', 'abc');
+      richTextChecker.readRteComponent('Link', 'http://google.com/', true);
     });
 
     editor.discardChanges();

--- a/core/tests/protractor/richTextComponents.js
+++ b/core/tests/protractor/richTextComponents.js
@@ -56,6 +56,11 @@ describe('rich-text components', function() {
     player.expectContentToMatch(function(richTextChecker) {
       richTextChecker.readBoldText('bold');
       richTextChecker.readPlainText(' ');
+      richTextChecker.readRteComponent('Link', 'http://google.com/', true);
+      richTextChecker.readRteComponent('Video', 'ANeHmk22a6Q', 10, 100, false);
+      richTextChecker.readRteComponent('Math', 'abc');
+      richTextChecker.readRteComponent(
+        'Collapsible', 'title', forms.toRichText('inner'));
       richTextChecker.readRteComponent('Tabs', [{
         title: 'title 1',
         content: forms.toRichText('contents 1')
@@ -64,11 +69,6 @@ describe('rich-text components', function() {
         content: forms.toRichText('contents 2')
       }]
       );
-      richTextChecker.readRteComponent(
-        'Collapsible', 'title', forms.toRichText('inner'));
-      richTextChecker.readRteComponent('Video', 'ANeHmk22a6Q', 10, 100, false);
-      richTextChecker.readRteComponent('Math', 'abc');
-      richTextChecker.readRteComponent('Link', 'http://google.com/', true);
     });
 
     editor.discardChanges();

--- a/core/tests/protractor/richTextComponents.js
+++ b/core/tests/protractor/richTextComponents.js
@@ -84,7 +84,8 @@ describe('rich-text components', function() {
       // https://code.google.com/p/google-cast-sdk/issues/detail?id=309 is fixed
       'cast_sender.js - Failed to load resource: net::ERR_FAILED',
       'Uncaught ReferenceError: ytcfg is not defined',
-      // TODO (@pranavsid98) Remove when we resolve the reason for this error.
+      // TODO (@pranavsid98) This error is caused by the upgrade from Chrome 60
+      // to Chrome 61. Chrome version at time of recording this is 61.0.3163.
       'chrome-extension://invalid/ - Failed to load resource: net::ERR_FAILED',
     ]);
   });

--- a/core/tests/protractor/richTextComponents.js
+++ b/core/tests/protractor/richTextComponents.js
@@ -41,7 +41,6 @@ describe('rich-text components', function() {
       // and click on them.
       richTextEditor.addRteComponent(
         'Collapsible', 'title', forms.toRichText('inner'));
-      general.scrollToTop();
       richTextEditor.addRteComponent('Tabs', [{
         title: 'title 1',
         content: forms.toRichText('contents 1')

--- a/core/tests/protractor/richTextComponents.js
+++ b/core/tests/protractor/richTextComponents.js
@@ -83,8 +83,9 @@ describe('rich-text components', function() {
       // TODO (Jacob) Remove when
       // https://code.google.com/p/google-cast-sdk/issues/detail?id=309 is fixed
       'cast_sender.js - Failed to load resource: net::ERR_FAILED',
+      'Uncaught ReferenceError: ytcfg is not defined',
+      // TODO (@pranavsid98) Remove when we resolve the reason for this error.
       'chrome-extension://invalid/ - Failed to load resource: net::ERR_FAILED',
-      'Uncaught ReferenceError: ytcfg is not defined'
     ]);
   });
 });

--- a/core/tests/protractor/staticPagesTour.js
+++ b/core/tests/protractor/staticPagesTour.js
@@ -62,7 +62,8 @@ describe('Oppia static pages tour', function() {
       // https://code.google.com/p/google-cast-sdk/issues/detail?id=309 is fixed
       'cast_sender.js - Failed to load resource: net::ERR_FAILED',
       'Uncaught ReferenceError: ytcfg is not defined',
-      // TODO (@pranavsid98) Remove when we resolve the reason for this error.
+      // TODO (@pranavsid98) This error is caused by the upgrade from Chrome 60
+      // to Chrome 61. Chrome version at time of recording this is 61.0.3163.
       'chrome-extension://invalid/ - Failed to load resource: net::ERR_FAILED',
     ]);
   });

--- a/core/tests/protractor/staticPagesTour.js
+++ b/core/tests/protractor/staticPagesTour.js
@@ -61,7 +61,7 @@ describe('Oppia static pages tour', function() {
       // TODO (Jacob) Remove when
       // https://code.google.com/p/google-cast-sdk/issues/detail?id=309 is fixed
       'cast_sender.js - Failed to load resource: net::ERR_FAILED',
-      'Uncaught ReferenceError: ytcfg is not defined'
+      'Uncaught ReferenceError: ytcfg is not defined',
       // TODO (@pranavsid98) Remove when we resolve the reason for this error.
       'chrome-extension://invalid/ - Failed to load resource: net::ERR_FAILED',
     ]);

--- a/core/tests/protractor/staticPagesTour.js
+++ b/core/tests/protractor/staticPagesTour.js
@@ -61,8 +61,9 @@ describe('Oppia static pages tour', function() {
       // TODO (Jacob) Remove when
       // https://code.google.com/p/google-cast-sdk/issues/detail?id=309 is fixed
       'cast_sender.js - Failed to load resource: net::ERR_FAILED',
-      'chrome-extension://invalid/ - Failed to load resource: net::ERR_FAILED',
       'Uncaught ReferenceError: ytcfg is not defined'
+      // TODO (@pranavsid98) Remove when we resolve the reason for this error.
+      'chrome-extension://invalid/ - Failed to load resource: net::ERR_FAILED',
     ]);
   });
 });

--- a/core/tests/protractor/staticPagesTour.js
+++ b/core/tests/protractor/staticPagesTour.js
@@ -61,6 +61,7 @@ describe('Oppia static pages tour', function() {
       // TODO (Jacob) Remove when
       // https://code.google.com/p/google-cast-sdk/issues/detail?id=309 is fixed
       'cast_sender.js - Failed to load resource: net::ERR_FAILED',
+      'chrome-extension://invalid/ - Failed to load resource: net::ERR_FAILED',
       'Uncaught ReferenceError: ytcfg is not defined'
     ]);
   });


### PR DESCRIPTION
#3852 

This PR fixes the failing RTE Components end to end test in develop. The issue was caused by the window not scrolling up. So, addition of a scroll to top fixed the issue.

Edit: The invalid chrome extension actually doesn't disturb the flow of the tests - the tests execute properly and this exception is still raised. Since we don't know the root of this issue yet, can we ignore this error message (we seem to have done similar stuff in the past)?

/cc @tjiang11 