### PR TITLE
Introduce event model schema version and modify ExplorationStatsModel

### DIFF
--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -817,7 +817,8 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
             self.state_name: stats_domain.StateStats.create_default()
         }
         exploration_stats = stats_domain.ExplorationStats(
-            self.exp_id, self.exp_version, 0, 0, 0, state_stats_mapping)
+            self.exp_id, self.exp_version, 0, 0, 0, 0, 0, 0,
+            state_stats_mapping)
         stats_services.create_stats_model(exploration_stats)
 
     def test_answer_submitted_handler(self):
@@ -842,10 +843,10 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
             self.exp_id, self.exp_version)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                self.state_name].total_answers_count, 1)
+                self.state_name].total_answers_count_v2, 1)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                self.state_name].useful_feedback_count, 0)
+                self.state_name].useful_feedback_count_v2, 0)
 
     def test_state_hit_handler(self):
         """Test the handler for recording state hit events."""
@@ -865,10 +866,10 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
             self.exp_id, self.exp_version)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                self.state_name].total_hit_count, 1)
+                self.state_name].total_hit_count_v2, 1)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                self.state_name].first_hit_count, 1)
+                self.state_name].first_hit_count_v2, 1)
 
     def test_state_complete_handler(self):
         """Test the handler for recording state complete events."""
@@ -886,7 +887,7 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
             self.exp_id, self.exp_version)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                self.state_name].num_completions, 1)
+                self.state_name].num_completions_v2, 1)
 
     def test_exploration_actual_start_handler(self):
         """Test the handler for recording exploration actual start events."""
@@ -902,7 +903,7 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
         # Check that the models are updated.
         exploration_stats = stats_services.get_exploration_stats_by_id(
             self.exp_id, self.exp_version)
-        self.assertEqual(exploration_stats.num_actual_starts, 1)
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 1)
 
     def test_solution_hit_handler(self):
         """Test the handler for recording solution hit events."""
@@ -920,7 +921,7 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
             self.exp_id, self.exp_version)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                self.state_name].num_times_solution_viewed, 1)
+                self.state_name].num_times_solution_viewed_v2, 1)
 
     def test_exploration_complete_handler(self):
         """Test the handler for recording exploration complete events."""
@@ -938,7 +939,7 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
         # Check that the models are updated.
         exploration_stats = stats_services.get_exploration_stats_by_id(
             self.exp_id, self.exp_version)
-        self.assertEqual(exploration_stats.num_completions, 1)
+        self.assertEqual(exploration_stats.num_completions_v2, 1)
 
     def test_exploration_start_handler(self):
         """Test the handler for recording exploration start events."""
@@ -954,4 +955,4 @@ class StatsEventHandlerTest(test_utils.GenericTestBase):
         # Check that the models are updated.
         exploration_stats = stats_services.get_exploration_stats_by_id(
             self.exp_id, self.exp_version)
-        self.assertEqual(exploration_stats.num_starts, 1)
+        self.assertEqual(exploration_stats.num_starts_v2, 1)

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -171,9 +171,8 @@ class StateStats(object):
         self.total_hit_count_v2 = total_hit_count_v2
         self.first_hit_count_v1 = first_hit_count_v1
         self.first_hit_count_v2 = first_hit_count_v2
-        # There is no version 1 for the solution viewed count because
-        # solutions were introduced recently and there are no existing event
-        # models that record solution viewed events.
+        # Solution view analytics were only introduced in v2, and there are no
+        # existing event models in v1 that record solution viewed events.
         self.num_times_solution_viewed_v2 = num_times_solution_viewed_v2
         self.num_completions_v1 = num_completions_v1
         self.num_completions_v2 = num_completions_v2

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -53,14 +53,16 @@ class ExplorationStats(object):
         Args:
             exp_id: str. ID of the exploration.
             exp_version: int. Version of the exploration.
-            num_starts_v1, num_starts_v2: int. Number of learners who started
-                the exploration.
-            num_actual_starts_v1, num_actual_starts_v2: int. Number of learners
-                who actually attempted the exploration. These are the learners
-                who have completed the initial state of the exploration and
-                traversed to the next state.
-            num_completions_v1, num_completions_v2: int. Number of learners who
-                completed the exploration.
+            num_starts_v1: int. Number of learners who started the exploration.
+            num_starts_v2: int. As above, but for events with version 2.
+            num_actual_starts_v1: int. Number of learners who actually attempted
+                the exploration. These are the learners who have completed the
+                initial state of the exploration and traversed to the next
+                state.
+            num_actual_starts_v2: int. As above, but for events with version 2.
+            num_completions_v1: int. Number of learners who completed the
+                exploration.
+            num_completions_v2: int. As above, but for events with version 2.
             state_stats_mapping: dict. A dictionary mapping the state names of
                 an exploration to the corresponding StateStats domain object.
         """
@@ -92,6 +94,15 @@ class ExplorationStats(object):
     def validate(self):
         """Validates the ExplorationStats domain object."""
 
+        exploration_stats_properties = [
+            'num_starts_v1',
+            'num_starts_v2',
+            'num_actual_starts_v1',
+            'num_actual_starts_v2',
+            'num_completions_v1',
+            'num_completions_v2',
+        ]
+
         if not isinstance(self.exp_id, basestring):
             raise utils.ValidationError(
                 'Expected exp_id to be a string, received %s' % (self.exp_id))
@@ -101,51 +112,16 @@ class ExplorationStats(object):
                 'Expected exp_version to be an int, received %s' % (
                     self.exp_version))
 
-        if not isinstance(self.num_starts_v1, int):
-            raise utils.ValidationError(
-                'Expected num_starts_v1 to be an int, received %s' % (
-                    self.num_starts_v1))
+        exploration_stats_dict = self.to_dict()
 
-        if not isinstance(self.num_starts_v2, int):
-            raise utils.ValidationError(
-                'Expected num_starts_v2 to be an int, received %s' % (
-                    self.num_starts_v2))
-
-        if not isinstance(self.num_actual_starts_v1, int):
-            raise utils.ValidationError(
-                'Expected num_actual_starts_v1 to be an int, received %s' % (
-                    self.num_actual_starts_v1))
-
-        if self.num_actual_starts_v1 < 0:
-            raise utils.ValidationError(
-                '%s cannot have negative values' % ('num_actual_starts_v1'))
-
-        if not isinstance(self.num_actual_starts_v2, int):
-            raise utils.ValidationError(
-                'Expected num_actual_starts_v2 to be an int, received %s' % (
-                    self.num_actual_starts_v2))
-
-        if self.num_actual_starts_v2 < 0:
-            raise utils.ValidationError(
-                '%s cannot have negative values' % ('num_actual_starts_v2'))
-
-        if not isinstance(self.num_completions_v1, int):
-            raise utils.ValidationError(
-                'Expected num_completions_v1 to be an int, received %s' % (
-                    self.num_completions_v1))
-
-        if self.num_completions_v1 < 0:
-            raise utils.ValidationError(
-                '%s cannot have negative values' % ('num_completions_v1'))
-
-        if not isinstance(self.num_completions_v2, int):
-            raise utils.ValidationError(
-                'Expected num_completions_v2 to be an int, received %s' % (
-                    self.num_completions_v2))
-
-        if self.num_completions_v2 < 0:
-            raise utils.ValidationError(
-                '%s cannot have negative values' % ('num_completions_v2'))
+        for stat_property in exploration_stats_properties:
+            if not isinstance(exploration_stats_dict[stat_property], int):
+                raise utils.ValidationError(
+                    'Expected %s to be an int, received %s' % (
+                        stat_property, exploration_stats_dict[stat_property]))
+            if exploration_stats_dict[stat_property] < 0:
+                raise utils.ValidationError(
+                    '%s cannot have negative values' % (stat_property))
 
         if not isinstance(self.state_stats_mapping, dict):
             raise utils.ValidationError(
@@ -168,18 +144,24 @@ class StateStats(object):
         """Constructs a StateStats domain object.
 
         Args:
