### PR TITLE
Run only the production e2e tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,20 +22,13 @@ branches:
 
 env:
   matrix:
-    - RUN_E2E_TESTS_MAIN_EDITOR=true
-    - RUN_E2E_TESTS_EDITOR_FEATURES=true
-    - RUN_E2E_TESTS_EXTENSIONS=true
-    - RUN_E2E_TESTS_LIBRARY=true
-    - RUN_E2E_TESTS_MISC=true
-    - RUN_E2E_TESTS_USERS=true
-    - RUN_E2E_TESTS_EMBEDDING=true
+    - RUN_LINT=true
+    - RUN_FRONTEND_TESTS=true
     - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=false EXCLUDE_LOAD_TESTS=true
     # TODO(sll): Reinstate this when we can get it to run in reasonable time.
     # - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=true
     # TODO(sll): Reinstate this when the load tests are more reliable.
     # - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=true EXCLUDE_LOAD_TESTS=false
-    - RUN_LINT=true
-    - RUN_FRONTEND_TESTS=true
     - RUN_E2E_TESTS_MAIN_EDITOR_PROD=true
     - RUN_E2E_TESTS_EDITOR_FEATURES_PROD=true
     - RUN_E2E_TESTS_EXTENSIONS_PROD=true
@@ -86,21 +79,14 @@ install:
 - source scripts/setup_gae.sh || exit 1
 
 script:
-- if [ $RUN_E2E_TESTS_MAIN_EDITOR == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="mainEditor"; fi
-- if [ $RUN_E2E_TESTS_EDITOR_FEATURES == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="editorFeatures"; fi
-- if [ $RUN_E2E_TESTS_EXTENSIONS == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="extensions"; fi
-- if [ $RUN_E2E_TESTS_LIBRARY == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="library"; fi
-- if [ $RUN_E2E_TESTS_MISC == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="misc"; fi
-- if [ $RUN_E2E_TESTS_USERS == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="users"; fi
-- if [ $RUN_E2E_TESTS_EMBEDDING == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="embedding"; fi
-- if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'true' ] && [ $EXCLUDE_LOAD_TESTS == 'true' ]; then bash scripts/run_backend_tests.sh --generate_coverage_report --exclude_load_tests; fi
-- if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'false' ] && [ $EXCLUDE_LOAD_TESTS == 'true' ]; then bash scripts/run_backend_tests.sh --exclude_load_tests; fi
-- if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'true' ] && [ $EXCLUDE_LOAD_TESTS == 'false' ]; then bash scripts/run_backend_tests.sh --generate_coverage_report; fi
-- if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'false' ] && [ $EXCLUDE_LOAD_TESTS == 'false' ]; then bash scripts/run_backend_tests.sh; fi
 - if [ $RUN_LINT == 'true' ]; then bash scripts/install_third_party.sh; python scripts/pre_commit_linter.py --path=.; fi
 # Travis aborts test run if nothing is printed back to STDOUT for some time.
 # -x is used to avoid that.
 - if [ $RUN_FRONTEND_TESTS == 'true' ]; then travis_retry bash -x scripts/run_frontend_tests.sh --run-minified-tests=true; fi
+- if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'true' ] && [ $EXCLUDE_LOAD_TESTS == 'true' ]; then bash scripts/run_backend_tests.sh --generate_coverage_report --exclude_load_tests; fi
+- if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'false' ] && [ $EXCLUDE_LOAD_TESTS == 'true' ]; then bash scripts/run_backend_tests.sh --exclude_load_tests; fi
+- if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'true' ] && [ $EXCLUDE_LOAD_TESTS == 'false' ]; then bash scripts/run_backend_tests.sh --generate_coverage_report; fi
+- if [ $RUN_BACKEND_TESTS == 'true' ] && [ $REPORT_BACKEND_COVERAGE == 'false' ] && [ $EXCLUDE_LOAD_TESTS == 'false' ]; then bash scripts/run_backend_tests.sh; fi
 # Run e2e tests in production mode.
 - if [ $RUN_E2E_TESTS_MAIN_EDITOR_PROD == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="mainEditor" --prod_env; fi
 - if [ $RUN_E2E_TESTS_EDITOR_FEATURES_PROD == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="editorFeatures" --prod_env; fi


### PR DESCRIPTION
The aim of this PR is to run only the production e2e tests and not the dev ones, in order to shorten the amount of time needed for Travis to pass a PR. Since Oppia runs in production mode on the server anyway it's not entirely clear to me what the benefit of the dev tests is.

**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
