### PR TITLE
Fix #3792 Add underline to 'Back to collection' link

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -137,13 +137,14 @@ otherwise they will interfere with the iframed conversation skin directive.
 
   /* All classes below should start with .conversation-skin */
   .conversation-skin-back-to-collection-container {
-    margin-top: 25px;
     margin-bottom: 92px;
+    margin-top: 25px; 
     text-align: center;
   }
 
   .conversation-skin-back-to-collection {
     color: #064b46;
+    text-decoration: underline;
   }
 
   .conversation-skin-progress-dots {


### PR DESCRIPTION
@seanlip The only reason for the margin-top change was to move it below margin-bottom in keeping with the CSS styling rules of alphabetical attribute order.
