### PR TITLE
Fix issue with lastComputedArrangement occasionally being undefined when calculating the destination state lists.

### DIFF
--- a/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
@@ -78,37 +78,43 @@ oppia.directive('outcomeDestinationEditor', [
               StateGraphLayoutService.getLastComputedArrangement());
             var allStateNames = explorationStatesService.getStateNames();
 
-            var maxDepth = 0;
-            var maxOffset = 0;
-            for (var stateName in lastComputedArrangement) {
-              maxDepth = Math.max(
-                maxDepth, lastComputedArrangement[stateName].depth);
-              maxOffset = Math.max(
-                maxOffset, lastComputedArrangement[stateName].offset);
-            }
-
-            // Higher scores come later.
-            var allStateScores = {};
-            var unarrangedStateCount = 0;
-            for (var i = 0; i < allStateNames.length; i++) {
-              var stateName = allStateNames[i];
-              if (lastComputedArrangement.hasOwnProperty(stateName)) {
-                allStateScores[stateName] = (
-                  lastComputedArrangement[stateName].depth * (maxOffset + 1) +
-                  lastComputedArrangement[stateName].offset);
-              } else {
-                // States that have just been added in the rule 'create new'
-                // modal are not yet included as part of
-                // lastComputedArrangement so we account for them here.
-                allStateScores[stateName] = (
-                  (maxDepth + 1) * (maxOffset + 1) + unarrangedStateCount);
-                unarrangedStateCount++;
+            // It is possible that lastComputedArrangement is null if the graph
+            // has never been rendered at the time this computation is being
+            // carried out.
+            var stateNames = angular.copy(allStateNames);
+            if (lastComputedArrangement) {
+              var maxDepth = 0;
+              var maxOffset = 0;
+              for (var stateName in lastComputedArrangement) {
+                maxDepth = Math.max(
+                  maxDepth, lastComputedArrangement[stateName].depth);
+                maxOffset = Math.max(
+                  maxOffset, lastComputedArrangement[stateName].offset);
               }
-            }
 
-            var stateNames = allStateNames.sort(function(a, b) {
-              return allStateScores[a] - allStateScores[b];
-            });
+              // Higher scores come later.
+              var allStateScores = {};
+              var unarrangedStateCount = 0;
+              for (var i = 0; i < allStateNames.length; i++) {
+                var stateName = allStateNames[i];
+                if (lastComputedArrangement.hasOwnProperty(stateName)) {
+                  allStateScores[stateName] = (
+                    lastComputedArrangement[stateName].depth * (maxOffset + 1) +
+                    lastComputedArrangement[stateName].offset);
+                } else {
+                  // States that have just been added in the rule 'create new'
+                  // modal are not yet included as part of
+                  // lastComputedArrangement so we account for them here.
+                  allStateScores[stateName] = (
+                    (maxDepth + 1) * (maxOffset + 1) + unarrangedStateCount);
+                  unarrangedStateCount++;
+                }
+              }
+
+              stateNames = allStateNames.sort(function(a, b) {
+                return allStateScores[a] - allStateScores[b];
+              });
+            }
 
             for (var i = 0; i < stateNames.length; i++) {
               if (stateNames[i] !== currentStateName) {

--- a/core/templates/dev/head/components/StateGraphLayoutService.js
+++ b/core/templates/dev/head/components/StateGraphLayoutService.js
@@ -526,7 +526,7 @@ oppia.factory('StateGraphLayoutService', [
       },
       modifyPositionValues: function(nodeData, graphWidth, graphHeight) {
         var HORIZONTAL_NODE_PROPERTIES = ['x0', 'width', 'xLabel'];
-        var VERTICAL_NODE_PROPERTIES = ['y0', 'height', 'yLabel'];  
+        var VERTICAL_NODE_PROPERTIES = ['y0', 'height', 'yLabel'];
 
         // Change the position values in nodeData to use pixels.
         for (var nodeId in nodeData) {
@@ -546,7 +546,7 @@ oppia.factory('StateGraphLayoutService', [
         // to use as a scaling factor to determine the width of graph nodes.
         // This is not an entirely accurate description because it also takes
         // into account the horizontal whitespace between graph nodes.
-        var letterWidthInPixels = 10.5;          
+        var letterWidthInPixels = 10.5;
         return maxNodesPerRow * maxNodeLabelLength * letterWidthInPixels;
       },
       getGraphHeight: function(nodeData) {


### PR DESCRIPTION
In production, we noticed an occasional error of the form "lastComputedArrangement does not have a hasOwnProperty() method". This seems to be due to its value occasionally being null when the graph has not yet been computed, which messes up the computation of the destination states dropdown. This fix catches that case (which happens rarely) and provides the states in random order instead.