### PR TITLE
Fix part of #4374: Add docstrings to core.domain.classifier_domain

### DIFF
--- a/core/domain/classifier_domain.py
+++ b/core/domain/classifier_domain.py
@@ -125,46 +125,124 @@ class ClassifierTrainingJob(object):
 
     @property
     def job_id(self):
+        """Returns the job_id of the classifier training job.
+
+        Returns:
+            str. The unique id of the classifier training job.
+
+        """
         return self._job_id
 
     @property
     def algorithm_id(self):
+        """Returns the algorithm_id of the algorithm used for generating
+            the classifier.
+
+        Returns:
+            str. The id of the algorithm used for generating the classifier.
+        """
         return self._algorithm_id
 
     @property
     def interaction_id(self):
+        """Returns the interaction_id to which the algorithm belongs.
+
+        Returns:
+            str. The id of the interaction to which the algorithm belongs.
+        """
         return self._interaction_id
 
     @property
     def exp_id(self):
+        """Returns the exploration id for which the classifier will be
+            generated.
+
+        Returns:
+            str. The id of the exploration that contains the state
+                for which classifier will be generated.
+        """
         return self._exp_id
 
     @property
     def exp_version(self):
+        """Returns the exploration version.
+
+        Returns:
+            str. The version of the exploration when the training job was
+                generated.
+        """
         return self._exp_version
 
     @property
     def next_scheduled_check_time(self):
+        """Returns the next scheduled time to check the job.
+
+        Returns:
+            datetime.datetime. The next scheduled time to check the job.
+        """
         return self._next_scheduled_check_time
 
     @property
     def state_name(self):
+        """Returns the state_name for which the classifier will be generated.
+
+        Returns:
+            str. The name of the state for which the classifier will be
+                generated.
+        """
         return self._state_name
 
     @property
     def status(self):
+        """Returns the status of the training job request.
+
+        Returns:
+            str. The status of the training job request. This can be either
+                NEW (default), PENDING (when a job has been picked up) or
+                COMPLETE.
+        """
         return self._status
 
     @property
     def training_data(self):
+        """Returns the training data used for training the classifier.
+
+        Returns:
+            list. The training data that is used for training the
+                classifier. This is populated lazily when the job request is
+                picked up by the VM. The list contains dicts where each dict
+                represents a single training data group, for example:
+                training_data = [
+                    {
+                        'answer_group_index': 1,
+                        'answers': ['a1', 'a2']
+                    },
+                    {
+                        'answer_group_index': 2,
+                        'answers': ['a2', 'a3']
+                    }
+                ]
+        """
         return self._training_data
 
     @property
     def classifier_data(self):
+        """Returns the classifier data.
+
+        Returns:
+            dict. The actual classifier model used for
+                classification purpose.
+        """
         return self._classifier_data
 
     @property
     def data_schema_version(self):
+        """Returns the schema version of the data used by the classifier.
+
+        Returns:
+            int. Schema version of the data used by the
+                classifier. This depends on the algorithm ID.
+        """
         return self._data_schema_version
 
     def update_status(self, status):
@@ -348,18 +426,40 @@ class TrainingJobExplorationMapping(object):
 
     @property
     def exp_id(self):
+        """Returns the exploration id.
+
+        Returns:
+            str. The id of the exploration.
+        """
         return self._exp_id
 
     @property
     def exp_version(self):
+        """Returns the exploration version.
+
+        Returns:
+            int. The exploration version at the time the
+                corresponding classifier's training job was created.
+        """
         return self._exp_version
 
     @property
     def state_name(self):
+        """Returns the state_name to which the classifier belongs.
+
+        Returns:
+            str. The name of the state to which the classifier belongs.
+        """
         return self._state_name
 
     @property
     def job_id(self):
+        """Returns the job_id of the training job.
+
+        Returns:
+            str. The unique ID of the training job in the
+                job-exploration mapping.
+        """
         return self._job_id
 
     def to_dict(self):

--- a/core/domain/classifier_domain.py
+++ b/core/domain/classifier_domain.py
@@ -42,7 +42,7 @@ class ClassifierTrainingJob(object):
             belongs.
         exp_id: str. The id of the exploration that contains the state
             for which the classifier will be generated.
-        exp_version: str. The version of the exploration when
+        exp_version: int. The version of the exploration when
             the training job was generated.
         next_scheduled_check_time: datetime.datetime. The next scheduled time to
             check the job.
@@ -84,7 +84,7 @@ class ClassifierTrainingJob(object):
             belongs.
         exp_id: str. The id of the exploration id that contains the state
             for which classifier will be generated.
