### PR TITLE
GenerateAllStats job

### DIFF
--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -916,10 +916,10 @@ class StatisticsAudit(jobs.BaseMapReduceOneOffJobManager):
                         sum_state_hit[state_name]),)
 
 
-class GenerateMissingStatsModelsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
-    """Generates state stats models for explorations which do not have events
-    recorded. This should be run after GenerateV1StatisticsJob has completed a
-    successful run.
+class GenerateAllStatsModelsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
+    """Generates default state stats models for all explorations. This should be
+    run before GenerateV1StatisticsJob. If there are existing stats models,
+    their values are refreshed.
     """
 
     @classmethod
@@ -952,29 +952,6 @@ class GenerateMissingStatsModelsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                     exp_id, version_numbers))
         except Exception as e:
             yield (exp_id, str(e))
-            return
-
-        exp_stats_by_version = (
-            stats_services.get_multiple_exploration_stats_by_version(
-                exp_id, version_numbers))
-        versions_with_no_stats = []
-        versions_with_stats = []
-        for index, per_version_stats in enumerate(exp_stats_by_version):
-            if per_version_stats is None:
-                versions_with_no_stats.append(index + 1)
-            else:
-                versions_with_stats.append(index + 1)
-        if versions_with_no_stats and versions_with_stats:
-            yield (
-                exp_id,
-                'ERROR: Stats models incompletely generated, has stats %s, '
-                'has no stats %s' % (
-                    versions_with_stats, versions_with_no_stats))
-            return
-
-        if versions_with_stats:
-            # All stats models have been generated for this exploration.
-            # Nothing further needs to be done.
             return
 
         yield (exp_id, 'Stats initial generation started')

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -48,7 +48,7 @@ ONE_OFF_JOB_MANAGERS = [
     stats_jobs_one_off.GenerateV1StatisticsJob,
     stats_jobs_one_off.StatisticsAuditV1,
     stats_jobs_one_off.StatisticsAudit,
-    stats_jobs_one_off.GenerateMissingStatsModelsOneOffJob,
+    stats_jobs_one_off.GenerateAllStatsModelsOneOffJob,
     user_jobs_one_off.DashboardSubscriptionsOneOffJob,
     user_jobs_one_off.LongUserBiosOneOffJob,
     user_jobs_one_off.UserContributionsOneOffJob,

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -711,18 +711,18 @@ class ExplorationStatsModel(base_models.BaseModel):
     # Version of exploration.
     exp_version = ndb.IntegerProperty(indexed=True)
     # Number of learners starting the exploration (v1 - data collected before
-    # Nov 2017).
+    # Dec 2017).
     num_starts_v1 = ndb.IntegerProperty(indexed=True)
     num_starts_v2 = ndb.IntegerProperty(indexed=True)
     # Number of students who actually attempted the exploration. Only learners
     # who spent a minimum time on the exploration are considered to have
-    # actually started the exploration (v1 - data collected before Nov 2017).
-    num_actual_starts_v1 = ndb.IntegerProperty(indexed=False)
-    num_actual_starts_v2 = ndb.IntegerProperty(indexed=False)
+    # actually started the exploration (v1 - data collected before Dec 2017).
+    num_actual_starts_v1 = ndb.IntegerProperty(indexed=True)
+    num_actual_starts_v2 = ndb.IntegerProperty(indexed=True)
     # Number of students who completed the exploration (v1 - data collected
-    # before Nov 2017).
-    num_completions_v1 = ndb.IntegerProperty(indexed=False)
-    num_completions_v2 = ndb.IntegerProperty(indexed=False)
+    # before Dec 2017).
+    num_completions_v1 = ndb.IntegerProperty(indexed=True)
+    num_completions_v2 = ndb.IntegerProperty(indexed=True)
     # Keyed by state name that describes the analytics for that state.
     # {state_name: {
     #   'total_answers_count_v1': ...,

--- a/core/templates/dev/head/pages/exploration_editor/statistics_tab/PieChartDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/statistics_tab/PieChartDirective.js
@@ -32,9 +32,12 @@ oppia.directive('pieChart', [function() {
         return;
       }
       var options = $scope.options();
-      var chart = new google.visualization.PieChart($element[0]);
+      var chart = null;
 
       var redrawChart = function() {
+        if (!chart) {
+          chart = new google.visualization.PieChart($element[0]);
+        }
         chart.draw(google.visualization.arrayToDataTable($scope.data()), {
           title: options.title,
           pieHole: options.pieHole,

--- a/core/templates/dev/head/pages/exploration_editor/statistics_tab/StatisticsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/statistics_tab/StatisticsTab.js
@@ -115,7 +115,7 @@ oppia.controller('StatisticsTab', [
           var numCompletions = data.num_completions;
           $scope.stateStats = data.state_stats_mapping;
 
-          if (numStarts > 0) {
+          if (numActualStarts > 0) {
             $scope.explorationHasBeenVisited = true;
           }
 

--- a/core/templates/dev/head/pages/exploration_player/PlayerServices.js
+++ b/core/templates/dev/head/pages/exploration_player/PlayerServices.js
@@ -157,6 +157,15 @@ oppia.factory('ExplorationPlayerService', [
       if (!_editorPreviewMode && exploration.isStateTerminal(newStateName)) {
         StatsReportingService.recordExplorationCompleted(
           newStateName, LearnerParamsService.getAllParams());
+
+        // For single state explorations, when the exploration reaches the
+        // terminal state and explorationActuallyStarted is false, record
+        // exploration actual start event.
+        if (!explorationActuallyStarted) {
+          StatsReportingService.recordExplorationActuallyStarted(
+            newStateName);
+          explorationActuallyStarted = true;
+        }
       }
     });
 


### PR DESCRIPTION
This PR modifies the GenerateMissingStats job to create default stats models for every exploration instead.
This also indexes the num_actual_starts and num_completions fields of ExplorationStatsModels.

Thanks