### PR TITLE
Upgrade ui-bootstrap to 0.14.3.

### DIFF
--- a/core/tests/protractor/cacheSlugs.js
+++ b/core/tests/protractor/cacheSlugs.js
@@ -56,7 +56,8 @@ describe('Cache Slugs', function() {
   it('should check that errors get logged for missing resources', function() {
     browser.get(ERROR_PAGE_URL_SUFFIX);
     var expectedErrors = [
-      'http://localhost:9001/build/fail/logo/288x128_logo_white.png'
+      'http://localhost:9001/build/fail/logo/288x128_logo_white.png',
+      '\\$modal is now deprecated. Use \\$uibModal instead.'
     ];
     checkConsoleErrorsExist(expectedErrors);
   });

--- a/manifest.json
+++ b/manifest.json
@@ -395,14 +395,14 @@
         }
       },
       "uiBootstrap": {
-        "version": "0.13.4",
+        "version": "0.14.3",
         "downloadFormat": "files",
         "url": "https://raw.githubusercontent.com/angular-ui/bootstrap/gh-pages",
         "rootDirPrefix": "ui-bootstrap-",
         "targetDirPrefix": "ui-bootstrap-",
-        "files": ["ui-bootstrap-tpls-0.13.4.js", "ui-bootstrap-tpls-0.13.4.min.js"],
+        "files": ["ui-bootstrap-tpls-0.14.3.js", "ui-bootstrap-tpls-0.14.3.min.js"],
         "bundle": {
-          "js": ["ui-bootstrap-tpls-0.13.4.js"]
+          "js": ["ui-bootstrap-tpls-0.14.3.js"]
         }
       },
       "uiCodemirror": {


### PR DESCRIPTION
E2e tests are failing randomly with a "Cannot set property 'isOpen' of null" error. It appears that this is fixed in versions 0.14.0 and onwards of UI Bootstrap:

https://github.com/angular-ui/bootstrap/pull/5267/commits/2dd17fbb4e6a48d006dc9b370a8b2d572db1a2d4

There are further versions of UI Bootstrap but upgrading to these requires resolving breaking changes, so this PR does just a minimal update for now to unbreak the e2e tests.