### PR TITLE
Fix part of #4195: Modify the references to the continuous stats aggregator

### DIFF
--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -442,7 +442,7 @@ class ExpVersionReference(object):
     """Value object representing an exploration ID and a version number."""
 
     def __init__(self, exp_id, version):
-        """Initializes a ExpVersionReference domain object.
+        """Initializes an ExpVersionReference domain object.
 
         Args:
             exp_id: str. ID of the exploration.

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -438,6 +438,47 @@ class AudioTranslation(object):
                 self.needs_update)
 
 
+class ExpVersionReference(object):
+    """Value object representing an exploration ID and a version number."""
+
+    def __init__(self, exp_id, version):
+        """Initializes a ExpVersionReference domain object.
+
+        Args:
+            exp_id: str. ID of the exploration.
+            version: int. Version of the exploration.
+        """
+        self.exp_id = exp_id
+        self.version = version
+        self.validate()
+
+    def to_dict(self):
+        """Returns a dict representing this ExpVersionReference domain object.
+
+        Returns:
+            dict. A dict, mapping all fields of ExpVersionReference instance.
+        """
+        return {
+            'exp_id': self.exp_id,
+            'version': self.version
+        }
+
+    def validate(self):
+        """Validates properties of the ExpVersionReference.
+
+        Raises:
+            ValidationError: One or more attributes of the ExpVersionReference
+            are invalid.
+        """
+        if not isinstance(self.exp_id, str):
+            raise utils.ValidationError(
+                'Expected exp_id to be a str, received %s' % self.exp_id)
+
+        if not isinstance(self.version, int):
+            raise utils.ValidationError(
+                'Expected version to be an int, received %s' % self.version)
+
+
 class SubtitledHtml(object):
     """Value object representing subtitled HTML."""
 

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -142,20 +142,23 @@ class ExplorationStats(object):
             exp_version: int. Version of the exploration.
             state_stats_mapping: dict. A dict mapping state names to their
                 corresponding StateStats.
