### PR TITLE
Fix #4179: update calculation for 'addressed' status; make some UI fixes.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/EditorServices.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorServices.js
@@ -662,7 +662,6 @@ oppia.factory('explorationStatesService', [
               stateName,
               _states.getState(stateName),
               solution.correctAnswer,
-              true,
               $injector.get(
                 AngularNameService.getNameOfInteractionRulesService(
                   _states.getState(stateName).interaction.id))));

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/SolutionVerificationService.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/SolutionVerificationService.js
@@ -28,7 +28,7 @@ oppia.factory('SolutionVerificationService', [
         var rulesService = $injector.get(rulesServiceName);
         var result = (
           AnswerClassificationService.getMatchingClassificationResult(
-            explorationId, state.name, state, correctAnswer, true, rulesService
+            explorationId, state.name, state, correctAnswer, rulesService
           ));
         return state.name !== result.outcome.dest;
       }

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
@@ -317,8 +317,7 @@ oppia.controller('StateResponses', [
 
               var classificationResult = (
                 AnswerClassificationService.getMatchingClassificationResult(
-                  _explorationId, _stateName, _state, answer, true,
-                  rulesService));
+                  _explorationId, _stateName, _state, answer, rulesService));
               var feedback = 'Nothing';
               var dest = classificationResult.outcome.dest;
               if (classificationResult.outcome.feedback.length > 0) {

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/TrainingModalService.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/TrainingModalService.js
@@ -75,7 +75,7 @@ oppia.factory('TrainingModalService', [
                 var classificationResult = (
                   AnswerClassificationService.getMatchingClassificationResult(
                     explorationId, currentStateName, state, unhandledAnswer,
-                    true, rulesService));
+                    rulesService));
                 var feedback = 'Nothing';
                 var dest = classificationResult.outcome.dest;
                 if (classificationResult.outcome.feedback.length > 0) {

--- a/core/templates/dev/head/pages/exploration_player/AnswerClassificationService.js
+++ b/core/templates/dev/head/pages/exploration_player/AnswerClassificationService.js
@@ -105,8 +105,6 @@ oppia.factory('AnswerClassificationService', [
        * @param {object} oldState - The state where the user submitted the
        *   answer.
        * @param {*} answer - The answer that the user has submitted.
-       * @param {boolean} isInEditorMode - Whether the function is being called
-       *   in editor mode.
        * @param {function} interactionRulesService - The service which contains
        *   the explicit rules of that interaction.
        *
@@ -114,8 +112,7 @@ oppia.factory('AnswerClassificationService', [
        *   AnswerClassificationResult domain object.
        */
       getMatchingClassificationResult: function(
-          explorationId, stateName, oldState, answer, isInEditorMode,
-          interactionRulesService) {
+          explorationId, stateName, oldState, answer, interactionRulesService) {
         var answerClassificationResult = null;
 
         var answerGroups = oldState.interaction.answerGroups;
@@ -162,6 +159,15 @@ oppia.factory('AnswerClassificationService', [
         }
 
         return answerClassificationResult;
+      },
+      isClassifiedExplicitlyOrGoesToNewState: function(
+          explorationId, stateName, state, answer, interactionRulesService) {
+        var result = this.getMatchingClassificationResult(
+          explorationId, stateName, state, answer, interactionRulesService);
+        return (
+          result.outcome.dest !== state.name ||
+          result.classificationCategorization !==
+            DEFAULT_OUTCOME_CLASSIFICATION);
       }
     };
   }

--- a/core/templates/dev/head/pages/exploration_player/AnswerClassificationServiceSpec.js
+++ b/core/templates/dev/head/pages/exploration_player/AnswerClassificationServiceSpec.js
@@ -118,8 +118,7 @@ describe('Answer classification service with string classifier disabled',
 
     it('should fail if no frontend rules are provided', function() {
       expect(function() {
-        acs.getMatchingClassificationResult(
-          explorationId, stateName, state, 0, false)
+        acs.getMatchingClassificationResult(explorationId, stateName, state, 0)
       }).toThrow();
     });
 
@@ -127,21 +126,21 @@ describe('Answer classification service with string classifier disabled',
        'spec', function() {
       expect(
         acs.getMatchingClassificationResult(
-          explorationId, stateName, state, 10, false, rules)
+          explorationId, stateName, state, 10, rules)
       ).toEqual(acrof.createNew(
         oof.createNew('outcome 1', [''], []), 0, 0, EXPLICIT_CLASSIFICATION
       ));
 
       expect(
         acs.getMatchingClassificationResult(
-          explorationId, stateName, state, 5, false, rules)
+          explorationId, stateName, state, 5, rules)
       ).toEqual(acrof.createNew(
         oof.createNew('outcome 2', [''], []), 1, 0, EXPLICIT_CLASSIFICATION
       ));
 
       expect(
         acs.getMatchingClassificationResult(
-          explorationId, stateName, state, 6, false, rules)
+          explorationId, stateName, state, 6, rules)
       ).toEqual(acrof.createNew(
         oof.createNew('outcome 2', [''], []), 1, 1, EXPLICIT_CLASSIFICATION
       ));
@@ -150,7 +149,7 @@ describe('Answer classification service with string classifier disabled',
     it('should return the default rule if no answer group matches', function() {
       expect(
         acs.getMatchingClassificationResult(
-          explorationId, stateName, state, 7, false, rules)
+          explorationId, stateName, state, 7, rules)
       ).toEqual(acrof.createNew(
         oof.createNew('default', [], []), 2, 0, DEFAULT_OUTCOME_CLASSIFICATION
       ));
@@ -191,7 +190,7 @@ describe('Answer classification service with string classifier disabled',
 
       expect(function() {
         acs.getMatchingClassificationResult(
-          explorationId, stateName, state, 0, false)
+          explorationId, stateName, state, 0)
       }).toThrow();
     });
   });
@@ -330,7 +329,7 @@ describe('Answer classification service with string classifier enabled',
       // in PredictionAlgorithmRegistryService.
       expect(
         acs.getMatchingClassificationResult(
-          explorationId, stateName, state, 0, false, rules)
+          explorationId, stateName, state, 0, rules)
       ).toEqual(
         acrof.createNew(
           state.interaction.answerGroups[1].outcome, 1, 2,
@@ -342,7 +341,7 @@ describe('Answer classification service with string classifier enabled',
        'interaction is not trainable', function() {
       expect(
         acs.getMatchingClassificationResult(
-          explorationId, stateName, state2, 0, false, rules)
+          explorationId, stateName, state2, 0, rules)
       ).toEqual(acrof.createNew(
         oof.createNew('default', [], []), 2, 0, DEFAULT_OUTCOME_CLASSIFICATION
       ));

--- a/core/templates/dev/head/pages/exploration_player/PlayerServices.js
+++ b/core/templates/dev/head/pages/exploration_player/PlayerServices.js
@@ -316,7 +316,7 @@ oppia.factory('ExplorationPlayerService', [
         var oldState = exploration.getState(oldStateName);
         var classificationResult = (
           AnswerClassificationService.getMatchingClassificationResult(
-            _explorationId, oldStateName, oldState, answer, false,
+            _explorationId, oldStateName, oldState, answer,
             interactionRulesService));
 
         if (!_editorPreviewMode) {

--- a/extensions/visualizations/visualizations.html
+++ b/extensions/visualizations/visualizations.html
@@ -8,7 +8,7 @@
     <tr>
       <th><[options.column_headers[0]]></th>
       <th><[options.column_headers[1]]></th>
-      <th ng-if="isAddressed !== null">Addressed?</th>
+      <th ng-if="isAddressed !== null">Addressed specifically?</th>
     </tr>
     <tr ng-repeat="row in data track by $index">
       <td><[row.answer]></td>
@@ -36,7 +36,7 @@
     <tr>
       <th><[options.column_headers[0]]></th>
       <th><[options.column_headers[1]]></th>
-      <th ng-if="isAddressed !== null">Addressed?</th>
+      <th ng-if="isAddressed !== null">Addressed specifically?</th>
     </tr>
     <tr ng-repeat="row in data track by $index">
       <td>


### PR DESCRIPTION
@pranavsid98 -- I'm taking "addressed" to mean "goes to another state or is non-default". I think we may need to adjust the "useful feedback" calculation in GenerateV1StatsJob as well as in the incremental updates for v2 to have a similar definition...