### PR TITLE
Fix error in one off stats migration job.

### DIFF
--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -265,7 +265,7 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
             if version == 1:
                 # Create default state stats mapping for the first version.
                 state_stats_mapping = collections.defaultdict(
-                    lambda: stats_domain.StateStats.create_default())
+                    stats_domain.StateStats.create_default())
             else:
                 change_list = snapshots_by_version[version - 1]['commit_cmds']
 

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -264,9 +264,8 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
             revert_to_version = None
             if version == 1:
                 # Create default state stats mapping for the first version.
-                for state_name in versioned_exploration.states:
-                    state_stats_mapping[state_name] = (
-                        stats_domain.StateStats.create_default())
+                state_stats_mapping = collections.defaultdict(
+                    lambda: stats_domain.StateStats.create_default())
             else:
                 change_list = snapshots_by_version[version - 1]['commit_cmds']
 

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+#
 # Copyright 2014 The Oppia Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,7 +113,7 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
             value = {
                 'event_type': feconf.EVENT_TYPE_STATE_HIT,
                 'version': item.exploration_version,
-                'state_name': item.state_name,
+                'state_name': item.state_name.encode('utf-8'),
                 'session_id': item.session_id,
                 'created_on': utils.get_time_in_millisecs(item.created_on)
             }
@@ -127,7 +129,7 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
             value = {
                 'event_type': GenerateV1StatisticsJob.EVENT_TYPE_STATE_ANSWERS,
                 'version': item.exploration_version,
-                'state_name': item.state_name,
+                'state_name': item.state_name.encode('utf-8'),
                 'total_answers_count': total_answers_count,
                 'useful_feedback_count': useful_feedback_count
             }
@@ -265,7 +267,7 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
             if version == 1:
                 # Create default state stats mapping for the first version.
                 for state_name in versioned_exploration.states:
-                    state_stats_mapping[state_name] = (
+                    state_stats_mapping[state_name.encode('utf-8')] = (
                         stats_domain.StateStats.create_default())
             else:
                 change_list = snapshots_by_version[version - 1]['commit_cmds']
@@ -273,14 +275,18 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
                 # Handling state additions, renames and deletions.
                 for change_dict in change_list:
                     if change_dict['cmd'] == exp_domain.CMD_ADD_STATE:
-                        state_stats_mapping[change_dict['state_name']] = (
-                            stats_domain.StateStats.create_default())
+                        state_stats_mapping[change_dict[
+                            'state_name'].encode('utf-8')] = (
+                                stats_domain.StateStats.create_default())
                     elif change_dict['cmd'] == exp_domain.CMD_DELETE_STATE:
-                        state_stats_mapping.pop(change_dict['state_name'])
+                        state_stats_mapping.pop(
+                            change_dict['state_name'].encode('utf-8'))
                     elif change_dict['cmd'] == exp_domain.CMD_RENAME_STATE:
-                        state_stats_mapping[change_dict['new_state_name']] = (
-                            state_stats_mapping.pop(
-                                change_dict['old_state_name']))
+                        state_stats_mapping[change_dict[
+                            'new_state_name'].encode('utf-8')] = (
+                                state_stats_mapping.pop(
+                                    change_dict['old_state_name'].encode(
+                                        'utf-8')))
                     elif change_dict['cmd'] == 'AUTO_revert_version_number':
                         revert_to_version = change_dict['version_number']
 
@@ -317,8 +323,9 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
                     yield (
                         'ERROR: State not in stats mapping exp_id %s, version '
                         '%s, State %s, state_stats_mapping [%s]' % (
-                            exp_id, version, state_name,
+                            exp_id, version, state_name.encode('utf-8'),
                             ', '.join(map(str, state_stats_mapping.keys()))))
+                    raise
 
             # Compute num_completions for the states.
             for state_name in state_completion_counts_for_this_version:
@@ -352,28 +359,32 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
                 # implicit, pseudo-END state.
                 init_state = versioned_exploration.states[
                     versioned_exploration.init_state_name]
-                first_hits_from_init_state = []
-                # log exp_id, exp_version, state_names, state_stats_mapping.
+                first_hit_counts_from_init_state = []
+                # Log exp_id, exp_version, state_names, state_stats_mapping.
                 for answer_group in init_state.interaction.answer_groups:
                     dest_state = answer_group.outcome.dest
                     if dest_state != (
                             versioned_exploration.init_state_name) and (
                                 dest_state in versioned_exploration.states):
                         try:
-                            first_hits_from_init_state.append(
+                            first_hit_counts_from_init_state.append(
                                 state_stats_mapping[
-                                    dest_state].first_hit_count_v1)
+                                    dest_state.encode(
+                                        'utf-8')].first_hit_count_v1)
                         except KeyError:
