### PR TITLE
Fix ExplorationStateIdMapping job: Catch Exception when failing to retrieve explorations.

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -371,8 +371,13 @@ class ExplorationStateIdMappingJob(jobs.BaseMapReduceOneOffJobManager):
             # exploration.
             versions = range(1, exploration.version)
             # Get all exploration versions for current exploration id.
-            explorations = exp_services.get_multiple_explorations_by_version(
-                exploration.id, versions)
+            try:
+                explorations = (
+                    exp_services.get_multiple_explorations_by_version(
+                        exploration.id, versions))
+            except Exception as e:
+                yield e
+                return
 
         # Append latest exploration to the list of explorations.
         explorations.append(exploration)


### PR DESCRIPTION
This job catches exceptions when job fails to retrieve explorations.