### PR TITLE
Reinstate if condition on subtitledHtml in the audioTranslationsEditor directive.

### DIFF
--- a/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
+++ b/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
@@ -43,8 +43,16 @@ oppia.directive('audioTranslationsEditor', [
             AssetsBackendApiService) {
           $scope.isEditable = editabilityService.isEditable;
 
-          $scope.audioTranslations = (
-            $scope.subtitledHtml.getBindableAudioTranslations());
+          // The following if-condition is present because, sometimes,
+          // Travis-CI throws an error of the form "Cannot read property
+          // getBindableAudioTranslations of undefined". It looks like there is
+          // a race condition that is causing this directive to get
+          // initialized when it shouldn't. This is hard to reproduce
+          // deterministically, hence this guard.
+          if ($scope.subtitledHtml) {
+            $scope.audioTranslations = (
+              $scope.subtitledHtml.getBindableAudioTranslations());
+          }
 
           var explorationId = ExplorationContextService.getExplorationId();
 


### PR DESCRIPTION
Reverses a change made in #4313.

**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
