### PR TITLE
Fixed On mobile, the info icon(centered vertically

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
@@ -168,7 +168,7 @@
       display: none;
     }
     .oppia-exploration-footer .oppia-navbar-footer-info-icon {
-      margin-top: -11px;
+      margin-top: -1px;
     }
     .oppia-exploration-footer .oppia-navbar-footer-info-icon:hover {
       margin-top: -11px;

--- a/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_footer_directive.html
@@ -168,10 +168,10 @@
       display: none;
     }
     .oppia-exploration-footer .oppia-navbar-footer-info-icon {
-      margin-top: -1px;
+      margin-top: -3px;
     }
     .oppia-exploration-footer .oppia-navbar-footer-info-icon:hover {
-      margin-top: -11px;
+      margin-top: -3px;
     }
   }
 


### PR DESCRIPTION
Fix https://github.com/oppia/oppia/issues/3807
On mobile and on PC(when size of window is minimized), the info icon in the footer is centered vertically .
Signed-off-by: Aashishgaba097 <aashishgaba097@gmail.com>

@tjiang11 Please review it .