### PR TITLE
Implement one off MapRreduce job to generate state id mapping model for explorations.

### DIFF
--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -2724,8 +2724,10 @@ class StateIdMappingTests(test_utils.GenericTestBase):
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
 
         # Create a default exploration.
-        self.exploration = self.save_new_valid_exploration(
-            self.EXP_ID, self.owner_id)
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            self.exploration = self.save_new_valid_exploration(
+                self.EXP_ID, self.owner_id)
+
         self.mapping = exp_services.get_state_id_mapping(
             self.EXP_ID, self.exploration.version)
 
@@ -2744,12 +2746,13 @@ class StateIdMappingTests(test_utils.GenericTestBase):
     def test_that_mapping_remains_same_when_exp_params_changes(self):
         """Test that state id mapping is unchanged when exploration params are
         changed."""
-        exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, [{
-                'cmd': 'edit_exploration_property',
-                'property_name': 'title',
-                'new_value': 'New title'
-            }], 'Changes.')
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': 'edit_exploration_property',
+                    'property_name': 'title',
+                    'new_value': 'New title'
+                }], 'Changes.')
 
         new_exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         new_mapping = exp_services.get_state_id_mapping(
@@ -2766,11 +2769,12 @@ class StateIdMappingTests(test_utils.GenericTestBase):
     def test_that_mapping_is_correct_when_new_state_is_added(self):
         """Test that new state id is added in state id mapping when new state is
         added in exploration."""
-        exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, [{
-                'cmd': exp_domain.CMD_ADD_STATE,
-                'state_name': 'new state',
-            }], 'Add state name')
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'new state',
+                }], 'Add state name')
 
         new_exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         new_mapping = exp_services.get_state_id_mapping(
@@ -2788,16 +2792,17 @@ class StateIdMappingTests(test_utils.GenericTestBase):
     def test_that_mapping_is_correct_when_old_state_is_deleted(self):
         """Test that state id is removed from state id mapping when the
         state is removed from exploration."""
-        exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, [{
-                'cmd': exp_domain.CMD_ADD_STATE,
-                'state_name': 'new state',
-            }], 'Add state name')
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'new state',
+                }], 'Add state name')
 
-        exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
-            'cmd': exp_domain.CMD_DELETE_STATE,
-            'state_name': 'new state',
-            }], 'delete state')
+            exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
+                'cmd': exp_domain.CMD_DELETE_STATE,
+                'state_name': 'new state',
+                }], 'delete state')
 
         new_exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         new_mapping = exp_services.get_state_id_mapping(
@@ -2814,17 +2819,18 @@ class StateIdMappingTests(test_utils.GenericTestBase):
     def test_that_mapping_remains_when_state_is_renamed(self):
         """Test that state id mapping is changed accordingly when a state
         is renamed in exploration."""
-        exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, [{
-                'cmd': exp_domain.CMD_ADD_STATE,
-                'state_name': 'new state',
-            }], 'Add state name')
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'new state',
+                }], 'Add state name')
 
