### PR TITLE
Fix #4152: fix bug in solution verification service.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/SolutionVerificationService.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/SolutionVerificationService.js
@@ -17,14 +17,12 @@
  */
 
 oppia.factory('SolutionVerificationService', [
-  '$injector', 'stateInteractionIdService', 'ExplorationContextService',
-  'EditorStateService', 'AngularNameService', 'AnswerClassificationService',
+  '$injector', 'AngularNameService', 'AnswerClassificationService',
   function(
-    $injector, stateInteractionIdService, ExplorationContextService,
-    EditorStateService, AngularNameService, AnswerClassificationService) {
+    $injector, AngularNameService, AnswerClassificationService) {
     return {
       verifySolution: function(explorationId, state, correctAnswer) {
-        var interactionId = stateInteractionIdService.savedMemento;
+        var interactionId = state.interaction.id;
         var rulesServiceName = (
           AngularNameService.getNameOfInteractionRulesService(interactionId));
         var rulesService = $injector.get(rulesServiceName);
@@ -32,7 +30,7 @@ oppia.factory('SolutionVerificationService', [
           AnswerClassificationService.getMatchingClassificationResult(
             explorationId, state.name, state, correctAnswer, true, rulesService
           ));
-        return EditorStateService.getActiveStateName() !== result.outcome.dest;
+        return state.name !== result.outcome.dest;
       }
     }
   }]);

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/SolutionVerificationServiceSpec.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/SolutionVerificationServiceSpec.js
@@ -35,7 +35,7 @@ describe('Solution Verification Service', function() {
     });
   });
 
-  var ecs, ess, siis, scas, idc, sof, svs, IS, mockFunctions;
+  var ess, siis, scas, idc, sof, svs, IS, mockFunctions;
   var rootScope;
   var mockExplorationData;
   var successCallbackSpy, errorCallbackSpy;
@@ -52,7 +52,6 @@ describe('Solution Verification Service', function() {
   });
 
   beforeEach(inject(function($rootScope, $controller, $injector) {
-    ecs = $injector.get('EditorStateService');
     ess = $injector.get('explorationStatesService');
     siis = $injector.get('stateInteractionIdService');
     scas = $injector.get('stateCustomizationArgsService');
@@ -121,7 +120,6 @@ describe('Solution Verification Service', function() {
 
   describe('Success case', function() {
     it('should verify a correct solution', function() {
-      ecs.setActiveStateName('First State');
       var state = ess.getState('First State');
       siis.init(
         'First State', state.interaction.id, state.interaction, 'widget_id');
@@ -141,7 +139,6 @@ describe('Solution Verification Service', function() {
 
   describe('Failure case', function() {
     it('should verify an incorrect solution', function() {
-      ecs.setActiveStateName('First State');
       var state = ess.getState('First State');
       siis.init(
         'First State', state.interaction.id, state.interaction, 'widget_id');


### PR DESCRIPTION
The SolutionVerificationService was assuming that the state it was being called on was the "currently active" state. This worked fine when it was being used only in the editor tab, but not when it started getting used in the stats tab. This PR makes that service stateless so that it can be called more generally.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/blob/develop/CONTRIBUTING.md#style-rules).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.  