+
+        Returns:
+            ExplorationStats. The exploration stats domain object.
         """
         return cls(exp_id, exp_version, 0, 0, 0, 0, 0, 0, state_stats_mapping)
 
-    def compute_answer_count(self):
-        """Compute the answer count for the exploration stats."""
-        answer_count = 0
-        # For each state, find the number of first entries to the state.
-        # This is approximately considered to be equal to number of users
-        # who answered the state because very few users enter a state and
-        # leave without answering.
+    def get_sum_of_first_hit_counts(self):
+        """Compute the sum of first hit counts for the exploration stats.
+
+        Returns:
+            int. Sum of first hit counts.
+        """
+        sum_first_hits = 0
         for state_name in self.state_stats_mapping:
             state_stats = self.state_stats_mapping[state_name]
-            answer_count += state_stats.first_hit_count
-        return answer_count
+            sum_first_hits += state_stats.first_hit_count
+        return sum_first_hits
 
     def validate(self):
         """Validates the ExplorationStats domain object."""

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -81,6 +81,18 @@ class ExplorationStats(object):
         self.num_completions_v2 = num_completions_v2
         self.state_stats_mapping = state_stats_mapping
 
+    @property
+    def num_starts(self):
+        return self.num_starts_v1 + self.num_starts_v2
+
+    @property
+    def num_actual_starts(self):
+        return self.num_actual_starts_v1 + self.num_actual_starts_v2
+
+    @property
+    def num_completions(self):
+        return self.num_completions_v1 + self.num_completions_v2
+
     def to_dict(self):
         """Returns a dict representation of the domain object."""
         state_stats_mapping_dict = {}
@@ -113,11 +125,9 @@ class ExplorationStats(object):
         exploration_stats_dict = {
             'exp_id': self.exp_id,
             'exp_version': self.exp_version,
-            'num_starts': self.num_starts_v1 + self.num_starts_v2,
-            'num_actual_starts': (
-                self.num_actual_starts_v1 + self.num_actual_starts_v2),
-            'num_completions': (
-                self.num_completions_v1 + self.num_completions_v2),
+            'num_starts': self.num_starts,
+            'num_actual_starts': self.num_actual_starts,
+            'num_completions': self.num_completions,
             'state_stats_mapping': state_stats_mapping_dict
         }
         return exploration_stats_dict
@@ -221,6 +231,30 @@ class StateStats(object):
         self.num_completions_v1 = num_completions_v1
         self.num_completions_v2 = num_completions_v2
 
+    @property
+    def total_answers_count(self):
+        return self.total_answers_count_v1 + self.total_answers_count_v2
+
+    @property
+    def useful_feedback_count(self):
+        return self.useful_feedback_count_v1 + self.useful_feedback_count_v2
+
+    @property
+    def total_hit_count(self):
+        return self.total_hit_count_v1 + self.total_hit_count_v2
+
+    @property
+    def first_hit_count(self):
+        return self.first_hit_count_v1 + self.first_hit_count_v2
+
+    @property
+    def num_completions(self):
+        return self.num_completions_v1 + self.num_completions_v2
+
+    @property
+    def num_times_solution_viewed(self):
+        return self.num_times_solution_viewed_v2
+
     @classmethod
     def create_default(cls):
         """Creates a StateStats domain object and sets all properties to 0."""
@@ -249,16 +283,12 @@ class StateStats(object):
         frontend.
         """
         state_stats_dict = {
-            'total_answers_count': (
-                self.total_answers_count_v1 + self.total_answers_count_v2),
-            'useful_feedback_count': (
-                self.useful_feedback_count_v1 + self.useful_feedback_count_v2),
-            'total_hit_count': (
-                self.total_hit_count_v1 + self.total_hit_count_v2),
-            'first_hit_count': (
-                self.first_hit_count_v1 + self.first_hit_count_v2),
-            'num_times_solution_viewed': self.num_times_solution_viewed_v2,
-            'num_completions': self.num_completions_v1 + self.num_completions_v2
+            'total_answers_count': self.total_answers_count,
+            'useful_feedback_count': self.useful_feedback_count,
+            'total_hit_count': self.total_hit_count,
+            'first_hit_count': self.first_hit_count,
+            'num_times_solution_viewed': self.num_times_solution_viewed,
+            'num_completions': self.num_completions
         }
         return state_stats_dict
 

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -145,6 +145,18 @@ class ExplorationStats(object):
         """
         return cls(exp_id, exp_version, 0, 0, 0, 0, 0, 0, state_stats_mapping)
 
+    def compute_answer_count(self):
+        """Compute the answer count for the exploration stats."""
+        answer_count = 0
+        # For each state, find the number of first entries to the state.
+        # This is approximately considered to be equal to number of users
+        # who answered the state because very few users enter a state and
+        # leave without answering.
+        for state_name in self.state_stats_mapping:
+            state_stats = self.state_stats_mapping[state_name]
+            answer_count += state_stats.first_hit_count
+        return answer_count
+
     def validate(self):
         """Validates the ExplorationStats domain object."""
 

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -73,6 +73,40 @@ class ExplorationStatsTests(test_utils.GenericTestBase):
             expected_exploration_stats_dict,
             observed_exploration_stats.to_dict())
 
+    def test_get_sum_of_first_hit_counts(self):
+        """Test the get_sum_of_first_hit_counts method."""
+        state_stats_dict = {
+            'total_answers_count_v1': 0,
+            'total_answers_count_v2': 10,
+            'useful_feedback_count_v1': 0,
+            'useful_feedback_count_v2': 4,
+            'total_hit_count_v1': 0,
+            'total_hit_count_v2': 18,
+            'first_hit_count_v1': 0,
+            'first_hit_count_v2': 7,
+            'num_times_solution_viewed_v2': 2,
+            'num_completions_v1': 0,
+            'num_completions_v2': 2
+        }
+        exploration_stats_dict = {
+            'exp_id': 'exp_id1',
+            'exp_version': 1,
+            'num_starts_v1': 0,
+            'num_starts_v2': 30,
+            'num_actual_starts_v1': 0,
+            'num_actual_starts_v2': 10,
+            'num_completions_v1': 0,
+            'num_completions_v2': 5,
+            'state_stats_mapping': {
+                'Home': state_stats_dict,
+                'Home2': state_stats_dict
+            }
+        }
+        exploration_stats = self._get_exploration_stats_from_dict(
+            exploration_stats_dict)
+
+        self.assertEqual(exploration_stats.get_sum_of_first_hit_counts(), 14)
+
     def test_validate(self):
         state_stats_dict = {
             'total_answers_count_v1': 0,

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -295,6 +295,28 @@ def save_stats_model_transactional(exploration_stats):
         _save_stats_model, exploration_stats)
 
 
+def get_view_multi(exploration_ids, version_numbers):
+    """Retrieves the view counts for the given exploration IDs.
+
+        Args:
+            exploration_ids: list(str). The list of exploration IDs to get view
+                counts for.
+            version_numbers: list(int). List of version numbers of explorations.
+
+        Returns:
+            list(int). The number of times each exploration in exploration_ids
+                has been viewed.
+    """
+    exploration_stats_models = (
+        stats_models.ExplorationStatsModel.get_multi_stats_models(
+            exploration_ids, version_numbers))
+
+    return [
+        exploration_stats_models[i].num_starts_v1 if (
+            exploration_stats_models[i] is not None) else 0
+        for i in range(len(exploration_ids))]
+
+
 def get_visualizations_info(exp_id, state_name, interaction_id):
     """Returns a list of visualization info. Each item in the list is a dict
     with keys 'data' and 'options'.

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -295,26 +295,29 @@ def save_stats_model_transactional(exploration_stats):
         _save_stats_model, exploration_stats)
 
 
