### PR TITLE
Add refresher exploration redirection

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -587,29 +587,6 @@ oppia.factory('rteHelperService', [
 
 oppia.constant('LABEL_FOR_CLEARING_FOCUS', 'labelForClearingFocus');
 
-// Service for manipulating the page URL.
-oppia.factory('urlService', ['$window', function($window) {
-  return {
-    getUrlParams: function() {
-      var params = {};
-      var parts = $window.location.href.replace(
-        /[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
-          params[key] = value;
-        }
-      );
-      return params;
-    },
-    isIframed: function() {
-      var pathname = this.getPathname();
-      var urlParts = pathname.split('/');
-      return urlParts[1] === 'embed';
-    },
-    getPathname: function() {
-      return window.location.pathname;
-    }
-  };
-}]);
-
 // Service for sending events to Google Analytics.
 //
 // Note that events are only sent if the CAN_SEND_ANALYTICS_EVENTS flag is

--- a/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
+++ b/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
@@ -137,8 +137,8 @@ oppia.directive('explorationSummaryTile', [
               if ($scope.getParentExplorationIds()) {
                 var parentExplorationIds = $scope.getParentExplorationIds();
                 for (var i = 0; i < parentExplorationIds.length - 1; i++ ) {
-                  result = UrlService.addField(result, 'parent',
-                    parentExplorationIds[i]);
+                  result = UrlService.addField(
+                    result, 'parent', parentExplorationIds[i]);
                 }
                 return result;
               }

--- a/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
+++ b/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
@@ -45,7 +45,7 @@ oppia.directive('explorationSummaryTile', [
         // desktop version of the summary tile is always displayed.
         mobileCutoffPx: '@mobileCutoffPx',
         isPlaylistTile: '&isPlaylistTile',
-        parameters: '=',
+        parentExplorationIds: '&parentExplorationIds',
         showLearnerDashboardIconsIfPossible: (
           '&showLearnerDashboardIconsIfPossible')
       },
@@ -81,11 +81,11 @@ oppia.directive('explorationSummaryTile', [
       controller: [
         '$scope', '$http',
         'DateTimeFormatService', 'RatingComputationService',
-        'WindowDimensionsService',
+        'WindowDimensionsService', 'UrlService',
         function(
           $scope, $http,
           DateTimeFormatService, RatingComputationService,
-          WindowDimensionsService) {
+          WindowDimensionsService, UrlService) {
           $scope.userIsLoggedIn = GLOBALS.userIsLoggedIn;
           $scope.ACTIVITY_TYPE_EXPLORATION = (
             constants.ACTIVITY_TYPE_EXPLORATION);
@@ -133,14 +133,10 @@ oppia.directive('explorationSummaryTile', [
               if ($scope.getCollectionId()) {
                 result += ('?collection_id=' + $scope.getCollectionId());
               }
-              if ($scope.parameters) {
-                var parameterList = $scope.parameters.split('&');
-                parameterList.splice(-1,1);
-                for (var i = 0; i < parameterList.length; i++) {
-                  result += parameterList[i] + '&';
-                }
-                if (parameterList.length > 0) {
-                  result = result.slice(0,-1);
+              if ($scope.parentExplorationIds()) {
+                var parameterList = $scope.parentExplorationIds();
+                if (parameterList.length > 1) {
+                  result += UrlService.updateParameterList(parameterList);
                 }
               }
             }

--- a/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
+++ b/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
@@ -45,7 +45,7 @@ oppia.directive('explorationSummaryTile', [
         // desktop version of the summary tile is always displayed.
         mobileCutoffPx: '@mobileCutoffPx',
         isPlaylistTile: '&isPlaylistTile',
-        parentExplorationIds: '&parentExplorationIds',
+        getParentExplorationIds: '&parentExplorationIds',
         showLearnerDashboardIconsIfPossible: (
           '&showLearnerDashboardIconsIfPossible')
       },
@@ -131,13 +131,17 @@ oppia.directive('explorationSummaryTile', [
             } else {
               var result = '/explore/' + $scope.getExplorationId();
               if ($scope.getCollectionId()) {
-                result += ('?collection_id=' + $scope.getCollectionId());
+                result = UrlService.addParams(result, 'collection_id',
+                  $scope.getCollectionId())
               }
-              if ($scope.parentExplorationIds()) {
-                var parameterList = $scope.parentExplorationIds();
-                if (parameterList.length > 1) {
-                  result += UrlService.updateParameterList(parameterList);
+              if ($scope.getParentExplorationIds()) {
+                var parentExplorationIds = $scope.getParentExplorationIds();
+                var i = 0;
+                for (var i = 0; i < parentExplorationIds.length - 1; i++ ) {
+                  result = UrlService.addParams(result, 'parent',
+                    parentExplorationIds[i]);
                 }
+                return result;
               }
             }
             return result;

--- a/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
+++ b/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
@@ -45,6 +45,7 @@ oppia.directive('explorationSummaryTile', [
         // desktop version of the summary tile is always displayed.
         mobileCutoffPx: '@mobileCutoffPx',
         isPlaylistTile: '&isPlaylistTile',
+        parameters: '=',
         showLearnerDashboardIconsIfPossible: (
           '&showLearnerDashboardIconsIfPossible')
       },
@@ -131,6 +132,16 @@ oppia.directive('explorationSummaryTile', [
               var result = '/explore/' + $scope.getExplorationId();
               if ($scope.getCollectionId()) {
                 result += ('?collection_id=' + $scope.getCollectionId());
+              }
+              if ($scope.parameters) {
+                var parameterList = $scope.parameters.split('&');
+                parameterList.splice(-1,1);
+                for (var i = 0; i < parameterList.length; i++) {
+                  result += parameterList[i] + '&';
+                }
+                if (parameterList.length > 0) {
+                  result = result.slice(0,-1);
+                }
               }
             }
             return result;

--- a/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
+++ b/core/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js
@@ -131,14 +131,13 @@ oppia.directive('explorationSummaryTile', [
             } else {
               var result = '/explore/' + $scope.getExplorationId();
               if ($scope.getCollectionId()) {
-                result = UrlService.addParams(result, 'collection_id',
-                  $scope.getCollectionId())
+                result = UrlService.addField(
+                  result, 'collection_id', $scope.getCollectionId());
               }
               if ($scope.getParentExplorationIds()) {
                 var parentExplorationIds = $scope.getParentExplorationIds();
-                var i = 0;
                 for (var i = 0; i < parentExplorationIds.length - 1; i++ ) {
-                  result = UrlService.addParams(result, 'parent',
+                  result = UrlService.addField(result, 'parent',
                     parentExplorationIds[i]);
                 }
                 return result;

--- a/core/templates/dev/head/pages/collection_player/CollectionPlayer.js
+++ b/core/templates/dev/head/pages/collection_player/CollectionPlayer.js
@@ -236,7 +236,8 @@ oppia.controller('CollectionPlayer', [
 
     $http.get('/collectionsummarieshandler/data', {
       params: {
-        stringified_collection_ids: JSON.stringify([$scope.collectionId])
+        stringified_collection_ids: JSON.stringify(
+          [decodeURIComponent($scope.collectionId)])
       }
     }).then(
       function(response) {

--- a/core/templates/dev/head/pages/collection_player/CollectionPlayer.js
+++ b/core/templates/dev/head/pages/collection_player/CollectionPlayer.js
@@ -236,8 +236,7 @@ oppia.controller('CollectionPlayer', [
 
     $http.get('/collectionsummarieshandler/data', {
       params: {
-        stringified_collection_ids: JSON.stringify(
-          [decodeURIComponent($scope.collectionId)])
+        stringified_collection_ids: JSON.stringify([$scope.collectionId])
       }
     }).then(
       function(response) {

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationDataService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationDataService.js
@@ -20,14 +20,14 @@
 oppia.factory('ExplorationDataService', [
   '$http', '$log', '$window', '$q', 'AlertsService',
   'EditableExplorationBackendApiService', 'LocalStorageService',
-  'ReadOnlyExplorationBackendApiService', 'urlService',
+  'ReadOnlyExplorationBackendApiService', 'UrlService',
   function($http, $log, $window, $q, AlertsService,
     EditableExplorationBackendApiService, LocalStorageService,
-    ReadOnlyExplorationBackendApiService, urlService) {
+    ReadOnlyExplorationBackendApiService, UrlService) {
     // The pathname (without the hash) should be: .../create/{exploration_id}
     var explorationId = '';
     var draftChangeListId = null;
-    var pathnameArray = urlService.getPathname().split('/');
+    var pathnameArray = UrlService.getPathname().split('/');
     for (var i = 0; i < pathnameArray.length; i++) {
       if (pathnameArray[i] === 'create') {
         var explorationId = pathnameArray[i + 1];

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationDataServiceSpec.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationDataServiceSpec.js
@@ -39,7 +39,7 @@ describe('Exploration data service', function() {
       });
       module(function($provide) {
         $provide.value(
-          'urlService', mockUrlService);
+          'UrlService', mockUrlService);
       });
     });
 

--- a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
@@ -436,8 +436,8 @@ oppia.directive('conversationSkin', [
             }
 
             if (ExplorationPlayerStateService.isStateTerminal(stateName)) {
-              $scope.parentExplorationIds = UrlService.
-                getParentExplorationIds();
+              $scope.parentExplorationIds = UrlService.getParamValuesAsList(
+                'parent');
               if ($scope.parentExplorationIds) {
                 var parentExplorationId = $scope.parentExplorationIds[
                   $scope.parentExplorationIds.length - 1];

--- a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
@@ -438,18 +438,18 @@ oppia.directive('conversationSkin', [
             if (ExplorationPlayerStateService.isStateTerminal(stateName)) {
               $scope.parentExplorationIds =
                 UrlService.getQueryFieldValuesAsList('parent');
-              var recommendedExploration = [];
+              var recommendedExplorationIds = [];
               if ($scope.parentExplorationIds.length > 0) {
                 var parentExplorationId = $scope.parentExplorationIds[
                   $scope.parentExplorationIds.length - 1];
-                recommendedExploration.push(parentExplorationId);
+                recommendedExplorationIds.push(parentExplorationId);
               } else {
-                recommendedExploration =
+                recommendedExplorationIds =
                   ExplorationPlayerStateService.getAuthorRecommendedExpIds(
                     stateName);
               }
               ExplorationRecommendationsService.getRecommendedSummaryDicts(
-                recommendedExploration,
+                recommendedExplorationIds,
                 function(summaries) {
                   $scope.recommendedExplorationSummaries = summaries;
                 });

--- a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
@@ -436,13 +436,24 @@ oppia.directive('conversationSkin', [
             }
 
             if (ExplorationPlayerStateService.isStateTerminal(stateName)) {
-              ExplorationRecommendationsService.getRecommendedSummaryDicts(
-                ExplorationPlayerStateService.getAuthorRecommendedExpIds(
-                  stateName),
-                function(summaries) {
-                  $scope.recommendedExplorationSummaries = summaries;
-                });
-            }
+              var lastParameter = UrlService.getUrlParams();
+              if (lastParameter.parent) {
+                var parent = [];
+                parent.push(lastParameter.parent);
+                ExplorationRecommendationsService.getRecommendedSummaryDicts(
+                  parent,
+                  function(summaries) {
+                    $scope.recommendedExplorationSummaries = summaries;
+                  });
+              } else {
+                  ExplorationRecommendationsService.getRecommendedSummaryDicts(
+                    ExplorationPlayerStateService.getAuthorRecommendedExpIds(
+                      stateName),
+                    function(summaries) {
+                      $scope.recommendedExplorationSummaries = summaries;
+                    });
+                }
+              }
           };
 
           $scope.initializePage = function() {

--- a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
@@ -446,14 +446,14 @@ oppia.directive('conversationSkin', [
                     $scope.recommendedExplorationSummaries = summaries;
                   });
               } else {
-                  ExplorationRecommendationsService.getRecommendedSummaryDicts(
-                    ExplorationPlayerStateService.getAuthorRecommendedExpIds(
-                      stateName),
-                    function(summaries) {
-                      $scope.recommendedExplorationSummaries = summaries;
-                    });
-                }
+                ExplorationRecommendationsService.getRecommendedSummaryDicts(
+                  ExplorationPlayerStateService.getAuthorRecommendedExpIds(
+                    stateName),
+                  function(summaries) {
+                    $scope.recommendedExplorationSummaries = summaries;
+                  });
               }
+            }
           };
 
           $scope.initializePage = function() {

--- a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
@@ -436,16 +436,16 @@ oppia.directive('conversationSkin', [
             }
 
             if (ExplorationPlayerStateService.isStateTerminal(stateName)) {
-              var lastParameter = UrlService.getUrlParams();
-              if (lastParameter.parent) {
-                var parent = [];
-                parent.push(lastParameter.parent);
+              var parentExplorationId = UrlService.getParentExplorationId();
+              if (parentExplorationId) {
+                $scope.parameters = UrlService.getParameters();
                 ExplorationRecommendationsService.getRecommendedSummaryDicts(
-                  parent,
+                  [parentExplorationId],
                   function(summaries) {
                     $scope.recommendedExplorationSummaries = summaries;
                   });
               } else {
+                $scope.parameters = null;
                 ExplorationRecommendationsService.getRecommendedSummaryDicts(
                   ExplorationPlayerStateService.getAuthorRecommendedExpIds(
                     stateName),

--- a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
@@ -436,24 +436,23 @@ oppia.directive('conversationSkin', [
             }
 
             if (ExplorationPlayerStateService.isStateTerminal(stateName)) {
-              $scope.parentExplorationIds = UrlService.getParamValuesAsList(
-                'parent');
-              if ($scope.parentExplorationIds) {
+              $scope.parentExplorationIds =
+                UrlService.getQueryFieldValuesAsList('parent');
+              var recommendedExploration = [];
+              if ($scope.parentExplorationIds.length > 0) {
                 var parentExplorationId = $scope.parentExplorationIds[
                   $scope.parentExplorationIds.length - 1];
-                ExplorationRecommendationsService.getRecommendedSummaryDicts(
-                  [parentExplorationId],
-                  function(summaries) {
-                    $scope.recommendedExplorationSummaries = summaries;
-                  });
+                recommendedExploration.push(parentExplorationId);
               } else {
-                ExplorationRecommendationsService.getRecommendedSummaryDicts(
+                recommendedExploration =
                   ExplorationPlayerStateService.getAuthorRecommendedExpIds(
-                    stateName),
-                  function(summaries) {
-                    $scope.recommendedExplorationSummaries = summaries;
-                  });
+                    stateName);
               }
+              ExplorationRecommendationsService.getRecommendedSummaryDicts(
+                recommendedExploration,
+                function(summaries) {
+                  $scope.recommendedExplorationSummaries = summaries;
+                });
             }
           };
 

--- a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
@@ -436,16 +436,17 @@ oppia.directive('conversationSkin', [
             }
 
             if (ExplorationPlayerStateService.isStateTerminal(stateName)) {
-              var parentExplorationId = UrlService.getParentExplorationId();
-              if (parentExplorationId) {
-                $scope.parameters = UrlService.getParameters();
+              $scope.parentExplorationIds = UrlService.
+                getParentExplorationIds();
+              if ($scope.parentExplorationIds) {
+                var parentExplorationId = $scope.parentExplorationIds[
+                  $scope.parentExplorationIds.length - 1];
                 ExplorationRecommendationsService.getRecommendedSummaryDicts(
                   [parentExplorationId],
                   function(summaries) {
                     $scope.recommendedExplorationSummaries = summaries;
                   });
               } else {
-                $scope.parameters = null;
                 ExplorationRecommendationsService.getRecommendedSummaryDicts(
                   ExplorationPlayerStateService.getAuthorRecommendedExpIds(
                     stateName),

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -86,7 +86,7 @@
                                   collection-id="collectionId"
                                   exploration-id="exp.id"
                                   exploration-title="exp.title"
-                                  parameters="parameters"
+                                  parent-exploration-ids="parentExplorationIds"
                                   last-updated-msec="exp.last_updated_msec"
                                   objective="exp.objective"
                                   category="exp.category"

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -86,6 +86,7 @@
                                   collection-id="collectionId"
                                   exploration-id="exp.id"
                                   exploration-title="exp.title"
+                                  parameters="parameters"
                                   last-updated-msec="exp.last_updated_msec"
                                   objective="exp.objective"
                                   category="exp.category"

--- a/core/templates/dev/head/services/contextual/UrlService.js
+++ b/core/templates/dev/head/services/contextual/UrlService.js
@@ -28,6 +28,15 @@ oppia.factory('UrlService', ['$window', function($window) {
       );
       return params;
     },
+    getParentExplorationId: function() {
+      var params = {};
+      var parts = $window.location.href.replace(
+        /[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
+          params[key] = value;
+        }
+      );
+      return params.parent ? params.parent : null;
+    },
     isIframed: function() {
       var pathname = this.getPathname();
       var urlParts = pathname.split('/');
@@ -35,6 +44,9 @@ oppia.factory('UrlService', ['$window', function($window) {
     },
     getPathname: function() {
       return $window.location.pathname;
+    },
+    getParameters: function() {
+      return $window.location.search;
     },
     getHash: function() {
       return $window.location.hash;

--- a/core/templates/dev/head/services/contextual/UrlService.js
+++ b/core/templates/dev/head/services/contextual/UrlService.js
@@ -65,10 +65,10 @@ oppia.factory('UrlService', ['$window', function($window) {
       return fieldValues;
     },
     addField: function(url, fieldName, fieldValue) {
-      fieldValue = encodeURIComponent(fieldValue);
-      fieldName = encodeURIComponent(fieldName);
-      return url + (url.indexOf('?') != -1 ? '&' : '?') + fieldName + '=' +
-        fieldValue;
+      encodedFieldValue = encodeURIComponent(fieldValue);
+      encodedFieldName = encodeURIComponent(fieldName);
+      return url + (url.indexOf('?') != -1 ? '&' : '?') + encodedFieldName +
+        '=' + encodedFieldValue;
     },
     getHash: function() {
       return this.getCurrentLocation().hash;

--- a/core/templates/dev/head/services/contextual/UrlService.js
+++ b/core/templates/dev/head/services/contextual/UrlService.js
@@ -65,8 +65,8 @@ oppia.factory('UrlService', ['$window', function($window) {
       return fieldValues;
     },
     addField: function(url, fieldName, fieldValue) {
-      encodedFieldValue = encodeURIComponent(fieldValue);
-      encodedFieldName = encodeURIComponent(fieldName);
+      var encodedFieldValue = encodeURIComponent(fieldValue);
+      var encodedFieldName = encodeURIComponent(fieldName);
       return url + (url.indexOf('?') != -1 ? '&' : '?') + encodedFieldName +
         '=' + encodedFieldValue;
     },

--- a/core/templates/dev/head/services/contextual/UrlService.js
+++ b/core/templates/dev/head/services/contextual/UrlService.js
@@ -20,17 +20,20 @@
 oppia.factory('UrlService', ['$window', function($window) {
   return {
     // This function is for testing purposes (to mock $window.location)
-    queryUrlParams: function() {
+    getCurrentLocation: function() {
       return $window.location;
+    },
+    getCurrentHref: function() {
+      return this.getCurrentLocation().href;
     },
     /* As params[key] is overwritten, if query string has multiple fieldValues
        for same fieldName, use getQueryFieldValuesAsList(fieldName) to get it
        in array form. */
     getUrlParams: function() {
       var params = {};
-      var parts = this.queryUrlParams().href.replace(
+      var parts = this.getCurrentHref().replace(
         /[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
-          params[key] = value;
+          params[decodeURIComponent(key)] = decodeURIComponent(value);
         }
       );
       return params;
@@ -41,16 +44,19 @@ oppia.factory('UrlService', ['$window', function($window) {
       return urlParts[1] === 'embed';
     },
     getPathname: function() {
-      return this.queryUrlParams().pathname;
+      return this.getCurrentLocation().pathname;
     },
     getQueryFieldValuesAsList: function(fieldName) {
       var fieldValues = [];
-      if (this.queryUrlParams().href.indexOf('?') > -1) {
-        var url = this.queryUrlParams().href.slice(
-          this.queryUrlParams().href.indexOf('?') + 1).split('&');
-        for (var i = 0; i < url.length; i++) {
-          var currentFieldName = url[i].split('=')[0];
-          var currentFieldValue = url[i].split('=')[1];
+      if (this.getCurrentHref().indexOf('?') > -1) {
+        // Each queryItem return one field-value pair in the url.
+        var queryItems = this.getCurrentHref().slice(
+          this.getCurrentHref().indexOf('?') + 1).split('&');
+        for (var i = 0; i < queryItems.length; i++) {
+          var currentFieldName = decodeURIComponent(
+            queryItems[i].split('=')[0]);
+          var currentFieldValue = decodeURIComponent(
+            queryItems[i].split('=')[1]);
           if (currentFieldName === fieldName) {
             fieldValues.push(currentFieldValue);
           }
@@ -59,11 +65,13 @@ oppia.factory('UrlService', ['$window', function($window) {
       return fieldValues;
     },
     addField: function(url, fieldName, fieldValue) {
+      fieldValue = encodeURIComponent(fieldValue);
+      fieldName = encodeURIComponent(fieldName);
       return url + (url.indexOf('?') != -1 ? '&' : '?') + fieldName + '=' +
         fieldValue;
     },
     getHash: function() {
-      return this.queryUrlParams().hash;
+      return this.getCurrentLocation().hash;
     }
   };
 }]);

--- a/core/templates/dev/head/services/contextual/UrlService.js
+++ b/core/templates/dev/head/services/contextual/UrlService.js
@@ -17,62 +17,49 @@
  * functions on $window to be mocked in unit tests.
  */
 
-oppia.factory('UrlService', [
-  '$window', '$location',
-  function(
-      $window, $location) {
-    return {
-      // This function is for testing purposes (to mock $window.location)
-      getCurrentUrl: function() {
-        return $window.location;
-      },
-      getUrlParams: function() {
-        var params = {};
-        var parts = this.getCurrentUrl().href.replace(
-          /[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
-            params[key] = value;
-          }
-        );
-        return params;
-      },
-      isIframed: function() {
-        var pathname = this.getPathname();
-        var urlParts = pathname.split('/');
-        return urlParts[1] === 'embed';
-      },
-      getPathname: function() {
-        return this.getCurrentUrl().pathname;
-      },
-      getParentExplorationIds: function() {
-        if ($location.search().parent) {
-          if ($location.search().parent.constructor === Array) {
-            return $location.search().parent;
-          } else if ($location.search().parent) {
-          /* By default, single parent id gave a single string whereas, an array
-             with  a single element is what is required, hence the additional
-             condition */
-            return [$location.search().parent];
-          }
-        } else {
-          return null;
+oppia.factory('UrlService', ['$window', function($window) {
+  return {
+    // This function is for testing purposes (to mock $window.location)
+    getCurrentUrl: function() {
+      return $window.location;
+    },
+    getUrlParams: function() {
+      var params = {};
+      var parts = this.getCurrentUrl().href.replace(
+        /[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
+          params[key] = value;
         }
-      },
-      /* parameterList is an array of exploration ids from which 1 is popped out
-         and then, URL updated. */
-      updateParameterList: function(parameterList) {
-        var parameterString = '#?parent=';
-        for (var i = 0; i < parameterList.length - 1; i++) {
-          parameterString += parameterList[i] + '&';
+      );
+      return params;
+    },
+    isIframed: function() {
+      var pathname = this.getPathname();
+      var urlParts = pathname.split('/');
+      return urlParts[1] === 'embed';
+    },
+    getPathname: function() {
+      return this.getCurrentUrl().pathname;
+    },
+    getParamValuesAsList: function(queryTag) {
+      var url = this.getCurrentUrl().href.slice(
+        this.getCurrentUrl().href.indexOf('?') + 1).split('&');
+      var parentIdArray = [];
+      for (var i = 0; i < url.length; i++) {
+        var urlparam = url[i].split('=');
+        if (urlparam[0] === queryTag) {
+          parentIdArray.push(urlparam[1]);
         }
-        return parameterString.slice(0, -1);
-      },
-      /* Use UrlService.pushParentIdToUrl(id); at the state which
-         redirects to push current exploration id to url stack. */
-      pushParentIdToUrl: function(explorationId) {
-        $location.search({parent: explorationId});
-      },
-      getHash: function() {
-        return this.getCurrentUrl().hash;
       }
-    };
-  }]);
+      return parentIdArray.length > 0 ? parentIdArray : null;
+    },
+    /* Use UrlService.pushParentIdToUrl(url, explorationId); at the state which
+       redirects to push current exploration id to url stack. */
+    addParams: function(url, queryTag, queryValue) {
+      return url + (url.indexOf('?') != -1 ? '&' : '?') + queryTag + '=' +
+        queryValue;
+    },
+    getHash: function() {
+      return this.getCurrentUrl().hash;
+    }
+  };
+}]);

--- a/core/templates/dev/head/services/contextual/UrlService.js
+++ b/core/templates/dev/head/services/contextual/UrlService.js
@@ -19,9 +19,13 @@
 
 oppia.factory('UrlService', ['$window', function($window) {
   return {
+    // This function is for testing purposes (to mock $window.location)
+    getCurrentUrl: function() {
+      return $window.location;
+    },
     getUrlParams: function() {
       var params = {};
-      var parts = $window.location.href.replace(
+      var parts = this.getCurrentUrl().href.replace(
         /[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
           params[key] = value;
         }
@@ -30,7 +34,7 @@ oppia.factory('UrlService', ['$window', function($window) {
     },
     getParentExplorationId: function() {
       var params = {};
-      var parts = $window.location.href.replace(
+      var parts = this.getCurrentUrl().href.replace(
         /[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
           params[key] = value;
         }
@@ -43,13 +47,13 @@ oppia.factory('UrlService', ['$window', function($window) {
       return urlParts[1] === 'embed';
     },
     getPathname: function() {
-      return $window.location.pathname;
+      return this.getCurrentUrl().pathname;
     },
     getParameters: function() {
-      return $window.location.search;
+      return this.getCurrentUrl().search;
     },
     getHash: function() {
-      return $window.location.hash;
+      return this.getCurrentUrl().hash;
     }
   };
 }]);

--- a/core/templates/dev/head/services/contextual/UrlService.js
+++ b/core/templates/dev/head/services/contextual/UrlService.js
@@ -20,12 +20,15 @@
 oppia.factory('UrlService', ['$window', function($window) {
   return {
     // This function is for testing purposes (to mock $window.location)
-    getCurrentUrl: function() {
+    queryUrlParams: function() {
       return $window.location;
     },
+    /* As params[key] is overwritten, if query string has multiple fieldValues
+       for same fieldName, use getQueryFieldValuesAsList(fieldName) to get it
+       in array form. */
     getUrlParams: function() {
       var params = {};
-      var parts = this.getCurrentUrl().href.replace(
+      var parts = this.queryUrlParams().href.replace(
         /[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
           params[key] = value;
         }
@@ -38,28 +41,29 @@ oppia.factory('UrlService', ['$window', function($window) {
       return urlParts[1] === 'embed';
     },
     getPathname: function() {
-      return this.getCurrentUrl().pathname;
+      return this.queryUrlParams().pathname;
     },
-    getParamValuesAsList: function(queryTag) {
-      var url = this.getCurrentUrl().href.slice(
-        this.getCurrentUrl().href.indexOf('?') + 1).split('&');
-      var parentIdArray = [];
-      for (var i = 0; i < url.length; i++) {
-        var urlparam = url[i].split('=');
-        if (urlparam[0] === queryTag) {
-          parentIdArray.push(urlparam[1]);
+    getQueryFieldValuesAsList: function(fieldName) {
+      var fieldValues = [];
+      if (this.queryUrlParams().href.indexOf('?') > -1) {
+        var url = this.queryUrlParams().href.slice(
+          this.queryUrlParams().href.indexOf('?') + 1).split('&');
+        for (var i = 0; i < url.length; i++) {
+          var currentFieldName = url[i].split('=')[0];
+          var currentFieldValue = url[i].split('=')[1];
+          if (currentFieldName === fieldName) {
+            fieldValues.push(currentFieldValue);
+          }
         }
       }
-      return parentIdArray.length > 0 ? parentIdArray : null;
+      return fieldValues;
     },
-    /* Use UrlService.pushParentIdToUrl(url, explorationId); at the state which
-       redirects to push current exploration id to url stack. */
-    addParams: function(url, queryTag, queryValue) {
-      return url + (url.indexOf('?') != -1 ? '&' : '?') + queryTag + '=' +
-        queryValue;
+    addField: function(url, fieldName, fieldValue) {
+      return url + (url.indexOf('?') != -1 ? '&' : '?') + fieldName + '=' +
+        fieldValue;
     },
     getHash: function() {
-      return this.getCurrentUrl().hash;
+      return this.queryUrlParams().hash;
     }
   };
 }]);

--- a/core/templates/dev/head/services/contextual/UrlServiceSpec.js
+++ b/core/templates/dev/head/services/contextual/UrlServiceSpec.js
@@ -64,17 +64,17 @@ describe('Url Service', function() {
       var queryValue = '&value=1?';
       var queryField = 'field 1';
       var baseUrl = '/sample';
+      var encodedQueryField = encodeURIComponent(queryField);
+      var encodedQueryValue = encodeURIComponent(queryValue);
       expect(
         UrlService.addField(baseUrl, queryField, queryValue)).toBe(
-          baseUrl + '?' + encodeURIComponent(queryField) + '=' +
-          encodeURIComponent(queryValue)
+          baseUrl + '?' + encodedQueryField + '=' + encodedQueryValue
       );
 
       baseUrl = '/sample?field=value';
       expect(
         UrlService.addField(baseUrl, queryField, queryValue)).toBe(
-          baseUrl + '&' + encodeURIComponent(queryField) + '=' +
-          encodeURIComponent(queryValue)
+          baseUrl + '&' + encodedQueryField + '=' + encodedQueryValue
       );
     });
 

--- a/core/templates/dev/head/services/contextual/UrlServiceSpec.js
+++ b/core/templates/dev/head/services/contextual/UrlServiceSpec.js
@@ -1,0 +1,53 @@
+// Copyright 2016 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for the BackgroundMaskService.
+ */
+
+describe('Url Service', function() {
+  var UrlService = null;
+  var parameterList = '?parent=parent1&parent=parent2';
+  var location = {
+    href: 'http://sample.com' + parameterList,
+    search: parameterList
+  };
+
+  beforeEach(module('oppia'));
+  beforeEach(inject(function($injector) {
+    UrlService = $injector.get('UrlService');
+    spyOn(UrlService, 'getCurrentUrl').and.returnValue(location);
+  }));
+
+  it('should get correct parameters', function() {
+    expect(UrlService.getParameters()).toBe(parameterList);
+  });
+
+  it('should correctly get last parent id if parent id present', function() {
+    expect(UrlService.getParentExplorationId()).toBe('parent2');
+  });
+
+  it('should return null if parent id not present', function() {
+    location.href = 'http://sample.com';
+    expect(UrlService.getParentExplorationId()).toBe(null);
+  });
+
+  it('should correctly get last url parameter', function() {
+    var lastParameter = {
+      parent: 'parent2'
+    };
+    location.href = 'http://sample.com' + parameterList;
+    expect(UrlService.getUrlParams()).toEqual(lastParameter);
+  });
+});

--- a/core/templates/dev/head/services/contextual/UrlServiceSpec.js
+++ b/core/templates/dev/head/services/contextual/UrlServiceSpec.js
@@ -37,7 +37,7 @@ describe('Url Service', function() {
 
     mockLocation.href = 'http://' + pathname + '?field1=value1&' +
       'field2=value2&field1=value3&field1=value4&field2=value5&' +
-      'field1=value6&field1=' + encodeURIComponent('value?= &6');
+      'field1=value6&field1=value%3F%3D%20%266';
     var expectedList1 = ['value1', 'value3', 'value4', 'value6', 'value?= &6'];
     var expectedList2 = ['value2', 'value5'];
     expect(
@@ -52,10 +52,8 @@ describe('Url Service', function() {
         field1: '?value=1',
         field2: '?value&1'
       };
-      var queryValue1 = encodeURIComponent(expectedObject.field1);
-      var queryValue2 = encodeURIComponent(expectedObject.field2);
-      mockLocation.href = 'http://' + pathname + '?field1=' + queryValue1 +
-        '&field2=' + queryValue2;
+      mockLocation.href = 'http://' + pathname +
+        '?field1=%3Fvalue%3D1&field2=%3Fvalue%261';
       expect(UrlService.getUrlParams()).toEqual(expectedObject);
     });
 
@@ -64,15 +62,13 @@ describe('Url Service', function() {
       var queryValue = '&value=1?';
       var queryField = 'field 1';
       var baseUrl = '/sample';
-      var expectedUrl1 = baseUrl + '?' + encodeURIComponent(queryField) + '=' +
-        encodeURIComponent(queryValue);
+      var expectedUrl1 = baseUrl + '?field%201=%26value%3D1%3F';
       expect(
         UrlService.addField(baseUrl, queryField, queryValue)).toBe(
           expectedUrl1);
 
       baseUrl = '/sample?field=value';
-      var expectedUrl2 = baseUrl + '&' + encodeURIComponent(queryField) + '=' +
-        encodeURIComponent(queryValue);
+      var expectedUrl2 = baseUrl + '&field%201=%26value%3D1%3F';
       expect(
         UrlService.addField(baseUrl, queryField, queryValue)).toBe(
           expectedUrl2);

--- a/core/templates/dev/head/services/contextual/UrlServiceSpec.js
+++ b/core/templates/dev/head/services/contextual/UrlServiceSpec.js
@@ -30,17 +30,8 @@ describe('Url Service', function() {
   beforeEach(module('oppia'));
   beforeEach(inject(function($injector) {
     UrlService = $injector.get('UrlService');
-    spyOn(UrlService, 'queryUrlParams').and.returnValue(window);
+    spyOn(UrlService, 'getCurrentLocation').and.returnValue(window);
   }));
-
-  it('should correctly get query values as a single object', function() {
-    window.href = 'http://' + pathname + '?field1=value1&field2=value2';
-    var expectedObject = {
-      field1: 'value1',
-      field2: 'value2'
-    };
-    expect(UrlService.getUrlParams()).toEqual(expectedObject);
-  });
 
   it('should add query fields and return correct object after decoding it',
     function() {
@@ -67,22 +58,41 @@ describe('Url Service', function() {
         UrlService.getQueryFieldValuesAsList('field2')).toEqual(expectedList);
     });
 
-  it('should correctly get parameter list based on key value', function() {
-    var expectedList = ['parent1', 'parent2'];
-    window.href = 'http://' + pathname + queryString;
-    expect(
-      UrlService.getQueryFieldValuesAsList('parent')).toEqual(expectedList);
-    window.href = 'http://' + pathname;
-    expect(UrlService.getQueryFieldValuesAsList('parent')).toEqual([]);
-  });
+  it('should correctly encode and encode special characters in URI',
+    function() {
+      window.href = 'http://' + pathname;
+      var expectedObject = {
+        field1: '?value=1'
+      };
+      window.href = UrlService.addField(window.href, 'field1', '?value=1');
+      expect(UrlService.getUrlParams()).toEqual(expectedObject);
+      window.href = UrlService.addField(window.href, 'field2', '?value&1');
+      expectedObject = {
+        field1: '?value=1',
+        field2: '?value&1'
+      };
+      expect(UrlService.getUrlParams()).toEqual(expectedObject);
+      window.href = UrlService.addField(window.href, 'field2','=&?value 1');
+      var expectedList = ['?value&1','=&?value 1'];
+      expect(
+        UrlService.getQueryFieldValuesAsList('field2')).toEqual(expectedList);
+    });
+
+  it('should correctly get empty array when parameter list is empty',
+    function() {
+      window.href = 'http://' + pathname;
+      expect(UrlService.getQueryFieldValuesAsList('parent')).toEqual([]);
+    });
 
   it('should correctly add parameter values to url', function() {
-    expect(UrlService.addField('/sample', 'parent', 'parent1')).toBe(
-      '/sample?parent=parent1'
+    expect(
+      UrlService.addField('/sample', 'field1', 'value')).toBe(
+      '/sample?field1=value'
     );
-    expect(UrlService.addField(
-      '/sample?parent=parent1', 'parent', 'parent2')).toBe(
-      '/sample?parent=parent1&parent=parent2'
+    expect(
+      UrlService.addField(
+        '/sample?field1=value', 'field2', 'value')).toBe(
+          '/sample?field1=value&field2=value'
     );
   });
 

--- a/core/templates/dev/head/services/contextual/UrlServiceSpec.js
+++ b/core/templates/dev/head/services/contextual/UrlServiceSpec.js
@@ -64,18 +64,18 @@ describe('Url Service', function() {
       var queryValue = '&value=1?';
       var queryField = 'field 1';
       var baseUrl = '/sample';
-      var encodedQueryField = encodeURIComponent(queryField);
-      var encodedQueryValue = encodeURIComponent(queryValue);
+      var expectedUrl1 = baseUrl + '?' + encodeURIComponent(queryField) + '=' +
+        encodeURIComponent(queryValue);
       expect(
         UrlService.addField(baseUrl, queryField, queryValue)).toBe(
-          baseUrl + '?' + encodedQueryField + '=' + encodedQueryValue
-      );
+          expectedUrl1);
 
       baseUrl = '/sample?field=value';
+      var expectedUrl2 = baseUrl + '&' + encodeURIComponent(queryField) + '=' +
+        encodeURIComponent(queryValue);
       expect(
         UrlService.addField(baseUrl, queryField, queryValue)).toBe(
-          baseUrl + '&' + encodedQueryField + '=' + encodedQueryValue
-      );
+          expectedUrl2);
     });
 
   it('should correctly return true if embed present in pathname', function() {

--- a/core/templates/dev/head/services/contextual/UrlServiceSpec.js
+++ b/core/templates/dev/head/services/contextual/UrlServiceSpec.js
@@ -18,11 +18,10 @@
 
 describe('Url Service', function() {
   var UrlService = null;
-  var parameterList = '#?parent=parent1&parent=parent2';
-  var location = null;
+  var parameterList = '?parent=parent1&parent=parent2';
   var sampleHash = 'sampleHash';
   var window = {
-    href: 'http://sample.com/embed',
+    href: 'http://sample.com/embed' + parameterList,
     pathname: 'sample.com/embed',
     hash: sampleHash
   };
@@ -30,7 +29,6 @@ describe('Url Service', function() {
   beforeEach(module('oppia'));
   beforeEach(inject(function($injector) {
     UrlService = $injector.get('UrlService');
-    location = $injector.get('$location');
     spyOn(UrlService, 'getCurrentUrl').and.returnValue(window);
   }));
 
@@ -39,38 +37,21 @@ describe('Url Service', function() {
     expect(UrlService.getUrlParams()).toEqual({parent: 'parent2'});
   });
 
-  it('should correctly get parent id list when list has more than 1 elements',
-    function() {
-      var parentList = ['parent1', 'parent2'];
-      spyOn(location, 'search').and.returnValue({parent: parentList});
-      expect(UrlService.getParentExplorationIds()).toEqual(parentList);
-    });
+  it('should correctly parameter list based on key value', function() {
+    var expectedList = ['parent1', 'parent2'];
+    expect(UrlService.getParamValuesAsList('parent')).toEqual(expectedList);
+    window.href = 'http://sample.com/embed';
+    expect(UrlService.getParamValuesAsList('parent')).toBe(null);
+  });
 
-  it('should correctly get a single element array when a single string of ' +
-     'parent id is present',
-    function() {
-      spyOn(location, 'search').and.returnValue({parent: 'parent1'});
-      expect(UrlService.getParentExplorationIds()).toEqual(['parent1']);
-    });
-
-  it('should correctly return null when list has no elements',
-    function() {
-      spyOn(location, 'search').and.returnValue([]);
-      expect(UrlService.getParentExplorationIds()).toBe(null);
-    });
-
-  it('should pop last parent id and return correct parameter string',
-    function() {
-      var parameterList = ['parent1', 'parent2'];
-      var expectedString = '#?parent=parent1';
-      expect(UrlService.updateParameterList(parameterList)).toBe(
-        expectedString);
-    });
-
-  it('should correctly push a parent id to url stack', function() {
-    spyOn(location, 'search');
-    UrlService.pushParentIdToUrl('parent1');
-    expect(location.search).toHaveBeenCalledWith({parent: 'parent1'});
+  it('should correctly add parameter values to url', function() {
+    expect(UrlService.addParams('/sample', 'parent', 'parent1')).toBe(
+      '/sample?parent=parent1'
+    );
+    expect(UrlService.addParams(
+      '/sample?parent=parent1', 'parent', 'parent2')).toBe(
+      '/sample?parent=parent1&parent=parent2'
+    );
   });
 
   it('should correctly return true if embed present in pathname', function() {

--- a/core/templates/dev/head/services/contextual/UrlServiceSpec.js
+++ b/core/templates/dev/head/services/contextual/UrlServiceSpec.js
@@ -18,36 +18,71 @@
 
 describe('Url Service', function() {
   var UrlService = null;
-  var parameterList = '?parent=parent1&parent=parent2';
-  var location = {
-    href: 'http://sample.com' + parameterList,
-    search: parameterList
+  var parameterList = '#?parent=parent1&parent=parent2';
+  var location = null;
+  var sampleHash = 'sampleHash';
+  var window = {
+    href: 'http://sample.com/embed',
+    pathname: 'sample.com/embed',
+    hash: sampleHash
   };
 
   beforeEach(module('oppia'));
   beforeEach(inject(function($injector) {
     UrlService = $injector.get('UrlService');
-    spyOn(UrlService, 'getCurrentUrl').and.returnValue(location);
+    location = $injector.get('$location');
+    spyOn(UrlService, 'getCurrentUrl').and.returnValue(window);
   }));
 
-  it('should get correct parameters', function() {
-    expect(UrlService.getParameters()).toBe(parameterList);
-  });
-
-  it('should correctly get last parent id if parent id present', function() {
-    expect(UrlService.getParentExplorationId()).toBe('parent2');
-  });
-
-  it('should return null if parent id not present', function() {
-    location.href = 'http://sample.com';
-    expect(UrlService.getParentExplorationId()).toBe(null);
-  });
-
   it('should correctly get last url parameter', function() {
-    var lastParameter = {
-      parent: 'parent2'
-    };
-    location.href = 'http://sample.com' + parameterList;
-    expect(UrlService.getUrlParams()).toEqual(lastParameter);
+    window.href = 'http://sample.com' + parameterList;
+    expect(UrlService.getUrlParams()).toEqual({parent: 'parent2'});
+  });
+
+  it('should correctly get parent id list when list has more than 1 elements',
+    function() {
+      var parentList = ['parent1', 'parent2'];
+      spyOn(location, 'search').and.returnValue({parent: parentList});
+      expect(UrlService.getParentExplorationIds()).toEqual(parentList);
+    });
+
+  it('should correctly get a single element array when a single string of ' +
+     'parent id is present',
+    function() {
+      spyOn(location, 'search').and.returnValue({parent: 'parent1'});
+      expect(UrlService.getParentExplorationIds()).toEqual(['parent1']);
+    });
+
+  it('should correctly return null when list has no elements',
+    function() {
+      spyOn(location, 'search').and.returnValue([]);
+      expect(UrlService.getParentExplorationIds()).toBe(null);
+    });
+
+  it('should pop last parent id and return correct parameter string',
+    function() {
+      var parameterList = ['parent1', 'parent2'];
+      var expectedString = '#?parent=parent1';
+      expect(UrlService.updateParameterList(parameterList)).toBe(
+        expectedString);
+    });
+
+  it('should correctly push a parent id to url stack', function() {
+    spyOn(location, 'search');
+    UrlService.pushParentIdToUrl('parent1');
+    expect(location.search).toHaveBeenCalledWith({parent: 'parent1'});
+  });
+
+  it('should correctly return true if embed present in pathname', function() {
+    expect(UrlService.isIframed()).toBe(true);
+  });
+
+  it('should correctly return false if embed not in pathname', function() {
+    window.pathname = '/sample.com';
+    expect(UrlService.isIframed()).toBe(false);
+  });
+
+  it('should correctly return hash value of window.location', function() {
+    expect(UrlService.getHash()).toBe(sampleHash);
   });
 });

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -34,60 +34,58 @@ describe('Full exploration editor', function() {
 
   beforeAll(function() {
     explorationPlayerPage = new ExplorationPlayerPage.ExplorationPlayerPage();
-    users.createUser('user4@editorAndPlayer.com', 'user4EditorAndPlayer');
-    users.login('user4@editorAndPlayer.com');
-
-    workflow.createAndPublishExploration('Title 1', 'Algebra',
-      'It is a sample exploration.');
-    browser.getCurrentUrl().then(function(url) {
-      pathname = url.split('/');
-      /* In the url a # is added at the end that is not part of exploration
-         ID */
-      parentId1 = pathname[4].slice(0, -1);
-    });
-
-    workflow.createAndPublishExploration('Title 2', 'Algebra',
-      'It is a sample exploration.');
-    browser.getCurrentUrl().then(function(url) {
-      pathname = url.split('/');
-      parentId2 = pathname[4].slice(0, -1);
-    });
-
-    workflow.createAndPublishExploration('Title 3', 'Algebra',
-      'It is a sample exploration.');
-    browser.getCurrentUrl().then(function(url) {
-      pathname = url.split('/');
-      refresherExplorationId = pathname[4].slice(0, -1);
-    });
   });
 
   it('should redirect back to parent exploration correctly when parent id is ' +
       'given as query parameter', function() {
-    browser.get('/explore/' + refresherExplorationId + '?parent=' +
-      parentId1 + '&parent=' + parentId2);
-    browser.waitForAngular();
+    users.createUser('user1@editorAndPlayer.com', 'user1EditorAndPlayer');
+    users.login('user1@editorAndPlayer.com');
 
-    /* The summary tile for redirection has to be scrolled down in the
-       chrome window to be in view of the automated test,
-       hence the scrollTo. */
-    browser.executeScript('window.scrollTo(571,700);').then(function() {
-      element(by.css('.protractor-test-exp-summary-tile-title')).click();
-    });
-    browser.waitForAngular();
-    browser.getCurrentUrl().then(function(url) {
-      currentExplorationId = url.split('/')[4].split('?')[0];
-      expect(currentExplorationId).toBe(parentId2);
-    });
+    workflow.createAndPublishExploration(
+      'Parent Exploration 1',
+      'Algebra',
+      'This is the topmost parent exploration.');
+    general.getExplorationIdFromEditor().then(function(explorationId) {
+      parentId1 = explorationId;
 
-    browser.executeScript('window.scrollTo(571,700);').then(function() {
-      element(by.css('.protractor-test-exp-summary-tile-title')).click();
-    });
-    browser.waitForAngular();
-    browser.getCurrentUrl().then(function(url) {
-      currentExplorationId = url.split('/')[4];
-      expect(currentExplorationId).toBe(parentId1);
-    });
+      workflow.createAndPublishExploration(
+        'Parent Exploration 1',
+        'Algebra',
+        'This is the second parent exploration to which refresher ' +
+        'exploration redirects.');
+      general.getExplorationIdFromEditor().then(function(explorationId) {
+        parentId2 = explorationId;
 
+        workflow.createAndPublishExploration(
+          'Refresher Exploration',
+          'Algebra',
+          'This is the most basic refresher exploration');
+        general.getExplorationIdFromEditor().then(function(explorationId) {
+          refresherExplorationId = explorationId;
+
+          browser.get('/explore/' + refresherExplorationId + '?parent=' +
+            parentId1 + '&parent=' + parentId2);
+          browser.waitForAngular();
+
+          /* The summary tile for redirection has to be scrolled down in the
+             chrome window to be in view of the automated test,
+             hence the scrollTo. */
+          explorationPlayerPage.clickOnSummaryTileAtEnd();
+
+          browser.getCurrentUrl().then(function(url) {
+            currentExplorationId = url.split('/')[4].split('?')[0];
+            expect(currentExplorationId).toBe(parentId2);
+          });
+
+          explorationPlayerPage.clickOnSummaryTileAtEnd();
+
+          browser.getCurrentUrl().then(function(url) {
+            currentExplorationId = url.split('/')[4];
+            expect(currentExplorationId).toBe(parentId1);
+          });
+        });
+      });
+    });
     users.logout();
   });
 

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -62,34 +62,34 @@ describe('Full exploration editor', function() {
   });
 
   it('should redirect back to parent exploration correctly when parent id is ' +
-     'given as query parameter', function() {
-        browser.get('/explore/' + refresherExplorationId + '?parent=' +
-          parentId1 + '&parent=' + parentId2);
-        browser.waitForAngular();
+      'given as query parameter', function() {
+    browser.get('/explore/' + refresherExplorationId + '?parent=' +
+      parentId1 + '&parent=' + parentId2);
+    browser.waitForAngular();
 
-        /* The summary tile for redirection has to be scrolled down in the
-           chrome window to be in view of the automated test,
-           hence the scrollTo. */
-        browser.executeScript('window.scrollTo(571,700);').then(function() {
-          element(by.css('.protractor-test-exp-summary-tile-title')).click();
-        });
-        browser.waitForAngular();
-        browser.getCurrentUrl().then(function(url) {
-          currentExplorationId = url.split('/')[4].split('?')[0];
-          expect(currentExplorationId).toBe(parentId2);
-        });
+    /* The summary tile for redirection has to be scrolled down in the
+       chrome window to be in view of the automated test,
+       hence the scrollTo. */
+    browser.executeScript('window.scrollTo(571,700);').then(function() {
+      element(by.css('.protractor-test-exp-summary-tile-title')).click();
+    });
+    browser.waitForAngular();
+    browser.getCurrentUrl().then(function(url) {
+      currentExplorationId = url.split('/')[4].split('?')[0];
+      expect(currentExplorationId).toBe(parentId2);
+    });
 
-        browser.executeScript('window.scrollTo(571,700);').then(function() {
-          element(by.css('.protractor-test-exp-summary-tile-title')).click();
-        });
-        browser.waitForAngular();
-        browser.getCurrentUrl().then(function(url) {
-          currentExplorationId = url.split('/')[4];
-          expect(currentExplorationId).toBe(parentId1);
-        });
+    browser.executeScript('window.scrollTo(571,700);').then(function() {
+      element(by.css('.protractor-test-exp-summary-tile-title')).click();
+    });
+    browser.waitForAngular();
+    browser.getCurrentUrl().then(function(url) {
+      currentExplorationId = url.split('/')[4];
+      expect(currentExplorationId).toBe(parentId1);
+    });
 
-        users.logout();
-     });
+    users.logout();
+  });
 
   it('should navigate multiple states correctly, with parameters', function() {
     users.createUser('user4@editorAndPlayer.com', 'user4EditorAndPlayer');

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -49,7 +49,7 @@ describe('Full exploration editor', function() {
       parentId1 = explorationId;
 
       workflow.createAndPublishExploration(
-        'Parent Exploration 1',
+        'Parent Exploration 2',
         'Algebra',
         'This is the second parent exploration to which refresher ' +
         'exploration redirects.');
@@ -67,9 +67,6 @@ describe('Full exploration editor', function() {
             parentId1 + '&parent=' + parentId2);
           browser.waitForAngular();
 
-          /* The summary tile for redirection has to be scrolled down in the
-             chrome window to be in view of the automated test,
-             hence the scrollTo. */
           explorationPlayerPage.clickOnSummaryTileAtEnd();
 
           browser.getCurrentUrl().then(function(url) {

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -26,10 +26,70 @@ var ExplorationPlayerPage =
 
 describe('Full exploration editor', function() {
   var explorationPlayerPage = null;
+  var parentId2 = null;
+  var refresherExplorationId = null;
+  var currentExplorationId = null;
+  var pathname = null;
+  var parentId1 = null;
 
   beforeAll(function() {
     explorationPlayerPage = new ExplorationPlayerPage.ExplorationPlayerPage();
+    users.createUser('user4@editorAndPlayer.com', 'user4EditorAndPlayer');
+    users.login('user4@editorAndPlayer.com');
+
+    workflow.createAndPublishExploration('Title 1', 'Algebra',
+      'It is a sample exploration.');
+    browser.getCurrentUrl().then(function(url) {
+      pathname = url.split('/');
+      /* In the url a # is added at the end that is not part of exploration
+         ID */
+      parentId1 = pathname[4].slice(0, -1);
+    });
+
+    workflow.createAndPublishExploration('Title 2', 'Algebra',
+      'It is a sample exploration.');
+    browser.getCurrentUrl().then(function(url) {
+      pathname = url.split('/');
+      parentId2 = pathname[4].slice(0, -1);
+    });
+
+    workflow.createAndPublishExploration('Title 3', 'Algebra',
+      'It is a sample exploration.');
+    browser.getCurrentUrl().then(function(url) {
+      pathname = url.split('/');
+      refresherExplorationId = pathname[4].slice(0, -1);
+    });
   });
+
+  it('should redirect back to parent exploration correctly when parent id is ' +
+     'given as query parameter', function() {
+        browser.get('/explore/' + refresherExplorationId + '?parent=' +
+          parentId1 + '&parent=' + parentId2);
+        browser.waitForAngular();
+
+        /* The summary tile for redirection has to be scrolled down in the
+           chrome window to be in view of the automated test,
+           hence the scrollTo. */
+        browser.executeScript('window.scrollTo(571,700);').then(function() {
+          element(by.css('.protractor-test-exp-summary-tile-title')).click();
+        });
+        browser.waitForAngular();
+        browser.getCurrentUrl().then(function(url) {
+          currentExplorationId = url.split('/')[4].split('?')[0];
+          expect(currentExplorationId).toBe(parentId2);
+        });
+
+        browser.executeScript('window.scrollTo(571,700);').then(function() {
+          element(by.css('.protractor-test-exp-summary-tile-title')).click();
+        });
+        browser.waitForAngular();
+        browser.getCurrentUrl().then(function(url) {
+          currentExplorationId = url.split('/')[4];
+          expect(currentExplorationId).toBe(parentId1);
+        });
+
+        users.logout();
+     });
 
   it('should navigate multiple states correctly, with parameters', function() {
     users.createUser('user4@editorAndPlayer.com', 'user4EditorAndPlayer');

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -26,11 +26,6 @@ var ExplorationPlayerPage =
 
 describe('Full exploration editor', function() {
   var explorationPlayerPage = null;
-  var parentId2 = null;
-  var refresherExplorationId = null;
-  var currentExplorationId = null;
-  var pathname = null;
-  var parentId1 = null;
 
   beforeAll(function() {
     explorationPlayerPage = new ExplorationPlayerPage.ExplorationPlayerPage();
@@ -46,7 +41,7 @@ describe('Full exploration editor', function() {
       'Algebra',
       'This is the topmost parent exploration.');
     general.getExplorationIdFromEditor().then(function(explorationId) {
-      parentId1 = explorationId;
+      var parentId1 = explorationId;
 
       workflow.createAndPublishExploration(
         'Parent Exploration 2',
@@ -54,14 +49,14 @@ describe('Full exploration editor', function() {
         'This is the second parent exploration to which refresher ' +
         'exploration redirects.');
       general.getExplorationIdFromEditor().then(function(explorationId) {
-        parentId2 = explorationId;
+        var parentId2 = explorationId;
 
         workflow.createAndPublishExploration(
           'Refresher Exploration',
           'Algebra',
           'This is the most basic refresher exploration');
         general.getExplorationIdFromEditor().then(function(explorationId) {
-          refresherExplorationId = explorationId;
+          var refresherExplorationId = explorationId;
 
           browser.get('/explore/' + refresherExplorationId + '?parent=' +
             parentId1 + '&parent=' + parentId2);
@@ -70,7 +65,7 @@ describe('Full exploration editor', function() {
           explorationPlayerPage.clickOnSummaryTileAtEnd();
 
           browser.getCurrentUrl().then(function(url) {
-            currentExplorationId = url.split('/')[4].split('?')[0];
+            var currentExplorationId = url.split('/')[4].split('?')[0];
             expect(currentExplorationId).toBe(parentId2);
           });
 

--- a/core/tests/protractor_utils/ExplorationPlayerPage.js
+++ b/core/tests/protractor_utils/ExplorationPlayerPage.js
@@ -75,6 +75,9 @@ var ExplorationPlayerPage = function() {
   };
 
   this.clickOnSummaryTileAtEnd = function() {
+    /* The summary tile for redirection has to be scrolled down in the
+       chrome window to be in view of the automated test,
+       hence the scrollTo. */
     browser.executeScript('window.scrollTo(571,700);').then(function() {
       explorationSummaryTile.click();
     });

--- a/core/tests/protractor_utils/ExplorationPlayerPage.js
+++ b/core/tests/protractor_utils/ExplorationPlayerPage.js
@@ -50,6 +50,8 @@ var ExplorationPlayerPage = function() {
   var viewHintButton = element(by.css('.protractor-test-view-hint'));
   var viewSolutionButton = element(by.css('.protractor-test-view-solution'));
   var gotItButton = element(by.css('.oppia-learner-got-it-button'));
+  var explorationSummaryTile = element(
+    by.css('.protractor-test-exp-summary-tile-title'))
 
   var feedbackPopupLink =
     element(by.css('.protractor-test-exploration-feedback-popup-link'));
@@ -70,6 +72,13 @@ var ExplorationPlayerPage = function() {
 
   this.clickGotItButton = function() {
     gotItButton.click();
+  };
+
+  this.clickOnSummaryTileAtEnd = function() {
+    browser.executeScript('window.scrollTo(571,700);').then(function() {
+      explorationSummaryTile.click();
+    });
+    browser.waitForAngular();
   };
 
   // This verifies the question just asked, including formatting and


### PR DESCRIPTION
Currently, if we manually give parameters for parent exploration id, at the end of a refresher exploration, a summary tile for parent exploration is shown.

**Checklist**
- [x] Popping of parent url from stack after redirection.
- [x]  Add karma test for UrlService.
- [x]  Add e2e test for testing exploration redirection.