### PR TITLE
Fix part of #4057 - Test frontend services in domain/classifier

### DIFF
--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -18,25 +18,22 @@
  
 describe('Answer Classification Object Factory', function() {
   var AnswerClassificationResultObjectFactory;
-  var EXPLICIT_CLASSIFICATION,oof;
   beforeEach(module('oppia'));
 
   beforeEach(inject(function($injector) {
     AnswerClassificationResultObjectFactory = $injector.get(
         'AnswerClassificationResultObjectFactory');
-    EXPLICIT_CLASSIFICATION = $injector.get(
-        'EXPLICIT_CLASSIFICATION');
   }));
 
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-         false, 1, 0, EXPLICIT_CLASSIFICATION));
+         false, 1, 0, 'EXPLICIT_CLASSIFICATION'));
 
     expect(answerClassificationResult.outcome).toEqual(false);
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(
-      EXPLICIT_CLASSIFICATION);
+      'EXPLICIT_CLASSIFICATION');
   });
 });

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -18,7 +18,7 @@
  
 describe('Answer classification result object factory', function() {
   var AnswerClassificationResultObjectFactory;
-  var DEFAULT_OUTCOME_CLASSIFICATION
+  var DEFAULT_OUTCOME_CLASSIFICATION;
   var oof;
   
   beforeEach(module('oppia'));

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -27,7 +27,7 @@ describe('Answer classification result object factory', function() {
     oof = $injector.get('OutcomeObjectFactory');
     DEFAULT_OUTCOME_CLASSIFICATION = $injector.get(
       'DEFAULT_OUTCOME_CLASSIFICATION');
-    }));
+  }));
 
   it('should create a new result', function() {
     var answerClassificationResult = (

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -18,7 +18,7 @@
  
 describe('Answer Classification Object Factory', function() {
   var AnswerClassificationResultObjectFactory;
-  var SampleOutcome = {
+  var sampleOutcome = {
     dest: 'default',
     feedback: {
       html: '',
@@ -38,9 +38,9 @@ describe('Answer Classification Object Factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-      SampleOutcome, 1, 0, DEFAULT_OUTCOME_CLASSIFICATION));
+      sampleOutcome, 1, 0, DEFAULT_OUTCOME_CLASSIFICATION));
 
-    expect(answerClassificationResult.outcome).toEqual(SampleOutcome);
+    expect(answerClassificationResult.outcome).toEqual(sampleOutcome);
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -30,9 +30,22 @@ describe('Answer Classification Object Factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-        {'outcome 1', {'', {}}, []}, 1, 0, EXPLICIT_CLASSIFICATION));
+        {
+            dest: 'default',
+            feedback: {
+              html: '',
+              audio_translations: {}
+            }, param_changes: []
+        }, []}, 1, 0, EXPLICIT_CLASSIFICATION));
 
-    expect(answerClassificationResult.outcome).toEqual({'outcome 1', {'', {}}, []});
+    expect(answerClassificationResult.outcome).toEqual({
+            dest: 'default',
+            feedback: {
+              html: '',
+              audio_translations: {}
+            },
+            param_changes: []
+          });
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -28,12 +28,12 @@ describe('Answer Classification Object Factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-        false, 1, 0, {}));
+        {}, 1, 0, 'default_outcome'));
 
-    expect(answerClassificationResult.outcome).toEqual(false);
+    expect(answerClassificationResult.outcome).toEqual({});
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(
-      {});
+      'default_outcome');
   });
 });

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -18,6 +18,14 @@
  
 describe('Answer Classification Object Factory', function() {
   var AnswerClassificationResultObjectFactory;
+  var SampleOutcome = {
+    dest: 'default',
+    feedback: {
+      html: '',
+      audio_translations: {}
+    }, param_changes: []
+  };
+  
   beforeEach(module('oppia'));
 
   beforeEach(inject(function($injector) {
@@ -30,21 +38,9 @@ describe('Answer Classification Object Factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-        {
-          dest: 'default',
-          feedback: {
-            html: '',
-            audio_translations: {}
-          }, param_changes: []
-        }, 1, 0, DEFAULT_OUTCOME_CLASSIFICATION));
+      SampleOutcome, 1, 0, DEFAULT_OUTCOME_CLASSIFICATION));
 
-    expect(answerClassificationResult.outcome).toEqual({
-      dest: 'default',
-      feedback: {
-        html: '',
-        audio_translations: {}
-      },param_changes: []
-    });
+    expect(answerClassificationResult.outcome).toEqual(SampleOutcome);
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -27,8 +27,7 @@ describe('Answer classification result object factory', function() {
     oof = $injector.get('OutcomeObjectFactory');
     DEFAULT_OUTCOME_CLASSIFICATION = $injector.get(
       'DEFAULT_OUTCOME_CLASSIFICATION');
-    
-  }));
+    }));
 
   it('should create a new result', function() {
     var answerClassificationResult = (

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -23,17 +23,19 @@ describe('Answer Classification Object Factory', function() {
   beforeEach(inject(function($injector) {
     AnswerClassificationResultObjectFactory = $injector.get(
       'AnswerClassificationResultObjectFactory');
+    EXPLICIT_CLASSIFICATION = $injector.get(
+      'EXPLICIT_CLASSIFICATION');
   }));
 
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-        {}, 1, 0, 'default_outcome'));
+        {}, 1, 0, EXPLICIT_CLASSIFICATION));
 
     expect(answerClassificationResult.outcome).toEqual({});
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(
-      'default_outcome');
+      EXPLICIT_CLASSIFICATION);
   });
 });

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -31,21 +31,20 @@ describe('Answer Classification Object Factory', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
         {
-            dest: 'default',
-            feedback: {
-              html: '',
-              audio_translations: {}
-            }, param_changes: []
+          dest: 'default',
+          feedback: {
+            html: '',
+            audio_translations: {}
+          }, param_changes: []
         }, 1, 0, EXPLICIT_CLASSIFICATION));
 
     expect(answerClassificationResult.outcome).toEqual({
-            dest: 'default',
-            feedback: {
-              html: '',
-              audio_translations: {}
-            },
-            param_changes: []
-          });
+      dest: 'default',
+      feedback: {
+        html: '',
+        audio_translations: {}
+        },param_changes: []
+      });
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -30,9 +30,9 @@ describe('Answer Classification Object Factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-        "defaultOutcome", 1, 0, EXPLICIT_CLASSIFICATION));
+        'defaultOutcome', 1, 0, EXPLICIT_CLASSIFICATION));
 