-def get_view_multi(exploration_ids, version_numbers):
-    """Retrieves the view counts for the given exploration IDs.
+def get_exploration_stats_multi(exp_version_references):
+    """Retrieves the exploration stats for the given explorations.
 
-        Args:
-            exploration_ids: list(str). The list of exploration IDs to get view
-                counts for.
-            version_numbers: list(int). List of version numbers of explorations.
+    Args:
+        exp_version_references: list(ExpVersionReference). List of exploration
+            version reference domain objects.
 
-        Returns:
-            list(int). The number of times each exploration in exploration_ids
-                has been viewed.
+    Returns:
+        list(ExplorationStats). The list of exploration stats domain objects.
     """
+    exp_version_reference_dicts = [
+        exp_version_reference.to_dict()
+        for exp_version_reference in exp_version_references]
+
     exploration_stats_models = (
         stats_models.ExplorationStatsModel.get_multi_stats_models(
-            exploration_ids, version_numbers))
+            exp_version_reference_dicts))
 
-    return [
-        exploration_stats_models[i].num_starts_v1 if (
-            exploration_stats_models[i] is not None) else 0
-        for i in range(len(exploration_ids))]
+    exploration_stats_list = [
+        get_exploration_stats_from_model(exploration_stats_model)
+        for exploration_stats_model in exploration_stats_models]
+
+    return exploration_stats_list
 
 
 def get_visualizations_info(exp_id, state_name, interaction_id):

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -305,13 +305,9 @@ def get_exploration_stats_multi(exp_version_references):
     Returns:
         list(ExplorationStats). The list of exploration stats domain objects.
     """
-    exp_version_reference_dicts = [
-        exp_version_reference.to_dict()
-        for exp_version_reference in exp_version_references]
-
     exploration_stats_models = (
         stats_models.ExplorationStatsModel.get_multi_stats_models(
-            exp_version_reference_dicts))
+            exp_version_references))
 
     exploration_stats_list = [
         get_exploration_stats_from_model(exploration_stats_model)

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -479,7 +479,9 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             exp_version_references)
         self.assertEqual(len(exp_stats_list), 2)
         self.assertEqual(exp_stats_list[0].exp_id, self.exp_id)
+        self.assertEqual(exp_stats_list[0].exp_version, self.exp_version)
         self.assertEqual(exp_stats_list[1].exp_id, 'exp_id2')
+        self.assertEqual(exp_stats_list[0].exp_version, 2)
 
 
 class ModifiedStatisticsAggregator(stats_jobs_continuous.StatisticsAggregator):

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -467,6 +467,16 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         self.assertEqual(exploration_stats.num_actual_starts_v2, 5)
         self.assertEqual(exploration_stats.num_completions_v2, 2)
 
