### PR TITLE
Prevent hint tooltip from going offscreen on mobile

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/HintButtonDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/HintButtonDirective.js
@@ -43,7 +43,8 @@ oppia.directive('hintButton', [
             WindowDimensionsService.getWidth() < TWO_CARD_THRESHOLD_PX;
 
           $scope.getTooltipPlacement = function() {
-            return (viewportIsNarrow && $scope.isSupplementalCard) ? 'right' : 'left';
+            return (viewportIsNarrow && $scope.isSupplementalCard) ?
+              'right' : 'left';
           };
 
           var showNeedHintIfNecessary = function() {

--- a/core/templates/dev/head/pages/exploration_player/HintButtonDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/HintButtonDirective.js
@@ -26,7 +26,8 @@ oppia.directive('hintButton', [
       scope: {
         onClickHintButton: '&',
         allHintsAreExhausted: '&',
-        currentHintIsAvailable: '&'
+        currentHintIsAvailable: '&',
+        isSupplementalCard: '='
       },
       templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
         '/pages/exploration_player/' +
@@ -42,7 +43,7 @@ oppia.directive('hintButton', [
             WindowDimensionsService.getWidth() < TWO_CARD_THRESHOLD_PX;
 
           $scope.getTooltipPlacement = function() {
-            return viewportIsNarrow ? 'right' : 'left';
+            return (viewportIsNarrow && $scope.isSupplementalCard) ? 'right' : 'left';
           };
 
           var showNeedHintIfNecessary = function() {

--- a/core/templates/dev/head/pages/exploration_player/HintButtonDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/HintButtonDirective.js
@@ -27,7 +27,7 @@ oppia.directive('hintButton', [
         onClickHintButton: '&',
         allHintsAreExhausted: '&',
         currentHintIsAvailable: '&',
-        isSupplementalCard: '='
+        isSupplementalCard: '&'
       },
       templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
         '/pages/exploration_player/' +
@@ -43,7 +43,7 @@ oppia.directive('hintButton', [
             WindowDimensionsService.getWidth() < TWO_CARD_THRESHOLD_PX;
 
           $scope.getTooltipPlacement = function() {
-            return (viewportIsNarrow && $scope.isSupplementalCard) ?
+            return (viewportIsNarrow && $scope.isSupplementalCard()) ?
               'right' : 'left';
           };
 

--- a/core/templates/dev/head/pages/exploration_player/hint_button_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/hint_button_directive.html
@@ -1,4 +1,4 @@
-<span ng-if="allHintsAreExhausted()" tooltip="<['I18N_PLAYER_HINTS_EXHAUSTED' | translate]>" tooltip-placement="left">
+<span ng-if="allHintsAreExhausted()" tooltip="<['I18N_PLAYER_HINTS_EXHAUSTED' | translate]>" tooltip-placement="<[getTooltipPlacement()]>">
   <md-button class="hint-button"
              ng-click="onClickHintButton()"
              ng-disabled="!currentHintIsAvailable()"
@@ -17,7 +17,7 @@
       <i class="fa fa-lightbulb-o"></i>
     </md-button>
   </span>
-  <span ng-if="!currentHintIsAvailable()" tooltip="<['I18N_PLAYER_HINT_NOT_AVAILABLE' | translate]>" tooltip-placement="left">
+  <span ng-if="!currentHintIsAvailable()" tooltip="<['I18N_PLAYER_HINT_NOT_AVAILABLE' | translate]>" tooltip-placement="<[getTooltipPlacement()]>">
     <md-button class="hint-button"
                ng-click="onClickHintButton()"
                ng-disabled="!currentHintIsAvailable()"

--- a/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
@@ -25,10 +25,11 @@
        angular-html-bind="activeCard.interactionHtml">
   </div>
   <div ng-if="hintsExist" style="text-align: left; padding: 8px">
-    <hint-button ng-if="!areAllHintsExhausted()"
+    <hint-button ng-show="!areAllHintsExhausted() || (areAllHintsExhausted() && !solutionExists)"
                  on-click-hint-button="consumeHint()"
                  current-hint-is-available="isHintAvailable()"
-                 all-hints-are-exhausted="areAllHintsExhausted()">
+                 all-hints-are-exhausted="areAllHintsExhausted()"
+                 is-supplemental-card="true">
     </hint-button>
     <solution-button ng-if="areAllHintsExhausted()"
                      on-click-solution-button="viewSolution()"

--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -82,10 +82,11 @@
                angular-html-bind="activeCard.interactionHtml">
           </div>
           <div ng-if="hintsExist" style="text-align: right">
-            <hint-button ng-if="!areAllHintsExhausted()"
+            <hint-button ng-show="!areAllHintsExhausted() || (areAllHintsExhausted() && !solutionExists)"
                          on-click-hint-button="consumeHint()"
                          current-hint-is-available="isHintAvailable()"
-                         all-hints-are-exhausted="areAllHintsExhausted()">
+                         all-hints-are-exhausted="areAllHintsExhausted()"
+                         is-supplemental-card="false">
             </hint-button>
             <solution-button ng-if="areAllHintsExhausted()"
                              on-click-solution-button="viewSolution()"


### PR DESCRIPTION
This PR also adds back in the hint button after all hints are exhausted. For some reason, it seems like the hint button was being hidden after hints are exhausted (when no solution is present), but I don't believe this was the design's intention.