### PR TITLE
Added validity checks for the newly added customization args for Fractions Interaction

### DIFF
--- a/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
@@ -154,7 +154,7 @@ oppia.factory('FractionInputValidationService', [
                 }
                 break;
               case 'HasIntegerPartEqualTo':
-                if (!allowNonzeroIntegerPart) {
+                if (!allowNonzeroIntegerPart && rule.inputs.x !== 0) {
                   warningsList.push({
                     type: WARNING_TYPES.ERROR,
                     message: (

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
@@ -43,6 +43,7 @@ oppia.factory('FractionInputValidationService', [
             customizationArgs.allowImproperFraction.value;
         var allowNonzeroIntegerPart =
           customizationArgs.allowNonzeroIntegerPart.value;
+
         warningsList = warningsList.concat(
           this.getCustomizationArgsWarnings(customizationArgs));
 

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
@@ -39,7 +39,10 @@ oppia.factory('FractionInputValidationService', [
         var warningsList = [];
         var shouldBeInSimplestForm =
           customizationArgs.requireSimplestForm.value;
-
+        var allowImproperFraction =
+            customizationArgs.allowImproperFraction.value;
+        var allowNonzeroIntegerPart =
+          customizationArgs.allowNonzeroIntegerPart.value;
         warningsList = warningsList.concat(
           this.getCustomizationArgsWarnings(customizationArgs));
 
@@ -102,6 +105,32 @@ oppia.factory('FractionInputValidationService', [
                     });
                   }
                 }
+                if (!allowImproperFraction) {
+                  var fraction = FractionObjectFactory.fromDict(rule.inputs.f);
+                  if (fraction.isImproperFraction()) {
+                    warningsList.push({
+                      type: WARNING_TYPES.ERROR,
+                      message: (
+                        'Rule ' + (j + 1) + ' from answer group ' +
+                        (i + 1) +
+                        ' will never be matched because it is an ' +
+                        'improper fraction')
+                    });
+                  }
+                }
+                if (!allowNonzeroIntegerPart) {
+                  var fraction = FractionObjectFactory.fromDict(rule.inputs.f);
+                  if (fraction.hasNonzeroIntegerPart()) {
+                    warningsList.push({
+                      type: WARNING_TYPES.ERROR,
+                      message: (
+                        'Rule ' + (j + 1) + ' from answer group ' +
+                        (i + 1) +
+                        ' will never be matched because it has a ' +
+                        'non zero integer part')
+                    });
+                  }
+                }
                 var f = toFloat(rule.inputs.f);
                 setLowerAndUpperBounds(range, f, f, true, true);
                 break;
@@ -124,6 +153,16 @@ oppia.factory('FractionInputValidationService', [
                 }
                 break;
               case 'HasIntegerPartEqualTo':
+                if (!allowNonzeroIntegerPart) {
+                  warningsList.push({
+                    type: WARNING_TYPES.ERROR,
+                    message: (
+                      'Rule ' + (j + 1) + ' from answer group ' +
+                      (i + 1) +
+                      ' will never be matched because integer part ' +
+                      'has to be zero')
+                  });
+                }
                 if (!Number.isInteger(rule.inputs.x)) {
                   warningsList.push(getNonIntegerInputWarning(i, j));
                 }

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
@@ -289,35 +289,35 @@ describe('FractionInputValidationService', function() {
 
   it('should catch not allowImproperFraction and rule has improper fraction',
     function(){
-    customizationArgs.allowImproperFraction.value = false;
-    answerGroups[0].rules = [equalsThreeByTwoRule];
-    var warnings = validatorService.getAllWarnings(
-      currentState, customizationArgs, answerGroups,
-      goodDefaultOutcome);
-    expect(warnings).toEqual([{
-      type: WARNING_TYPES.ERROR,
-      message: (
-        'Rule ' + 1 + ' from answer group ' +
-        1 + ' will never be matched because it is an ' +
-        'improper fraction')
-    }]);
-  });
+      customizationArgs.allowImproperFraction.value = false;
+      answerGroups[0].rules = [equalsThreeByTwoRule];
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArgs, answerGroups,
+        goodDefaultOutcome);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: (
+          'Rule ' + 1 + ' from answer group ' +
+          1 + ' will never be matched because it is an ' +
+          'improper fraction')
+      }]);
+    });
 
   it('should catch not allowNonzeroIntegerPart and rule has integer part',
     function(){
-    customizationArgs.allowNonzeroIntegerPart.value = false;
-    answerGroups[0].rules = [equalsOneAndHalfRule];
-    var warnings = validatorService.getAllWarnings(
-      currentState, customizationArgs, answerGroups,
-      goodDefaultOutcome);
-    expect(warnings).toEqual([{
-      type: WARNING_TYPES.ERROR,
-      message: (
-        'Rule ' + 1 + ' from answer group ' +
-        1 + ' will never be matched because it has a ' +
-        'non zero integer part')
-    }]);
-  });
+      customizationArgs.allowNonzeroIntegerPart.value = false;
+      answerGroups[0].rules = [equalsOneAndHalfRule];
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArgs, answerGroups,
+        goodDefaultOutcome);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: (
+          'Rule ' + 1 + ' from answer group ' +
+          1 + ' will never be matched because it has a ' +
+          'non zero integer part')
+      }]);
+    });
 
   it('should catch if not allowNonzeroIntegerPart and ' +
     'rule is HasIntegerPartEqualTo', function(){

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
@@ -45,6 +45,12 @@ describe('FractionInputValidationService', function() {
     customizationArgs = {
       requireSimplestForm: {
         value: true
+      },
+      allowImproperFraction: {
+        value: true
+      },
+      allowNonzeroIntegerPart: {
+        value: true
       }
     };
 
@@ -67,10 +73,31 @@ describe('FractionInputValidationService', function() {
       }
     });
 
+    equalsThreeByTwoRule = rof.createFromBackendDict({
+      rule_type: 'IsExactlyEqualTo',
+      inputs: {
+        f: createFractionDict(false, 0, 3, 2)
+      }
+    });
+
+    equalsOneAndHalfRule = rof.createFromBackendDict({
+      rule_type: 'IsExactlyEqualTo',
+      inputs: {
+        f: createFractionDict(false, 1, 1, 2)
+      }
+    });
+
     greaterThanMinusOneRule = rof.createFromBackendDict({
       rule_type: 'IsGreaterThan',
       inputs: {
         f: createFractionDict(true, 0, 1, 1)
+      }
+    });
+
+    integerPartEqualsOne = rof.createFromBackendDict({
+      rule_type: 'HasIntegerPartEqualTo',
+      inputs: {
+        x: 1
       }
     });
 
@@ -258,5 +285,53 @@ describe('FractionInputValidationService', function() {
         1 + ' is invalid: denominator should be ' +
         'greater than zero.')
     }]);
+  });
+
+  it('should catch not allowImproperFraction and rule has improper fraction',
+    function(){
+      customizationArgs.allowImproperFraction.value = false;
+      answerGroups[0].rules = [equalsThreeByTwoRule];
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArgs, answerGroups,
+        goodDefaultOutcome);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: (
+          'Rule ' + 1 + ' from answer group ' +
+          1 + ' will never be matched because it is an ' +
+          'improper fraction')
+      }]);
+  });
+
+  it('should catch not allowNonzeroIntegerPart and rule has integer part',
+    function(){
+      customizationArgs.allowNonzeroIntegerPart.value = false;
+      answerGroups[0].rules = [equalsOneAndHalfRule];
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArgs, answerGroups,
+        goodDefaultOutcome);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: (
+          'Rule ' + 1 + ' from answer group ' +
+          1 + ' will never be matched because it has a ' +
+          'non zero integer part')
+      }]);
+  });
+
+  it('should catch if not allowNonzeroIntegerPart and ' +
+    'rule is HasIntegerPartEqualTo', function(){
+      customizationArgs.allowNonzeroIntegerPart.value = false;
+      answerGroups[0].rules = [integerPartEqualsOne];
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArgs, answerGroups,
+        goodDefaultOutcome);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: (
+          'Rule ' + 1 + ' from answer group ' +
+          1 + ' will never be matched because integer part ' +
+          'has to be zero')
+      }]);
   });
 });

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
@@ -289,49 +289,49 @@ describe('FractionInputValidationService', function() {
 
   it('should catch not allowImproperFraction and rule has improper fraction',
     function(){
-      customizationArgs.allowImproperFraction.value = false;
-      answerGroups[0].rules = [equalsThreeByTwoRule];
-      var warnings = validatorService.getAllWarnings(
-        currentState, customizationArgs, answerGroups,
-        goodDefaultOutcome);
-      expect(warnings).toEqual([{
-        type: WARNING_TYPES.ERROR,
-        message: (
-          'Rule ' + 1 + ' from answer group ' +
-          1 + ' will never be matched because it is an ' +
-          'improper fraction')
-      }]);
+    customizationArgs.allowImproperFraction.value = false;
+    answerGroups[0].rules = [equalsThreeByTwoRule];
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([{
+      type: WARNING_TYPES.ERROR,
+      message: (
+        'Rule ' + 1 + ' from answer group ' +
+        1 + ' will never be matched because it is an ' +
+        'improper fraction')
+    }]);
   });
 
   it('should catch not allowNonzeroIntegerPart and rule has integer part',
     function(){
-      customizationArgs.allowNonzeroIntegerPart.value = false;
-      answerGroups[0].rules = [equalsOneAndHalfRule];
-      var warnings = validatorService.getAllWarnings(
-        currentState, customizationArgs, answerGroups,
-        goodDefaultOutcome);
-      expect(warnings).toEqual([{
-        type: WARNING_TYPES.ERROR,
-        message: (
-          'Rule ' + 1 + ' from answer group ' +
-          1 + ' will never be matched because it has a ' +
-          'non zero integer part')
-      }]);
+    customizationArgs.allowNonzeroIntegerPart.value = false;
+    answerGroups[0].rules = [equalsOneAndHalfRule];
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([{
+      type: WARNING_TYPES.ERROR,
+      message: (
+        'Rule ' + 1 + ' from answer group ' +
+        1 + ' will never be matched because it has a ' +
+        'non zero integer part')
+    }]);
   });
 
   it('should catch if not allowNonzeroIntegerPart and ' +
     'rule is HasIntegerPartEqualTo', function(){
-      customizationArgs.allowNonzeroIntegerPart.value = false;
-      answerGroups[0].rules = [integerPartEqualsOne];
-      var warnings = validatorService.getAllWarnings(
-        currentState, customizationArgs, answerGroups,
-        goodDefaultOutcome);
-      expect(warnings).toEqual([{
-        type: WARNING_TYPES.ERROR,
-        message: (
-          'Rule ' + 1 + ' from answer group ' +
-          1 + ' will never be matched because integer part ' +
-          'has to be zero')
-      }]);
+    customizationArgs.allowNonzeroIntegerPart.value = false;
+    answerGroups[0].rules = [integerPartEqualsOne];
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([{
+      type: WARNING_TYPES.ERROR,
+      message: (
+        'Rule ' + 1 + ' from answer group ' +
+        1 + ' will never be matched because integer part ' +
+        'has to be zero')
+    }]);
   });
 });

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
@@ -101,6 +101,13 @@ describe('FractionInputValidationService', function() {
       }
     });
 
