### PR TITLE
Fix #1251: Set cursor color to black for MathExpressionInput.

### DIFF
--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -18,6 +18,7 @@
   .guppy_active .main_cursor {
     animation: guppy-blink-animation 1s steps(2, start) infinite;
     -webkit-animation: guppy-blink-animation 1s steps(2, start) infinite;
+    color: black !important;
   }
 
   @keyframes guppy-blink-animation {

--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -18,6 +18,7 @@
   .guppy_active .main_cursor {
     animation: guppy-blink-animation 1s steps(2, start) infinite;
     -webkit-animation: guppy-blink-animation 1s steps(2, start) infinite;
+    <!-- Overrides the inline styling and sets the cursor color to black. -->
     color: black !important;
   }
 


### PR DESCRIPTION
This PR sets the red cursor color to black in MathExpressionInput.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
