### PR TITLE
Fix ExplorationStateIdMapping MapReduce job.

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -365,7 +365,7 @@ class ExplorationStateIdMappingJob(jobs.BaseMapReduceOneOffJobManager):
         exploration = exp_services.get_exploration_from_model(item)
         explorations = []
 
-        # Fetch all versions of the exploration, if exist.
+        # Fetch all versions of the exploration, if they exist.
         if exploration.version > 1:
             # Ignore latest version since we already have corresponding
             # exploration.
@@ -373,7 +373,8 @@ class ExplorationStateIdMappingJob(jobs.BaseMapReduceOneOffJobManager):
             # Get all exploration versions for current exploration id.
             explorations = exp_services.get_multiple_explorations_by_version(
                 exploration.id, versions)
-            # Append latest exploration to the list of explorations.
+
+        # Append latest exploration to the list of explorations.
         explorations.append(exploration)
 
         # Get all commit cmds for all versions of exploration.

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -363,13 +363,17 @@ class ExplorationStateIdMappingJob(jobs.BaseMapReduceOneOffJobManager):
             return
 
         exploration = exp_services.get_exploration_from_model(item)
-        # Ignore latest version since we already have corresponding exploration.
-        versions = range(1, exploration.version)
+        explorations = []
 
-        # Get all exploration versions for current exploration id.
-        explorations = exp_services.get_multiple_explorations_by_version(
-            exploration.id, versions)
-        # Append latest exploration to the list of explorations.
+        # Fetch all versions of the exploration, if exist.
+        if exploration.version > 1:
+            # Ignore latest version since we already have corresponding
+            # exploration.
+            versions = range(1, exploration.version)
+            # Get all exploration versions for current exploration id.
+            explorations = exp_services.get_multiple_explorations_by_version(
+                exploration.id, versions)
+            # Append latest exploration to the list of explorations.
         explorations.append(exploration)
 
         # Get all commit cmds for all versions of exploration.

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -665,6 +665,28 @@ class ExplorationStateIdMappingJobTest(test_utils.GenericTestBase):
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
 
+    def test_that_mapreduce_job_works_for_first_version_of_exploration(self):
+        """Tests that mapreduce job works correctly when the only first
+        exploration version exists."""
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', False):
+            exploration = self.save_new_valid_exploration(
+                self.EXP_ID, self.owner_id)
+
+        job_id = exp_jobs_one_off.ExplorationStateIdMappingJob.create_new()
+        exp_jobs_one_off.ExplorationStateIdMappingJob.enqueue(job_id)
+
+        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
+            self.process_and_flush_pending_tasks()
+
+        expected_mapping = {
+            exploration.init_state_name: 0
+        }
+        mapping = exp_services.get_state_id_mapping(self.EXP_ID, 1)
+        self.assertEqual(mapping.exploration_id, self.EXP_ID)
+        self.assertEqual(mapping.exploration_version, 1)
+        self.assertEqual(mapping.largest_state_id_used, 0)
+        self.assertDictEqual(mapping.state_names_to_ids, expected_mapping)
+
     def test_that_mapreduce_job_works(self):
         """Test that mapreduce job is working as expected."""
         with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', False):


### PR DESCRIPTION
The MapReduce job failed on the trial run because it does not consider the scenario when the only first version of the exploration is available. This PR fixes the issue.