### PR TITLE
Fix #4159: update link to coding style guide

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 - [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
 - [ ] The linter/Karma presubmit checks have passed.
   - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
-- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/blob/develop/CONTRIBUTING.md#style-rules).
+- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
 - [ ] The PR is assigned to an appropriate reviewer.
   - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
   - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.  


### PR DESCRIPTION
**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/blob/develop/CONTRIBUTING.md#style-rules).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.  