-    expect(answerClassificationResult.outcome).toEqual("defaultOutcome");
+    expect(answerClassificationResult.outcome).toEqual('defaultOutcome');
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -22,18 +22,18 @@ describe('Answer Classification Object Factory', function() {
 
   beforeEach(inject(function($injector) {
     AnswerClassificationResultObjectFactory = $injector.get(
-        'AnswerClassificationResultObjectFactory');
+      'AnswerClassificationResultObjectFactory');
   }));
 
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-         false, 1, 0, 'EXPLICIT_CLASSIFICATION'));
+        false, 1, 0, {}));
 
     expect(answerClassificationResult.outcome).toEqual(false);
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(
-      'EXPLICIT_CLASSIFICATION');
+    {});
   });
 });

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -18,13 +18,7 @@
  
 describe('Answer classification result object factory', function() {
   var AnswerClassificationResultObjectFactory;
-  var sampleOutcome = {
-    dest: 'default',
-    feedback: {
-      html: '',
-      audio_translations: {}
-    }, param_changes: []
-  };
+  var DEFAULT_OUTCOME_CLASSIFICATION,oof;
   
   beforeEach(module('oppia'));
 
@@ -33,14 +27,17 @@ describe('Answer classification result object factory', function() {
       'AnswerClassificationResultObjectFactory');
     DEFAULT_OUTCOME_CLASSIFICATION = $injector.get(
       'DEFAULT_OUTCOME_CLASSIFICATION');
+    oof = $injector.get('OutcomeObjectFactory');
   }));
 
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-      sampleOutcome, 1, 0, DEFAULT_OUTCOME_CLASSIFICATION));
+      oof.createNew('outcome 1', '', []), 1, 0, DEFAULT_OUTCOME_CLASSIFICATION));
 