+    def test_get_views_multi(self):
+        """Test the get_view_multi method."""
+        stats_models.ExplorationStatsModel.create(
+            'exp_id2', 2, 10, 0, 0, 0, 0, 0, {})
+        exp_ids = [self.exp_id, 'exp_id2']
+        version_numbers = [self.exp_version, 2]
+
+        views = stats_services.get_view_multi(exp_ids, version_numbers)
+        self.assertEqual(views, [0, 10])
+
 
 class ModifiedStatisticsAggregator(stats_jobs_continuous.StatisticsAggregator):
     """A modified StatisticsAggregator that does not start a new batch

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -467,15 +467,19 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         self.assertEqual(exploration_stats.num_actual_starts_v2, 5)
         self.assertEqual(exploration_stats.num_completions_v2, 2)
 
-    def test_get_views_multi(self):
-        """Test the get_view_multi method."""
+    def test_get_exploration_stats_multi(self):
+        """Test the get_exploration_stats_multi method."""
         stats_models.ExplorationStatsModel.create(
             'exp_id2', 2, 10, 0, 0, 0, 0, 0, {})
-        exp_ids = [self.exp_id, 'exp_id2']
-        version_numbers = [self.exp_version, 2]
+        exp_version_references = [
+            exp_domain.ExpVersionReference(self.exp_id, self.exp_version),
+            exp_domain.ExpVersionReference('exp_id2', 2)]
 
-        views = stats_services.get_view_multi(exp_ids, version_numbers)
-        self.assertEqual(views, [0, 10])
+        exp_stats_list = stats_services.get_exploration_stats_multi(
+            exp_version_references)
+        self.assertEqual(len(exp_stats_list), 2)
+        self.assertEqual(exp_stats_list[0].exp_id, self.exp_id)
+        self.assertEqual(exp_stats_list[1].exp_id, 'exp_id2')
 
 
 class ModifiedStatisticsAggregator(stats_jobs_continuous.StatisticsAggregator):

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -481,7 +481,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         self.assertEqual(exp_stats_list[0].exp_id, self.exp_id)
         self.assertEqual(exp_stats_list[0].exp_version, self.exp_version)
         self.assertEqual(exp_stats_list[1].exp_id, 'exp_id2')
-        self.assertEqual(exp_stats_list[0].exp_version, 2)
+        self.assertEqual(exp_stats_list[1].exp_version, 2)
 
 
 class ModifiedStatisticsAggregator(stats_jobs_continuous.StatisticsAggregator):

--- a/core/domain/summary_services.py
+++ b/core/domain/summary_services.py
@@ -23,7 +23,10 @@ from core.domain import exp_services
 from core.domain import rights_manager
 from core.domain import search_services
 from core.domain import stats_jobs_continuous
+from core.domain import stats_services
 from core.domain import user_services
+
+import feconf
 import utils
 
 _LIBRARY_INDEX_GROUPS = [{
@@ -372,9 +375,16 @@ def get_displayable_exp_summary_dicts(exploration_summaries):
         exploration_summary.id
         for exploration_summary in exploration_summaries]
 
-    view_counts = (
-        stats_jobs_continuous.StatisticsAggregator.get_views_multi(
-            exploration_ids))
+    if feconf.ENABLE_NEW_STATS_FRAMEWORK:
+        version_numbers = [
+            exploration_summary.version
+            for exploration_summary in exploration_summaries]
+        view_counts = stats_services.get_view_multi(
+            exploration_ids, version_numbers)
+    else:
+        view_counts = (
+            stats_jobs_continuous.StatisticsAggregator.get_views_multi(
+                exploration_ids))
     displayable_exp_summaries = []
 
     for ind, exploration_summary in enumerate(exploration_summaries):

--- a/core/domain/summary_services.py
+++ b/core/domain/summary_services.py
@@ -19,6 +19,7 @@
 from constants import constants
 from core.domain import activity_services
 from core.domain import collection_services
+from core.domain import exp_domain
 from core.domain import exp_services
 from core.domain import rights_manager
 from core.domain import search_services
@@ -376,11 +377,13 @@ def get_displayable_exp_summary_dicts(exploration_summaries):
         for exploration_summary in exploration_summaries]
 
     if feconf.ENABLE_NEW_STATS_FRAMEWORK:
-        version_numbers = [
-            exploration_summary.version
-            for exploration_summary in exploration_summaries]
-        view_counts = stats_services.get_view_multi(
-            exploration_ids, version_numbers)
+        exp_version_references = [
+            exp_domain.ExpVersionReference(exp_summary.id, exp_summary.version)
+            for exp_summary in exploration_summaries]
+        exp_stats_list = stats_services.get_exploration_stats_multi(
+            exp_version_references)
+        view_counts = [
+            exp_stats.num_starts for exp_stats in exp_stats_list]
     else:
         view_counts = (
             stats_jobs_continuous.StatisticsAggregator.get_views_multi(

--- a/core/domain/user_jobs_continuous.py
+++ b/core/domain/user_jobs_continuous.py
@@ -553,7 +553,11 @@ class UserStatsMRJobManager(
         if feconf.ENABLE_NEW_STATS_FRAMEWORK:
             exploration_stats = stats_services.get_exploration_stats(
                 item.id, item.version)
-            answer_count = exploration_stats.compute_answer_count()
+            # For each state, find the number of first entries to the state.
+            # This is approximately considered to be equal to number of users
+            # who answered the state because very few users enter a state and
+            # leave without answering.
+            answer_count = exploration_stats.get_sum_of_first_hit_counts()
             num_starts = exploration_stats.num_starts
         else:
             statistics = (

--- a/core/domain/user_jobs_continuous.py
+++ b/core/domain/user_jobs_continuous.py
@@ -554,9 +554,9 @@ class UserStatsMRJobManager(
             exploration_stats = stats_services.get_exploration_stats(
                 item.id, item.version)
             # For each state, find the number of first entries to the state.
-            # This is approximately considered to be equal to number of users
-            # who answered the state because very few users enter a state and
-            # leave without answering.
+            # This is considered to be approximately equal to the number of
+            # users who answered the state because very few users enter a state
+            # and leave without answering anything at all.
             answer_count = exploration_stats.get_sum_of_first_hit_counts()
             num_starts = exploration_stats.num_starts
         else:

--- a/core/domain/user_jobs_continuous.py
+++ b/core/domain/user_jobs_continuous.py
@@ -551,26 +551,18 @@ class UserStatsMRJobManager(
             calculate_exploration_impact_score = False
 
         if feconf.ENABLE_NEW_STATS_FRAMEWORK:
-            exploration_stats_dict = stats_services.get_exploration_stats(
+            exploration_stats = stats_services.get_exploration_stats(
                 item.id, item.version)
-            # The domain object is passed in always. In the tests, we pass the
-            # dict directly instead.
-            if not isinstance(exploration_stats_dict, dict):
-                exploration_stats_dict = exploration_stats_dict.to_dict()
             answer_count = 0
             # For each state, find the number of first entries to the state.
             # This is approximately considered to be equal to number of users
             # who answered the state because very few users enter a state and
             # leave without answering.
-            for state_name in exploration_stats_dict['state_stats_mapping']:
-                state_stats = exploration_stats_dict['state_stats_mapping'][
-                    state_name]
-                first_hit_count = (
-                    state_stats.get('first_hit_count_v1', 0) +
-                    state_stats.get('first_hit_count_v2', 0))
+            for state_name in exploration_stats.state_stats_mapping:
+                state_stats = exploration_stats.state_stats_mapping[state_name]
+                first_hit_count = state_stats.first_hit_count
                 answer_count += first_hit_count
-            num_starts = exploration_stats_dict.get('num_starts_v1', 0) + (
-                exploration_stats_dict.get('num_starts_v2', 0))
+            num_starts = exploration_stats.num_starts
         else:
             statistics = (
                 stats_jobs_continuous.StatisticsAggregator.get_statistics(
@@ -587,7 +579,7 @@ class UserStatsMRJobManager(
                 first_entry_count = state_stats.get('first_entry_count', 0)
                 no_answer_count = state_stats.get('no_answer_count', 0)
                 answer_count += first_entry_count - no_answer_count
-            num_starts = statistics.get('start_exploration_count')
+            num_starts = statistics['start_exploration_count']
 
         # Turn answer count into reach
         reach = answer_count**exponent

--- a/core/domain/user_jobs_continuous.py
+++ b/core/domain/user_jobs_continuous.py
@@ -553,15 +553,7 @@ class UserStatsMRJobManager(
         if feconf.ENABLE_NEW_STATS_FRAMEWORK:
             exploration_stats = stats_services.get_exploration_stats(
                 item.id, item.version)
-            answer_count = 0
-            # For each state, find the number of first entries to the state.
-            # This is approximately considered to be equal to number of users
-            # who answered the state because very few users enter a state and
-            # leave without answering.
-            for state_name in exploration_stats.state_stats_mapping:
-                state_stats = exploration_stats.state_stats_mapping[state_name]
-                first_hit_count = state_stats.first_hit_count
-                answer_count += first_hit_count
+            answer_count = exploration_stats.compute_answer_count()
             num_starts = exploration_stats.num_starts
         else:
             statistics = (

--- a/core/domain/user_jobs_continuous_test.py
+++ b/core/domain/user_jobs_continuous_test.py
@@ -27,7 +27,7 @@ from core.domain import exp_services
 from core.domain import feedback_services
 from core.domain import rating_services
 from core.domain import rights_manager
-from core.domain import stats_jobs_continuous
+from core.domain import stats_services
 from core.domain import user_jobs_continuous
 from core.domain import user_services
 from core.platform import models
@@ -607,41 +607,35 @@ class UserStatsAggregatorTest(test_utils.GenericTestBase):
     def _mock_get_statistics(self, exp_id, unused_version):
         current_completions = {
             self.EXP_ID_1: {
-                'complete_exploration_count': (
-                    self.num_completions[self.EXP_ID_1]),
-                'start_exploration_count': (
-                    self.num_starts[self.EXP_ID_1]),
-                'state_hit_counts': {
+                'num_starts_v1': 5,
+                'num_starts_v2': 2,
+                'state_stats_mapping': {
                     'state1': {
-                        'first_entry_count': 3,
-                        'no_answer_count': 1
+                        'first_hit_count_v1': 3,
+                        'first_hit_count_v2': 1
                     },
                     'state2': {
-                        'first_entry_count': 7,
-                        'no_answer_count': 1
+                        'first_hit_count_v1': 7,
+                        'first_hit_count_v2': 1
                     },
                 }
             },
             self.EXP_ID_2: {
-                'complete_exploration_count': (
-                    self.num_completions[self.EXP_ID_2]),
-                'start_exploration_count': (
-                    self.num_starts[self.EXP_ID_2]),
-                'state_hit_counts': {
+                'num_starts_v1': 5,
+                'num_starts_v2': 2,
+                'state_stats_mapping': {
                     'state1': {
-                        'first_entry_count': 3,
-                        'no_answer_count': 1
+                        'first_hit_count_v1': 3,
+                        'first_hit_count_v2': 1
                     },
                     'state2': {
-                        'first_entry_count': 7,
-                        'no_answer_count': 1
+                        'first_hit_count_v1': 7,
+                        'first_hit_count_v2': 1
                     },
                 }
             },
             self.EXP_ID_3: {
-                'start_exploration_count': (
-                    self.num_starts[self.EXP_ID_3]),
-                'state_hit_counts': {}
+                'state_stats_mapping': {}
             }
         }
         return current_completions[exp_id]
@@ -662,10 +656,12 @@ class UserStatsAggregatorTest(test_utils.GenericTestBase):
         """Runs the MapReduce job after running the continuous
         statistics aggregator for explorations to get the correct num
         completion events."""
-        with self.swap(stats_jobs_continuous.StatisticsAggregator,
-                       'get_statistics', self._mock_get_statistics):
-            ModifiedUserStatsAggregator.start_computation()
-            self.process_and_flush_pending_tasks()
+        with self.swap(feconf, 'ENABLE_NEW_STATS_FRAMEWORK', True):
+            with self.swap(
+                stats_services, 'get_exploration_stats',
+                self._mock_get_statistics):
+                ModifiedUserStatsAggregator.start_computation()
+                self.process_and_flush_pending_tasks()
 
     def _generate_user_ids(self, count):
         """Generate unique user ids to rate an exploration. Each user id needs