-        exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
-            'cmd': exp_domain.CMD_RENAME_STATE,
-            'old_state_name': 'new state',
-            'new_state_name': 'state',
-        }], 'Change state name')
+            exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
+                'cmd': exp_domain.CMD_RENAME_STATE,
+                'old_state_name': 'new state',
+                'new_state_name': 'state',
+            }], 'Change state name')
 
         new_exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         new_mapping = exp_services.get_state_id_mapping(
@@ -2842,13 +2848,14 @@ class StateIdMappingTests(test_utils.GenericTestBase):
     def test_that_mapping_is_changed_when_interaction_id_is_changed(self):
         """Test that state id mapping is changed accordingly when interaction
         id of state is changed."""
-        exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, [{
-                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': self.exploration.init_state_name,
-                'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
-                'new_value': 'MultipleChoiceInput'
-            }], 'Update interaction.')
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'state_name': self.exploration.init_state_name,
+                    'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
+                    'new_value': 'MultipleChoiceInput'
+                }], 'Update interaction.')
 
         new_exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         new_mapping = exp_services.get_state_id_mapping(
@@ -2866,36 +2873,37 @@ class StateIdMappingTests(test_utils.GenericTestBase):
     def test_that_mapping_is_correct_for_series_of_changes(self):
         """Test that state id mapping is changed accordingly for series
         of add, rename, remove and update state changes."""
-        exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, [{
-                'cmd': exp_domain.CMD_ADD_STATE,
-                'state_name': 'new state',
-            }, {
-                'cmd': exp_domain.CMD_RENAME_STATE,
-                'old_state_name': 'new state',
-                'new_state_name': 'state'
-            }, {
-                'cmd': exp_domain.CMD_ADD_STATE,
-                'state_name': 'extra state'
-            }, {
-                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': 'state',
-                'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
-                'new_value': 'MultipleChoiceInput'
-            }, {
-                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': 'extra state',
-                'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
-                'new_value': 'TextInput'
-            }, {
-                'cmd': exp_domain.CMD_ADD_STATE,
-                'state_name': 'new state',
-            }, {
-                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': 'new state',
-                'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
-                'new_value': 'TextInput'
-            }], 'Heavy changes')
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'new state',
+                }, {
+                    'cmd': exp_domain.CMD_RENAME_STATE,
+                    'old_state_name': 'new state',
+                    'new_state_name': 'state'
+                }, {
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'extra state'
+                }, {
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'state_name': 'state',
+                    'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
+                    'new_value': 'MultipleChoiceInput'
+                }, {
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'state_name': 'extra state',
+                    'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
+                    'new_value': 'TextInput'
+                }, {
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'new state',
+                }, {
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'state_name': 'new state',
+                    'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
+                    'new_value': 'TextInput'
+                }], 'Heavy changes')
 
         new_exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         new_mapping = exp_services.get_state_id_mapping(
@@ -2912,32 +2920,33 @@ class StateIdMappingTests(test_utils.GenericTestBase):
         self.assertEqual(new_mapping.state_names_to_ids, expected_mapping)
         self.assertEqual(new_mapping.largest_state_id_used, 3)
 
-        exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, [{
-                'cmd': exp_domain.CMD_DELETE_STATE,
-                'state_name': 'state',
-            }, {
-                'cmd': exp_domain.CMD_RENAME_STATE,
-                'old_state_name': 'extra state',
-                'new_state_name': 'state'
-            }, {
-                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': 'state',
-                'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
-                'new_value': 'MultipleChoiceInput'
-            }, {
-                'cmd': exp_domain.CMD_ADD_STATE,
-                'state_name': 'extra state'
-            }, {
-                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': 'extra state',
-                'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
-                'new_value': 'TextInput'
-            }, {
-                'cmd': exp_domain.CMD_RENAME_STATE,
-                'old_state_name': 'new state',
-                'new_state_name': 'other state'
-            }], 'Heavy changes 2')
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_DELETE_STATE,
+                    'state_name': 'state',
+                }, {
+                    'cmd': exp_domain.CMD_RENAME_STATE,
+                    'old_state_name': 'extra state',
+                    'new_state_name': 'state'
+                }, {
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'state_name': 'state',
+                    'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
+                    'new_value': 'MultipleChoiceInput'
+                }, {
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'extra state'
+                }, {
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'state_name': 'extra state',
+                    'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
+                    'new_value': 'TextInput'
+                }, {
+                    'cmd': exp_domain.CMD_RENAME_STATE,
+                    'old_state_name': 'new state',
+                    'new_state_name': 'other state'
+                }], 'Heavy changes 2')
 
         new_exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         new_mapping = exp_services.get_state_id_mapping(

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -373,10 +373,10 @@ class ExplorationStateIdMappingJob(jobs.BaseMapReduceOneOffJobManager):
         explorations.append(exploration)
 
         # Get all commit cmds for all versions of exploration.
-        commits = (
+        commit_log_models = (
             exp_models.ExplorationCommitLogEntryModel.get_all_exploration_commits( # pylint: disable=line-too-long
                 exploration.id, exploration.version))
-        change_lists = [commit.commit_cmds for commit in commits]
+        change_lists = [commit.commit_cmds for commit in commit_log_models]
 
         # Create and save state id mapping model for all exploration versions.
         for exploration, change_list in zip(explorations, change_lists):

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -652,3 +652,82 @@ class ExplorationMigrationJobTest(test_utils.GenericTestBase):
         # Ensure the exploration is still deleted.
         with self.assertRaisesRegexp(Exception, 'Entity .* not found'):
             exp_services.get_exploration_by_id(self.NEW_EXP_ID)
+
+
+class ExplorationStateIdMappingJobTest(test_utils.GenericTestBase):
+    """Tests for the ExplorationStateIdMapping one off job."""
+
+    EXP_ID = 'eid'
+
+    def setUp(self):
+        """Initialize owner before each test case."""
+        super(ExplorationStateIdMappingJobTest, self).setUp()
+        self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
+        self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
+
+    def test_that_mapreduce_job_works(self):
+        """Test that mapreduce job is working as expected."""
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', False):
+            exploration = self.save_new_valid_exploration(
+                self.EXP_ID, self.owner_id)
+
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'new state',
+                }], 'Add state name')
+
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'new state 2',
+                }, {
+                    'cmd': exp_domain.CMD_DELETE_STATE,
+                    'state_name': 'new state'
+                }], 'Modify states')
+
+            exp_services.revert_exploration(self.owner_id, self.EXP_ID, 3, 1)
+
+        job_id = exp_jobs_one_off.ExplorationStateIdMappingJob.create_new()
+        exp_jobs_one_off.ExplorationStateIdMappingJob.enqueue(job_id)
+
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            self.process_and_flush_pending_tasks()
+
+        expected_mapping = {
+            exploration.init_state_name: 0
+        }
+        mapping = exp_services.get_state_id_mapping(self.EXP_ID, 1)
+        self.assertEqual(mapping.exploration_id, self.EXP_ID)
+        self.assertEqual(mapping.exploration_version, 1)
+        self.assertEqual(mapping.largest_state_id_used, 0)
+        self.assertDictEqual(mapping.state_names_to_ids, expected_mapping)
+
+        expected_mapping = {
+            exploration.init_state_name: 0,
+            'new state': 1
+        }
+        mapping = exp_services.get_state_id_mapping(self.EXP_ID, 2)
+        self.assertEqual(mapping.exploration_id, self.EXP_ID)
+        self.assertEqual(mapping.exploration_version, 2)
+        self.assertEqual(mapping.largest_state_id_used, 1)
+        self.assertDictEqual(mapping.state_names_to_ids, expected_mapping)
+
+        expected_mapping = {
+            exploration.init_state_name: 0,
+            'new state 2': 2
+        }
+        mapping = exp_services.get_state_id_mapping(self.EXP_ID, 3)
+        self.assertEqual(mapping.exploration_id, self.EXP_ID)
+        self.assertEqual(mapping.exploration_version, 3)
+        self.assertEqual(mapping.largest_state_id_used, 2)
+        self.assertDictEqual(mapping.state_names_to_ids, expected_mapping)
+
+        expected_mapping = {
+            exploration.init_state_name: 0
+        }
+        mapping = exp_services.get_state_id_mapping(self.EXP_ID, 4)
+        self.assertEqual(mapping.exploration_id, self.EXP_ID)
+        self.assertEqual(mapping.exploration_version, 4)
+        self.assertEqual(mapping.largest_state_id_used, 2)
+        self.assertDictEqual(mapping.state_names_to_ids, expected_mapping)

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -1972,6 +1972,9 @@ def create_and_save_state_id_mapping_model(exploration, change_list):
     Returns:
         StateIdMapping. Domain object of StateIdMappingModel instance.
     """
+    if not feconf.ENABLE_STATE_ID_MAPPING:
+        return
+
     if exploration.version > 1:
         # Get state id mapping for new exploration from old exploration with
         # the help of change list.
@@ -2005,6 +2008,9 @@ def create_and_save_state_id_mapping_model_for_reverted_exploration(
     Returns:
         StateIdMapping. Domain object of StateIdMappingModel instance.
     """
