### PR TITLE
Update the CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ This file contains a summary of changes to the Oppia code base. For a full chang
     https://github.com/oppia/oppia/commits/master
 
 
-v2.5.4 (21 Sep 2017)
+v2.5.4 (22 Sep 2017)
 --------------------
 Learner Dashboard:
 * Learner dashboard 3.2 (#3759)


### PR DESCRIPTION
Update the CHANGELOG to refer to the correct date that 2.5.4 was released