-            total_answers_count_v1, total_answers_count_v2: int. Total number of
-                answers submitted to this state.
-            useful_feedback_count_v1, useful_feedback_count_v2: int. Total
-                number of answers that received useful feedback.
-            total_hit_count_v1, total_hit_count_v2: int. Total number of times
-                the state was entered.
-            first_hit_count_v1, first_hit_count_v2: int. Number of times the
-                state was entered for the first time.
+            total_answers_count_v1: int. Total number of answers submitted to
+                this state.
+            total_answers_count_v2: int. As above, but for events with version
+                2.
+            useful_feedback_count_v1: int. Total number of answers that received
+                useful feedback.
+            useful_feedback_count_v2: int. As above, but for events with version
+                2.
+            total_hit_count_v1: int. Total number of times the state was
+                entered.
+            total_hit_count_v2: int. As above, but for events with version 2.
+            first_hit_count_v1: int. Number of times the state was entered for
+                the first time.
+            first_hit_count_v2: int. As above, but for events with version 2.
             num_times_solution_viewed_v2: int. Number of times the solution
-                button was triggered to answer a state.
-            num_completions_v1, num_completions_v2: int. Number of times the
-                state was completed.
+                button was triggered to answer a state (only for version 2).
+            num_completions_v1: int. Number of times the state was completed.
+            num_completions_v2: int. As above, but for events with version 2.
         """
         self.total_answers_count_v1 = total_answers_count_v1
         self.total_answers_count_v2 = total_answers_count_v2
@@ -189,6 +171,9 @@ class StateStats(object):
         self.total_hit_count_v2 = total_hit_count_v2
         self.first_hit_count_v1 = first_hit_count_v1
         self.first_hit_count_v2 = first_hit_count_v2
+        # There is no version 1 for the solution viewed count because
+        # solutions were introduced recently and there are no existing event
+        # models that record solution viewed events.
         self.num_times_solution_viewed_v2 = num_times_solution_viewed_v2
         self.num_completions_v1 = num_completions_v1
         self.num_completions_v2 = num_completions_v2
@@ -257,7 +242,6 @@ class StateStats(object):
                 raise utils.ValidationError(
                     'Expected %s to be an int, received %s' % (
                         stat_property, state_stats_dict[stat_property]))
-
             if state_stats_dict[stat_property] < 0:
                 raise utils.ValidationError(
                     '%s cannot have negative values' % (stat_property))

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -45,28 +45,33 @@ class ExplorationStats(object):
     """Domain object representing analytics data for an exploration."""
 
     def __init__(
-            self, exp_id, exp_version, num_starts, num_actual_starts,
-            num_completions, state_stats_mapping):
+            self, exp_id, exp_version, num_starts_v1, num_starts_v2,
+            num_actual_starts_v1, num_actual_starts_v2, num_completions_v1,
+            num_completions_v2, state_stats_mapping):
         """Constructs an ExplorationStats domain object.
 
         Args:
             exp_id: str. ID of the exploration.
             exp_version: int. Version of the exploration.
-            num_starts: int. Number of learners who started the exploration.
-            num_actual_starts: int. Number of learners who actually attempted
-                the exploration. Theses are the learners who have completed
-                the initial state of the exploration and traversed to the next
-                state.
-            num_completions: int. Number of learners who completed the
-                exploration.
+            num_starts_v1, num_starts_v2: int. Number of learners who started
+                the exploration.
+            num_actual_starts_v1, num_actual_starts_v2: int. Number of learners
+                who actually attempted the exploration. These are the learners
+                who have completed the initial state of the exploration and
+                traversed to the next state.
+            num_completions_v1, num_completions_v2: int. Number of learners who
+                completed the exploration.
             state_stats_mapping: dict. A dictionary mapping the state names of
                 an exploration to the corresponding StateStats domain object.
         """
         self.exp_id = exp_id
         self.exp_version = exp_version
-        self.num_starts = num_starts
-        self.num_actual_starts = num_actual_starts
-        self.num_completions = num_completions
+        self.num_starts_v1 = num_starts_v1
+        self.num_starts_v2 = num_starts_v2
+        self.num_actual_starts_v1 = num_actual_starts_v1
+        self.num_actual_starts_v2 = num_actual_starts_v2
+        self.num_completions_v1 = num_completions_v1
+        self.num_completions_v2 = num_completions_v2
         self.state_stats_mapping = state_stats_mapping
 
     def to_dict(self):
@@ -74,9 +79,12 @@ class ExplorationStats(object):
         exploration_stats_dict = {
             'exp_id': self.exp_id,
             'exp_version': self.exp_version,
-            'num_starts': self.num_starts,
-            'num_actual_starts': self.num_actual_starts,
-            'num_completions': self.num_completions,
+            'num_starts_v1': self.num_starts_v1,
+            'num_starts_v2': self.num_starts_v2,
+            'num_actual_starts_v1': self.num_actual_starts_v1,
+            'num_actual_starts_v2': self.num_actual_starts_v2,
+            'num_completions_v1': self.num_completions_v1,
+            'num_completions_v2': self.num_completions_v2,
             'state_stats_mapping': self.state_stats_mapping
         }
         return exploration_stats_dict
@@ -93,28 +101,51 @@ class ExplorationStats(object):
                 'Expected exp_version to be an int, received %s' % (
                     self.exp_version))
 
-        if not isinstance(self.num_starts, int):
+        if not isinstance(self.num_starts_v1, int):
             raise utils.ValidationError(
-                'Expected num_starts to be an int, received %s' % (
-                    self.num_starts))
+                'Expected num_starts_v1 to be an int, received %s' % (
+                    self.num_starts_v1))
 
-        if not isinstance(self.num_actual_starts, int):
+        if not isinstance(self.num_starts_v2, int):
             raise utils.ValidationError(
-                'Expected num_actual_starts to be an int, received %s' % (
-                    self.num_actual_starts))
+                'Expected num_starts_v2 to be an int, received %s' % (
+                    self.num_starts_v2))
 
-        if self.num_actual_starts < 0:
+        if not isinstance(self.num_actual_starts_v1, int):
             raise utils.ValidationError(
-                '%s cannot have negative values' % ('num_actual_starts'))
+                'Expected num_actual_starts_v1 to be an int, received %s' % (
+                    self.num_actual_starts_v1))
 
-        if not isinstance(self.num_completions, int):
+        if self.num_actual_starts_v1 < 0:
             raise utils.ValidationError(
-                'Expected num_completions to be an int, received %s' % (
-                    self.num_completions))
+                '%s cannot have negative values' % ('num_actual_starts_v1'))
 
-        if self.num_completions < 0:
+        if not isinstance(self.num_actual_starts_v2, int):
             raise utils.ValidationError(
-                '%s cannot have negative values' % ('num_completions'))
+                'Expected num_actual_starts_v2 to be an int, received %s' % (
+                    self.num_actual_starts_v2))
+
+        if self.num_actual_starts_v2 < 0:
+            raise utils.ValidationError(
+                '%s cannot have negative values' % ('num_actual_starts_v2'))
+
+        if not isinstance(self.num_completions_v1, int):
+            raise utils.ValidationError(
+                'Expected num_completions_v1 to be an int, received %s' % (
+                    self.num_completions_v1))
+
+        if self.num_completions_v1 < 0:
+            raise utils.ValidationError(
+                '%s cannot have negative values' % ('num_completions_v1'))
+
+        if not isinstance(self.num_completions_v2, int):
+            raise utils.ValidationError(
+                'Expected num_completions_v2 to be an int, received %s' % (
+                    self.num_completions_v2))
+
+        if self.num_completions_v2 < 0:
+            raise utils.ValidationError(
+                '%s cannot have negative values' % ('num_completions_v2'))
 
         if not isinstance(self.state_stats_mapping, dict):
             raise utils.ValidationError(
@@ -129,44 +160,59 @@ class StateStats(object):
     """
 
     def __init__(
-            self, total_answers_count, useful_feedback_count, total_hit_count,
-            first_hit_count, num_times_solution_viewed, num_completions):
+            self, total_answers_count_v1, total_answers_count_v2,
+            useful_feedback_count_v1, useful_feedback_count_v2,
+            total_hit_count_v1, total_hit_count_v2, first_hit_count_v1,
+            first_hit_count_v2, num_times_solution_viewed_v2,
+            num_completions_v1, num_completions_v2):
         """Constructs a StateStats domain object.
 
         Args:
-            total_answers_count: int. Total number of answers submitted to this
-                state.
-            useful_feedback_count: int. Total number of answers that received
-                useful feedback.
-            total_hit_count: int. Total number of times the state was entered.
-            first_hit_count: int. Number of times the state was entered for the
-                first time.
-            num_times_solution_viewed: int. Number of times the solution
+            total_answers_count_v1, total_answers_count_v2: int. Total number of
+                answers submitted to this state.
+            useful_feedback_count_v1, useful_feedback_count_v2: int. Total
+                number of answers that received useful feedback.
+            total_hit_count_v1, total_hit_count_v2: int. Total number of times
+                the state was entered.
+            first_hit_count_v1, first_hit_count_v2: int. Number of times the
+                state was entered for the first time.
+            num_times_solution_viewed_v2: int. Number of times the solution
                 button was triggered to answer a state.
-            num_completions: int. Number of times the state was completed.
+            num_completions_v1, num_completions_v2: int. Number of times the
+                state was completed.
         """
