### PR TITLE
Reformat frontend error message so that StackDriver hopefully catches it.

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -400,9 +400,9 @@ oppia.factory('$exceptionHandler', ['$log', function($log) {
     var messageAndSourceAndStackTrace = [
       '',
       'Cause: ' + cause,
-      'Source: ' + window.location.href,
       exception.message,
-      String(exception.stack)
+      String(exception.stack),
+      '    at URL: ' + window.location.href
     ].join('\n');
 
     // Catch all errors, to guard against infinite recursive loops.


### PR DESCRIPTION
I was trying to debug this StackDriver error:

```
TypeError: Cannot read property 'interaction' of undefined
at f.getInteractionId (ExplorationObjectFactory.js:1)
at Object.getInteractionHtml (https://www.oppia.org/build/templates/head/pages/exploration_player/PlayerServices.js:1)
at (https://www.oppia.org/build/templates/head/pages/exploration_player/ConversationSkinDirective.js:1)
at (https://www.oppia.org/third_party/static/angularjs-1.5.8/angular.min.js:158)
at e (https://www.oppia.org/third_party/static/angularjs-1.5.8/angular.min.js:45)
at (https://www.oppia.org/third_party/static/angularjs-1.5.8/angular.min.js:48)
```

and it is very hard to do that without the page URL. On investigation it turns out that we do log the page URL but StackDriver omits it. This PR tries to reformat what is logged so that it (hopefully) shows up in StackDriver.