### PR TITLE
Fixed  #2943: Adjust the tooltip displayed when a user hovers over the globe icon on the library page

### DIFF
--- a/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
+++ b/core/templates/dev/head/components/summary_tile/exploration_summary_tile_directive.html
@@ -20,8 +20,8 @@
           <circular-image ng-if="avatarsList.length > 0"
                           src="avatarsList[0].image"
                           link="avatarsList[0].link"
-                          tooltip="<[avatarsList[0].tooltipText | truncate:14]>"
-                          tooltip-placement="right">
+                          tooltip="<[avatarsList[0].tooltipText | truncate:16]>"
+                          tooltip-placement="bottom">
           </circular-image>
         </div>
       </div>


### PR DESCRIPTION
fix https://github.com/oppia/oppia/issues/2943
