### PR TITLE
Add audio translations to feedback, hint, and solution in editor

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -71,6 +71,12 @@ oppia.constant('FATAL_ERROR_CODES', [400, 401, 404, 500]);
 
 oppia.constant('RTE_COMPONENT_SPECS', richTextComponents);
 
+// Do not modify these, for backwards-compatibility reasons.
+oppia.constant('COMPONENT_NAME_CONTENT', 'content');
+oppia.constant('COMPONENT_NAME_HINT', 'hint');
+oppia.constant('COMPONENT_NAME_SOLUTION', 'solution');
+oppia.constant('COMPONENT_NAME_FEEDBACK', 'feedback');
+
 // Add RTE extensions to textAngular toolbar options.
 oppia.config(['$provide', function($provide) {
   $provide.decorator('taOptions', [

--- a/core/templates/dev/head/components/HintEditorDirective.js
+++ b/core/templates/dev/head/components/HintEditorDirective.js
@@ -22,18 +22,22 @@ oppia.directive('hintEditor', [
       restrict: 'E',
       scope: {
         hint: '=',
-        getIndexPlusOne: '&index',
+        getIndexPlusOne: '&indexPlusOne',
         getOnSaveFn: '&onSave'
       },
       templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
         '/components/hint_editor_directive.html'),
       controller: [
         '$scope', 'editabilityService', 'stateHintsService',
-        function($scope, editabilityService, stateHintsService) {
+        'COMPONENT_NAME_HINT',
+        function($scope, editabilityService, stateHintsService,
+            COMPONENT_NAME_HINT) {
           $scope.isEditable = editabilityService.isEditable();
           $scope.stateHintsService = stateHintsService;
           $scope.editHintForm = {};
           $scope.hintEditorIsOpen = false;
+
+          $scope.COMPONENT_NAME_HINT = COMPONENT_NAME_HINT;
 
           $scope.HINT_FORM_SCHEMA = {
             type: 'html',

--- a/core/templates/dev/head/components/HintEditorDirective.js
+++ b/core/templates/dev/head/components/HintEditorDirective.js
@@ -22,15 +22,16 @@ oppia.directive('hintEditor', [
       restrict: 'E',
       scope: {
         hint: '=',
-        getIndex: '&index',
+        getIndexPlusOne: '&index',
         getOnSaveFn: '&onSave'
       },
       templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
         '/components/hint_editor_directive.html'),
       controller: [
-        '$scope', 'editabilityService', function($scope, editabilityService) {
+        '$scope', 'editabilityService', 'stateHintsService',
+        function($scope, editabilityService, stateHintsService) {
           $scope.isEditable = editabilityService.isEditable();
-
+          $scope.stateHintsService = stateHintsService;
           $scope.editHintForm = {};
           $scope.hintEditorIsOpen = false;
 
@@ -58,6 +59,18 @@ oppia.directive('hintEditor', [
             $scope.hint = angular.copy($scope.hintMemento);
             $scope.hintMemento = null;
             $scope.hintEditorIsOpen = false;
+          };
+
+          $scope.onAudioTranslationsStartEditAction = function() {
+            // Close the content editor and save all existing changes to the
+            // HTML.
+            if ($scope.hintEditorIsOpen) {
+              $scope.saveThisHint();
+            }
+          };
+
+          $scope.onAudioTranslationsEdited = function() {
+            stateHintsService.saveDisplayedValue();
           };
 
           $scope.$on('externalSave', function() {

--- a/core/templates/dev/head/components/OutcomeEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeEditorDirective.js
@@ -145,6 +145,19 @@ oppia.directive('outcomeEditor', [
             $scope.outcome.dest = angular.copy($scope.savedOutcome.dest);
             $scope.destinationEditorIsOpen = false;
           };
+
+
+          $scope.onAudioTranslationsStartEditAction = function() {
+            // Close the content editor and save all existing changes to the
+            // HTML.
+            if ($scope.feedbackEditorIsOpen) {
+              $scope.saveThisFeedback();
+            }
+          };
+
+          $scope.onAudioTranslationsEdited = function() {
+            $scope.saveThisFeedback();
+          };
         }
       ]
     };

--- a/core/templates/dev/head/components/OutcomeEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeEditorDirective.js
@@ -33,15 +33,17 @@ oppia.directive('outcomeEditor', [
         'outcome_editor_directive.html'),
       controller: [
         '$scope', 'EditorStateService',
-        'stateInteractionIdService',
+        'stateInteractionIdService', 'COMPONENT_NAME_FEEDBACK',
         function($scope, EditorStateService,
-          stateInteractionIdService) {
+          stateInteractionIdService, COMPONENT_NAME_FEEDBACK) {
           $scope.editOutcomeForm = {};
           $scope.feedbackEditorIsOpen = false;
           $scope.destinationEditorIsOpen = false;
           // TODO(sll): Investigate whether this line can be removed, due to
           // $scope.savedOutcome now being set in onExternalSave().
           $scope.savedOutcome = angular.copy($scope.outcome);
+
+          $scope.COMPONENT_NAME_FEEDBACK = COMPONENT_NAME_FEEDBACK;
 
           var onExternalSave = function() {
             // The reason for this guard is because, when the editor page for an

--- a/core/templates/dev/head/components/SolutionExplanationEditorDirective.js
+++ b/core/templates/dev/head/components/SolutionExplanationEditorDirective.js
@@ -53,6 +53,18 @@ oppia.directive('solutionExplanationEditor', [
             $scope.explanationEditorIsOpen = false;
           };
 
+          $scope.onAudioTranslationsStartEditAction = function() {
+            // Close the content editor and save all existing changes to the
+            // HTML.
+            if ($scope.explanationEditorIsOpen) {
+              $scope.saveThisExplanation();
+            }
+          };
+
+          $scope.onAudioTranslationsEdited = function() {
+            stateSolutionService.saveDisplayedValue();
+          };
+
           $scope.$on('externalSave', function() {
             if ($scope.explanationEditorIsOpen &&
               $scope.editSolutionForm.$valid) {

--- a/core/templates/dev/head/components/SolutionExplanationEditorDirective.js
+++ b/core/templates/dev/head/components/SolutionExplanationEditorDirective.js
@@ -26,12 +26,16 @@ oppia.directive('solutionExplanationEditor', [
         '/components/solution_explanation_editor_directive.html'),
       controller: [
         '$scope', 'editabilityService', 'stateSolutionService',
-        function($scope, editabilityService, stateSolutionService) {
+        'COMPONENT_NAME_SOLUTION',
+        function($scope, editabilityService, stateSolutionService,
+            COMPONENT_NAME_SOLUTION) {
           $scope.isEditable = editabilityService.isEditable();
 
           $scope.editSolutionForm = {};
-          $scope.stateSolutionService = stateSolutionService;
           $scope.explanationEditorIsOpen = false;
+
+          $scope.stateSolutionService = stateSolutionService;
+          $scope.COMPONENT_NAME_SOLUTION = COMPONENT_NAME_SOLUTION;
 
           $scope.EXPLANATION_FORM_SCHEMA = {
             type: 'html',

--- a/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
+++ b/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
@@ -143,6 +143,7 @@ oppia.directive('audioTranslationsEditor', [
                   };
 
                   var generateNewFilename = function() {
+                    console.log(componentName);
                     return componentName + '-' +
                       $scope.languageCode + '-' +
                       IdGenerationService.generateNewId() + '.mp3';

--- a/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
+++ b/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
@@ -21,6 +21,7 @@ oppia.directive('audioTranslationsEditor', [
     return {
       restrict: 'E',
       scope: {
+        componentName: '@',
         subtitledHtml: '=',
         // A function that must be called at the outset of every attempt to
         // edit, even if the action is not subsequently taken through to
@@ -41,8 +42,11 @@ oppia.directive('audioTranslationsEditor', [
             LanguageUtilService, AlertsService, ExplorationContextService,
             AssetsBackendApiService) {
           $scope.isEditable = editabilityService.isEditable;
-          $scope.audioTranslations = (
-            $scope.subtitledHtml.getBindableAudioTranslations());
+          if ($scope.subtitledHtml) {
+            $scope.audioTranslations = (
+              $scope.subtitledHtml.getBindableAudioTranslations());
+          }
+
           var explorationId = ExplorationContextService.getExplorationId();
 
           $scope.getAudioLanguageDescription = (
@@ -81,16 +85,21 @@ oppia.directive('audioTranslationsEditor', [
               resolve: {
                 allowedAudioLanguageCodes: function() {
                   return allowedAudioLanguageCodes;
+                },
+                componentName: function() {
+                  return $scope.componentName;
                 }
               },
               controller: [
                 '$scope', '$uibModalInstance', 'LanguageUtilService',
                 'allowedAudioLanguageCodes', 'AlertsService',
                 'ExplorationContextService', 'IdGenerationService',
+                'componentName',
                 function(
                     $scope, $uibModalInstance, LanguageUtilService,
                     allowedAudioLanguageCodes, AlertsService,
-                    ExplorationContextService, IdGenerationService) {
+                    ExplorationContextService, IdGenerationService,
+                    componentName) {
                   var ERROR_MESSAGE_BAD_FILE_UPLOAD = (
                     'There was an error uploading the audio file.');
                   var BUTTON_TEXT_SAVE = 'Save';
@@ -134,9 +143,10 @@ oppia.directive('audioTranslationsEditor', [
                   };
 
                   var generateNewFilename = function() {
-                    return (
-                      'content-' + $scope.languageCode + '-' +
-                      IdGenerationService.generateNewId() + '.mp3');
+                    var newFilename = componentName + '-' + $scope.languageCode + '-' +
+                      IdGenerationService.generateNewId() + '.mp3';
+                    console.log(newFilename);
+                    return newFilename;
                   };
 
                   $scope.save = function() {

--- a/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
+++ b/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
@@ -143,10 +143,9 @@ oppia.directive('audioTranslationsEditor', [
                   };
 
                   var generateNewFilename = function() {
-                    var newFilename = componentName + '-' + $scope.languageCode + '-' +
+                    return componentName + '-' +
+                      $scope.languageCode + '-' +
                       IdGenerationService.generateNewId() + '.mp3';
-                    console.log(newFilename);
-                    return newFilename;
                   };
 
                   $scope.save = function() {

--- a/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
+++ b/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
@@ -143,7 +143,6 @@ oppia.directive('audioTranslationsEditor', [
                   };
 
                   var generateNewFilename = function() {
-                    console.log(componentName);
                     return componentName + '-' +
                       $scope.languageCode + '-' +
                       IdGenerationService.generateNewId() + '.mp3';

--- a/core/templates/dev/head/components/forms/audio_translations_editor_directive.html
+++ b/core/templates/dev/head/components/forms/audio_translations_editor_directive.html
@@ -80,6 +80,7 @@
     color: #333;
     position: absolute;
     right: 24px;
+    z-index: 51;
   }
   audio-translations-editor .add-audio-translation-btn-container:hover,
   audio-translations-editor .add-audio-translation-btn-container:focus {

--- a/core/templates/dev/head/components/forms/audio_translations_editor_directive.html
+++ b/core/templates/dev/head/components/forms/audio_translations_editor_directive.html
@@ -1,6 +1,6 @@
 <div>
   <span ng-if="subtitledHtml.hasAudioTranslations()">
-    <hr>
+    <hr class="oppia-audio-translations-divider">
     <h4 class="oppia-audio-translations-header">Audio Translations</h4>
     <div ng-repeat="(languageCode, audioTranslation) in subtitledHtml.getBindableAudioTranslations()">
       <div class="row">
@@ -39,7 +39,20 @@
 </div>
 
 <style>
+  audio-translations-editor hr {
+    display: none;
+  }
+
+  state-content-editor audio-translations-editor .oppia-audio-translations-divider {
+    display: block;
+  }
+
   audio-translations-editor .oppia-audio-translations-header {
+    display: none;
+  }
+
+  state-content-editor audio-translations-editor .oppia-audio-translations-header {
+    display: block;
     font-size: 1em;
     font-weight: bold;
   }
@@ -76,12 +89,16 @@
   }
 
   audio-translations-editor .add-audio-translation-btn-container {
-    bottom: 6px;
     color: #333;
-    position: absolute;
-    right: 24px;
+    position: relative;
     z-index: 51;
   }
+
+  state-content-editor audio-translations-editor .add-audio-translation-btn-container {
+    float: right;
+    transform: translate(50px, 12px);
+  }
+
   audio-translations-editor .add-audio-translation-btn-container:hover,
   audio-translations-editor .add-audio-translation-btn-container:focus {
     color: #0844aa;

--- a/core/templates/dev/head/components/hint_editor_directive.html
+++ b/core/templates/dev/head/components/hint_editor_directive.html
@@ -13,7 +13,7 @@
           </i>
         </div>
 
-        <strong>Hint #<[getIndex()]> is...</strong>
+        <strong>Hint #<[getIndexPlusOne()]> is...</strong>
         <span class="oppia-rte-editor" angular-html-bind="hint.hintContent.getHtml()"></span>
       </div>
     </div>
@@ -25,7 +25,7 @@
           name="editHintForm"
           ng-submit="saveThisHint()">
       <div class="oppia-rule-details-header">
-        <strong>Hint #<[getIndex()]> is...</strong>
+        <strong>Hint #<[getIndexPlusOne()]> is...</strong>
         <!-- TODO(sll): Find a way to do this without resorting to private properties like _html -->
         <schema-based-editor schema="HINT_FORM_SCHEMA"
                              local-value="hint.hintContent._html">
@@ -50,5 +50,12 @@
 
       <div style="clear: both;"></div>
     </div>
+  </div>
+
+  <div ng-if="stateHintsService.savedMemento[getIndexPlusOne() - 1] && !stateHintsService.savedMemento[getIndexPlusOne() - 1].isEmpty()">
+    <audio-translations-editor subtitled-html="stateHintsService.displayed[getIndexPlusOne() - 1].hintContent"
+                               on-start-edit="onAudioTranslationsStartEditAction"
+                               on-change="onAudioTranslationsEdited">
+    </audio-translations-editor>
   </div>
 </div>

--- a/core/templates/dev/head/components/hint_editor_directive.html
+++ b/core/templates/dev/head/components/hint_editor_directive.html
@@ -53,7 +53,8 @@
   </div>
 
   <div ng-if="stateHintsService.savedMemento[getIndexPlusOne() - 1] && !stateHintsService.savedMemento[getIndexPlusOne() - 1].isEmpty()">
-    <audio-translations-editor subtitled-html="stateHintsService.displayed[getIndexPlusOne() - 1].hintContent"
+    <audio-translations-editor component-name="hint"
+                               subtitled-html="stateHintsService.displayed[getIndexPlusOne() - 1].hintContent"
                                on-start-edit="onAudioTranslationsStartEditAction"
                                on-change="onAudioTranslationsEdited">
     </audio-translations-editor>

--- a/core/templates/dev/head/components/hint_editor_directive.html
+++ b/core/templates/dev/head/components/hint_editor_directive.html
@@ -53,7 +53,7 @@
   </div>
 
   <div ng-if="stateHintsService.savedMemento[getIndexPlusOne() - 1] && !stateHintsService.savedMemento[getIndexPlusOne() - 1].isEmpty()">
-    <audio-translations-editor component-name="hint"
+    <audio-translations-editor component-name="<[COMPONENT_NAME_HINT]>"
                                subtitled-html="stateHintsService.displayed[getIndexPlusOne() - 1].hintContent"
                                on-start-edit="onAudioTranslationsStartEditAction"
                                on-change="onAudioTranslationsEdited">

--- a/core/templates/dev/head/components/outcome_editor_directive.html
+++ b/core/templates/dev/head/components/outcome_editor_directive.html
@@ -67,7 +67,7 @@
 </div>
 
 <div ng-if="!outcome.feedback.getHtml().isEmpty() && displayFeedback">
-  <audio-translations-editor component-name="feedback"
+  <audio-translations-editor component-name="<[COMPONENT_NAME_FEEDBACK]>"
                              subtitled-html="outcome.feedback"
                              on-start-edit="onAudioTranslationsStartEditAction"
                              on-change="onAudioTranslationsEdited">

--- a/core/templates/dev/head/components/outcome_editor_directive.html
+++ b/core/templates/dev/head/components/outcome_editor_directive.html
@@ -66,7 +66,7 @@
   </div>
 </div>
 
-<div ng-if="!outcome.feedback.getHtml().isEmpty()">
+<div ng-if="!outcome.feedback.getHtml().isEmpty() && displayFeedback">
   <audio-translations-editor component-name="feedback"
                              subtitled-html="outcome.feedback"
                              on-start-edit="onAudioTranslationsStartEditAction"

--- a/core/templates/dev/head/components/outcome_editor_directive.html
+++ b/core/templates/dev/head/components/outcome_editor_directive.html
@@ -66,6 +66,14 @@
   </div>
 </div>
 
+<div ng-if="!outcome.feedback.getHtml().isEmpty()">
+  <audio-translations-editor component-name="feedback"
+                             subtitled-html="outcome.feedback"
+                             on-start-edit="onAudioTranslationsStartEditAction"
+                             on-change="onAudioTranslationsEdited">
+  </audio-translations-editor>
+</div>
+
 <br ng-if="displayFeedback">
 
 <div ng-if="!destinationEditorIsOpen"

--- a/core/templates/dev/head/components/solution_explanation_editor_directive.html
+++ b/core/templates/dev/head/components/solution_explanation_editor_directive.html
@@ -44,4 +44,12 @@
       <div style="clear: both;"></div>
     </div>
   </div>
+
+  <div ng-if="stateSolutionService.savedMemento.explanation && !stateSolutionService.savedMemento.explanation.isEmpty()">
+    <audio-translations-editor component-name="solution"
+                               subtitled-html="stateSolutionService.displayed.explanation"
+                               on-start-edit="onAudioTranslationsStartEditAction"
+                               on-change="onAudioTranslationsEdited">
+    </audio-translations-editor>
+  </div>
 </div>

--- a/core/templates/dev/head/components/solution_explanation_editor_directive.html
+++ b/core/templates/dev/head/components/solution_explanation_editor_directive.html
@@ -46,7 +46,7 @@
   </div>
 
   <div ng-if="stateSolutionService.savedMemento.explanation && !stateSolutionService.savedMemento.explanation.isEmpty()">
-    <audio-translations-editor component-name="solution"
+    <audio-translations-editor component-name="<[COMPONENT_NAME_SOLUTION]>"
                                subtitled-html="stateSolutionService.displayed.explanation"
                                on-start-edit="onAudioTranslationsStartEditAction"
                                on-change="onAudioTranslationsEdited">

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateContentEditorDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateContentEditorDirective.js
@@ -36,11 +36,11 @@ oppia.directive('stateContentEditor', [
       controller: [
         '$scope', '$uibModal', 'stateContentService', 'editabilityService',
         'EditorFirstTimeEventsService', 'explorationInitStateNameService',
-        'EditorStateService',
+        'EditorStateService', 'COMPONENT_NAME_CONTENT',
         function(
             $scope, $uibModal, stateContentService, editabilityService,
             EditorFirstTimeEventsService, explorationInitStateNameService,
-            EditorStateService) {
+            EditorStateService, COMPONENT_NAME_CONTENT) {
           $scope.HTML_SCHEMA = {
             type: 'html'
           };
@@ -48,6 +48,7 @@ oppia.directive('stateContentEditor', [
           $scope.stateContentService = stateContentService;
           $scope.contentEditorIsOpen = false;
           $scope.isEditable = editabilityService.isEditable;
+          $scope.COMPONENT_NAME_CONTENT = COMPONENT_NAME_CONTENT;
 
           var saveContent = function() {
             stateContentService.saveDisplayedValue();

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_content_editor_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_content_editor_directive.html
@@ -27,7 +27,7 @@
   </div>
 
   <div ng-if="stateContentService.savedMemento && !stateContentService.savedMemento.isEmpty()">
-    <audio-translations-editor component-name="content"
+    <audio-translations-editor component-name="<[COMPONENT_NAME_CONTENT]>"
                                subtitled-html="stateContentService.displayed"
                                on-start-edit="onAudioTranslationsStartEditAction"
                                on-change="onAudioTranslationsEdited">

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_content_editor_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_content_editor_directive.html
@@ -27,7 +27,8 @@
   </div>
 
   <div ng-if="stateContentService.savedMemento && !stateContentService.savedMemento.isEmpty()">
-    <audio-translations-editor subtitled-html="stateContentService.displayed"
+    <audio-translations-editor component-name="content"
+                               subtitled-html="stateContentService.displayed"
                                on-start-edit="onAudioTranslationsStartEditAction"
                                on-change="onAudioTranslationsEdited">
     </audio-translations-editor>

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_hints.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_hints.html
@@ -38,7 +38,7 @@
               <div ng-if="activeHintIndex === $index">
                 <div class="oppia-editor-card-section protractor-test-hint-body-<[$index]>">
                   <hint-editor hint="hint"
-                               index="$index + 1"
+                               index-plus-one="$index + 1"
                                on-save="onSaveInlineHint">
                   </hint-editor>
                 </div>


### PR DESCRIPTION
Design considerations I wasn't sure about:
1. It looked really cluttered to include the "Audio Translations" header in feedback, hint, solutions so I decided to not show it. It seems clear enough? Not sure.
2. Should the "Add audio translation" button still be on the right for the components that aren't the main content? I thought it just felt a little awkward so I put it right below the html.