### PR TITLE
Fix a flaky protractor test.

### DIFF
--- a/core/tests/protractor/stateEditor.js
+++ b/core/tests/protractor/stateEditor.js
@@ -159,7 +159,7 @@ describe('State editor', function() {
       by.css('.protractor-test-save-interaction'));
     expect(saveInteractionBtn.isPresent()).toBe(false);
 
-    element(by.css('.protractor-test-close-add-response-modal')).click();
+    editor.closeAddResponseModal();
 
     // The Continue input has customization options. Therefore the
     // customization modal does appear and so does the save interaction button.


### PR DESCRIPTION
The protractor test file was clicking an element directly instead of using a standard method in the editor.js protractor_utils page which included a post-click wait. This caused the next action to be attempted before the modal closed, which is resulting in flaky tests.

**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.