### PR TITLE
Fix #4086: flaky linter check on Travis.

### DIFF
--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -442,10 +442,8 @@ def _pre_commit_linter(all_files):
     print '\n'.join(js_messages)
     print '----------------------------------------'
     summary_messages = []
-    # Require block = False to prevent unnecessary waiting for the process
-    # output.
-    summary_messages.append(js_result.get(block=False))
-    summary_messages.append(py_result.get(block=False))
+    summary_messages.append(js_result.get())
+    summary_messages.append(py_result.get())
     print '\n'.join(summary_messages)
     print ''
     return summary_messages


### PR DESCRIPTION
Hi @kevinlee12 -- could you PTAL at this when you get a chance? Basically, I'm not sure why we're using `block=False`, and we're occasionally running into the Queue.Empty exception as described [here](https://docs.python.org/2/library/multiprocessing.html#multiprocessing.Queue.get). I saw the comment in the code but I don't understand why we would want to prevent waiting, and I looked at #1335 but I don't see any comments related to this. Could you PTAL and check that I'm not missing something here?

Thanks!

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