+    integerPartEqualsZero = rof.createFromBackendDict({
+      rule_type: 'HasIntegerPartEqualTo',
+      inputs: {
+        x: 0
+      }
+    });
+
     lessThanTwoRule = rof.createFromBackendDict({
       rule_type: 'IsLessThan',
       inputs: {
@@ -288,7 +295,7 @@ describe('FractionInputValidationService', function() {
   });
 
   it('should catch not allowImproperFraction and rule has improper fraction',
-    function(){
+    function() {
       customizationArgs.allowImproperFraction.value = false;
       answerGroups[0].rules = [equalsThreeByTwoRule];
       var warnings = validatorService.getAllWarnings(
@@ -304,7 +311,7 @@ describe('FractionInputValidationService', function() {
     });
 
   it('should catch not allowNonzeroIntegerPart and rule has integer part',
-    function(){
+    function() {
       customizationArgs.allowNonzeroIntegerPart.value = false;
       answerGroups[0].rules = [equalsOneAndHalfRule];
       var warnings = validatorService.getAllWarnings(
@@ -320,7 +327,7 @@ describe('FractionInputValidationService', function() {
     });
 
   it('should catch if not allowNonzeroIntegerPart and ' +
-    'rule is HasIntegerPartEqualTo', function(){
+    'rule is HasIntegerPartEqualTo a non zero value', function() {
     customizationArgs.allowNonzeroIntegerPart.value = false;
     answerGroups[0].rules = [integerPartEqualsOne];
     var warnings = validatorService.getAllWarnings(
@@ -333,5 +340,15 @@ describe('FractionInputValidationService', function() {
         1 + ' will never be matched because integer part ' +
         'has to be zero')
     }]);
+  });
+
+  it('should allow if not allowNonzeroIntegerPart and ' +
+    'rule is HasIntegerPartEqualTo a zero value', function() {
+    customizationArgs.allowNonzeroIntegerPart.value = false;
+    answerGroups[0].rules = [integerPartEqualsZero];
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([]);
   });
 });


### PR DESCRIPTION
This PR adds relevant validity checks for the newly added customization args for the fractions interactions namely allowImproperFraction and allowNonzeroIntegerPart. Also adds karma unit tests for the same

**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
