### PR TITLE
Rename existing Angular services Group-5  #3825

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -79,13 +79,13 @@ oppia.constant(
 oppia.config(['$provide', function($provide) {
   $provide.decorator('taOptions', [
     '$delegate', '$document', '$modal', '$timeout', 'focusService',
-    'taRegisterTool', 'rteHelperService', 'alertsService',
-    'explorationContextService', 'PAGE_CONTEXT',
+    'taRegisterTool', 'rteHelperService', 'AlertsService',
+    'ExplorationContextService', 'PAGE_CONTEXT',
     'UrlInterpolationService',
     function(
       taOptions, $document, $modal, $timeout, focusService,
-      taRegisterTool, rteHelperService, alertsService,
-      explorationContextService, PAGE_CONTEXT,
+      taRegisterTool, rteHelperService, AlertsService,
+      ExplorationContextService, PAGE_CONTEXT,
       UrlInterpolationService) {
       taOptions.disableSanitizer = true;
       taOptions.forceTextAngularSanitize = false;
@@ -165,7 +165,7 @@ oppia.config(['$provide', function($provide) {
 
       rteHelperService.getRichTextComponents().forEach(function(componentDefn) {
         var buttonDisplay = rteHelperService.createToolbarIcon(componentDefn);
-        var canUseFs = explorationContextService.getPageContext() ===
+        var canUseFs = ExplorationContextService.getPageContext() ===
           PAGE_CONTEXT.EDITOR;
 
         taRegisterTool(componentDefn.name, {
@@ -187,7 +187,7 @@ oppia.config(['$provide', function($provide) {
               if (!canUseFs && componentDefn.requiresFs) {
                 var FS_UNAUTHORIZED_WARNING = 'Unfortunately, only ' +
                   'exploration authors can make changes involving files.';
-                alertsService.addWarning(FS_UNAUTHORIZED_WARNING);
+                AlertsService.addWarning(FS_UNAUTHORIZED_WARNING);
                 // Without this, the view will not update to show the warning.
                 textAngular.$editor().$parent.$apply();
                 return;
@@ -304,7 +304,7 @@ oppia.config([
     // Add an interceptor to convert requests to strings and to log and show
     // warnings for error responses.
     $httpProvider.interceptors.push([
-      '$q', '$log', 'alertsService', function($q, $log, alertsService) {
+      '$q', '$log', 'AlertsService', function($q, $log, AlertsService) {
         return {
           request: function(config) {
             if (config.data) {
@@ -329,7 +329,7 @@ oppia.config([
               if (rejection.data && rejection.data.error) {
                 warningMessage = rejection.data.error;
               }
-              alertsService.addWarning(warningMessage);
+              AlertsService.addWarning(warningMessage);
             }
             return $q.reject(rejection);
           }
@@ -511,9 +511,9 @@ oppia.factory('IdGenerationService', [function() {
 }]);
 
 oppia.factory('rteHelperService', [
-  '$filter', '$log', '$interpolate', 'explorationContextService',
+  '$filter', '$log', '$interpolate', 'ExplorationContextService',
   'RTE_COMPONENT_SPECS', 'oppiaHtmlEscaper',
-  function($filter, $log, $interpolate, explorationContextService,
+  function($filter, $log, $interpolate, ExplorationContextService,
            RTE_COMPONENT_SPECS, oppiaHtmlEscaper) {
     var _RICH_TEXT_COMPONENTS = [];
 
@@ -566,7 +566,7 @@ oppia.factory('rteHelperService', [
       // Returns a DOM node.
       createRteElement: function(componentDefn, customizationArgsDict) {
         var el = $('<img/>');
-        if (explorationContextService.isInExplorationContext()) {
+        if (ExplorationContextService.isInExplorationContext()) {
           // TODO(sll): This extra key was introduced in commit
           // 19a934ce20d592a3fc46bd97a2f05f41d33e3d66 in order to retrieve an
           // image for RTE previews. However, it has had the unfortunate side-
@@ -575,7 +575,7 @@ oppia.factory('rteHelperService', [
           // convertRteToHtml(), but we need to find a less invasive way to
           // handle previews.
           customizationArgsDict = angular.extend(customizationArgsDict, {
-            explorationId: explorationContextService.getExplorationId()
+            explorationId: ExplorationContextService.getExplorationId()
           });
         }
         var interpolatedUrl = $interpolate(

--- a/core/templates/dev/head/components/AnswerGroupEditorDirective.js
+++ b/core/templates/dev/head/components/AnswerGroupEditorDirective.js
@@ -35,11 +35,11 @@ oppia.directive('answerGroupEditor', [
         'answer_group_editor_directive.html'),
       controller: [
         '$scope', 'stateInteractionIdService', 'responsesService',
-        'editorContextService', 'alertsService', 'INTERACTION_SPECS',
+        'editorContextService', 'AlertsService', 'INTERACTION_SPECS',
         'RULE_TYPE_CLASSIFIER', 'RuleObjectFactory',
         function(
             $scope, stateInteractionIdService, responsesService,
-            editorContextService, alertsService, INTERACTION_SPECS,
+            editorContextService, AlertsService, INTERACTION_SPECS,
             RULE_TYPE_CLASSIFIER, RuleObjectFactory) {
           $scope.rulesMemento = null;
           $scope.activeRuleIndex = responsesService.getActiveRuleIndex();
@@ -203,7 +203,7 @@ oppia.directive('answerGroupEditor', [
             $scope.saveRules();
 
             if ($scope.rules.length === 0) {
-              alertsService.addWarning(
+              AlertsService.addWarning(
                 'All answer groups must have at least one rule.');
             }
           };

--- a/core/templates/dev/head/components/ClassifierRulePanelDirective.js
+++ b/core/templates/dev/head/components/ClassifierRulePanelDirective.js
@@ -28,17 +28,17 @@ oppia.directive('classifierRulePanel', [
         '/components/' +
         'classifier_panel_directive.html'),
       controller: [
-        '$scope', '$modal', 'oppiaExplorationHtmlFormatterService',
+        '$scope', '$modal', 'OppiaExplorationHtmlFormatterService',
         'stateInteractionIdService', 'stateCustomizationArgsService',
         'trainingModalService',
-        function($scope, $modal, oppiaExplorationHtmlFormatterService,
+        function($scope, $modal, OppiaExplorationHtmlFormatterService,
             stateInteractionIdService, stateCustomizationArgsService,
             trainingModalService) {
           $scope.trainingDataHtmlList = [];
           var trainingData = $scope.ruleInputs.training_data;
           for (var i = 0; i < trainingData.length; i++) {
             $scope.trainingDataHtmlList.push(
-              oppiaExplorationHtmlFormatterService.getShortAnswerHtml(
+              OppiaExplorationHtmlFormatterService.getShortAnswerHtml(
                 trainingData[i], stateInteractionIdService.savedMemento,
                 stateCustomizationArgsService.savedMemento));
           }

--- a/core/templates/dev/head/components/CollectionCreationService.js
+++ b/core/templates/dev/head/components/CollectionCreationService.js
@@ -21,10 +21,10 @@
 // ExplorationCreationService.
 
 oppia.factory('CollectionCreationService', [
-  '$http', '$window', '$rootScope', '$timeout', 'alertsService',
+  '$http', '$window', '$rootScope', '$timeout', 'AlertsService',
   'UrlInterpolationService', 'siteAnalyticsService',
   function(
-      $http, $window, $rootScope, $timeout, alertsService,
+      $http, $window, $rootScope, $timeout, AlertsService,
       UrlInterpolationService, siteAnalyticsService) {
     var CREATE_NEW_COLLECTION_URL_TEMPLATE = (
       '/collection_editor/create/<collection_id>');
@@ -37,7 +37,7 @@ oppia.factory('CollectionCreationService', [
         }
 
         collectionCreationInProgress = true;
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
 
         $rootScope.loadingMessage = 'Creating collection';
         $http.post('/collection_editor_handler/create_new', {})

--- a/core/templates/dev/head/components/ExplorationCreationService.js
+++ b/core/templates/dev/head/components/ExplorationCreationService.js
@@ -19,10 +19,10 @@
 
 oppia.factory('ExplorationCreationService', [
   '$http', '$modal', '$timeout', '$rootScope', '$window',
-  'alertsService', 'siteAnalyticsService', 'UrlInterpolationService',
+  'AlertsService', 'siteAnalyticsService', 'UrlInterpolationService',
   function(
       $http, $modal, $timeout, $rootScope, $window,
-      alertsService, siteAnalyticsService, UrlInterpolationService) {
+      AlertsService, siteAnalyticsService, UrlInterpolationService) {
     var CREATE_NEW_EXPLORATION_URL_TEMPLATE = '/create/<exploration_id>';
 
     var explorationCreationInProgress = false;
@@ -34,7 +34,7 @@ oppia.factory('ExplorationCreationService', [
         }
 
         explorationCreationInProgress = true;
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
         $rootScope.loadingMessage = 'Creating exploration';
 
         $http.post('/contributehandler/create_new', {
@@ -55,7 +55,7 @@ oppia.factory('ExplorationCreationService', [
         });
       },
       showUploadExplorationModal: function() {
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
 
         $modal.open({
           backdrop: true,
@@ -68,7 +68,7 @@ oppia.factory('ExplorationCreationService', [
                 var returnObj = {};
                 var file = document.getElementById('newFileInput').files[0];
                 if (!file || !file.size) {
-                  alertsService.addWarning('Empty file detected.');
+                  AlertsService.addWarning('Empty file detected.');
                   return;
                 }
                 returnObj.yamlFile = file;
@@ -78,7 +78,7 @@ oppia.factory('ExplorationCreationService', [
 
               $scope.cancel = function() {
                 $modalInstance.dismiss('cancel');
-                alertsService.clearWarnings();
+                AlertsService.clearWarnings();
               };
             }
           ]
@@ -112,7 +112,7 @@ oppia.factory('ExplorationCreationService', [
           }).fail(function(data) {
             var transformedData = data.responseText.substring(5);
             var parsedResponse = JSON.parse(transformedData);
-            alertsService.addWarning(
+            AlertsService.addWarning(
               parsedResponse.error || 'Error communicating with server.');
             $rootScope.loadingMessage = '';
             $scope.$apply();

--- a/core/templates/dev/head/components/SolutionEditorDirective.js
+++ b/core/templates/dev/head/components/SolutionEditorDirective.js
@@ -19,16 +19,16 @@
 oppia.directive('solutionEditor', [
   '$modal', 'UrlInterpolationService', 'stateSolutionService',
   'editorContextService', 'explorationStatesService',
-  'explorationWarningsService', 'alertsService',
+  'explorationWarningsService', 'AlertsService',
   'SolutionObjectFactory', 'SolutionVerificationService',
-  'explorationContextService', 'oppiaExplorationHtmlFormatterService',
+  'ExplorationContextService', 'OppiaExplorationHtmlFormatterService',
   'stateInteractionIdService', 'stateCustomizationArgsService',
   'INFO_MESSAGE_SOLUTION_IS_INVALID',
   function($modal, UrlInterpolationService, stateSolutionService,
            editorContextService, explorationStatesService,
-           explorationWarningsService, alertsService,
+           explorationWarningsService, AlertsService,
            SolutionObjectFactory, SolutionVerificationService,
-           explorationContextService, oppiaExplorationHtmlFormatterService,
+           ExplorationContextService, OppiaExplorationHtmlFormatterService,
            stateInteractionIdService, stateCustomizationArgsService,
            INFO_MESSAGE_SOLUTION_IS_INVALID) {
     return {
@@ -50,7 +50,7 @@ oppia.directive('solutionEditor', [
           };
 
           $scope.getAnswerHtml = function () {
-            return oppiaExplorationHtmlFormatterService.getAnswerHtml(
+            return OppiaExplorationHtmlFormatterService.getAnswerHtml(
               stateSolutionService.savedMemento.correctAnswer,
               stateInteractionIdService.savedMemento,
               stateCustomizationArgsService.savedMemento);
@@ -65,17 +65,17 @@ oppia.directive('solutionEditor', [
               controller: [
                 '$scope', '$modalInstance', 'stateInteractionIdService',
                 'stateSolutionService', 'editorContextService',
-                'oppiaExplorationHtmlFormatterService',
+                'OppiaExplorationHtmlFormatterService',
                 'explorationStatesService',
                 function($scope, $modalInstance, stateInteractionIdService,
                          stateSolutionService, editorContextService,
-                         oppiaExplorationHtmlFormatterService,
+                         OppiaExplorationHtmlFormatterService,
                          explorationStatesService) {
                   $scope.SOLUTION_EDITOR_FOCUS_LABEL = (
                     'currentCorrectAnswerEditorHtmlForSolutionEditor');
                   $scope.correctAnswer = null;
                   $scope.correctAnswerEditorHtml = (
-                    oppiaExplorationHtmlFormatterService.getInteractionHtml(
+                    OppiaExplorationHtmlFormatterService.getInteractionHtml(
                       stateInteractionIdService.savedMemento,
                       /* eslint-disable max-len */
                       explorationStatesService.getInteractionCustomizationArgsMemento(
@@ -113,7 +113,7 @@ oppia.directive('solutionEditor', [
 
                   $scope.cancel = function() {
                     $modalInstance.dismiss('cancel');
-                    alertsService.clearWarnings();
+                    AlertsService.clearWarnings();
                   };
                 }
               ]
@@ -122,7 +122,7 @@ oppia.directive('solutionEditor', [
               var currentStateName = editorContextService.getActiveStateName();
               var state = explorationStatesService.getState(currentStateName);
               SolutionVerificationService.verifySolution(
-                explorationContextService.getExplorationId(),
+                ExplorationContextService.getExplorationId(),
                 state,
                 correctAnswer,
                 function () {
@@ -134,7 +134,7 @@ oppia.directive('solutionEditor', [
                   explorationStatesService.updateSolutionValidity(
                     currentStateName, false);
                   explorationWarningsService.updateWarnings();
-                  alertsService.addInfoMessage(
+                  AlertsService.addInfoMessage(
                     INFO_MESSAGE_SOLUTION_IS_INVALID);
                 }
               );

--- a/core/templates/dev/head/components/VersionDiffVisualizationDirective.js
+++ b/core/templates/dev/head/components/VersionDiffVisualizationDirective.js
@@ -250,15 +250,15 @@ oppia.directive('versionDiffVisualization', [
             controller: [
               '$scope', '$http', '$modalInstance', '$timeout', 'newStateName',
               'oldStateName', 'newState', 'oldState', 'headers',
-              'explorationContextService', 'UrlInterpolationService',
+              'ExplorationContextService', 'UrlInterpolationService',
               function(
                   $scope, $http, $modalInstance, $timeout, newStateName,
                   oldStateName, newState, oldState, headers,
-                  explorationContextService, UrlInterpolationService) {
+                  ExplorationContextService, UrlInterpolationService) {
                 var STATE_YAML_URL = UrlInterpolationService.interpolateUrl(
                   '/createhandler/state_yaml/<exploration_id>', {
                     exploration_id: (
-                      explorationContextService.getExplorationId())
+                      ExplorationContextService.getExplorationId())
                   });
 
                 $scope.headers = headers;

--- a/core/templates/dev/head/components/alerts/AlertMessageDirective.js
+++ b/core/templates/dev/head/components/alerts/AlertMessageDirective.js
@@ -25,9 +25,9 @@ oppia.directive('alertMessage', [function() {
     },
     template: '<div class="oppia-alert-message"></div>',
     controller: [
-      '$scope', 'alertsService', 'toastr',
-      function($scope, alertsService, toastr) {
-        $scope.alertsService = alertsService;
+      '$scope', 'AlertsService', 'toastr',
+      function($scope, AlertsService, toastr) {
+        $scope.AlertsService = AlertsService;
         $scope.toastr = toastr;
       }
     ],
@@ -36,13 +36,13 @@ oppia.directive('alertMessage', [function() {
       if (message.type === 'info') {
         scope.toastr.info(message.content, {
           onHidden: function() {
-            scope.alertsService.deleteMessage(message);
+            scope.AlertsService.deleteMessage(message);
           }
         });
       } else if (message.type === 'success') {
         scope.toastr.success(message.content, {
           onHidden: function() {
-            scope.alertsService.deleteMessage(message);
+            scope.AlertsService.deleteMessage(message);
           }
         });
       }

--- a/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
+++ b/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
@@ -34,16 +34,16 @@ oppia.directive('audioTranslationsEditor', [
         '/components/forms/audio_translations_editor_directive.html'),
       controller: [
         '$scope', '$modal', '$sce', 'stateContentService', 'editabilityService',
-        'LanguageUtilService', 'alertsService', 'explorationContextService',
+        'LanguageUtilService', 'AlertsService', 'ExplorationContextService',
         'AssetsBackendApiService',
         function(
             $scope, $modal, $sce, stateContentService, editabilityService,
-            LanguageUtilService, alertsService, explorationContextService,
+            LanguageUtilService, AlertsService, ExplorationContextService,
             AssetsBackendApiService) {
           $scope.isEditable = editabilityService.isEditable;
           $scope.audioTranslations = (
             $scope.subtitledHtml.getBindableAudioTranslations());
-          var explorationId = explorationContextService.getExplorationId();
+          var explorationId = ExplorationContextService.getExplorationId();
 
           $scope.getAudioLanguageDescription = (
             LanguageUtilService.getAudioLanguageDescription);
@@ -66,7 +66,7 @@ oppia.directive('audioTranslationsEditor', [
                 $scope.subtitledHtml.getAudioLanguageCodes()));
 
             if (allowedAudioLanguageCodes.length === 0) {
-              alertsService.addWarning(
+              AlertsService.addWarning(
                 'Sorry, there are no more available languages to translate ' +
                 'into.');
               return;
@@ -85,12 +85,12 @@ oppia.directive('audioTranslationsEditor', [
               },
               controller: [
                 '$scope', '$modalInstance', 'LanguageUtilService',
-                'allowedAudioLanguageCodes', 'alertsService',
-                'explorationContextService', 'IdGenerationService',
+                'allowedAudioLanguageCodes', 'AlertsService',
+                'ExplorationContextService', 'IdGenerationService',
                 function(
                     $scope, $modalInstance, LanguageUtilService,
-                    allowedAudioLanguageCodes, alertsService,
-                    explorationContextService, IdGenerationService) {
+                    allowedAudioLanguageCodes, AlertsService,
+                    ExplorationContextService, IdGenerationService) {
                   var ERROR_MESSAGE_BAD_FILE_UPLOAD = (
                     'There was an error uploading the audio file.');
                   var BUTTON_TEXT_SAVE = 'Save';
@@ -145,7 +145,7 @@ oppia.directive('audioTranslationsEditor', [
                       $scope.saveInProgress = true;
                       var generatedFilename = generateNewFilename();
                       var explorationId = (
-                        explorationContextService.getExplorationId());
+                        ExplorationContextService.getExplorationId());
                       AssetsBackendApiService.saveAudio(
                         explorationId, generatedFilename, uploadedFile
                       ).then(function() {
@@ -166,7 +166,7 @@ oppia.directive('audioTranslationsEditor', [
 
                   $scope.cancel = function() {
                     $modalInstance.dismiss('cancel');
-                    alertsService.clearWarnings();
+                    AlertsService.clearWarnings();
                   };
                 }
               ]
@@ -206,7 +206,7 @@ oppia.directive('audioTranslationsEditor', [
 
                   $scope.cancel = function() {
                     $modalInstance.dismiss('cancel');
-                    alertsService.clearWarnings();
+                    AlertsService.clearWarnings();
                   };
                 }
               ]

--- a/core/templates/dev/head/domain/collection/SearchExplorationsBackendApiService.js
+++ b/core/templates/dev/head/domain/collection/SearchExplorationsBackendApiService.js
@@ -17,10 +17,10 @@
  */
 
 oppia.factory('SearchExplorationsBackendApiService', [
-  '$http', '$q', 'alertsService', 'SEARCH_EXPLORATION_URL_TEMPLATE',
+  '$http', '$q', 'AlertsService', 'SEARCH_EXPLORATION_URL_TEMPLATE',
   'UrlInterpolationService',
   function(
-      $http, $q, alertsService, SEARCH_EXPLORATION_URL_TEMPLATE,
+      $http, $q, AlertsService, SEARCH_EXPLORATION_URL_TEMPLATE,
       UrlInterpolationService) {
     var _fetchExplorations = function(
       searchQuery, successCallback, errorCallback) {

--- a/core/templates/dev/head/domain/exploration/SolutionObjectFactory.js
+++ b/core/templates/dev/head/domain/exploration/SolutionObjectFactory.js
@@ -18,8 +18,8 @@
  */
 
 oppia.factory('SolutionObjectFactory', [
-  '$filter', 'oppiaHtmlEscaper', 'oppiaExplorationHtmlFormatterService',
-  function($filter, oppiaHtmlEscaper, oppiaExplorationHtmlFormatterService) {
+  '$filter', 'oppiaHtmlEscaper', 'OppiaExplorationHtmlFormatterService',
+  function($filter, oppiaHtmlEscaper, OppiaExplorationHtmlFormatterService) {
     var Solution = function(answerIsExclusive, correctAnswer, explanation) {
       this.answerIsExclusive = answerIsExclusive;
       this.correctAnswer = correctAnswer;
@@ -82,7 +82,7 @@ oppia.factory('SolutionObjectFactory', [
     Solution.prototype.getOppiaResponseHtml = function(interaction) {
       return (
         (this.answerIsExclusive ? 'The only' : 'One') + ' answer is:<br>' +
-        oppiaExplorationHtmlFormatterService.getShortAnswerHtml(
+        OppiaExplorationHtmlFormatterService.getShortAnswerHtml(
           this.correctAnswer, interaction.id, interaction.customizationArgs) +
         '. ' + this.explanation);
     };

--- a/core/templates/dev/head/domain/learner_dashboard/LearnerPlaylistService.js
+++ b/core/templates/dev/head/domain/learner_dashboard/LearnerPlaylistService.js
@@ -17,8 +17,8 @@
  */
 
  oppia.factory('LearnerPlaylistService', [
-  '$http', '$modal', 'alertsService', 'UrlInterpolationService',
-  function($http, $modal, alertsService, UrlInterpolationService) {
+  '$http', '$modal', 'AlertsService', 'UrlInterpolationService',
+  function($http, $modal, AlertsService, UrlInterpolationService) {
     var _addToLearnerPlaylist = function(activityId, activityType) {
       var successfullyAdded = true;
       var addToLearnerPlaylistUrl = (
@@ -31,24 +31,24 @@
         .then(function(response) {
           if (response.data.belongs_to_completed_or_incomplete_list) {
             successfullyAdded = false;
-            alertsService.addInfoMessage(
+            AlertsService.addInfoMessage(
               'You have already completed or are completing this ' +
               'activity.');
           }
           if (response.data.belongs_to_subscribed_activities) {
             successfullyAdded = false;
-            alertsService.addInfoMessage(
+            AlertsService.addInfoMessage(
               'This is present in your creator dashboard');
           }
           if (response.data.playlist_limit_exceeded) {
             successfullyAdded = false;
-            alertsService.addInfoMessage(
+            AlertsService.addInfoMessage(
               'Your \'Play Later\' list is full!  Either you can ' +
               'complete some or you can head to the learner dashboard ' +
               'and remove some.');
           }
           if (successfullyAdded) {
-            alertsService.addSuccessMessage(
+            AlertsService.addSuccessMessage(
               'Successfully added to your \'Play Later\' list.');
           }
         });

--- a/core/templates/dev/head/domain/summary/ExplorationSummaryBackendApiService.js
+++ b/core/templates/dev/head/domain/summary/ExplorationSummaryBackendApiService.js
@@ -19,15 +19,15 @@
 
 oppia.factory('ExplorationSummaryBackendApiService', [
   '$http', '$q', 'EXPLORATION_SUMMARY_DATA_URL_TEMPLATE',
-  'ValidatorsService', 'alertsService',
+  'ValidatorsService', 'AlertsService',
   function(
       $http, $q, EXPLORATION_SUMMARY_DATA_URL_TEMPLATE,
-      ValidatorsService, alertsService) {
+      ValidatorsService, AlertsService) {
     var _fetchExpSummaries = function(
         explorationIds, includePrivateExplorations, successCallback,
         errorCallback) {
       if (!explorationIds.every(ValidatorsService.isValidExplorationId)) {
-        alertsService.addWarning('Please enter a valid exploration ID.');
+        AlertsService.addWarning('Please enter a valid exploration ID.');
 
         var deferred = $q.defer();
         var returnValue = [];

--- a/core/templates/dev/head/domain/utilities/UrlInterpolationService.js
+++ b/core/templates/dev/head/domain/utilities/UrlInterpolationService.js
@@ -18,16 +18,16 @@
  */
 
 oppia.factory('UrlInterpolationService', [
-  'alertsService', 'utilsService', function(alertsService, utilsService) {
+  'AlertsService', 'utilsService', function(AlertsService, utilsService) {
     var validateResourcePath = function(resourcePath) {
       if (!resourcePath) {
-        alertsService.fatalWarning('Empty path passed in method.');
+        AlertsService.fatalWarning('Empty path passed in method.');
       }
 
       var RESOURCE_PATH_STARTS_WITH_FORWARD_SLASH = /^\//;
       // Ensure that resourcePath starts with a forward slash.
       if (!resourcePath.match(RESOURCE_PATH_STARTS_WITH_FORWARD_SLASH)) {
-        alertsService.fatalWarning(
+        AlertsService.fatalWarning(
           'Path must start with \'\/\': \'' + resourcePath + '\'.');
       }
     };
@@ -84,7 +84,7 @@ oppia.factory('UrlInterpolationService', [
        */
       interpolateUrl: function(urlTemplate, interpolationValues) {
         if (!urlTemplate) {
-          alertsService.fatalWarning(
+          AlertsService.fatalWarning(
             'Invalid or empty URL template passed in: \'' + urlTemplate + '\'');
           return null;
         }
@@ -93,7 +93,7 @@ oppia.factory('UrlInterpolationService', [
         if (!(interpolationValues instanceof Object) || (
             Object.prototype.toString.call(
               interpolationValues) === '[object Array]')) {
-          alertsService.fatalWarning(
+          AlertsService.fatalWarning(
             'Expected an object of interpolation values to be passed into ' +
             'interpolateUrl.');
           return null;
@@ -112,7 +112,7 @@ oppia.factory('UrlInterpolationService', [
 
         if (urlTemplate.match(INVALID_VARIABLE_REGEX) ||
             urlTemplate.match(EMPTY_VARIABLE_REGEX)) {
-          alertsService.fatalWarning(
+          AlertsService.fatalWarning(
             'Invalid URL template received: \'' + urlTemplate + '\'');
           return null;
         }
@@ -121,14 +121,14 @@ oppia.factory('UrlInterpolationService', [
         for (var varName in interpolationValues) {
           var value = interpolationValues[varName];
           if (!utilsService.isString(value)) {
-            alertsService.fatalWarning(
+            AlertsService.fatalWarning(
               'Parameters passed into interpolateUrl must be strings.');
             return null;
           }
 
           // Ensure the value is valid.
           if (!value.match(VALID_URL_PARAMETER_VALUE_REGEX)) {
-            alertsService.fatalWarning(
+            AlertsService.fatalWarning(
               'Parameter values passed into interpolateUrl must only contain ' +
               'alphanumerical characters, hyphens, underscores or spaces: \'' +
               value + '\'');
@@ -145,7 +145,7 @@ oppia.factory('UrlInterpolationService', [
         while (match) {
           var varName = match[1];
           if (!escapedInterpolationValues.hasOwnProperty(varName)) {
-            alertsService.fatalWarning('Expected variable \'' + varName +
+            AlertsService.fatalWarning('Expected variable \'' + varName +
               '\' when interpolating URL.');
             return null;
           }
@@ -172,7 +172,7 @@ oppia.factory('UrlInterpolationService', [
        */
       getInteractionThumbnailImageUrl: function(interactionId) {
         if (!interactionId) {
-          alertsService.fatalWarning(
+          AlertsService.fatalWarning(
             'Empty interactionId passed in getInteractionThumbnailImageUrl.');
         }
         return getExtensionResourceUrl('/interactions/' + interactionId +

--- a/core/templates/dev/head/pages/Base.js
+++ b/core/templates/dev/head/pages/Base.js
@@ -17,11 +17,11 @@
  */
 
 oppia.controller('Base', [
-  '$scope', '$rootScope', '$document', 'alertsService', 'BackgroundMaskService',
+  '$scope', '$rootScope', '$document', 'AlertsService', 'BackgroundMaskService',
   'SidebarStatusService',
-  function($scope, $rootScope, $document, alertsService, BackgroundMaskService,
+  function($scope, $rootScope, $document, AlertsService, BackgroundMaskService,
   SidebarStatusService) {
-    $scope.alertsService = alertsService;
+    $scope.AlertsService = AlertsService;
     $scope.currentLang = 'en';
     $scope.promoBarIsEnabled = GLOBALS.PROMO_BAR_IS_ENABLED;
     $scope.promoBarMessage = GLOBALS.PROMO_BAR_MESSAGE;

--- a/core/templates/dev/head/pages/admin/admin.html
+++ b/core/templates/dev/head/pages/admin/admin.html
@@ -99,8 +99,8 @@
 
     <script src="{{TEMPLATE_DIR_PREFIX}}/pages/admin/misc_tab/AdminMiscTabDirective.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/directives.js"></script>
-    <script src="{{TEMPLATE_DIR_PREFIX}}/services/alertsService.js"></script>
-    <script src="{{TEMPLATE_DIR_PREFIX}}/services/explorationContextService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/AlertsService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/ExplorationContextService.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/services/utilsService.js"></script>
 
     <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/FormBuilder.js"></script>

--- a/core/templates/dev/head/pages/base.html
+++ b/core/templates/dev/head/pages/base.html
@@ -1,8 +1,8 @@
 {% macro warnings_and_loader() -%}
   <div tabindex="0" aria-label="Oppia Main Content" id="oppia-main-content" class="protractor-test-main-content" ng-cloak>
     <div class="oppia-toast-container toast-top-center">
-      <div ng-repeat="warning in (alertsService.warnings | limitTo:5) track by $index" class="toast toast-warning oppia-toast">
-        <button type="button" class="toast-close-button" ng-click="alertsService.deleteWarning(warning)" role="button">&times;</button>
+      <div ng-repeat="warning in (AlertsService.warnings | limitTo:5) track by $index" class="toast toast-warning oppia-toast">
+        <button type="button" class="toast-close-button" ng-click="AlertsService.deleteWarning(warning)" role="button">&times;</button>
         <div class="toast-message">
           <[warning.content]>
         </div>
@@ -10,7 +10,7 @@
     </div>
 
     <div>
-      <div ng-repeat="message in alertsService.messages track by $index">
+      <div ng-repeat="message in AlertsService.messages track by $index">
         <alert-message message-object="message" message-index="$index"></alert-message>
       </div>
     </div>
@@ -204,8 +204,8 @@
 
     <script src="{{TEMPLATE_DIR_PREFIX}}/pages/Base.js"></script>
 
-    <script src="{{TEMPLATE_DIR_PREFIX}}/services/alertsService.js"></script>
-    <script src="{{TEMPLATE_DIR_PREFIX}}/services/explorationContextService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/AlertsService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/ExplorationContextService.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/services/utilsService.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/services/ValidatorsService.js"></script>
 

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
@@ -22,14 +22,14 @@ oppia.directive('collectionEditorNavbar', [
       restrict: 'E',
       templateUrl: 'inline/collection_editor_navbar_directive',
       controller: [
-        '$scope', '$modal', 'alertsService', 'routerService', 'UndoRedoService',
+        '$scope', '$modal', 'AlertsService', 'routerService', 'UndoRedoService',
         'CollectionEditorStateService', 'CollectionValidationService',
         'CollectionRightsBackendApiService',
         'EditableCollectionBackendApiService',
         'EVENT_COLLECTION_INITIALIZED', 'EVENT_COLLECTION_REINITIALIZED',
         'EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED',
         function(
-            $scope, $modal, alertsService, routerService, UndoRedoService,
+            $scope, $modal, AlertsService, routerService, UndoRedoService,
             CollectionEditorStateService, CollectionValidationService,
             CollectionRightsBackendApiService,
             EditableCollectionBackendApiService,
@@ -179,15 +179,15 @@ oppia.directive('collectionEditorNavbar', [
 
                     $scope.save = function() {
                       if (!$scope.newTitle) {
-                        alertsService.addWarning('Please specify a title');
+                        AlertsService.addWarning('Please specify a title');
                         return;
                       }
                       if (!$scope.newObjective) {
-                        alertsService.addWarning('Please specify an objective');
+                        AlertsService.addWarning('Please specify an objective');
                         return;
                       }
                       if (!$scope.newCategory) {
-                        alertsService.addWarning('Please specify a category');
+                        AlertsService.addWarning('Please specify a category');
                         return;
                       }
 
@@ -238,7 +238,7 @@ oppia.directive('collectionEditorNavbar', [
                 CollectionEditorStateService.setCollectionRights(
                   $scope.collectionRights);
               }, function() {
-                alertsService.addWarning(
+                AlertsService.addWarning(
                   'There was an error when unpublishing the collection.');
               });
           };

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorStateService.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorStateService.js
@@ -23,12 +23,12 @@ oppia.constant('EVENT_COLLECTION_INITIALIZED', 'collectionInitialized');
 oppia.constant('EVENT_COLLECTION_REINITIALIZED', 'collectionReinitialized');
 
 oppia.factory('CollectionEditorStateService', [
-  '$rootScope', 'alertsService', 'CollectionObjectFactory',
+  '$rootScope', 'AlertsService', 'CollectionObjectFactory',
   'CollectionRightsBackendApiService', 'CollectionRightsObjectFactory',
   'UndoRedoService', 'EditableCollectionBackendApiService',
   'EVENT_COLLECTION_INITIALIZED', 'EVENT_COLLECTION_REINITIALIZED',
   function(
-      $rootScope, alertsService, CollectionObjectFactory,
+      $rootScope, AlertsService, CollectionObjectFactory,
       CollectionRightsBackendApiService, CollectionRightsObjectFactory,
       UndoRedoService, EditableCollectionBackendApiService,
       EVENT_COLLECTION_INITIALIZED, EVENT_COLLECTION_REINITIALIZED) {
@@ -74,7 +74,7 @@ oppia.factory('CollectionEditorStateService', [
             _updateCollection(newBackendCollectionObject);
           },
           function(error) {
-            alertsService.addWarning(
+            AlertsService.addWarning(
               error || 'There was an error when loading the collection.');
             _isLoadingCollection = false;
           });
@@ -83,7 +83,7 @@ oppia.factory('CollectionEditorStateService', [
             _updateCollectionRights(newBackendCollectionRightsObject);
             _isLoadingCollection = false;
           }, function(error) {
-            alertsService.addWarning(
+            AlertsService.addWarning(
               error ||
               'There was an error when loading the collection rights.');
             _isLoadingCollection = false;
@@ -163,7 +163,7 @@ oppia.factory('CollectionEditorStateService', [
        */
       saveCollection: function(commitMessage, successCallback) {
         if (!_collectionIsInitialized) {
-          alertsService.fatalWarning(
+          AlertsService.fatalWarning(
             'Cannot save a collection before one is loaded.');
         }
 
@@ -183,7 +183,7 @@ oppia.factory('CollectionEditorStateService', [
               successCallback();
             }
           }, function(error) {
-            alertsService.addWarning(
+            AlertsService.addWarning(
               error || 'There was an error when saving the collection.');
             _isSavingCollection = false;
           });

--- a/core/templates/dev/head/pages/collection_editor/editor_tab/CollectionNodeCreatorDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/editor_tab/CollectionNodeCreatorDirective.js
@@ -24,13 +24,13 @@ oppia.directive('collectionNodeCreator', [
         '/pages/collection_editor/editor_tab/' +
         'collection_node_creator_directive.html'),
       controller: [
-        '$scope', '$http', '$window', '$filter', 'alertsService',
+        '$scope', '$http', '$window', '$filter', 'AlertsService',
         'ValidatorsService', 'CollectionEditorStateService',
         'CollectionLinearizerService', 'CollectionUpdateService',
         'CollectionNodeObjectFactory', 'ExplorationSummaryBackendApiService',
         'SearchExplorationsBackendApiService', 'siteAnalyticsService',
         function(
-            $scope, $http, $window, $filter, alertsService,
+            $scope, $http, $window, $filter, AlertsService,
             ValidatorsService, CollectionEditorStateService,
             CollectionLinearizerService, CollectionUpdateService,
             CollectionNodeObjectFactory, ExplorationSummaryBackendApiService,
@@ -62,7 +62,7 @@ oppia.directive('collectionNodeCreator', [
                   });
                 return options;
               }, function() {
-                alertsService.addWarning(
+                AlertsService.addWarning(
                   'There was an error when searching for matching ' + 
                   'explorations.');
               });
@@ -80,11 +80,11 @@ oppia.directive('collectionNodeCreator', [
 
           var addExplorationToCollection = function(newExplorationId) {
             if (!newExplorationId) {
-              alertsService.addWarning('Cannot add an empty exploration ID.');
+              AlertsService.addWarning('Cannot add an empty exploration ID.');
               return;
             }
             if ($scope.collection.containsCollectionNode(newExplorationId)) {
-              alertsService.addWarning(
+              AlertsService.addWarning(
                 'There is already an exploration in this collection ' +
                 'with that id.');
               return;
@@ -102,12 +102,12 @@ oppia.directive('collectionNodeCreator', [
                   CollectionLinearizerService.appendCollectionNode(
                     $scope.collection, newExplorationId, summaryBackendObject);
                 } else {
-                  alertsService.addWarning(
+                  AlertsService.addWarning(
                     'That exploration does not exist or you do not have edit ' +
                     'access to it.');
                 }
               }, function() {
-                alertsService.addWarning(
+                AlertsService.addWarning(
                   'There was an error while adding an exploration to the ' +
                   'collection.');
               }

--- a/core/templates/dev/head/pages/collection_editor/editor_tab/CollectionNodeEditorDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/editor_tab/CollectionNodeEditorDirective.js
@@ -31,10 +31,10 @@ oppia.directive('collectionNodeEditor', [
         'collection_node_editor_directive.html'),
       controller: [
         '$scope', 'CollectionEditorStateService', 'CollectionLinearizerService',
-        'CollectionUpdateService', 'alertsService',
+        'CollectionUpdateService', 'AlertsService',
         function(
             $scope, CollectionEditorStateService, CollectionLinearizerService,
-            CollectionUpdateService, alertsService) {
+            CollectionUpdateService, AlertsService) {
           $scope.collection = CollectionEditorStateService.getCollection();
 
           // Deletes this collection node from the frontend collection
@@ -43,7 +43,7 @@ oppia.directive('collectionNodeEditor', [
             var explorationId = $scope.getCollectionNode().getExplorationId();
             if (!CollectionLinearizerService.removeCollectionNode(
                 $scope.collection, explorationId)) {
-              alertsService.fatalWarning(
+              AlertsService.fatalWarning(
                 'Internal collection editor error. Could not delete ' +
                 'exploration by ID: ' + explorationId);
             }
@@ -55,7 +55,7 @@ oppia.directive('collectionNodeEditor', [
             var explorationId = $scope.getCollectionNode().getExplorationId();
             if (!CollectionLinearizerService.shiftNodeLeft(
                 $scope.collection, explorationId)) {
-              alertsService.fatalWarning(
+              AlertsService.fatalWarning(
                 'Internal collection editor error. Could not shift node left ' +
                 'with ID: ' + explorationId);
             }
@@ -67,7 +67,7 @@ oppia.directive('collectionNodeEditor', [
             var explorationId = $scope.getCollectionNode().getExplorationId();
             if (!CollectionLinearizerService.shiftNodeRight(
                 $scope.collection, explorationId)) {
-              alertsService.fatalWarning(
+              AlertsService.fatalWarning(
                 'Internal collection editor error. Could not shift node ' +
                 'right with ID: ' + explorationId);
             }

--- a/core/templates/dev/head/pages/collection_editor/settings_tab/CollectionDetailsEditorDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/settings_tab/CollectionDetailsEditorDirective.js
@@ -27,12 +27,12 @@ oppia.directive('collectionDetailsEditor', [
         'collection_details_editor_directive.html'),
       controller: [
         '$scope', 'CollectionEditorStateService', 'CollectionUpdateService',
-        'CollectionValidationService', 'alertsService', 'ALL_CATEGORIES',
+        'CollectionValidationService', 'AlertsService', 'ALL_CATEGORIES',
         'EVENT_COLLECTION_INITIALIZED', 'EVENT_COLLECTION_REINITIALIZED',
         'COLLECTION_TITLE_INPUT_FOCUS_LABEL',
         function(
             $scope, CollectionEditorStateService, CollectionUpdateService,
-            CollectionValidationService, alertsService, ALL_CATEGORIES,
+            CollectionValidationService, AlertsService, ALL_CATEGORIES,
             EVENT_COLLECTION_INITIALIZED, EVENT_COLLECTION_REINITIALIZED,
             COLLECTION_TITLE_INPUT_FOCUS_LABEL) {
           $scope.collection = CollectionEditorStateService.getCollection();
@@ -115,7 +115,7 @@ oppia.directive('collectionDetailsEditor', [
               $scope.displayedCollectionTags);
             if (!CollectionValidationService.isTagValid(
                   $scope.displayedCollectionTags)) {
-              alertsService.addWarning(
+              AlertsService.addWarning(
                 'Please ensure that there are no duplicate tags and that all ' +
                 'tags contain only lower case and spaces.');
               return;

--- a/core/templates/dev/head/pages/collection_player/CollectionPlayer.js
+++ b/core/templates/dev/head/pages/collection_player/CollectionPlayer.js
@@ -34,11 +34,11 @@ oppia.controller('CollectionPlayer', [
   '$scope', '$anchorScroll', '$location', '$http',
   'ReadOnlyCollectionBackendApiService',
   'CollectionObjectFactory', 'CollectionPlaythroughObjectFactory',
-  'alertsService', 'UrlInterpolationService',
+  'AlertsService', 'UrlInterpolationService',
   function($scope, $anchorScroll, $location, $http,
            ReadOnlyCollectionBackendApiService,
            CollectionObjectFactory, CollectionPlaythroughObjectFactory,
-           alertsService, UrlInterpolationService) {
+           AlertsService, UrlInterpolationService) {
     $scope.collection = null;
     $scope.collectionPlaythrough = null;
     $scope.collectionId = GLOBALS.collectionId;
@@ -77,7 +77,7 @@ oppia.controller('CollectionPlayer', [
       var collectionNode = (
         $scope.collection.getCollectionNodeByExplorationId(explorationId));
       if (!collectionNode) {
-        alertsService.addWarning('There was an error loading the collection.');
+        AlertsService.addWarning('There was an error loading the collection.');
       }
       return collectionNode;
     };
@@ -241,7 +241,7 @@ oppia.controller('CollectionPlayer', [
         $scope.collectionSummary = response.data.summaries[0];
       },
       function() {
-        alertsService.addWarning(
+        AlertsService.addWarning(
           'There was an error while fetching the collection summary.');
       }
     );
@@ -268,7 +268,7 @@ oppia.controller('CollectionPlayer', [
         // NOTE TO DEVELOPERS: Check the backend console for an indication as to
         // why this error occurred; sometimes the errors are noisy, so they are
         // not shown to the user.
-        alertsService.addWarning(
+        AlertsService.addWarning(
           'There was an error loading the collection.');
       }
     );

--- a/core/templates/dev/head/pages/creator_dashboard/CreatorDashboard.js
+++ b/core/templates/dev/head/pages/creator_dashboard/CreatorDashboard.js
@@ -47,14 +47,14 @@ oppia.constant('HUMAN_READABLE_SUBSCRIPTION_SORT_BY_KEYS', {
 });
 
 oppia.controller('CreatorDashboard', [
-  '$scope', '$rootScope', '$window', 'oppiaDatetimeFormatter', 'alertsService',
+  '$scope', '$rootScope', '$window', 'oppiaDatetimeFormatter', 'AlertsService',
   'CreatorDashboardBackendApiService', 'RatingComputationService',
   'ExplorationCreationService', 'UrlInterpolationService', 'FATAL_ERROR_CODES',
   'EXPLORATION_DROPDOWN_STATS', 'EXPLORATIONS_SORT_BY_KEYS',
   'HUMAN_READABLE_EXPLORATIONS_SORT_BY_KEYS', 'SUBSCRIPTION_SORT_BY_KEYS',
   'HUMAN_READABLE_SUBSCRIPTION_SORT_BY_KEYS',
   function(
-      $scope, $rootScope, $window, oppiaDatetimeFormatter, alertsService,
+      $scope, $rootScope, $window, oppiaDatetimeFormatter, AlertsService,
       CreatorDashboardBackendApiService, RatingComputationService,
       ExplorationCreationService, UrlInterpolationService, FATAL_ERROR_CODES,
       EXPLORATION_DROPDOWN_STATS, EXPLORATIONS_SORT_BY_KEYS,
@@ -210,7 +210,7 @@ oppia.controller('CreatorDashboard', [
       },
       function(errorResponse) {
         if (FATAL_ERROR_CODES.indexOf(errorResponse.status) !== -1) {
-          alertsService.addWarning('Failed to get dashboard data');
+          AlertsService.addWarning('Failed to get dashboard data');
         }
       }
     );

--- a/core/templates/dev/head/pages/creator_dashboard/CreatorDashboardSpec.js
+++ b/core/templates/dev/head/pages/creator_dashboard/CreatorDashboardSpec.js
@@ -77,7 +77,7 @@ describe('Creator dashboard controller', function() {
         scope = $rootScope.$new();
         ctrl = $controller('CreatorDashboard', {
           $scope: scope,
-          alertsService: null,
+          AlertsService: null,
           CreatorDashboardBackendApiService: mockDashboardBackendApiService
         });
       }

--- a/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorNavigationDirective.js
@@ -29,14 +29,14 @@ oppia.directive('editorNavigation', [
         'explorationWarningsService',
         'stateEditorTutorialFirstTimeService',
         'threadDataService', 'siteAnalyticsService',
-        'explorationContextService', 'windowDimensionsService',
+        'ExplorationContextService', 'windowDimensionsService',
         function(
             $scope, $rootScope, $timeout, $modal,
             routerService, explorationRightsService,
             explorationWarningsService,
             stateEditorTutorialFirstTimeService,
             threadDataService, siteAnalyticsService,
-            explorationContextService, windowDimensionsService) {
+            ExplorationContextService, windowDimensionsService) {
           $scope.postTutorialHelpPopoverIsShown = false;
           $scope.isLargeScreen = (windowDimensionsService.getWidth() >= 1024);
 
@@ -54,7 +54,7 @@ oppia.directive('editorNavigation', [
           $scope.userIsLoggedIn = GLOBALS.userIsLoggedIn;
 
           $scope.showUserHelpModal = function() {
-            var explorationId = explorationContextService.getExplorationId();
+            var explorationId = ExplorationContextService.getExplorationId();
             siteAnalyticsService.registerClickHelpButtonEvent(explorationId);
             var modalInstance = $modal.open({
               templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
@@ -63,12 +63,12 @@ oppia.directive('editorNavigation', [
               backdrop: true,
               controller: [
                 '$scope', '$modalInstance',
-                'siteAnalyticsService', 'explorationContextService',
+                'siteAnalyticsService', 'ExplorationContextService',
                 function(
                   $scope, $modalInstance,
-                  siteAnalyticsService, explorationContextService) {
+                  siteAnalyticsService, ExplorationContextService) {
                   var explorationId = (
-                    explorationContextService.getExplorationId());
+                    ExplorationContextService.getExplorationId());
 
                   $scope.beginTutorial = function() {
                     siteAnalyticsService

--- a/core/templates/dev/head/pages/exploration_editor/EditorServices.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorServices.js
@@ -18,10 +18,10 @@
 
 // Service for handling all interactions with the exploration editor backend.
 oppia.factory('explorationData', [
-  '$http', '$log', '$window', '$q', 'alertsService',
+  '$http', '$log', '$window', '$q', 'AlertsService',
   'EditableExplorationBackendApiService', 'LocalStorageService',
   'ReadOnlyExplorationBackendApiService', 'urlService',
-  function($http, $log, $window, $q, alertsService,
+  function($http, $log, $window, $q, AlertsService,
     EditableExplorationBackendApiService, LocalStorageService,
     ReadOnlyExplorationBackendApiService, urlService) {
     // The pathname (without the hash) should be: .../create/{exploration_id}
@@ -137,7 +137,7 @@ oppia.factory('explorationData', [
           });
       },
       resolveAnswers: function(stateName, resolvedAnswersList) {
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
         $http.put(
           resolvedAnswersUrlPrefix + '/' + encodeURIComponent(stateName), {
             resolved_answers: resolvedAnswersList
@@ -159,7 +159,7 @@ oppia.factory('explorationData', [
         EditableExplorationBackendApiService.updateExploration(explorationId,
           explorationData.data.version, commitMessage, changeList).then(
             function(response) {
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
               explorationData.data = response;
               if (successCallback) {
                 successCallback(
@@ -243,10 +243,10 @@ oppia.factory('editabilityService', [function() {
 // A service that maintains a provisional list of changes to be committed to
 // the server.
 oppia.factory('changeListService', [
-  '$rootScope', '$log', 'alertsService', 'explorationData',
+  '$rootScope', '$log', 'AlertsService', 'explorationData',
   'autosaveInfoModalsService',
   function(
-      $rootScope, $log, alertsService, explorationData,
+      $rootScope, $log, AlertsService, explorationData,
       autosaveInfoModalsService) {
     // TODO(sll): Implement undo, redo functionality. Show a message on each
     // step saying what the step is doing.
@@ -310,7 +310,7 @@ oppia.factory('changeListService', [
           }
         },
         function() {
-          alertsService.clearWarnings();
+          AlertsService.clearWarnings();
           $log.error(
             'nonStrictValidationFailure: ' +
             JSON.stringify(explorationChangeList));
@@ -373,7 +373,7 @@ oppia.factory('changeListService', [
        */
       editExplorationProperty: function(backendName, newValue, oldValue) {
         if (!ALLOWED_EXPLORATION_BACKEND_NAMES.hasOwnProperty(backendName)) {
-          alertsService.addWarning(
+          AlertsService.addWarning(
             'Invalid exploration property: ' + backendName);
           return;
         }
@@ -396,7 +396,7 @@ oppia.factory('changeListService', [
        */
       editStateProperty: function(stateName, backendName, newValue, oldValue) {
         if (!ALLOWED_STATE_BACKEND_NAMES.hasOwnProperty(backendName)) {
-          alertsService.addWarning('Invalid state property: ' + backendName);
+          AlertsService.addWarning('Invalid state property: ' + backendName);
           return;
         }
         addChange({
@@ -441,7 +441,7 @@ oppia.factory('changeListService', [
       },
       undoLastChange: function() {
         if (explorationChangeList.length === 0) {
-          alertsService.addWarning('There are no changes to undo.');
+          AlertsService.addWarning('There are no changes to undo.');
           return;
         }
         var lastChange = explorationChangeList.pop();
@@ -454,8 +454,8 @@ oppia.factory('changeListService', [
 
 // A data service that stores data about the rights for this exploration.
 oppia.factory('explorationRightsService', [
-  '$http', '$q', 'explorationData', 'alertsService',
-  function($http, $q, explorationData, alertsService) {
+  '$http', '$q', 'explorationData', 'AlertsService',
+  function($http, $q, explorationData, AlertsService) {
     return {
       init: function(
           ownerNames, editorNames, viewerNames, status, clonedFrom,
@@ -499,7 +499,7 @@ oppia.factory('explorationRightsService', [
           make_community_owned: true
         }).then(function(response) {
           var data = response.data;
-          alertsService.clearWarnings();
+          AlertsService.clearWarnings();
           that.init(
             data.rights.owner_names, data.rights.editor_names,
             data.rights.viewer_names, data.rights.status,
@@ -520,7 +520,7 @@ oppia.factory('explorationRightsService', [
           viewable_if_private: viewableIfPrivate
         }).then(function(response) {
           var data = response.data;
-          alertsService.clearWarnings();
+          AlertsService.clearWarnings();
           that.init(
             data.rights.owner_names, data.rights.editor_names,
             data.rights.viewer_names, data.rights.status,
@@ -542,7 +542,7 @@ oppia.factory('explorationRightsService', [
           new_member_username: newMemberUsername
         }).then(function(response) {
           var data = response.data;
-          alertsService.clearWarnings();
+          AlertsService.clearWarnings();
           that.init(
             data.rights.owner_names, data.rights.editor_names,
             data.rights.viewer_names, data.rights.status,
@@ -562,7 +562,7 @@ oppia.factory('explorationRightsService', [
           make_public: true
         }).then(function(response) {
           var data = response.data;
-          alertsService.clearWarnings();
+          AlertsService.clearWarnings();
           that.init(
             data.rights.owner_names, data.rights.editor_names,
             data.rights.viewer_names, data.rights.status,
@@ -583,7 +583,7 @@ oppia.factory('explorationRightsService', [
           version: explorationData.data.version
         }).then(function(response) {
           var data = response.data;
-          alertsService.clearWarnings();
+          AlertsService.clearWarnings();
           that.init(
             data.rights.owner_names, data.rights.editor_names,
             data.rights.viewer_names, data.rights.status,
@@ -596,8 +596,8 @@ oppia.factory('explorationRightsService', [
 ]);
 
 oppia.factory('explorationPropertyService', [
-  '$rootScope', '$log', 'changeListService', 'alertsService',
-  function($rootScope, $log, changeListService, alertsService) {
+  '$rootScope', '$log', 'changeListService', 'AlertsService',
+  function($rootScope, $log, changeListService, AlertsService) {
     // Public base API for data services corresponding to exploration properties
     // (title, category, etc.)
 
@@ -662,7 +662,7 @@ oppia.factory('explorationPropertyService', [
           return;
         }
 
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
 
         var newBackendValue = angular.copy(this.displayed);
         var oldBackendValue = angular.copy(this.savedMemento);
@@ -831,16 +831,16 @@ oppia.factory('explorationParamChangesService', [
 // mementos.
 oppia.factory('explorationStatesService', [
   '$log', '$modal', '$filter', '$location', '$rootScope', '$injector', '$q',
-  'explorationInitStateNameService', 'alertsService', 'changeListService',
+  'explorationInitStateNameService', 'AlertsService', 'changeListService',
   'editorContextService', 'ValidatorsService', 'StatesObjectFactory',
   'SolutionValidityService', 'angularNameService',
-  'AnswerClassificationService', 'explorationContextService',
+  'AnswerClassificationService', 'ExplorationContextService',
   function(
       $log, $modal, $filter, $location, $rootScope, $injector, $q,
-      explorationInitStateNameService, alertsService, changeListService,
+      explorationInitStateNameService, AlertsService, changeListService,
       editorContextService, ValidatorsService, StatesObjectFactory,
       SolutionValidityService, angularNameService,
-      AnswerClassificationService, explorationContextService) {
+      AnswerClassificationService, ExplorationContextService) {
     var _states = null;
     // Properties that have a different backend representation from the
     // frontend and must be converted.
@@ -962,7 +962,7 @@ oppia.factory('explorationStatesService', [
           if (solution) {
             var result = (
               AnswerClassificationService.getMatchingClassificationResult(
-                explorationContextService.getExplorationId(),
+                ExplorationContextService.getExplorationId(),
               stateName,
               _states.getState(stateName),
               solution.correctAnswer,
@@ -994,7 +994,7 @@ oppia.factory('explorationStatesService', [
       isNewStateNameValid: function(newStateName, showWarnings) {
         if (_states.hasState(newStateName)) {
           if (showWarnings) {
-            alertsService.addWarning('A state with this name already exists.');
+            AlertsService.addWarning('A state with this name already exists.');
           }
           return false;
         }
@@ -1077,10 +1077,10 @@ oppia.factory('explorationStatesService', [
           return;
         }
         if (_states.hasState(newStateName)) {
-          alertsService.addWarning('A state with this name already exists.');
+          AlertsService.addWarning('A state with this name already exists.');
           return;
         }
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
 
         _states.addState(newStateName);
 
@@ -1091,14 +1091,14 @@ oppia.factory('explorationStatesService', [
         }
       },
       deleteState: function(deleteStateName) {
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
 
         var initStateName = explorationInitStateNameService.displayed;
         if (deleteStateName === initStateName) {
           return;
         }
         if (!_states.hasState(deleteStateName)) {
-          alertsService.addWarning(
+          AlertsService.addWarning(
             'No state with name ' + deleteStateName + ' exists.');
           return;
         }
@@ -1124,7 +1124,7 @@ oppia.factory('explorationStatesService', [
 
               $scope.cancel = function() {
                 $modalInstance.dismiss('cancel');
-                alertsService.clearWarnings();
+                AlertsService.clearWarnings();
               };
             }
           ]
@@ -1151,10 +1151,10 @@ oppia.factory('explorationStatesService', [
           return;
         }
         if (_states.hasState(newStateName)) {
-          alertsService.addWarning('A state with this name already exists.');
+          AlertsService.addWarning('A state with this name already exists.');
           return;
         }
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
 
         _states.renameState(oldStateName, newStateName);
 
@@ -1178,8 +1178,8 @@ oppia.factory('explorationStatesService', [
 ]);
 
 oppia.factory('statePropertyService', [
-  '$log', 'changeListService', 'alertsService', 'explorationStatesService',
-  function($log, changeListService, alertsService, explorationStatesService) {
+  '$log', 'changeListService', 'AlertsService', 'explorationStatesService',
+  function($log, changeListService, AlertsService, explorationStatesService) {
     // Public base API for data services corresponding to state properties
     // (interaction id, content, etc.)
     // WARNING: This should be initialized only in the context of the state
@@ -1238,7 +1238,7 @@ oppia.factory('statePropertyService', [
           return;
         }
 
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
 
         var setterFunc = explorationStatesService[this.setterMethodKey];
         setterFunc(this.stateName, angular.copy(this.displayed));

--- a/core/templates/dev/head/pages/exploration_editor/EditorServicesSpec.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorServicesSpec.js
@@ -177,7 +177,7 @@ describe('Change list service', function() {
         addWarning: function() {}
       };
       module(function($provide) {
-        $provide.value('alertsService', mockWarningsData);
+        $provide.value('AlertsService', mockWarningsData);
       });
       spyOn(mockWarningsData, 'addWarning');
       mockExplorationData = {

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
@@ -43,7 +43,7 @@ oppia.controller('ExplorationEditor', [
   'editabilityService', 'explorationStatesService', 'routerService',
   'graphDataService', 'stateEditorTutorialFirstTimeService',
   'explorationParamSpecsService', 'explorationParamChangesService',
-  'explorationWarningsService', '$templateCache', 'explorationContextService',
+  'explorationWarningsService', '$templateCache', 'ExplorationContextService',
   'explorationAdvancedFeaturesService', '$modal', 'changeListService',
   'autosaveInfoModalsService', 'siteAnalyticsService',
   'UserEmailPreferencesService', 'ParamChangesObjectFactory',
@@ -57,7 +57,7 @@ oppia.controller('ExplorationEditor', [
       editabilityService, explorationStatesService, routerService,
       graphDataService, stateEditorTutorialFirstTimeService,
       explorationParamSpecsService, explorationParamChangesService,
-      explorationWarningsService, $templateCache, explorationContextService,
+      explorationWarningsService, $templateCache, ExplorationContextService,
       explorationAdvancedFeaturesService, $modal, changeListService,
       autosaveInfoModalsService, siteAnalyticsService,
       UserEmailPreferencesService, ParamChangesObjectFactory,
@@ -70,7 +70,7 @@ oppia.controller('ExplorationEditor', [
      *********************************************************/
     $rootScope.loadingMessage = 'Loading';
 
-    $scope.explorationId = explorationContextService.getExplorationId();
+    $scope.explorationId = ExplorationContextService.getExplorationId();
     $scope.explorationUrl = '/create/' + $scope.explorationId;
     $scope.explorationDownloadUrl = (
       '/createhandler/download/' + $scope.explorationId);
@@ -375,10 +375,10 @@ oppia.controller('ExplorationEditor', [
         backdrop: true,
         controller: [
           '$scope', '$modalInstance', 'siteAnalyticsService',
-          'explorationContextService',
+          'ExplorationContextService',
           function($scope, $modalInstance, siteAnalyticsService,
-          explorationContextService) {
-            var explorationId = explorationContextService.getExplorationId();
+          ExplorationContextService) {
+            var explorationId = ExplorationContextService.getExplorationId();
 
             siteAnalyticsService.registerTutorialModalOpenEvent(explorationId);
 

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
@@ -18,7 +18,7 @@
 
 oppia.factory('explorationSaveService', [
   '$modal', '$timeout', '$rootScope', '$log', '$q',
-  'alertsService', 'explorationData', 'explorationStatesService',
+  'AlertsService', 'explorationData', 'explorationStatesService',
   'explorationTagsService', 'explorationTitleService',
   'explorationObjectiveService', 'explorationCategoryService',
   'explorationLanguageCodeService', 'explorationRightsService',
@@ -28,7 +28,7 @@ oppia.factory('explorationSaveService', [
   'StatesObjectFactory', 'UrlInterpolationService',
   function(
       $modal, $timeout, $rootScope, $log, $q,
-      alertsService, explorationData, explorationStatesService,
+      AlertsService, explorationData, explorationStatesService,
       explorationTagsService, explorationTitleService,
       explorationObjectiveService, explorationCategoryService,
       explorationLanguageCodeService, explorationRightsService,
@@ -58,15 +58,15 @@ oppia.factory('explorationSaveService', [
 
     var areRequiredFieldsFilled = function() {
       if (!explorationTitleService.displayed) {
-        alertsService.addWarning('Please specify a title');
+        AlertsService.addWarning('Please specify a title');
         return false;
       }
       if (!explorationObjectiveService.displayed) {
-        alertsService.addWarning('Please specify an objective');
+        AlertsService.addWarning('Please specify an objective');
         return false;
       }
       if (!explorationCategoryService.displayed) {
-        alertsService.addWarning('Please specify a category');
+        AlertsService.addWarning('Please specify a category');
         return false;
       }
 
@@ -80,8 +80,8 @@ oppia.factory('explorationSaveService', [
           'post_publish_modal_directive.html'),
         backdrop: true,
         controller: [
-          '$scope', '$modalInstance', 'explorationContextService',
-          function($scope, $modalInstance, explorationContextService) {
+          '$scope', '$modalInstance', 'ExplorationContextService',
+          function($scope, $modalInstance, ExplorationContextService) {
             $scope.congratsImgUrl = UrlInterpolationService.getStaticImageUrl(
               '/general/congrats.svg');
             $scope.DEFAULT_TWITTER_SHARE_MESSAGE_EDITOR = (
@@ -90,7 +90,7 @@ oppia.factory('explorationSaveService', [
               $modalInstance.dismiss('cancel');
             };
             $scope.explorationId = (
-              explorationContextService.getExplorationId());
+              ExplorationContextService.getExplorationId());
           }
         ]
       });
@@ -112,7 +112,7 @@ oppia.factory('explorationSaveService', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
               whenModalClosed.resolve();
             };
           }
@@ -176,7 +176,7 @@ oppia.factory('explorationSaveService', [
           $rootScope.$broadcast('refreshVersionHistory', {
             forceRefresh: true
           });
-          alertsService.addSuccessMessage('Changes saved.');
+          AlertsService.addSuccessMessage('Changes saved.');
           saveIsInProgress = false;
           whenSavingDone.resolve();
         }, function() {
@@ -216,7 +216,7 @@ oppia.factory('explorationSaveService', [
             }
           ]
         }).result.then(function() {
-          alertsService.clearWarnings();
+          AlertsService.clearWarnings();
           $rootScope.$broadcast('externalSave');
 
           $modal.open({
@@ -236,7 +236,7 @@ oppia.factory('explorationSaveService', [
           });
 
           changeListService.discardAllChanges();
-          alertsService.addSuccessMessage('Changes discarded.');
+          AlertsService.addSuccessMessage('Changes discarded.');
           $rootScope.$broadcast('initExplorationPage');
 
           // The reload is necessary because, otherwise, the
@@ -254,7 +254,7 @@ oppia.factory('explorationSaveService', [
 
         siteAnalyticsService.registerOpenPublishExplorationModalEvent(
           explorationData.explorationId);
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
 
         // If the metadata has not yet been specified, open the pre-publication
         // 'add exploration metadata' modal.
@@ -387,7 +387,7 @@ oppia.factory('explorationSaveService', [
                   explorationTagsService.restoreFromMemento();
 
                   $modalInstance.dismiss('cancel');
-                  alertsService.clearWarnings();
+                  AlertsService.clearWarnings();
                 };
               }
             ]
@@ -449,7 +449,7 @@ oppia.factory('explorationSaveService', [
             explorationWarningsService.countWarnings() > 0) {
           // If the exploration is not private, warnings should be fixed before
           // it can be saved.
-          alertsService.addWarning(explorationWarningsService.getWarnings()[0]);
+          AlertsService.addWarning(explorationWarningsService.getWarnings()[0]);
           return;
         }
 
@@ -477,7 +477,7 @@ oppia.factory('explorationSaveService', [
           // TODO(wxy): after diff supports exploration metadata, add a check to
           // exit if changes cancel each other out.
 
-          alertsService.clearWarnings();
+          AlertsService.clearWarnings();
 
           // If the modal is open, do not open another one.
           if (modalIsOpen) {
@@ -525,7 +525,7 @@ oppia.factory('explorationSaveService', [
                 };
                 $scope.cancel = function() {
                   $modalInstance.dismiss('cancel');
-                  alertsService.clearWarnings();
+                  AlertsService.clearWarnings();
                 };
               }
             ]

--- a/core/templates/dev/head/pages/exploration_editor/ParamChangesEditorDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/ParamChangesEditorDirective.js
@@ -30,11 +30,11 @@ oppia.directive('paramChangesEditor', [
         'param_changes_editor_directive.html'),
       controller: [
         '$scope', '$rootScope', 'editabilityService',
-        'explorationParamSpecsService', 'alertsService',
+        'explorationParamSpecsService', 'AlertsService',
         'ParamChangeObjectFactory',
         function(
             $scope, $rootScope, editabilityService,
-            explorationParamSpecsService, alertsService,
+            explorationParamSpecsService, AlertsService,
             ParamChangeObjectFactory) {
           $scope.editabilityService = editabilityService;
           $scope.isParamChangesEditorOpen = false;
@@ -171,7 +171,7 @@ oppia.directive('paramChangesEditor', [
           $scope.saveParamChanges = function() {
             // Validate displayed value.
             if (!$scope.areDisplayedParamChangesValid()) {
-              alertsService.addWarning('Invalid parameter changes.');
+              AlertsService.addWarning('Invalid parameter changes.');
               return;
             }
 
@@ -198,7 +198,7 @@ oppia.directive('paramChangesEditor', [
           $scope.deleteParamChange = function(index) {
             if (index < 0 ||
                 index >= $scope.paramChangesService.displayed.length) {
-              alertsService.addWarning(
+              AlertsService.addWarning(
                 'Cannot delete parameter change at position ' + index +
                 ': index out of range');
             }

--- a/core/templates/dev/head/pages/exploration_editor/UserEmailPreferencesService.js
+++ b/core/templates/dev/head/pages/exploration_editor/UserEmailPreferencesService.js
@@ -17,10 +17,10 @@
  */
 
 oppia.factory('UserEmailPreferencesService', [
-  '$http', '$q', 'explorationData', 'alertsService',
+  '$http', '$q', 'explorationData', 'AlertsService',
   'UrlInterpolationService',
   function(
-      $http, $q, explorationData, alertsService, UrlInterpolationService) {
+      $http, $q, explorationData, AlertsService, UrlInterpolationService) {
     var MESSAGE_TYPE_SUGGESTION = 'suggestion';
     var MESSAGE_TYPE_FEEDBACK = 'feedback';
     return {
@@ -58,7 +58,7 @@ oppia.factory('UserEmailPreferencesService', [
         $http.put(emailPreferencesUrl, requestParams).then(
           function(response) {
             var data = response.data;
-            alertsService.clearWarnings();
+            AlertsService.clearWarnings();
             that.init(
               data.email_preferences.mute_feedback_notifications,
               data.email_preferences.mute_suggestion_notifications);

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/ExplorationGraph.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/ExplorationGraph.js
@@ -17,11 +17,11 @@
  */
 
 oppia.controller('ExplorationGraph', [
-  '$scope', '$modal', 'editorContextService', 'alertsService',
+  '$scope', '$modal', 'editorContextService', 'AlertsService',
   'explorationStatesService', 'editabilityService', 'routerService',
   'graphDataService',
   function(
-      $scope, $modal, editorContextService, alertsService,
+      $scope, $modal, editorContextService, AlertsService,
       explorationStatesService, editabilityService, routerService,
       graphDataService) {
     $scope.getGraphData = graphDataService.getGraphData;
@@ -47,7 +47,7 @@ oppia.controller('ExplorationGraph', [
     };
 
     $scope.openStateGraphModal = function() {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
 
       $modal.open({
         templateUrl: 'modals/stateGraph',
@@ -83,7 +83,7 @@ oppia.controller('ExplorationGraph', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/SolutionVerificationService.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/SolutionVerificationService.js
@@ -17,10 +17,10 @@
  */
 
 oppia.factory('SolutionVerificationService', [
-  '$injector', 'stateInteractionIdService', 'explorationContextService',
+  '$injector', 'stateInteractionIdService', 'ExplorationContextService',
   'editorContextService', 'angularNameService', 'AnswerClassificationService',
   function(
-    $injector, stateInteractionIdService, explorationContextService,
+    $injector, stateInteractionIdService, ExplorationContextService,
     editorContextService, angularNameService, AnswerClassificationService) {
     return {
       verifySolution: function(

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateEditor.js
@@ -87,11 +87,11 @@ oppia.controller('StateEditor', [
 // A service which handles opening and closing the training modal used for both
 // unresolved answers and answers within the training data of a classifier.
 oppia.factory('trainingModalService', [
-  '$rootScope', '$modal', 'alertsService',
-  function($rootScope, $modal, alertsService) {
+  '$rootScope', '$modal', 'AlertsService',
+  function($rootScope, $modal, AlertsService) {
     return {
       openTrainUnresolvedAnswerModal: function(unhandledAnswer, externalSave) {
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
         if (externalSave) {
           $rootScope.$broadcast('externalSave');
         }
@@ -102,11 +102,11 @@ oppia.factory('trainingModalService', [
           controller: [
             '$scope', '$injector', '$modalInstance',
             'explorationStatesService', 'editorContextService',
-            'AnswerClassificationService', 'explorationContextService',
+            'AnswerClassificationService', 'ExplorationContextService',
             'stateInteractionIdService', 'angularNameService',
             function($scope, $injector, $modalInstance,
                 explorationStatesService, editorContextService,
-                AnswerClassificationService, explorationContextService,
+                AnswerClassificationService, ExplorationContextService,
                 stateInteractionIdService, angularNameService) {
               $scope.trainingDataAnswer = '';
               $scope.trainingDataFeedback = '';
@@ -125,7 +125,7 @@ oppia.factory('trainingModalService', [
 
               $scope.init = function() {
                 var explorationId =
-                  explorationContextService.getExplorationId();
+                  ExplorationContextService.getExplorationId();
                 var currentStateName =
                   editorContextService.getActiveStateName();
                 var state = explorationStatesService.getState(currentStateName);
@@ -383,12 +383,12 @@ oppia.directive('trainingPanel', [function() {
     },
     templateUrl: 'teaching/trainingPanel',
     controller: [
-      '$scope', 'oppiaExplorationHtmlFormatterService',
+      '$scope', 'OppiaExplorationHtmlFormatterService',
       'editorContextService', 'explorationStatesService',
       'trainingDataService', 'responsesService', 'stateInteractionIdService',
       'stateCustomizationArgsService', 'AnswerGroupObjectFactory',
       'OutcomeObjectFactory',
-      function($scope, oppiaExplorationHtmlFormatterService,
+      function($scope, OppiaExplorationHtmlFormatterService,
           editorContextService, explorationStatesService,
           trainingDataService, responsesService, stateInteractionIdService,
           stateCustomizationArgsService, AnswerGroupObjectFactory,
@@ -403,7 +403,7 @@ oppia.directive('trainingPanel', [function() {
 
         var _updateAnswerTemplate = function() {
           $scope.answerTemplate = (
-            oppiaExplorationHtmlFormatterService.getAnswerHtml(
+            OppiaExplorationHtmlFormatterService.getAnswerHtml(
               $scope.answer, stateInteractionIdService.savedMemento,
               stateCustomizationArgsService.savedMemento));
         };

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateHints.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateHints.js
@@ -18,13 +18,13 @@
 
 oppia.controller('StateHints', [
   '$scope', '$rootScope', '$modal', '$filter', 'editorContextService',
-  'alertsService', 'INTERACTION_SPECS', 'stateHintsService',
+  'AlertsService', 'INTERACTION_SPECS', 'stateHintsService',
   'explorationStatesService', 'stateInteractionIdService',
   'UrlInterpolationService', 'HintObjectFactory', 'oppiaPlayerService',
   'stateSolutionService',
   function(
     $scope, $rootScope, $modal, $filter, editorContextService,
-    alertsService, INTERACTION_SPECS, stateHintsService,
+    AlertsService, INTERACTION_SPECS, stateHintsService,
     explorationStatesService, stateInteractionIdService,
     UrlInterpolationService, HintObjectFactory, oppiaPlayerService,
     stateSolutionService) {
@@ -60,7 +60,7 @@ oppia.controller('StateHints', [
           openDeleteLastHintModal();
           return;
         } else {
-          alertsService.addInfoMessage('Deleting empty hint.');
+          AlertsService.addInfoMessage('Deleting empty hint.');
           stateHintsService.displayed.splice(currentActiveIndex, 1);
           stateHintsService.saveDisplayedValue();
         }
@@ -80,7 +80,7 @@ oppia.controller('StateHints', [
     };
 
     $scope.openAddHintModal = function() {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $rootScope.$broadcast('externalSave');
 
       $modal.open({
@@ -110,7 +110,7 @@ oppia.controller('StateHints', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]
@@ -142,7 +142,7 @@ oppia.controller('StateHints', [
     };
 
     var openDeleteLastHintModal = function() {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
 
       $modal.open({
         templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
@@ -157,7 +157,7 @@ oppia.controller('StateHints', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]
@@ -174,7 +174,7 @@ oppia.controller('StateHints', [
       // state of the hint.
       evt.stopPropagation();
 
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $modal.open({
         templateUrl: 'modals/deleteHint',
         backdrop: true,
@@ -186,7 +186,7 @@ oppia.controller('StateHints', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
@@ -18,20 +18,20 @@
 
 oppia.controller('StateInteraction', [
   '$scope', '$http', '$rootScope', '$modal', '$injector', '$filter',
-  'alertsService', 'editorContextService', 'oppiaHtmlEscaper',
+  'AlertsService', 'editorContextService', 'oppiaHtmlEscaper',
   'INTERACTION_SPECS', 'stateInteractionIdService',
   'stateCustomizationArgsService', 'editabilityService',
   'explorationStatesService', 'graphDataService', 
   'InteractionDetailsCacheService',
-  'oppiaExplorationHtmlFormatterService', 'UrlInterpolationService',
+  'OppiaExplorationHtmlFormatterService', 'UrlInterpolationService',
   'SubtitledHtmlObjectFactory', 'stateSolutionService', 'stateContentService',
   function($scope, $http, $rootScope, $modal, $injector, $filter,
-      alertsService, editorContextService, oppiaHtmlEscaper,
+      AlertsService, editorContextService, oppiaHtmlEscaper,
       INTERACTION_SPECS, stateInteractionIdService,
       stateCustomizationArgsService, editabilityService,
       explorationStatesService, graphDataService,
       InteractionDetailsCacheService,
-      oppiaExplorationHtmlFormatterService, UrlInterpolationService,
+      OppiaExplorationHtmlFormatterService, UrlInterpolationService,
       SubtitledHtmlObjectFactory, stateSolutionService, stateContentService) {
     var DEFAULT_TERMINAL_STATE_CONTENT = 'Congratulations, you have finished!';
 
@@ -66,7 +66,7 @@ oppia.controller('StateInteraction', [
       if (!stateInteractionIdService.savedMemento) {
         return '';
       }
-      return oppiaExplorationHtmlFormatterService.getInteractionHtml(
+      return OppiaExplorationHtmlFormatterService.getInteractionHtml(
         stateInteractionIdService.savedMemento, interactionCustomizationArgs);
     };
 
@@ -149,7 +149,7 @@ oppia.controller('StateInteraction', [
 
     $scope.openInteractionCustomizerModal = function() {
       if (editabilityService.isEditable()) {
-        alertsService.clearWarnings();
+        AlertsService.clearWarnings();
 
         $modal.open({
           templateUrl: 'modals/customizeInteraction',
@@ -323,7 +323,7 @@ oppia.controller('StateInteraction', [
     };
 
     $scope.deleteInteraction = function() {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $modal.open({
         templateUrl: 'modals/deleteInteraction',
         backdrop: true,
@@ -335,7 +335,7 @@ oppia.controller('StateInteraction', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
@@ -46,16 +46,16 @@ oppia.factory('responsesService', [
   '$rootScope', 'stateInteractionIdService', 'INTERACTION_SPECS',
   'answerGroupsCache', 'editorContextService', 'changeListService',
   'explorationStatesService', 'graphDataService', 'OutcomeObjectFactory',
-  'stateSolutionService', 'SolutionVerificationService', 'alertsService',
-  'explorationContextService', 'explorationWarningsService',
+  'stateSolutionService', 'SolutionVerificationService', 'AlertsService',
+  'ExplorationContextService', 'explorationWarningsService',
   'INFO_MESSAGE_SOLUTION_IS_VALID', 'INFO_MESSAGE_SOLUTION_IS_INVALID',
   'INFO_MESSAGE_SOLUTION_IS_INVALID_FOR_CURRENT_RULE',
   function(
       $rootScope, stateInteractionIdService, INTERACTION_SPECS,
       answerGroupsCache, editorContextService, changeListService,
       explorationStatesService, graphDataService, OutcomeObjectFactory,
-      stateSolutionService, SolutionVerificationService, alertsService,
-      explorationContextService, explorationWarningsService,
+      stateSolutionService, SolutionVerificationService, AlertsService,
+      ExplorationContextService, explorationWarningsService,
       INFO_MESSAGE_SOLUTION_IS_VALID, INFO_MESSAGE_SOLUTION_IS_INVALID,
       INFO_MESSAGE_SOLUTION_IS_INVALID_FOR_CURRENT_RULE) {
     var _answerGroupsMemento = null;
@@ -97,7 +97,7 @@ oppia.factory('responsesService', [
             explorationStatesService.isSolutionValid(
               editorContextService.getActiveStateName()));
           SolutionVerificationService.verifySolution(
-            explorationContextService.getExplorationId(),
+            ExplorationContextService.getExplorationId(),
             explorationStatesService.getState(currentStateName),
             stateSolutionService.savedMemento.correctAnswer,
             function() {
@@ -105,7 +105,7 @@ oppia.factory('responsesService', [
                 currentStateName, true);
               explorationWarningsService.updateWarnings();
               if (!solutionWasPreviouslyValid) {
-                alertsService.addInfoMessage(INFO_MESSAGE_SOLUTION_IS_VALID);
+                AlertsService.addInfoMessage(INFO_MESSAGE_SOLUTION_IS_VALID);
               }
             },
             function() {
@@ -113,10 +113,10 @@ oppia.factory('responsesService', [
                 currentStateName, false);
               explorationWarningsService.updateWarnings();
               if (solutionWasPreviouslyValid) {
-                alertsService.addInfoMessage(
+                AlertsService.addInfoMessage(
                   INFO_MESSAGE_SOLUTION_IS_INVALID_FOR_CURRENT_RULE);
               } else {
-                alertsService.addInfoMessage(INFO_MESSAGE_SOLUTION_IS_INVALID);
+                AlertsService.addInfoMessage(INFO_MESSAGE_SOLUTION_IS_INVALID);
               }
             }
           );
@@ -375,14 +375,14 @@ oppia.factory('responsesService', [
 
 oppia.controller('StateResponses', [
   '$scope', '$rootScope', '$modal', '$filter', 'stateInteractionIdService',
-  'editorContextService', 'alertsService', 'responsesService', 'routerService',
-  'explorationContextService', 'trainingDataService',
+  'editorContextService', 'AlertsService', 'responsesService', 'routerService',
+  'ExplorationContextService', 'trainingDataService',
   'stateCustomizationArgsService', 'PLACEHOLDER_OUTCOME_DEST',
   'INTERACTION_SPECS', 'UrlInterpolationService', 'AnswerGroupObjectFactory',
   function(
       $scope, $rootScope, $modal, $filter, stateInteractionIdService,
-      editorContextService, alertsService, responsesService, routerService,
-      explorationContextService, trainingDataService,
+      editorContextService, AlertsService, responsesService, routerService,
+      ExplorationContextService, trainingDataService,
       stateCustomizationArgsService, PLACEHOLDER_OUTCOME_DEST,
       INTERACTION_SPECS, UrlInterpolationService, AnswerGroupObjectFactory) {
     $scope.editorContextService = editorContextService;
@@ -391,7 +391,7 @@ oppia.controller('StateResponses', [
       '/general/drag_dots.png');
 
     var _initializeTrainingData = function() {
-      var explorationId = explorationContextService.getExplorationId();
+      var explorationId = ExplorationContextService.getExplorationId();
       var currentStateName = editorContextService.getActiveStateName();
       trainingDataService.initializeTrainingData(
         explorationId, currentStateName);
@@ -601,7 +601,7 @@ oppia.controller('StateResponses', [
     });
 
     $scope.openTeachOppiaModal = function() {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $rootScope.$broadcast('externalSave');
 
       $modal.open({
@@ -609,27 +609,27 @@ oppia.controller('StateResponses', [
         backdrop: false,
         controller: [
           '$scope', '$injector', '$modalInstance',
-          'oppiaExplorationHtmlFormatterService',
+          'OppiaExplorationHtmlFormatterService',
           'stateInteractionIdService', 'stateCustomizationArgsService',
-          'explorationContextService', 'editorContextService',
+          'ExplorationContextService', 'editorContextService',
           'explorationStatesService', 'trainingDataService',
           'AnswerClassificationService', 'focusService',
           'angularNameService', 'RULE_TYPE_CLASSIFIER',
           function(
               $scope, $injector, $modalInstance,
-              oppiaExplorationHtmlFormatterService,
+              OppiaExplorationHtmlFormatterService,
               stateInteractionIdService, stateCustomizationArgsService,
-              explorationContextService, editorContextService,
+              ExplorationContextService, editorContextService,
               explorationStatesService, trainingDataService,
               AnswerClassificationService, focusService,
               angularNameService, RULE_TYPE_CLASSIFIER) {
-            var _explorationId = explorationContextService.getExplorationId();
+            var _explorationId = ExplorationContextService.getExplorationId();
             var _stateName = editorContextService.getActiveStateName();
             var _state = explorationStatesService.getState(_stateName);
 
             $scope.stateContent = _state.content.getHtml();
             $scope.inputTemplate = (
-              oppiaExplorationHtmlFormatterService.getInteractionHtml(
+              OppiaExplorationHtmlFormatterService.getInteractionHtml(
                 stateInteractionIdService.savedMemento,
                 stateCustomizationArgsService.savedMemento,
                 'testInteractionInput'));
@@ -667,7 +667,7 @@ oppia.controller('StateResponses', [
 
             $scope.submitAnswer = function(answer) {
               $scope.answerTemplate = (
-                oppiaExplorationHtmlFormatterService.getAnswerHtml(
+                OppiaExplorationHtmlFormatterService.getAnswerHtml(
                   answer, stateInteractionIdService.savedMemento,
                   stateCustomizationArgsService.savedMemento));
 
@@ -710,7 +710,7 @@ oppia.controller('StateResponses', [
     };
 
     $scope.openAddAnswerGroupModal = function() {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $rootScope.$broadcast('externalSave');
 
       $modal.open({
@@ -772,7 +772,7 @@ oppia.controller('StateResponses', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]
@@ -816,7 +816,7 @@ oppia.controller('StateResponses', [
       // state of the answer group.
       evt.stopPropagation();
 
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $modal.open({
         templateUrl: 'modals/deleteAnswerGroup',
         backdrop: true,
@@ -828,7 +828,7 @@ oppia.controller('StateResponses', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateSolution.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateSolution.js
@@ -17,18 +17,18 @@
  */
 
 oppia.controller('StateSolution', [
-  '$scope', '$rootScope', '$modal', 'editorContextService', 'alertsService',
+  '$scope', '$rootScope', '$modal', 'editorContextService', 'AlertsService',
   'INTERACTION_SPECS', 'stateSolutionService', 'explorationStatesService',
-  'SolutionVerificationService', 'oppiaExplorationHtmlFormatterService',
+  'SolutionVerificationService', 'OppiaExplorationHtmlFormatterService',
   'stateInteractionIdService', 'stateHintsService', 'UrlInterpolationService',
-  'SolutionObjectFactory', 'explorationContextService',
+  'SolutionObjectFactory', 'ExplorationContextService',
   'explorationWarningsService', 'INFO_MESSAGE_SOLUTION_IS_INVALID',
   function(
-    $scope, $rootScope, $modal, editorContextService, alertsService,
+    $scope, $rootScope, $modal, editorContextService, AlertsService,
     INTERACTION_SPECS, stateSolutionService, explorationStatesService,
-    SolutionVerificationService, oppiaExplorationHtmlFormatterService,
+    SolutionVerificationService, OppiaExplorationHtmlFormatterService,
     stateInteractionIdService, stateHintsService, UrlInterpolationService,
-    SolutionObjectFactory, explorationContextService,
+    SolutionObjectFactory, ExplorationContextService,
     explorationWarningsService, INFO_MESSAGE_SOLUTION_IS_INVALID) {
     $scope.correctAnswer = null;
     $scope.correctAnswerEditorHtml = '';
@@ -48,7 +48,7 @@ oppia.controller('StateSolution', [
     };
 
     $scope.correctAnswerEditorHtml = (
-      oppiaExplorationHtmlFormatterService.getInteractionHtml(
+      OppiaExplorationHtmlFormatterService.getInteractionHtml(
         stateInteractionIdService.savedMemento,
         explorationStatesService.getInteractionCustomizationArgsMemento(
           editorContextService.getActiveStateName()),
@@ -72,7 +72,7 @@ oppia.controller('StateSolution', [
     };
 
     $scope.openAddOrUpdateSolutionModal = function() {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $rootScope.$broadcast('externalSave');
       $scope.inlineSolutionEditorIsActive = false;
 
@@ -87,7 +87,7 @@ oppia.controller('StateSolution', [
             $scope, $modalInstance, stateSolutionService) {
             $scope.stateSolutionService = stateSolutionService;
             $scope.correctAnswerEditorHtml = (
-              oppiaExplorationHtmlFormatterService.getInteractionHtml(
+              OppiaExplorationHtmlFormatterService.getInteractionHtml(
                 stateInteractionIdService.savedMemento,
                 explorationStatesService.getInteractionCustomizationArgsMemento(
                   editorContextService.getActiveStateName()),
@@ -118,7 +118,7 @@ oppia.controller('StateSolution', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]
@@ -127,7 +127,7 @@ oppia.controller('StateSolution', [
         var currentStateName = editorContextService.getActiveStateName();
         var state = explorationStatesService.getState(currentStateName);
         SolutionVerificationService.verifySolution(
-          explorationContextService.getExplorationId(),
+          ExplorationContextService.getExplorationId(),
           state,
           correctAnswer,
           function () {
@@ -139,7 +139,7 @@ oppia.controller('StateSolution', [
             explorationStatesService.updateSolutionValidity(
               currentStateName, false);
             explorationWarningsService.updateWarnings();
-            alertsService.addInfoMessage(INFO_MESSAGE_SOLUTION_IS_INVALID);
+            AlertsService.addInfoMessage(INFO_MESSAGE_SOLUTION_IS_INVALID);
           }
         );
 
@@ -151,7 +151,7 @@ oppia.controller('StateSolution', [
     $scope.deleteSolution = function(evt) {
       evt.stopPropagation();
 
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $modal.open({
         templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
           '/pages/exploration_editor/editor_tab/delete_solution_modal.html'),
@@ -165,7 +165,7 @@ oppia.controller('StateSolution', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateStatistics.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateStatistics.js
@@ -20,12 +20,12 @@
 oppia.controller('StateStatistics', [
   '$rootScope', '$scope', '$modal', 'explorationData', 'editorContextService',
   'explorationStatesService', 'trainingDataService',
-  'stateCustomizationArgsService', 'oppiaExplorationHtmlFormatterService',
+  'stateCustomizationArgsService', 'OppiaExplorationHtmlFormatterService',
   'trainingModalService', 'INTERACTION_SPECS',
   function(
       $rootScope, $scope, $modal, explorationData, editorContextService,
       explorationStatesService, trainingDataService,
-      stateCustomizationArgsService, oppiaExplorationHtmlFormatterService,
+      stateCustomizationArgsService, OppiaExplorationHtmlFormatterService,
       trainingModalService, INTERACTION_SPECS) {
     $scope.isInteractionTrainable = false;
 
@@ -44,7 +44,7 @@ oppia.controller('StateStatistics', [
           trainingDataService.getTrainingDataFrequencies());
         for (var i = 0; i < trainingDataAnswers.length; i++) {
           var answerHtml = (
-            oppiaExplorationHtmlFormatterService.getShortAnswerHtml(
+            OppiaExplorationHtmlFormatterService.getShortAnswerHtml(
               trainingDataAnswers[i], data.interaction.id,
               stateCustomizationArgsService.savedMemento));
           $scope.trainingDataButtonContentsList.push({

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -196,7 +196,7 @@
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/SolutionExplanationEditorDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/StateGraphLayoutService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/VersionDiffVisualizationDirective.js"></script>
-  <script src="{{TEMPLATE_DIR_PREFIX}}/services/autoplayedVideosService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/AutoplayedVideosService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/CircularImageDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
@@ -17,13 +17,13 @@
  */
 
 oppia.controller('FeedbackTab', [
-  '$scope', '$http', '$modal', '$timeout', '$rootScope', 'alertsService',
+  '$scope', '$http', '$modal', '$timeout', '$rootScope', 'AlertsService',
   'oppiaDatetimeFormatter', 'threadStatusDisplayService',
   'threadDataService', 'explorationStatesService', 'explorationData',
   'changeListService', 'StateObjectFactory', 'ACTION_ACCEPT_SUGGESTION',
   'ACTION_REJECT_SUGGESTION',
   function(
-    $scope, $http, $modal, $timeout, $rootScope, alertsService,
+    $scope, $http, $modal, $timeout, $rootScope, AlertsService,
     oppiaDatetimeFormatter, threadStatusDisplayService,
     threadDataService, explorationStatesService, explorationData,
     changeListService, StateObjectFactory, ACTION_ACCEPT_SUGGESTION,
@@ -66,11 +66,11 @@ oppia.controller('FeedbackTab', [
 
           $scope.create = function(newThreadSubject, newThreadText) {
             if (!newThreadSubject) {
-              alertsService.addWarning('Please specify a thread subject.');
+              AlertsService.addWarning('Please specify a thread subject.');
               return;
             }
             if (!newThreadText) {
-              alertsService.addWarning('Please specify a message.');
+              AlertsService.addWarning('Please specify a message.');
               return;
             }
 
@@ -88,7 +88,7 @@ oppia.controller('FeedbackTab', [
         threadDataService.createNewThread(
           result.newThreadSubject, result.newThreadText, function() {
             $scope.clearActiveThread();
-            alertsService.addSuccessMessage('Feedback thread created.');
+            AlertsService.addSuccessMessage('Feedback thread created.');
           });
       });
     };
@@ -241,11 +241,11 @@ oppia.controller('FeedbackTab', [
 
     $scope.addNewMessage = function(threadId, tmpText, tmpStatus) {
       if (threadId === null) {
-        alertsService.addWarning('Cannot add message to thread with ID: null.');
+        AlertsService.addWarning('Cannot add message to thread with ID: null.');
         return;
       }
       if (!tmpStatus) {
-        alertsService.addWarning('Invalid message status: ' + tmpStatus);
+        AlertsService.addWarning('Invalid message status: ' + tmpStatus);
         return;
       }
 

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadDataService.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadDataService.js
@@ -18,9 +18,9 @@
  */
 
 oppia.factory('threadDataService', [
-  '$http', '$q', 'explorationData', 'alertsService', 'ACTION_ACCEPT_SUGGESTION',
+  '$http', '$q', 'explorationData', 'AlertsService', 'ACTION_ACCEPT_SUGGESTION',
   function(
-      $http, $q, explorationData, alertsService, ACTION_ACCEPT_SUGGESTION) {
+      $http, $q, explorationData, AlertsService, ACTION_ACCEPT_SUGGESTION) {
     var _expId = explorationData.explorationId;
     var _FEEDBACK_STATS_HANDLER_URL = '/feedbackstatshandler/' + _expId;
     var _THREAD_LIST_HANDLER_URL = '/threadlisthandler/' + _expId;
@@ -102,7 +102,7 @@ oppia.factory('threadDataService', [
           }
         }, function() {
           _openThreadsCount -= 1;
-          alertsService.addWarning('Error creating new thread.');
+          AlertsService.addWarning('Error creating new thread.');
         });
       },
       markThreadAsSeen: function(threadId) {

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
@@ -22,7 +22,7 @@ oppia.controller('SettingsTab', [
   'explorationObjectiveService', 'explorationLanguageCodeService',
   'explorationTagsService', 'explorationRightsService',
   'explorationInitStateNameService', 'explorationParamSpecsService',
-  'changeListService', 'alertsService', 'explorationStatesService',
+  'changeListService', 'AlertsService', 'explorationStatesService',
   'explorationParamChangesService', 'explorationWarningsService',
   'explorationAdvancedFeaturesService', 'ALL_CATEGORIES',
   'EXPLORATION_TITLE_INPUT_FOCUS_LABEL', 'UserEmailPreferencesService',
@@ -33,7 +33,7 @@ oppia.controller('SettingsTab', [
       explorationObjectiveService, explorationLanguageCodeService,
       explorationTagsService, explorationRightsService,
       explorationInitStateNameService, explorationParamSpecsService,
-      changeListService, alertsService, explorationStatesService,
+      changeListService, AlertsService, explorationStatesService,
       explorationParamChangesService, explorationWarningsService,
       explorationAdvancedFeaturesService, ALL_CATEGORIES,
       EXPLORATION_TITLE_INPUT_FOCUS_LABEL, UserEmailPreferencesService,
@@ -145,7 +145,7 @@ oppia.controller('SettingsTab', [
       var newInitStateName = explorationInitStateNameService.displayed;
 
       if (!explorationStatesService.getState(newInitStateName)) {
-        alertsService.addWarning(
+        AlertsService.addWarning(
           'Invalid initial state name: ' + newInitStateName);
         explorationInitStateNameService.restoreFromMemento();
         return;
@@ -216,7 +216,7 @@ oppia.controller('SettingsTab', [
     * Methods relating to control buttons.
     ********************************************/
     $scope.previewSummaryTile = function() {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $modal.open({
         templateUrl: 'modals/previewSummaryTile',
         backdrop: true,
@@ -250,7 +250,7 @@ oppia.controller('SettingsTab', [
 
             $scope.close = function() {
               $modalInstance.dismiss();
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]
@@ -258,7 +258,7 @@ oppia.controller('SettingsTab', [
     };
 
     $scope.showTransferExplorationOwnershipModal = function() {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $modal.open({
         templateUrl: 'modals/transferExplorationOwnership',
         backdrop: true,
@@ -268,7 +268,7 @@ oppia.controller('SettingsTab', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]
@@ -278,7 +278,7 @@ oppia.controller('SettingsTab', [
     };
 
     $scope.deleteExploration = function() {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
 
       $modal.open({
         templateUrl: 'modals/deleteExploration',
@@ -289,7 +289,7 @@ oppia.controller('SettingsTab', [
 
             $scope.cancel = function() {
               $modalInstance.dismiss('cancel');
-              alertsService.clearWarnings();
+              AlertsService.clearWarnings();
             };
           }
         ]
@@ -302,7 +302,7 @@ oppia.controller('SettingsTab', [
     };
 
     var openModalForModeratorAction = function(action) {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
 
       var moderatorEmailDraftUrl = '/moderatorhandler/email_draft/' + action;
 
@@ -343,7 +343,7 @@ oppia.controller('SettingsTab', [
 
               $scope.cancel = function() {
                 $modalInstance.dismiss('cancel');
-                alertsService.clearWarnings();
+                AlertsService.clearWarnings();
               };
             }
           ]

--- a/core/templates/dev/head/pages/exploration_editor/statistics_tab/StatisticsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/statistics_tab/StatisticsTab.js
@@ -20,12 +20,12 @@
 oppia.constant('IMPROVE_TYPE_INCOMPLETE', 'incomplete');
 
 oppia.controller('StatisticsTab', [
-  '$scope', '$http', '$modal', 'alertsService', 'explorationStatesService',
+  '$scope', '$http', '$modal', 'AlertsService', 'explorationStatesService',
   'explorationData', 'computeGraphService', 'oppiaDatetimeFormatter',
   'StatesObjectFactory', 'StateImprovementSuggestionService',
   'ReadOnlyExplorationBackendApiService', 'IMPROVE_TYPE_INCOMPLETE',
   function(
-      $scope, $http, $modal, alertsService, explorationStatesService,
+      $scope, $http, $modal, AlertsService, explorationStatesService,
       explorationData, computeGraphService, oppiaDatetimeFormatter,
       StatesObjectFactory, StateImprovementSuggestionService,
       ReadOnlyExplorationBackendApiService, IMPROVE_TYPE_INCOMPLETE) {
@@ -125,7 +125,7 @@ oppia.controller('StatisticsTab', [
     };
 
     $scope.showStateStatsModal = function(stateName, improvementType) {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
 
       $http.get(
         '/createhandler/state_rules_stats/' + $scope.explorationId + '/' +
@@ -178,7 +178,7 @@ oppia.controller('StatisticsTab', [
 
               $scope.cancel = function() {
                 $modalInstance.dismiss('cancel');
-                alertsService.clearWarnings();
+                AlertsService.clearWarnings();
               };
             }
           ]

--- a/core/templates/dev/head/pages/exploration_player/AnswerClassificationService.js
+++ b/core/templates/dev/head/pages/exploration_player/AnswerClassificationService.js
@@ -26,13 +26,13 @@ oppia.constant('STATISTICAL_CLASSIFICATION', 'statistical_classifier')
 oppia.constant('DEFAULT_OUTCOME_CLASSIFICATION', 'default_outcome')
 
 oppia.factory('AnswerClassificationService', [
-  '$http', 'LearnerParamsService', 'alertsService',
+  '$http', 'LearnerParamsService', 'AlertsService',
   'AnswerClassificationResultObjectFactory',
   'PredictionAlgorithmRegistryService', 'StateClassifierMappingService',
   'INTERACTION_SPECS', 'ENABLE_ML_CLASSIFIERS', 'EXPLICIT_CLASSIFICATION',
   'DEFAULT_OUTCOME_CLASSIFICATION', 'STATISTICAL_CLASSIFICATION',
   'RULE_TYPE_CLASSIFIER',
-  function($http, LearnerParamsService, alertsService,
+  function($http, LearnerParamsService, AlertsService,
       AnswerClassificationResultObjectFactory,
       PredictionAlgorithmRegistryService, StateClassifierMappingService,
       INTERACTION_SPECS, ENABLE_ML_CLASSIFIERS, EXPLICIT_CLASSIFICATION,
@@ -73,7 +73,7 @@ oppia.factory('AnswerClassificationService', [
           defaultOutcome, answerGroups.length, 0, DEFAULT_OUTCOME_CLASSIFICATION
         );
       } else {
-        alertsService.addWarning('Something went wrong with the exploration.');
+        AlertsService.addWarning('Something went wrong with the exploration.');
       }
     };
 
@@ -124,7 +124,7 @@ oppia.factory('AnswerClassificationService', [
           answerClassificationResult = classifyAnswer(
             answer, answerGroups, defaultOutcome, interactionRulesService);
         } else {
-          alertsService.addWarning(
+          AlertsService.addWarning(
             'Something went wrong with the exploration: no ' +
             'interactionRulesService was available.');
           throw Error(

--- a/core/templates/dev/head/pages/exploration_player/AudioPreloaderService.js
+++ b/core/templates/dev/head/pages/exploration_player/AudioPreloaderService.js
@@ -17,10 +17,10 @@
  */
 
 oppia.factory('AudioPreloaderService', [
-  '$modal', 'explorationContextService', 'AssetsBackendApiService',
+  '$modal', 'ExplorationContextService', 'AssetsBackendApiService',
   'ExplorationPlayerStateService', 'UrlInterpolationService',
   'AudioTranslationManagerService', 'LanguageUtilService',
-  function($modal, explorationContextService, AssetsBackendApiService,
+  function($modal, ExplorationContextService, AssetsBackendApiService,
       ExplorationPlayerStateService, UrlInterpolationService,
       AudioTranslationManagerService, LanguageUtilService) {
     // List of languages that have been preloaded in the exploration.
@@ -33,7 +33,7 @@ oppia.factory('AudioPreloaderService', [
 
       allAudioTranslations.map(function(audioTranslation) {
         AssetsBackendApiService.loadAudio(
-          explorationContextService.getExplorationId(),
+          ExplorationContextService.getExplorationId(),
           audioTranslation.filename);
       });
 

--- a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
@@ -253,7 +253,7 @@ oppia.directive('conversationSkin', [
         'playerPositionService', 'explorationRecommendationsService',
         'StatsReportingService',
         'siteAnalyticsService', 'ExplorationPlayerStateService',
-        'TWO_CARD_THRESHOLD_PX', 'CONTENT_FOCUS_LABEL_PREFIX', 'alertsService',
+        'TWO_CARD_THRESHOLD_PX', 'CONTENT_FOCUS_LABEL_PREFIX', 'AlertsService',
         'CONTINUE_BUTTON_FOCUS_LABEL', 'EVENT_ACTIVE_CARD_CHANGED',
         'FatigueDetectionService',
         function(
@@ -264,7 +264,7 @@ oppia.directive('conversationSkin', [
             playerPositionService, explorationRecommendationsService,
             StatsReportingService,
             siteAnalyticsService, ExplorationPlayerStateService,
-            TWO_CARD_THRESHOLD_PX, CONTENT_FOCUS_LABEL_PREFIX, alertsService,
+            TWO_CARD_THRESHOLD_PX, CONTENT_FOCUS_LABEL_PREFIX, AlertsService,
             CONTINUE_BUTTON_FOCUS_LABEL, EVENT_ACTIVE_CARD_CHANGED,
             FatigueDetectionService) {
           $scope.CONTINUE_BUTTON_FOCUS_LABEL = CONTINUE_BUTTON_FOCUS_LABEL;
@@ -784,7 +784,7 @@ oppia.directive('conversationSkin', [
                 $scope.collectionSummary = response.data.summaries[0];
               },
               function() {
-                alertsService.addWarning(
+                AlertsService.addWarning(
                   'There was an error while fetching the collection summary.');
               }
             );

--- a/core/templates/dev/head/pages/exploration_player/ExplorationFooterDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ExplorationFooterDirective.js
@@ -28,12 +28,12 @@ oppia.directive('explorationFooter', [
         '/pages/exploration_player/' +
         'exploration_footer_directive.html'),
       controller: [
-        '$scope', '$http', '$log', 'explorationContextService',
+        '$scope', '$http', '$log', 'ExplorationContextService',
         'ExplorationSummaryBackendApiService', 'windowDimensionsService',
         function(
-            $scope, $http, $log, explorationContextService,
+            $scope, $http, $log, ExplorationContextService,
             ExplorationSummaryBackendApiService, windowDimensionsService) {
-          $scope.explorationId = explorationContextService.getExplorationId();
+          $scope.explorationId = ExplorationContextService.getExplorationId();
 
           $scope.getStaticImageUrl = UrlInterpolationService.getStaticImageUrl;
 

--- a/core/templates/dev/head/pages/exploration_player/ExplorationRecommendationsService.js
+++ b/core/templates/dev/head/pages/exploration_player/ExplorationRecommendationsService.js
@@ -18,18 +18,18 @@
  */
 
 oppia.factory('explorationRecommendationsService', [
-  '$http', 'urlService', 'explorationContextService', 'PAGE_CONTEXT',
+  '$http', 'urlService', 'ExplorationContextService', 'PAGE_CONTEXT',
   'EDITOR_TAB_CONTEXT',
   function(
-      $http, urlService, explorationContextService, PAGE_CONTEXT,
+      $http, urlService, ExplorationContextService, PAGE_CONTEXT,
       EDITOR_TAB_CONTEXT) {
     var isIframed = urlService.isIframed();
     var isInEditorPage = (
-      explorationContextService.getPageContext() === PAGE_CONTEXT.EDITOR);
+      ExplorationContextService.getPageContext() === PAGE_CONTEXT.EDITOR);
     var isInEditorPreviewMode = isInEditorPage && (
-      explorationContextService.getEditorTabContext() ===
+      ExplorationContextService.getEditorTabContext() ===
       EDITOR_TAB_CONTEXT.PREVIEW);
-    var explorationId = explorationContextService.getExplorationId();
+    var explorationId = ExplorationContextService.getExplorationId();
 
     return {
       getRecommendedSummaryDicts: function(

--- a/core/templates/dev/head/pages/exploration_player/FeedbackPopupDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/FeedbackPopupDirective.js
@@ -36,11 +36,11 @@ oppia.directive('feedbackPopup', [
         '/pages/exploration_player/feedback_popup_directive.html'),
       controller: [
         '$scope', '$element', '$http', '$timeout', 'focusService',
-        'alertsService', 'BackgroundMaskService', 'playerPositionService',
+        'AlertsService', 'BackgroundMaskService', 'playerPositionService',
         'windowDimensionsService',
         function(
             $scope, $element, $http, $timeout, focusService,
-            alertsService, BackgroundMaskService, playerPositionService,
+            AlertsService, BackgroundMaskService, playerPositionService,
             windowDimensionsService) {
           $scope.feedbackText = '';
           $scope.isSubmitterAnonymized = false;

--- a/core/templates/dev/head/pages/exploration_player/InputResponsePairDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/InputResponsePairDirective.js
@@ -30,11 +30,11 @@ oppia.directive('inputResponsePair', [
         'input_response_pair_directive.html'),
       controller: [
         '$scope', 'oppiaPlayerService', 'playerTranscriptService',
-        'oppiaExplorationHtmlFormatterService', 'INTERACTION_SPECS',
+        'OppiaExplorationHtmlFormatterService', 'INTERACTION_SPECS',
         'playerPositionService',
         function(
             $scope, oppiaPlayerService, playerTranscriptService,
-            oppiaExplorationHtmlFormatterService, INTERACTION_SPECS,
+            OppiaExplorationHtmlFormatterService, INTERACTION_SPECS,
             playerPositionService) {
           $scope.isCurrentCardAtEndOfTranscript = function() {
             return playerTranscriptService.isLastCard(
@@ -45,7 +45,7 @@ oppia.directive('inputResponsePair', [
             var interaction = oppiaPlayerService.getInteraction(
               playerPositionService.getCurrentStateName());
             if ($scope.data) {
-              return oppiaExplorationHtmlFormatterService.getAnswerHtml(
+              return OppiaExplorationHtmlFormatterService.getAnswerHtml(
                 $scope.data.learnerInput, interaction.id,
                 interaction.customizationArgs);
             }
@@ -60,7 +60,7 @@ oppia.directive('inputResponsePair', [
             if ($scope.data && interaction.id &&
                 INTERACTION_SPECS[interaction.id].needs_summary) {
               shortAnswerHtml = (
-                oppiaExplorationHtmlFormatterService.getShortAnswerHtml(
+                OppiaExplorationHtmlFormatterService.getShortAnswerHtml(
                   $scope.data.learnerInput, interaction.id,
                   interaction.customizationArgs));
             }

--- a/core/templates/dev/head/pages/exploration_player/LearnerLocalNav.js
+++ b/core/templates/dev/head/pages/exploration_player/LearnerLocalNav.js
@@ -19,9 +19,9 @@ oppia.constant(
   'FLAG_EXPLORATION_URL_TEMPLATE', '/flagexplorationhandler/<exploration_id>');
 
 oppia.controller('LearnerLocalNav', [
-  '$scope', '$modal', '$http', 'oppiaPlayerService', 'alertsService',
+  '$scope', '$modal', '$http', 'oppiaPlayerService', 'AlertsService',
   'UrlInterpolationService', 'focusService', 'FLAG_EXPLORATION_URL_TEMPLATE',
-  function($scope, $modal, $http, oppiaPlayerService, alertsService,
+  function($scope, $modal, $http, oppiaPlayerService, AlertsService,
     UrlInterpolationService, focusService, FLAG_EXPLORATION_URL_TEMPLATE) {
     $scope.explorationId = oppiaPlayerService.getExplorationId();
     $scope.showLearnerSuggestionModal = function() {
@@ -67,7 +67,7 @@ oppia.controller('LearnerLocalNav', [
           description: result.description,
           suggestion_html: result.suggestionHtml
         }).error(function(res) {
-          alertsService.addWarning(res);
+          AlertsService.addWarning(res);
         });
         $modal.open({
           templateUrl: 'modals/learnerSuggestionSubmitted',
@@ -130,7 +130,7 @@ oppia.controller('LearnerLocalNav', [
         $http.post(flagExplorationUrl, {
           report_text: report
         }).error(function(error) {
-          alertsService.addWarning(error);
+          AlertsService.addWarning(error);
         });
         $modal.open({
           templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(

--- a/core/templates/dev/head/pages/exploration_player/LearnerViewInfo.js
+++ b/core/templates/dev/head/pages/exploration_player/LearnerViewInfo.js
@@ -18,11 +18,11 @@
  */
 
 oppia.controller('LearnerViewInfo', [
-  '$scope', '$modal', '$http', '$log', 'explorationContextService',
+  '$scope', '$modal', '$http', '$log', 'ExplorationContextService',
   'EXPLORATION_SUMMARY_DATA_URL_TEMPLATE', 'UrlInterpolationService',
-  function($scope, $modal, $http, $log, explorationContextService,
+  function($scope, $modal, $http, $log, ExplorationContextService,
     EXPLORATION_SUMMARY_DATA_URL_TEMPLATE, UrlInterpolationService) {
-    var explorationId = explorationContextService.getExplorationId();
+    var explorationId = ExplorationContextService.getExplorationId();
     var expInfo = null;
 
     $scope.showInformationCard = function() {

--- a/core/templates/dev/head/pages/exploration_player/PlayerServices.js
+++ b/core/templates/dev/head/pages/exploration_player/PlayerServices.js
@@ -26,8 +26,8 @@ oppia.constant('INTERACTION_SPECS', GLOBALS.INTERACTION_SPECS);
 // in the learner view, or whether it is being previewed in the editor view.
 oppia.factory('oppiaPlayerService', [
   '$http', '$rootScope', '$q', 'LearnerParamsService',
-  'alertsService', 'AnswerClassificationService', 'explorationContextService',
-  'PAGE_CONTEXT', 'oppiaExplorationHtmlFormatterService',
+  'AlertsService', 'AnswerClassificationService', 'ExplorationContextService',
+  'PAGE_CONTEXT', 'OppiaExplorationHtmlFormatterService',
   'playerTranscriptService', 'ExplorationObjectFactory',
   'ExpressionInterpolationService', 'StateClassifierMappingService',
   'StatsReportingService', 'UrlInterpolationService',
@@ -36,17 +36,17 @@ oppia.factory('oppiaPlayerService', [
   'LanguageUtilService',
   function(
       $http, $rootScope, $q, LearnerParamsService,
-      alertsService, AnswerClassificationService, explorationContextService,
-      PAGE_CONTEXT, oppiaExplorationHtmlFormatterService,
+      AlertsService, AnswerClassificationService, ExplorationContextService,
+      PAGE_CONTEXT, OppiaExplorationHtmlFormatterService,
       playerTranscriptService, ExplorationObjectFactory,
       ExpressionInterpolationService, StateClassifierMappingService,
       StatsReportingService, UrlInterpolationService,
       ReadOnlyExplorationBackendApiService,
       EditableExplorationBackendApiService, AudioTranslationManagerService,
       LanguageUtilService) {
-    var _explorationId = explorationContextService.getExplorationId();
+    var _explorationId = ExplorationContextService.getExplorationId();
     var _editorPreviewMode = (
-      explorationContextService.getPageContext() === PAGE_CONTEXT.EDITOR);
+      ExplorationContextService.getPageContext() === PAGE_CONTEXT.EDITOR);
     var _isLoggedIn = GLOBALS.userIsLoggedIn;
     var answerIsBeingProcessed = false;
 
@@ -109,13 +109,13 @@ oppia.factory('oppiaPlayerService', [
       var newParams = makeParams(
         oldParams, initialState.paramChanges, [oldParams]);
       if (newParams === null) {
-        alertsService.addWarning('Expression parsing error.');
+        AlertsService.addWarning('Expression parsing error.');
         return;
       }
 
       var questionHtml = makeQuestion(initialState, [newParams]);
       if (questionHtml === null) {
-        alertsService.addWarning('Expression parsing error.');
+        AlertsService.addWarning('Expression parsing error.');
         return;
       }
 
@@ -269,7 +269,7 @@ oppia.factory('oppiaPlayerService', [
           return null;
         }
 
-        return oppiaExplorationHtmlFormatterService.getInteractionHtml(
+        return OppiaExplorationHtmlFormatterService.getInteractionHtml(
           interactionId,
           exploration.getInteractionCustomizationArgs(stateName),
           labelForFocusTarget);
@@ -336,7 +336,7 @@ oppia.factory('oppiaPlayerService', [
         var feedbackHtml = makeFeedback(outcome.feedback, [oldParams]);
         if (feedbackHtml === null) {
           answerIsBeingProcessed = false;
-          alertsService.addWarning('Expression parsing error.');
+          AlertsService.addWarning('Expression parsing error.');
           return;
         }
 
@@ -345,7 +345,7 @@ oppia.factory('oppiaPlayerService', [
             oldParams, newState.paramChanges, [oldParams]) : oldParams);
         if (newParams === null) {
           answerIsBeingProcessed = false;
-          alertsService.addWarning('Expression parsing error.');
+          AlertsService.addWarning('Expression parsing error.');
           return;
         }
 
@@ -354,7 +354,7 @@ oppia.factory('oppiaPlayerService', [
         }]);
         if (questionHtml === null) {
           answerIsBeingProcessed = false;
-          alertsService.addWarning('Expression parsing error.');
+          AlertsService.addWarning('Expression parsing error.');
           return;
         }
 

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -123,7 +123,7 @@
   <script src="{{ASSET_DIR_PREFIX}}/extensions/objects/templates/MathLatexStringEditor.js"></script>
   <script src="{{ASSET_DIR_PREFIX}}/extensions/objects/templates/SanitizedUrlEditor.js"></script>
 
-  <script src="{{TEMPLATE_DIR_PREFIX}}/services/autoplayedVideosService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/AutoplayedVideosService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/services/explorationServices.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/services/messengerService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/services/AudioPlayerService.js"></script>

--- a/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
+++ b/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
@@ -67,7 +67,7 @@ oppia.constant('FEEDBACK_THREADS_SORT_BY_KEYS_AND_I18N_IDS', {
 });
 
 oppia.controller('LearnerDashboard', [
-  '$scope', '$rootScope', '$window', '$http', '$modal', 'alertsService',
+  '$scope', '$rootScope', '$window', '$http', '$modal', 'AlertsService',
   'EXPLORATIONS_SORT_BY_KEYS_AND_I18N_IDS',
   'SUBSCRIPTION_SORT_BY_KEYS_AND_I18N_IDS', 'FATAL_ERROR_CODES', 
   'LearnerDashboardBackendApiService', 'UrlInterpolationService',
@@ -76,7 +76,7 @@ oppia.controller('LearnerDashboard', [
   'oppiaDatetimeFormatter', 'FEEDBACK_THREADS_SORT_BY_KEYS_AND_I18N_IDS',
   'FeedbackThreadSummaryObjectFactory', 'FeedbackMessageSummaryObjectFactory',
   function(
-      $scope, $rootScope, $window, $http, $modal, alertsService,
+      $scope, $rootScope, $window, $http, $modal, AlertsService,
       EXPLORATIONS_SORT_BY_KEYS_AND_I18N_IDS,
       SUBSCRIPTION_SORT_BY_KEYS_AND_I18N_IDS, FATAL_ERROR_CODES,
       LearnerDashboardBackendApiService, UrlInterpolationService,
@@ -568,7 +568,7 @@ oppia.controller('LearnerDashboard', [
       },
       function(errorResponse) {
         if (FATAL_ERROR_CODES.indexOf(errorResponse.status) !== -1) {
-          alertsService.addWarning('Failed to get learner dashboard data');
+          AlertsService.addWarning('Failed to get learner dashboard data');
         }
       }
     );

--- a/core/templates/dev/head/pages/library/Library.js
+++ b/core/templates/dev/head/pages/library/Library.js
@@ -30,14 +30,14 @@ oppia.controller('Library', [
   '$scope', '$http', '$modal', '$rootScope', '$window', '$timeout',
   'i18nIdService', 'urlService', 'ALL_CATEGORIES', 'searchService',
   'windowDimensionsService', 'UrlInterpolationService', 'LIBRARY_PAGE_MODES',
-  'LIBRARY_TILE_WIDTH_PX', 'alertsService',
+  'LIBRARY_TILE_WIDTH_PX', 'AlertsService',
   'LearnerDashboardIdsBackendApiService',
   'LearnerDashboardActivityIdsObjectFactory', 'LearnerPlaylistService',
   function(
       $scope, $http, $modal, $rootScope, $window, $timeout,
       i18nIdService, urlService, ALL_CATEGORIES, searchService,
       windowDimensionsService, UrlInterpolationService, LIBRARY_PAGE_MODES,
-      LIBRARY_TILE_WIDTH_PX, alertsService,
+      LIBRARY_TILE_WIDTH_PX, AlertsService,
       LearnerDashboardIdsBackendApiService,
       LearnerDashboardActivityIdsObjectFactory, LearnerPlaylistService) {
     $rootScope.loadingMessage = 'I18N_LIBRARY_LOADING';

--- a/core/templates/dev/head/pages/library/LibrarySpec.js
+++ b/core/templates/dev/head/pages/library/LibrarySpec.js
@@ -77,7 +77,7 @@ describe('Library controller', function() {
       rootScope = $rootScope;
       ctrl = $controller('Library', {
         $scope: scope,
-        alertsService: null,
+        AlertsService: null,
         oppiaDatetimeFormatter: null
       });
     }));

--- a/core/templates/dev/head/pages/maintenance/maintenance.html
+++ b/core/templates/dev/head/pages/maintenance/maintenance.html
@@ -51,9 +51,9 @@
     {% include 'pages/footer_js_libs.html' %}
     <script src="{{TEMPLATE_DIR_PREFIX}}/app.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/i18n.js"></script>
-    <script src="{{TEMPLATE_DIR_PREFIX}}/services/alertsService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/AlertsService.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/services/utilsService.js"></script>
-    <script src="{{TEMPLATE_DIR_PREFIX}}/services/explorationContextService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/ExplorationContextService.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/FormBuilder.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/ObjectEditorDirective.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/domain/utilities/UrlInterpolationService.js"></script>

--- a/core/templates/dev/head/pages/moderator/Moderator.js
+++ b/core/templates/dev/head/pages/moderator/Moderator.js
@@ -17,8 +17,8 @@
 */
 
 oppia.controller('Moderator', [
-  '$scope', '$http', '$rootScope', 'oppiaDatetimeFormatter', 'alertsService',
-  function($scope, $http, $rootScope, oppiaDatetimeFormatter, alertsService) {
+  '$scope', '$http', '$rootScope', 'oppiaDatetimeFormatter', 'AlertsService',
+  function($scope, $http, $rootScope, oppiaDatetimeFormatter, AlertsService) {
     $scope.getDatetimeAsString = function(millisSinceEpoch) {
       return oppiaDatetimeFormatter.getLocaleAbbreviatedDatetimeString(
         millisSinceEpoch);
@@ -96,7 +96,7 @@ oppia.controller('Moderator', [
     };
 
     $scope.saveFeaturedActivityReferences = function() {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
 
       var activityReferencesToSave = angular.copy(
         $scope.displayedFeaturedActivityReferences);
@@ -104,7 +104,7 @@ oppia.controller('Moderator', [
         featured_activity_reference_dicts: activityReferencesToSave
       }).then(function() {
         $scope.lastSavedFeaturedActivityReferences = activityReferencesToSave;
-        alertsService.addSuccessMessage('Featured activities saved.');
+        AlertsService.addSuccessMessage('Featured activities saved.');
       });
     };
   }

--- a/core/templates/dev/head/pages/preferences/Preferences.js
+++ b/core/templates/dev/head/pages/preferences/Preferences.js
@@ -18,10 +18,10 @@
 
 oppia.controller('Preferences', [
   '$scope', '$http', '$rootScope', '$modal', '$timeout', '$translate',
-  'alertsService', 'UrlInterpolationService', 'utilsService',
+  'AlertsService', 'UrlInterpolationService', 'utilsService',
   'DASHBOARD_TYPE_CREATOR', 'DASHBOARD_TYPE_LEARNER',
   function(
-      $scope, $http, $rootScope, $modal, $timeout, $translate, alertsService,
+      $scope, $http, $rootScope, $modal, $timeout, $translate, AlertsService,
       UrlInterpolationService, utilsService, DASHBOARD_TYPE_CREATOR,
       DASHBOARD_TYPE_LEARNER) {
     var _PREFERENCES_DATA_URL = '/preferenceshandler/data';
@@ -84,7 +84,7 @@ oppia.controller('Preferences', [
     };
 
     $scope.onSubjectInterestsSelectionChange = function(subjectInterests) {
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $scope.subjectInterestsChangedAtLeastOnce = true;
       $scope.subjectInterestsWarningText = null;
       $scope.updateSubjectInterestsWarning(subjectInterests);

--- a/core/templates/dev/head/pages/preferences/PreferencesSpec.js
+++ b/core/templates/dev/head/pages/preferences/PreferencesSpec.js
@@ -38,7 +38,7 @@ describe('Preferences Controller', function() {
         $scope: scope,
         $http: $http,
         $rootScope: $rootScope,
-        alertsService: mockAlertsService
+        AlertsService: mockAlertsService
       });
     }));
 

--- a/core/templates/dev/head/pages/signup/Signup.js
+++ b/core/templates/dev/head/pages/signup/Signup.js
@@ -17,10 +17,10 @@
  */
 
 oppia.controller('Signup', [
-  '$scope', '$http', '$rootScope', '$modal', 'alertsService', 'urlService',
+  '$scope', '$http', '$rootScope', '$modal', 'AlertsService', 'urlService',
   'focusService', 'siteAnalyticsService',
   function(
-      $scope, $http, $rootScope, $modal, alertsService, urlService,
+      $scope, $http, $rootScope, $modal, AlertsService, urlService,
       focusService, siteAnalyticsService) {
     var _SIGNUP_DATA_URL = '/signuphandler/data';
     $rootScope.loadingMessage = 'I18N_SIGNUP_LOADING';
@@ -67,7 +67,7 @@ oppia.controller('Signup', [
       if ($scope.hasUsername) {
         return;
       }
-      alertsService.clearWarnings();
+      AlertsService.clearWarnings();
       $scope.blurredAtLeastOnce = true;
       $scope.updateWarningText(username);
       if (!$scope.warningI18nCode) {
@@ -112,7 +112,7 @@ oppia.controller('Signup', [
     $scope.submitPrerequisitesForm = function(
         agreedToTerms, username, canReceiveEmailUpdates) {
       if (!agreedToTerms) {
-        alertsService.addWarning('I18N_SIGNUP_ERROR_MUST_AGREE_TO_TERMS');
+        AlertsService.addWarning('I18N_SIGNUP_ERROR_MUST_AGREE_TO_TERMS');
         return;
       }
 

--- a/core/templates/dev/head/pages/signup/SignupSpec.js
+++ b/core/templates/dev/head/pages/signup/SignupSpec.js
@@ -47,7 +47,7 @@ describe('Signup controller', function() {
         $scope: scope,
         $http: $http,
         $rootScope: rootScope,
-        alertsService: mockAlertsService
+        AlertsService: mockAlertsService
       });
     }));
 

--- a/core/templates/dev/head/services/AlertsService.js
+++ b/core/templates/dev/head/services/AlertsService.js
@@ -16,8 +16,8 @@
  * @fileoverview Factory for handling warnings and info messages.
  */
 
-oppia.factory('alertsService', ['$log', function($log) {
-  var alertsService = {
+oppia.factory('AlertsService', ['$log', function($log) {
+  var AlertsService = {
     /**
      * Each element in each of the arrays here is an object with two keys:
      *   - type:  a string specifying the type of message or warning.
@@ -43,12 +43,12 @@ oppia.factory('alertsService', ['$log', function($log) {
    * Adds a warning message.
    * @param {string} warning - The warning message to display.
    */
-  alertsService.addWarning = function(warning) {
+  AlertsService.addWarning = function(warning) {
     $log.error(warning);
-    if (alertsService.warnings.length >= MAX_TOTAL_WARNINGS) {
+    if (AlertsService.warnings.length >= MAX_TOTAL_WARNINGS) {
       return;
     }
-    alertsService.warnings.push({
+    AlertsService.warnings.push({
       type: 'warning',
       content: warning
     });
@@ -59,8 +59,8 @@ oppia.factory('alertsService', ['$log', function($log) {
    * exception to cause a hard failure in the frontend.
    * @param {string} warning - The warning message to display.
    */
-  alertsService.fatalWarning = function(warning) {
-    alertsService.addWarning(warning);
+  AlertsService.fatalWarning = function(warning) {
+    AlertsService.addWarning(warning);
     throw new Error(warning);
   };
 
@@ -68,22 +68,22 @@ oppia.factory('alertsService', ['$log', function($log) {
    * Deletes the warning from the warnings list.
    * @param {Object} warningObject - The warning message to be deleted.
    */
-  alertsService.deleteWarning = function(warningObject) {
-    var warnings = alertsService.warnings;
+  AlertsService.deleteWarning = function(warningObject) {
+    var warnings = AlertsService.warnings;
     var newWarnings = [];
     for (var i = 0; i < warnings.length; i++) {
       if (warnings[i].content !== warningObject.content) {
         newWarnings.push(warnings[i]);
       }
     }
-    alertsService.warnings = newWarnings;
+    AlertsService.warnings = newWarnings;
   };
 
   /**
    * Clears all warnings.
    */
-  alertsService.clearWarnings = function() {
-    alertsService.warnings = [];
+  AlertsService.clearWarnings = function() {
+    AlertsService.warnings = [];
   };
 
   /**
@@ -91,11 +91,11 @@ oppia.factory('alertsService', ['$log', function($log) {
    * @param {string} type - Type of message
    * @param {string} message - Message content
    */
-  alertsService.addMessage = function(type, message) {
-    if (alertsService.messages.length >= MAX_TOTAL_MESSAGES) {
+  AlertsService.addMessage = function(type, message) {
+    if (AlertsService.messages.length >= MAX_TOTAL_MESSAGES) {
       return;
     }
-    alertsService.messages.push({
+    AlertsService.messages.push({
       type: type,
       content: message
     });
@@ -105,8 +105,8 @@ oppia.factory('alertsService', ['$log', function($log) {
    * Deletes the message from the messages list.
    * @param {Object} messageObject - Message to be deleted.
    */
-  alertsService.deleteMessage = function(messageObject) {
-    var messages = alertsService.messages;
+  AlertsService.deleteMessage = function(messageObject) {
+    var messages = AlertsService.messages;
     var newMessages = [];
     for (var i = 0; i < messages.length; i++) {
       if (messages[i].type !== messageObject.type ||
@@ -114,31 +114,31 @@ oppia.factory('alertsService', ['$log', function($log) {
         newMessages.push(messages[i]);
       }
     }
-    alertsService.messages = newMessages;
+    AlertsService.messages = newMessages;
   };
 
   /**
    * Adds an info message.
    * @param {string} message - Info message to display.
    */
-  alertsService.addInfoMessage = function(message) {
-    alertsService.addMessage('info', message);
+  AlertsService.addInfoMessage = function(message) {
+    AlertsService.addMessage('info', message);
   };
 
   /**
    * Adds a success message.
    * @param {string} message - Success message to display
    */
-  alertsService.addSuccessMessage = function(message) {
-    alertsService.addMessage('success', message);
+  AlertsService.addSuccessMessage = function(message) {
+    AlertsService.addMessage('success', message);
   };
 
   /**
    * Clears all messages.
    */
-  alertsService.clearMessages = function() {
-    alertsService.messages = [];
+  AlertsService.clearMessages = function() {
+    AlertsService.messages = [];
   };
 
-  return alertsService;
+  return AlertsService;
 }]);

--- a/core/templates/dev/head/services/AudioPlayerService.js
+++ b/core/templates/dev/head/services/AudioPlayerService.js
@@ -18,10 +18,10 @@
 
 oppia.factory('AudioPlayerService', [
   '$q', '$timeout', 'ngAudio', 'AssetsBackendApiService',
-  'explorationContextService',
+  'ExplorationContextService',
   function(
       $q, $timeout, ngAudio, AssetsBackendApiService,
-      explorationContextService) {
+      ExplorationContextService) {
     // The ID of the directive that contains the currently playing
     // audio. This is a unique generated string in each directive.
     var _currentAudioControlsDirectiveId = null;
@@ -32,7 +32,7 @@ oppia.factory('AudioPlayerService', [
         filename, directiveId, successCallback, errorCallback) {
       if (filename !== _currentTrackFilename) {
         AssetsBackendApiService.loadAudio(
-        explorationContextService.getExplorationId(), filename)
+        ExplorationContextService.getExplorationId(), filename)
           .then(function(audioBlob) {
             var blobUrl = URL.createObjectURL(audioBlob);
             _currentTrack = ngAudio.load(blobUrl);

--- a/core/templates/dev/head/services/AutoplayedVideosService.js
+++ b/core/templates/dev/head/services/AutoplayedVideosService.js
@@ -25,7 +25,7 @@
 // component and use that id instead to determine whether to suppress
 // autoplaying.
 
-oppia.factory('autoplayedVideosService', [function() {
+oppia.factory('AutoplayedVideosService', [function() {
   var autoplayedVideosDict = {};
   return {
     addAutoplayedVideo: function(videoId) {

--- a/core/templates/dev/head/services/ExplorationContextService.js
+++ b/core/templates/dev/head/services/ExplorationContextService.js
@@ -28,7 +28,7 @@ oppia.constant('EDITOR_TAB_CONTEXT', {
   PREVIEW: 'preview'
 });
 
-oppia.factory('explorationContextService', [
+oppia.factory('ExplorationContextService', [
   'currentLocationService', 'PAGE_CONTEXT', 'EDITOR_TAB_CONTEXT',
   function(currentLocationService, PAGE_CONTEXT, EDITOR_TAB_CONTEXT) {
     var pageContext = null;
@@ -100,7 +100,7 @@ oppia.factory('explorationContextService', [
           }
 
           throw Error(
-            'ERROR: explorationContextService should not be used outside the ' +
+            'ERROR: ExplorationContextService should not be used outside the ' +
             'context of an exploration.');
         }
       },

--- a/core/templates/dev/head/services/ValidatorsService.js
+++ b/core/templates/dev/head/services/ValidatorsService.js
@@ -18,7 +18,7 @@
  */
 
 oppia.factory('ValidatorsService', [
-  '$filter', 'alertsService', function($filter, alertsService) {
+  '$filter', 'AlertsService', function($filter, AlertsService) {
     return {
       /**
        * Checks whether an entity name is valid, and displays a warning message
@@ -32,7 +32,7 @@ oppia.factory('ValidatorsService', [
         input = $filter('normalizeWhitespace')(input);
         if (!input && !allowEmpty) {
           if (showWarnings) {
-            alertsService.addWarning('Please enter a non-empty name.');
+            AlertsService.addWarning('Please enter a non-empty name.');
           }
           return false;
         }
@@ -40,7 +40,7 @@ oppia.factory('ValidatorsService', [
         for (var i = 0; i < GLOBALS.INVALID_NAME_CHARS.length; i++) {
           if (input.indexOf(GLOBALS.INVALID_NAME_CHARS[i]) !== -1) {
             if (showWarnings) {
-              alertsService.addWarning(
+              AlertsService.addWarning(
                'Invalid input. Please use a non-empty description consisting ' +
                'of alphanumeric characters, spaces and/or hyphens.'
               );
@@ -57,7 +57,7 @@ oppia.factory('ValidatorsService', [
 
         if (input.length > 40) {
           if (showWarnings) {
-            alertsService.addWarning(
+            AlertsService.addWarning(
               'Exploration titles should be at most 40 characters long.');
           }
           return false;
@@ -74,7 +74,7 @@ oppia.factory('ValidatorsService', [
 
         if (input.length > 50) {
           if (showWarnings) {
-            alertsService.addWarning(
+            AlertsService.addWarning(
               'Card names should be at most 50 characters long.');
           }
           return false;
@@ -87,7 +87,7 @@ oppia.factory('ValidatorsService', [
           if (showWarnings) {
             // TODO(sll): Allow this warning to be more specific in terms of
             // what needs to be entered.
-            alertsService.addWarning('Please enter a non-empty value.');
+            AlertsService.addWarning('Please enter a non-empty value.');
           }
           return false;
         }
@@ -98,7 +98,7 @@ oppia.factory('ValidatorsService', [
         var VALID_ID_CHARS_REGEX = /^[a-zA-Z0-9_\-]+$/g;
         if (!input || !VALID_ID_CHARS_REGEX.test(input)) {
           if (showWarnings) {
-            alertsService.addWarning('Please enter a valid exploration ID.');
+            AlertsService.addWarning('Please enter a valid exploration ID.');
           }
           return false;
         }

--- a/core/templates/dev/head/services/alertsServiceSpec.js
+++ b/core/templates/dev/head/services/alertsServiceSpec.js
@@ -17,184 +17,184 @@
  */
 
 describe('Alerts Service', function() {
-  var alertsService;
+  var AlertsService;
 
   beforeEach(module('oppia'));
   beforeEach(inject(function($injector) {
-    alertsService = $injector.get('alertsService');
+    AlertsService = $injector.get('AlertsService');
   }));
 
   describe('Warnings', function() {
     it('should add a warning', function() {
-      expect(alertsService.warnings.length).toBe(0);
-      alertsService.addWarning('Warning 1');
-      expect(alertsService.warnings.length).toBe(1);
+      expect(AlertsService.warnings.length).toBe(0);
+      AlertsService.addWarning('Warning 1');
+      expect(AlertsService.warnings.length).toBe(1);
     });
 
     it('should delete a warning (no duplicates)', function() {
       var warning = 'Warning 1';
       // Warning message to be deleted
-      alertsService.addWarning(warning);
+      AlertsService.addWarning(warning);
       // Add a few other warning message
-      alertsService.addWarning('Warning 2');
-      alertsService.addWarning('Warning 3');
+      AlertsService.addWarning('Warning 2');
+      AlertsService.addWarning('Warning 3');
 
-      expect(alertsService.warnings.length).toBe(3);
-      alertsService.deleteWarning({
+      expect(AlertsService.warnings.length).toBe(3);
+      AlertsService.deleteWarning({
         type: 'warning',
         content: warning
       });
-      expect(alertsService.warnings.length).toBe(2);
+      expect(AlertsService.warnings.length).toBe(2);
 
       // Search for the deleted warning message
       var found = false;
-      for (var i = 0; i < alertsService.warnings.length; i++) {
-        if (alertsService.warnings[i].content === warning) {
+      for (var i = 0; i < AlertsService.warnings.length; i++) {
+        if (AlertsService.warnings[i].content === warning) {
           found = true;
         }
       }
       expect(found).toBe(false);
-      expect(alertsService.warnings[0].content).toBe('Warning 2');
-      expect(alertsService.warnings[1].content).toBe('Warning 3');
+      expect(AlertsService.warnings[0].content).toBe('Warning 2');
+      expect(AlertsService.warnings[1].content).toBe('Warning 3');
     });
 
     it('should delete a warning (with duplicates)', function() {
       var warning = 'Warning 1';
       // Warning message to be deleted
-      alertsService.addWarning(warning);
+      AlertsService.addWarning(warning);
       // Add a few other warning message
-      alertsService.addWarning('Warning 2');
-      alertsService.addWarning(warning);
-      alertsService.addWarning('Warning 3');
+      AlertsService.addWarning('Warning 2');
+      AlertsService.addWarning(warning);
+      AlertsService.addWarning('Warning 3');
 
-      expect(alertsService.warnings.length).toBe(4);
-      alertsService.deleteWarning({
+      expect(AlertsService.warnings.length).toBe(4);
+      AlertsService.deleteWarning({
         type: 'warning',
         content: warning
       });
-      expect(alertsService.warnings.length).toBe(2);
+      expect(AlertsService.warnings.length).toBe(2);
 
       // Search for the deleted warning message
       var found = false;
-      for (var i = 0; i < alertsService.warnings.length; i++) {
-        if (alertsService.warnings[i].content === warning) {
+      for (var i = 0; i < AlertsService.warnings.length; i++) {
+        if (AlertsService.warnings[i].content === warning) {
           found = true;
         }
       }
       expect(found).toBe(false);
-      expect(alertsService.warnings[0].content).toBe('Warning 2');
-      expect(alertsService.warnings[1].content).toBe('Warning 3');
+      expect(AlertsService.warnings[0].content).toBe('Warning 2');
+      expect(AlertsService.warnings[1].content).toBe('Warning 3');
     });
 
     it('should not add more than 10 warnings', function() {
       var warning = 'Warning ';
       for (var i = 1; i < 15; i++) {
-        alertsService.addWarning(warning + i);
+        AlertsService.addWarning(warning + i);
       }
-      expect(alertsService.warnings.length).toBe(10);
+      expect(AlertsService.warnings.length).toBe(10);
     });
 
     it('should clear all the warning messages', function() {
-      alertsService.addWarning('Warning 1');
-      alertsService.addWarning('Warning 2');
-      alertsService.addWarning('Warning 3');
-      alertsService.clearWarnings();
-      expect(alertsService.warnings.length).toBe(0);
+      AlertsService.addWarning('Warning 1');
+      AlertsService.addWarning('Warning 2');
+      AlertsService.addWarning('Warning 3');
+      AlertsService.clearWarnings();
+      expect(AlertsService.warnings.length).toBe(0);
     });
   });
 
   describe('Messages', function() {
     it('should add an info message', function() {
       var message = 'Info 1';
-      expect(alertsService.messages.length).toBe(0);
-      alertsService.addInfoMessage(message);
-      expect(alertsService.messages.length).toBe(1);
-      expect(alertsService.messages[0].type).toBe('info');
-      expect(alertsService.messages[0].content).toBe(message);
+      expect(AlertsService.messages.length).toBe(0);
+      AlertsService.addInfoMessage(message);
+      expect(AlertsService.messages.length).toBe(1);
+      expect(AlertsService.messages[0].type).toBe('info');
+      expect(AlertsService.messages[0].content).toBe(message);
     });
 
     it('should add a success message', function() {
       var message = 'Success 1';
-      expect(alertsService.messages.length).toBe(0);
-      alertsService.addSuccessMessage(message);
-      alertsService.addInfoMessage('Info 1');
-      expect(alertsService.messages.length).toBe(2);
-      expect(alertsService.messages[0].type).toBe('success');
-      expect(alertsService.messages[0].content).toBe(message);
+      expect(AlertsService.messages.length).toBe(0);
+      AlertsService.addSuccessMessage(message);
+      AlertsService.addInfoMessage('Info 1');
+      expect(AlertsService.messages.length).toBe(2);
+      expect(AlertsService.messages[0].type).toBe('success');
+      expect(AlertsService.messages[0].content).toBe(message);
     });
 
     it('should delete a message (no duplicates)', function() {
       var message = 'Info 1';
       // Info Message to be deleted
-      alertsService.addInfoMessage(message);
+      AlertsService.addInfoMessage(message);
       // Add a few other messages
-      alertsService.addInfoMessage('Info 2');
-      alertsService.addSuccessMessage('Success 1');
+      AlertsService.addInfoMessage('Info 2');
+      AlertsService.addSuccessMessage('Success 1');
 
-      expect(alertsService.messages.length).toBe(3);
-      alertsService.deleteMessage({
+      expect(AlertsService.messages.length).toBe(3);
+      AlertsService.deleteMessage({
         type: 'info',
         content: message
       });
-      expect(alertsService.messages.length).toBe(2);
+      expect(AlertsService.messages.length).toBe(2);
 
       // Search for the message
       var found = false;
-      for (var i = 0; i < alertsService.messages.length; i++) {
-        if (alertsService.messages[i].content === message &&
-            alertsService.messages[i].type === 'info') {
+      for (var i = 0; i < AlertsService.messages.length; i++) {
+        if (AlertsService.messages[i].content === message &&
+            AlertsService.messages[i].type === 'info') {
           found = true;
         }
       }
       expect(found).toBe(false);
-      expect(alertsService.messages[0].content).toBe('Info 2');
-      expect(alertsService.messages[1].content).toBe('Success 1');
+      expect(AlertsService.messages[0].content).toBe('Info 2');
+      expect(AlertsService.messages[1].content).toBe('Success 1');
     });
 
     it('should delete a message (with duplicates)', function() {
       var message = 'Info 1';
       // Info Message to be deleted
-      alertsService.addInfoMessage(message);
+      AlertsService.addInfoMessage(message);
       // Add a few other messages
-      alertsService.addInfoMessage('Info 2');
-      alertsService.addSuccessMessage('Success 1');
-      alertsService.addInfoMessage(message);
+      AlertsService.addInfoMessage('Info 2');
+      AlertsService.addSuccessMessage('Success 1');
+      AlertsService.addInfoMessage(message);
 
-      expect(alertsService.messages.length).toBe(4);
-      alertsService.deleteMessage({
+      expect(AlertsService.messages.length).toBe(4);
+      AlertsService.deleteMessage({
         type: 'info',
         content: message
       });
-      expect(alertsService.messages.length).toBe(2);
+      expect(AlertsService.messages.length).toBe(2);
 
       // Search for the message
       var found = false;
-      for (var i = 0; i < alertsService.messages.length; i++) {
-        if (alertsService.messages[i].content === message &&
-            alertsService.messages[i].type === 'info') {
+      for (var i = 0; i < AlertsService.messages.length; i++) {
+        if (AlertsService.messages[i].content === message &&
+            AlertsService.messages[i].type === 'info') {
           found = true;
         }
       }
       expect(found).toBe(false);
-      expect(alertsService.messages[0].content).toBe('Info 2');
-      expect(alertsService.messages[1].content).toBe('Success 1');
+      expect(AlertsService.messages[0].content).toBe('Info 2');
+      expect(AlertsService.messages[1].content).toBe('Success 1');
     });
 
     it('should not add more than 10 messages', function() {
       var message = 'Info ';
       for (var i = 1; i < 15; i++) {
-        alertsService.addInfoMessage(message + i);
+        AlertsService.addInfoMessage(message + i);
       }
-      alertsService.addSuccessMessage('Success 1');
-      expect(alertsService.messages.length).toBe(10);
+      AlertsService.addSuccessMessage('Success 1');
+      expect(AlertsService.messages.length).toBe(10);
     });
 
     it('should clear all the messages', function() {
-      alertsService.addInfoMessage('Info 1');
-      alertsService.addInfoMessage('Info 2');
-      alertsService.addSuccessMessage('Success 1');
-      alertsService.clearMessages();
-      expect(alertsService.messages.length).toBe(0);
+      AlertsService.addInfoMessage('Info 1');
+      AlertsService.addInfoMessage('Info 2');
+      AlertsService.addSuccessMessage('Success 1');
+      AlertsService.clearMessages();
+      expect(AlertsService.messages.length).toBe(0);
     });
   });
 });

--- a/core/templates/dev/head/services/explorationContextServiceSpec.js
+++ b/core/templates/dev/head/services/explorationContextServiceSpec.js
@@ -36,7 +36,7 @@ describe('Exploration context service', function() {
     beforeEach(module('oppia', GLOBALS.TRANSLATOR_PROVIDER_FOR_TESTS));
 
     beforeEach(inject(function($injector) {
-      ecs = $injector.get('explorationContextService');
+      ecs = $injector.get('ExplorationContextService');
     }));
 
     it('should correctly retrieve the exploration id', function() {
@@ -62,7 +62,7 @@ describe('Exploration context service', function() {
     });
 
     beforeEach(inject(function($injector) {
-      ecs = $injector.get('explorationContextService');
+      ecs = $injector.get('ExplorationContextService');
     }));
 
     it('should correctly retrieve the exploration id', function() {
@@ -88,7 +88,7 @@ describe('Exploration context service', function() {
     });
 
     beforeEach(inject(function($injector) {
-      ecs = $injector.get('explorationContextService');
+      ecs = $injector.get('ExplorationContextService');
     }));
 
     it('should throw an error when trying to retrieve the exploration id',

--- a/core/templates/dev/head/services/explorationServices.js
+++ b/core/templates/dev/head/services/explorationServices.js
@@ -19,7 +19,7 @@
 
 // A service that provides a number of utility functions useful to both the
 // editor and player.
-oppia.factory('oppiaExplorationHtmlFormatterService', [
+oppia.factory('OppiaExplorationHtmlFormatterService', [
   '$filter', 'extensionTagAssemblerService', 'oppiaHtmlEscaper',
   function($filter, extensionTagAssemblerService, oppiaHtmlEscaper) {
     return {


### PR DESCRIPTION
IMPORTANT NOTES (please read, then delete):

 Fix #3825 : Rename existing Angular services Group-5

[x]services/alertsService.js (alertsService → AlertsService)
[x]services/autoplayedVideosService.js (autoplayedVideosService → AutoplayedVideosService)
[x]services/explorationContextService.js (explorationContextService → ExplorationContextService)
[x]services/explorationServices.js (oppiaExplorationHtmlFormatterService → OppiaExplorationHtmlFormatterService)
