### PR TITLE
Fix #4427: Show previous answer for map interaction

### DIFF
--- a/extensions/interactions/CodeRepl/directives/CodeRepl.js
+++ b/extensions/interactions/CodeRepl/directives/CodeRepl.js
@@ -44,7 +44,7 @@ oppia.directive('oppiaInteractiveCodeRepl', [
             EVENT_PROGRESS_NAV_SUBMITTED) {
           $scope.interactionIsActive = ($scope.getLastAnswer() === null);
 
-          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function(evt, data) {
+          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.interactionIsActive = false;
           });
           $scope.language = HtmlEscaperService.escapedJsonToObj(

--- a/extensions/interactions/GraphInput/directives/GraphInput.js
+++ b/extensions/interactions/GraphInput/directives/GraphInput.js
@@ -62,7 +62,7 @@ oppia.directive('oppiaInteractiveGraphInput', [
           };
           $scope.$on(EVENT_PROGRESS_NAV_SUBMITTED, $scope.submitGraph);
           $scope.interactionIsActive = ($scope.getLastAnswer() === null);
-          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function(evt, data) {
+          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.interactionIsActive = false;
 
             $scope.canAddVertex = false;
@@ -294,7 +294,7 @@ oppia.directive('graphViz', [
           $scope.VERTEX_RADIUS = graphDetailService.VERTEX_RADIUS;
           $scope.EDGE_WIDTH = graphDetailService.EDGE_WIDTH;
 
-          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function(evt, data) {
+          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.state.currentMode = null;
           });
 

--- a/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
+++ b/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
@@ -96,7 +96,7 @@ oppia.directive('oppiaInteractiveImageClickInput', [
               return 'inline';
             }
           };
-          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function(evt, data) {
+          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.interactionIsActive = false;
           });
           $scope.onMousemoveImage = function(event) {

--- a/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
+++ b/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
@@ -44,14 +44,28 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
           $scope.interactionIsActive = ($scope.getLastAnswer() === null);
           $scope.mapMarkers = [];
 
-          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
-            $scope.interactionIsActive = false;
+          $scope.setOverlay = function() {
             $scope.overlayStyle = {
               'background-color': 'black'
             };
             $scope.mapStyle = {
               opacity: '0.8'
             };
+          };
+
+          $scope.hideOverlay = function() {
+            $scope.overlayStyle = {
+              'background-color': 'white'
+            };
+            $scope.mapStyle = {
+              opacity: '1'
+            };
+          };
+
+
+          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
+            $scope.interactionIsActive = false;
+            $scope.setOverlay();
           });
 
           $scope.$on('showInteraction', function() {
@@ -86,28 +100,18 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
             draggable: $scope.interactionIsActive
           };
 
-          $scope.showOverlay = function() {
+          $scope.onMouseOver = function() {
             if ($scope.interactionIsActive) {
               return;
             }
-            $scope.overlayStyle = {
-              'background-color': 'black'
-            };
-            $scope.mapStyle = {
-              opacity: '0.8'
-            };
+            $scope.setOverlay();
           };
 
-          $scope.hideOverlay = function() {
+          $scope.onMouseOut = function() {
             if ($scope.interactionIsActive) {
               return;
             }
-            $scope.overlayStyle = {
-              'background-color': 'white'
-            };
-            $scope.mapStyle = {
-              opacity: '1'
-            };
+            $scope.hideOverlay();
           };
 
           $scope.registerClick = function($event, $params) {

--- a/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
+++ b/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
@@ -86,7 +86,7 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
             draggable: $scope.interactionIsActive
           };
 
-          $scope.setOverlay = function() {
+          $scope.showOverlay = function() {
             if ($scope.interactionIsActive) {
               return;
             }
@@ -98,7 +98,7 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
             };
           };
 
-          $scope.resetOverlay = function() {
+          $scope.hideOverlay = function() {
             if ($scope.interactionIsActive) {
               return;
             }

--- a/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
+++ b/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
@@ -46,6 +46,12 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
 
           $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.interactionIsActive = false;
+            $scope.overlayStyle = {
+              'background-color' : 'black'
+            };
+            $scope.mapStyle = {
+              'opacity' : '0.8'
+            };
           });
 
           $scope.$on('showInteraction', function() {
@@ -78,6 +84,30 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
             zoom: zoomLevel,
             mapTypeId: google.maps.MapTypeId.ROADMAP,
             draggable: $scope.interactionIsActive
+          };
+
+          $scope.setOverlay = function() {
+            if ($scope.interactionIsActive) {
+              return;
+            }
+            $scope.overlayStyle = {
+              'background-color' : 'black'
+            };
+            $scope.mapStyle = {
+              'opacity' : '0.8'
+            };
+          };
+
+          $scope.resetOverlay = function() {
+            if ($scope.interactionIsActive) {
+              return;
+            }
+            $scope.overlayStyle = {
+              'background-color' : 'white'
+            };
+            $scope.mapStyle = {
+              'opacity' : '1'
+            };
           };
 
           $scope.registerClick = function($event, $params) {

--- a/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
+++ b/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
@@ -50,7 +50,7 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
               'background-color' : 'black'
             };
             $scope.mapStyle = {
-              'opacity' : '0.8'
+              opacity : '0.8'
             };
           });
 
@@ -94,7 +94,7 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
               'background-color' : 'black'
             };
             $scope.mapStyle = {
-              'opacity' : '0.8'
+              opacity : '0.8'
             };
           };
 
@@ -106,7 +106,7 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
               'background-color' : 'white'
             };
             $scope.mapStyle = {
-              'opacity' : '1'
+              opacity : '1'
             };
           };
 

--- a/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
+++ b/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
@@ -44,7 +44,7 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
           $scope.interactionIsActive = ($scope.getLastAnswer() === null);
           $scope.mapMarkers = [];
 
-          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function(evt, data) {
+          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.interactionIsActive = false;
           });
 