+    if not feconf.ENABLE_STATE_ID_MAPPING:
+        return
+
     old_state_id_mapping = get_state_id_mapping(
         exploration_id, revert_to_version)
     previous_state_id_mapping = get_state_id_mapping(
@@ -2031,6 +2037,9 @@ def delete_state_id_mapping_model_for_exploration(
         exploration_id: str. Id of the exploration.
         exploration_version: int. Latest version of the exploration.
     """
+    if not feconf.ENABLE_STATE_ID_MAPPING:
+        return
+
     exp_versions = range(1, exploration_version + 1)
     exp_models.StateIdMappingModel.delete_state_id_mapping_models(
         exploration_id, exp_versions)

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -2842,8 +2842,9 @@ class ExplorationStateIdMappingTests(test_utils.GenericTestBase):
     def test_that_correct_state_id_mapping_model_is_stored(self):
         """Test that correct mapping model is stored for new and edited
         exploration."""
-        exploration = self.save_new_valid_exploration(
-            self.EXP_ID, self.owner_id)
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exploration = self.save_new_valid_exploration(
+                self.EXP_ID, self.owner_id)
 
         mapping = exp_services.get_state_id_mapping(
             self.EXP_ID, exploration.version)
@@ -2857,11 +2858,12 @@ class ExplorationStateIdMappingTests(test_utils.GenericTestBase):
             mapping.largest_state_id_used, 0)
         self.assertDictEqual(mapping.state_names_to_ids, expected_mapping)
 
-        exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, [{
-                'cmd': exp_domain.CMD_ADD_STATE,
-                'state_name': 'new state',
-            }], 'Add state name')
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'new state',
+                }], 'Add state name')
 
         new_exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         new_mapping = exp_services.get_state_id_mapping(
@@ -2878,16 +2880,20 @@ class ExplorationStateIdMappingTests(test_utils.GenericTestBase):
 
     def test_that_state_id_mapping_model_is_deleted(self):
         """Test that state id mapping model is correctly deleted."""
-        exploration = self.save_new_valid_exploration(
-            self.EXP_ID, self.owner_id)
-        exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, [{
-                'cmd': exp_domain.CMD_ADD_STATE,
-                'state_name': 'new state',
-            }], 'Add state name')
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exploration = self.save_new_valid_exploration(
+                self.EXP_ID, self.owner_id)
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'new state',
+                }], 'Add state name')
+
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)
-        exp_services.delete_state_id_mapping_model_for_exploration(
-            exploration.id, exploration.version)
+
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exp_services.delete_state_id_mapping_model_for_exploration(
+                exploration.id, exploration.version)
 
         with self.assertRaisesRegexp(
             Exception,
@@ -2905,17 +2911,18 @@ class ExplorationStateIdMappingTests(test_utils.GenericTestBase):
     def test_that_mapping_is_correct_when_exploration_is_reverted(self):
         """Test that state id mapping is correct when exploration is reverted
         to old version."""
-        exploration = self.save_new_valid_exploration(
-            self.EXP_ID, self.owner_id)
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            exploration = self.save_new_valid_exploration(
+                self.EXP_ID, self.owner_id)
 
-        exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, [{
-                'cmd': exp_domain.CMD_ADD_STATE,
-                'state_name': 'new state',
-            }], 'Add state name')
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_ADD_STATE,
+                    'state_name': 'new state',
+                }], 'Add state name')
 
-        # Revert exploration to version 1.
-        exp_services.revert_exploration(self.owner_id, self.EXP_ID, 2, 1)
+            # Revert exploration to version 1.
+            exp_services.revert_exploration(self.owner_id, self.EXP_ID, 2, 1)
 
         new_exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         new_mapping = exp_services.get_state_id_mapping(

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -288,6 +288,16 @@ class ExplorationCommitLogEntryModel(base_models.BaseModel):
     post_commit_is_private = ndb.BooleanProperty(indexed=True)
 
     @classmethod
+    def _get_instance_id(cls, exp_id, exp_version):
+        """Returns ID of the exploration commit log entry model.
+
+        Args:
+            exp_id: str. The exploration id whose states are mapped.
+            exp_version: int. The version of the exploration.
+        """
+        return 'exploration-%s-%s' % (exp_id, exp_version)
+
+    @classmethod
     def get_all_commits(cls, page_size, urlsafe_start_cursor):
         """Fetches a list of all the commits sorted by their last updated
         attribute.
@@ -354,7 +364,7 @@ class ExplorationCommitLogEntryModel(base_models.BaseModel):
 
     @classmethod
     def get_all_exploration_commits(cls, exp_id, latest_version):
-        """Fetches all the commits made on a particular exploration upto latest
+        """Fetches all the commits made on a particular exploration up to latest
         version of exploration.
 
         Args:
@@ -367,7 +377,7 @@ class ExplorationCommitLogEntryModel(base_models.BaseModel):
         """
         model_ids = []
         for version in range(1, latest_version + 1):
-            model_ids.append('exploration-%s-%s' % (exp_id, version))
+            model_ids.append(cls._get_instance_id(exp_id, version))
 
         models = cls.get_multi(model_ids)
         return models

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -352,6 +352,26 @@ class ExplorationCommitLogEntryModel(base_models.BaseModel):
         return cls._fetch_page_sorted_by_last_updated(
             query, page_size, urlsafe_start_cursor)
 
+    @classmethod
+    def get_all_exploration_commits(cls, exp_id, latest_version):
+        """Fetches all the commits made on a particular exploration upto latest
+        version of exploration.
+
+        Args:
+            exp_id: str. The exploration id.
+            latest_version: int. Latest version of the exploration.
+
+        Returns:
+            list(ExplorationCommitLogEntryModel). Commit log entry model
+            for each version of the given exploration.
+        """
+        model_ids = []
+        for version in range(1, latest_version + 1):
+            model_ids.append('exploration-%s-%s' % (exp_id, version))
+
+        models = cls.get_multi(model_ids)
+        return models
+
 
 class ExpSummaryModel(base_models.BaseModel):
     """Summary model for an Oppia exploration.

--- a/feconf.py
+++ b/feconf.py
@@ -645,6 +645,9 @@ OPEN_FEEDBACK_COUNT_DASHBOARD = 3
 ENABLE_ML_CLASSIFIERS = False
 SHOW_COLLECTION_NAVIGATION_TAB_HISTORY = False
 SHOW_COLLECTION_NAVIGATION_TAB_STATS = False
+# Whether state id mapping model should be generated and stored when exploration
+# is created or updated.
+ENABLE_STATE_ID_MAPPING = False
 
 # Bool to enable update of analytics models.
 # NOTE TO DEVELOPERS: This should be synchronized with app.js


### PR DESCRIPTION
This PR implements MapReduce job for state id mapping model and also introduces a FLAG to stop generation of state id mapping model in production.