### PR TITLE
Fix errors in the one-off job for stats migration

### DIFF
--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -264,12 +264,21 @@ def get_multiple_explorations_by_version(exp_id, version_numbers):
 
     Returns:
         list(Exploration). List of Exploration domain objects.
+
+    Raises:
+        Exception. ERROR: Exploration, version could not be converted to latest
+            schema version.
     """
     explorations = []
     exploration_models = exp_models.ExplorationModel.get_multi_versions(
         exp_id, version_numbers)
-    for exploration_model in exploration_models:
-        explorations.append(get_exploration_from_model(exploration_model))
+    for index, exploration_model in enumerate(exploration_models):
+        try:
+            explorations.append(get_exploration_from_model(exploration_model))
+        except utils.ExplorationConversionError:
+            raise Exception(
+                "ERROR: Exploration %s, version %s could not be converted to "
+                "latest schema version." % (exp_id, index + 1))
     return explorations
 
 

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -277,7 +277,7 @@ def get_multiple_explorations_by_version(exp_id, version_numbers):
         try:
             explorations.append(get_exploration_from_model(exploration_model))
         except utils.ExplorationConversionError:
-            error_versions.append(index + 1)
+            error_versions.append(version_numbers[index])
 
     if error_versions:
         raise Exception(

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -266,19 +266,23 @@ def get_multiple_explorations_by_version(exp_id, version_numbers):
         list(Exploration). List of Exploration domain objects.
 
     Raises:
-        Exception. ERROR: Exploration, version could not be converted to latest
-            schema version.
+        Exception. One or more of the given versions of the exploration could
+            not be converted to the latest schema version.
     """
     explorations = []
     exploration_models = exp_models.ExplorationModel.get_multi_versions(
         exp_id, version_numbers)
+    error_versions = []
     for index, exploration_model in enumerate(exploration_models):
         try:
             explorations.append(get_exploration_from_model(exploration_model))
         except utils.ExplorationConversionError:
-            raise Exception(
-                "ERROR: Exploration %s, version %s could not be converted to "
-                "latest schema version." % (exp_id, index + 1))
+            error_versions.append(index + 1)
+
+    if error_versions:
+        raise Exception(
+            "Exploration %s, versions [%s] could not be converted to latest"
+            "schema version." % (exp_id, ', '.join(map(str, error_versions))))
     return explorations
 
 

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -263,8 +263,14 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
                     state_stats_mapping[state_name] = (
                         stats_domain.StateStats.create_default())
             else:
-                exp_commit_log = exp_models.ExplorationCommitLogEntryModel.get(
-                    'exploration-%s-%s' % (exp_id, version))
+                try:
+                    exp_commit_log = (
+                        exp_models.ExplorationCommitLogEntryModel.get(
+                            'exploration-%s-%s' % (exp_id, version)))
+                except Exception:
+                    yield "Check if the exploration %s has snapshot models." % (
+                        exp_id)
+                    return
                 change_list = exp_commit_log.commit_cmds
 
                 # Handling state additions, renames and deletions.

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -162,6 +162,8 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
         snapshots_by_version = (
             exp_models.ExplorationModel.get_snapshots_metadata(
                 exp_id, version_numbers))
+        # Sort these in increasing order of version numbers.
+        snapshots_by_version.sort(key=lambda s:s['version_number'])
         exploration_stats_by_version = (
             stats_services.get_multiple_exploration_stats_by_version(
                 exp_id, version_numbers))
@@ -270,7 +272,7 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
                     state_stats_mapping[state_name] = (
                         stats_domain.StateStats.create_default())
             else:
-                change_list = snapshots_by_version[version-1]['commit_cmds']
+                change_list = snapshots_by_version[version - 1]['commit_cmds']
 
                 # Handling state additions, renames and deletions.
                 for change_dict in change_list:

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -154,8 +154,8 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
                     exp_id, version_numbers))
         except utils.ExplorationConversionError:
             yield (
-                "ERROR: Exploration %s contains non-existent features that "
-                "need to be looked into." % (exp_id))
+                "ERROR: Exploration %s could not be converted to latest schema "
+                "version." % (exp_id))
             return
         # Retrieve list of snapshot models representing each version of the
         # exploration.

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -152,10 +152,8 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
             explorations_by_version = (
                 exp_services.get_multiple_explorations_by_version(
                     exp_id, version_numbers))
-        except utils.ExplorationConversionError:
-            yield (
-                "ERROR: Exploration %s could not be converted to latest schema "
-                "version." % (exp_id))
+        except Exception as e:
+            yield e
             return
         # Retrieve list of snapshot models representing each version of the
         # exploration.

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -162,8 +162,6 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
         snapshots_by_version = (
             exp_models.ExplorationModel.get_snapshots_metadata(
                 exp_id, version_numbers))
-        # Sort these in increasing order of version numbers.
-        snapshots_by_version.sort(key=lambda s:s['version_number'])
         exploration_stats_by_version = (
             stats_services.get_multiple_exploration_stats_by_version(
                 exp_id, version_numbers))


### PR DESCRIPTION
This PR handles the ExplorationConversionError and the 'END' state KeyError for the GenerateV1StatisticsJob.
Thanks!