### PR TITLE
Fix error in GenerateV1StatisticsJob

### DIFF
--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -110,7 +110,7 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
             })
 
         elif isinstance(item, stats_models.StateHitEventLogEntryModel):
-            if state_name is None:
+            if item.state_name is None:
                 yield (
                     "ERROR: State name is None for this event of type %s "
                     "created on %s for exploration with ID %s." % (

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -110,10 +110,19 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
             })
 
         elif isinstance(item, stats_models.StateHitEventLogEntryModel):
+            try:
+                state_name = item.state_name.encode('utf-8')
+            except AttributeError:
+                yield (
+                    "ERROR: State name is None for this event of type %s "
+                    "created on %s for exploration with ID %s." % (
+                        feconf.EVENT_TYPE_STATE_HIT, item.created_on,
+                        item.exploration_id))
+                return
             value = {
                 'event_type': feconf.EVENT_TYPE_STATE_HIT,
                 'version': item.exploration_version,
-                'state_name': item.state_name.encode('utf-8'),
+                'state_name': state_name,
                 'session_id': item.session_id,
                 'created_on': utils.get_time_in_millisecs(item.created_on)
             }

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -110,7 +110,6 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
             })
 
         elif isinstance(item, stats_models.StateHitEventLogEntryModel):
-            state_name = item.state_name.encode('utf-8')
             if state_name is None:
                 yield (
                     "ERROR: State name is None for this event of type %s "
@@ -118,6 +117,7 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
                         feconf.EVENT_TYPE_STATE_HIT, item.created_on,
                         item.exploration_id))
                 return
+            state_name = item.state_name.encode('utf-8')
             value = {
                 'event_type': feconf.EVENT_TYPE_STATE_HIT,
                 'version': item.exploration_version,

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -117,11 +117,10 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
                         feconf.EVENT_TYPE_STATE_HIT, item.created_on,
                         item.exploration_id))
                 return
-            state_name = item.state_name.encode('utf-8')
             value = {
                 'event_type': feconf.EVENT_TYPE_STATE_HIT,
                 'version': item.exploration_version,
-                'state_name': state_name,
+                'state_name': item.state_name.encode('utf-8'),
                 'session_id': item.session_id,
                 'created_on': utils.get_time_in_millisecs(item.created_on)
             }

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -110,9 +110,8 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
             })
 
         elif isinstance(item, stats_models.StateHitEventLogEntryModel):
-            try:
-                state_name = item.state_name.encode('utf-8')
-            except AttributeError:
+            state_name = item.state_name.encode('utf-8')
+            if state_name is None:
                 yield (
                     "ERROR: State name is None for this event of type %s "
                     "created on %s for exploration with ID %s." % (


### PR DESCRIPTION
This PR adds a try catch statement block to handle the issue where some state names in events are defined as None. In these cases, we yield the event type, created/last-updated on and also the ID of the exploration.

/cc @seanlip @tjiang11 PTAL!

Thanks
