### PR TITLE
Fix #4143: Align buttons on splash page properly

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3750,6 +3750,7 @@ md-card.preview-conversation-skin-supplemental-card {
     padding-top: 80px;
   }
 }
+
 @media (max-width: 768px) {
   .oppia-splash-button-browse {
     left: 50%;
@@ -3775,6 +3776,16 @@ md-card.preview-conversation-skin-supplemental-card {
 
   .oppia-splash-section-two-content {
     padding-top: 160px;
+  }
+}
+
+@media (max-width: 365px) {
+  .oppia-splash-button-container {
+    margin-left: -1.5%;
+    text-align: center;
+  }
+  .oppia-splash-button {
+    min-width: 90%;
   }
 }
 

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3779,18 +3779,18 @@ md-card.preview-conversation-skin-supplemental-card {
   }
 }
 
-@media (max-width: 365px) {
-  .oppia-splash-button {
-    min-width: 95%;
-  }
-}
-
 @media (min-width: 575px) {
   .oppia-splash-button {
     left: -webkit-calc(130px + 15%);
     left: -moz-calc(130px + 15%);
     left: -o-calc(130px + 15%);
     left: calc(130px + 15%);
+  }
+}
+
+@media (max-width: 365px) {
+  .oppia-splash-button {
+    min-width: 95%;
   }
 }
 

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3780,12 +3780,17 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 
 @media (max-width: 365px) {
-  .oppia-splash-button-container {
-    margin-left: -1.5%;
-    text-align: center;
-  }
   .oppia-splash-button {
-    min-width: 90%;
+    min-width: 95%;
+  }
+}
+
+@media (min-width: 575px) {
+  .oppia-splash-button {
+    left: -webkit-calc(130px + 15%);
+    left: -moz-calc(130px + 15%);
+    left: -o-calc(130px + 15%);
+    left: calc(130px + 15%);
   }
 }
 

--- a/core/templates/dev/head/pages/splash/splash.html
+++ b/core/templates/dev/head/pages/splash/splash.html
@@ -126,19 +126,19 @@
                   ng-if="!userIsLoggedIn"
                   ng-click="onRedirectToLogin('/creator_dashboard?mode=create')"
                   class="btn oppia-splash-button oppia-splash-button-create oppia-transition-200"
-                  style="left: -webkit-calc(130px + 15%); left: -moz-calc(130px + 15%); left: -o-calc(130px + 15%); left: calc(130px + 15%); bottom: 210px; z-index: 10;"
+                  style="bottom: 210px; z-index: 10;"
                   translate="I18N_ACTION_CREATE_LESSON">
           </button>
           <button type="button"
                   ng-if="userIsLoggedIn"
                   ng-click="onClickCreateExplorationButton()"
                   class="btn oppia-splash-button oppia-splash-button-create oppia-transition-200"
-                  style="left: -webkit-calc(130px + 15%); left: -moz-calc(130px + 15%); left: -o-calc(130px + 15%); left: calc(130px + 15%); bottom: 210px; z-index: 10;"
+                  style="bottom: 210px; z-index: 10;"
                   translate="I18N_ACTION_CREATE_LESSON">
           </button>
           <button type="button" ng-click="onClickBrowseLibraryButton()"
                   class="btn oppia-splash-button oppia-splash-button-browse oppia-transition-200"
-                  style="left: -webkit-calc(130px + 15%); left: -moz-calc(130px + 15%); left: -o-calc(130px + 15%); left: calc(130px + 15%); bottom: 150px; z-index: 10;"
+                  style="bottom: 150px; z-index: 10;"
                   translate="I18N_ACTION_BROWSE_LESSONS">
           </button>
         </div>


### PR DESCRIPTION
Fix of #4143 : The buttons are now aligned at the centre on smaller mobile devices.
