### PR TITLE
Changes styling for help button on editor view

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
@@ -102,12 +102,10 @@
 </ul>
 <style type="text/css">
   .oppia-help-dropdown .uib-popover{
-    background-color: black;
     color: white;
     font-size: 14px;
     max-width: 200px;
     text-align: center;
-    z-index: -1;
   }
   .oppia-help-dropdown .uib-popover.bottom > .arrow{
     border-bottom-color: #000;


### PR DESCRIPTION
This fixes the hidden help button in the editor view. 
@seanlip PTAL. Thanks
**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
