### PR TITLE
Upgrade SSL library version; remove obsolete challenge-response handler.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -129,7 +129,7 @@ libraries:
   version: '1.6.1'
 # This is needed for sending requests to a mailgun HTTPS URL.
 - name: ssl
-  version: '2.7'
+  version: '2.7.11'
 - name: webapp2
   version: '2.5.2'
 # This environmental variable is for serving minified resources
@@ -137,6 +137,7 @@ libraries:
 # running the server in the dev environment.
 env_variables:
   MINIFICATION: false
+  PYTHONHTTPSVERIFY: 1
 
 
 skip_files:

--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -41,27 +41,6 @@ import utils
 current_user_services = models.Registry.import_current_user_services()
 
 
-SSL_CHALLENGE_RESPONSES = config_domain.ConfigProperty(
-    'ssl_challenge_responses', {
-        'type': 'list',
-        'items': {
-            'type': 'dict',
-            'properties': [{
-                'name': 'challenge',
-                'schema': {
-                    'type': 'unicode'
-                }
-            }, {
-                'name': 'response',
-                'schema': {
-                    'type': 'unicode'
-                }
-            }]
-        },
-    },
-    'Challenge-response pairs for SSL validation.', [])
-
-
 class AdminPage(base.BaseHandler):
     """Admin page shown in the App Engine admin console."""
     @acl_decorators.can_access_admin_page
@@ -390,22 +369,3 @@ class DataExtractionQueryHandler(base.BaseHandler):
             'data': extracted_answers
         }
         self.render_json(response)
-
-
-class SslChallengeHandler(base.BaseHandler):
-    """Plaintext page for responding to LetsEncrypt SSL challenges."""
-
-    @acl_decorators.open_access
-    def get(self, challenge):
-        """Handles GET requests."""
-        challenge_responses = SSL_CHALLENGE_RESPONSES.value
-        response = None
-        for challenge_response_pair in challenge_responses:
-            if challenge_response_pair['challenge'] == challenge:
-                response = challenge_response_pair['response']
-
-        if response is None:
-            raise self.PageNotFoundException()
-
-        self.response.headers['Content-Type'] = 'text/plain'
-        self.response.write(response)

--- a/core/controllers/admin_test.py
+++ b/core/controllers/admin_test.py
@@ -14,7 +14,6 @@
 
 """Tests for the admin page."""
 
-from core.controllers import admin
 from core.controllers import base
 from core.domain import exp_domain
 from core.domain import exp_services
@@ -300,44 +299,4 @@ class DataExtractionQueryHandlerTests(test_utils.GenericTestBase):
         self.assertEqual(
             response['error'],
             'Exploration \'exp\' does not have \'state name\' state.')
-        self.assertEqual(
-            response['status_code'], 400)
-
-
-class SslChallengeHandlerTests(test_utils.GenericTestBase):
-    """Tests for SSL challenge handler."""
-
-    CHALLENGE = 'hello'
-    RESPONSE = 'goodbye'
-
-    def setUp(self):
-        """Complete the signup process for self.ADMIN_EMAIL."""
-        super(SslChallengeHandlerTests, self).setUp()
-        self.signup(self.ADMIN_EMAIL, self.ADMIN_USERNAME)
-
-        self.login(self.ADMIN_EMAIL, is_super_admin=True)
-        response = self.testapp.get('/admin')
-        csrf_token = self.get_csrf_token_from_response(response)
-
-        payload = {
-            'action': 'save_config_properties',
-            'new_config_property_values': {
-                admin.SSL_CHALLENGE_RESPONSES.name: [{
-                    'challenge': self.CHALLENGE,
-                    'response': self.RESPONSE,
-                }]
-            }
-        }
-        self.post_json('/adminhandler', payload, csrf_token)
-        self.logout()
-
-    def test_ssl_challenge_page_functions_correctly(self):
-        response = self.testapp.get(
-            '/.well-known/acme-challenge/%s' % self.CHALLENGE)
-        self.assertEqual(response.body, self.RESPONSE)
-
-    def test_nonexistent_ssl_challenge_page(self):
-        response = self.testapp.get(
-            '/.well-known/acme-challenge/unknown_challenge',
-            expect_errors=True)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response['status_code'], 400)

--- a/core/domain/config_domain.py
+++ b/core/domain/config_domain.py
@@ -97,6 +97,7 @@ class ConfigProperty(object):
     - splash_page_exploration_id
     - splash_page_exploration_version
     - splash_page_youtube_video_id
+    - ssl_challenge_responses
     - whitelisted_email_senders
     """
 

--- a/main.py
+++ b/main.py
@@ -486,9 +486,6 @@ URLS = MAPREDUCE_HANDLERS + [
         r'/ml/trainedclassifierhandler', classifier.TrainedClassifierHandler),
     get_redirect_route(
         r'/ml/nextjobhandler', classifier.NextJobHandler),
-    get_redirect_route(
-        r'/.well-known/acme-challenge/<challenge>',
-        admin.SslChallengeHandler),
 
     # 404 error handler.
     get_redirect_route(r'/<:.*>', base.Error404Handler),


### PR DESCRIPTION
Reverts #3600 (since the functionality isn't needed anymore) and updates SSL library version to newest version.