### PR TITLE
Fix #3821 : Add timestamps to individual messages on the learner Dashboard

### DIFF
--- a/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
+++ b/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
@@ -69,7 +69,7 @@ oppia.constant('FEEDBACK_THREADS_SORT_BY_KEYS_AND_I18N_IDS', {
 oppia.controller('LearnerDashboard', [
   '$scope', '$rootScope', '$window', '$http', '$modal', 'alertsService',
   'EXPLORATIONS_SORT_BY_KEYS_AND_I18N_IDS',
-  'SUBSCRIPTION_SORT_BY_KEYS_AND_I18N_IDS', 'FATAL_ERROR_CODES', 
+  'SUBSCRIPTION_SORT_BY_KEYS_AND_I18N_IDS', 'FATAL_ERROR_CODES',
   'LearnerDashboardBackendApiService', 'UrlInterpolationService',
   'LEARNER_DASHBOARD_SECTION_I18N_IDS',
   'LEARNER_DASHBOARD_SUBSECTION_I18N_IDS', 'threadStatusDisplayService',

--- a/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
+++ b/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
@@ -663,7 +663,7 @@
               <tr ng-repeat="message in messageSummaries" style="padding: 13px 8px 7px 8px;">
                 <td>
                   <div class="row">
-                    <div class="col-sm-12">
+                    <div class="col-sm-9">
                       <span class="feedback-message-header">
                         <span ng-if="message.authorPictureDataUrl" style="display: inline-block;">
                           <img ng-src="<[message.authorPictureDataUrl]>"
@@ -685,7 +685,11 @@
                             translate-values="{threadStatus: getHumanReadableStatus(message.updatedStatus)}"></em>
                       </span>
                     </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3">
+                      <span><[getLocaleAbbreviatedDatetimeString(message.createdOn)]></span>
+                    </div>
                   </div>
+
                   <div class="row">
                     <div class="col-sm-2 feedback-message-spacing" style="width: 8%;"></div>
                     <div class="col-sm-10 feedback-thread-message-body">


### PR DESCRIPTION
Fix issue#3821 PR#3873 Show individual messages timestamps also in the learner dashboard feedback updates.