-    expect(answerClassificationResult.outcome).toEqual(sampleOutcome);
+    expect(answerClassificationResult.outcome).toEqual(
+      oof.createNew('outcome 1', '', [])
+    );
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -43,8 +43,8 @@ describe('Answer Classification Object Factory', function() {
       feedback: {
         html: '',
         audio_translations: {}
-        },param_changes: []
-      });
+      },param_changes: []
+    });
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -23,8 +23,8 @@ describe('Answer Classification Object Factory', function() {
   beforeEach(inject(function($injector) {
     AnswerClassificationResultObjectFactory = $injector.get(
       'AnswerClassificationResultObjectFactory');
-    EXPLICIT_CLASSIFICATION = $injector.get(
-      'EXPLICIT_CLASSIFICATION');
+    DEFAULT_OUTCOME_CLASSIFICATION = $injector.get(
+      'DEFAULT_OUTCOME_CLASSIFICATION');
   }));
 
   it('should create a new result', function() {
@@ -36,7 +36,7 @@ describe('Answer Classification Object Factory', function() {
             html: '',
             audio_translations: {}
           }, param_changes: []
-        }, 1, 0, EXPLICIT_CLASSIFICATION));
+        }, 1, 0, DEFAULT_OUTCOME_CLASSIFICATION));
 
     expect(answerClassificationResult.outcome).toEqual({
       dest: 'default',
@@ -48,6 +48,6 @@ describe('Answer Classification Object Factory', function() {
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(
-      EXPLICIT_CLASSIFICATION);
+      DEFAULT_OUTCOME_CLASSIFICATION);
   });
 });

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -16,7 +16,7 @@
  * @fileoverview Unit tests for the AnswerClassificationResultObjectFactory.
  */
  