-        self.total_answers_count = total_answers_count
-        self.useful_feedback_count = useful_feedback_count
-        self.total_hit_count = total_hit_count
-        self.first_hit_count = first_hit_count
-        self.num_times_solution_viewed = num_times_solution_viewed
-        self.num_completions = num_completions
+        self.total_answers_count_v1 = total_answers_count_v1
+        self.total_answers_count_v2 = total_answers_count_v2
+        self.useful_feedback_count_v1 = useful_feedback_count_v1
+        self.useful_feedback_count_v2 = useful_feedback_count_v2
+        self.total_hit_count_v1 = total_hit_count_v1
+        self.total_hit_count_v2 = total_hit_count_v2
+        self.first_hit_count_v1 = first_hit_count_v1
+        self.first_hit_count_v2 = first_hit_count_v2
+        self.num_times_solution_viewed_v2 = num_times_solution_viewed_v2
+        self.num_completions_v1 = num_completions_v1
+        self.num_completions_v2 = num_completions_v2
 
     @classmethod
     def create_default(cls):
         """Creates a StateStats domain object and sets all properties to 0."""
-        return cls(0, 0, 0, 0, 0, 0)
+        return cls(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
     def to_dict(self):
         """Returns a dict representation of the domain oject."""
         state_stats_dict = {
-            'total_answers_count': self.total_answers_count,
-            'useful_feedback_count': self.useful_feedback_count,
-            'total_hit_count': self.total_hit_count,
-            'first_hit_count': self.first_hit_count,
-            'num_times_solution_viewed': (
-                self.num_times_solution_viewed),
-            'num_completions': self.num_completions
+            'total_answers_count_v1': self.total_answers_count_v1,
+            'total_answers_count_v2': self.total_answers_count_v2,
+            'useful_feedback_count_v1': self.useful_feedback_count_v1,
+            'useful_feedback_count_v2': self.useful_feedback_count_v2,
+            'total_hit_count_v1': self.total_hit_count_v1,
+            'total_hit_count_v2': self.total_hit_count_v2,
+            'first_hit_count_v1': self.first_hit_count_v1,
+            'first_hit_count_v2': self.first_hit_count_v2,
+            'num_times_solution_viewed_v2': (
+                self.num_times_solution_viewed_v2),
+            'num_completions_v1': self.num_completions_v1,
+            'num_completions_v2': self.num_completions_v2
         }
         return state_stats_dict
 
@@ -174,24 +220,34 @@ class StateStats(object):
     def from_dict(cls, state_stats_dict):
         """Constructs a StateStats domain object from a dict."""
         return cls(
-            state_stats_dict['total_answers_count'],
-            state_stats_dict['useful_feedback_count'],
-            state_stats_dict['total_hit_count'],
-            state_stats_dict['first_hit_count'],
-            state_stats_dict['num_times_solution_viewed'],
-            state_stats_dict['num_completions']
+            state_stats_dict['total_answers_count_v1'],
+            state_stats_dict['total_answers_count_v2'],
+            state_stats_dict['useful_feedback_count_v1'],
+            state_stats_dict['useful_feedback_count_v2'],
+            state_stats_dict['total_hit_count_v1'],
+            state_stats_dict['total_hit_count_v2'],
+            state_stats_dict['first_hit_count_v1'],
+            state_stats_dict['first_hit_count_v2'],
+            state_stats_dict['num_times_solution_viewed_v2'],
+            state_stats_dict['num_completions_v1'],
+            state_stats_dict['num_completions_v2']
         )
 
     def validate(self):
         """Validates the StateStats domain object."""
 
         state_stats_properties = [
-            'total_answers_count',
-            'useful_feedback_count',
-            'total_hit_count',
-            'first_hit_count',
-            'num_times_solution_viewed',
-            'num_completions'
+            'total_answers_count_v1',
+            'total_answers_count_v2',
+            'useful_feedback_count_v1',
+            'useful_feedback_count_v2',
+            'total_hit_count_v1',
+            'total_hit_count_v2',
+            'first_hit_count_v1',
+            'first_hit_count_v2',
+            'num_times_solution_viewed_v2',
+            'num_completions_v1',
+            'num_completions_v2'
         ]
 
         state_stats_dict = self.to_dict()

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -28,18 +28,24 @@ class ExplorationStatsTests(test_utils.GenericTestBase):
         return stats_domain.ExplorationStats(
             exploration_stats_dict['exp_id'],
             exploration_stats_dict['exp_version'],
-            exploration_stats_dict['num_starts'],
-            exploration_stats_dict['num_actual_starts'],
-            exploration_stats_dict['num_completions'],
+            exploration_stats_dict['num_starts_v1'],
+            exploration_stats_dict['num_starts_v2'],
+            exploration_stats_dict['num_actual_starts_v1'],
+            exploration_stats_dict['num_actual_starts_v2'],
+            exploration_stats_dict['num_completions_v1'],
+            exploration_stats_dict['num_completions_v2'],
             exploration_stats_dict['state_stats_mapping'])
 
     def test_to_dict(self):
         expected_exploration_stats_dict = {
             'exp_id': 'exp_id1',
             'exp_version': 1,
-            'num_starts': 30,
-            'num_actual_starts': 10,
-            'num_completions': 5,
+            'num_starts_v1': 0,
+            'num_starts_v2': 30,
+            'num_actual_starts_v1': 0,
+            'num_actual_starts_v2': 10,
+            'num_completions_v1': 0,
+            'num_completions_v2': 5,
             'state_stats_mapping': {
                 'Home': {}
             }
@@ -54,9 +60,12 @@ class ExplorationStatsTests(test_utils.GenericTestBase):
         exploration_stats_dict = {
             'exp_id': 'exp_id1',
             'exp_version': 1,
-            'num_starts': 30,
-            'num_actual_starts': 10,
-            'num_completions': 5,
+            'num_starts_v1': 0,
+            'num_starts_v2': 30,
+            'num_actual_starts_v1': 0,
+            'num_actual_starts_v2': 10,
+            'num_completions_v1': 0,
+            'num_completions_v2': 5,
             'state_stats_mapping': {
                 'Home': {}
             }
@@ -73,13 +82,13 @@ class ExplorationStatsTests(test_utils.GenericTestBase):
 
         # Make the num_actual_starts string.
         exploration_stats.exp_id = 'exp_id1'
-        exploration_stats.num_actual_starts = '0'
+        exploration_stats.num_actual_starts_v2 = '0'
         with self.assertRaisesRegexp(utils.ValidationError, (
-            'Expected num_actual_starts to be an int')):
+            'Expected num_actual_starts_v2 to be an int')):
             exploration_stats.validate()
 
         # Make the state_stats_mapping list.
-        exploration_stats.num_actual_starts = 10
+        exploration_stats.num_actual_starts_v2 = 10
         exploration_stats.state_stats_mapping = []
         with self.assertRaisesRegexp(utils.ValidationError, (
             'Expected state_stats_mapping to be a dict')):
@@ -87,9 +96,9 @@ class ExplorationStatsTests(test_utils.GenericTestBase):
 
         # Make the num_completions negative.
         exploration_stats.state_stats_mapping = {}
-        exploration_stats.num_completions = -5
+        exploration_stats.num_completions_v2 = -5
         with self.assertRaisesRegexp(utils.ValidationError, (
-            '%s cannot have negative values' % ('num_completions'))):
+            '%s cannot have negative values' % ('num_completions_v2'))):
             exploration_stats.validate()
 
 
