### PR TITLE
Fix for #4432 - Flaky protractor test

### DIFF
--- a/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
@@ -55,7 +55,7 @@ oppia.directive('outcomeDestinationEditor', [
           // development.
           $scope.canEditRefresherExplorationId = (
             GLOBALS.isAdmin || GLOBALS.isModerator);
-          $scope.explorationIdPattern = /^[a-zA-Z0-9.-]+$/;
+          $scope.explorationIdPattern = /^[a-zA-Z0-9.-_]+$/;
 
           $scope.isSelfLoop = function() {
             return $scope.outcome.dest === currentStateName;


### PR DESCRIPTION
I think the reason for this was that in the $scope.explorationIdPattern for refresher exploration id, '_' was not included and that could be part of exploration id and hence the button was disabled and therefore not clickable for only some explorations.
I thought it might be a scrolling issue, but in my browser, it automatically scrolled down. 

  