### PR TITLE
Fix part of #3950: Replace Jinja templates in frontend with Angular

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateStatistics.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateStatistics.js
@@ -28,6 +28,8 @@ oppia.controller('StateStatistics', [
       stateCustomizationArgsService, oppiaExplorationHtmlFormatterService,
       TrainingModalService, INTERACTION_SPECS) {
     $scope.isInteractionTrainable = false;
+    $scope.SHOW_TRAINABLE_UNRESOLVED_ANSWERS =
+      GLOBALS.SHOW_TRAINABLE_UNRESOLVED_ANSWERS;
 
     $scope.initStateStatistics = function(data) {
       $scope.isInteractionTrainable = (

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_statistics.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_statistics.html
@@ -1,6 +1,5 @@
 <div ng-controller="StateStatistics">
-  {% if SHOW_TRAINABLE_UNRESOLVED_ANSWERS %}
-  <div ng-if="isInteractionTrainable && trainingDataButtonContentsList.length > 0">
+  <div ng-if="SHOW_TRAINABLE_UNRESOLVED_ANSWERS && isInteractionTrainable && trainingDataButtonContentsList.length > 0">
     <div class="oppia-editor-header">
       <strong>Learner Answers to Teach Oppia</strong>
     </div>
@@ -12,5 +11,4 @@
       </span>
     </button>
   </div>
-  {% endif %}
 </div>


### PR DESCRIPTION
fix part of https://github.com/oppia/oppia/issues/3950
Replace Jinja templates in the frontend with Angular 
 
exploration_editor/editor_tab/state_statistics.html 
    {% if SHOW_TRAINABLE_UNRESOLVED_ANSWERS %}
