### PR TITLE
Fix #4260: Remove uib-collapse property from navbar

### DIFF
--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -182,7 +182,7 @@ oppia.directive('topNavigationBar', [
             // height of the navbar (56px) in Chrome's inspector and rounding
             // up. If the height of the navbar is changed in the future this
             // will need to be updated.
-            if (document.querySelector('div.uib-collapse.navbar-collapse')
+            if (document.querySelector('div.collapse.navbar-collapse')
               .clientHeight > 60) {
               for (var i = 0; i < NAV_ELEMENTS_ORDER.length; i++) {
                 if (

--- a/core/templates/dev/head/pages/base.html
+++ b/core/templates/dev/head/pages/base.html
@@ -142,7 +142,7 @@
                 <div class="navbar-container">
                   <top-navigation-bar></top-navigation-bar>
 
-                  <div uib-collapse class="uib-collapse navbar-collapse oppia-navbar-collapse ng-cloak">
+                  <div class="collapse navbar-collapse oppia-navbar-collapse ng-cloak">
                     {% block navbar_breadcrumb %}
                     {% endblock navbar_breadcrumb %}
 


### PR DESCRIPTION
Removed the `uib-collapse` property, this was formerly empty which resulted to the collapse attribute always being set to false. 

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.  
