### PR TITLE
Shorten answer group header summaries so that the existence of multiple rules can be seen.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
@@ -552,7 +552,10 @@ oppia.filter('summarizeAnswerGroup', [
       }
 
       if (hasFeedback) {
-        summary += $filter('convertToPlainText')(outcome.feedback[0]);
+        summary += (
+          shortenRule ?
+          $filter('truncate')(outcome.feedback[0], 30) :
+          $filter('convertToPlainText')(outcome.feedback[0]));
       }
       return summary;
     };


### PR DESCRIPTION
This isn't foolproof, but makes it more likely that, if there are multiple rules in an answer group, it's possible to see their existence. Otherwise the feedback text can crowd the "+1" label off to the right of the rule header.

Here's an example of the effect:

![screenshot from 2017-10-27 02-16-06](https://user-images.githubusercontent.com/10575562/32096950-d254a7b2-babc-11e7-8689-e9e9a6b36ad5.png)

In develop, the feedback displayed in the second rule header would extend all the way to the right, and the "+1" would not be shown at all.