### PR TITLE
Fix #3976: Show supplemental interactions in embedded explorations

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -617,6 +617,11 @@ directive. -->
   }
 
   @media screen and (max-width: 959px) {
+    .conversation-skin-main-tutor-card-embed,
+    .conversation-skin-future-tutor-card-embed {
+      margin-left: 0;
+    }
+
     .conversation-skin-main-tutor-card-embed.conversation-skin-animate-tutor-card-on-narrow {
       position: absolute;
     }
@@ -631,9 +636,11 @@ directive. -->
     }
 
     .conversation-skin-cards-container.with-supplementary-card {
-      min-height: 440px;
+      /* TODO(tjiang11): Find a way to handle arbitrarily long/short content.
+         in supplemental interactions.
+      */
+      min-height: 1000px;
     }
-
 
     .conversation-skin-main-tutor-card {
       left: 0;

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -22,7 +22,8 @@
          ng-class="{'animate-to-two-cards': isAnimatingToTwoCards, 'animate-to-one-card': isAnimatingToOneCard, 'with-supplementary-card': isCurrentSupplementalCardNonempty()}">
 
       <div class="conversation-skin-main-tutor-card-embed"
-           ng-class="{ 'conversation-skin-animate-tutor-card-on-narrow': isViewportNarrow() && isCurrentSupplementalCardNonempty()}">
+           ng-class="{ 'conversation-skin-animate-tutor-card-on-narrow': isViewportNarrow() && isCurrentSupplementalCardNonempty()}"
+           ng-style="{'margin-bottom': (isViewportNarrow()) ? '100px' : '0'}">
         <tutor-card on-click-continue-button="showUpcomingCard()"
                     on-submit-answer="submitAnswer(answer, rulesService)"
                     start-card-change-animation="startCardChangeAnimation">
@@ -115,7 +116,9 @@ directive. -->
   }
 
   .grid-container{
-     width: 100%;
+    bottom: 0;
+    position: fixed;
+    width: 100%;
   }
 
   .bottom-nav-row:before,
@@ -335,9 +338,6 @@ directive. -->
   .conversation-skin-help-card {
     background: #fff;
     border-radius: 2px;
-    /* We move the help card lower so that it does not block
-     the terminal output in the CodeRepl interaction.
-    */
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.24), 0 1px 3px rgba(0, 0, 0, 0.12);
     min-height: 50px;
     opacity: 1;
@@ -349,7 +349,6 @@ directive. -->
   }
 
   .help-card-standard {
-    bottom: -50px;
     position: absolute;
   }
 
@@ -357,7 +356,6 @@ directive. -->
     bottom: 50px;
     position: fixed;
   }
-
 
   .conversation-skin-help-card.ng-enter,
   .conversation-skin-help-card.ng-leave-active {
@@ -619,11 +617,6 @@ directive. -->
   }
 
   @media screen and (max-width: 959px) {
-    .conversation-skin-main-tutor-card-embed,
-    .conversation-skin-future-tutor-card-embed {
-      margin-left: 0;
-    }
-
     .conversation-skin-main-tutor-card-embed.conversation-skin-animate-tutor-card-on-narrow {
       position: absolute;
     }

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -23,7 +23,7 @@
 
       <div class="conversation-skin-main-tutor-card-embed"
            ng-class="{ 'conversation-skin-animate-tutor-card-on-narrow': isViewportNarrow() && isCurrentSupplementalCardNonempty()}"
-           ng-style="{'margin-bottom': (isViewportNarrow()) ? '100px' : '0'}">
+           style="margin-bottom: 100px">
         <tutor-card on-click-continue-button="showUpcomingCard()"
                     on-submit-answer="submitAnswer(answer, rulesService)"
                     start-card-change-animation="startCardChangeAnimation">

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -27,6 +27,11 @@
                     on-submit-answer="submitAnswer(answer, rulesService)"
                     start-card-change-animation="startCardChangeAnimation">
         </tutor-card>
+        <div ng-if="isCurrentSupplementalCardNonempty() && isViewportNarrow()">
+          <supplemental-card on-click-continue-button="showUpcomingCard()"
+                             on-submit-answer="submitAnswer(answer, rulesService)">
+          </supplemental-card>
+        </div>
       </div>
 
       <div ng-if="isCurrentSupplementalCardNonempty() && !isViewportNarrow()"


### PR DESCRIPTION
Some changes:

- Changed footer to be fixed so that it always appears at the bottom of the iframe. A margin of 100px is added to the bottom of the card to make room for it.
- In CodeRepl interactions, the help card previously was shifted below the terminal output, but that only worked for short feedback. I think it makes sense to just show the help card at the bottom right regardless of whether it's covering the terminal output. Otherwise, it looks pretty ugly to have to shift the feedback all the way below everything else.

Issues:

- Right now, the min-height property is being used to determine how much of the content/interaction to show in supplemental interactions. This is problematic since the content can be arbitrarily long. I'm not sure how to go about accounting for this. Will file as a separate issue if not addressed by the time this PR is merged.