--- a/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
+++ b/extensions/interactions/InteractiveMap/directives/InteractiveMap.js
@@ -47,10 +47,10 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
           $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.interactionIsActive = false;
             $scope.overlayStyle = {
-              'background-color' : 'black'
+              'background-color': 'black'
             };
             $scope.mapStyle = {
-              opacity : '0.8'
+              opacity: '0.8'
             };
           });
 
@@ -91,10 +91,10 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
               return;
             }
             $scope.overlayStyle = {
-              'background-color' : 'black'
+              'background-color': 'black'
             };
             $scope.mapStyle = {
-              opacity : '0.8'
+              opacity: '0.8'
             };
           };
 
@@ -103,10 +103,10 @@ oppia.directive('oppiaInteractiveInteractiveMap', [
               return;
             }
             $scope.overlayStyle = {
-              'background-color' : 'white'
+              'background-color': 'white'
             };
             $scope.mapStyle = {
-              opacity : '1'
+              opacity: '1'
             };
           };
 

--- a/extensions/interactions/InteractiveMap/directives/interactive_map_interaction_directive.html
+++ b/extensions/interactions/InteractiveMap/directives/interactive_map_interaction_directive.html
@@ -35,7 +35,10 @@
 </style>
 
 <div class="interactive-map-container">
-  <div id="map_canvas" ui-map="map" ui-options="mapOptions"
-       ui-event="{'map-click': 'registerClick($event, $params)'}">
+  <div ng-style="overlayStyle">
+    <div id="map_canvas" ng-style="mapStyle" ui-map="map" ui-options="mapOptions"
+        ui-event="{'map-click': 'registerClick($event, $params)', 'map-mouseover': 'setOverlay()',
+                   'map-mouseout': 'resetOverlay()'}">
+    </div>
   </div>
 </div>

--- a/extensions/interactions/InteractiveMap/directives/interactive_map_interaction_directive.html
+++ b/extensions/interactions/InteractiveMap/directives/interactive_map_interaction_directive.html
@@ -37,8 +37,8 @@
 <div class="interactive-map-container">
   <div ng-style="overlayStyle">
     <div id="map_canvas" ng-style="mapStyle" ui-map="map" ui-options="mapOptions"
-        ui-event="{'map-click': 'registerClick($event, $params)', 'map-mouseover': 'setOverlay()',
-                   'map-mouseout': 'resetOverlay()'}">
+        ui-event="{'map-click': 'registerClick($event, $params)', 'map-mouseover': 'showOverlay()',
+                   'map-mouseout': 'hideOverlay()'}">
     </div>
   </div>
 </div>

--- a/extensions/interactions/InteractiveMap/directives/interactive_map_interaction_directive.html
+++ b/extensions/interactions/InteractiveMap/directives/interactive_map_interaction_directive.html
@@ -37,8 +37,8 @@
 <div class="interactive-map-container">
   <div ng-style="overlayStyle">
     <div id="map_canvas" ng-style="mapStyle" ui-map="map" ui-options="mapOptions"
-        ui-event="{'map-click': 'registerClick($event, $params)', 'map-mouseover': 'showOverlay()',
-                   'map-mouseout': 'hideOverlay()'}">
+        ui-event="{'map-click': 'registerClick($event, $params)', 'map-mouseover': 'onMouseOver()',
+                   'map-mouseout': 'onMouseOut()'}">
     </div>
   </div>
 </div>

--- a/extensions/interactions/LogicProof/directives/LogicProof.js
+++ b/extensions/interactions/LogicProof/directives/LogicProof.js
@@ -44,7 +44,7 @@ oppia.directive('oppiaInteractiveLogicProof', [
           $scope.questionData = angular.copy(LOGIC_PROOF_DEFAULT_QUESTION_DATA);
 
           $scope.interactionIsActive = ($scope.getLastAnswer() === null);
-          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function(evt, data) {
+          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.interactionIsActive = false;
           });
 

--- a/extensions/interactions/MusicNotesInput/directives/MusicNotesInput.js
+++ b/extensions/interactions/MusicNotesInput/directives/MusicNotesInput.js
@@ -114,7 +114,7 @@ oppia.directive('oppiaInteractiveMusicNotesInput', [
           HtmlEscaperService.escapedJsonToObj(attrs.initialSequenceWithValue) :
           scope.getLastAnswer();
 
-        scope.$on(EVENT_NEW_CARD_AVAILABLE, function(evt, data) {
+        scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
           scope.interactionIsActive = false;
           scope.initialSequence = scope.getLastAnswer();
           scope.reinitStaff();

--- a/extensions/interactions/PencilCodeEditor/directives/PencilCodeEditor.js
+++ b/extensions/interactions/PencilCodeEditor/directives/PencilCodeEditor.js
@@ -47,7 +47,7 @@ oppia.directive('oppiaInteractivePencilCodeEditor', [
           var iframeDiv = $element.find('.pencil-code-editor-iframe').get(0);
           var pce = new PencilCodeEmbed(iframeDiv);
           pce.beginLoad($scope.initialCode);
-          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function(evt, data) {
+          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.interactionIsActive = false;
             pce.hideMiddleButton();
             pce.hideToggleButton();


### PR DESCRIPTION
Similar to other supplementary interactions, now MapsInteraction is also disabled with last answer shown, when it is revisited.