### PR TITLE
Fix #4167: Update answer summarizers job to properly handle answers corresponding to deleted explorations

### DIFF
--- a/core/domain/stats_jobs_continuous.py
+++ b/core/domain/stats_jobs_continuous.py
@@ -609,7 +609,7 @@ class InteractionAnswerSummariesMRJobManager(
         # Ensure the exploration corresponding to these answers exists.
         exp = exp_services.get_exploration_by_id(
             exploration_id, strict=False)
-        if not exp:
+        if exp is None:
             return
 
         if exploration_version == VERSION_ALL:
@@ -628,8 +628,6 @@ class InteractionAnswerSummariesMRJobManager(
                         'since the latest exploration version is %s' % (
                             latest_version, exp.version))
                     versions = []
-            elif not exp:
-                versions = []
 
         # In the VERSION_ALL case, we only take into account the most recent
         # consecutive block of versions with the same interaction ID as the

--- a/core/domain/stats_jobs_continuous.py
+++ b/core/domain/stats_jobs_continuous.py
@@ -606,14 +606,18 @@ class InteractionAnswerSummariesMRJobManager(
         latest_version = versions[0]
         latest_interaction_id = versioned_interaction_ids[latest_version][0]
 
+        # Ensure the exploration corresponding to these answers exists.
+        exp = exp_services.get_exploration_by_id(
+            exploration_id, strict=False)
+        if not exp:
+            return
+
         if exploration_version == VERSION_ALL:
             # If aggregating across all versions, verify that the latest answer
             # version is equal to the latest version of the exploration,
             # otherwise ignore all answers since none of them can be applied to
             # the latest version.
-            exp = exp_services.get_exploration_by_id(
-                exploration_id, strict=False)
-            if exp and state_name in exp.states:
+            if state_name in exp.states:
                 loaded_interaction_id = exp.states[state_name].interaction.id
                 # Only check if the version mismatches if the new version has a
                 # different interaction ID.

--- a/core/domain/stats_jobs_continuous.py
+++ b/core/domain/stats_jobs_continuous.py
@@ -611,8 +611,9 @@ class InteractionAnswerSummariesMRJobManager(
             # version is equal to the latest version of the exploration,
             # otherwise ignore all answers since none of them can be applied to
             # the latest version.
-            exp = exp_services.get_exploration_by_id(exploration_id)
-            if state_name in exp.states:
+            exp = exp_services.get_exploration_by_id(
+                exploration_id, strict=False)
+            if exp and state_name in exp.states:
                 loaded_interaction_id = exp.states[state_name].interaction.id
                 # Only check if the version mismatches if the new version has a
                 # different interaction ID.
@@ -623,6 +624,8 @@ class InteractionAnswerSummariesMRJobManager(
                         'since the latest exploration version is %s' % (
                             latest_version, exp.version))
                     versions = []
+            elif not exp:
+                versions = []
 
         # In the VERSION_ALL case, we only take into account the most recent
         # consecutive block of versions with the same interaction ID as the

--- a/core/domain/stats_jobs_continuous_test.py
+++ b/core/domain/stats_jobs_continuous_test.py
@@ -560,15 +560,12 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
                     taskqueue_services.QUEUE_NAME_CONTINUOUS_JOBS), 0)
 
             # There should be no job output corresponding to all versions since
-            # the exploration was deleted before the job could run. Note that if
-            # the job before and after deletion, the old output would still be
-            # available. This is also true for deleted explorations and data
-            # corresponding to specific versions. This is fine in practice since
-            # the deleted exploration is not accessible, so its answer stats
-            # should never be loaded by the frontend.
+            # the exploration was deleted before the job could run. Note that
+            # this applies regardless of whether the job runs before or after
+            # deletion of the exploration.
             calc_output_model = self._get_calc_output_model(
                 exp_id, first_state_name, 'AnswerFrequencies')
-            self.assertEqual(calc_output_model.calculation_output, [])
+            self.assertIsNone(calc_output_model)
 
     def test_answers_across_multiple_exploration_versions(self):
         with self.swap(


### PR DESCRIPTION
Update InteractionAnswerSummariesMRJobManager to properly handle answers corresponding to deleted explorations corresponding to deleted explorations in the VERSION_ALL aggregation case.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.  
