### PR TITLE
Fix of #4253: Stopped weird flickering in the card

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3272,7 +3272,7 @@ div#ng-curtain {
 .ta-editor.form-control.oppia-rte-content, .ta-scroll-window.form-control.oppia-rte-content {
   min-height: 80px;
   height: auto;
-  overflow: auto;
+  overflow: hidden;
   font-family: inherit;
   font-size: 100%;
 }


### PR DESCRIPTION
Fix of #4253 : Stopped weird flickering in the card by changing the default overflow property.