### PR TITLE
Fix #4169: Fixes Key error due to plus sign replacements

### DIFF
--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -230,7 +230,9 @@ class GenerateV1StatisticsJob(jobs.BaseMapReduceOneOffJobManager):
 
                 # Some state names in events have spaces replaced with plus
                 # signs. We explicitly log these for future reference.
-                if '+' in state_name:
+                versioned_exploration = explorations_by_version[version - 1]
+                if '+' in state_name and (
+                        state_name not in versioned_exploration.states):
                     state_name = state_name.replace('+', ' ')
                     value['state_name'] = state_name
                     yield (

--- a/core/domain/stats_jobs_one_off_test.py
+++ b/core/domain/stats_jobs_one_off_test.py
@@ -395,3 +395,31 @@ class GenerateV1StatisticsJobTest(test_utils.GenericTestBase):
         # Since exploration is deleted, ExplorationStatsModel instance is not
         # created.
         self.assertEqual(exploration_stats, None)
+
+    def test_state_name_sign_replacement_works(self):
+        # Update exploration to version 2.
+        change_list = [{
+            'cmd': exp_domain.CMD_ADD_STATE,
+            'state_name': u'New + day',
+        }]
+        exp_services.update_exploration(
+            feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
+
+        self.exploration = exp_services.get_exploration_by_id(self.exp_id)
+
+        stats_models.StateHitEventLogEntryModel.create(
+            self.exp_id, self.exploration.version, u'New + day',
+            'session_id4', {}, feconf.PLAY_TYPE_NORMAL)
+
+        job_id = stats_jobs_one_off.GenerateV1StatisticsJob.create_new()
+        stats_jobs_one_off.GenerateV1StatisticsJob.enqueue(job_id)
+
+        self.assertEqual(self.count_jobs_in_taskqueue(
+            taskqueue_services.QUEUE_NAME_ONE_OFF_JOBS), 1)
+        self.process_and_flush_pending_tasks()
+
+        exploration_stats = stats_services.get_exploration_stats_by_id(
+            self.exp_id, self.exploration.version)
+        self.assertEqual(
+            exploration_stats.state_stats_mapping[
+                'New + day'].total_hit_count_v1, 1)


### PR DESCRIPTION
#4169 

This PR adds an additional check before replacing plus signs in state names retrieved from state hit events.
An additional test is also added to ensure that this change works.
The test was failing before the change was made to the job, and worked after the change.
/cc @seanlip 

Thanks