@@ -98,68 +107,100 @@ class StateStatsTests(test_utils.GenericTestBase):
 
     def test_from_dict(self):
         state_stats_dict = {
-            'total_answers_count': 10,
-            'useful_feedback_count': 4,
-            'total_hit_count': 18,
-            'first_hit_count': 7,
-            'num_times_solution_viewed': 2,
-            'num_completions': 2
+            'total_answers_count_v1': 0,
+            'total_answers_count_v2': 10,
+            'useful_feedback_count_v1': 0,
+            'useful_feedback_count_v2': 4,
+            'total_hit_count_v1': 0,
+            'total_hit_count_v2': 18,
+            'first_hit_count_v1': 0,
+            'first_hit_count_v2': 7,
+            'num_times_solution_viewed_v2': 2,
+            'num_completions_v1': 0,
+            'num_completions_v2': 2
         }
-        state_stats = stats_domain.StateStats(10, 4, 18, 7, 2, 2)
+        state_stats = stats_domain.StateStats(0, 10, 0, 4, 0, 18, 0, 7, 2, 0, 2)
         expected_state_stats = stats_domain.StateStats.from_dict(
             state_stats_dict)
         self.assertEqual(
-            state_stats.total_answers_count,
-            expected_state_stats.total_answers_count)
+            state_stats.total_answers_count_v1,
+            expected_state_stats.total_answers_count_v1)
         self.assertEqual(
-            state_stats.useful_feedback_count,
-            expected_state_stats.useful_feedback_count)
+            state_stats.total_answers_count_v2,
+            expected_state_stats.total_answers_count_v2)
         self.assertEqual(
-            state_stats.total_hit_count, expected_state_stats.total_hit_count)
+            state_stats.useful_feedback_count_v1,
+            expected_state_stats.useful_feedback_count_v1)
         self.assertEqual(
-            state_stats.first_hit_count, expected_state_stats.first_hit_count)
+            state_stats.useful_feedback_count_v2,
+            expected_state_stats.useful_feedback_count_v2)
         self.assertEqual(
-            state_stats.num_times_solution_viewed,
-            expected_state_stats.num_times_solution_viewed)
+            state_stats.total_hit_count_v1,
+            expected_state_stats.total_hit_count_v1)
         self.assertEqual(
-            state_stats.num_completions,
-            expected_state_stats.num_completions)
+            state_stats.total_hit_count_v2,
+            expected_state_stats.total_hit_count_v2)
+        self.assertEqual(
+            state_stats.first_hit_count_v1,
+            expected_state_stats.first_hit_count_v1)
+        self.assertEqual(
+            state_stats.first_hit_count_v2,
+            expected_state_stats.first_hit_count_v2)
+        self.assertEqual(
+            state_stats.num_times_solution_viewed_v2,
+            expected_state_stats.num_times_solution_viewed_v2)
+        self.assertEqual(
+            state_stats.num_completions_v1,
+            expected_state_stats.num_completions_v1)
+        self.assertEqual(
+            state_stats.num_completions_v2,
+            expected_state_stats.num_completions_v2)
 
     def test_create_default(self):
         state_stats = stats_domain.StateStats.create_default()
-        self.assertEqual(state_stats.total_answers_count, 0)
-        self.assertEqual(state_stats.useful_feedback_count, 0)
-        self.assertEqual(state_stats.total_hit_count, 0)
-        self.assertEqual(state_stats.total_answers_count, 0)
-        self.assertEqual(state_stats.num_times_solution_viewed, 0)
-        self.assertEqual(state_stats.num_completions, 0)
+        self.assertEqual(state_stats.total_answers_count_v1, 0)
+        self.assertEqual(state_stats.total_answers_count_v2, 0)
+        self.assertEqual(state_stats.useful_feedback_count_v1, 0)
+        self.assertEqual(state_stats.useful_feedback_count_v2, 0)
+        self.assertEqual(state_stats.total_hit_count_v1, 0)
+        self.assertEqual(state_stats.total_hit_count_v2, 0)
+        self.assertEqual(state_stats.total_answers_count_v1, 0)
+        self.assertEqual(state_stats.total_answers_count_v2, 0)
+        self.assertEqual(state_stats.num_times_solution_viewed_v2, 0)
+        self.assertEqual(state_stats.num_completions_v1, 0)
+        self.assertEqual(state_stats.num_completions_v2, 0)
 
     def test_to_dict(self):
         state_stats_dict = {
-            'total_answers_count': 10,
-            'useful_feedback_count': 4,
-            'total_hit_count': 18,
-            'first_hit_count': 7,
-            'num_times_solution_viewed': 2,
-            'num_completions': 2
+            'total_answers_count_v1': 0,
+            'total_answers_count_v2': 10,
+            'useful_feedback_count_v1': 0,
+            'useful_feedback_count_v2': 4,
+            'total_hit_count_v1': 0,
+            'total_hit_count_v2': 18,
+            'first_hit_count_v1': 0,
+            'first_hit_count_v2': 7,
+            'num_times_solution_viewed_v2': 2,
+            'num_completions_v1': 0,
+            'num_completions_v2': 2
         }
-        state_stats = stats_domain.StateStats(10, 4, 18, 7, 2, 2)
+        state_stats = stats_domain.StateStats(0, 10, 0, 4, 0, 18, 0, 7, 2, 0, 2)
         self.assertEqual(state_stats_dict, state_stats.to_dict())
 
     def test_validation(self):
-        state_stats = stats_domain.StateStats(10, 4, 18, 7, 2, 2)
+        state_stats = stats_domain.StateStats(0, 10, 0, 4, 0, 18, 0, 7, 2, 0, 2)
         state_stats.validate()
 
         # Change total_answers_count to string.
-        state_stats.total_answers_count = '10'
+        state_stats.total_answers_count_v2 = '10'
         with self.assertRaisesRegexp(utils.ValidationError, (
-            'Expected total_answers_count to be an int')):
+            'Expected total_answers_count_v2 to be an int')):
             state_stats.validate()
 
         # Make the total_answers_count negative.
-        state_stats.total_answers_count = -5
+        state_stats.total_answers_count_v2 = -5
         with self.assertRaisesRegexp(utils.ValidationError, (
-            '%s cannot have negative values' % ('total_answers_count'))):
+            '%s cannot have negative values' % ('total_answers_count_v2'))):
             state_stats.validate()
 
 

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -43,29 +43,29 @@ def update_stats(exp_id, exp_version, state_name, event_type, update_params):
         exp_id, exp_version)
 
     if event_type == feconf.EVENT_TYPE_START_EXPLORATION:
-        exploration_stats.num_starts += 1
+        exploration_stats.num_starts_v2 += 1
     elif event_type == feconf.EVENT_TYPE_ACTUAL_START_EXPLORATION:
-        exploration_stats.num_actual_starts += 1
+        exploration_stats.num_actual_starts_v2 += 1
     elif event_type == feconf.EVENT_TYPE_COMPLETE_EXPLORATION:
-        exploration_stats.num_completions += 1
+        exploration_stats.num_completions_v2 += 1
     elif event_type == feconf.EVENT_TYPE_ANSWER_SUBMITTED:
         exploration_stats.state_stats_mapping[
-            state_name].total_answers_count += 1
+            state_name].total_answers_count_v2 += 1
         if update_params['feedback_is_useful']:
             exploration_stats.state_stats_mapping[
-                state_name].useful_feedback_count += 1
+                state_name].useful_feedback_count_v2 += 1
     elif event_type == feconf.EVENT_TYPE_STATE_HIT:
         exploration_stats.state_stats_mapping[
-            state_name].total_hit_count += 1
+            state_name].total_hit_count_v2 += 1
         if update_params['is_first_hit']:
             exploration_stats.state_stats_mapping[
-                state_name].first_hit_count += 1
+                state_name].first_hit_count_v2 += 1
     elif event_type == feconf.EVENT_TYPE_STATE_COMPLETED:
         exploration_stats.state_stats_mapping[
-            state_name].num_completions += 1
+            state_name].num_completions_v2 += 1
     elif event_type == feconf.EVENT_TYPE_SOLUTION_HIT:
         exploration_stats.state_stats_mapping[
-            state_name].num_times_solution_viewed += 1
+            state_name].num_times_solution_viewed_v2 += 1
 
     save_stats_model(exploration_stats)
 
