### PR TITLE
Prevent 3-letter language codes from being used as the language code for an exploration, otherwise this breaks App Engine's search service.

### DIFF
--- a/core/domain/collection_domain.py
+++ b/core/domain/collection_domain.py
@@ -1193,6 +1193,13 @@ class Collection(object):
             raise utils.ValidationError(
                 'Invalid language code: %s' % self.language_code)
 
+        # TODO(sll): Remove this check once App Engine supports 3-letter
+        # language codes in search.
+        if len(self.language_code) != 2:
+            raise utils.ValidationError(
+                'Invalid language_code, it should have exactly 2 letters: %s' %
+                self.language_code)
+
         if not isinstance(self.tags, list):
             raise utils.ValidationError(
                 'Expected tags to be a list, received %s' % self.tags)

--- a/core/domain/collection_domain_test.py
+++ b/core/domain/collection_domain_test.py
@@ -99,6 +99,11 @@ class CollectionDomainUnitTests(test_utils.GenericTestBase):
         self.collection.language_code = 0
         self._assert_validation_error('Expected language code to be a string')
 
+        # TODO(sll): Remove the next two lines once the App Engine search
+        # service supports 3-letter language codes.
+        self.collection.language_code = 'kab'
+        self._assert_validation_error('it should have exactly 2 letters')
+
         self.collection.language_code = 'xz'
         self._assert_validation_error('Invalid language code')
 

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -1855,6 +1855,12 @@ class Exploration(object):
                     for lc in constants.ALL_LANGUAGE_CODES]):
             raise utils.ValidationError(
                 'Invalid language_code: %s' % self.language_code)
+        # TODO(sll): Remove this check once App Engine supports 3-letter
+        # language codes in search.
+        if len(self.language_code) != 2:
+            raise utils.ValidationError(
+                'Invalid language_code, it should have exactly 2 letters: %s' %
+                self.language_code)
 
         if not isinstance(self.tags, list):
             raise utils.ValidationError(

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -417,6 +417,10 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         self._assert_validation_error(exploration, 'Invalid language_code')
         exploration.language_code = 'English'
         self._assert_validation_error(exploration, 'Invalid language_code')
+        # TODO(sll): Remove the next two lines once the App Engine search
+        # service supports 3-letter language codes.
+        exploration.language_code = 'kab'
+        self._assert_validation_error(exploration, 'Invalid language_code')
         exploration.language_code = 'en'
         exploration.validate()
 

--- a/core/templates/dev/head/pages/collection_editor/settings_tab/CollectionDetailsEditorDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/settings_tab/CollectionDetailsEditorDirective.js
@@ -49,7 +49,14 @@ oppia.directive('collectionDetailsEditor', [
             }
           );
 
-          $scope.languageListForSelect = constants.ALL_LANGUAGE_CODES;
+          // TODO(sll): Remove the filter once the App Engine search API
+          // supports 3-letter language codes.
+          $scope.languageListForSelect = (
+            constants.ALL_LANGUAGE_CODES.filter(function(languageCodeDict) {
+              return languageCodeDict.code.length === 2;
+            })
+          );
+
           $scope.TAG_REGEX = GLOBALS.TAG_REGEX;
 
           var refreshSettingsTab = function() {

--- a/core/templates/dev/head/pages/exploration_editor/EditorServices.js
+++ b/core/templates/dev/head/pages/exploration_editor/EditorServices.js
@@ -421,7 +421,11 @@ oppia.factory('explorationLanguageCodeService', [
     var child = Object.create(explorationPropertyService);
     child.propertyName = 'language_code';
     child.getAllLanguageCodes = function() {
-      return constants.ALL_LANGUAGE_CODES;
+      // TODO(sll): Update this once the App Engine search service supports
+      // 3-letter language codes.
+      return constants.ALL_LANGUAGE_CODES.filter(function(languageCodeDict) {
+        return languageCodeDict.code.length === 2;
+      });
     };
     child.getCurrentLanguageDescription = function() {
       for (var i = 0; i < constants.ALL_LANGUAGE_CODES.length; i++) {
@@ -432,7 +436,9 @@ oppia.factory('explorationLanguageCodeService', [
     };
     child._isValid = function(value) {
       return constants.ALL_LANGUAGE_CODES.some(function(elt) {
-        return elt.code === value;
+        // TODO(sll): Remove the second clause once the App Engine search
+        // service supports 3-letter language codes.
+        return elt.code === value && elt.code.length === 2;
       });
     };
     return child;

--- a/core/templates/dev/head/pages/library/SearchBarDirective.js
+++ b/core/templates/dev/head/pages/library/SearchBarDirective.js
@@ -43,13 +43,18 @@ oppia.directive('searchBar', [
               }
             )
           );
-          $scope.ALL_LANGUAGE_CODES = GLOBALS.LANGUAGE_CODES_AND_NAMES.map(
+          // TODO(sll): Remove the filter once the App Engine Search API
+          // supports 3-letter language codes.
+          $scope.ALL_LANGUAGE_CODES = GLOBALS.LANGUAGE_CODES_AND_NAMES.filter(
             function(languageItem) {
-              return {
-                id: languageItem.code,
-                text: languageItem.name
-              };
-            });
+              return languageItem.code.length === 2;
+            }
+          ).map(function(languageItem) {
+            return {
+              id: languageItem.code,
+              text: languageItem.name
+            };
+          });
 
           $scope.searchQuery = '';
           $scope.selectionDetails = {


### PR DESCRIPTION
Hotfixing a crash due to GAE's search service not supporting languages with 3-letter ISO codes.

**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.