### PR TITLE
Allow editing of refresher exploration ID.

### DIFF
--- a/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
@@ -35,6 +35,8 @@ oppia.directive('outcomeDestinationEditor', [
             $scope, EditorStateService, explorationStatesService,
             StateGraphLayoutService, PLACEHOLDER_OUTCOME_DEST,
             FocusManagerService, EditorFirstTimeEventsService) {
+          var currentStateName = null;
+
           $scope.$on('saveOutcomeDestDetails', function() {
             // Create new state if specified.
             if ($scope.outcome.dest === PLACEHOLDER_OUTCOME_DEST) {
@@ -49,6 +51,17 @@ oppia.directive('outcomeDestinationEditor', [
             }
           });
 
+          // We restrict editing of refresher exploration IDs to
+          // admins/moderators for now, since the feature is still in
+          // development.
+          $scope.canEditRefresherExplorationId = (
+            GLOBALS.isAdmin || GLOBALS.isModerator);
+          $scope.explorationIdPattern = /^[a-zA-Z0-9.-]+$/;
+
+          $scope.isSelfLoop = function() {
+            return $scope.outcome.dest === currentStateName;
+          };
+
           $scope.onDestSelectorChange = function() {
             if ($scope.outcome.dest === PLACEHOLDER_OUTCOME_DEST) {
               FocusManagerService.setFocus('newStateNameInputField');
@@ -62,7 +75,7 @@ oppia.directive('outcomeDestinationEditor', [
           $scope.newStateNamePattern = /^[a-zA-Z0-9.\s-]+$/;
           $scope.destChoices = [];
           $scope.$watch(explorationStatesService.getStates, function() {
-            var currentStateName = EditorStateService.getActiveStateName();
+            currentStateName = EditorStateService.getActiveStateName();
 
             // This is a list of objects, each with an ID and name. These
             // represent all states, as well as an option to create a

--- a/core/templates/dev/head/components/OutcomeEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeEditorDirective.js
@@ -29,8 +29,7 @@ oppia.directive('outcomeEditor', [
         suppressWarnings: '&suppressWarnings'
       },
       templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
-        '/components/' +
-        'outcome_editor_directive.html'),
+        '/components/outcome_editor_directive.html'),
       controller: [
         '$scope', 'EditorStateService',
         'stateInteractionIdService', 'COMPONENT_NAME_FEEDBACK',
@@ -134,6 +133,12 @@ oppia.directive('outcomeEditor', [
             $scope.$broadcast('saveOutcomeDestDetails');
             $scope.destinationEditorIsOpen = false;
             $scope.savedOutcome.dest = angular.copy($scope.outcome.dest);
+            if (!$scope.isSelfLoop($scope.outcome)) {
+              $scope.outcome.refresherExplorationId = null;
+            }
+            $scope.savedOutcome.refresherExplorationId = (
+              $scope.outcome.refresherExplorationId);
+
             $scope.getOnSaveDestFn()($scope.savedOutcome);
           };
 
@@ -145,6 +150,8 @@ oppia.directive('outcomeEditor', [
 
           $scope.cancelThisDestinationEdit = function() {
             $scope.outcome.dest = angular.copy($scope.savedOutcome.dest);
+            $scope.outcome.refresherExplorationId = (
+              $scope.savedOutcome.refresherExplorationId);
             $scope.destinationEditorIsOpen = false;
           };
 

--- a/core/templates/dev/head/components/outcome_destination_editor_directive.html
+++ b/core/templates/dev/head/components/outcome_destination_editor_directive.html
@@ -15,4 +15,9 @@
     </span>
     <p ng-show="newStateNameForm.newStateName.$error.pattern" class="help-block oppia-form-error" style="font-size: 0.85em;">Please pick a card name consisting of alphanumeric characters, spaces and/or hyphens.</p>
   </ng-form>
+
+  <div ng-if="isSelfLoop() && canEditRefresherExplorationId" style="margin-top: 12px;">
+    <b>Refresher exploration ID (optional):</b>
+    <input type="text" name="refresherExplorationId" ng-model="outcome.refresherExplorationId" class="form-control" tabindex="0" aria-invalid="false" ng-pattern="explorationIdPattern">
+  </div>
 </div>

--- a/core/templates/dev/head/components/outcome_editor_directive.html
+++ b/core/templates/dev/head/components/outcome_editor_directive.html
@@ -97,7 +97,10 @@
           <[outcome.dest]>
         </span>
         <span ng-if="isSelfLoop(outcome)" style="position: relative;">
-          (try again)
+          <span ng-if="!outcome.refresherExplorationId">(try again)</span>
+          <span ng-if="outcome.refresherExplorationId">
+            (try again, with refresher exploration "<[outcome.refresherExplorationId]>")
+          </span>
         </span>
       </div>
     </div>

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/ResponsesService.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/ResponsesService.js
@@ -98,14 +98,18 @@ oppia.factory('ResponsesService', [
 
     var _updateAnswerGroup = function(index, updates) {
       var answerGroup = _answerGroups[index];
-      if (updates.rules) {
+      if (updates.hasOwnProperty('rules')) {
         answerGroup.rules = updates.rules;
       }
-      if (updates.feedback) {
+      if (updates.hasOwnProperty('feedback')) {
         answerGroup.outcome.feedback = updates.feedback;
       }
-      if (updates.dest) {
+      if (updates.hasOwnProperty('dest')) {
         answerGroup.outcome.dest = updates.dest;
+      }
+      if (updates.hasOwnProperty('refresherExplorationId')) {
+        answerGroup.outcome.refresherExplorationId = (
+          updates.refresherExplorationId);
       }
       if (updates.hasOwnProperty('labelledAsCorrect')) {
         answerGroup.labelledAsCorrect = updates.labelledAsCorrect;
@@ -237,11 +241,14 @@ oppia.factory('ResponsesService', [
       },
       updateDefaultOutcome: function(updates) {
         var outcome = _defaultOutcome;
-        if (updates.feedback) {
+        if (updates.hasOwnProperty('feedback')) {
           outcome.feedback = updates.feedback;
         }
-        if (updates.dest) {
+        if (updates.hasOwnProperty('dest')) {
           outcome.dest = updates.dest;
+        }
+        if (updates.hasOwnProperty('refresherExplorationId')) {
+          outcome.refresherExplorationId = updates.refresherExplorationId;
         }
         _saveDefaultOutcome(outcome);
       },

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
@@ -470,7 +470,8 @@ oppia.controller('StateResponses', [
 
     $scope.saveActiveAnswerGroupDest = function(updatedOutcome) {
       ResponsesService.updateActiveAnswerGroup({
-        dest: updatedOutcome.dest
+        dest: updatedOutcome.dest,
+        refresherExplorationId: updatedOutcome.refresherExplorationId
       });
     };
 
@@ -495,7 +496,8 @@ oppia.controller('StateResponses', [
 
     $scope.saveDefaultOutcomeDest = function(updatedOutcome) {
       ResponsesService.updateDefaultOutcome({
-        dest: updatedOutcome.dest
+        dest: updatedOutcome.dest,
+        refresherExplorationId: updatedOutcome.refresherExplorationId
       });
     };
 


### PR DESCRIPTION
This PR adds functionality to add refresher exploration IDs in the editor. Since this functionality is experimental, we restrict it to admins/moderators for now.

**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.