@@ -85,7 +85,7 @@ def handle_stats_creation_for_new_exploration(exp_id, exp_version, state_names):
     }
 
     exploration_stats = stats_domain.ExplorationStats(
-        exp_id, exp_version, 0, 0, 0, state_stats_mapping)
+        exp_id, exp_version, 0, 0, 0, 0, 0, 0, state_stats_mapping)
     create_stats_model(exploration_stats)
 
 
@@ -170,9 +170,12 @@ def get_exploration_stats_from_model(exploration_stats_model):
     return stats_domain.ExplorationStats(
         exploration_stats_model.exp_id,
         exploration_stats_model.exp_version,
-        exploration_stats_model.num_starts,
-        exploration_stats_model.num_actual_starts,
-        exploration_stats_model.num_completions,
+        exploration_stats_model.num_starts_v1,
+        exploration_stats_model.num_starts_v2,
+        exploration_stats_model.num_actual_starts_v1,
+        exploration_stats_model.num_actual_starts_v2,
+        exploration_stats_model.num_completions_v1,
+        exploration_stats_model.num_completions_v2,
         new_state_stats_mapping)
 
 
@@ -194,9 +197,12 @@ def create_stats_model(exploration_stats):
     instance_id = stats_models.ExplorationStatsModel.create(
         exploration_stats.exp_id,
         exploration_stats.exp_version,
-        exploration_stats.num_starts,
-        exploration_stats.num_actual_starts,
-        exploration_stats.num_completions,
+        exploration_stats.num_starts_v1,
+        exploration_stats.num_starts_v2,
+        exploration_stats.num_actual_starts_v1,
+        exploration_stats.num_actual_starts_v2,
+        exploration_stats.num_completions_v1,
+        exploration_stats.num_completions_v2,
         new_state_stats_mapping
     )
     return instance_id
@@ -218,10 +224,16 @@ def save_stats_model(exploration_stats):
     exploration_stats_model = stats_models.ExplorationStatsModel.get_model(
         exploration_stats.exp_id, exploration_stats.exp_version)
 
-    exploration_stats_model.num_starts = exploration_stats.num_starts
-    exploration_stats_model.num_actual_starts = (
-        exploration_stats.num_actual_starts)
-    exploration_stats_model.num_completions = exploration_stats.num_completions
+    exploration_stats_model.num_starts_v1 = exploration_stats.num_starts_v1
+    exploration_stats_model.num_starts_v2 = exploration_stats.num_starts_v2
+    exploration_stats_model.num_actual_starts_v1 = (
+        exploration_stats.num_actual_starts_v1)
+    exploration_stats_model.num_actual_starts_v2 = (
+        exploration_stats.num_actual_starts_v2)
+    exploration_stats_model.num_completions_v1 = (
+        exploration_stats.num_completions_v1)
+    exploration_stats_model.num_completions_v2 = (
+        exploration_stats.num_completions_v2)
     exploration_stats_model.state_stats_mapping = new_state_stats_mapping
 
     exploration_stats_model.put()

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -41,7 +41,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         self.exp_version = 1
         self.stats_model_id = (
             stats_models.ExplorationStatsModel.create(
-                'exp_id1', 1, 0, 0, 0, {}))
+                'exp_id1', 1, 0, 0, 0, 0, 0, 0, {}))
 
     def test_update_stats_method(self):
         """Test the update_stats method."""
@@ -58,7 +58,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'exp_id1', 1, 'Home', feconf.EVENT_TYPE_START_EXPLORATION, {})
         exploration_stats = stats_services.get_exploration_stats_by_id(
             'exp_id1', 1)
-        self.assertEqual(exploration_stats.num_starts, 1)
+        self.assertEqual(exploration_stats.num_starts_v2, 1)
 
         # Pass in exploration actual start event.
         stats_services.update_stats(
@@ -66,7 +66,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             {})
         exploration_stats = stats_services.get_exploration_stats_by_id(
             'exp_id1', 1)
-        self.assertEqual(exploration_stats.num_actual_starts, 1)
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 1)
 
         # Pass in exploration complete event.
         stats_services.update_stats(
@@ -74,7 +74,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             {})
         exploration_stats = stats_services.get_exploration_stats_by_id(
             'exp_id1', 1)
