### PR TITLE
Fixes #3905: Added check for missing docstrings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -45,13 +45,14 @@ ignore-imports=yes
 
 [MESSAGES CONTROL]
 
+enable=missing_docstring
+
 # TODO(sll): Consider re-enabling the following checks:
 #    abstract-method
 #    arguments-differ
 #    broad-except
 #    duplicate-code
 #    fixme
-#    missing-docstring
 #    no-member
 #    no-self-use
 #    redefined-variable-type
@@ -65,7 +66,7 @@ ignore-imports=yes
 #    too-many-statements
 # and fix those issues.
 
-disable=consider-using-ternary,locally-disabled,locally-enabled,logging-not-lazy,abstract-method,arguments-differ,broad-except,duplicate-code,fixme,len-as-condition,missing-docstring,no-else-return,no-member,no-self-use,not-context-manager,redefined-variable-type,too-many-arguments,too-many-boolean-expressions,too-many-branches,too-many-instance-attributes,too-many-lines,too-many-locals,too-many-public-methods,too-many-nested-blocks,too-many-statements
+disable=consider-using-ternary,locally-disabled,locally-enabled,logging-not-lazy,abstract-method,arguments-differ,broad-except,duplicate-code,fixme,len-as-condition,no-else-return,no-member,no-self-use,not-context-manager,redefined-variable-type,too-many-arguments,too-many-boolean-expressions,too-many-branches,too-many-instance-attributes,too-many-lines,too-many-locals,too-many-public-methods,too-many-nested-blocks,too-many-statements
 
 [REPORTS]
 


### PR DESCRIPTION
`pre_commit_linter.py` now checks for missing docstrings for Python.

**Checklist**
- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [X] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [X] The PR is made from a branch that's **not** called "develop".
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
