### PR TITLE
"Fix" #4304: Always show something in the lost changes modal, even if the data cannot be parsed.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/ChangesInHumanReadableFormService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ChangesInHumanReadableFormService.js
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /**
- * @fileoverview Service to get changes in human readable form.  
+ * @fileoverview Service to get changes in human readable form.
  */
 
 oppia.factory('ChangesInHumanReadableFormService', [
@@ -283,7 +283,14 @@ oppia.factory('ChangesInHumanReadableFormService', [
     };
 
     return {
-      makeHumanReadable: makeHumanReadable
+      makeHumanReadable: function(lostChanges) {
+        try {
+          return makeHumanReadable(lostChanges);
+        } catch (e) {
+          return angular.element(
+            '<div>Error: Could not recover lost changes.</div>');
+        }
+      }
     };
   }]
 );


### PR DESCRIPTION
This is a somewhat unlikely "fix" for #4304. More details will be added as a comment to that issue.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.