### PR TITLE
Update deploy script

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -16,7 +16,6 @@
 
 import os
 import subprocess
-import sys
 
 
 def ensure_directory_exists(d):

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -76,15 +76,8 @@ def verify_local_repo_is_clean():
 
     branch_is_clean_message = 'nothing to commit, working directory clean'
     if not branch_is_clean_message in git_status_output:
-        while True:
-            print 'WARNING: Your local branch state is not clean.'
-            print 'Please confirm: are you okay with proceeding? '
-            answer = raw_input().lower()
-            if answer in ['y', 'ye', 'yes']:
-                break
-            elif answer:
-                print 'Exiting since local branch is not clean.'
-                sys.exit()
+        raise Exception(
+            'ERROR: This script should be run from a clean branch.')
 
 
 def get_current_branch_name():

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -16,6 +16,7 @@
 
 import os
 import subprocess
+import sys
 
 
 def ensure_directory_exists(d):
@@ -75,8 +76,15 @@ def verify_local_repo_is_clean():
 
     branch_is_clean_message = 'nothing to commit, working directory clean'
     if not branch_is_clean_message in git_status_output:
-        raise Exception(
-            'ERROR: This script should be run from a clean branch.')
+        while True:
+            print 'WARNING: Your local branch state is not clean.'
+            print 'Please confirm: are you okay with proceeding? '
+            answer = raw_input().lower()
+            if answer in ['y', 'ye', 'yes']:
+                break
+            elif answer:
+                print 'Exiting since local branch is not clean.'
+                sys.exit()
 
 
 def get_current_branch_name():

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -165,7 +165,10 @@ def _get_served_version():
     """
     listed_versions = subprocess.check_output(
         [APPCFG_PATH, '--application=%s' % APP_NAME, 'list_versions'])
-    listed_versions = listed_versions[listed_versions.index('default: [') + 10:]
+    default_version_line_start_str = 'default: ['
+    listed_versions = listed_versions[
+        listed_versions.index(default_version_line_start_str) + len(
+            default_version_line_start_str):]
     return listed_versions[:listed_versions.index(',')].replace('-', '.')
 
 
@@ -175,9 +178,11 @@ def _get_current_release_version():
     Returns:
         (str): The current (local) Oppia release version.
     """
-    if not CURRENT_BRANCH_NAME.startswith('release-'):
+    release_branch_name_prefix = 'release-'
+    if not CURRENT_BRANCH_NAME.startswith(release_branch_name_prefix):
         raise Exception('Deploy script must be run from a release branch.')
-    return CURRENT_BRANCH_NAME[8:].replace('-', '.')
+    return CURRENT_BRANCH_NAME[len(
+        release_branch_name_prefix):].replace('-', '.')
 
 
 def _execute_deployment():

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -231,8 +231,9 @@ def _execute_deployment():
 
         print 'Returning to oppia/ root directory.'
 
-    # If this is a test server deployment, open the library page (for sanity
-    # checking) and the GAE error logs.
+    # If this is a test server deployment and the current release version is
+    # already serving, open the library page (for sanity checking) and the GAE
+    # error logs.
     if (APP_NAME == APP_NAME_OPPIATESTSERVER or 'migration' in APP_NAME) and (
             _get_served_version() == _get_current_release_version()):
         common.open_new_tab_in_browser_if_possible(

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -66,11 +66,14 @@ _PARSER.add_argument(
 
 APP_NAME_OPPIASERVER = 'oppiaserver'
 APP_NAME_OPPIATESTSERVER = 'oppiatestserver'
+APP_NAME_OPPIASERVER_BACKUP_MIGRATION = 'oppiaserver-backup-migration'
 
 PARSED_ARGS = _PARSER.parse_args()
 if PARSED_ARGS.app_name:
     APP_NAME = PARSED_ARGS.app_name
-    if APP_NAME not in [APP_NAME_OPPIASERVER, APP_NAME_OPPIATESTSERVER]:
+    if APP_NAME not in [
+            APP_NAME_OPPIASERVER, APP_NAME_OPPIATESTSERVER,
+            APP_NAME_OPPIASERVER_BACKUP_MIGRATION]:
         raise Exception('Invalid app name: %s' % APP_NAME)
 else:
     raise Exception('No app name specified.')
@@ -207,16 +210,6 @@ def _execute_deployment():
                     current_git_revision))
 
         print 'Returning to oppia/ root directory.'
-
-    # If this is a test server deployment, open the library page (for sanity
-    # checking) and the GAE error logs.
-    if APP_NAME == APP_NAME_OPPIATESTSERVER:
-        common.open_new_tab_in_browser_if_possible(
-            'https://console.cloud.google.com/logs/viewer?'
-            'project=%s&key1=default&minLogLevel=500'
-            % APP_NAME_OPPIATESTSERVER)
-        common.open_new_tab_in_browser_if_possible(
-            'https://%s.appspot.com/library' % APP_NAME_OPPIATESTSERVER)
 
     print 'Done!'
 


### PR DESCRIPTION
Update deploy script to ask rather than force-close when trying to deploy with a non-clean directory, and to not open the library/logging pages by default since it may open them for the wrong version on initial deployment.