### PR TITLE
Prevent audio from being shared across states in creator view

### DIFF
--- a/core/templates/dev/head/components/forms/audio_translations_editor_directive.html
+++ b/core/templates/dev/head/components/forms/audio_translations_editor_directive.html
@@ -14,8 +14,7 @@
           <[getAudioLanguageDescription(languageCode)]>
         </div>
         <div class="col-lg-8 col-md-8 col-sm-8">
-          <audio controls preload="none" controlsList="nodownload">
-            <source ng-src="<[getAudioTranslationFullUrl(audioTranslation.filename)]>" type="audio/mpeg">
+          <audio controls preload="metadata" controlsList="nodownload" ng-src="<[getAudioTranslationFullUrl(audioTranslation.filename)]>">
           </audio>
         </div>
         <div class="col-lg-1 col-md-1 col-sm-1">


### PR DESCRIPTION
I'm not sure exactly why this works, but it seems to fix the problem. I guess maybe there's some abstraction between the source element and audio element that causes the audio to persist with the same source.