### PR TITLE
Fix #4090: limit number of progress dots for narrow window

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/ProgressDotsDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ProgressDotsDirective.js
@@ -32,8 +32,9 @@ oppia.directive('progressDots', [
         function($scope, $rootScope, PlayerPositionService, UrlService,
             WindowDimensionsService) {
           var isIframed = UrlService.isIframed();
-          $scope.MAX_DOTS = WindowDimensionsService.isWindowNarrow() ||
-            isIframed ? 6 : 18;
+          $scope.MAX_DOTS = (
+            WindowDimensionsService.isWindowNarrow() || isIframed ?
+            6 : 18);
           $scope.dots = [];
           $scope.currentDotIndex = PlayerPositionService.getActiveCardIndex();
           var initialDotCount = $scope.getNumDots();

--- a/core/templates/dev/head/pages/exploration_player/ProgressDotsDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ProgressDotsDirective.js
@@ -28,9 +28,12 @@ oppia.directive('progressDots', [
         'progress_dots_directive.html'),
       controller: [
         '$scope', '$rootScope', 'PlayerPositionService', 'UrlService',
-        function($scope, $rootScope, PlayerPositionService, UrlService) {
+        'WindowDimensionsService',
+        function($scope, $rootScope, PlayerPositionService, UrlService,
+            WindowDimensionsService) {
           var isIframed = UrlService.isIframed();
-          $scope.MAX_DOTS = isIframed ? 6 : 18;
+          $scope.MAX_DOTS = WindowDimensionsService.isWindowNarrow() ||
+            isIframed ? 6 : 18;
           $scope.dots = [];
           $scope.currentDotIndex = PlayerPositionService.getActiveCardIndex();
           var initialDotCount = $scope.getNumDots();


### PR DESCRIPTION
Add WindowDimensionsService to ProgressDotsDirective.js. Limit the number of ProgressDots on mobile view to 6. 


