### PR TITLE
Fix #4377: Display hints and solutions in preview tab in editor

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -305,6 +305,7 @@
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/collection/GuestCollectionProgressObjectFactory.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/collection/GuestCollectionProgressService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/objects/FractionObjectFactory.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/domain/summary/ExplorationSummaryBackendApiService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/utilities/StopwatchObjectFactory.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/utilities/LanguageUtilService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/domain/utilities/AudioLanguageObjectFactory.js"></script>
@@ -326,6 +327,7 @@
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/PlayerCorrectnessFeedbackEnabledService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/ContinueButtonDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/ConversationSkinDirective.js"></script>
+  <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/ExplorationFooterDirective.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/ExplorationRecommendationsService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/HintsAndSolutionManagerService.js"></script>
   <script src="{{TEMPLATE_DIR_PREFIX}}/pages/exploration_player/HintAndSolutionModalService.js"></script>

--- a/core/templates/dev/head/pages/exploration_editor/preview_tab/preview_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/preview_tab/preview_tab.html
@@ -34,7 +34,7 @@
     display: block;
     position: absolute;
     right: 5px;
-    padding-bottom: 10%;
+    padding-bottom: 2em;
   }
 
   .oppia-preview-bottom-right-container .oppia-parameter-summary {

--- a/core/templates/dev/head/pages/exploration_editor/preview_tab/preview_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/preview_tab/preview_tab.html
@@ -4,6 +4,8 @@
       <div class="oppia-preview-state-warning"><[previewWarning]></div>
     </div>
     <conversation-skin></conversation-skin>
+    <exploration-footer twitter-text="{{DEFAULT_TWITTER_SHARE_MESSAGE_PLAYER}}"></exploration-footer>
+
   </div>
 
   <div class="oppia-preview-bottom-right-container">
@@ -32,6 +34,7 @@
     display: block;
     position: absolute;
     right: 5px;
+    padding-bottom: 10%;
   }
 
   .oppia-preview-bottom-right-container .oppia-parameter-summary {


### PR DESCRIPTION
I have added and included exploration_footer_directive in preview tab also.
**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
