### PR TITLE
Fix the e2e error in the search page.

### DIFF
--- a/core/tests/protractor/libraryPagesTour.js
+++ b/core/tests/protractor/libraryPagesTour.js
@@ -45,7 +45,16 @@ describe('Library pages tour', function() {
 
   var visitRecentlyPublishedPage = function() {
     browser.get('library/recently_published');
-  }
+  };
+
+  it('visits the search page', function() {
+    visitLibraryPage();
+    element(by.css('.protractor-test-search-input')).sendKeys(SEARCH_TERM);
+    // It takes a while for the URL to change.
+    general.waitForSystem();
+    general.waitForSystem();
+    expect(browser.getCurrentUrl()).toContain('search/find?q=python');
+  });
 
   it('visits the library index page', function() {
     visitLibraryPage();
@@ -75,18 +84,6 @@ describe('Library pages tour', function() {
   it('visits the recent explorations page', function() {
     visitRecentlyPublishedPage();
     expect(browser.getCurrentUrl()).toContain('library/recently_published');
-  });
-
-  it('visits the search page', function() {
-    visitLibraryPage();
-    element(by.css('.protractor-test-search-input')).sendKeys(SEARCH_TERM);
-    browser.driver.wait(function() {
-      return browser.getCurrentUrl().then(function(url) {
-        return /search/.test(url);
-      });
-    }, 4000);
-    general.waitForSystem();
-    expect(browser.getCurrentUrl()).toContain('search/find?q=python');
   });
 
   afterEach(function() {


### PR DESCRIPTION
I managed to reproduce the e2e error locally (it still occurs even after #4192). The issue is that the URL gets checked before/while it is changing, so I think the extra pause should sort it out once and for all.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.