### PR TITLE
Update the backups script

### DIFF
--- a/scripts/prepare_automatic_backups.py
+++ b/scripts/prepare_automatic_backups.py
@@ -60,7 +60,8 @@ def update_cron_dict(cron_dict):
     if len(backup_url) > warning_threshold:
         print (
             'IMPORTANT: Bad things are going to happen in the next release if '
-            'you don\'t fix this. Bring it up at the TL meeting.')
+            'a permanent solution to backups is not found for this release. '
+            'Bring this up at the TL meeting.')
     if len(backup_url) > _MAX_BACKUP_URL_LENGTH:
         raise Exception(
             'Backup URL exceeds app engine limit by %d: %s' % (

--- a/scripts/prepare_automatic_backups.py
+++ b/scripts/prepare_automatic_backups.py
@@ -32,14 +32,7 @@ _OMITTED_MODELS = [
     'UserRecentChangesBatchModel', 'UserStatsModel']
 
 
-def generate_backup_url():
-    sys_args = sys.argv
-    cloud_storage_bucket_name = sys_args[1]
-    module_class_names = [
-        module_name for module_name in sys_args[2:]
-        if module_name not in _OMITTED_MODELS]
-    print 'Generating URL to backup %d models (%d were skipped)' % (
-        len(module_class_names), len(sys_args[2:]) - len(module_class_names))
+def generate_backup_url(cloud_storage_bucket_name, module_class_names):
     return (
         '/_ah/datastore_admin/backup.create?name=%s&kind=%s&queue=%s'
         '&filesystem=gs&gs_bucket_name=%s' % (
@@ -50,11 +43,29 @@ def generate_backup_url():
 
 
 def update_cron_dict(cron_dict):
-    backup_url = generate_backup_url()
+    sys_args = sys.argv
+    cloud_storage_bucket_name = sys_args[1]
+    module_class_names = [
+        module_name for module_name in sys_args[2:]
+        if module_name not in _OMITTED_MODELS]
+    backup_url = generate_backup_url(
+        cloud_storage_bucket_name, module_class_names)
+    print 'Generating URL to backup %d models (%d were skipped)' % (
+        len(module_class_names), len(sys_args[2:]) - len(module_class_names))
+
+    average_model_name_length = (
+        sum([len(model_name) for model_name in module_class_names])
+        / len(module_class_names))
+    warning_threshold = _MAX_BACKUP_URL_LENGTH - average_model_name_length * 3
+    if len(backup_url) > warning_threshold:
+        print (
+            'IMPORTANT: Bad things are going to happen in the next release if '
+            'you don\'t fix this. Bring it up at the TL meeting.')
     if len(backup_url) > _MAX_BACKUP_URL_LENGTH:
         raise Exception(
             'Backup URL exceeds app engine limit by %d: %s' % (
                 len(backup_url) - _MAX_BACKUP_URL_LENGTH, backup_url))
+
     cron_dict['cron'].append({
         'description': 'weekly backup',
         'url': '%s' % backup_url,

--- a/scripts/prepare_automatic_backups.py
+++ b/scripts/prepare_automatic_backups.py
@@ -26,8 +26,7 @@ _BACKUP_EVENT_QUEUE_RATE = '5/s'
 _MAX_BACKUP_URL_LENGTH = 2000
 _CRON_YAML_FILE_NAME = 'cron.yaml'
 _OMITTED_MODELS = [
-    'JobModel', 'ContinuousComputationModel', 'ClassifierTrainingJobModel',
-    'TrainingJobExplorationMappingModel', 'FeedbackAnalyticsModel',
+    'JobModel', 'ContinuousComputationModel', 'FeedbackAnalyticsModel',
     'ExplorationRecommendationsModel', 'TopicSimilaritiesModel',
     'ExplorationAnnotationsModel', 'StateAnswersCalcOutputModel',
     'UserRecentChangesBatchModel', 'UserStatsModel']

--- a/scripts/prepare_automatic_backups.sh
+++ b/scripts/prepare_automatic_backups.sh
@@ -17,4 +17,4 @@
 ##########################################################################
 
 export PYTHONPATH=.:$PYTHONPATH
-find core/storage -not -path "core/storage/base_model/*" -name "gae_models.py" | xargs grep -E "class .+?Model" | awk '{print $2}' | cut -d "(" -f 1 | tr '\n' ' ' | xargs python scripts/prepare_automatic_backups.py $1
+find core/storage -not -path "core/storage/base_model/*" -name "gae_models.py" | xargs grep -E "class [^\d\W]\w*Model" | awk '{print $2}' | cut -d "(" -f 1 | tr '\n' ' ' | xargs python scripts/prepare_automatic_backups.py $1


### PR DESCRIPTION
Update the backups script to ignore models which can be reconsistuted from a fresh backup of Oppia. Updated the shell script to properly extract model names and not comments (before the script was generating a malformed URL).
