### PR TITLE
Fix part of #3826: Extract and rename services from FormBuilder.js

### DIFF
--- a/core/templates/dev/head/components/forms/FormBuilder.js
+++ b/core/templates/dev/head/components/forms/FormBuilder.js
@@ -113,49 +113,6 @@ oppia.filter('convertUnicodeWithParamsToHtml', ['$filter', function($filter) {
   };
 }]);
 
-oppia.factory('schemaDefaultValueService', [function() {
-  return {
-    // TODO(sll): Rewrite this to take validators into account, so that
-    // we always start with a valid value.
-    getDefaultValue: function(schema) {
-      if (schema.choices) {
-        return schema.choices[0];
-      } else if (schema.type === 'bool') {
-        return false;
-      } else if (schema.type === 'unicode' || schema.type === 'html') {
-        return '';
-      } else if (schema.type === 'list') {
-        return [this.getDefaultValue(schema.items)];
-      } else if (schema.type === 'dict') {
-        var result = {};
-        for (var i = 0; i < schema.properties.length; i++) {
-          result[schema.properties[i].name] = this.getDefaultValue(
-            schema.properties[i].schema);
-        }
-        return result;
-      } else if (schema.type === 'int' || schema.type === 'float') {
-        return 0;
-      } else {
-        console.error('Invalid schema type: ' + schema.type);
-      }
-    }
-  };
-}]);
-
-oppia.factory('schemaUndefinedLastElementService', [function() {
-  return {
-    // Returns true if the input value, taken as the last element in a list,
-    // should be considered as 'undefined' and therefore deleted.
-    getUndefinedValue: function(schema) {
-      if (schema.type === 'unicode' || schema.type === 'html') {
-        return '';
-      } else {
-        return undefined;
-      }
-    }
-  };
-}]);
-
 oppia.filter('sanitizeHtmlForRte', ['$sanitize', function($sanitize) {
   var _EXTENSION_SELECTOR = '[class^=oppia-noninteractive-]';
 
@@ -395,51 +352,6 @@ oppia.directive('requireIsFloat', ['$filter', function($filter) {
 
       ctrl.$parsers.unshift(floatValidator);
       ctrl.$formatters.unshift(floatValidator);
-    }
-  };
-}]);
-
-// Prevents timeouts due to recursion in nested directives. See:
-//
-//   http://stackoverflow.com/q/14430655
-oppia.factory('recursionHelper', ['$compile', function($compile) {
-  return {
-    /**
-     * Manually compiles the element, fixing the recursion loop.
-     * @param {DOM element} element
-     * @param {function|object} link - A post-link function, or an object with
-     *   function(s) registered via pre and post properties.
-     * @return {object} An object containing the linking functions.
-     */
-    compile: function(element, link) {
-      // Normalize the link parameter
-      if (angular.isFunction(link)) {
-        link = {
-          post: link
-        };
-      }
-
-      // Break the recursion loop by removing the contents,
-      var contents = element.contents().remove();
-      var compiledContents;
-      return {
-        pre: (link && link.pre) ? link.pre : null,
-        post: function(scope, element) {
-          // Compile the contents.
-          if (!compiledContents) {
-            compiledContents = $compile(contents);
-          }
-          // Re-add the compiled contents to the element.
-          compiledContents(scope, function(clone) {
-            element.append(clone);
-          });
-
-          // Call the post-linking function, if any.
-          if (link && link.post) {
-            link.post.apply(null, arguments);
-          }
-        }
-      };
     }
   };
 }]);

--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedChoicesEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedChoicesEditorDirective.js
@@ -17,8 +17,10 @@
  */
 
 oppia.directive('schemaBasedChoicesEditor', [
-  'recursionHelper', 'UrlInterpolationService',
-  function(recursionHelper, UrlInterpolationService) {
+  'NestedDirectivesRecursionTimeoutPreventionService',
+  'UrlInterpolationService', function(
+    NestedDirectivesRecursionTimeoutPreventionService,
+    UrlInterpolationService) {
     return {
       scope: {
         localValue: '=',
@@ -33,7 +35,7 @@ oppia.directive('schemaBasedChoicesEditor', [
         '/components/forms/schema_editors/' +
         'schema_based_choices_editor_directive.html'),
       restrict: 'E',
-      compile: recursionHelper.compile,
+      compile: NestedDirectivesRecursionTimeoutPreventionService.compile,
       controller: ['$scope', function($scope) {
         $scope.getReadonlySchema = function() {
           var readonlySchema = angular.copy($scope.schema());

--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedCustomEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedCustomEditorDirective.js
@@ -17,8 +17,10 @@
  */
 
 oppia.directive('schemaBasedCustomEditor', [
-  'recursionHelper', 'UrlInterpolationService',
-  function(recursionHelper, UrlInterpolationService) {
+  'NestedDirectivesRecursionTimeoutPreventionService',
+  'UrlInterpolationService', function(
+    NestedDirectivesRecursionTimeoutPreventionService,
+    UrlInterpolationService) {
     return {
       scope: {
         localValue: '=',
@@ -29,7 +31,7 @@ oppia.directive('schemaBasedCustomEditor', [
         '/components/forms/schema_editors/' +
         'schema_based_custom_editor_directive.html'),
       restrict: 'E',
-      compile: recursionHelper.compile
+      compile: NestedDirectivesRecursionTimeoutPreventionService.compile
     };
   }
 ]);

--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedDictEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedDictEditorDirective.js
@@ -17,8 +17,10 @@
  */
 
 oppia.directive('schemaBasedDictEditor', [
-  'recursionHelper', 'UrlInterpolationService',
-  function(recursionHelper, UrlInterpolationService) {
+  'NestedDirectivesRecursionTimeoutPreventionService',
+  'UrlInterpolationService', function(
+    NestedDirectivesRecursionTimeoutPreventionService,
+    UrlInterpolationService) {
     return {
       scope: {
         localValue: '=',
@@ -32,7 +34,7 @@ oppia.directive('schemaBasedDictEditor', [
         '/components/forms/schema_editors/' +
         'schema_based_dict_editor_directive.html'),
       restrict: 'E',
-      compile: recursionHelper.compile,
+      compile: NestedDirectivesRecursionTimeoutPreventionService.compile,
       controller: [
         '$scope', 'IdGenerationService',
         function($scope, IdGenerationService) {

--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
@@ -17,11 +17,13 @@
  */
 
 oppia.directive('schemaBasedListEditor', [
-  'schemaDefaultValueService', 'recursionHelper', 'FocusManagerService',
-  'schemaUndefinedLastElementService', 'IdGenerationService',
+  'SchemaDefaultValueService',
+  'NestedDirectivesRecursionTimeoutPreventionService', 'FocusManagerService',
+  'SchemaUndefinedLastElementService', 'IdGenerationService',
   'UrlInterpolationService', function(
-    schemaDefaultValueService, recursionHelper, FocusManagerService,
-    schemaUndefinedLastElementService, IdGenerationService,
+    SchemaDefaultValueService,
+    NestedDirectivesRecursionTimeoutPreventionService, FocusManagerService,
+    SchemaUndefinedLastElementService, IdGenerationService,
     UrlInterpolationService) {
     return {
       scope: {
@@ -41,7 +43,7 @@ oppia.directive('schemaBasedListEditor', [
         '/components/forms/schema_editors/' +
         'schema_based_list_editor_directive.html'),
       restrict: 'E',
-      compile: recursionHelper.compile,
+      compile: NestedDirectivesRecursionTimeoutPreventionService.compile,
       controller: ['$scope', function($scope) {
         var baseFocusLabel = (
           $scope.labelForFocusTarget() ||
@@ -98,7 +100,7 @@ oppia.directive('schemaBasedListEditor', [
 
         while ($scope.localValue.length < $scope.minListLength) {
           $scope.localValue.push(
-            schemaDefaultValueService.getDefaultValue($scope.itemSchema()));
+            SchemaDefaultValueService.getDefaultValue($scope.itemSchema()));
         }
 
         $scope.hasDuplicates = function() {
@@ -121,7 +123,7 @@ oppia.directive('schemaBasedListEditor', [
             }
 
             $scope.localValue.push(
-              schemaDefaultValueService.getDefaultValue($scope.itemSchema()));
+              SchemaDefaultValueService.getDefaultValue($scope.itemSchema()));
             FocusManagerService.setFocus(
               $scope.getFocusLabel($scope.localValue.length - 1));
           };
@@ -129,7 +131,7 @@ oppia.directive('schemaBasedListEditor', [
           var _deleteLastElementIfUndefined = function() {
             var lastValueIndex = $scope.localValue.length - 1;
             var valueToConsiderUndefined = (
-              schemaUndefinedLastElementService.getUndefinedValue(
+              SchemaUndefinedLastElementService.getUndefinedValue(
                 $scope.itemSchema()));
             if ($scope.localValue[lastValueIndex] ===
                 valueToConsiderUndefined) {

--- a/core/templates/dev/head/components/forms/schema_viewers/SchemaBasedCustomViewerDirective.js
+++ b/core/templates/dev/head/components/forms/schema_viewers/SchemaBasedCustomViewerDirective.js
@@ -17,8 +17,10 @@
  */
 
 oppia.directive('schemaBasedCustomViewer', [
-  'recursionHelper', 'UrlInterpolationService',
-  function(recursionHelper, UrlInterpolationService) {
+  'NestedDirectivesRecursionTimeoutPreventionService',
+  'UrlInterpolationService', function(
+    NestedDirectivesRecursionTimeoutPreventionService,
+    UrlInterpolationService) {
     return {
       scope: {
         localValue: '=',
@@ -29,7 +31,7 @@ oppia.directive('schemaBasedCustomViewer', [
         '/components/forms/schema_viewers/' +
         'schema_based_custom_viewer_directive.html'),
       restrict: 'E',
-      compile: recursionHelper.compile
+      compile: NestedDirectivesRecursionTimeoutPreventionService.compile
     };
   }
 ]);

--- a/core/templates/dev/head/components/forms/schema_viewers/SchemaBasedDictViewerDirective.js
+++ b/core/templates/dev/head/components/forms/schema_viewers/SchemaBasedDictViewerDirective.js
@@ -17,8 +17,10 @@
  */
 
 oppia.directive('schemaBasedDictViewer', [
-  'recursionHelper', 'UrlInterpolationService',
-  function(recursionHelper, UrlInterpolationService) {
+  'NestedDirectivesRecursionTimeoutPreventionService',
+  'UrlInterpolationService', function(
+    NestedDirectivesRecursionTimeoutPreventionService,
+    UrlInterpolationService) {
     return {
       scope: {
         localValue: '=',
@@ -30,7 +32,7 @@ oppia.directive('schemaBasedDictViewer', [
         '/components/forms/schema_viewers/' +
         'schema_based_dict_viewer.html'),
       restrict: 'E',
-      compile: recursionHelper.compile,
+      compile: NestedDirectivesRecursionTimeoutPreventionService.compile,
       controller: ['$scope', function($scope) {
         $scope.getHumanReadablePropertyDescription = function(property) {
           return property.description || '[' + property.name + ']';

--- a/core/templates/dev/head/components/forms/schema_viewers/SchemaBasedListViewerDirective.js
+++ b/core/templates/dev/head/components/forms/schema_viewers/SchemaBasedListViewerDirective.js
@@ -17,8 +17,10 @@
  */
 
 oppia.directive('schemaBasedListViewer', [
-  'recursionHelper', 'UrlInterpolationService',
-  function(recursionHelper, UrlInterpolationService) {
+  'NestedDirectivesRecursionTimeoutPreventionService',
+  'UrlInterpolationService', function(
+    NestedDirectivesRecursionTimeoutPreventionService,
+    UrlInterpolationService) {
     return {
       scope: {
         localValue: '=',
@@ -29,7 +31,7 @@ oppia.directive('schemaBasedListViewer', [
         '/components/forms/schema_viewers/' +
         'schema_based_list_viewer_directive.html'),
       restrict: 'E',
-      compile: recursionHelper.compile
+      compile: NestedDirectivesRecursionTimeoutPreventionService.compile
     };
   }
 ]);

--- a/core/templates/dev/head/pages/admin/admin.html
+++ b/core/templates/dev/head/pages/admin/admin.html
@@ -120,6 +120,9 @@
     <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_editors/SchemaBasedIntEditorDirective.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_editors/SchemaBasedListEditorDirective.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_editors/SchemaBasedUnicodeEditorDirective.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/SchemaDefaultValueService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/SchemaUndefinedLastElementService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/NestedDirectivesRecursionTimeoutPreventionService.js"></script>
 
     <script src="{{TEMPLATE_DIR_PREFIX}}/expressions/ExpressionSyntaxTreeService.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/expressions/ExpressionEvaluatorService.js"></script>

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -150,6 +150,9 @@
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/ImageUploaderDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/AudioTranslationsEditorDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/AudioFileUploaderDirective.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/SchemaDefaultValueService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/SchemaUndefinedLastElementService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/NestedDirectivesRecursionTimeoutPreventionService.js"></script>
 
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/loading/LoadingDotsDirective.js"></script>
 

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -189,6 +189,9 @@
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_viewers/SchemaBasedPrimitiveViewerDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_viewers/SchemaBasedUnicodeViewerDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_viewers/SchemaBasedViewerDirective.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/SchemaDefaultValueService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/SchemaUndefinedLastElementService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/NestedDirectivesRecursionTimeoutPreventionService.js"></script>
 
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/loading/LoadingDotsDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/RatingComputationService.js"></script>

--- a/core/templates/dev/head/pages/moderator/moderator.html
+++ b/core/templates/dev/head/pages/moderator/moderator.html
@@ -99,6 +99,9 @@
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_editors/SchemaBasedEditorDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_editors/SchemaBasedListEditorDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_editors/SchemaBasedUnicodeEditorDirective.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/SchemaDefaultValueService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/SchemaUndefinedLastElementService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/NestedDirectivesRecursionTimeoutPreventionService.js"></script>
 
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/moderator/Moderator.js"></script>
 {% endblock footer_js %}

--- a/core/templates/dev/head/pages/tests/FormBuilderTestPage.js
+++ b/core/templates/dev/head/pages/tests/FormBuilderTestPage.js
@@ -17,8 +17,10 @@
  */
 
 oppia.directive('formOverlay', [
-  'recursionHelper', 'UrlInterpolationService',
-  function(recursionHelper, UrlInterpolationService) {
+  'NestedDirectivesRecursionTimeoutPreventionService',
+  'UrlInterpolationService', function(
+    NestedDirectivesRecursionTimeoutPreventionService,
+    UrlInterpolationService) {
     return {
       scope: {
         definition: '=',
@@ -28,7 +30,7 @@ oppia.directive('formOverlay', [
       templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
         '/pages/tests/form_entry_point_modal_directive.html'),
       restrict: 'E',
-      compile: recursionHelper.compile,
+      compile: NestedDirectivesRecursionTimeoutPreventionService.compile,
       controller: ['$scope', function($scope) {
         $scope.$watch('savedValue', function() {
           $scope.localValue = angular.copy($scope.savedValue);

--- a/core/templates/dev/head/pages/tests/form_builder_test_page.html
+++ b/core/templates/dev/head/pages/tests/form_builder_test_page.html
@@ -126,4 +126,8 @@
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_viewers/SchemaBasedUnicodeViewerDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_viewers/SchemaBasedViewerDirective.js"></script>
 
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/SchemaDefaultValueService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/SchemaUndefinedLastElementService.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/services/NestedDirectivesRecursionTimeoutPreventionService.js"></script>
+
 {% endblock footer_js %}

--- a/core/templates/dev/head/services/NestedDirectivesRecursionTimeoutPreventionService.js
+++ b/core/templates/dev/head/services/NestedDirectivesRecursionTimeoutPreventionService.js
@@ -1,0 +1,62 @@
+// Copyright 2014 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Service prevents timeouts due to recursion
+ * in nested directives. See: http://stackoverflow.com/q/14430655
+ */
+
+oppia.factory('NestedDirectivesRecursionTimeoutPreventionService', [
+  '$compile', function($compile) {
+    return {
+      /**
+       * Manually compiles the element, fixing the recursion loop.
+       * @param {DOM element} element
+       * @param {function|object} link - A post-link function, or an object with
+       *   function(s) registered via pre and post properties.
+       * @return {object} An object containing the linking functions.
+       */
+      compile: function(element, link) {
+        // Normalize the link parameter
+        if (angular.isFunction(link)) {
+          link = {
+            post: link
+          };
+        }
+
+        // Break the recursion loop by removing the contents,
+        var contents = element.contents().remove();
+        var compiledContents;
+        return {
+          pre: (link && link.pre) ? link.pre : null,
+          post: function(scope, element) {
+            // Compile the contents.
+            if (!compiledContents) {
+              compiledContents = $compile(contents);
+            }
+            // Re-add the compiled contents to the element.
+            compiledContents(scope, function(clone) {
+              element.append(clone);
+            });
+
+            // Call the post-linking function, if any.
+            if (link && link.post) {
+              link.post.apply(null, arguments);
+            }
+          }
+        };
+      }
+    };
+  }
+]);

--- a/core/templates/dev/head/services/SchemaDefaultValueService.js
+++ b/core/templates/dev/head/services/SchemaDefaultValueService.js
@@ -1,0 +1,46 @@
+// Copyright 2014 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Service provides correct default value for SchemaBasedList item
+ */
+
+oppia.factory('SchemaDefaultValueService', [function() {
+  return {
+    // TODO(sll): Rewrite this to take validators into account, so that
+    // we always start with a valid value.
+    getDefaultValue: function(schema) {
+      if (schema.choices) {
+        return schema.choices[0];
+      } else if (schema.type === 'bool') {
+        return false;
+      } else if (schema.type === 'unicode' || schema.type === 'html') {
+        return '';
+      } else if (schema.type === 'list') {
+        return [this.getDefaultValue(schema.items)];
+      } else if (schema.type === 'dict') {
+        var result = {};
+        for (var i = 0; i < schema.properties.length; i++) {
+          result[schema.properties[i].name] = this.getDefaultValue(
+            schema.properties[i].schema);
+        }
+        return result;
+      } else if (schema.type === 'int' || schema.type === 'float') {
+        return 0;
+      } else {
+        console.error('Invalid schema type: ' + schema.type);
+      }
+    }
+  };
+}]);

--- a/core/templates/dev/head/services/SchemaUndefinedLastElementService.js
+++ b/core/templates/dev/head/services/SchemaUndefinedLastElementService.js
@@ -1,0 +1,27 @@
+// Copyright 2014 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+oppia.factory('SchemaUndefinedLastElementService', [function() {
+  return {
+    // Returns true if the input value, taken as the last element in a list,
+    // should be considered as 'undefined' and therefore deleted.
+    getUndefinedValue: function(schema) {
+      if (schema.type === 'unicode' || schema.type === 'html') {
+        return '';
+      } else {
+        return undefined;
+      }
+    }
+  };
+}]);


### PR DESCRIPTION
Fix part of #3826: Extract and rename services from FormBuilder.js
 schemaDefaultValueService → SchemaDefaultValueService
 schemaUndefinedLastElementService → SchemaUndefinedLastElementService
 recursionHelper → NestedDirectivesRecursionTimeoutPreventionService
