### PR TITLE
Fixes #4279

### DIFF
--- a/core/templates/dev/head/pages/library/SearchBarDirective.js
+++ b/core/templates/dev/head/pages/library/SearchBarDirective.js
@@ -134,6 +134,7 @@ oppia.directive('searchBar', [
           $scope.deselectAll = function(itemsType) {
             $scope.selectionDetails[itemsType].selections = {};
             updateSelectionDetails(itemsType);
+            onSearchQueryChangeExec();
           };
 
           $scope.$watch('searchQuery', function(newQuery, oldQuery) {


### PR DESCRIPTION
This PR changes the search query appropriately when languages/categories are deselected in the search area of the library.  
**Checklist**
- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [X] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [X] The PR is made from a branch that's **not** called "develop".
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