-        self.assertEqual(exploration_stats.num_completions, 1)
+        self.assertEqual(exploration_stats.num_completions_v2, 1)
 
         # Pass in answer submitted event.
         stats_services.update_stats(
@@ -83,11 +83,11 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         exploration_stats = stats_services.get_exploration_stats_by_id(
             'exp_id1', 1)
         self.assertEqual(
-            exploration_stats.state_stats_mapping['Home'].total_answers_count,
-            1)
+            exploration_stats.state_stats_mapping[
+                'Home'].total_answers_count_v2, 1)
         self.assertEqual(
-            exploration_stats.state_stats_mapping['Home'].useful_feedback_count,
-            1)
+            exploration_stats.state_stats_mapping[
+                'Home'].useful_feedback_count_v2, 1)
 
         # Pass in state hit event.
         stats_services.update_stats(
@@ -96,9 +96,9 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         exploration_stats = stats_services.get_exploration_stats_by_id(
             'exp_id1', 1)
         self.assertEqual(
-            exploration_stats.state_stats_mapping['Home'].total_hit_count, 1)
+            exploration_stats.state_stats_mapping['Home'].total_hit_count_v2, 1)
         self.assertEqual(
-            exploration_stats.state_stats_mapping['Home'].first_hit_count, 1)
+            exploration_stats.state_stats_mapping['Home'].first_hit_count_v2, 1)
 
         # Pass in state finish event.
         stats_services.update_stats(
@@ -106,7 +106,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         exploration_stats = stats_services.get_exploration_stats_by_id(
             'exp_id1', 1)
         self.assertEqual(
-            exploration_stats.state_stats_mapping['Home'].num_completions, 1)
+            exploration_stats.state_stats_mapping['Home'].num_completions_v2, 1)
 
         # Pass in solution hit event.
         stats_services.update_stats(
@@ -115,7 +115,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'exp_id1', 1)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                'Home'].num_times_solution_viewed, 1)
+                'Home'].num_times_solution_viewed_v2, 1)
 
     def test_calls_to_stats_methods(self):
         """Test that calls are being made to the
@@ -186,9 +186,12 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             exploration.id, exploration.version)
         self.assertEqual(exploration_stats.exp_id, exp_id)
         self.assertEqual(exploration_stats.exp_version, 1)
-        self.assertEqual(exploration_stats.num_starts, 0)
-        self.assertEqual(exploration_stats.num_actual_starts, 0)
-        self.assertEqual(exploration_stats.num_completions, 0)
+        self.assertEqual(exploration_stats.num_starts_v1, 0)
+        self.assertEqual(exploration_stats.num_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_actual_starts_v1, 0)
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_completions_v1, 0)
+        self.assertEqual(exploration_stats.num_completions_v2, 0)
         self.assertEqual(
             exploration_stats.state_stats_mapping.keys(), ['Home', 'End'])
 
@@ -223,8 +226,8 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             exploration.id, exploration.version)
         self.assertEqual(exploration_stats.exp_id, exp_id)
         self.assertEqual(exploration_stats.exp_version, 2)
-        self.assertEqual(exploration_stats.num_actual_starts, 0)
-        self.assertEqual(exploration_stats.num_completions, 0)
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_completions_v2, 0)
         self.assertEqual(
             exploration_stats.state_stats_mapping.keys(), [
                 'Home', 'New state 2', 'End', 'New state'])
@@ -331,16 +334,16 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         # instance.
         exploration_stats_model = stats_models.ExplorationStatsModel.get_model(
             exploration.id, exploration.version)
-        exploration_stats_model.num_actual_starts = 5
-        exploration_stats_model.num_completions = 2
+        exploration_stats_model.num_actual_starts_v2 = 5
+        exploration_stats_model.num_completions_v2 = 2
         exploration_stats_model.state_stats_mapping['New state 4'][
-            'total_answers_count'] = 12
+            'total_answers_count_v2'] = 12
         exploration_stats_model.state_stats_mapping['Home'][
-            'total_hit_count'] = 8
+            'total_hit_count_v2'] = 8
         exploration_stats_model.state_stats_mapping['Renamed state'][
-            'first_hit_count'] = 2
+            'first_hit_count_v2'] = 2
         exploration_stats_model.state_stats_mapping['End'][
-            'useful_feedback_count'] = 4
+            'useful_feedback_count_v2'] = 4
         exploration_stats_model.put()
 
         # Test deletion, addition and rename.
@@ -371,22 +374,22 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
                 'Home', 'New state 4', 'Renamed state', 'End'])
 
         # Test the values of the stats carried over from the last version.
-        self.assertEqual(exploration_stats.num_actual_starts, 5)
-        self.assertEqual(exploration_stats.num_completions, 2)
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 5)
+        self.assertEqual(exploration_stats.num_completions_v2, 2)
         self.assertEqual(
-            exploration_stats.state_stats_mapping['Home'].total_hit_count, 8)
+            exploration_stats.state_stats_mapping['Home'].total_hit_count_v2, 8)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                'Renamed state'].first_hit_count, 2)
+                'Renamed state'].first_hit_count_v2, 2)
         self.assertEqual(
-            exploration_stats.state_stats_mapping['End'].useful_feedback_count,
-            4)
+            exploration_stats.state_stats_mapping[
+                'End'].useful_feedback_count_v2, 4)
         # State 'New state 4' has been deleted and recreated, so it should
         # now contain default values for stats instead of the values it
         # contained in the last version.
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                'New state 4'].total_answers_count, 0)
+                'New state 4'].total_answers_count_v2, 0)
 
     def test_get_exploration_stats_from_model(self):
         """Test the get_exploration_stats_from_model method."""
@@ -395,9 +398,12 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             model)
         self.assertEqual(exploration_stats.exp_id, 'exp_id1')
         self.assertEqual(exploration_stats.exp_version, 1)
-        self.assertEqual(exploration_stats.num_starts, 0)
-        self.assertEqual(exploration_stats.num_actual_starts, 0)
-        self.assertEqual(exploration_stats.num_completions, 0)
+        self.assertEqual(exploration_stats.num_starts_v1, 0)
+        self.assertEqual(exploration_stats.num_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_actual_starts_v1, 0)
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_completions_v1, 0)
+        self.assertEqual(exploration_stats.num_completions_v2, 0)
         self.assertEqual(exploration_stats.state_stats_mapping, {})
 
     def test_get_exploration_stats_by_id(self):
@@ -406,9 +412,12 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             self.exp_id, self.exp_version)
         self.assertEqual(exploration_stats.exp_id, 'exp_id1')
         self.assertEqual(exploration_stats.exp_version, 1)
-        self.assertEqual(exploration_stats.num_starts, 0)
-        self.assertEqual(exploration_stats.num_actual_starts, 0)
-        self.assertEqual(exploration_stats.num_completions, 0)
+        self.assertEqual(exploration_stats.num_starts_v1, 0)
+        self.assertEqual(exploration_stats.num_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_actual_starts_v1, 0)
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_completions_v1, 0)
+        self.assertEqual(exploration_stats.num_completions_v2, 0)
         self.assertEqual(exploration_stats.state_stats_mapping, {})
 
     def test_create_stats_model(self):
@@ -421,9 +430,12 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             self.exp_id, self.exp_version+1)
         self.assertEqual(exploration_stats.exp_id, 'exp_id1')
         self.assertEqual(exploration_stats.exp_version, 2)
-        self.assertEqual(exploration_stats.num_starts, 0)
-        self.assertEqual(exploration_stats.num_actual_starts, 0)
-        self.assertEqual(exploration_stats.num_completions, 0)
+        self.assertEqual(exploration_stats.num_starts_v1, 0)
+        self.assertEqual(exploration_stats.num_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_actual_starts_v1, 0)
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_completions_v1, 0)
+        self.assertEqual(exploration_stats.num_completions_v2, 0)
         self.assertEqual(exploration_stats.state_stats_mapping, {})
 
         # Test create method with different state_stats_mapping.
@@ -435,18 +447,26 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         model = stats_models.ExplorationStatsModel.get(model_id)
         self.assertEqual(model.exp_id, 'exp_id1')
         self.assertEqual(model.exp_version, 3)
-        self.assertEqual(exploration_stats.num_starts, 0)
-        self.assertEqual(model.num_actual_starts, 0)
-        self.assertEqual(model.num_completions, 0)
+        self.assertEqual(exploration_stats.num_starts_v1, 0)
+        self.assertEqual(exploration_stats.num_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_actual_starts_v1, 0)
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_completions_v1, 0)
+        self.assertEqual(exploration_stats.num_completions_v2, 0)
         self.assertEqual(
             model.state_stats_mapping, {
                 'Home': {
-                    'total_answers_count': 0,
-                    'useful_feedback_count': 0,
-                    'total_hit_count': 0,
-                    'first_hit_count': 0,
-                    'num_times_solution_viewed': 0,
-                    'num_completions': 0
+                    'total_answers_count_v1': 0,
+                    'total_answers_count_v2': 0,
+                    'useful_feedback_count_v1': 0,
+                    'useful_feedback_count_v2': 0,
+                    'total_hit_count_v1': 0,
+                    'total_hit_count_v2': 0,
+                    'first_hit_count_v1': 0,
+                    'first_hit_count_v2': 0,
+                    'num_times_solution_viewed_v2': 0,
+                    'num_completions_v1': 0,
+                    'num_completions_v2': 0
                 }
             })
 
@@ -454,16 +474,16 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         """Test the save_stats_model method."""
         exploration_stats = stats_services.get_exploration_stats_by_id(
             self.exp_id, self.exp_version)
-        exploration_stats.num_starts += 15
-        exploration_stats.num_actual_starts += 5
-        exploration_stats.num_completions += 2
+        exploration_stats.num_starts_v2 += 15
+        exploration_stats.num_actual_starts_v2 += 5
+        exploration_stats.num_completions_v2 += 2
         stats_services.save_stats_model(exploration_stats)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             self.exp_id, self.exp_version)
-        self.assertEqual(exploration_stats.num_starts, 15)
-        self.assertEqual(exploration_stats.num_actual_starts, 5)
-        self.assertEqual(exploration_stats.num_completions, 2)
+        self.assertEqual(exploration_stats.num_starts_v2, 15)
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 5)
+        self.assertEqual(exploration_stats.num_completions_v2, 2)
 
 
 class ModifiedStatisticsAggregator(stats_jobs_continuous.StatisticsAggregator):

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -715,7 +715,7 @@ class ExplorationStatsModel(base_models.BaseModel):
     num_starts_v2 = ndb.IntegerProperty(indexed=True)
     # Number of students who actually attempted the exploration. Only learners
     # who spent a minimum time on the exploration are considered to have
-    # actually started the exploration (v1 - data collected before Nov 2017)
+    # actually started the exploration (v1 - data collected before Nov 2017).
     num_actual_starts_v1 = ndb.IntegerProperty(indexed=False)
     num_actual_starts_v2 = ndb.IntegerProperty(indexed=False)
     # Number of students who completed the exploration (v1 - data collected

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -82,6 +82,10 @@ class AnswerSubmittedEventLogEntryModel(base_models.BaseModel):
     time_spent_in_state_secs = ndb.FloatProperty()
     # Whether the submitted answer received useful feedback
     is_feedback_useful = ndb.BooleanProperty(indexed=True)
+    # The version of the event schema used to describe an event of this type.
+    # Details on the schema are given in the docstring for this class.
+    event_schema_version = ndb.IntegerProperty(
+        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -124,6 +128,10 @@ class ExplorationActualStartEventLogEntryModel(base_models.BaseModel):
     state_name = ndb.StringProperty(indexed=True)
     # ID of current student's session
     session_id = ndb.StringProperty(indexed=True)
+    # The version of the event schema used to describe an event of this type.
+    # Details on the schema are given in the docstring for this class.
+    event_schema_version = ndb.IntegerProperty(
+        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -162,6 +170,10 @@ class SolutionHitEventLogEntryModel(base_models.BaseModel):
     session_id = ndb.StringProperty(indexed=True)
     # Time since start of this state before this event occurred (in sec).
     time_spent_in_state_secs = ndb.FloatProperty()
+    # The version of the event schema used to describe an event of this type.
+    # Details on the schema are given in the docstring for this class.
+    event_schema_version = ndb.IntegerProperty(
+        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -207,9 +219,6 @@ class StartExplorationEventLogEntryModel(base_models.BaseModel):
         params: Current parameter values, in the form of a map of parameter
             name to value.
     """
