### PR TITLE
Fix #3794: Complete milestone one of introducing the new fraction interaction.

### DIFF
--- a/core/templates/dev/head/domain/objects/FractionObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactory.js
@@ -25,8 +25,8 @@ oppia.constant('FractionParsingErrors', {
   DivideByZero: 'Please do not put 0 in the denominator'
 });
 
-oppia.factory('FractionObjectFactory', ['FractionParsingErrors',
-  function(FractionParsingErrors) {
+oppia.factory('FractionObjectFactory', [
+  'FractionParsingErrors', function(FractionParsingErrors) {
     var Fraction = function(isNegative, wholeNumber, numerator, denominator) {
       this.isNegative = isNegative;
       this.wholeNumber = wholeNumber;

--- a/core/templates/dev/head/domain/objects/FractionObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactory.js
@@ -17,16 +17,16 @@
  * domain objects.
  */
 
-oppia.constant('FractionParsingErrors', {
-  InvalidChars:
+oppia.constant('FRACTION_PARSING_ERRORS', {
+  INVALID_CHARS:
     'Please only use numerical digits, spaces or forward slashes (/)',
-  InvalidFormat:
+  INVALID_FORMAT:
     'Please enter answer in fraction format (e.g. 5/3 or 1 2/3)',
-  DivideByZero: 'Please do not put 0 in the denominator'
+  DIVISION_BY_ZERO: 'Please do not put 0 in the denominator'
 });
 
 oppia.factory('FractionObjectFactory', [
-  'FractionParsingErrors', function(FractionParsingErrors) {
+  'FRACTION_PARSING_ERRORS', function(FRACTION_PARSING_ERRORS) {
     var Fraction = function(isNegative, wholeNumber, numerator, denominator) {
       this.isNegative = isNegative;
       this.wholeNumber = wholeNumber;
@@ -63,11 +63,11 @@ oppia.factory('FractionObjectFactory', [
     Fraction.fromRawInputString = function(rawInput) {
       var INVALID_CHARS_REGEX = /[^\d\s\/-]/g;
       if (INVALID_CHARS_REGEX.test(rawInput)) {
-        throw new Error(FractionParsingErrors.InvalidChars);
+        throw new Error(FRACTION_PARSING_ERRORS.INVALID_CHARS);
       }
       var FRACTION_REGEX = /^\s*-?\s*((\d*\s*\d+\s*\/\s*\d+)|\d+)\s*$/;
       if (!FRACTION_REGEX.test(rawInput)) {
-        throw new Error(FractionParsingErrors.InvalidFormat);
+        throw new Error(FRACTION_PARSING_ERRORS.INVALID_FORMAT);
       }
       var isNegative = false;
       var wholeNumber = 0;
@@ -97,7 +97,7 @@ oppia.factory('FractionObjectFactory', [
         denominator = parseInt(numbers[2]);
       }
       if (denominator === 0) {
-        throw new Error(FractionParsingErrors.DivideByZero);
+        throw new Error(FRACTION_PARSING_ERRORS.DIVISION_BY_ZERO);
       }
       return new Fraction(isNegative, wholeNumber, numerator, denominator);
     };

--- a/core/templates/dev/head/domain/objects/FractionObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactory.js
@@ -20,8 +20,10 @@
 oppia.factory('FractionObjectFactory', [
  function() {
    var errors = {
-     InvalidChars: 'Please only use numerical digits, spaces or forward slashes (/)',
-     InvalidFormat: 'Please enter answer in fraction format (e.g. 5/3 or 1 2/3)',
+     InvalidChars:
+       'Please only use numerical digits, spaces or forward slashes (/)',
+     InvalidFormat:
+       'Please enter answer in fraction format (e.g. 5/3 or 1 2/3)',
      DivideByZero: 'Please do not put 0 in the denominator'
    };
 

--- a/core/templates/dev/head/domain/objects/FractionObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactory.js
@@ -16,6 +16,7 @@
  * @fileoverview Factory for creating instances of Fraction
  * domain objects.
  */
+
 oppia.constant('FractionParsingErrors', {
   InvalidChars:
     'Please only use numerical digits, spaces or forward slashes (/)',

--- a/core/templates/dev/head/domain/objects/FractionObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactory.js
@@ -26,91 +26,90 @@ oppia.constant('FractionParsingErrors', {
 });
 
 oppia.factory('FractionObjectFactory', ['FractionParsingErrors',
- function(FractionParsingErrors) {
-   var Fraction = function(isNegative, wholeNumber, numerator, denominator) {
-     this.isNegative = isNegative;
-     this.wholeNumber = wholeNumber;
-     this.numerator = numerator;
-     this.denominator = denominator;
-   };
+  function(FractionParsingErrors) {
+    var Fraction = function(isNegative, wholeNumber, numerator, denominator) {
+      this.isNegative = isNegative;
+      this.wholeNumber = wholeNumber;
+      this.numerator = numerator;
+      this.denominator = denominator;
+    };
 
-   Fraction.prototype.toString = function () {
-     var fractionString = '';
-     if (this.numerator !== 0) {
-       fractionString += this.numerator + '/' + this.denominator;
-     }
-     if (this.wholeNumber !== 0) {
-       fractionString = this.wholeNumber + ' ' + fractionString;
-       // If the fractional part was empty then there will be a trailing
-       // whitespace.
-       fractionString = fractionString.trim();
-     }
-     if (this.isNegative && fractionString !== '') {
-       fractionString = '-' + fractionString;
-     }
-     return fractionString === '' ? '0' : fractionString;
-   };
+    Fraction.prototype.toString = function () {
+      var fractionString = '';
+      if (this.numerator !== 0) {
+        fractionString += this.numerator + '/' + this.denominator;
+      }
+      if (this.wholeNumber !== 0) {
+        fractionString = this.wholeNumber + ' ' + fractionString;
+        // If the fractional part was empty then there will be a trailing
+        // whitespace.
+        fractionString = fractionString.trim();
+      }
+      if (this.isNegative && fractionString !== '') {
+        fractionString = '-' + fractionString;
+      }
+      return fractionString === '' ? '0' : fractionString;
+    };
 
-   Fraction.prototype.toDict = function() {
-     return {
-       isNegative: this.isNegative,
-       wholeNumber: this.wholeNumber,
-       numerator: this.numerator,
-       denominator: this.denominator
-     };
-   };
+    Fraction.prototype.toDict = function() {
+      return {
+        isNegative: this.isNegative,
+        wholeNumber: this.wholeNumber,
+        numerator: this.numerator,
+        denominator: this.denominator
+      };
+    };
 
-   Fraction.fromRawInputString = function(rawInput) {
-    // TODO(aa): Perform error checking on the input using regexes.
-     var INVALID_CHARS_REGEX = /[^\d\s\/-]/g;
-     if (INVALID_CHARS_REGEX.test(rawInput)) {
-       throw new Error(FractionParsingErrors.InvalidChars);
-     }
-     var FRACTION_REGEX = /^\s*-?\s*((\d*\s*\d+\s*\/\s*\d+)|\d+)\s*$/;
-     if (!FRACTION_REGEX.test(rawInput)) {
-       throw new Error(FractionParsingErrors.InvalidFormat);
-     }
-     var isNegative = false;
-     var wholeNumber = 0;
-     var numerator = 0;
-     var denominator = 1;
-     rawInput = rawInput.trim();
-     if (rawInput.charAt(0) === '-') {
-       isNegative = true;
-       // Remove the negative char from the string.
-       rawInput = rawInput.substring(1);
-     }
-     // Filter result from split to remove empty strings.
-     var numbers = rawInput.split(/\/|\s/g).filter(function(token) {
-       // The empty string will evaluate to false.
-       return Boolean(token);
-     });
+    Fraction.fromRawInputString = function(rawInput) {
+      var INVALID_CHARS_REGEX = /[^\d\s\/-]/g;
+      if (INVALID_CHARS_REGEX.test(rawInput)) {
+        throw new Error(FractionParsingErrors.InvalidChars);
+      }
+      var FRACTION_REGEX = /^\s*-?\s*((\d*\s*\d+\s*\/\s*\d+)|\d+)\s*$/;
+      if (!FRACTION_REGEX.test(rawInput)) {
+        throw new Error(FractionParsingErrors.InvalidFormat);
+      }
+      var isNegative = false;
+      var wholeNumber = 0;
+      var numerator = 0;
+      var denominator = 1;
+      rawInput = rawInput.trim();
+      if (rawInput.charAt(0) === '-') {
+        isNegative = true;
+        // Remove the negative char from the string.
+        rawInput = rawInput.substring(1);
+      }
+      // Filter result from split to remove empty strings.
+      var numbers = rawInput.split(/\/|\s/g).filter(function(token) {
+        // The empty string will evaluate to false.
+        return Boolean(token);
+      });
 
-     if (numbers.length === 1) {
-       wholeNumber = parseInt(numbers[0]);
-     } else if (numbers.length === 2) {
-       numerator = parseInt(numbers[0]);
-       denominator = parseInt(numbers[1]);
-     } else {
-       // numbers.length == 3
-       wholeNumber = parseInt(numbers[0]);
-       numerator = parseInt(numbers[1]);
-       denominator = parseInt(numbers[2]);
-     }
-     if (denominator === 0) {
-       throw new Error(FractionParsingErrors.DivideByZero);
-     }
-     return new Fraction(isNegative, wholeNumber, numerator, denominator);
-   };
+      if (numbers.length === 1) {
+        wholeNumber = parseInt(numbers[0]);
+      } else if (numbers.length === 2) {
+        numerator = parseInt(numbers[0]);
+        denominator = parseInt(numbers[1]);
+      } else {
+        // numbers.length == 3
+        wholeNumber = parseInt(numbers[0]);
+        numerator = parseInt(numbers[1]);
+        denominator = parseInt(numbers[2]);
+      }
+      if (denominator === 0) {
+        throw new Error(FractionParsingErrors.DivideByZero);
+      }
+      return new Fraction(isNegative, wholeNumber, numerator, denominator);
+    };
 
-   Fraction.fromDict = function(fractionDict) {
-     return new Fraction(
-       fractionDict.isNegative,
-       fractionDict.wholeNumber,
-       fractionDict.numerator,
-       fractionDict.denominator);
-   };
+    Fraction.fromDict = function(fractionDict) {
+      return new Fraction(
+        fractionDict.isNegative,
+        fractionDict.wholeNumber,
+        fractionDict.numerator,
+        fractionDict.denominator);
+    };
 
-   return Fraction;
- }
+    return Fraction;
+  }
 ]);

--- a/core/templates/dev/head/domain/objects/FractionObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactory.js
@@ -1,0 +1,116 @@
+// Copyright 2017 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Factory for creating instances of Fraction
+ * domain objects.
+ */
+
+oppia.factory('FractionObjectFactory', [
+ function() {
+   var errors = {
+     InvalidChars: 'Please only use numerical digits, spaces or forward slashes (/)',
+     InvalidFormat: 'Please enter answer in fraction format (e.g. 5/3 or 1 2/3)',
+     DivideByZero: 'Please do not put 0 in the denominator'
+   };
+
+   var Fraction = function(isNegative, wholeNumber, numerator, denominator) {
+     this.isNegative = isNegative;
+     this.wholeNumber = wholeNumber;
+     this.numerator = numerator;
+     this.denominator = denominator;
+   };
+
+   Fraction.prototype.toString = function () {
+     var fractionstring = '';
+     if (this.numerator !== 0) {
+       fractionstring += this.numerator + '/' + this.denominator;
+     }
+     if (this.wholeNumber !== 0) {
+       fractionstring = this.wholeNumber + ' ' + fractionstring;
+       // if fractional part was empty then there will be a trailing whitespace.
+       fractionstring = fractionstring.trim();
+     }
+     if (this.isNegative && fractionstring !== '') {
+       fractionstring = '-' + fractionstring;
+     }
+     return fractionstring === '' ? '0' : fractionstring;
+   };
+
+   Fraction.prototype.toDict = function() {
+     return {
+       isNegative: this.isNegative,
+       wholeNumber: this.wholeNumber,
+       numerator: this.numerator,
+       denominator: this.denominator
+     };
+   };
+
+   Fraction.parse = function(rawInput) {
+    // TODO(aa): Perform error checking on the input using regexes.
+     var invalidChars = /[^\d\s\/-]/g;
+     if (invalidChars.test(rawInput)) {
+       throw new Error(errors.InvalidChars);
+     }
+     var validFormat = /^\s*-?\s*((\d*\s*\d+\s*\/\s*\d+)|\d+)\s*$/;
+     if (!validFormat.test(rawInput)) {
+       throw new Error(errors.InvalidFormat);
+     }
+     var isNegative = false;
+     var wholeNumber = 0;
+     var numerator = 0;
+     var denominator = 0;
+     rawInput = rawInput.trim();
+     if (rawInput.charAt(0) === '-') {
+       isNegative = true;
+       // Remove the negative char from the string.
+       rawInput = rawInput.substring(1);
+     }
+     // Filter result from split to remove empty strings.
+     var numbers = rawInput.split(/\/|\s/g).filter(function(token) {
+       // The empty string will evaluate to false.
+       return token;
+     });
+
+     if (numbers.length == 1) {
+       wholeNumber = parseInt(numbers[0]);
+     } else if (numbers.length == 2) {
+       numerator = parseInt(numbers[0]);
+       denominator = parseInt(numbers[1]);
+       if (denominator === 0) {
+         throw new Error(errors.DivideByZero);
+       }
+     } else {
+       // numbers.length == 3
+       wholeNumber = parseInt(numbers[0]);
+       numerator = parseInt(numbers[1]);
+       denominator = parseInt(numbers[2]);
+       if (denominator === 0) {
+         throw new Error(errors.DivideByZero);
+       }
+     }
+     return new Fraction(isNegative, wholeNumber, numerator, denominator);
+   };
+
+   Fraction.fromDict = function(fractionDict) {
+     return new Fraction(
+       fractionDict.isNegative,
+       fractionDict.wholeNumber,
+       fractionDict.numerator,
+       fractionDict.denominator);
+   };
+
+   return Fraction;
+ }
+]);

--- a/core/templates/dev/head/domain/objects/FractionObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactory.js
@@ -16,17 +16,16 @@
  * @fileoverview Factory for creating instances of Fraction
  * domain objects.
  */
+oppia.constant('FractionParsingErrors', {
+  InvalidChars:
+    'Please only use numerical digits, spaces or forward slashes (/)',
+  InvalidFormat:
+    'Please enter answer in fraction format (e.g. 5/3 or 1 2/3)',
+  DivideByZero: 'Please do not put 0 in the denominator'
+});
 
-oppia.factory('FractionObjectFactory', [
- function() {
-   var errors = {
-     InvalidChars:
-       'Please only use numerical digits, spaces or forward slashes (/)',
-     InvalidFormat:
-       'Please enter answer in fraction format (e.g. 5/3 or 1 2/3)',
-     DivideByZero: 'Please do not put 0 in the denominator'
-   };
-
+oppia.factory('FractionObjectFactory', ['FractionParsingErrors',
+ function(FractionParsingErrors) {
    var Fraction = function(isNegative, wholeNumber, numerator, denominator) {
      this.isNegative = isNegative;
      this.wholeNumber = wholeNumber;
@@ -35,19 +34,20 @@ oppia.factory('FractionObjectFactory', [
    };
 
    Fraction.prototype.toString = function () {
-     var fractionstring = '';
+     var fractionString = '';
      if (this.numerator !== 0) {
-       fractionstring += this.numerator + '/' + this.denominator;
+       fractionString += this.numerator + '/' + this.denominator;
      }
      if (this.wholeNumber !== 0) {
-       fractionstring = this.wholeNumber + ' ' + fractionstring;
-       // if fractional part was empty then there will be a trailing whitespace.
-       fractionstring = fractionstring.trim();
+       fractionString = this.wholeNumber + ' ' + fractionString;
+       // If the fractional part was empty then there will be a trailing
+       // whitespace.
+       fractionString = fractionString.trim();
      }
-     if (this.isNegative && fractionstring !== '') {
-       fractionstring = '-' + fractionstring;
+     if (this.isNegative && fractionString !== '') {
+       fractionString = '-' + fractionString;
      }
-     return fractionstring === '' ? '0' : fractionstring;
+     return fractionString === '' ? '0' : fractionString;
    };
 
    Fraction.prototype.toDict = function() {
@@ -59,20 +59,20 @@ oppia.factory('FractionObjectFactory', [
      };
    };
 
-   Fraction.parse = function(rawInput) {
+   Fraction.fromRawInputString = function(rawInput) {
     // TODO(aa): Perform error checking on the input using regexes.
-     var invalidChars = /[^\d\s\/-]/g;
-     if (invalidChars.test(rawInput)) {
-       throw new Error(errors.InvalidChars);
+     var INVALID_CHARS_REGEX = /[^\d\s\/-]/g;
+     if (INVALID_CHARS_REGEX.test(rawInput)) {
+       throw new Error(FractionParsingErrors.InvalidChars);
      }
-     var validFormat = /^\s*-?\s*((\d*\s*\d+\s*\/\s*\d+)|\d+)\s*$/;
-     if (!validFormat.test(rawInput)) {
-       throw new Error(errors.InvalidFormat);
+     var FRACTION_REGEX = /^\s*-?\s*((\d*\s*\d+\s*\/\s*\d+)|\d+)\s*$/;
+     if (!FRACTION_REGEX.test(rawInput)) {
+       throw new Error(FractionParsingErrors.InvalidFormat);
      }
      var isNegative = false;
      var wholeNumber = 0;
      var numerator = 0;
-     var denominator = 0;
+     var denominator = 1;
      rawInput = rawInput.trim();
      if (rawInput.charAt(0) === '-') {
        isNegative = true;
@@ -82,25 +82,22 @@ oppia.factory('FractionObjectFactory', [
      // Filter result from split to remove empty strings.
      var numbers = rawInput.split(/\/|\s/g).filter(function(token) {
        // The empty string will evaluate to false.
-       return token;
+       return Boolean(token);
      });
 
-     if (numbers.length == 1) {
+     if (numbers.length === 1) {
        wholeNumber = parseInt(numbers[0]);
-     } else if (numbers.length == 2) {
+     } else if (numbers.length === 2) {
        numerator = parseInt(numbers[0]);
        denominator = parseInt(numbers[1]);
-       if (denominator === 0) {
-         throw new Error(errors.DivideByZero);
-       }
      } else {
        // numbers.length == 3
        wholeNumber = parseInt(numbers[0]);
        numerator = parseInt(numbers[1]);
        denominator = parseInt(numbers[2]);
-       if (denominator === 0) {
-         throw new Error(errors.DivideByZero);
-       }
+     }
+     if (denominator === 0) {
+       throw new Error(FractionParsingErrors.DivideByZero);
      }
      return new Fraction(isNegative, wholeNumber, numerator, denominator);
    };

--- a/core/templates/dev/head/domain/objects/FractionObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactorySpec.js
@@ -16,7 +16,7 @@
  * @fileoverview unit tests for the fraction object type factory service.
  */
 
- fdescribe('FractionObjectFactory', function() {
+ describe('FractionObjectFactory', function() {
    beforeEach(module('oppia'));
 
    describe('fraction object factory', function() {

--- a/core/templates/dev/head/domain/objects/FractionObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactorySpec.js
@@ -21,8 +21,10 @@
 
    describe('fraction object factory', function() {
      var errors = {
-       InvalidChars: 'Please only use numerical digits, spaces or forward slashes (/)',
-       InvalidFormat: 'Please enter answer in fraction format (e.g. 5/3 or 1 2/3)',
+       InvalidChars:
+         'Please only use numerical digits, spaces or forward slashes (/)',
+       InvalidFormat:
+         'Please enter answer in fraction format (e.g. 5/3 or 1 2/3)',
        DivideByZero: 'Please do not put 0 in the denominator'
      };
      var Fraction = null;
@@ -92,8 +94,6 @@
          new Error(errors.DivideByZero));
        expect(function() {Fraction.parse('1 2 /0')}).toThrow(
          new Error(errors.DivideByZero));
-
      });
-
    });
  });

--- a/core/templates/dev/head/domain/objects/FractionObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactorySpec.js
@@ -23,7 +23,7 @@
      var Fraction = null;
 
      beforeEach(inject(function($injector) {
-       errors = $injector.get('FractionParsingErrors');
+       errors = $injector.get('FRACTION_PARSING_ERRORS');
        Fraction = $injector.get('FractionObjectFactory');
      }));
 
@@ -64,37 +64,37 @@
      it('should throw errors for invalid fractions', function() {
        // Invalid characters.
        expect(function() {Fraction.fromRawInputString('3 \ b')}).toThrow(
-         new Error(errors.InvalidChars));
+         new Error(errors.INVALID_CHARS));
        expect(function() {Fraction.fromRawInputString('a 3/5')}).toThrow(
-           new Error(errors.InvalidChars));
+           new Error(errors.INVALID_CHARS));
        expect(function() {Fraction.fromRawInputString('5 b/c')}).toThrow(
-         new Error(errors.InvalidChars));
+         new Error(errors.INVALID_CHARS));
        expect(function() {Fraction.fromRawInputString('a b/c')}).toThrow(
-         new Error(errors.InvalidChars));
+         new Error(errors.INVALID_CHARS));
        // Invalid format.
        expect(function() {Fraction.fromRawInputString('1 / -3')}).toThrow(
-         new Error(errors.InvalidFormat));
+         new Error(errors.INVALID_FORMAT));
        expect(function() {Fraction.fromRawInputString('-1 -3/2')}).toThrow(
-         new Error(errors.InvalidFormat));
+         new Error(errors.INVALID_FORMAT));
        expect(function() {Fraction.fromRawInputString('3 -')}).toThrow(
-         new Error(errors.InvalidFormat));
+         new Error(errors.INVALID_FORMAT));
        expect(function() {Fraction.fromRawInputString('1  1')}).toThrow(
-         new Error(errors.InvalidFormat));
+         new Error(errors.INVALID_FORMAT));
        expect(function() {Fraction.fromRawInputString('1/3 1/2')}).toThrow(
-         new Error(errors.InvalidFormat));
+         new Error(errors.INVALID_FORMAT));
        expect(function() {Fraction.fromRawInputString('1 2 3 / 4')}).toThrow(
-         new Error(errors.InvalidFormat));
+         new Error(errors.INVALID_FORMAT));
        expect(function() {Fraction.fromRawInputString('1 / 2 3')}).toThrow(
-         new Error(errors.InvalidFormat));
+         new Error(errors.INVALID_FORMAT));
        expect(function() {Fraction.fromRawInputString('- / 3')}).toThrow(
-            new Error(errors.InvalidFormat));
+            new Error(errors.INVALID_FORMAT));
        expect(function() {Fraction.fromRawInputString('/ 3')}).toThrow(
-         new Error(errors.InvalidFormat));
+         new Error(errors.INVALID_FORMAT));
        // Division by zero.
        expect(function() {Fraction.fromRawInputString(' 1/0')}).toThrow(
-         new Error(errors.DivideByZero));
+         new Error(errors.DIVISION_BY_ZERO));
        expect(function() {Fraction.fromRawInputString('1 2 /0')}).toThrow(
-         new Error(errors.DivideByZero));
+         new Error(errors.DIVISION_BY_ZERO));
      });
    });
  });

--- a/core/templates/dev/head/domain/objects/FractionObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactorySpec.js
@@ -1,0 +1,99 @@
+// Copyright 2017 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview unit tests for the fraction object type factory service.
+ */
+
+ fdescribe('FractionObjectFactory', function() {
+   beforeEach(module('oppia'));
+
+   describe('fraction object factory', function() {
+     var errors = {
+       InvalidChars: 'Please only use numerical digits, spaces or forward slashes (/)',
+       InvalidFormat: 'Please enter answer in fraction format (e.g. 5/3 or 1 2/3)',
+       DivideByZero: 'Please do not put 0 in the denominator'
+     };
+     var Fraction = null;
+
+     beforeEach(inject(function($injector) {
+       Fraction = $injector.get(
+         'FractionObjectFactory');
+     }));
+
+     it('should convert itself to a string in fraction format', function() {
+       expect(new Fraction(true, 1, 2 ,3).toString()).toBe('-1 2/3');
+       expect(new Fraction(false, 1, 2 ,3).toString()).toBe('1 2/3');
+       expect(new Fraction(true, 0, 2 ,3).toString()).toBe('-2/3');
+       expect(new Fraction(false, 0, 2 ,3).toString()).toBe('2/3');
+       expect(new Fraction(true, 1, 0, 3).toString()).toBe('-1');
+       expect(new Fraction(false, 1, 0, 3).toString()).toBe('1');
+       expect(new Fraction(true, 0, 0, 3).toString()).toBe('0');
+       expect(new Fraction(false, 0, 0, 3).toString()).toBe('0');
+     });
+
+     it('should parse valid strings', function() {
+       expect(Fraction.parse('1   1/ 2').toDict()).toEqual(
+         new Fraction(false, 1, 1, 2).toDict());
+       expect(Fraction.parse('- 1 1 /2').toDict()).toEqual(
+         new Fraction(true, 1, 1, 2).toDict());
+       expect(Fraction.parse('1      ').toDict()).toEqual(
+         new Fraction(false, 1, 0, 0).toDict());
+       expect(Fraction.parse('  - 1').toDict()).toEqual(
+         new Fraction(true, 1, 0, 0).toDict());
+       expect(Fraction.parse('1  /  2').toDict()).toEqual(
+         new Fraction(false, 0, 1, 2).toDict());
+       expect(Fraction.parse(' -1 /2').toDict()).toEqual(
+         new Fraction(true, 0, 1, 2).toDict());
+       expect(Fraction.parse('0  1/2').toDict()).toEqual(
+         new Fraction(false, 0, 1, 2).toDict());
+       expect(Fraction.parse('1 0 /2').toDict()).toEqual(
+         new Fraction(false, 1, 0, 2).toDict());
+     });
+
+     it('should throw errors for invalid fractions', function() {
+       // Invalid characters.
+       expect(function() {Fraction.parse('3 \ b')}).toThrow(
+         new Error(errors.InvalidChars));
+       expect(function() {Fraction.parse('a 3/5')}).toThrow(
+           new Error(errors.InvalidChars));
+       expect(function() {Fraction.parse('5 b/c')}).toThrow(
+         new Error(errors.InvalidChars));
+       expect(function() {Fraction.parse('a b/c')}).toThrow(
+         new Error(errors.InvalidChars));
+       // Invalid format.
+       expect(function() {Fraction.parse('3 -')}).toThrow(
+         new Error(errors.InvalidFormat));
+       expect(function() {Fraction.parse('1  1')}).toThrow(
+         new Error(errors.InvalidFormat));
+       expect(function() {Fraction.parse('1/3 1/2')}).toThrow(
+         new Error(errors.InvalidFormat));
+       expect(function() {Fraction.parse('1 2 3 / 4')}).toThrow(
+         new Error(errors.InvalidFormat));
+       expect(function() {Fraction.parse('1 / 2 3')}).toThrow(
+         new Error(errors.InvalidFormat));
+       expect(function() {Fraction.parse('- / 3')}).toThrow(
+            new Error(errors.InvalidFormat));
+       expect(function() {Fraction.parse('/ 3')}).toThrow(
+         new Error(errors.InvalidFormat));
+       // Division by zero.
+       expect(function() {Fraction.parse(' 1/0')}).toThrow(
+         new Error(errors.DivideByZero));
+       expect(function() {Fraction.parse('1 2 /0')}).toThrow(
+         new Error(errors.DivideByZero));
+
+     });
+
+   });
+ });

--- a/core/templates/dev/head/domain/objects/FractionObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactorySpec.js
@@ -15,23 +15,16 @@
 /**
  * @fileoverview unit tests for the fraction object type factory service.
  */
-
  describe('FractionObjectFactory', function() {
    beforeEach(module('oppia'));
 
    describe('fraction object factory', function() {
-     var errors = {
-       InvalidChars:
-         'Please only use numerical digits, spaces or forward slashes (/)',
-       InvalidFormat:
-         'Please enter answer in fraction format (e.g. 5/3 or 1 2/3)',
-       DivideByZero: 'Please do not put 0 in the denominator'
-     };
+     var errors = null;
      var Fraction = null;
 
      beforeEach(inject(function($injector) {
-       Fraction = $injector.get(
-         'FractionObjectFactory');
+       errors = $injector.get('FractionParsingErrors');
+       Fraction = $injector.get('FractionObjectFactory');
      }));
 
      it('should convert itself to a string in fraction format', function() {
@@ -46,53 +39,61 @@
      });
 
      it('should parse valid strings', function() {
-       expect(Fraction.parse('1   1/ 2').toDict()).toEqual(
+       expect(Fraction.fromRawInputString('10/ 2').toDict()).toEqual(
+         new Fraction(false, 0, 10, 2).toDict());
+       expect(Fraction.fromRawInputString('10/20').toDict()).toEqual(
+         new Fraction(false, 0, 10, 20).toDict());
+       expect(Fraction.fromRawInputString('1   1/ 2').toDict()).toEqual(
          new Fraction(false, 1, 1, 2).toDict());
-       expect(Fraction.parse('- 1 1 /2').toDict()).toEqual(
+       expect(Fraction.fromRawInputString('- 1 1 /2').toDict()).toEqual(
          new Fraction(true, 1, 1, 2).toDict());
-       expect(Fraction.parse('1      ').toDict()).toEqual(
-         new Fraction(false, 1, 0, 0).toDict());
-       expect(Fraction.parse('  - 1').toDict()).toEqual(
-         new Fraction(true, 1, 0, 0).toDict());
-       expect(Fraction.parse('1  /  2').toDict()).toEqual(
-         new Fraction(false, 0, 1, 2).toDict());
-       expect(Fraction.parse(' -1 /2').toDict()).toEqual(
+       expect(Fraction.fromRawInputString('1      ').toDict()).toEqual(
+         new Fraction(false, 1, 0, 1).toDict());
+       expect(Fraction.fromRawInputString('  - 1').toDict()).toEqual(
+         new Fraction(true, 1, 0, 1).toDict());
+       expect(Fraction.fromRawInputString('1  /  22').toDict()).toEqual(
+         new Fraction(false, 0, 1, 22).toDict());
+       expect(Fraction.fromRawInputString(' -1 /2').toDict()).toEqual(
          new Fraction(true, 0, 1, 2).toDict());
-       expect(Fraction.parse('0  1/2').toDict()).toEqual(
+       expect(Fraction.fromRawInputString('0  1/2').toDict()).toEqual(
          new Fraction(false, 0, 1, 2).toDict());
-       expect(Fraction.parse('1 0 /2').toDict()).toEqual(
+       expect(Fraction.fromRawInputString('1 0 /2').toDict()).toEqual(
          new Fraction(false, 1, 0, 2).toDict());
      });
 
      it('should throw errors for invalid fractions', function() {
        // Invalid characters.
-       expect(function() {Fraction.parse('3 \ b')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('3 \ b')}).toThrow(
          new Error(errors.InvalidChars));
-       expect(function() {Fraction.parse('a 3/5')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('a 3/5')}).toThrow(
            new Error(errors.InvalidChars));
-       expect(function() {Fraction.parse('5 b/c')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('5 b/c')}).toThrow(
          new Error(errors.InvalidChars));
-       expect(function() {Fraction.parse('a b/c')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('a b/c')}).toThrow(
          new Error(errors.InvalidChars));
        // Invalid format.
-       expect(function() {Fraction.parse('3 -')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('1 / -3')}).toThrow(
          new Error(errors.InvalidFormat));
-       expect(function() {Fraction.parse('1  1')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('-1 -3/2')}).toThrow(
          new Error(errors.InvalidFormat));
-       expect(function() {Fraction.parse('1/3 1/2')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('3 -')}).toThrow(
          new Error(errors.InvalidFormat));
-       expect(function() {Fraction.parse('1 2 3 / 4')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('1  1')}).toThrow(
          new Error(errors.InvalidFormat));
-       expect(function() {Fraction.parse('1 / 2 3')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('1/3 1/2')}).toThrow(
          new Error(errors.InvalidFormat));
-       expect(function() {Fraction.parse('- / 3')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('1 2 3 / 4')}).toThrow(
+         new Error(errors.InvalidFormat));
+       expect(function() {Fraction.fromRawInputString('1 / 2 3')}).toThrow(
+         new Error(errors.InvalidFormat));
+       expect(function() {Fraction.fromRawInputString('- / 3')}).toThrow(
             new Error(errors.InvalidFormat));
-       expect(function() {Fraction.parse('/ 3')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('/ 3')}).toThrow(
          new Error(errors.InvalidFormat));
        // Division by zero.
-       expect(function() {Fraction.parse(' 1/0')}).toThrow(
+       expect(function() {Fraction.fromRawInputString(' 1/0')}).toThrow(
          new Error(errors.DivideByZero));
-       expect(function() {Fraction.parse('1 2 /0')}).toThrow(
+       expect(function() {Fraction.fromRawInputString('1 2 /0')}).toThrow(
          new Error(errors.DivideByZero));
      });
    });

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -157,6 +157,7 @@
   <script src="{{ASSET_DIR_PREFIX}}/extensions/objects/templates/CodeStringEditor.js"></script>
   <script src="{{ASSET_DIR_PREFIX}}/extensions/objects/templates/CoordTwoDimEditor.js"></script>
   <script src="{{ASSET_DIR_PREFIX}}/extensions/objects/templates/FilepathEditor.js"></script>
+  <script src="{{ASSET_DIR_PREFIX}}/extensions/objects/templates/FractionEditor.js"></script>
   <script src="{{ASSET_DIR_PREFIX}}/extensions/objects/templates/GraphEditor.js"></script>
   <script src="{{ASSET_DIR_PREFIX}}/extensions/objects/templates/GraphPropertyEditor.js"></script>
   <script src="{{ASSET_DIR_PREFIX}}/extensions/objects/templates/HtmlEditor.js"></script>

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -283,6 +283,7 @@
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/exploration/ParamSpecObjectFactory.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/exploration/ParamSpecsObjectFactory.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/exploration/ParamTypeObjectFactory.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/domain/objects/FractionObjectFactory.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/utilities/StopwatchObjectFactory.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/utilities/LanguageUtilService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/utilities/AudioLanguageObjectFactory.js"></script>

--- a/extensions/interactions/object_defaults.json
+++ b/extensions/interactions/object_defaults.json
@@ -21,5 +21,11 @@
     "SetOfHtmlString": [],
     "SetOfNormalizedString": [],
     "SetOfUnicodeString": [],
-    "UnicodeString": ""
+    "UnicodeString": "",
+    "Fraction": {
+      "isNegative": false,
+      "wholeNumber": 0,
+      "numerator": 0,
+      "denominator": 1
+    }
 }

--- a/extensions/objects/models/objects.py
+++ b/extensions/objects/models/objects.py
@@ -171,6 +171,20 @@ class NonnegativeInt(BaseObject):
         }]
     }
 
+class PositiveInt(BaseObject):
+    """Nonnegative integer class."""
+
+    description = 'A positive integer.'
+    default_value = 1
+
+    SCHEMA = {
+        'type': 'int',
+        'validators': [{
+            'id': 'is_at_least',
+            'min_value': 1
+        }]
+    }
+
 
 class CodeString(BaseObject):
     """Code string class. This is like a normal string, but it should not
@@ -808,6 +822,6 @@ class Fraction(BaseObject):
             'schema': NonnegativeInt.SCHEMA
         }, {
             'name': 'denominator',
-            'schema': NonnegativeInt.SCHEMA
+            'schema': PositiveInt.SCHEMA
         }]
     }

--- a/extensions/objects/models/objects.py
+++ b/extensions/objects/models/objects.py
@@ -779,3 +779,38 @@ class MathExpression(BaseObject):
             'schema': UnicodeString.SCHEMA,
         }]
     }
+
+class Fraction(BaseObject):
+    """Fraction class."""
+
+    description = 'A fraction type'
+    edit_html_filename = 'unicode_string_editor'
+    edit_js_filename = 'FractionEditor'
+    default_value = {False, 0, 0, 1}
+
+    SCHEMA = {
+        'type': 'dict',
+        'properties': [{
+            'name': 'is_negative',
+            'schema': {
+                'type': 'bool'
+            }
+        }, {
+            'name': 'whole_number',
+            'schema': {
+                'type': 'int'
+            }
+
+        }, {
+            'name': 'numerator',
+            'schema': {
+                'type': 'int'
+            }
+
+        }, {
+            'name': 'denominator',
+            'schema': {
+                'type': 'int'
+            }
+        }]
+    }

--- a/extensions/objects/models/objects.py
+++ b/extensions/objects/models/objects.py
@@ -786,7 +786,12 @@ class Fraction(BaseObject):
     description = 'A fraction type'
     edit_html_filename = 'unicode_string_editor'
     edit_js_filename = 'FractionEditor'
-    default_value = {False, 0, 0, 1}
+    default_value = {
+        'is_negative': False,
+        'whole_number': 0,
+        'numerator': 0,
+        'denominator': 1
+    }
 
     SCHEMA = {
         'type': 'dict',

--- a/extensions/objects/models/objects.py
+++ b/extensions/objects/models/objects.py
@@ -787,8 +787,8 @@ class Fraction(BaseObject):
     edit_html_filename = 'unicode_string_editor'
     edit_js_filename = 'FractionEditor'
     default_value = {
-        'is_negative': False,
-        'whole_number': 0,
+        'isNegative': False,
+        'wholeNumber': 0,
         'numerator': 0,
         'denominator': 1
     }
@@ -796,14 +796,14 @@ class Fraction(BaseObject):
     SCHEMA = {
         'type': 'dict',
         'properties': [{
-            'name': 'is_negative',
+            'name': 'isNegative',
             'schema': {
                 'type': 'bool'
             }
         }, {
-            'name': 'whole_number',
+            'name': 'wholeNumber',
             'schema': {
-                'type': 'int'
+                'type': NonnegativeInt.SCHEMA
             }
         }, {
             'name': 'numerator',

--- a/extensions/objects/models/objects.py
+++ b/extensions/objects/models/objects.py
@@ -805,17 +805,11 @@ class Fraction(BaseObject):
             'schema': {
                 'type': 'int'
             }
-
         }, {
             'name': 'numerator',
-            'schema': {
-                'type': 'int'
-            }
-
+            'schema': NonnegativeInt.SCHEMA
         }, {
             'name': 'denominator',
-            'schema': {
-                'type': 'int'
-            }
+            'schema': NonnegativeInt.SCHEMA
         }]
     }

--- a/extensions/objects/models/objects.py
+++ b/extensions/objects/models/objects.py
@@ -784,7 +784,7 @@ class Fraction(BaseObject):
     """Fraction class."""
 
     description = 'A fraction type'
-    edit_html_filename = 'unicode_string_editor'
+    edit_html_filename = 'fraction_editor'
     edit_js_filename = 'FractionEditor'
     default_value = {
         'isNegative': False,

--- a/extensions/objects/models/objects.py
+++ b/extensions/objects/models/objects.py
@@ -802,9 +802,7 @@ class Fraction(BaseObject):
             }
         }, {
             'name': 'wholeNumber',
-            'schema': {
-                'type': NonnegativeInt.SCHEMA
-            }
+            'schema': NonnegativeInt.SCHEMA
         }, {
             'name': 'numerator',
             'schema': NonnegativeInt.SCHEMA

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -206,7 +206,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
         self.check_normalization(objects.SanitizedUrl, mappings, invalid_vals)
 
     def test_checked_proof_validation(self):
-        """Tests objects of type CheckedProof"""
+        """Tests objects of type CheckedProof."""
         valid_example_1 = {
             'assumptions_string': 'p',
             'target_string': 'q',
@@ -239,7 +239,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
             objects.CheckedProof, mappings, invalid_values)
 
     def test_logic_question_validation(self):
-        """Tests objects of type LogicQuestion"""
+        """Tests objects of type LogicQuestion."""
         p_expression = {
             'top_kind_name': 'variable',
             'top_operator_name': 'p',
@@ -267,7 +267,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
             objects.LogicQuestion, mappings, invalid_values)
 
     def test_logic_error_category_validation(self):
-        """Tests objects of type LogicErrorCategory"""
+        """Tests objects of type LogicErrorCategory."""
 
         mappings = [
             ('parsing', 'parsing'), ('typing', 'typing'),
@@ -279,7 +279,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
             objects.LogicErrorCategory, mappings, invalid_values)
 
     def test_graph(self):
-        """Tests objects of type Graph"""
+        """Tests objects of type Graph."""
         empty_graph = {
             'vertices': [],
             'edges': [],
@@ -369,7 +369,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
             objects.Graph, mappings, invalid_values)
 
     def test_graph_property_validation(self):
-        """Tests objects of type GraphProperty"""
+        """Tests objects of type GraphProperty."""
 
         mappings = [
             ('acyclic', 'acyclic'), ('regular', 'regular'),
@@ -382,7 +382,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
             objects.GraphProperty, mappings, invalid_values)
 
     def test_set_of_html_string(self):
-        """Tests objects of the type StringList"""
+        """Tests objects of the type StringList."""
 
         mappings = [(['abc', 'abb'], [u'abc', u'abb']), ([], [])]
         invalid_values = ['123', {'a': 1}, 3.0, None, [3, 'a'], [1, 2, 1]]
@@ -390,7 +390,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
             objects.SetOfHtmlString, mappings, invalid_values)
 
     def test_fraction(self):
-        """Tests objects of type Fraction"""
+        """Tests objects of type Fraction."""
         mappings = [(
             self._create_fraction_dict(True, 0, 0, 0),
             self._create_fraction_dict(True, 0, 0, 0)
@@ -402,6 +402,10 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
         invalid_values = [self._create_fraction_dict('non-boolean', 1, 2, 3),
                           self._create_fraction_dict(True, 'non-int', 2, 3),
                           self._create_fraction_dict(None, None, None, None),
+                          self._create_fraction_dict(False, 10, 1, -3),
+                          self._create_fraction_dict(False, -10, 11, 3),
+                          self._create_fraction_dict(False, 10, -11, 3),
+                          self._create_fraction_dict(False, -10, -11, -3),
                           {},
                           '1/3',
                           1]

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -392,21 +392,21 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
     def test_fraction(self):
         """Tests objects of type Fraction"""
         mappings = [(self._create_fraction_dict(True, 0, 0, 0),
-            self._create_fraction_dict(True, 0, 0, 0),
-            (self._create_fraction_dict(False, 1, 2, 3),
-            self._create_fraction_dict(False, 1, 2, 3)))]
+                    self._create_fraction_dict(True, 0, 0, 0),
+                    (self._create_fraction_dict(False, 1, 2, 3),
+                    self._create_fraction_dict(False, 1, 2, 3)))]
 
         invalid_values = [self._create_fraction_dict('non-boolean', 1, 2, 3),
-            self._create_fraction_dict(True, 'non-int', 2, 3),
-            self._create_fraction_dict(None, None, None, None),
-            {},
-            '1/3',
-            1]
+                          self._create_fraction_dict(True, 'non-int', 2, 3),
+                          self._create_fraction_dict(None, None, None, None),
+                          {},
+                          '1/3',
+                          1]
 
         self.check_normalization(objects.Fraction, mappings, invalid_values)
 
     def _create_fraction_dict(
-        self, is_negative, whole_number, numerator, denominator):
+            self, is_negative, whole_number, numerator, denominator):
         return {
             "is_negative": is_negative,
             "whole_number": whole_number,

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -389,6 +389,30 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
         self.check_normalization(
             objects.SetOfHtmlString, mappings, invalid_values)
 
+    def test_fraction(self):
+        """Tests objects of type Fraction"""
+        mappings = [(self._create_fraction_dict(True, 0, 0, 0),
+            self._create_fraction_dict(True, 0, 0, 0),
+            (self._create_fraction_dict(False, 1, 2, 3),
+            self._create_fraction_dict(False, 1, 2, 3)))]
+
+        invalid_values = [self._create_fraction_dict('non-boolean', 1, 2, 3),
+            self._create_fraction_dict(True, 'non-int', 2, 3),
+            self._create_fraction_dict(None, None, None, None),
+            {},
+            '1/3',
+            1]
+
+        self.check_normalization(objects.Fraction, mappings, invalid_values)
+
+    def _create_fraction_dict(
+        self, is_negative, whole_number, numerator, denominator):
+        return {
+            "is_negative": is_negative,
+            "whole_number": whole_number,
+            "numerator": numerator,
+            "denominator": denominator
+        }
 
 class SchemaValidityTests(test_utils.GenericTestBase):
 
@@ -400,7 +424,7 @@ class SchemaValidityTests(test_utils.GenericTestBase):
                     schema_utils_test.validate_schema(member.SCHEMA)
                     count += 1
 
-        self.assertEquals(count, 30)
+        self.assertEquals(count, 31)
 
 
 class ObjectDefinitionTests(test_utils.GenericTestBase):

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -394,7 +394,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
         mappings = [(self._create_fraction_dict(True, 0, 0, 0),
                      self._create_fraction_dict(True, 0, 0, 0),
                      (self._create_fraction_dict(False, 1, 2, 3),
-                     self._create_fraction_dict(False, 1, 2, 3)))]
+                      self._create_fraction_dict(False, 1, 2, 3)))]
 
         invalid_values = [self._create_fraction_dict('non-boolean', 1, 2, 3),
                           self._create_fraction_dict(True, 'non-int', 2, 3),

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -392,9 +392,9 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
     def test_fraction(self):
         """Tests objects of type Fraction"""
         mappings = [(self._create_fraction_dict(True, 0, 0, 0),
-                    self._create_fraction_dict(True, 0, 0, 0),
-                    (self._create_fraction_dict(False, 1, 2, 3),
-                    self._create_fraction_dict(False, 1, 2, 3)))]
+                     self._create_fraction_dict(True, 0, 0, 0),
+                     (self._create_fraction_dict(False, 1, 2, 3),
+                     self._create_fraction_dict(False, 1, 2, 3)))]
 
         invalid_values = [self._create_fraction_dict('non-boolean', 1, 2, 3),
                           self._create_fraction_dict(True, 'non-int', 2, 3),

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -411,8 +411,8 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
     def _create_fraction_dict(
             self, is_negative, whole_number, numerator, denominator):
         return {
-            "is_negative": is_negative,
-            "whole_number": whole_number,
+            "isNegative": is_negative,
+            "wholeNumber": whole_number,
             "numerator": numerator,
             "denominator": denominator
         }

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -391,10 +391,13 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
 
     def test_fraction(self):
         """Tests objects of type Fraction"""
-        mappings = [(self._create_fraction_dict(True, 0, 0, 0),
-                     self._create_fraction_dict(True, 0, 0, 0),
-                     (self._create_fraction_dict(False, 1, 2, 3),
-                      self._create_fraction_dict(False, 1, 2, 3)))]
+        mappings = [(
+            self._create_fraction_dict(True, 0, 0, 0),
+            self._create_fraction_dict(True, 0, 0, 0)
+        ), (
+            self._create_fraction_dict(False, 1, 2, 3),
+            self._create_fraction_dict(False, 1, 2, 3))
+        )]
 
         invalid_values = [self._create_fraction_dict('non-boolean', 1, 2, 3),
                           self._create_fraction_dict(True, 'non-int', 2, 3),

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -396,7 +396,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
             self._create_fraction_dict(True, 0, 0, 0)
         ), (
             self._create_fraction_dict(False, 1, 2, 3),
-            self._create_fraction_dict(False, 1, 2, 3))
+            self._create_fraction_dict(False, 1, 2, 3)
         )]
 
         invalid_values = [self._create_fraction_dict('non-boolean', 1, 2, 3),

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -78,6 +78,15 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
         self.check_normalization(
             objects.NonnegativeInt, mappings, invalid_vals)
 
+    def test_positive_int_validation(self):
+        """Tests objects of type PositiveInt."""
+        mappings = [(20, 20), ('20', 20), ('02', 2), (3.00, 3),
+                    (3.05, 3), ]
+        invalid_vals = ['a', '', {'a': 3}, [3], None, -1, '-1', 0, '0']
+
+        self.check_normalization(
+            objects.NonnegativeInt, mappings, invalid_vals)
+
     def test_code_evaluation_validation(self):
         """Tests objects of type codeEvaluation."""
         mappings = [(
@@ -406,6 +415,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
                           self._create_fraction_dict(False, -10, 11, 3),
                           self._create_fraction_dict(False, 10, -11, 3),
                           self._create_fraction_dict(False, -10, -11, -3),
+                          self._create_fraction_dict(False, 1, 1, 0),
                           {},
                           '1/3',
                           1]
@@ -431,7 +441,7 @@ class SchemaValidityTests(test_utils.GenericTestBase):
                     schema_utils_test.validate_schema(member.SCHEMA)
                     count += 1
 
-        self.assertEquals(count, 31)
+        self.assertEquals(count, 32)
 
 
 class ObjectDefinitionTests(test_utils.GenericTestBase):

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -85,7 +85,7 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
         invalid_vals = ['a', '', {'a': 3}, [3], None, -1, '-1', 0, '0']
 
         self.check_normalization(
-            objects.NonnegativeInt, mappings, invalid_vals)
+            objects.PositiveInt, mappings, invalid_vals)
 
     def test_code_evaluation_validation(self):
         """Tests objects of type codeEvaluation."""
@@ -401,8 +401,8 @@ class ObjectNormalizationUnitTests(test_utils.GenericTestBase):
     def test_fraction(self):
         """Tests objects of type Fraction."""
         mappings = [(
-            self._create_fraction_dict(True, 0, 0, 0),
-            self._create_fraction_dict(True, 0, 0, 0)
+            self._create_fraction_dict(True, 0, 0, 1),
+            self._create_fraction_dict(True, 0, 0, 1)
         ), (
             self._create_fraction_dict(False, 1, 2, 3),
             self._create_fraction_dict(False, 1, 2, 3)

--- a/extensions/objects/templates/FractionEditor.js
+++ b/extensions/objects/templates/FractionEditor.js
@@ -89,7 +89,7 @@ oppia.factory('FractionObjectFactory', [
        fractionDict.denominator);
    };
 
-     return Fraction;
+   return Fraction;
  }
 ]);
 

--- a/extensions/objects/templates/FractionEditor.js
+++ b/extensions/objects/templates/FractionEditor.js
@@ -27,8 +27,6 @@ oppia.directive('fractionEditor', [
       scope: true,
       template: '<span ng-include="getTemplateUrl()"></span>',
       controller: ['$scope', function($scope) {
-        $scope.alwaysEditable = true;
-        $scope.largeInput = false;
         var errorMessage = '';
         var fractionString = '0';
         if ($scope.$parent.value != null) {

--- a/extensions/objects/templates/FractionEditor.js
+++ b/extensions/objects/templates/FractionEditor.js
@@ -62,7 +62,11 @@
         rawInput = rawInput.substring(1);
       }
       // Filter result from split to remove empty strings.
-      var numbers = rawInput.split(/\/|\s/g).filter((token) => token);
+      var numbers = rawInput.split(/\/|\s/g).filter(function(token) {
+        // The empty string will evaluate to false.
+        return token;
+      });
+      
       if (numbers.length == 1) {
         wholeNumber = parseInt(numbers[0]);
       } else if (numbers.length == 2) {

--- a/extensions/objects/templates/FractionEditor.js
+++ b/extensions/objects/templates/FractionEditor.js
@@ -42,7 +42,7 @@ oppia.directive('fractionEditor', [
 
         $scope.$watch('localValue.label', function(newValue) {
           try {
-            var fraction = FractionObjectFactory.parse(newValue);
+            var fraction = FractionObjectFactory.fromRawInputString(newValue);
             $scope.$parent.value = fraction;
             errorMessage = '';
           } catch (parsingError) {

--- a/extensions/objects/templates/FractionEditor.js
+++ b/extensions/objects/templates/FractionEditor.js
@@ -51,34 +51,34 @@
 
      Fraction.parse = function(rawInput) {
       // TODO(aa): Perform error checking on the input using regexes.
-      var isNegative = false;
-      var wholeNumber = 0;
-      var numerator = 0;
-      var denominator = 0;
-      rawInput = rawInput.trim();
-      if (rawInput.charAt(0) === '-') {
-        isNegative = true;
-        // Remove the negative char from the string.
-        rawInput = rawInput.substring(1);
-      }
-      // Filter result from split to remove empty strings.
-      var numbers = rawInput.split(/\/|\s/g).filter(function(token) {
-        // The empty string will evaluate to false.
-        return token;
-      });
-      
-      if (numbers.length == 1) {
-        wholeNumber = parseInt(numbers[0]);
-      } else if (numbers.length == 2) {
-        numerator = parseInt(numbers[0]);
-        denominator = parseInt(numbers[1]);
-      } else {
-        // numbers.length == 3
-        wholeNumber = parseInt(numbers[0]);
-        numerator = parseInt(numbers[1]);
-        denominator = parseInt(numbers[2]);
-      }
-      return new Fraction(isNegative, wholeNumber, numerator, denominator);
+       var isNegative = false;
+       var wholeNumber = 0;
+       var numerator = 0;
+       var denominator = 0;
+       rawInput = rawInput.trim();
+       if (rawInput.charAt(0) === '-') {
+         isNegative = true;
+         // Remove the negative char from the string.
+         rawInput = rawInput.substring(1);
+       }
+       // Filter result from split to remove empty strings.
+       var numbers = rawInput.split(/\/|\s/g).filter(function(token) {
+         // The empty string will evaluate to false.
+         return token;
+       });
+
+       if (numbers.length == 1) {
+         wholeNumber = parseInt(numbers[0]);
+       } else if (numbers.length == 2) {
+         numerator = parseInt(numbers[0]);
+         denominator = parseInt(numbers[1]);
+       } else {
+         // numbers.length == 3
+         wholeNumber = parseInt(numbers[0]);
+         numerator = parseInt(numbers[1]);
+         denominator = parseInt(numbers[2]);
+       }
+       return new Fraction(isNegative, wholeNumber, numerator, denominator);
     };
 
      Fraction.fromDict = function(fractionDict) {

--- a/extensions/objects/templates/FractionEditor.js
+++ b/extensions/objects/templates/FractionEditor.js
@@ -17,69 +17,69 @@
  * domain objects.
  */
 
- oppia.factory('FractionObjectFactory', [
-   function() {
-     var Fraction = function(isNegative, wholeNumber, numerator, denominator) {
-       this.isNegative = isNegative;
-       this.wholeNumber = wholeNumber;
-       this.numerator = numerator;
-       this.denominator = denominator;
+oppia.factory('FractionObjectFactory', [
+ function() {
+   var Fraction = function(isNegative, wholeNumber, numerator, denominator) {
+     this.isNegative = isNegative;
+     this.wholeNumber = wholeNumber;
+     this.numerator = numerator;
+     this.denominator = denominator;
+   };
+
+   Fraction.prototype.toString = function () {
+     var fractionSring = '';
+     if (this.numerator !== 0) {
+       fractionSring += this.numerator + '/' + this.denominator;
+     }
+     if (this.wholeNumber !== 0) {
+       fractionSring = this.wholeNumber + ' ' + fractionSring;
+     }
+     if (this.isNegative && fractionSring !== '') {
+       fractionSring = '-' + fractionSring;
+     }
+     return fractionSring === '' ? '0' : fractionSring;
+   };
+
+   Fraction.prototype.toDict = function() {
+     return {
+       isNegative: this.isNegative,
+       wholeNumber: this.wholeNumber,
+       numerator: this.numerator,
+       denominator: this.denominator
      };
+   };
 
-     Fraction.prototype.toString = function () {
-       var fractionSring = '';
-       if (this.numerator !== 0) {
-         fractionSring += this.numerator + '/' + this.denominator;
-       }
-       if (this.wholeNumber !== 0) {
-         fractionSring = this.wholeNumber + ' ' + fractionSring;
-       }
-       if (this.isNegative && fractionSring !== '') {
-         fractionSring = '-' + fractionSring;
-       }
-       return fractionSring === '' ? '0' : fractionSring;
+   Fraction.parse = function(rawInput) {
+    // TODO(aa): Perform error checking on the input using regexes.
+     var isNegative = false;
+     var wholeNumber = 0;
+     var numerator = 0;
+     var denominator = 0;
+     rawInput = rawInput.trim();
+     if (rawInput.charAt(0) === '-') {
+       isNegative = true;
+       // Remove the negative char from the string.
+       rawInput = rawInput.substring(1);
+     }
+     // Filter result from split to remove empty strings.
+     var numbers = rawInput.split(/\/|\s/g).filter(function(token) {
+       // The empty string will evaluate to false.
+       return token;
+     });
+
+     if (numbers.length == 1) {
+       wholeNumber = parseInt(numbers[0]);
+     } else if (numbers.length == 2) {
+       numerator = parseInt(numbers[0]);
+       denominator = parseInt(numbers[1]);
+     } else {
+       // numbers.length == 3
+       wholeNumber = parseInt(numbers[0]);
+       numerator = parseInt(numbers[1]);
+       denominator = parseInt(numbers[2]);
+     }
+     return new Fraction(isNegative, wholeNumber, numerator, denominator);
      };
-
-     Fraction.prototype.toDict = function() {
-       return {
-         isNegative: this.isNegative,
-         wholeNumber: this.wholeNumber,
-         numerator: this.numerator,
-         denominator: this.denominator
-       };
-     };
-
-     Fraction.parse = function(rawInput) {
-      // TODO(aa): Perform error checking on the input using regexes.
-       var isNegative = false;
-       var wholeNumber = 0;
-       var numerator = 0;
-       var denominator = 0;
-       rawInput = rawInput.trim();
-       if (rawInput.charAt(0) === '-') {
-         isNegative = true;
-         // Remove the negative char from the string.
-         rawInput = rawInput.substring(1);
-       }
-       // Filter result from split to remove empty strings.
-       var numbers = rawInput.split(/\/|\s/g).filter(function(token) {
-         // The empty string will evaluate to false.
-         return token;
-       });
-
-       if (numbers.length == 1) {
-         wholeNumber = parseInt(numbers[0]);
-       } else if (numbers.length == 2) {
-         numerator = parseInt(numbers[0]);
-         denominator = parseInt(numbers[1]);
-       } else {
-         // numbers.length == 3
-         wholeNumber = parseInt(numbers[0]);
-         numerator = parseInt(numbers[1]);
-         denominator = parseInt(numbers[2]);
-       }
-       return new Fraction(isNegative, wholeNumber, numerator, denominator);
-    };
 
      Fraction.fromDict = function(fractionDict) {
        return new Fraction(
@@ -90,10 +90,10 @@
      };
 
      return Fraction;
-   }
- ]);
+  }
+]);
 
-oppia.directive('fractionEditor', [
+ oppia.directive('fractionEditor', [
   '$compile', 'FractionObjectFactory', 'OBJECT_EDITOR_URL_PREFIX',
   function($compile, FractionObjectFactory, OBJECT_EDITOR_URL_PREFIX) {
     return {

--- a/extensions/objects/templates/FractionEditor.js
+++ b/extensions/objects/templates/FractionEditor.js
@@ -12,86 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/**
- * @fileoverview Factory for creating instances of Fraction
- * domain objects.
- */
-
-oppia.factory('FractionObjectFactory', [
- function() {
-   var Fraction = function(isNegative, wholeNumber, numerator, denominator) {
-     this.isNegative = isNegative;
-     this.wholeNumber = wholeNumber;
-     this.numerator = numerator;
-     this.denominator = denominator;
-   };
-
-   Fraction.prototype.toString = function () {
-     var fractionSring = '';
-     if (this.numerator !== 0) {
-       fractionSring += this.numerator + '/' + this.denominator;
-     }
-     if (this.wholeNumber !== 0) {
-       fractionSring = this.wholeNumber + ' ' + fractionSring;
-     }
-     if (this.isNegative && fractionSring !== '') {
-       fractionSring = '-' + fractionSring;
-     }
-     return fractionSring === '' ? '0' : fractionSring;
-   };
-
-   Fraction.prototype.toDict = function() {
-     return {
-       isNegative: this.isNegative,
-       wholeNumber: this.wholeNumber,
-       numerator: this.numerator,
-       denominator: this.denominator
-     };
-   };
-
-   Fraction.parse = function(rawInput) {
-    // TODO(aa): Perform error checking on the input using regexes.
-     var isNegative = false;
-     var wholeNumber = 0;
-     var numerator = 0;
-     var denominator = 0;
-     rawInput = rawInput.trim();
-     if (rawInput.charAt(0) === '-') {
-       isNegative = true;
-       // Remove the negative char from the string.
-       rawInput = rawInput.substring(1);
-     }
-     // Filter result from split to remove empty strings.
-     var numbers = rawInput.split(/\/|\s/g).filter(function(token) {
-       // The empty string will evaluate to false.
-       return token;
-     });
-
-     if (numbers.length == 1) {
-       wholeNumber = parseInt(numbers[0]);
-     } else if (numbers.length == 2) {
-       numerator = parseInt(numbers[0]);
-       denominator = parseInt(numbers[1]);
-     } else {
-       // numbers.length == 3
-       wholeNumber = parseInt(numbers[0]);
-       numerator = parseInt(numbers[1]);
-       denominator = parseInt(numbers[2]);
-     }
-     return new Fraction(isNegative, wholeNumber, numerator, denominator);
-   };
-
-   Fraction.fromDict = function(fractionDict) {
-     return new Fraction(
-       fractionDict.isNegative,
-       fractionDict.wholeNumber,
-       fractionDict.numerator,
-       fractionDict.denominator);
-   };
-
-   return Fraction;
- }
-]);
 
 oppia.directive('fractionEditor', [
   '$compile', 'FractionObjectFactory', 'OBJECT_EDITOR_URL_PREFIX',
@@ -109,21 +29,29 @@ oppia.directive('fractionEditor', [
       controller: ['$scope', function($scope) {
         $scope.alwaysEditable = true;
         $scope.largeInput = false;
+        var errorMessage = "";
         var fractionString = '0';
         if ($scope.$parent.value != null) {
-          var fraction = FractionObjectFactory.fromDict($scope.$parent.value);
-          fractionString = fraction.toString();
+          var defaultFraction = FractionObjectFactory.fromDict($scope.$parent.value);
+          defaultFractionString = defaultFraction.toString();
         }
         $scope.localValue = {
-          label: fractionString
+          label: defaultFractionString
         };
 
         $scope.$watch('localValue.label', function(newValue) {
-          var fraction = FractionObjectFactory.parse(newValue);
-          if (fraction) {
+          try {
+            var fraction = FractionObjectFactory.parse(newValue);
             $scope.$parent.value = fraction;
+            errorMessage = "";
+          } catch (parsingError) {
+            errorMessage = parsingError.message;
           }
         });
+
+        $scope.getWarningText = function() {
+          return errorMessage;
+        }
       }]
     };
   }]);

--- a/extensions/objects/templates/FractionEditor.js
+++ b/extensions/objects/templates/FractionEditor.js
@@ -29,10 +29,11 @@ oppia.directive('fractionEditor', [
       controller: ['$scope', function($scope) {
         $scope.alwaysEditable = true;
         $scope.largeInput = false;
-        var errorMessage = "";
+        var errorMessage = '';
         var fractionString = '0';
         if ($scope.$parent.value != null) {
-          var defaultFraction = FractionObjectFactory.fromDict($scope.$parent.value);
+          var defaultFraction =
+            FractionObjectFactory.fromDict($scope.$parent.value);
           defaultFractionString = defaultFraction.toString();
         }
         $scope.localValue = {
@@ -43,7 +44,7 @@ oppia.directive('fractionEditor', [
           try {
             var fraction = FractionObjectFactory.parse(newValue);
             $scope.$parent.value = fraction;
-            errorMessage = "";
+            errorMessage = '';
           } catch (parsingError) {
             errorMessage = parsingError.message;
           }

--- a/extensions/objects/templates/FractionEditor.js
+++ b/extensions/objects/templates/FractionEditor.js
@@ -1,0 +1,125 @@
+// Copyright 2017 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Factory for creating instances of Fraction
+ * domain objects.
+ */
+
+ oppia.factory('FractionObjectFactory', [
+   function() {
+     var Fraction = function(isNegative, wholeNumber, numerator, denominator) {
+       this.isNegative = isNegative;
+       this.wholeNumber = wholeNumber;
+       this.numerator = numerator;
+       this.denominator = denominator;
+     };
+
+     Fraction.prototype.toString = function () {
+       var fractionSring = '';
+       if (this.numerator !== 0) {
+         fractionSring += this.numerator + '/' + this.denominator;
+       }
+       if (this.wholeNumber !== 0) {
+         fractionSring = this.wholeNumber + ' ' + fractionSring;
+       }
+       if (this.isNegative && fractionSring !== '') {
+         fractionSring = '-' + fractionSring;
+       }
+       return fractionSring === '' ? '0' : fractionSring;
+     };
+
+     Fraction.prototype.toDict = function() {
+       return {
+         isNegative: this.isNegative,
+         wholeNumber: this.wholeNumber,
+         numerator: this.numerator,
+         denominator: this.denominator
+       };
+     };
+
+     Fraction.parse = function(rawInput) {
+      // TODO(aa): Perform error checking on the input using regexes.
+      var isNegative = false;
+      var wholeNumber = 0;
+      var numerator = 0;
+      var denominator = 0;
+      rawInput = rawInput.trim();
+      if (rawInput.charAt(0) === '-') {
+        isNegative = true;
+        // Remove the negative char from the string.
+        rawInput = rawInput.substring(1);
+      }
+      // Filter result from split to remove empty strings.
+      var numbers = rawInput.split(/\/|\s/g).filter((token) => token);
+      if (numbers.length == 1) {
+        wholeNumber = parseInt(numbers[0]);
+      } else if (numbers.length == 2) {
+        numerator = parseInt(numbers[0]);
+        denominator = parseInt(numbers[1]);
+      } else {
+        // numbers.length == 3
+        wholeNumber = parseInt(numbers[0]);
+        numerator = parseInt(numbers[1]);
+        denominator = parseInt(numbers[2]);
+      }
+      return new Fraction(isNegative, wholeNumber, numerator, denominator);
+    };
+
+     Fraction.fromDict = function(fractionDict) {
+       return new Fraction(
+         fractionDict.isNegative,
+         fractionDict.wholeNumber,
+         fractionDict.numerator,
+         fractionDict.denominator);
+     };
+
+     return Fraction;
+   }
+ ]);
+
+oppia.directive('fractionEditor', [
+  '$compile', 'FractionObjectFactory', 'OBJECT_EDITOR_URL_PREFIX',
+  function($compile, FractionObjectFactory, OBJECT_EDITOR_URL_PREFIX) {
+    return {
+      link: function(scope, element) {
+        scope.getTemplateUrl = function() {
+          return OBJECT_EDITOR_URL_PREFIX + 'Fraction';
+        };
+        $compile(element.contents())(scope);
+      },
+      restrict: 'E',
+      scope: true,
+      template: '<span ng-include="getTemplateUrl()"></span>',
+      controller: ['$scope', function($scope) {
+        $scope.alwaysEditable = true;
+        $scope.largeInput = false;
+        var fractionString = '0';
+        if ($scope.$parent.value != null) {
+          var fraction = FractionObjectFactory.fromDict($scope.$parent.value);
+          fractionString = fraction.toString();
+        }
+        $scope.localValue = {
+          label: fractionString
+        };
+
+        $scope.$watch('localValue.label', function(newValue) {
+          var fraction = FractionObjectFactory.parse(newValue);
+          if (fraction) {
+            $scope.$parent.value = fraction;
+          }
+        });
+      }]
+    };
+  }]);

--- a/extensions/objects/templates/FractionEditor.js
+++ b/extensions/objects/templates/FractionEditor.js
@@ -79,21 +79,21 @@ oppia.factory('FractionObjectFactory', [
        denominator = parseInt(numbers[2]);
      }
      return new Fraction(isNegative, wholeNumber, numerator, denominator);
-     };
+   };
 
-     Fraction.fromDict = function(fractionDict) {
-       return new Fraction(
-         fractionDict.isNegative,
-         fractionDict.wholeNumber,
-         fractionDict.numerator,
-         fractionDict.denominator);
-     };
+   Fraction.fromDict = function(fractionDict) {
+     return new Fraction(
+       fractionDict.isNegative,
+       fractionDict.wholeNumber,
+       fractionDict.numerator,
+       fractionDict.denominator);
+   };
 
      return Fraction;
-  }
+ }
 ]);
 
- oppia.directive('fractionEditor', [
+oppia.directive('fractionEditor', [
   '$compile', 'FractionObjectFactory', 'OBJECT_EDITOR_URL_PREFIX',
   function($compile, FractionObjectFactory, OBJECT_EDITOR_URL_PREFIX) {
     return {

--- a/extensions/objects/templates/fraction_editor.html
+++ b/extensions/objects/templates/fraction_editor.html
@@ -1,0 +1,15 @@
+<span ng-if="!active && !alwaysEditable">
+  <[localValue.label]>
+  (<a href="#" onclick="return false;" ng-click="openEditor()">Edit</a>)
+</span>
+
+<span ng-if="active || alwaysEditable">
+  <input type="text" ng-model="localValue.label" class="form-control">
+  <button type="button" class="btn btn-default" ng-if="!alwaysEditable" ng-click="replaceValue(localValue.label)">
+    Close
+  </button>
+</span>
+
+<div class="oppia-form-error">
+  <[getWarningText()]>
+</div>

--- a/extensions/objects/templates/fraction_editor.html
+++ b/extensions/objects/templates/fraction_editor.html
@@ -1,14 +1,4 @@
-<span ng-if="!active && !alwaysEditable">
-  <[localValue.label]>
-  (<a href="#" onclick="return false;" ng-click="openEditor()">Edit</a>)
-</span>
-
-<span ng-if="active || alwaysEditable">
-  <input type="text" ng-model="localValue.label" class="form-control">
-  <button type="button" class="btn btn-default" ng-if="!alwaysEditable" ng-click="replaceValue(localValue.label)">
-    Close
-  </button>
-</span>
+<input type="text" ng-model="localValue.label" class="form-control">
 
 <div class="oppia-form-error">
   <[getWarningText()]>


### PR DESCRIPTION
This commit introduces a new object type to represent fractions in the backend, along with the files required to enable the fraction to be used in rules. 
A few things to note:
* I chose to introduce a domain object to represent the fractions on the front-end side due to the need to parse fractions in various forms (parsing strings, javascript objects, converting between representations). This would be repeated when parsing learner submissions so it makes sense to create an abstraction for it. It is currently in the FractionEditor.js file but a more suitable place may become apparent in future milestones.
* The parseString method of the domain object mentioned above is incomplete in that it does not fully check user input. I will complete the method in the next milestone (which is concerned with creating rules). The domain object will also need unit tests too of course.
* I reused the HTML file from the Unicode text input rather than making my own. This seems to make sense until I reach a stage where the existing file seems not to be sufficient. 
* I did some manual testing of the FractionEditor.js methods by temporarily using it as a rule in the TextInput.js interaction. Based on this it seems to be working (although not with incorrect inputs of course, which will need to be handled in the next milestone).

If you want me to add unit tests for the FractionDomainObject in this milestone that is of course totally fine. One small issue I foresee is that I'm not sure where they should go. Normally it would be in-line with the file but as the other files don't have tests this feels a little strange. Or maybe the domain object should have its own separate file (although I'm not sure which folder would be most appropriate to put it in)?

Also, one last thing. I had an arrow function (or lambda) in my code and it was called up as a lint error. Just wondering if that's expected behaviour or not (for reference the linter found an unexpected character '>').

Thanks!