@@ -729,7 +725,7 @@ class UserStatsAggregatorTest(test_utils.GenericTestBase):
         self._rate_exploration(exploration.id, 5, avg_rating)
 
         # See state counts in _mock_get_statistics(), above.
-        expected_answer_count = 8
+        expected_answer_count = 15
         reach = expected_answer_count ** self.EXPONENT
         expected_user_impact_score = round(
             ((avg_rating - 2) * reach) ** self.EXPONENT)
@@ -748,7 +744,7 @@ class UserStatsAggregatorTest(test_utils.GenericTestBase):
         exp_services.update_exploration(self.user_b_id, self.EXP_ID_1, [], '')
 
         # See state counts in _mock_get_statistics(), above.
-        expected_answer_count = 8
+        expected_answer_count = 15
         reach = expected_answer_count ** self.EXPONENT
         contrib = 0.5
         expected_user_impact_score = round(
@@ -771,7 +767,7 @@ class UserStatsAggregatorTest(test_utils.GenericTestBase):
         self._rate_exploration(exploration_2.id, 2, avg_rating)
 
         # See state counts in _mock_get_statistics(), above.
-        expected_answer_count = 8
+        expected_answer_count = 15
         reach = expected_answer_count ** self.EXPONENT
         impact_per_exp = ((avg_rating - 2) * reach) # * 1 for contribution
         expected_user_impact_score = round(
@@ -975,7 +971,7 @@ class UserStatsAggregatorTest(test_utils.GenericTestBase):
         # Run the computation and check data from batch job.
         self._run_computation()
         user_stats_model = user_models.UserStatsModel.get(self.user_a_id)
-        self.assertEqual(user_stats_model.total_plays, 0)
+        self.assertEqual(user_stats_model.total_plays, 14)
         self.assertEqual(user_stats_model.num_ratings, 6)
         self.assertEqual(user_stats_model.average_ratings, 20/6.0)
 
@@ -990,6 +986,6 @@ class UserStatsAggregatorTest(test_utils.GenericTestBase):
         user_stats = (
             user_jobs_continuous.UserStatsAggregator.get_dashboard_stats(
                 self.user_a_id))
-        self.assertEquals(user_stats['total_plays'], 2)
+        self.assertEquals(user_stats['total_plays'], 16)
         self.assertEquals(user_stats['num_ratings'], 10)
         self.assertEquals(user_stats['average_ratings'], 32/10.0)

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -825,6 +825,25 @@ class ExplorationStatsModel(base_models.BaseModel):
         return exploration_stats_models
 
     @classmethod
+    def get_multi_stats_models(cls, exp_ids, version_numbers):
+        """Gets stats model instances for each exploration and the corresponding
+        version number.
+
+        Args:
+            exp_ids: list(str). IDs of the exploration.
+            version_numbers: list(int). List of version numbers.
+
+        Returns:
+            list(ExplorationStatsModel|None). Model instances representing the
+                given versions.
+        """
+        entity_ids = [cls.get_entity_id(
+            exp_id, version) for exp_id, version in zip(
+                exp_ids, version_numbers)]
+        exploration_stats_models = cls.get_multi(entity_ids)
+        return exploration_stats_models
+
+    @classmethod
     def save_multi(cls, exploration_stats_dicts):
         """Creates/Updates multiple ExplorationStatsModel entries.
 

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -825,23 +825,23 @@ class ExplorationStatsModel(base_models.BaseModel):
         return exploration_stats_models
 
     @classmethod
-    def get_multi_stats_models(cls, exp_version_reference_dicts):
+    def get_multi_stats_models(cls, exp_version_references):
         """Gets stats model instances for each exploration and the corresponding
         version number.
 
         Args:
-            exp_version_reference_dicts: list(dict). List of dicts where each
-                dict reprensents an exploration ID and a version number.
+            exp_version_references: list(ExpVersionReference). List of
+                ExpVersionReference domain objects.
 
         Returns:
             list(ExplorationStatsModel|None). Model instances representing the
-                given versions.
+                given versions or None if it does not exist.
         """
         entity_ids = [
             cls.get_entity_id(
-                exp_version_reference_dict['exp_id'],
-                exp_version_reference_dict['version'])
-            for exp_version_reference_dict in exp_version_reference_dicts]
+                exp_version_reference.exp_id,
+                exp_version_reference.version)
+            for exp_version_reference in exp_version_references]
         exploration_stats_models = cls.get_multi(entity_ids)
         return exploration_stats_models
 

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -825,21 +825,23 @@ class ExplorationStatsModel(base_models.BaseModel):
         return exploration_stats_models
 
     @classmethod
-    def get_multi_stats_models(cls, exp_ids, version_numbers):
+    def get_multi_stats_models(cls, exp_version_reference_dicts):
         """Gets stats model instances for each exploration and the corresponding
         version number.
 
         Args:
-            exp_ids: list(str). IDs of the exploration.
-            version_numbers: list(int). List of version numbers.
+            exp_version_reference_dicts: list(dict). List of dicts where each
+                dict reprensents an exploration ID and a version number.
 
         Returns:
             list(ExplorationStatsModel|None). Model instances representing the
                 given versions.
         """
-        entity_ids = [cls.get_entity_id(
-            exp_id, version) for exp_id, version in zip(
-                exp_ids, version_numbers)]
+        entity_ids = [
+            cls.get_entity_id(
+                exp_version_reference_dict['exp_id'],
+                exp_version_reference_dict['version'])
+            for exp_version_reference_dict in exp_version_reference_dicts]
         exploration_stats_models = cls.get_multi(entity_ids)
         return exploration_stats_models
 

--- a/core/storage/statistics/gae_models_test.py
+++ b/core/storage/statistics/gae_models_test.py
@@ -170,3 +170,37 @@ class ExplorationStatsModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(model.num_actual_starts_v2, 0)
         self.assertEqual(model.num_completions_v2, 0)
         self.assertEqual(model.state_stats_mapping, {})
+
+    def test_get_multi_stats_models(self):
+        stat_models.ExplorationStatsModel.create(
+            'exp_id1', 1, 0, 0, 0, 0, 0, 0, {})
+        stat_models.ExplorationStatsModel.create(
+            'exp_id1', 2, 0, 0, 0, 0, 0, 0, {})
+        stat_models.ExplorationStatsModel.create(
+            'exp_id2', 1, 0, 0, 0, 0, 0, 0, {})
+
+        exp_version_reference_dicts = [
+            {
+                'exp_id': 'exp_id1',
+                'version': 1
+            },
+            {
+                'exp_id': 'exp_id1',
+                'version': 2
+            },
+            {
+                'exp_id': 'exp_id2',
+                'version': 1
+            }
+        ]
+
+        stats_models = stat_models.ExplorationStatsModel.get_multi_stats_models(
+            exp_version_reference_dicts)
+
+        self.assertEqual(len(stats_models), 3)
+        self.assertEqual(stats_models[0].exp_id, 'exp_id1')
+        self.assertEqual(stats_models[0].exp_version, 1)
+        self.assertEqual(stats_models[1].exp_id, 'exp_id1')
+        self.assertEqual(stats_models[1].exp_version, 2)
+        self.assertEqual(stats_models[2].exp_id, 'exp_id2')
+        self.assertEqual(stats_models[2].exp_version, 1)

--- a/core/storage/statistics/gae_models_test.py
+++ b/core/storage/statistics/gae_models_test.py
@@ -16,6 +16,7 @@
 
 """Tests for Oppia statistics models."""
 
+from core.domain import exp_domain
 from core.platform import models
 from core.tests import test_utils
 import feconf
@@ -180,19 +181,9 @@ class ExplorationStatsModelUnitTests(test_utils.GenericTestBase):
             'exp_id2', 1, 0, 0, 0, 0, 0, 0, {})
 
         exp_version_reference_dicts = [
-            {
-                'exp_id': 'exp_id1',
-                'version': 1
-            },
-            {
-                'exp_id': 'exp_id1',
-                'version': 2
-            },
-            {
-                'exp_id': 'exp_id2',
-                'version': 1
-            }
-        ]
+            exp_domain.ExpVersionReference('exp_id1', 1),
+            exp_domain.ExpVersionReference('exp_id1', 2),
+            exp_domain.ExpVersionReference('exp_id2', 1)]
 
         stats_models = stat_models.ExplorationStatsModel.get_multi_stats_models(
             exp_version_reference_dicts)


### PR DESCRIPTION
#4195 

This PR changes the references to the statistics continuous aggregator in user_jobs_continuous and summary_services. Tests have been modified accordingly.

Thanks!