### PR TITLE
Fix #3800 Dropdown menu of the ABOUT in navigation bar

### DIFF
--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -73,8 +73,8 @@ oppia.directive('topNavigationBar', [
             angular.element(evt.currentTarget).parent().removeClass('open');
             $scope.profileDropdownIsActive = false;
           };
-          $scope.OnMouseoutDropdownMenuAbout = function(evt) {
-              angular.element(evt.currentTarget)[0].blur();
+          $scope.onMouseoutDropdownMenuAbout = function(evt) {
+            angular.element(evt.currentTarget)[0].blur();
           }
           $scope.onMouseoverDropdownMenu = function(evt) {
             angular.element(evt.currentTarget).parent().addClass('open');

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -73,7 +73,9 @@ oppia.directive('topNavigationBar', [
             angular.element(evt.currentTarget).parent().removeClass('open');
             $scope.profileDropdownIsActive = false;
           };
-
+          $scope.OnMouseoutDropdownMenuAbout = function(evt) {
+              angular.element(evt.currentTarget)[0].blur();
+          }
           $scope.onMouseoverDropdownMenu = function(evt) {
             angular.element(evt.currentTarget).parent().addClass('open');
           };

--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -30,7 +30,7 @@
            role="menuitem"
            aria-haspopup="true"
            aria-expanded="false"
-           tabindex="0">
+           tabindex="0" ng-mouseleave="OnMouseoutDropdownMenuAbout($event)">
           <span class="oppia-navbar-tab-content" translate="I18N_TOPNAV_ABOUT"></span>
           <span class="caret"></span>
         </a>

--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -30,7 +30,8 @@
            role="menuitem"
            aria-haspopup="true"
            aria-expanded="false"
-           tabindex="0" ng-mouseleave="OnMouseoutDropdownMenuAbout($event)">
+           tabindex="0"
+           ng-mouseleave="onMouseoutDropdownMenuAbout($event)">
           <span class="oppia-navbar-tab-content" translate="I18N_TOPNAV_ABOUT"></span>
           <span class="caret"></span>
         </a>


### PR DESCRIPTION
Pull Request For Issue #3800  . Regarding Dropdown menu of the ABOUT in navigation bar, after we click the ABOUT dropdown-menu, and hover out of the ABOUT dropdown-menu background-color didn't change to its original color.So I have fixed this issue by defining a Function onMouseoutDropMenuAbout which will blur the dropdown-menu on mouseleave it.