### PR TITLE
Fixes #4178 : "add to playlist" tooltip appears after coming back only.

### DIFF
--- a/core/templates/dev/head/domain/learner_dashboard/LearnerDashboardIconsDirective.js
+++ b/core/templates/dev/head/domain/learner_dashboard/LearnerDashboardIconsDirective.js
@@ -34,10 +34,19 @@ oppia.directive('learnerDashboardIcons', [
         'LearnerDashboardActivityIdsObjectFactory',
         'LearnerPlaylistService',
         function(
-            $scope, LearnerDashboardIdsBackendApiService,
-            LearnerDashboardActivityIdsObjectFactory,
-            LearnerPlaylistService) {
+          $scope, LearnerDashboardIdsBackendApiService,
+          LearnerDashboardActivityIdsObjectFactory,
+          LearnerPlaylistService) {
           $scope.activityIsCurrentlyHoveredOver = true;
+          $scope.Flag = false;
+
+          $scope.$watch('Flag', function () {
+            console.log($scope.Flag);
+          });
+
+          $scope.enableToolTip = function (state) {
+            $scope.Flag = state;
+          };
 
           $scope.$watch('activityActive', function(value) {
             $scope.activityIsCurrentlyHoveredOver = $scope.activityActive;
@@ -53,6 +62,7 @@ oppia.directive('learnerDashboardIcons', [
 
           $scope.setHoverState = function(hoverState) {
             $scope.activityIsCurrentlyHoveredOver = hoverState;
+            $scope.enableToolTip(false);
           };
 
           $scope.canActivityBeAddedToLearnerPlaylist = function(activityId) {

--- a/core/templates/dev/head/domain/learner_dashboard/learner_dashboard_icons_directive.html
+++ b/core/templates/dev/head/domain/learner_dashboard/learner_dashboard_icons_directive.html
@@ -9,6 +9,8 @@
    ng-if="belongsToLearnerPlaylist()"
    ng-click="removeFromLearnerPlaylist(getActivityId(), getActivityTitle(), getActivityType())"
    aria-hidden="true"
+   tooltip-enable="{{ Flag }}"
+   ng-mouseleave="enableToolTip(true)"
    uib-tooltip="<['I18N_LIBRARY_ACTIVITY_IN_LEARNER_PLAYLIST' | translate]>"
    tooltip-placement="left"></i>
 <i class="oppia-learner-dashboard-icon fa fa-check-circle-o"


### PR DESCRIPTION
Signed-off-by: Yash Ladha <201551061@iiitvadodara.ac.in>

Added a flag to temporarily disable the tooltip after click and again enabling it after user mouse leaves. The same procedure as suggested in the issue comment (#4178 ).

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
