### PR TITLE
Stabilize search page protractor tests by giving Protractor a bit more time to load the page.

### DIFF
--- a/core/tests/protractor/libraryPagesTour.js
+++ b/core/tests/protractor/libraryPagesTour.js
@@ -84,7 +84,8 @@ describe('Library pages tour', function() {
       return browser.getCurrentUrl().then(function(url) {
         return /search/.test(url);
       });
-    });
+    }, 4000);
+    general.waitForSystem();
     expect(browser.getCurrentUrl()).toContain('search/find?q=python');
   });
 


### PR DESCRIPTION
The protractor tests for the Search page in production keep failing with a "JavaScript error: document unloaded while waiting for result". I don't know what the cause is, but after browsing online it seems like giving the page a bit more time to load might be helpful.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.