### PR TITLE
Fixes #4327 : Corrected `collection_domain.py` for syntax error.

### DIFF
--- a/core/domain/collection_domain.py
+++ b/core/domain/collection_domain.py
@@ -1148,10 +1148,10 @@ class Collection(object):
                 present.
         """
         skill_id = None
-        if any([
-                skill_name == skill.name
-                for skill in self.skills.itervalues()]):
-            skill_id = skill.id
+        for skill in self.skills.itervalues():
+            if skill_name == skill.name:
+                skill_id = skill.id
+                break
         return skill_id
 
     def update_skill(self, skill_id, new_skill_name):


### PR DESCRIPTION
Signed-off-by: Yash Ladha <201551061@iiitvadodara.ac.in>

Fixes #4327 : Corrected the logic for getting the `skill_id` to remove the syntax error that was previosly present.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
