### PR TITLE
Fix #4247: Fix feedback popover selector

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/FeedbackPopupDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/FeedbackPopupDirective.js
@@ -76,7 +76,8 @@ oppia.directive('feedbackPopup', [
             var popoverChildElt = null;
             for (var i = 0; i < 10; i++) {
               elt = elt.parent();
-              if (!angular.isUndefined(elt.attr('popover-template-popup'))) {
+              if (!angular.isUndefined(
+                    elt.attr('uib-popover-template-popup'))) {
                 popoverChildElt = elt;
                 break;
               }


### PR DESCRIPTION
Change the for the feedback popup which was not being caught (#4247)

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.  