-describe('Answer Classification Object Factory', function() {
+describe('Answer classification result object factory', function() {
   var AnswerClassificationResultObjectFactory;
   var sampleOutcome = {
     dest: 'default',

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -30,15 +30,12 @@ describe('Answer classification result object factory', function() {
   }));
 
   it('should create a new result', function() {
-    var answerClassificationResult = (
-      acrof.createNew(
-        oof.createNew('default', '', []), 1, 0, DEFAULT_OUTCOME_CLASSIFICATION
-      )
+    var answerClassificationResult = acrof.createNew(
+      oof.createNew('default', '', []), 1, 0, DEFAULT_OUTCOME_CLASSIFICATION
     );
 
     expect(answerClassificationResult.outcome).toEqual(
-      oof.createNew('default', '', [])
-    );
+      oof.createNew('default', '', []));
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -18,7 +18,8 @@
  
 describe('Answer classification result object factory', function() {
   var AnswerClassificationResultObjectFactory;
-  var DEFAULT_OUTCOME_CLASSIFICATION,oof;
+  var DEFAULT_OUTCOME_CLASSIFICATION
+  var oof;
   
   beforeEach(module('oppia'));
 
@@ -33,12 +34,12 @@ describe('Answer classification result object factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-      oof.createNew('outcome 1', '', []), 1, 0, DEFAULT_OUTCOME_CLASSIFICATION
+      oof.createNew('default', '', []), 1, 0, DEFAULT_OUTCOME_CLASSIFICATION
       )
     );
 
     expect(answerClassificationResult.outcome).toEqual(
-      oof.createNew('outcome 1', '', [])
+      oof.createNew('default', '', [])
     );
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -30,9 +30,9 @@ describe('Answer Classification Object Factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-        'defaultOutcome', 1, 0, EXPLICIT_CLASSIFICATION));
+        ('outcome', '', []), 1, 0, EXPLICIT_CLASSIFICATION));
 
-    expect(answerClassificationResult.outcome).toEqual('defaultOutcome');
+    expect(answerClassificationResult.outcome).toEqual(('outcome', '', []));
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -17,24 +17,23 @@
  */
  
 describe('Answer classification result object factory', function() {
-  var AnswerClassificationResultObjectFactory;
+  var oof,acrof;
   var DEFAULT_OUTCOME_CLASSIFICATION;
-  var oof;
-  
+   
   beforeEach(module('oppia'));
 
   beforeEach(inject(function($injector) {
-    AnswerClassificationResultObjectFactory = $injector.get(
-      'AnswerClassificationResultObjectFactory');
+    acrof = $injector.get('AnswerClassificationResultObjectFactory');
+    oof = $injector.get('OutcomeObjectFactory');
     DEFAULT_OUTCOME_CLASSIFICATION = $injector.get(
       'DEFAULT_OUTCOME_CLASSIFICATION');
-    oof = $injector.get('OutcomeObjectFactory');
+    
   }));
 
   it('should create a new result', function() {
     var answerClassificationResult = (
-      AnswerClassificationResultObjectFactory.createNew(
-      oof.createNew('default', '', []), 1, 0, DEFAULT_OUTCOME_CLASSIFICATION
+      acrof.createNew(
+        oof.createNew('default', '', []), 1, 0, DEFAULT_OUTCOME_CLASSIFICATION
       )
     );
 

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -30,9 +30,9 @@ describe('Answer Classification Object Factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-        {}, 1, 0, EXPLICIT_CLASSIFICATION));
+        "defaultOutcome", 1, 0, EXPLICIT_CLASSIFICATION));
 
-    expect(answerClassificationResult.outcome).toEqual({});
+    expect(answerClassificationResult.outcome).toEqual("defaultOutcome");
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -36,7 +36,7 @@ describe('Answer Classification Object Factory', function() {
               html: '',
               audio_translations: {}
             }, param_changes: []
-        }, []}, 1, 0, EXPLICIT_CLASSIFICATION));
+        }, 1, 0, EXPLICIT_CLASSIFICATION));
 
     expect(answerClassificationResult.outcome).toEqual({
             dest: 'default',

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -30,7 +30,7 @@ describe('Answer Classification Object Factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-        ('outcome', '', []), 1, 0, EXPLICIT_CLASSIFICATION));
+        {'outcome 1', {'', {}}, []}, 1, 0, EXPLICIT_CLASSIFICATION));
 
     expect(answerClassificationResult.outcome).toEqual(('outcome', '', []));
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -30,7 +30,7 @@ describe('Answer Classification Object Factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-        {'outcome 1', {'', {}}, []}, 1, 0, EXPLICIT_CLASSIFICATION));
+        { 'outcome 1', { '', {} }, []}, 1, 0, EXPLICIT_CLASSIFICATION));
 
     expect(answerClassificationResult.outcome).toEqual(('outcome', '', []));
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -30,9 +30,9 @@ describe('Answer Classification Object Factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-        { 'outcome 1', { '', {} }, []}, 1, 0, EXPLICIT_CLASSIFICATION));
+        {'outcome 1', {'', {}}, []}, 1, 0, EXPLICIT_CLASSIFICATION));
 
-    expect(answerClassificationResult.outcome).toEqual(('outcome', '', []));
+    expect(answerClassificationResult.outcome).toEqual({'outcome 1', {'', {}}, []});
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -16,7 +16,7 @@
  * @fileoverview Unit tests for the AnswerClassificationResultObjectFactory.
  */
  
-describe('Answer classification result object factory', function() {
+describe('Answer Classification Object Factory', function() {
   var AnswerClassificationResultObjectFactory;
   var sampleOutcome = {
     dest: 'default',

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -33,7 +33,9 @@ describe('Answer classification result object factory', function() {
   it('should create a new result', function() {
     var answerClassificationResult = (
       AnswerClassificationResultObjectFactory.createNew(
-      oof.createNew('outcome 1', '', []), 1, 0, DEFAULT_OUTCOME_CLASSIFICATION));
+      oof.createNew('outcome 1', '', []), 1, 0, DEFAULT_OUTCOME_CLASSIFICATION
+      )
+    );
 
     expect(answerClassificationResult.outcome).toEqual(
       oof.createNew('outcome 1', '', [])

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -1,0 +1,42 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for the AnswerClassificationResultObjectFactory.
+ */
+ 
+describe('Answer Classification Object Factory', function() {
+  var AnswerClassificationResultObjectFactory;
+  var EXPLICIT_CLASSIFICATION,oof;
+  beforeEach(module('oppia'));
+
+  beforeEach(inject(function($injector) {
+    AnswerClassificationResultObjectFactory = $injector.get(
+        'AnswerClassificationResultObjectFactory');
+    EXPLICIT_CLASSIFICATION = $injector.get(
+        'EXPLICIT_CLASSIFICATION');
+  }));
+
+  it('should create a new result', function() {
+    var answerClassificationResult = (
+      AnswerClassificationResultObjectFactory.createNew(
+         false, 1, 0, EXPLICIT_CLASSIFICATION));
+
+    expect(answerClassificationResult.outcome).toEqual(false);
+    expect(answerClassificationResult.answerGroupIndex).toEqual(1);
+    expect(answerClassificationResult.ruleIndex).toEqual(0);
+    expect(answerClassificationResult.classificationCategorization).toEqual(
+      EXPLICIT_CLASSIFICATION);
+  });
+});

--- a/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/classifier/AnswerClassificationResultObjectFactorySpec.js
@@ -34,6 +34,6 @@ describe('Answer Classification Object Factory', function() {
     expect(answerClassificationResult.answerGroupIndex).toEqual(1);
     expect(answerClassificationResult.ruleIndex).toEqual(0);
     expect(answerClassificationResult.classificationCategorization).toEqual(
-    {});
+      {});
   });
 });


### PR DESCRIPTION
I wrote tests for the one file AnswerClassificationResultObjectFactorySpec.js present in domain/classifier.
The karma coverage for both the services after running front_end tests in my local machine are 100%.