### PR TITLE
Fix errors in production due to parameters not working correctly.

### DIFF
--- a/core/templates/dev/head/domain/exploration/ParamChangeObjectFactory.js
+++ b/core/templates/dev/head/domain/exploration/ParamChangeObjectFactory.js
@@ -42,7 +42,7 @@ oppia.factory('ParamChangeObjectFactory', [function() {
     };
   };
 
-  ParamChange.resetCustomizationArgs = function() {
+  ParamChange.prototype.resetCustomizationArgs = function() {
     this.customizationArgs = angular.copy(
       DEFAULT_CUSTOMIZATION_ARGS[this.generatorId]);
   };

--- a/core/tests/protractor/parameters.js
+++ b/core/tests/protractor/parameters.js
@@ -42,7 +42,7 @@ describe('Parameters', function() {
 
     editor.moveToState('card 2');
     editor.addParameterChange('a', '{{answer}}');
-    editor.addParameterChange('b', 3);
+    editor.addMultipleChoiceParameterChange('b', [3]);
     editor.setContent(forms.toRichText(
       'Change value of b from {{b}} to'));
     editor.setInteraction('NumericInput');

--- a/core/tests/protractor_utils/editor.js
+++ b/core/tests/protractor_utils/editor.js
@@ -284,6 +284,30 @@ var addParameterChange = function(paramName, paramValue) {
   general.waitForSystem(500);
 };
 
+// This function adds a multiple-choice parameter change, creating the
+// parameter if necessary.
+var addMultipleChoiceParameterChange = function(paramName, paramValues) {
+  element(by.css('.protractor-test-state-edit-param-changes')).click();
+  element(by.css('.protractor-test-add-param-button')).click();
+
+  var editorRowElem = element.all(by.css(
+    '.protractor-test-param-changes-list')).last();
+
+  forms.AutocompleteDropdownEditor(editorRowElem).setValue(paramName);
+
+  editorRowElem.element(by.cssContainingText('option', 'to one of')).click();
+
+  paramValues.forEach(function(paramValue) {
+    var item = editorRowElem.all(by.tagName('input')).last();
+    item.clear();
+    item.sendKeys(paramValue);
+  });
+
+  element(by.css('.protractor-test-save-param-changes-button')).click();
+
+  general.waitForSystem(500);
+};
+
 // This function adds a exploration level parameter change, creating
 // the parameter if necessary.
 var addExplorationLevelParameterChange = function(paramName, paramValue) {
@@ -1279,6 +1303,7 @@ exports.setRuleParametersInAddResponseModal = (
 exports.expectRuleParametersToBe = expectRuleParametersToBe;
 
 exports.addParameterChange = addParameterChange;
+exports.addMultipleChoiceParameterChange = addMultipleChoiceParameterChange;
 exports.addExplorationLevelParameterChange = addExplorationLevelParameterChange;
 
 exports.addResponse = addResponse;


### PR DESCRIPTION
We've been getting production errors along the following lines:
- paramChange.resetCustomizationArgs is not a function
- cannot read property 'length' of undefined

On investigation, this is due to errors being thrown when the "generator type" for the parameter is changed. This is due to an [omission of "prototype"](https://github.com/oppia/oppia/pull/3302/files#diff-e07f09bdd6d3f3ea33746fd28c69d0acR45) in #3302 (which I missed while reviewing). I've added a Protractor test to additionally guard against this in the future.