### PR TITLE
Fixed On mobile, buttons with long text go offcard

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -103,7 +103,7 @@
         <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
       </div>
       <div ng-if="isViewportNarrow()">
-        <md-button class="instructions-button" style="white-space:normal" ng-click="onDismiss()">
+        <md-button class="instructions-button"  ng-click="onDismiss()">
           <[interactionInstructions]>
         </md-button>
       </div>
@@ -140,6 +140,7 @@
   .conversation-skin-tutor-card .instructions-button {
     background: inherit;
     border: none;
+    white-space:normal;
   }
 
   .conversation-skin-tutor-card .hint-button {
@@ -266,6 +267,7 @@
       background-color: #0D48A1;
       color: #ffffff;
       padding: 6px 12px;
+      white-space:normal;
     }
 
     .conversation-skin-tutor-card .hint-button {

--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -103,7 +103,7 @@
         <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
       </div>
       <div ng-if="isViewportNarrow()">
-        <md-button class="instructions-button" ng-click="onDismiss()">
+        <md-button class="instructions-button" style="white-space:normal" ng-click="onDismiss()">
           <[interactionInstructions]>
         </md-button>
       </div>

--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -103,7 +103,7 @@
         <i class="material-icons md-18" style="position: relative; top: 3px;">&#xE5C8;</i>
       </div>
       <div ng-if="isViewportNarrow()">
-        <md-button class="instructions-button"  ng-click="onDismiss()">
+        <md-button class="instructions-button" ng-click="onDismiss()">
           <[interactionInstructions]>
         </md-button>
       </div>
@@ -140,7 +140,7 @@
   .conversation-skin-tutor-card .instructions-button {
     background: inherit;
     border: none;
-    white-space:normal;
+    white-space: normal;
   }
 
   .conversation-skin-tutor-card .hint-button {
@@ -267,7 +267,7 @@
       background-color: #0D48A1;
       color: #ffffff;
       padding: 6px 12px;
-      white-space:normal;
+      white-space: normal;
     }
 
     .conversation-skin-tutor-card .hint-button {


### PR DESCRIPTION
fixed https://github.com/oppia/oppia/issues/3812
On mobile and PC, buttons with long text , the size of the button gets auto adjusted according to the size of the window .
Signed-off-by: Aashishgaba097 <aashishgaba097@gmail.com>

  @tjiang11 please review it
