### PR TITLE
fix part of #4057 - Test frontend services in services/stateful

### DIFF
--- a/core/templates/dev/head/services/stateful/BackgroundMaskServiceSpec.js
+++ b/core/templates/dev/head/services/stateful/BackgroundMaskServiceSpec.js
@@ -1,0 +1,36 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for the BackgroundMaskService.
+ */
+
+describe('Background Mask Service', function() {
+  var BackgroundMaskService;
+
+  beforeEach(module('oppia'));
+  beforeEach(inject(function($injector) {
+    BackgroundMaskService = $injector.get('BackgroundMaskService');
+  }));
+
+  it('should activate mask', function() {
+    BackgroundMaskService.activateMask();
+    expect(BackgroundMaskService.isMaskActive()).toBe(true);
+  });
+
+  it('should deactivate mask', function() {
+    BackgroundMaskService.deactivateMask();
+    expect(BackgroundMaskService.isMaskActive()).toBe(false);
+  });
+});

--- a/core/templates/dev/head/services/stateful/FocusManagerService.js
+++ b/core/templates/dev/head/services/stateful/FocusManagerService.js
@@ -42,6 +42,9 @@ oppia.factory('FocusManagerService', [
           _nextLabelToFocusOn = null;
         });
       },
+      setFocusLabel: function(label) {
+        _nextLabelToFocusOn = label;
+      },
       setFocusIfOnDesktop: function(newFocusLabel) {
         if (!DeviceInfoService.isMobileDevice()) {
           this.setFocus(newFocusLabel);

--- a/core/templates/dev/head/services/stateful/FocusManagerService.js
+++ b/core/templates/dev/head/services/stateful/FocusManagerService.js
@@ -42,9 +42,6 @@ oppia.factory('FocusManagerService', [
           _nextLabelToFocusOn = null;
         });
       },
-      setFocusLabel: function(label) {
-        _nextLabelToFocusOn = label;
-      },
       setFocusIfOnDesktop: function(newFocusLabel) {
         if (!DeviceInfoService.isMobileDevice()) {
           this.setFocus(newFocusLabel);

--- a/core/templates/dev/head/services/stateful/FocusManagerServiceSpec.js
+++ b/core/templates/dev/head/services/stateful/FocusManagerServiceSpec.js
@@ -1,0 +1,24 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for the FocusManagerService.
+ */
+
+describe('Focus Manager Service', function() {
+  var FocusManagerService;
+
+  beforeEach(module('oppia'));
+
+});

--- a/core/templates/dev/head/services/stateful/FocusManagerServiceSpec.js
+++ b/core/templates/dev/head/services/stateful/FocusManagerServiceSpec.js
@@ -18,6 +18,59 @@
 
 describe('Focus Manager Service', function() {
   var FocusManagerService;
+  var DeviceInfoService;
+  var IdGenerationService;
+  var clearFocusLabel;
+  var rootScope;
+  var $timeout;
+  var focuslabel = 'FocusLabel';
 
   beforeEach(module('oppia'));
+  beforeEach(inject(function($injector, LABEL_FOR_CLEARING_FOCUS) {
+    FocusManagerService = $injector.get('FocusManagerService');
+    DeviceInfoService = $injector.get('DeviceInfoService');
+    IdGenerationService = $injector.get('IdGenerationService');
+    rootScope = $injector.get('$rootScope');
+    $timeout = $injector.get('$timeout');
+    clearLabel = LABEL_FOR_CLEARING_FOCUS;
+    spyOn(rootScope, '$broadcast');
+  }));
+
+  it('should generate a random string for focus label', function() {
+    spyOn(IdGenerationService, 'generateNewId');
+    FocusManagerService.generateFocusLabel();
+    expect(IdGenerationService.generateNewId).toHaveBeenCalled();
+  });
+
+  it('should set focus label and broadcast it', function() {
+    FocusManagerService.setFocus(focuslabel);
+    $timeout(function () {
+      expect(rootScope.$broadcast).toHaveBeenCalledWith('focusOn',focuslabel);
+    });
+    $timeout.flush();
+  });
+
+  it('should not set focus label if _nextLabelToFocusOn is set', function() {
+    FocusManagerService.setFocusLabel(focuslabel);
+    ctr = FocusManagerService.setFocus(focuslabel);
+    expect(ctr).toEqual(undefined);
+  });
+
+  it('should set label to clear focus and broadcast it', function() {
+    FocusManagerService.clearFocus();
+    $timeout(function () {
+      expect(rootScope.$broadcast).toHaveBeenCalledWith('focusOn',clearLabel);
+    });
+    $timeout.flush();
+  });
+
+  it('should set focus label if on desktop and broadcast it', function() {
+    FocusManagerService.setFocusIfOnDesktop(focuslabel);
+    if (!DeviceInfoService.isMobileDevice()) {
+      $timeout(function () {
+        expect(rootScope.$broadcast).toHaveBeenCalledWith('focusOn',focuslabel);
+      });
+      $timeout.flush();
+    }
+  });
 });

--- a/core/templates/dev/head/services/stateful/FocusManagerServiceSpec.js
+++ b/core/templates/dev/head/services/stateful/FocusManagerServiceSpec.js
@@ -28,12 +28,12 @@ describe('Focus Manager Service', function() {
 
   beforeEach(module('oppia'));
   beforeEach(inject(function($injector) {
+    clearLabel = $injector.get('LABEL_FOR_CLEARING_FOCUS');
     FocusManagerService = $injector.get('FocusManagerService');
     DeviceInfoService = $injector.get('DeviceInfoService');
     IdGenerationService = $injector.get('IdGenerationService');
     rootScope = $injector.get('$rootScope');
     $timeout = $injector.get('$timeout');
-    clearLabel = $injector.get('LABEL_FOR_CLEARING_FOCUS');
     spyOn(rootScope, '$broadcast');
   }));
 

--- a/core/templates/dev/head/services/stateful/FocusManagerServiceSpec.js
+++ b/core/templates/dev/head/services/stateful/FocusManagerServiceSpec.js
@@ -20,19 +20,20 @@ describe('Focus Manager Service', function() {
   var FocusManagerService;
   var DeviceInfoService;
   var IdGenerationService;
-  var clearFocusLabel;
   var rootScope;
   var $timeout;
-  var focuslabel = 'FocusLabel';
+  var clearLabel;
+  var focusLabel = 'FocusLabel';
+  var focusLabelTwo = 'FocusLabelTwo';
 
   beforeEach(module('oppia'));
-  beforeEach(inject(function($injector, LABEL_FOR_CLEARING_FOCUS) {
+  beforeEach(inject(function($injector) {
     FocusManagerService = $injector.get('FocusManagerService');
     DeviceInfoService = $injector.get('DeviceInfoService');
     IdGenerationService = $injector.get('IdGenerationService');
     rootScope = $injector.get('$rootScope');
     $timeout = $injector.get('$timeout');
-    clearLabel = LABEL_FOR_CLEARING_FOCUS;
+    clearLabel = $injector.get('LABEL_FOR_CLEARING_FOCUS');
     spyOn(rootScope, '$broadcast');
   }));
 
@@ -43,17 +44,19 @@ describe('Focus Manager Service', function() {
   });
 
   it('should set focus label and broadcast it', function() {
-    FocusManagerService.setFocus(focuslabel);
+    FocusManagerService.setFocus(focusLabel);
     $timeout(function () {
-      expect(rootScope.$broadcast).toHaveBeenCalledWith('focusOn',focuslabel);
+      expect(rootScope.$broadcast).toHaveBeenCalledWith('focusOn',focusLabel);
     });
     $timeout.flush();
   });
 
   it('should not set focus label if _nextLabelToFocusOn is set', function() {
-    FocusManagerService.setFocusLabel(focuslabel);
-    ctr = FocusManagerService.setFocus(focuslabel);
-    expect(ctr).toEqual(undefined);
+    FocusManagerService.setFocus(focusLabel);
+    expect(FocusManagerService.setFocus(focusLabelTwo)).toEqual(undefined);
+    $timeout.flush();
+    $timeout.verifyNoPendingTasks();
+    expect(rootScope.$broadcast).toHaveBeenCalledWith('focusOn',focusLabel);
   });
 
   it('should set label to clear focus and broadcast it', function() {
@@ -65,10 +68,10 @@ describe('Focus Manager Service', function() {
   });
 
   it('should set focus label if on desktop and broadcast it', function() {
-    FocusManagerService.setFocusIfOnDesktop(focuslabel);
+    FocusManagerService.setFocusIfOnDesktop(focusLabel);
     if (!DeviceInfoService.isMobileDevice()) {
       $timeout(function () {
-        expect(rootScope.$broadcast).toHaveBeenCalledWith('focusOn',focuslabel);
+        expect(rootScope.$broadcast).toHaveBeenCalledWith('focusOn',focusLabel);
       });
       $timeout.flush();
     }

--- a/core/templates/dev/head/services/stateful/FocusManagerServiceSpec.js
+++ b/core/templates/dev/head/services/stateful/FocusManagerServiceSpec.js
@@ -20,5 +20,4 @@ describe('Focus Manager Service', function() {
   var FocusManagerService;
 
   beforeEach(module('oppia'));
-
 });


### PR DESCRIPTION
I wrote tests for the two files BackgroundMaskService.js and FocusManagerService.js present in services/stateful.
The karma coverage for both the services after running front_end tests in my local machine are 100%.