### PR TITLE
Fix #3254: Load MathJax only where needed

### DIFF
--- a/core/templates/dev/head/mathjaxConfig.js
+++ b/core/templates/dev/head/mathjaxConfig.js
@@ -1,0 +1,12 @@
+window.MathJax = {
+  skipStartupTypeset: true,
+  messageStyle: 'none',
+  'HTML-CSS': {
+    linebreaks: {
+      automatic: true,
+      width: '500px'
+    },
+    scale: 91,
+    showMathMenu: false
+  }
+};

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -123,9 +123,12 @@
 {% block footer_js %}
   {{ super() }}
   <script src="/third_party/static/d3js-3.4.11/d3.min.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/mathjaxConfig.js"></script>
+  <script src="/third_party/static/MathJax-2.6.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   <script>
     {{ value_generators_js }}
   </script>
+
 
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/FormBuilder.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/schema_editors/SchemaBasedBoolEditorDirective.js"></script>

--- a/core/templates/dev/head/pages/exploration_player/exploration_player.html
+++ b/core/templates/dev/head/pages/exploration_player/exploration_player.html
@@ -86,6 +86,9 @@
 
 {% block footer_js %}
   {{ super() }}
+  <script src="{{TEMPLATE_DIR_PREFIX}}/mathjaxConfig.js"></script>
+  <script src="/third_party/static/MathJax-2.6.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+
   <script src="{{ASSET_DIR_PREFIX}}/extensions/objects/templates/MathLatexStringEditor.js"></script>
   <script src="{{ASSET_DIR_PREFIX}}/extensions/objects/templates/SanitizedUrlEditor.js"></script>
 

--- a/core/templates/dev/head/pages/header_js_libs.html
+++ b/core/templates/dev/head/pages/header_js_libs.html
@@ -10,20 +10,3 @@ rendering.-->
 <script src="/third_party/static/jqueryui-1.10.3/jquery-ui.min.js"></script>
 <script src="/third_party/static/angularjs-1.5.8/angular.min.js"></script>
 <script src="/third_party/static/jquery-ui-touch-punch-0.3.1/jquery.ui.touch-punch-improved.js"></script>
-<!-- See http://docs.mathjax.org/en/latest/start.html#mathjax-cdn -->
-<script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    skipStartupTypeset: true,
-    messageStyle: 'none',
-    'HTML-CSS': {
-      linebreaks: {
-        automatic: true,
-        width: '500px'
-      },
-      scale: 91,
-      showMathMenu: false
-    }
-  });
-  MathJax.Hub.Configured();
-</script>
-<script src="/third_party/static/MathJax-2.6.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>


### PR DESCRIPTION
Moved MathJax config to separate file and started loading the file only in pages where MathJax is used.
