### PR TITLE
Fix #4440 - Corrected RegEx for exploration id check

### DIFF
--- a/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
@@ -55,7 +55,7 @@ oppia.directive('outcomeDestinationEditor', [
           // development.
           $scope.canEditRefresherExplorationId = (
             GLOBALS.isAdmin || GLOBALS.isModerator);
-          $scope.explorationIdPattern = /^[a-zA-Z0-9.-_]+$/;
+          $scope.explorationIdPattern = /^[a-zA-Z0-9_-]+$/;
 
           $scope.isSelfLoop = function() {
             return $scope.outcome.dest === currentStateName;


### PR DESCRIPTION
Removed the '.' from the RegEx used for validating refresher exploration id. 