### PR TITLE
Fix #4223: corrected variable name of collection summary_dicts

### DIFF
--- a/core/domain/learner_progress_services.py
+++ b/core/domain/learner_progress_services.py
@@ -888,7 +888,7 @@ def get_collection_summary_dicts(collection_summaries):
             'category': collection_summary.category,
             'objective': collection_summary.objective,
             'language_code': collection_summary.language_code,
-            'last_updated': utils.get_time_in_millisecs(
+            'last_updated_msec': utils.get_time_in_millisecs(
                 collection_summary.collection_model_last_updated),
             'created_on': utils.get_time_in_millisecs(
                 collection_summary.collection_model_created_on),


### PR DESCRIPTION
corrected variable name 'last_updated' to 'last_updated_msec', was not assigned correctly when sending to client/front-end.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.  