+                            state_names = [s.encode('utf-8') for s in (
+                                versioned_exploration.states)]
                             yield (
                                 'ERROR: Pseudo-END state: exp_id %s, version '
-                                '%s, states [%s], state_stats_mapping [%s]' % (
-                                    exp_id, version,
-                                    ', '.join(
-                                        map(str, versioned_exploration.states)),
+                                '%s, dest-state: %s, states [%s], '
+                                'state_stats_mapping [%s]' % (
+                                    exp_id, version, dest_state,
+                                    ', '.join(map(str, state_names)),
                                     ', '.join(
                                         map(str, state_stats_mapping.keys()))))
+                            raise
                 num_actual_starts = max(
-                    first_hits_from_init_state or [0])
+                    first_hit_counts_from_init_state or [0])
 
             # Check if model already exists. If it does, update it, otherwise
             # create a fresh ExplorationStatsModel instance.

--- a/core/domain/stats_jobs_one_off_test.py
+++ b/core/domain/stats_jobs_one_off_test.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+#
 # Copyright 2014 The Oppia Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -171,7 +173,7 @@ class GenerateV1StatisticsJobTest(test_utils.GenericTestBase):
         # Update exploration to version 2.
         change_list = [{
             'cmd': exp_domain.CMD_ADD_STATE,
-            'state_name': 'New state',
+            'state_name': u'Klüft',
         }]
         exp_services.update_exploration(
             feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
@@ -186,7 +188,7 @@ class GenerateV1StatisticsJobTest(test_utils.GenericTestBase):
             self.exp_id, self.exploration.version, 'Home', 'session_id3',
             {}, feconf.PLAY_TYPE_NORMAL)
         stats_models.StateHitEventLogEntryModel.create(
-            self.exp_id, self.exploration.version, 'New state',
+            self.exp_id, self.exploration.version, u'Klüft',
             'session_id3', {}, feconf.PLAY_TYPE_NORMAL)
         stats_models.StateHitEventLogEntryModel.create(
             self.exp_id, self.exploration.version, 'End', 'session_id3',
@@ -199,11 +201,11 @@ class GenerateV1StatisticsJobTest(test_utils.GenericTestBase):
             'TextInput', 0, 0, exp_domain.DEFAULT_OUTCOME_CLASSIFICATION,
             'session_id3', 0, {}, 'answer2')
         event_services.AnswerSubmissionEventHandler.record(
-            self.exp_id, self.exploration.version, 'New state',
+            self.exp_id, self.exploration.version, u'Klüft',
             'TextInput', 0, 0, exp_domain.EXPLICIT_CLASSIFICATION,
             'session_id3', 0, {}, 'answer3')
         event_services.AnswerSubmissionEventHandler.record(
-            self.exp_id, self.exploration.version, 'New state',
+            self.exp_id, self.exploration.version, u'Klüft',
             'TextInput', 0, 0, exp_domain.DEFAULT_OUTCOME_CLASSIFICATION,
             'session_id3', 0, {}, 'answer4')
 
@@ -226,7 +228,7 @@ class GenerateV1StatisticsJobTest(test_utils.GenericTestBase):
             exploration_stats.state_stats_mapping['End'].first_hit_count_v1, 2)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                'New state'].first_hit_count_v1, 1)
+                u'Klüft'].first_hit_count_v1, 1)
 
         self.assertEqual(
             exploration_stats.state_stats_mapping['Home'].total_hit_count_v1, 4)
@@ -234,7 +236,7 @@ class GenerateV1StatisticsJobTest(test_utils.GenericTestBase):
             exploration_stats.state_stats_mapping['End'].total_hit_count_v1, 2)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                'New state'].total_hit_count_v1, 1)
+                u'Klüft'].total_hit_count_v1, 1)
 
         self.assertEqual(
             exploration_stats.state_stats_mapping['Home'].num_completions_v1, 3)
@@ -242,7 +244,7 @@ class GenerateV1StatisticsJobTest(test_utils.GenericTestBase):
             exploration_stats.state_stats_mapping['End'].num_completions_v1, 2)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                'New state'].num_completions_v1, 1)
+                u'Klüft'].num_completions_v1, 1)
 
         self.assertEqual(
             exploration_stats.state_stats_mapping[
@@ -252,7 +254,7 @@ class GenerateV1StatisticsJobTest(test_utils.GenericTestBase):
             0)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                'New state'].total_answers_count_v1, 2)
+                u'Klüft'].total_answers_count_v1, 2)
 
         self.assertEqual(
             exploration_stats.state_stats_mapping[
@@ -262,7 +264,7 @@ class GenerateV1StatisticsJobTest(test_utils.GenericTestBase):
                 'End'].useful_feedback_count_v1, 0)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
-                'New state'].useful_feedback_count_v1, 1)
+                u'Klüft'].useful_feedback_count_v1, 1)
 
     def test_creation_of_stats_model_for_deletion(self):
         # Update exploration to version 2.


### PR DESCRIPTION
This PR makes a small fix to the state_stats_mapping dict.

Keeping state_stats_mapping a defaultdict should ensure that key errors are handled whereas not aggregating wrong stats either (as all values are zero if the key is freshly created).
@seanlip What do you think?