-    # This value should be updated in the event of any event schema change.
-    CURRENT_EVENT_SCHEMA_VERSION = 1
-
     # Which specific type of event this is
     event_type = ndb.StringProperty(indexed=True)
     # Id of exploration currently being played.
@@ -233,7 +242,7 @@ class StartExplorationEventLogEntryModel(base_models.BaseModel):
     # The version of the event schema used to describe an event of this type.
     # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=CURRENT_EVENT_SCHEMA_VERSION)
+        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -318,9 +327,6 @@ class MaybeLeaveExplorationEventLogEntryModel(base_models.BaseModel):
         client_time_spent_in_secs: Time spent in this state before the event
             was triggered.
     """
-    # This value should be updated in the event of any event schema change.
-    CURRENT_EVENT_SCHEMA_VERSION = 1
-
     # Which specific type of event this is
     event_type = ndb.StringProperty(indexed=True)
     # Id of exploration currently being played.
@@ -347,7 +353,7 @@ class MaybeLeaveExplorationEventLogEntryModel(base_models.BaseModel):
     # The version of the event schema used to describe an event of this type.
     # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=CURRENT_EVENT_SCHEMA_VERSION)
+        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -426,9 +432,6 @@ class CompleteExplorationEventLogEntryModel(base_models.BaseModel):
     have the wrong 'last updated' timestamp. However, the 'created_on'
     timestamp is the same as that of the original model.
     """
-    # This value should be updated in the event of any event schema change.
-    CURRENT_EVENT_SCHEMA_VERSION = 1
-
     # Which specific type of event this is
     event_type = ndb.StringProperty(indexed=True)
     # Id of exploration currently being played.
@@ -455,7 +458,7 @@ class CompleteExplorationEventLogEntryModel(base_models.BaseModel):
     # The version of the event schema used to describe an event of this type.
     # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=CURRENT_EVENT_SCHEMA_VERSION)
+        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -517,9 +520,6 @@ class RateExplorationEventLogEntryModel(base_models.BaseModel):
         exploration_id: ID of exploration which is being rated.
         rating: Value of rating assigned to exploration.
     """
-    # This value should be updated in the event of any event schema change.
-    CURRENT_EVENT_SCHEMA_VERSION = 1
-
     # Which specific type of event this is
     event_type = ndb.StringProperty(indexed=True)
     # Id of exploration which has been rated.
@@ -532,7 +532,7 @@ class RateExplorationEventLogEntryModel(base_models.BaseModel):
     # The version of the event schema used to describe an event of this type.
     # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=CURRENT_EVENT_SCHEMA_VERSION)
+        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, user_id):
@@ -591,9 +591,6 @@ class StateHitEventLogEntryModel(base_models.BaseModel):
     amount of time between this event (i.e., the learner entering the
     state) and the other event.
     """
-    # This value should be updated in the event of any event schema change.
-    CURRENT_EVENT_SCHEMA_VERSION = 1
-
     # Which specific type of event this is
     event_type = ndb.StringProperty(indexed=True)
     # Id of exploration currently being played.
@@ -615,7 +612,7 @@ class StateHitEventLogEntryModel(base_models.BaseModel):
     # The version of the event schema used to describe an event of this type.
     # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=CURRENT_EVENT_SCHEMA_VERSION)
+        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -680,6 +677,10 @@ class StateCompleteEventLogEntryModel(base_models.BaseModel):
     session_id = ndb.StringProperty(indexed=True)
     # Time since start of this state before this event occurred (in sec).
     time_spent_in_state_secs = ndb.FloatProperty()
