### PR TITLE
Stop cards from going offscreen in mobile learner view.

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
@@ -42,7 +42,6 @@
 
   .conversation-skin-learner-answer-container {
     text-align: right;
-    width: 550px;
   }
 
   .conversation-skin-learner-answer-container .conversation-skin-user-avatar {
@@ -58,7 +57,6 @@
     border-color: rgb(236, 239, 241) transparent transparent rgb(236, 239, 241);
     content: ' ';
     height: 0;
-    left: 96.5%;
     position: absolute;
     top: 11%;  
     width: 0;


### PR DESCRIPTION
This PR addresses the issue where learners on mobile views can't view their own answers because they're pushed off to the right side of the screen.