### PR TITLE
Fix part of #3950: Replace jinja with angular in library title in library.html

### DIFF
--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -47,7 +47,7 @@ class LibraryPageTest(test_utils.GenericTestBase):
         """Test access to the library page."""
         response = self.testapp.get(feconf.LIBRARY_INDEX_URL)
         self.assertEqual(response.status_int, 200)
-        response.mustcontain('I18N_LIBRARY_PAGE_TITLE')
+        response.mustcontain('libraryTitle')
 
     def test_library_handler_demo_exploration(self):
         """Test the library data handler on demo explorations."""

--- a/core/templates/dev/head/pages/library/Library.js
+++ b/core/templates/dev/head/pages/library/Library.js
@@ -57,6 +57,12 @@ oppia.controller('Library', [
     // Keeps track of the index of the left-most visible card of each group.
     $scope.leftmostCardIndices = [];
 
+    if(['group', 'search'].indexOf($scope.pageMode) !== -1){
+    	$rootScope.libraryTitle = 'Find explorations to learn from - Oppia';
+    } else {
+    	$rootScope.libraryTitle = 'I18N_LIBRARY_PAGE_TITLE';
+    }
+
     if ($scope.pageMode === LIBRARY_PAGE_MODES.GROUP) {
       var pathnameArray = $window.location.pathname.split('/');
       $scope.groupName = pathnameArray[2];

--- a/core/templates/dev/head/pages/library/Library.js
+++ b/core/templates/dev/head/pages/library/Library.js
@@ -58,9 +58,9 @@ oppia.controller('Library', [
     $scope.leftmostCardIndices = [];
 
     if(['group', 'search'].indexOf($scope.pageMode) !== -1){
-    	$rootScope.libraryTitle = 'Find explorations to learn from - Oppia';
+      $rootScope.libraryTitle = 'Find explorations to learn from - Oppia';
     } else {
-    	$rootScope.libraryTitle = 'I18N_LIBRARY_PAGE_TITLE';
+      $rootScope.libraryTitle = 'I18N_LIBRARY_PAGE_TITLE';
     }
 
     if ($scope.pageMode === LIBRARY_PAGE_MODES.GROUP) {

--- a/core/templates/dev/head/pages/library/Library.js
+++ b/core/templates/dev/head/pages/library/Library.js
@@ -57,7 +57,7 @@ oppia.controller('Library', [
     // Keeps track of the index of the left-most visible card of each group.
     $scope.leftmostCardIndices = [];
 
-    if(['group', 'search'].indexOf($scope.pageMode) !== -1){
+    if([LIBRARY_PAGE_MODES.GROUP, LIBRARY_PAGE_MODES.SEARCH].indexOf($scope.pageMode) !== -1){
       $rootScope.libraryTitle = 'Find explorations to learn from - Oppia';
     } else {
       $rootScope.libraryTitle = 'I18N_LIBRARY_PAGE_TITLE';

--- a/core/templates/dev/head/pages/library/Library.js
+++ b/core/templates/dev/head/pages/library/Library.js
@@ -58,7 +58,7 @@ oppia.controller('Library', [
     $scope.leftmostCardIndices = [];
 
     if([LIBRARY_PAGE_MODES.GROUP,
-      LIBRARY_PAGE_MODES.SEARCH].indexOf($scope.pageMode) !== -1){
+        LIBRARY_PAGE_MODES.SEARCH].indexOf($scope.pageMode) !== -1){
       $rootScope.libraryTitle = 'Find explorations to learn from - Oppia';
     } else {
       $rootScope.libraryTitle = 'I18N_LIBRARY_PAGE_TITLE';

--- a/core/templates/dev/head/pages/library/Library.js
+++ b/core/templates/dev/head/pages/library/Library.js
@@ -57,7 +57,8 @@ oppia.controller('Library', [
     // Keeps track of the index of the left-most visible card of each group.
     $scope.leftmostCardIndices = [];
 
-    if([LIBRARY_PAGE_MODES.GROUP, LIBRARY_PAGE_MODES.SEARCH].indexOf($scope.pageMode) !== -1){
+    if([LIBRARY_PAGE_MODES.GROUP, 
+    	LIBRARY_PAGE_MODES.SEARCH].indexOf($scope.pageMode) !== -1){
       $rootScope.libraryTitle = 'Find explorations to learn from - Oppia';
     } else {
       $rootScope.libraryTitle = 'I18N_LIBRARY_PAGE_TITLE';

--- a/core/templates/dev/head/pages/library/Library.js
+++ b/core/templates/dev/head/pages/library/Library.js
@@ -57,8 +57,8 @@ oppia.controller('Library', [
     // Keeps track of the index of the left-most visible card of each group.
     $scope.leftmostCardIndices = [];
 
-    if([LIBRARY_PAGE_MODES.GROUP, 
-    	LIBRARY_PAGE_MODES.SEARCH].indexOf($scope.pageMode) !== -1){
+    if([LIBRARY_PAGE_MODES.GROUP,
+      LIBRARY_PAGE_MODES.SEARCH].indexOf($scope.pageMode) !== -1){
       $rootScope.libraryTitle = 'Find explorations to learn from - Oppia';
     } else {
       $rootScope.libraryTitle = 'I18N_LIBRARY_PAGE_TITLE';

--- a/core/templates/dev/head/pages/library/library.html
+++ b/core/templates/dev/head/pages/library/library.html
@@ -1,11 +1,9 @@
 {% extends 'pages/base.html' %}
 
 {% block maintitle %}
-  {% if page_mode in ['group', 'search'] %}
-    Find explorations to learn from - Oppia
-  {% else %}
-    I18N_LIBRARY_PAGE_TITLE
-  {% endif %}
+  {% raw %}
+    <[libraryTitle]>
+  {% endraw %}
 {% endblock maintitle %}
 
 {% block navbar_breadcrumb %}

--- a/core/templates/dev/head/pages/library/library.html
+++ b/core/templates/dev/head/pages/library/library.html
@@ -1,9 +1,7 @@
 {% extends 'pages/base.html' %}
 
 {% block maintitle %}
-  {% raw %}
-    <[libraryTitle]>
-  {% endraw %}
+  <[libraryTitle]>
 {% endblock maintitle %}
 
 {% block navbar_breadcrumb %}


### PR DESCRIPTION
created a new variable libraryTitle in library.js in $rootScope and replaced jinja in library.html with this variable.

Testing:

opened library link, check if title shows "Exploration Library - Oppia".

search something in the search bar, check if title changes to "Find explorations to learn from - Oppia".