### PR TITLE
Fix a bunch of issues related to the maintenance.html page not loading Angular properly.

### DIFF
--- a/core/domain/acl_decorators.py
+++ b/core/domain/acl_decorators.py
@@ -28,8 +28,8 @@ current_user_services = models.Registry.import_current_user_services()
 def open_access(handler):
     """Decorator to give access to everyone."""
 
-    def test_can_access(self, **kwargs):
-        return handler(self, **kwargs)
+    def test_can_access(self, *args, **kwargs):
+        return handler(self, *args, **kwargs)
     test_can_access.__wrapped__ = True
 
     return test_can_access

--- a/core/templates/dev/head/pages/maintenance/maintenance.html
+++ b/core/templates/dev/head/pages/maintenance/maintenance.html
@@ -10,6 +10,7 @@
       var GLOBALS = {
         ADDITIONAL_ANGULAR_MODULES: [],
         ASSET_DIR_PREFIX: JSON.parse('{{ASSET_DIR_PREFIX|js_string}}'),
+        DEV_MODE: JSON.parse('{{DEV_MODE|js_string}}')
       };
     </script>
     {% include 'pages/header_js_libs.html' %}
@@ -62,5 +63,10 @@
     <script src="{{TEMPLATE_DIR_PREFIX}}/components/forms/ObjectEditorDirective.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/domain/utilities/UrlInterpolationService.js"></script>
     <script src="{{TEMPLATE_DIR_PREFIX}}/pages/maintenance/Maintenance.js"></script>
+
+    <!-- These three files need to be loaded here only because they are dependencies for $provide, and Angular will not load without them. -->
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/contextual/DeviceInfoService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/stateful/FocusManagerService.js"></script>
+    <script src="{{TEMPLATE_DIR_PREFIX}}/services/TranslationFileHashLoaderService.js"></script>
   </body>
 </html>


### PR DESCRIPTION
During the 2.5.7 release we encountered a bunch of independent errors causing the maintenance page not to load properly. This PR fixes them.

- The open_access() handler was missing an argument and throwing errors. This is because the maintenance page corresponds to the catch-all regex in main.py, and that regex passes along an argument to the handler representing the page URL slug.
- The lack of a DEV_MODE specification in maintenance.html caused hashes to be queried for when none existed. This bug was introduced in commit 41291a01a116ab3c06d92bcbeec7b60fe73281ef.
- When a $provider is missing a dependency in an Angular config(), no error appears, and Angular just fails to load. Because some services were moved out of app.js to individual files, some dependencies were missing in the maintenance page, and this caused Angular to fail silently on that page. The relevant commits are:
  - a481e7ab0bf5ed1a4cb3c20a53cf70fd1cf649a1 -- FocusManagerService
  - d9e1592df52159123848cdaac93daac18d6d4462 -- DeviceInfoService (used by FocusManagerService)
  - f8676acc977a59d875e0547214770430f5638c6d -- TranslationFileHashLoaderService.js (used by TranslationFileHashLoaderService)