+    # The version of the event schema used to describe an event of this type.
+    # Details on the schema are given in the docstring for this class.
+    event_schema_version = ndb.IntegerProperty(
+        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -717,22 +718,30 @@ class ExplorationStatsModel(base_models.BaseModel):
     exp_id = ndb.StringProperty(indexed=True)
     # Version of exploration.
     exp_version = ndb.IntegerProperty(indexed=True)
-    # Number of learners starting the exploration.
-    num_starts = ndb.IntegerProperty(indexed=True)
+    # Number of learners starting the exploration (v1 - historical data).
+    num_starts_v1 = ndb.IntegerProperty(indexed=True)
+    num_starts_v2 = ndb.IntegerProperty(indexed=True)
     # Number of students who actually attempted the exploration. Only learners
     # who spent a minimum time on the exploration are considered to have
-    # actually started the exploration.
-    num_actual_starts = ndb.IntegerProperty(indexed=False)
-    # Number of students who completed the exploration.
-    num_completions = ndb.IntegerProperty(indexed=False)
+    # actually started the exploration (v1 - historical data).
+    num_actual_starts_v1 = ndb.IntegerProperty(indexed=False)
+    num_actual_starts_v2 = ndb.IntegerProperty(indexed=False)
+    # Number of students who completed the exploration (v1 - historical data).
+    num_completions_v1 = ndb.IntegerProperty(indexed=False)
+    num_completions_v2 = ndb.IntegerProperty(indexed=False)
     # Keyed by state name that describes the analytics for that state.
     # {state_name: {
-    #   'total_answers_count': ...,
-    #   'useful_feedback_count': ...,
-    #   'total_hit_count': ...,
-    #   'first_hit_count': ...,
-    #   'num_times_solution_viewed': ...,
-    #   'num_completions': ...}}
+    #   'total_answers_count_v1': ...,
+    #   'total_answers_count_v2': ...,
+    #   'useful_feedback_count_v1': ...,
+    #   'useful_feedback_count_v2': ...,
+    #   'total_hit_count_v1': ...,
+    #   'total_hit_count_v2': ...,
+    #   'first_hit_count_v1': ...,
+    #   'first_hit_count_v2': ...,
+    #   'num_times_solution_viewed_v2': ...,
+    #   'num_completions_v1': ...,
+    #   'num_completions_v2': ...}}
     state_stats_mapping = ndb.JsonProperty(indexed=False)
 
     @classmethod
@@ -767,18 +776,25 @@ class ExplorationStatsModel(base_models.BaseModel):
 
     @classmethod
     def create(
-            cls, exp_id, exp_version, num_starts, num_actual_starts,
-            num_completions, state_stats_mapping):
+            cls, exp_id, exp_version, num_starts_v1, num_starts_v2,
+            num_actual_starts_v1, num_actual_starts_v2, num_completions_v1,
+            num_completions_v2, state_stats_mapping):
         """Creates an ExplorationStatsModel instance and writes it to the
         datastore.
 
         Args:
             exp_id: str. ID of the exploration.
             exp_version: int. Version of the exploration.
-            num_starts: int. Number of learners who started the exploration.
-            num_actual_starts: int. Number of learners who attempted the
+            num_starts_v1: int. Number of learners who started the exploration (
+                historical data).
+            num_starts_v2: int. Number of learners who started the exploration.
+            num_actual_starts_v1: int. Number of learners who attempted the
+                exploration (historical data).
+            num_actual_starts_v2: int. Number of learners who attempted the
                 exploration.
-            num_completions: int. Number of learners who completed the
+            num_completions_v1: int. Number of learners who completed the
+                exploration (historical data).
+            num_completions_v2: int. Number of learners who completed the
                 exploration.
             state_stats_mapping: dict. Mapping from state names to state stats
                 dicts.
@@ -789,9 +805,12 @@ class ExplorationStatsModel(base_models.BaseModel):
         instance_id = cls.get_entity_id(exp_id, exp_version)
         stats_instance = cls(
             id=instance_id, exp_id=exp_id, exp_version=exp_version,
-            num_starts=num_starts,
-            num_actual_starts=num_actual_starts,
-            num_completions=num_completions,
+            num_starts_v1=num_starts_v1,
+            num_starts_v2=num_starts_v2,
+            num_actual_starts_v1=num_actual_starts_v1,
+            num_actual_starts_v2=num_actual_starts_v2,
+            num_completions_v1=num_completions_v1,
+            num_completions_v2=num_completions_v2,
             state_stats_mapping=state_stats_mapping)
         stats_instance.put()
         return instance_id

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -83,7 +83,6 @@ class AnswerSubmittedEventLogEntryModel(base_models.BaseModel):
     # Whether the submitted answer received useful feedback
     is_feedback_useful = ndb.BooleanProperty(indexed=True)
     # The version of the event schema used to describe an event of this type.
-    # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
         indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
@@ -129,7 +128,6 @@ class ExplorationActualStartEventLogEntryModel(base_models.BaseModel):
     # ID of current student's session
     session_id = ndb.StringProperty(indexed=True)
     # The version of the event schema used to describe an event of this type.
-    # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
         indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
@@ -171,7 +169,6 @@ class SolutionHitEventLogEntryModel(base_models.BaseModel):
     # Time since start of this state before this event occurred (in sec).
     time_spent_in_state_secs = ndb.FloatProperty()
     # The version of the event schema used to describe an event of this type.
-    # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
         indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
@@ -240,7 +237,6 @@ class StartExplorationEventLogEntryModel(base_models.BaseModel):
                                    choices=[feconf.PLAY_TYPE_PLAYTEST,
                                             feconf.PLAY_TYPE_NORMAL])
     # The version of the event schema used to describe an event of this type.
-    # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
         indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
@@ -351,7 +347,6 @@ class MaybeLeaveExplorationEventLogEntryModel(base_models.BaseModel):
                                    choices=[feconf.PLAY_TYPE_PLAYTEST,
                                             feconf.PLAY_TYPE_NORMAL])
     # The version of the event schema used to describe an event of this type.
-    # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
         indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
@@ -456,7 +451,6 @@ class CompleteExplorationEventLogEntryModel(base_models.BaseModel):
                                    choices=[feconf.PLAY_TYPE_PLAYTEST,
                                             feconf.PLAY_TYPE_NORMAL])
     # The version of the event schema used to describe an event of this type.
-    # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
         indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
@@ -530,7 +524,6 @@ class RateExplorationEventLogEntryModel(base_models.BaseModel):
     # user rates an exploration for the first time.
     old_rating = ndb.IntegerProperty(indexed=True)
     # The version of the event schema used to describe an event of this type.
-    # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
         indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
@@ -610,7 +603,6 @@ class StateHitEventLogEntryModel(base_models.BaseModel):
                                    choices=[feconf.PLAY_TYPE_PLAYTEST,
                                             feconf.PLAY_TYPE_NORMAL])
     # The version of the event schema used to describe an event of this type.
-    # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
         indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
@@ -678,7 +670,6 @@ class StateCompleteEventLogEntryModel(base_models.BaseModel):
     # Time since start of this state before this event occurred (in sec).
     time_spent_in_state_secs = ndb.FloatProperty()
     # The version of the event schema used to describe an event of this type.
-    # Details on the schema are given in the docstring for this class.
     event_schema_version = ndb.IntegerProperty(
         indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
 
@@ -718,15 +709,17 @@ class ExplorationStatsModel(base_models.BaseModel):
     exp_id = ndb.StringProperty(indexed=True)
     # Version of exploration.
     exp_version = ndb.IntegerProperty(indexed=True)
-    # Number of learners starting the exploration (v1 - historical data).
+    # Number of learners starting the exploration (v1 - data collected before
+    # Nov 2017).
     num_starts_v1 = ndb.IntegerProperty(indexed=True)
     num_starts_v2 = ndb.IntegerProperty(indexed=True)
     # Number of students who actually attempted the exploration. Only learners
     # who spent a minimum time on the exploration are considered to have
-    # actually started the exploration (v1 - historical data).
+    # actually started the exploration (v1 - data collected before Nov 2017)
     num_actual_starts_v1 = ndb.IntegerProperty(indexed=False)
     num_actual_starts_v2 = ndb.IntegerProperty(indexed=False)
-    # Number of students who completed the exploration (v1 - historical data).
+    # Number of students who completed the exploration (v1 - data collected
+    # before Nov 2017).
     num_completions_v1 = ndb.IntegerProperty(indexed=False)
     num_completions_v2 = ndb.IntegerProperty(indexed=False)
     # Keyed by state name that describes the analytics for that state.
@@ -785,17 +778,14 @@ class ExplorationStatsModel(base_models.BaseModel):
         Args:
             exp_id: str. ID of the exploration.
             exp_version: int. Version of the exploration.
-            num_starts_v1: int. Number of learners who started the exploration (
-                historical data).
-            num_starts_v2: int. Number of learners who started the exploration.
+            num_starts_v1: int. Number of learners who started the exploration.
+            num_starts_v2: int. As above, but for events with version 2.
             num_actual_starts_v1: int. Number of learners who attempted the
-                exploration (historical data).
-            num_actual_starts_v2: int. Number of learners who attempted the
                 exploration.
+            num_actual_starts_v2: int. As above, but for events with version 2.
             num_completions_v1: int. Number of learners who completed the
-                exploration (historical data).
-            num_completions_v2: int. Number of learners who completed the
                 exploration.
+            num_completions_v2: int. As above, but for events with version 2.
             state_stats_mapping: dict. Mapping from state names to state stats
                 dicts.
 

--- a/core/storage/statistics/gae_models_test.py
+++ b/core/storage/statistics/gae_models_test.py
@@ -154,7 +154,8 @@ class ExplorationStatsModelUnitTests(test_utils.GenericTestBase):
 
     def test_create_and_get_analytics_model(self):
         model_id = (
-            stat_models.ExplorationStatsModel.create('exp_id1', 1, 1, 0, 0, {}))
+            stat_models.ExplorationStatsModel.create(
+                'exp_id1', 1, 0, 0, 0, 0, 0, 0, {}))
 
         model = stat_models.ExplorationStatsModel.get_model(
             'exp_id1', 1)
@@ -162,7 +163,10 @@ class ExplorationStatsModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(model.id, model_id)
         self.assertEqual(model.exp_id, 'exp_id1')
         self.assertEqual(model.exp_version, 1)
-        self.assertEqual(model.num_starts, 1)
-        self.assertEqual(model.num_actual_starts, 0)
-        self.assertEqual(model.num_completions, 0)
+        self.assertEqual(model.num_starts_v1, 0)
+        self.assertEqual(model.num_actual_starts_v1, 0)
+        self.assertEqual(model.num_completions_v1, 0)
+        self.assertEqual(model.num_starts_v2, 0)
+        self.assertEqual(model.num_actual_starts_v2, 0)
+        self.assertEqual(model.num_completions_v2, 0)
         self.assertEqual(model.state_stats_mapping, {})

--- a/feconf.py
+++ b/feconf.py
@@ -641,7 +641,10 @@ SHOW_COLLECTION_NAVIGATION_TAB_STATS = False
 
 # Bool to enable update of analytics models.
 ENABLE_NEW_STATS_FRAMEWORK = False
-# Current event models schema version.
+# Current event models schema version. All event models with
+# event_schema_version as 1 are the events collected before the rework of the
+# statistics framework which brought about the recording of new event models.
+# This tentatively includes all models recorded before Nov 2017.
 CURRENT_EVENT_MODELS_SCHEMA_VERSION = 1
 
 # Output formats of downloaded explorations.

--- a/feconf.py
+++ b/feconf.py
@@ -641,6 +641,8 @@ SHOW_COLLECTION_NAVIGATION_TAB_STATS = False
 
 # Bool to enable update of analytics models.
 ENABLE_NEW_STATS_FRAMEWORK = False
+# Current event models schema version.
+CURRENT_EVENT_MODELS_SCHEMA_VERSION = 1
 
 # Output formats of downloaded explorations.
 OUTPUT_FORMAT_JSON = 'json'

--- a/feconf.py
+++ b/feconf.py
@@ -644,7 +644,7 @@ ENABLE_NEW_STATS_FRAMEWORK = False
 # Current event models schema version. All event models with
 # event_schema_version as 1 are the events collected before the rework of the
 # statistics framework which brought about the recording of new event models.
-# This tentatively includes all models recorded before Nov 2017.
+# This includes all models recorded before Nov 2017.
 CURRENT_EVENT_MODELS_SCHEMA_VERSION = 1
 
 # Output formats of downloaded explorations.


### PR DESCRIPTION
This PR introduces event model schema version for all event models (P.S. existing event models already have a default event_schema_version as 1 - so I didn't use None).

This also introduces changes to the ExplorationStatsModel. Now, all fields except num_times_solution_viewed have a field_v1 and a field_v2.

@seanlip PTAL!

Thanks!