### PR TITLE
Fix #4353: Added 2 more customization args for fractions

### DIFF
--- a/core/templates/dev/head/domain/objects/FractionObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/FractionObjectFactory.js
@@ -81,6 +81,14 @@ oppia.factory('FractionObjectFactory', [
         this.isNegative, this.wholeNumber, numerator, denominator);
     };
 
+    Fraction.prototype.isMixedFraction = function() {
+      return this.wholeNumber !== 0;
+    };
+
+    Fraction.prototype.isImproperFraction = function() {
+      return this.wholeNumber === 0 && this.denominator < this.numerator;
+    };
+
     Fraction.fromRawInputString = function(rawInput) {
       var INVALID_CHARS_REGEX = /[^\d\s\/-]/g;
       if (INVALID_CHARS_REGEX.test(rawInput)) {

--- a/extensions/interactions/FractionInput/FractionInput.py
+++ b/extensions/interactions/FractionInput/FractionInput.py
@@ -37,4 +37,19 @@ class FractionInput(base.BaseInteraction):
             'type': 'bool',
         },
         'default_value': False
+    }, {
+        'name': 'allowImproperFraction',
+        'description': 'Allow the learner\'s answer to be an improper fraction',
+        'schema': {
+            'type': 'bool',
+        },
+        'default_value': True
+    }, {
+        'name': 'allowNonZeroIntegerPart',
+        'description': (
+            'Allow the learner\'s answer to have a non-zero integer part'),
+        'schema': {
+            'type': 'bool',
+        },
+        'default_value': True
     }]

--- a/extensions/interactions/FractionInput/directives/FractionInput.js
+++ b/extensions/interactions/FractionInput/directives/FractionInput.js
@@ -41,6 +41,10 @@ oppia.directive('oppiaInteractiveFractionInput', [
           $scope.labelForFocusTarget = $attrs.labelForFocusTarget || null;
           var requireSimplestForm =
             $attrs.requireSimplestFormWithValue === 'true';
+          var allowImproperFraction =
+            $attrs.allowImproperFractionWithValue === 'true';
+          var allowNonZeroIntegerPart =
+            $attrs.allowNonZeroIntegerPartWithValue === 'true';
           var errorMessage = '';
           // Label for errors caused whilst parsing a fraction.
           var FORM_ERROR_TYPE = 'FRACTION_FORMAT_ERROR';
@@ -98,6 +102,20 @@ oppia.directive('oppiaInteractiveFractionInput', [
                 errorMessage = (
                   'Please enter an answer in simplest form ' +
                   '(e.g., 1/3 instead of 2/6).');
+                $scope.FractionInputForm.answer.$setValidity(
+                  FORM_ERROR_TYPE, false);
+              } else if (!allowImproperFraction && fraction.isImproperFraction()
+              ) {
+                errorMessage = (
+                  'Please enter an answer thats not an improper fraction ' +
+                  '(e.g., 1 2/3 instead of 5/3).');
+                $scope.FractionInputForm.answer.$setValidity(
+                  FORM_ERROR_TYPE, false);
+              } else if (!allowNonZeroIntegerPart && fraction.isMixedFraction()
+              ) {
+                errorMessage = (
+                  'Please enter an answer thats not a mixed fraction ' +
+                  '(e.g., 5/3 instead of 1 2/3).');
                 $scope.FractionInputForm.answer.$setValidity(
                   FORM_ERROR_TYPE, false);
               } else {


### PR DESCRIPTION
This PR adds 2 customization args for FractionInputInteraction namely allowNonZeroIntegerPart and allowImproperFraction. 

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
