### PR TITLE
Fix serious issue where the exploration tile in a collection is unclickable on mobile devices.

### DIFF
--- a/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/collection_summary_tile_directive.html
@@ -6,7 +6,6 @@
 </learner-dashboard-icons>
 <md-card class="oppia-activity-summary-tile"
          ng-class="{'oppia-activity-playlist-tile': isPlaylistTile()}"
-         ng-mouseenter="setHoverState(true)" ng-mouseleave="setHoverState(false)"
          style="position: relative; z-index: 5;">
   <a ng-href="<[getCollectionLink()]>" style="text-decoration: none;">
     <div class="title-section" style="background-color: <[getThumbnailBgColor()]>;">
@@ -34,7 +33,8 @@
         </li>
       </ul>
     </div>
-    <div ng-if="!isPlaylistTile()" class="title-section-mask"></div>
+    <div ng-if="!isPlaylistTile()" class="title-section-mask"
+         ng-mouseenter="setHoverState(true)" ng-mouseleave="setHoverState(false)"></div>
   </a>
 </md-card>
 

--- a/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
@@ -5,7 +5,6 @@
                          activity-active="explorationIsCurrentlyHoveredOver">
 </learner-dashboard-icons>
 <md-card ng-class="[isCollectionPreviewTile ? 'oppia-activity-summary-tile-mobile' : 'oppia-activity-summary-tile', {'small-width': !isWindowLarge}, {'oppia-activity-playlist-tile': isPlaylistTile()}]"
-         ng-mouseenter="setHoverState(true)" ng-mouseleave="setHoverState(false)"
          style="position: relative; z-index: 5;">
   <a ng-href="<[getExplorationLink()]>" target="<[openInNewWindow ? '_blank' : '_self']>">
     <div class="title-section" style="background-color: <[getThumbnailBgColor()]>;">
@@ -27,7 +26,9 @@
         </div>
       </div>
     </div>
-    <div ng-if="!isPlaylistTile()" class="title-section-mask"></div>
+    <div ng-if="!isPlaylistTile()" class="title-section-mask"
+         ng-mouseenter="setHoverState(true)" ng-mouseleave="setHoverState(false)">
+    </div>
     <div ng-attr-section="<[isWindowLarge ? undefined : 'right-section']>" class="summary-section">
       <div ng-if="isWindowLarge" class="objective protractor-test-exp-summary-tile-objective">
         <[getObjective() | truncateAndCapitalize: 95]>


### PR DESCRIPTION
This seems to be due to ng-mouseenter overriding the implicit ng-click on mobile devices (you can test using the browser emulator).