-        exp_version: str. The version of the exploration when
+        exp_version: int. The version of the exploration when
             the training job was generated.
         next_scheduled_check_time: datetime.datetime. The next scheduled time to
             check the job.
@@ -92,9 +92,9 @@ class ClassifierTrainingJob(object):
             generated.
         status: str. The status of the training job request. This can be either
             NEW (default), PENDING (when a job has been picked up) or COMPLETE.
-        training_data: list. The training data that is used for training the
-            classifier. This is populated lazily when the job request is picked
-            up by the VM. The list contains dicts where each dict
+        training_data: list(dict). The training data that is used for training
+            the classifier. This is populated lazily when the job request is
+            picked up by the VM. The list contains dicts where each dict
             represents a single training data group, for example:
             training_data = [
                 {
@@ -135,7 +135,7 @@ class ClassifierTrainingJob(object):
     @property
     def algorithm_id(self):
         """Returns the algorithm_id of the algorithm used for generating
-            the classifier.
+        the classifier.
 
         Returns:
             str. The id of the algorithm used for generating the classifier.
@@ -154,11 +154,11 @@ class ClassifierTrainingJob(object):
     @property
     def exp_id(self):
         """Returns the exploration id for which the classifier will be
-            generated.
+        generated.
 
         Returns:
             str. The id of the exploration that contains the state
-                for which classifier will be generated.
+            for which classifier will be generated.
         """
         return self._exp_id
 
@@ -167,8 +167,8 @@ class ClassifierTrainingJob(object):
         """Returns the exploration version.
 
         Returns:
-            str. The version of the exploration when the training job was
-                generated.
+            int. The version of the exploration when the training job was
+            generated.
         """
         return self._exp_version
 
@@ -187,7 +187,7 @@ class ClassifierTrainingJob(object):
 
         Returns:
             str. The name of the state for which the classifier will be
-                generated.
+            generated.
         """
         return self._state_name
 
@@ -197,8 +197,8 @@ class ClassifierTrainingJob(object):
 
         Returns:
             str. The status of the training job request. This can be either
-                NEW (default), PENDING (when a job has been picked up) or
-                COMPLETE.
+            NEW (default), PENDING (when a job has been picked up) or
+            COMPLETE.
         """
         return self._status
 
@@ -207,20 +207,20 @@ class ClassifierTrainingJob(object):
         """Returns the training data used for training the classifier.
 
         Returns:
-            list. The training data that is used for training the
-                classifier. This is populated lazily when the job request is
-                picked up by the VM. The list contains dicts where each dict
-                represents a single training data group, for example:
-                training_data = [
-                    {
-                        'answer_group_index': 1,
-                        'answers': ['a1', 'a2']
-                    },
-                    {
-                        'answer_group_index': 2,
-                        'answers': ['a2', 'a3']
-                    }
-                ]
+            list(dict). The training data that is used for training the
+            classifier. This is populated lazily when the job request is
+            picked up by the VM. The list contains dicts where each dict
+            represents a single training data group, for example:
+            training_data = [
+                {
+                    'answer_group_index': 1,
+                    'answers': ['a1', 'a2']
+                },
+                {
+                    'answer_group_index': 2,
+                    'answers': ['a2', 'a3']
+                }
+            ]
         """
         return self._training_data
 
@@ -230,7 +230,7 @@ class ClassifierTrainingJob(object):
 
         Returns:
             dict. The actual classifier model used for
-                classification purpose.
+            classification purpose.
         """
         return self._classifier_data
 
@@ -240,7 +240,7 @@ class ClassifierTrainingJob(object):
 
         Returns:
             int. Schema version of the data used by the
-                classifier. This depends on the algorithm ID.
+            classifier. This depends on the algorithm ID.
         """
         return self._data_schema_version
 
@@ -438,7 +438,7 @@ class TrainingJobExplorationMapping(object):
 
         Returns:
             int. The exploration version at the time the
-                corresponding classifier's training job was created.
+            corresponding classifier's training job was created.
         """
         return self._exp_version
 
@@ -457,7 +457,7 @@ class TrainingJobExplorationMapping(object):
 
         Returns:
             str. The unique ID of the training job in the
-                job-exploration mapping.
+            job-exploration mapping.
         """
         return self._job_id
 

--- a/core/domain/classifier_domain.py
+++ b/core/domain/classifier_domain.py
@@ -129,7 +129,6 @@ class ClassifierTrainingJob(object):
 
         Returns:
             str. The unique id of the classifier training job.
-
         """
         return self._job_id
 


### PR DESCRIPTION
This PR adds docstrings to `core.domain.classifier_domain.py`.

**Checklist**
- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [X] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [X] The PR is made from a branch that's **not** called "develop".
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [X] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
