### PR TITLE
Fix #4275: Embedding e2e test creation

### DIFF
--- a/assets/scripts/embedding_tests_dev_0.0.1.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.1.min.html
@@ -8,21 +8,27 @@
 
 <script src="/assets/scripts/oppia-player-0.0.1.js"></script>
 <script src="/assets/scripts/embedding_tests.js"></script>
+<script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
+
+<form action="#" onsubmit="update()">
+  <input id="embedding-exploration-id" type="text" placeholder="explorationId">
+  <input id="embedding-submit-btn" type="submit" value="Submit">
+</form>
 
 <div>
   <h3>Iframe embedding</h3>
-  <iframe src="/embed/exploration/12" width="700" height="600">
+  <iframe src="/embed/exploration/idToBeReplaced" width="700" height="600">
   </iframe>
 </div>
 
 <div class="protractor-test-standard">
   <h3>Standard embedding of the latest version</h3>
-  <oppia oppia-id="12"></oppia>
+  <oppia oppia-id="idToBeReplaced"></oppia>
 </div>
 
 <div class="protractor-test-old-version">
   <h3>Standard embedding of version 2 of the exploration with deferred loading</h3>
-  <oppia oppia-id="12" autoload="false" exploration-version="2"></oppia>
+  <oppia oppia-id="idToBeReplaced" autoload="false" exploration-version="2"></oppia>
 </div>
 
 <div class="protractor-test-missing-id">
@@ -41,32 +47,18 @@
 </div>
 
 <script type="text/javascript">
-  // Get exploration id of newly created exploration in embedding.js and
-  // replace old exploration id (12) with new one.
-  (function (){
-    var xhttp = new XMLHttpRequest();
-    xhttp.onreadystatechange = function() {
-      if (this.readyState == 4 && this.status == 200) {        
-        var res = xhttp.responseText.slice(5);
-        res = JSON.parse(res);
-        var activity_list = res['activity_list'];
-        if(activity_list.length === 0){
-          console.error('No explorations found');
-        }else if(activity_list.length > 1){
-          console.error('More than 1 explorations found');
-        }
-        // Get exploration id.
-        explorationId = activity_list[0]['id'];
-        document.getElementsByTagName('iframe')[0].src = '/embed/exploration/' + explorationId;
-        var elems = document.getElementsByTagName('oppia');
-        for(var i = 0; i < elems.length; i++){
-          if(elems[i].hasAttribute('oppia-id') && elems[i].getAttribute('oppia-id') === '12'){
-            elems[i].setAttribute('oppia-id', explorationId);
-          }
-        }  
-      }
-    };
-    xhttp.open("GET", "/searchhandler/data?q=Protractor Test", false);
-    xhttp.send(null);
-  })();
+  var currentExplorationId = 'idToBeReplaced';
+  var update = function(){
+    var newExplorationId = $('#embedding-exploration-id').val();
+    $('div > iframe').each(function(index){
+      var src = $(this).attr('src');
+      src = src.replace(currentExplorationId, newExplorationId);
+      $(this).attr('src', src);
+    });
+
+    // For first time loading of deferred loading version.
+    $('oppia[oppia-id="idToBeReplaced"]').each(function(index){
+      $(this).attr('oppia-id', newExplorationId);
+    });
+  }  
 </script>

--- a/assets/scripts/embedding_tests_dev_0.0.1.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.1.min.html
@@ -21,8 +21,8 @@
 </div>
 
 <div class="protractor-test-old-version">
-  <h3>Standard embedding of version 1 of the exploration with deferred loading</h3>
-  <oppia oppia-id="12" autoload="false" exploration-version="1"></oppia>
+  <h3>Standard embedding of version 2 of the exploration with deferred loading</h3>
+  <oppia oppia-id="12" autoload="false" exploration-version="2"></oppia>
 </div>
 
 <div class="protractor-test-missing-id">
@@ -39,3 +39,34 @@
   <h3>ERROR: 404 error with deferred loading</h3>
   <oppia oppia-id="fake_id" autoload="false"></oppia>
 </div>
+
+<script type="text/javascript">
+  // Get exploration id of newly created exploration in embedding.js and
+  // replace old exploration id (12) with new one.
+  (function (){
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+      if (this.readyState == 4 && this.status == 200) {        
+        var res = xhttp.responseText.slice(5);
+        res = JSON.parse(res);
+        var activity_list = res['activity_list'];
+        if(activity_list.length === 0){
+          console.error('No explorations found');
+        }else if(activity_list.length > 1){
+          console.error('More than 1 explorations found');
+        }
+        // Get exploration id.
+        explorationId = activity_list[0]['id'];
+        document.getElementsByTagName('iframe')[0].src = '/embed/exploration/' + explorationId;
+        var elems = document.getElementsByTagName('oppia');
+        for(var i = 0; i < elems.length; i++){
+          if(elems[i].hasAttribute('oppia-id') && elems[i].getAttribute('oppia-id') === '12'){
+            elems[i].setAttribute('oppia-id', explorationId);
+          }
+        }  
+      }
+    };
+    xhttp.open("GET", "/searchhandler/data?q=Protractor Test", false);
+    xhttp.send(null);
+  })();
+</script>

--- a/assets/scripts/embedding_tests_dev_0.0.1.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.1.min.html
@@ -6,57 +6,68 @@
   the Oppia iframe to the containing page.
 </p>
 
+<style type="text/css">
+  .embedding-content{
+    display: none;
+  }
+</style>
+
 <script src="/assets/scripts/oppia-player-0.0.1.js"></script>
 <script src="/assets/scripts/embedding_tests.js"></script>
 <script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
 
 <input id="embedding-exploration-id" type="text" placeholder="explorationId">
-<input id="embedding-submit-btn" type="submit" value="Submit" onclick="update()">
+<input id="embedding-submit-btn" type="submit" value="Update Exploration ID" onclick="onChangeExpId()">
 
-<div>
+<div class="embedding-content">
   <h3>Iframe embedding</h3>
   <iframe src="/embed/exploration/idToBeReplaced" width="700" height="600">
   </iframe>
 </div>
 
-<div class="protractor-test-standard">
+<div class="protractor-test-standard embedding-content">
   <h3>Standard embedding of the latest version</h3>
   <oppia oppia-id="idToBeReplaced"></oppia>
 </div>
 
-<div class="protractor-test-old-version">
+<div class="protractor-test-old-version embedding-content">
   <h3>Standard embedding of version 2 of the exploration with deferred loading</h3>
   <oppia oppia-id="idToBeReplaced" autoload="false" exploration-version="2"></oppia>
 </div>
 
-<div class="protractor-test-missing-id">
+<div class="protractor-test-missing-id embedding-content">
   <h3>ERROR: No oppia id specified</h3>
   <oppia></oppia>
 </div>
 
-<div class="protractor-test-invalid-id">
+<div class="protractor-test-invalid-id embedding-content">
   <h3>ERROR: 404 error</h3>
   <oppia oppia-id="fake_id"></oppia>
 </div>
 
-<div class="protractor-test-invalid-id-deferred">
+<div class="protractor-test-invalid-id-deferred embedding-content">
   <h3>ERROR: 404 error with deferred loading</h3>
   <oppia oppia-id="fake_id" autoload="false"></oppia>
 </div>
 
 <script type="text/javascript">
-  var currentExplorationId = 'idToBeReplaced';
-  var update = function(){
+  // To keep track of next exploration id to be replaced.
+  var placeHolderExplorationId = 'idToBeReplaced';
+  var onChangeExpId = function() {
     var newExplorationId = $('#embedding-exploration-id').val();
-    $('div > iframe').each(function(index){
+    $('div > iframe').each(function(index) {
       var src = $(this).attr('src');
-      src = src.replace(currentExplorationId, newExplorationId);
+      src = src.replace(placeHolderExplorationId, newExplorationId);
       $(this).attr('src', src);
     });
+    placeHolderExplorationId = newExplorationId;
 
     // For first time loading of deferred loading version.
-    $('oppia[oppia-id="idToBeReplaced"]').each(function(index){
+    $('oppia[oppia-id="idToBeReplaced"]').each(function(index) {
       $(this).attr('oppia-id', newExplorationId);
     });
-  }  
+
+    // Show the contents
+    $('.embedding-content').show();
+  };
 </script>

--- a/assets/scripts/embedding_tests_dev_0.0.1.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.1.min.html
@@ -10,10 +10,8 @@
 <script src="/assets/scripts/embedding_tests.js"></script>
 <script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
 
-<form action="#" onsubmit="update()">
-  <input id="embedding-exploration-id" type="text" placeholder="explorationId">
-  <input id="embedding-submit-btn" type="submit" value="Submit">
-</form>
+<input id="embedding-exploration-id" type="text" placeholder="explorationId">
+<input id="embedding-submit-btn" type="submit" value="Submit" onclick="update()">
 
 <div>
   <h3>Iframe embedding</h3>

--- a/assets/scripts/embedding_tests_dev_0.0.1.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.1.min.html
@@ -7,7 +7,7 @@
 </p>
 
 <style type="text/css">
-  .embedding-content{
+  .protractor-test-results {
     display: none;
   }
 </style>
@@ -16,58 +16,61 @@
 <script src="/assets/scripts/embedding_tests.js"></script>
 <script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
 
-<input id="embedding-exploration-id" type="text" placeholder="explorationId">
-<input id="embedding-submit-btn" type="submit" value="Update Exploration ID" onclick="onChangeExpId()">
+<input class="protractor-test-exploration-id-input-field" type="text" placeholder="explorationId">
+<input class="protractor-test-exploration-id-submit-button" type="submit" value="Update Exploration ID" onclick="onChangeExpId()">
 
-<div class="embedding-content">
-  <h3>Iframe embedding</h3>
-  <iframe src="/embed/exploration/idToBeReplaced" width="700" height="600">
-  </iframe>
-</div>
+<div class="protractor-test-results">
+  <div>
+    <h3>Iframe embedding</h3>
+    <iframe src="/embed/exploration/idToBeReplaced" width="700" height="600">
+    </iframe>
+  </div>
 
-<div class="protractor-test-standard embedding-content">
-  <h3>Standard embedding of the latest version</h3>
-  <oppia oppia-id="idToBeReplaced"></oppia>
-</div>
+  <div class="protractor-test-standard">
+    <h3>Standard embedding of the latest version</h3>
+    <oppia oppia-id="idToBeReplaced"></oppia>
+  </div>
 
-<div class="protractor-test-old-version embedding-content">
-  <h3>Standard embedding of version 2 of the exploration with deferred loading</h3>
-  <oppia oppia-id="idToBeReplaced" autoload="false" exploration-version="2"></oppia>
-</div>
+  <div class="protractor-test-old-version">
+    <h3>Standard embedding of version 2 of the exploration with deferred loading</h3>
+    <oppia oppia-id="idToBeReplaced" autoload="false" exploration-version="2"></oppia>
+  </div>
 
-<div class="protractor-test-missing-id embedding-content">
-  <h3>ERROR: No oppia id specified</h3>
-  <oppia></oppia>
-</div>
+  <div class="protractor-test-missing-id">
+    <h3>ERROR: No oppia id specified</h3>
+    <oppia></oppia>
+  </div>
 
-<div class="protractor-test-invalid-id embedding-content">
-  <h3>ERROR: 404 error</h3>
-  <oppia oppia-id="fake_id"></oppia>
-</div>
+  <div class="protractor-test-invalid-id">
+    <h3>ERROR: 404 error</h3>
+    <oppia oppia-id="fake_id"></oppia>
+  </div>
 
-<div class="protractor-test-invalid-id-deferred embedding-content">
-  <h3>ERROR: 404 error with deferred loading</h3>
-  <oppia oppia-id="fake_id" autoload="false"></oppia>
+  <div class="protractor-test-invalid-id-deferred">
+    <h3>ERROR: 404 error with deferred loading</h3>
+    <oppia oppia-id="fake_id" autoload="false"></oppia>
+  </div>
 </div>
 
 <script type="text/javascript">
   // To keep track of next exploration id to be replaced.
-  var placeHolderExplorationId = 'idToBeReplaced';
+  var placeholderExplorationId = 'idToBeReplaced';
   var onChangeExpId = function() {
-    var newExplorationId = $('#embedding-exploration-id').val();
+    var newExplorationId = $(
+      '.protractor-test-exploration-id-input-field').val();
     $('div > iframe').each(function(index) {
       var src = $(this).attr('src');
-      src = src.replace(placeHolderExplorationId, newExplorationId);
+      src = src.replace(placeholderExplorationId, newExplorationId);
       $(this).attr('src', src);
     });
-    placeHolderExplorationId = newExplorationId;
+    placeholderExplorationId = newExplorationId;
 
     // For first time loading of deferred loading version.
     $('oppia[oppia-id="idToBeReplaced"]').each(function(index) {
       $(this).attr('oppia-id', newExplorationId);
     });
 
-    // Show the contents
-    $('.embedding-content').show();
+    // Show the contents.
+    $('.protractor-test-results').show();
   };
 </script>

--- a/assets/scripts/embedding_tests_dev_0.0.2.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.2.min.html
@@ -21,8 +21,8 @@
 </div>
 
 <div class="protractor-test-old-version">
-  <h3>Standard embedding of version 1 of the exploration</h3>
-  <oppia oppia-id="12" exploration-version="1"></oppia>
+  <h3>Standard embedding of version 2 of the exploration</h3>
+  <oppia oppia-id="12" exploration-version="2"></oppia>
 </div>
 
 <div class="protractor-test-missing-id">
@@ -34,3 +34,34 @@
   <h3>ERROR: 404 error</h3>
   <oppia oppia-id="fake_id"></oppia>
 </div>
+
+<script type="text/javascript">
+  // Get exploration id of newly created exploration in embedding.js and
+  // replace old exploration id (12) with new one.
+  (function (){
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+      if (this.readyState == 4 && this.status == 200) {        
+        var res = xhttp.responseText.slice(5);
+        res = JSON.parse(res);
+        var activity_list = res['activity_list'];
+        if(activity_list.length === 0){
+          console.error('No explorations found');
+        }else if(activity_list.length > 1){
+          console.error('More than 1 explorations found');
+        }
+        // Get exploration id.
+        explorationId = activity_list[0]['id'];
+        document.getElementsByTagName('iframe')[0].src = '/embed/exploration/' + explorationId;
+        var elems = document.getElementsByTagName('oppia');
+        for(var i = 0; i < elems.length; i++){
+          if(elems[i].hasAttribute('oppia-id') && elems[i].getAttribute('oppia-id') === '12'){
+            elems[i].setAttribute('oppia-id', explorationId);
+          }
+        }  
+      }
+    };
+    xhttp.open("GET", "/searchhandler/data?q=Protractor Test", false);
+    xhttp.send(null);
+  })();
+</script>

--- a/assets/scripts/embedding_tests_dev_0.0.2.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.2.min.html
@@ -6,52 +6,63 @@
   the Oppia iframe to the containing page.
 </p>
 
+<style type="text/css">
+  .embedding-content{
+    display: none;
+  }
+</style>
+
 <script src="/assets/scripts/oppia-player-0.0.2.min.js"></script>
 <script src="/assets/scripts/embedding_tests.js"></script>
 <script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
 
 <input id="embedding-exploration-id" type="text" placeholder="explorationId">
-<input id="embedding-submit-btn" type="submit" value="Submit" onclick="update()">
+<input id="embedding-submit-btn" type="submit" value="Update Exploration ID" onclick="onChangeExpId()">
 
-<div>
+<div class=" embedding-content">
   <h3>Iframe embedding</h3>
   <iframe src="/embed/exploration/idToBeReplaced" width="700" height="600">
   </iframe>
 </div>
 
-<div class="protractor-test-standard">
+<div class="protractor-test-standard embedding-content">
   <h3>Standard embedding of the latest version</h3>
   <oppia oppia-id="idToBeReplaced"></oppia>
 </div>
 
-<div class="protractor-test-old-version">
+<div class="protractor-test-old-version embedding-content">
   <h3>Standard embedding of version 2 of the exploration</h3>
   <oppia oppia-id="idToBeReplaced" exploration-version="2"></oppia>
 </div>
 
-<div class="protractor-test-missing-id">
+<div class="protractor-test-missing-id embedding-content">
   <h3>ERROR: No oppia id specified</h3>
   <oppia></oppia>
 </div>
 
-<div class="protractor-test-invalid-id">
+<div class="protractor-test-invalid-id embedding-content">
   <h3>ERROR: 404 error</h3>
   <oppia oppia-id="fake_id"></oppia>
 </div>
 
 <script type="text/javascript">
-  var currentExplorationId = 'idToBeReplaced';
-  var update = function(){
+  // To keep track of next exploration id to be replaced.
+  var placeHolderExplorationId = 'idToBeReplaced';
+  var onChangeExpId = function() {
     var newExplorationId = $('#embedding-exploration-id').val();
-    $('div > iframe').each(function(index){
+    $('div > iframe').each(function(index) {
       var src = $(this).attr('src');
-      src = src.replace(currentExplorationId, newExplorationId);
+      src = src.replace(placeHolderExplorationId, newExplorationId);
       $(this).attr('src', src);
     });
+    placeHolderExplorationId = newExplorationId;
 
     // For first time loading of deferred loading version.
-    $('oppia[oppia-id="idToBeReplaced"]').each(function(index){
+    $('oppia[oppia-id="idToBeReplaced"]').each(function(index) {
       $(this).attr('oppia-id', newExplorationId);
     });
-  }  
+
+    // Show the contents
+    $('.embedding-content').show();
+  };
 </script>

--- a/assets/scripts/embedding_tests_dev_0.0.2.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.2.min.html
@@ -7,7 +7,7 @@
 </p>
 
 <style type="text/css">
-  .embedding-content{
+  .protractor-test-results {
     display: none;
   }
 </style>
@@ -16,46 +16,49 @@
 <script src="/assets/scripts/embedding_tests.js"></script>
 <script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
 
-<input id="embedding-exploration-id" type="text" placeholder="explorationId">
-<input id="embedding-submit-btn" type="submit" value="Update Exploration ID" onclick="onChangeExpId()">
+<input class="protractor-test-exploration-id-input-field" type="text" placeholder="explorationId">
+<input class="protractor-test-exploration-id-submit-button" type="submit" value="Update Exploration ID" onclick="onChangeExpId()">
 
-<div class=" embedding-content">
-  <h3>Iframe embedding</h3>
-  <iframe src="/embed/exploration/idToBeReplaced" width="700" height="600">
-  </iframe>
-</div>
+<div class="protractor-test-results">
+  <div>
+    <h3>Iframe embedding</h3>
+    <iframe src="/embed/exploration/idToBeReplaced" width="700" height="600">
+    </iframe>
+  </div>
 
-<div class="protractor-test-standard embedding-content">
-  <h3>Standard embedding of the latest version</h3>
-  <oppia oppia-id="idToBeReplaced"></oppia>
-</div>
+  <div class="protractor-test-standard">
+    <h3>Standard embedding of the latest version</h3>
+    <oppia oppia-id="idToBeReplaced"></oppia>
+  </div>
 
-<div class="protractor-test-old-version embedding-content">
-  <h3>Standard embedding of version 2 of the exploration</h3>
-  <oppia oppia-id="idToBeReplaced" exploration-version="2"></oppia>
-</div>
+  <div class="protractor-test-old-version">
+    <h3>Standard embedding of version 2 of the exploration</h3>
+    <oppia oppia-id="idToBeReplaced" exploration-version="2"></oppia>
+  </div>
 
-<div class="protractor-test-missing-id embedding-content">
-  <h3>ERROR: No oppia id specified</h3>
-  <oppia></oppia>
-</div>
+  <div class="protractor-test-missing-id">
+    <h3>ERROR: No oppia id specified</h3>
+    <oppia></oppia>
+  </div>
 
-<div class="protractor-test-invalid-id embedding-content">
-  <h3>ERROR: 404 error</h3>
-  <oppia oppia-id="fake_id"></oppia>
+  <div class="protractor-test-invalid-id">
+    <h3>ERROR: 404 error</h3>
+    <oppia oppia-id="fake_id"></oppia>
+  </div>
 </div>
 
 <script type="text/javascript">
   // To keep track of next exploration id to be replaced.
-  var placeHolderExplorationId = 'idToBeReplaced';
+  var placeholderExplorationId = 'idToBeReplaced';
   var onChangeExpId = function() {
-    var newExplorationId = $('#embedding-exploration-id').val();
+    var newExplorationId = $(
+      '.protractor-test-exploration-id-input-field').val();
     $('div > iframe').each(function(index) {
       var src = $(this).attr('src');
-      src = src.replace(placeHolderExplorationId, newExplorationId);
+      src = src.replace(placeholderExplorationId, newExplorationId);
       $(this).attr('src', src);
     });
-    placeHolderExplorationId = newExplorationId;
+    placeholderExplorationId = newExplorationId;
 
     // For first time loading of deferred loading version.
     $('oppia[oppia-id="idToBeReplaced"]').each(function(index) {
@@ -63,6 +66,6 @@
     });
 
     // Show the contents
-    $('.embedding-content').show();
+    $('.protractor-test-results').show();
   };
 </script>

--- a/assets/scripts/embedding_tests_dev_0.0.2.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.2.min.html
@@ -10,10 +10,8 @@
 <script src="/assets/scripts/embedding_tests.js"></script>
 <script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
 
-<form action="#" onsubmit="update()">
-  <input id="embedding-exploration-id" type="text" placeholder="explorationId">
-  <input id="embedding-submit-btn" type="submit" value="Submit">
-</form>
+<input id="embedding-exploration-id" type="text" placeholder="explorationId">
+<input id="embedding-submit-btn" type="submit" value="Submit" onclick="update()">
 
 <div>
   <h3>Iframe embedding</h3>

--- a/assets/scripts/embedding_tests_dev_0.0.2.min.html
+++ b/assets/scripts/embedding_tests_dev_0.0.2.min.html
@@ -8,21 +8,27 @@
 
 <script src="/assets/scripts/oppia-player-0.0.2.min.js"></script>
 <script src="/assets/scripts/embedding_tests.js"></script>
+<script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
+
+<form action="#" onsubmit="update()">
+  <input id="embedding-exploration-id" type="text" placeholder="explorationId">
+  <input id="embedding-submit-btn" type="submit" value="Submit">
+</form>
 
 <div>
   <h3>Iframe embedding</h3>
-  <iframe src="/embed/exploration/12" width="700" height="600">
+  <iframe src="/embed/exploration/idToBeReplaced" width="700" height="600">
   </iframe>
 </div>
 
 <div class="protractor-test-standard">
   <h3>Standard embedding of the latest version</h3>
-  <oppia oppia-id="12"></oppia>
+  <oppia oppia-id="idToBeReplaced"></oppia>
 </div>
 
 <div class="protractor-test-old-version">
   <h3>Standard embedding of version 2 of the exploration</h3>
-  <oppia oppia-id="12" exploration-version="2"></oppia>
+  <oppia oppia-id="idToBeReplaced" exploration-version="2"></oppia>
 </div>
 
 <div class="protractor-test-missing-id">
@@ -36,32 +42,18 @@
 </div>
 
 <script type="text/javascript">
-  // Get exploration id of newly created exploration in embedding.js and
-  // replace old exploration id (12) with new one.
-  (function (){
-    var xhttp = new XMLHttpRequest();
-    xhttp.onreadystatechange = function() {
-      if (this.readyState == 4 && this.status == 200) {        
-        var res = xhttp.responseText.slice(5);
-        res = JSON.parse(res);
-        var activity_list = res['activity_list'];
-        if(activity_list.length === 0){
-          console.error('No explorations found');
-        }else if(activity_list.length > 1){
-          console.error('More than 1 explorations found');
-        }
-        // Get exploration id.
-        explorationId = activity_list[0]['id'];
-        document.getElementsByTagName('iframe')[0].src = '/embed/exploration/' + explorationId;
-        var elems = document.getElementsByTagName('oppia');
-        for(var i = 0; i < elems.length; i++){
-          if(elems[i].hasAttribute('oppia-id') && elems[i].getAttribute('oppia-id') === '12'){
-            elems[i].setAttribute('oppia-id', explorationId);
-          }
-        }  
-      }
-    };
-    xhttp.open("GET", "/searchhandler/data?q=Protractor Test", false);
-    xhttp.send(null);
-  })();
+  var currentExplorationId = 'idToBeReplaced';
+  var update = function(){
+    var newExplorationId = $('#embedding-exploration-id').val();
+    $('div > iframe').each(function(index){
+      var src = $(this).attr('src');
+      src = src.replace(currentExplorationId, newExplorationId);
+      $(this).attr('src', src);
+    });
+
+    // For first time loading of deferred loading version.
+    $('oppia[oppia-id="idToBeReplaced"]').each(function(index){
+      $(this).attr('oppia-id', newExplorationId);
+    });
+  }  
 </script>

--- a/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
+++ b/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
@@ -5,10 +5,8 @@
 <script src="/assets/scripts/embedding_tests.js"></script>
 <script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
 
-<form action="#" onsubmit="update()">
-  <input id="embedding-exploration-id" type="text" placeholder="explorationId">
-  <input id="embedding-submit-btn" type="submit" value="Submit">
-</form>
+<input id="embedding-exploration-id" type="text" placeholder="explorationId">
+<input id="embedding-submit-btn" type="submit" value="Submit" onclick="update()">
 
 <div class="protractor-test-embedded-exploration">
   <h3>Standard embedding of the latest version</h3>

--- a/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
+++ b/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
@@ -2,7 +2,7 @@
 <p>For instructions: see the README file in /assets/scripts.</p>
 
 <style type="text/css">
-  .embedding-content{
+  .protractor-test-results {
     display: none;
   }
 </style>
@@ -11,28 +11,30 @@
 <script src="/assets/scripts/embedding_tests.js"></script>
 <script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
 
-<input id="embedding-exploration-id" type="text" placeholder="explorationId">
-<input id="embedding-submit-btn" type="submit" value="Update Exploration ID" onclick="onChangeExpId()">
+<input class="protractor-test-exploration-id-input-field" type="text" placeholder="explorationId">
+<input class="protractor-test-exploration-id-submit-button" type="submit" value="Update Exploration ID" onclick="onChangeExpId()">
 
-<div class="protractor-test-embedded-exploration embedding-content">
-  <h3>Standard embedding of the latest version</h3>
-  <oppia oppia-id="idToBeReplaced"></oppia>
+<div class="protractor-test-results">
+  <div class="protractor-test-embedded-exploration">
+    <h3>Standard embedding of the latest version</h3>
+    <oppia oppia-id="idToBeReplaced"></oppia>
+  </div>
 </div>
 
 <script type="text/javascript">
   // To keep track of next exploration id to be replaced.
-  var placeHolderExplorationId = 'idToBeReplaced';
+  var placeholderExplorationId = 'idToBeReplaced';
   var onChangeExpId = function() {
-    var newExplorationId = $('#embedding-exploration-id').val();
+    var newExplorationId = $(
+      '.protractor-test-exploration-id-input-field').val();
     $('div > iframe').each(function(index) {
       var src = $(this).attr('src');
-      src = src.replace(placeHolderExplorationId, newExplorationId);
+      src = src.replace(placeholderExplorationId, newExplorationId);
       $(this).attr('src', src);
     });
-    placeHolderExplorationId = newExplorationId;
+    placeholderExplorationId = newExplorationId;
 
-    // Show the contents
-    $('.embedding-content').show();
+    // Show the contents.
+    $('.protractor-test-results').show();
   };
 </script>
-

--- a/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
+++ b/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
@@ -3,34 +3,28 @@
 
 <script src="/assets/scripts/oppia-player-0.0.1.js"></script>
 <script src="/assets/scripts/embedding_tests.js"></script>
+<script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
+
+<form action="#" onsubmit="update()">
+  <input id="embedding-exploration-id" type="text" placeholder="explorationId">
+  <input id="embedding-submit-btn" type="submit" value="Submit">
+</form>
 
 <div class="protractor-test-embedded-exploration">
   <h3>Standard embedding of the latest version</h3>
-  <oppia oppia-id="12"></oppia>
+  <oppia oppia-id="idToBeReplaced"></oppia>
 </div>
 
 <script type="text/javascript">
-  // Get exploration id of newly created exploration in embedding.js and
-  // replace old exploration id (12) with new one.
-  (function (){
-    var xhttp = new XMLHttpRequest();
-    xhttp.onreadystatechange = function() {
-      if (this.readyState == 4 && this.status == 200) {        
-        var res = xhttp.responseText.slice(5);
-        res = JSON.parse(res);
-        var activity_list = res['activity_list'];
-        if(activity_list.length === 0){
-          console.error('No explorations found');
-        }else if(activity_list.length > 1){
-          console.error('More than 1 explorations found');
-        }
-        // Get exploration id.
-        explorationId = activity_list[0]['id'];
-        var elems = document.getElementsByTagName('oppia');
-        elems[0].setAttribute('oppia-id', explorationId);  
-      }
-    };
-    xhttp.open("GET", "/searchhandler/data?q=Protractor Test", false);
-    xhttp.send(null);
-  })();
+  var currentExplorationId = 'idToBeReplaced';
+  var update = function(){
+    var newExplorationId = $('#embedding-exploration-id').val();
+    $('div > iframe').each(function(index){
+      var src = $(this).attr('src');
+      src = src.replace(currentExplorationId, newExplorationId);
+      $(this).attr('src', src);
+      currentExplorationId = newExplorationId;
+    });
+  }  
 </script>
+

--- a/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
+++ b/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
@@ -1,28 +1,38 @@
 <h2>v0.0.1 (unminified)</h2>
 <p>For instructions: see the README file in /assets/scripts.</p>
 
+<style type="text/css">
+  .embedding-content{
+    display: none;
+  }
+</style>
+
 <script src="/assets/scripts/oppia-player-0.0.1.js"></script>
 <script src="/assets/scripts/embedding_tests.js"></script>
 <script src="../../third_party/static/jquery-3.2.1/jquery.min.js"></script>
 
 <input id="embedding-exploration-id" type="text" placeholder="explorationId">
-<input id="embedding-submit-btn" type="submit" value="Submit" onclick="update()">
+<input id="embedding-submit-btn" type="submit" value="Update Exploration ID" onclick="onChangeExpId()">
 
-<div class="protractor-test-embedded-exploration">
+<div class="protractor-test-embedded-exploration embedding-content">
   <h3>Standard embedding of the latest version</h3>
   <oppia oppia-id="idToBeReplaced"></oppia>
 </div>
 
 <script type="text/javascript">
-  var currentExplorationId = 'idToBeReplaced';
-  var update = function(){
+  // To keep track of next exploration id to be replaced.
+  var placeHolderExplorationId = 'idToBeReplaced';
+  var onChangeExpId = function() {
     var newExplorationId = $('#embedding-exploration-id').val();
-    $('div > iframe').each(function(index){
+    $('div > iframe').each(function(index) {
       var src = $(this).attr('src');
-      src = src.replace(currentExplorationId, newExplorationId);
+      src = src.replace(placeHolderExplorationId, newExplorationId);
       $(this).attr('src', src);
-      currentExplorationId = newExplorationId;
     });
-  }  
+    placeHolderExplorationId = newExplorationId;
+
+    // Show the contents
+    $('.embedding-content').show();
+  };
 </script>
 

--- a/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
+++ b/assets/scripts/embedding_tests_dev_i18n_0.0.1.html
@@ -8,3 +8,29 @@
   <h3>Standard embedding of the latest version</h3>
   <oppia oppia-id="12"></oppia>
 </div>
+
+<script type="text/javascript">
+  // Get exploration id of newly created exploration in embedding.js and
+  // replace old exploration id (12) with new one.
+  (function (){
+    var xhttp = new XMLHttpRequest();
+    xhttp.onreadystatechange = function() {
+      if (this.readyState == 4 && this.status == 200) {        
+        var res = xhttp.responseText.slice(5);
+        res = JSON.parse(res);
+        var activity_list = res['activity_list'];
+        if(activity_list.length === 0){
+          console.error('No explorations found');
+        }else if(activity_list.length > 1){
+          console.error('More than 1 explorations found');
+        }
+        // Get exploration id.
+        explorationId = activity_list[0]['id'];
+        var elems = document.getElementsByTagName('oppia');
+        elems[0].setAttribute('oppia-id', explorationId);  
+      }
+    };
+    xhttp.open("GET", "/searchhandler/data?q=Protractor Test", false);
+    xhttp.send(null);
+  })();
+</script>

--- a/core/tests/protractor/embedding.js
+++ b/core/tests/protractor/embedding.js
@@ -22,7 +22,7 @@ var users = require('../protractor_utils/users.js');
 var AdminPage = require('../protractor_utils/AdminPage.js');
 var editor = require('../protractor_utils/editor.js');
 var ExplorationPlayerPage =
-  require('../protractor_utils/ExplorationPlayerPage.js')
+  require('../protractor_utils/ExplorationPlayerPage.js');
 var workflow = require('../protractor_utils/workflow.js');
 
 describe('Embedding', function() {

--- a/core/tests/protractor/embedding.js
+++ b/core/tests/protractor/embedding.js
@@ -28,7 +28,7 @@ var workflow = require('../protractor_utils/workflow.js');
 describe('Embedding', function() {
   var adminPage = null;
   var explorationPlayerPage = null;
-  var exp_id = null;
+  var explorationId = null;
   var createCountingExploration = function (){
     // Intro
     editor.setStateName('Intro');
@@ -39,11 +39,13 @@ describe('Embedding', function() {
       )
     );
     editor.setInteraction('NumericInput');
-    editor.addResponse('NumericInput', null, 'correct but why', true, 'Equals', 6);
+    editor.addResponse(
+      'NumericInput', null, 'correct but why', true, 'Equals', 6);
     editor.addResponse('NumericInput', forms.toRichText('Surely there\'s ' +
       'at least one? For example, you might have the red ball on the left, ' +
-      'the blue ball in the middle, and the yellow ball on the right. Now try ' +
-      'and find a few more. How many different ways can you find, in total?')
+      'the blue ball in the middle, and the yellow ball on the right. ' +
+      'Now try and find a few more. ' +
+      'How many different ways can you find, in total?')
       , null, false, 'IsLessThanOrEqualTo', 0);
     editor.setDefaultOutcome(null, 'Not 6', true);
 
@@ -67,20 +69,21 @@ describe('Embedding', function() {
       , 'END', false, 'Contains', 'factorial');
     editor.setDefaultOutcome(forms.toRichText('OK! There are indeed 6 ways ' +
       'to arrange the balls: there are 3 ways to choose the leftmost one, ' +
-      'and for each of these, there are 2 ways to choose the second one; the ' +
-      'last choice is then forced. This gives 3 x 2 = 6 scenarios. If you do ' +
-      'a quick search for the words \'permutation\' or \'factorial\' on the ' +
-      'Internet, you\'ll also be able to find more information about this ' +
-      'topic. See if you can figure out what the answer for 4 balls is!')
+      'and for each of these, there are 2 ways to choose the second one; ' +
+      'the last choice is then forced. This gives 3 x 2 = 6 scenarios. ' +
+      'If you do a quick search for the words \'permutation\' ' +
+      'or \'factorial\' on the Internet, you\'ll also be able to find more' +
+      ' information about this topic. See if you can figure out what the ' +
+      'answer for 4 balls is!')
       , null, false);
 
     // Not 6
     editor.moveToState('Not 6');
-    editor.setContent(forms.toRichText('OK, I\'d be interested in seeing what ' +
-      'you came up with; could you list the different ways? Write them as ' +
-      'three-character words, like this: RBY, This means: put the red ball ' +
-      'on the left, the blue ball in the middle, and the yellow ball on the ' +
-      'right. Can you list all the ways you found?'));
+    editor.setContent(forms.toRichText('OK, I\'d be interested in seeing ' +
+      'what you came up with; could you list the different ways? Write ' +
+      'them as three-character words, like this: RBY, This means: put the ' +
+      'red ball on the left, the blue ball in the middle, and the yellow ' +
+      'ball on the right. Can you list all the ways you found?'));
     editor.setInteraction('Continue', 'try again');
     editor.setDefaultOutcome(null, 'Intro', false);
 
@@ -92,7 +95,8 @@ describe('Embedding', function() {
     // save changes
     title = 'Protractor Test';
     category = 'Mathematics';
-    objective = 'learn how to count permutations accurately and systematically';
+    objective = 'learn how to count permutations' + 
+      ' accurately and systematically';
     editor.setTitle(title);
     editor.setCategory(category);
     editor.setObjective(objective);
@@ -149,12 +153,12 @@ describe('Embedding', function() {
     // Create exploration.
     // version 1 is creation of the exploration.
     workflow.createExploration();
-    general.getExplorationIdFromEditor().then(function(explorationId){
-      exp_id = explorationId;
+    general.getExplorationIdFromEditor().then(function(expId){
+      explorationId = expId;
       // creates version 2 of the exploration.
       createCountingExploration();
 
-      general.openEditor(exp_id);
+      general.openEditor(explorationId);
       editor.setContent(forms.toRichText('Version 3'));
       editor.saveChanges('demonstration edit');
 
@@ -257,14 +261,14 @@ describe('Embedding', function() {
     users.login('embedder2@example.com', true);
 
     // Change language to Thai, which is not a supported site language.
-    general.openEditor(exp_id);
+    general.openEditor(explorationId);
     editor.setLanguage('ภาษาไทย');
     editor.saveChanges('Changing the language to a not supported one.');
     // We expect the default language, English
     checkPlaceholder('Type a number');
 
     // Change language to Spanish, which is a supported site language.
-    general.openEditor(exp_id);
+    general.openEditor(explorationId);
     editor.setLanguage('español');
     editor.saveChanges('Changing the language to a supported one.');
     checkPlaceholder('Ingresa un número');

--- a/core/tests/protractor/embedding.js
+++ b/core/tests/protractor/embedding.js
@@ -29,8 +29,8 @@ describe('Embedding', function() {
   var adminPage = null;
   var explorationPlayerPage = null;
   var explorationId = null;
-  var createCountingExploration = function (){
-    // Intro
+  var createCountingExploration = function () {
+    // Intro.
     editor.setStateName('Intro');
     editor.setContent(forms.toRichText(
       'Given three balls of different colors. How many ways are there ' +
@@ -43,7 +43,7 @@ describe('Embedding', function() {
       , null, false, 'IsLessThanOrEqualTo', 0);
     editor.setDefaultOutcome(null, 'Not 6', true);
 
-    // correct but why
+    // correct but why.
     editor.moveToState('correct but why');
     editor.setContent(forms.toRichText('Right! Why do you think it is 6?'));
     editor.setInteraction('TextInput', 'Type your answer here.', 5);
@@ -57,18 +57,18 @@ describe('Embedding', function() {
       'answer for 4 balls is!')
       , null, false);
 
-    // Not 6
+    // Not 6.
     editor.moveToState('Not 6');
     editor.setContent(forms.toRichText('List the different ways?'));
     editor.setInteraction('Continue', 'try again');
     editor.setDefaultOutcome(null, 'Intro', false);
 
-    // END
+    // END.
     editor.moveToState('END');
     editor.setContent(forms.toRichText('Congratulations, you have finished!'));
     editor.setInteraction('EndExploration');
 
-    // save changes
+    // Save changes.
     title = 'Protractor Test';
     category = 'Mathematics';
     objective = 'learn how to count permutations' + 
@@ -78,7 +78,7 @@ describe('Embedding', function() {
     editor.setObjective(objective);
     editor.saveChanges('Done!');
 
-    // publish changes
+    // Publish changes.
     workflow.publishExploration();
   };
 
@@ -125,11 +125,11 @@ describe('Embedding', function() {
     users.login('user1@embedding.com', true);
 
     // Create exploration.
-    // version 1 is creation of the exploration.
+    // Version 1 is creation of the exploration.
     workflow.createExploration();
-    general.getExplorationIdFromEditor().then(function(expId){
+    general.getExplorationIdFromEditor().then(function(expId) {
       explorationId = expId;
-      // Create version 2 of the exploration.
+      // Create Version 2 of the exploration.
       createCountingExploration();
 
       general.openEditor(explorationId);
@@ -137,34 +137,37 @@ describe('Embedding', function() {
       editor.saveChanges('demonstration edit');
 
       for (var i = 0; i < TEST_PAGES.length; i++) {
-        // This is necessary as the pages are non-angular;
+        // This is necessary as the pages are non-angular.
         var driver = browser.driver;
         driver.get(
           general.SERVER_URL_PREFIX + general.SCRIPTS_URL_SLICE +
           TEST_PAGES[i].filename);
 
-        driver.findElement(
-          by.css('#embedding-exploration-id')).sendKeys(explorationId);
-        driver.findElement(
-          by.css('#embedding-submit-btn')).click();
+        driver.findElement(by.css(
+          '.protractor-test-exploration-id-input-field')
+        ).sendKeys(explorationId);
 
-        // Test of standard loading (new and old versions)
+        driver.findElement(by.css(
+          '.protractor-test-exploration-id-submit-button')
+        ).click();
+
+        // Test of standard loading (new and old versions).
         browser.switchTo().frame(
           driver.findElement(
-            by.css('.protractor-test-standard iframe')));
+            by.css('.protractor-test-standard > iframe')));
         playCountingExploration(3);
         browser.switchTo().defaultContent();
 
         if (TEST_PAGES[i].isVersion1) {
-          // Test of deferred loading (old version)
+          // Test of deferred loading (old version).
           driver.findElement(
-            by.css('.protractor-test-old-version oppia div button')
+            by.css('.protractor-test-old-version > oppia > div > button')
           ).click();
         }
 
         browser.switchTo().frame(
           driver.findElement(
-            by.css('.protractor-test-old-version iframe')));
+            by.css('.protractor-test-old-version > iframe')));
         playCountingExploration(2);
         browser.switchTo().defaultContent();
       }
@@ -225,13 +228,16 @@ describe('Embedding', function() {
         general.SERVER_URL_PREFIX + general.SCRIPTS_URL_SLICE +
         'embedding_tests_dev_i18n_0.0.1.html');
 
-      driver.findElement(
-        by.css('#embedding-exploration-id')).sendKeys(explorationId);
-      driver.findElement(
-        by.css('#embedding-submit-btn')).click();
+      driver.findElement(by.css(
+        '.protractor-test-exploration-id-input-field')
+      ).sendKeys(explorationId);
+      
+      driver.findElement(by.css(
+        '.protractor-test-exploration-id-submit-button')
+      ).click();
 
       browser.switchTo().frame(driver.findElement(
-        by.css('.protractor-test-embedded-exploration iframe')));
+        by.css('.protractor-test-embedded-exploration > iframe')));
       general.waitForSystem();
       browser.waitForAngular();
       expect(driver.findElement(by.css('.protractor-test-float-form-input'))
@@ -246,7 +252,7 @@ describe('Embedding', function() {
     general.openEditor(explorationId);
     editor.setLanguage('ภาษาไทย');
     editor.saveChanges('Changing the language to a not supported one.');
-    // We expect the default language, English
+    // We expect the default language, English.
     checkPlaceholder('Type a number');
 
     // Change language to Spanish, which is a supported site language.
@@ -259,11 +265,11 @@ describe('Embedding', function() {
 
     // This error is to be ignored as 'idToBeReplaced' is not a valid
     // exploration id. It appers just after the page loads.
-    var errorsToIgnore = new RegExp('http:\/\/localhost:9001\/assets\/' +
+    var errorToIgnore = new RegExp('http:\/\/localhost:9001\/assets\/' +
       'scripts\/embedding_tests_dev_i18n_0.0.1.html - Refused to display ' +
       '\'http:\/\/localhost:9001\/explore\/idToBeReplaced\\?iframed=true&' +
       'locale=en#version=0.0.1&secret=.*\' in a frame because it set ' +
       '\'X-Frame-Options\' to \'deny\'.', 'g');
-    general.checkForConsoleErrors([errorsToIgnore]);
+    general.checkForConsoleErrors([errorToIgnore]);
   });
 });

--- a/core/tests/protractor/embedding.js
+++ b/core/tests/protractor/embedding.js
@@ -33,19 +33,14 @@ describe('Embedding', function() {
     // Intro
     editor.setStateName('Intro');
     editor.setContent(forms.toRichText(
-      'Suppose you were given three balls: one red, one blue, and one ' +
-      'yellow. How many ways are there to arrange them in a straight ' +
-      'line?'
+      'Given three balls of different colors. How many ways are there ' +
+      'to arrange them in a straight line?'
       )
     );
     editor.setInteraction('NumericInput');
     editor.addResponse(
       'NumericInput', null, 'correct but why', true, 'Equals', 6);
-    editor.addResponse('NumericInput', forms.toRichText('Surely there\'s ' +
-      'at least one? For example, you might have the red ball on the left, ' +
-      'the blue ball in the middle, and the yellow ball on the right. ' +
-      'Now try and find a few more. ' +
-      'How many different ways can you find, in total?')
+    editor.addResponse('NumericInput', forms.toRichText('Describe solution!!')
       , null, false, 'IsLessThanOrEqualTo', 0);
     editor.setDefaultOutcome(null, 'Not 6', true);
 
@@ -54,36 +49,18 @@ describe('Embedding', function() {
     editor.setContent(forms.toRichText('Right! Why do you think it is 6?'));
     editor.setInteraction('TextInput', 'Type your answer here.', 5);
     editor.addResponse('TextInput', forms.toRichText(
-      'Yes, the question is asking for the number of permutations of 3 ' +
-      'different balls, and that is 3! = 3 x 2 x 1. You can think about' +
-      ' this by noticing that there are 3 ways to pick the first ball --' +
-      ' then, once you\'ve done that, there are 2 ways to pick the second,' +
-      ' and the last choice is forced. That\'s 3 x 2 = 6 ways.')
+      'Yes, 3! = 3 x 2 x 1. That\'s 3 x 2 = 6 ways.')
       , 'END', true, 'Contains', 'permutation');
     editor.addResponse('TextInput', forms.toRichText(
-      'Yes, the question is asking for the number of permutations of 3 ' +
-      'different balls, and that is 3 factorial, or 3 x 2 x 1. You can ' +
-      'think about this by noticing that there are 3 ways to pick the first' +
-      ' ball -- then, once you\'ve done that, there are 2 ways to pick ' +
-      'the second, and the last choice is forced. That\'s 3 x 2 = 6 ways.')
+      'Yes, 3 factorial, or 3 x 2 x 1. That\'s 3 x 2 = 6 ways.')
       , 'END', false, 'Contains', 'factorial');
-    editor.setDefaultOutcome(forms.toRichText('OK! There are indeed 6 ways ' +
-      'to arrange the balls: there are 3 ways to choose the leftmost one, ' +
-      'and for each of these, there are 2 ways to choose the second one; ' +
-      'the last choice is then forced. This gives 3 x 2 = 6 scenarios. ' +
-      'If you do a quick search for the words \'permutation\' ' +
-      'or \'factorial\' on the Internet, you\'ll also be able to find more' +
-      ' information about this topic. See if you can figure out what the ' +
+    editor.setDefaultOutcome(forms.toRichText('Figure out what the ' +
       'answer for 4 balls is!')
       , null, false);
 
     // Not 6
     editor.moveToState('Not 6');
-    editor.setContent(forms.toRichText('OK, I\'d be interested in seeing ' +
-      'what you came up with; could you list the different ways? Write ' +
-      'them as three-character words, like this: RBY, This means: put the ' +
-      'red ball on the left, the blue ball in the middle, and the yellow ' +
-      'ball on the right. Can you list all the ways you found?'));
+    editor.setContent(forms.toRichText('List the different ways?'));
     editor.setInteraction('Continue', 'try again');
     editor.setDefaultOutcome(null, 'Intro', false);
 
@@ -126,10 +103,8 @@ describe('Embedding', function() {
 
       explorationPlayerPage.expectContentToMatch(
         forms.toRichText((version === 2) ?
-          'Suppose you were given three balls: one red, one blue, and one ' +
-          'yellow. How many ways are there to arrange them in a straight ' +
-          'line?' :
-          'Version 3'));
+          'Given three balls of different colors. How many ways are there ' +
+          'to arrange them in a straight line?' : 'Version 3'));
       explorationPlayerPage.submitAnswer('NumericInput', 6);
       explorationPlayerPage.expectContentToMatch(
         forms.toRichText('Right! Why do you think it is 6?'));
@@ -170,11 +145,22 @@ describe('Embedding', function() {
           general.SERVER_URL_PREFIX + general.SCRIPTS_URL_SLICE +
           TEST_PAGES[i].filename);
 
+        driver.findElement(by.xpath(
+          "//input[@id='embedding-exploration-id']")).sendKeys(explorationId);
+
+        /*
+          "https://stackoverflow.com/questions/34562061/
+          webdriver-click-vs-javascript-click"
+          This doesn't works: 
+          var elem = driver.findElement(
+            by.xpath("//input[@id='embedding-submit-btn'")).click();
+        */
+        driver.executeScript('window.update()');
+
         // Test of standard loading (new and old versions)
         browser.switchTo().frame(
           driver.findElement(
             by.xpath("//div[@class='protractor-test-standard']/iframe")));
-
         playCountingExploration(3);
         browser.switchTo().defaultContent();
 
@@ -236,7 +222,7 @@ describe('Embedding', function() {
       });
 
       users.logout();
-      general.checkForConsoleErrors([]);
+      general.checkForConsoleErrors(['.*idToBeReplaced.*']);
     });
   });
 
@@ -248,6 +234,11 @@ describe('Embedding', function() {
       driver.get(
         general.SERVER_URL_PREFIX + general.SCRIPTS_URL_SLICE +
         'embedding_tests_dev_i18n_0.0.1.html');
+
+      driver.findElement(by.xpath(
+        "//input[@id='embedding-exploration-id']")).sendKeys(explorationId);
+      driver.executeScript('window.update()');
+
       browser.switchTo().frame(driver.findElement(by.xpath(
           "//div[@class='protractor-test-embedded-exploration']/iframe")));
       general.waitForSystem();
@@ -274,6 +265,6 @@ describe('Embedding', function() {
     checkPlaceholder('Ingresa un número');
 
     users.logout();
-    general.checkForConsoleErrors([]);
+    general.checkForConsoleErrors(['.*idToBeReplaced.*']);
   });
 });

--- a/core/tests/protractor/embedding.js
+++ b/core/tests/protractor/embedding.js
@@ -256,8 +256,9 @@ describe('Embedding', function() {
       
       editor.setContent(forms.toRichText('Language Test'));
       editor.setInteraction('NumericInput');
-      editor.addResponse('NumericInput', forms.toRichText('Nice!!')
-        , 'END', true, 'IsLessThanOrEqualTo', 0);
+      editor.addResponse(
+        'NumericInput', forms.toRichText('Nice!!'),
+        'END', true, 'IsLessThanOrEqualTo', 0);
       editor.setDefaultOutcome(forms.toRichText('Ok!!'), null, false);
 
       editor.moveToState('END');
@@ -292,7 +293,7 @@ describe('Embedding', function() {
       users.logout();
 
       // This error is to be ignored as 'idToBeReplaced' is not a valid
-      // exploration id. It appers just after the page loads.
+      // exploration id. It appears just after the page loads.
       var errorToIgnore = 'http:\/\/localhost:9001\/assets\/' +
         'scripts\/embedding_tests_dev_i18n_0.0.1.html - Refused to display ' +
         '\'http:\/\/localhost:9001\/explore\/idToBeReplaced\\?iframed=true&' +

--- a/core/tests/protractor/embedding.js
+++ b/core/tests/protractor/embedding.js
@@ -34,8 +34,7 @@ describe('Embedding', function() {
     editor.setStateName('Intro');
     editor.setContent(forms.toRichText(
       'Given three balls of different colors. How many ways are there ' +
-      'to arrange them in a straight line?'
-      )
+      'to arrange them in a straight line?')
     );
     editor.setInteraction('NumericInput');
     editor.addResponse(
@@ -81,7 +80,7 @@ describe('Embedding', function() {
 
     // publish changes
     workflow.publishExploration();
-  }
+  };
 
   beforeEach(function() {
     adminPage = new AdminPage.AdminPage();
@@ -130,7 +129,7 @@ describe('Embedding', function() {
     workflow.createExploration();
     general.getExplorationIdFromEditor().then(function(expId){
       explorationId = expId;
-      // creates version 2 of the exploration.
+      // Create version 2 of the exploration.
       createCountingExploration();
 
       general.openEditor(explorationId);
@@ -138,44 +137,34 @@ describe('Embedding', function() {
       editor.saveChanges('demonstration edit');
 
       for (var i = 0; i < TEST_PAGES.length; i++) {
-        // This is necessary as the pages are non-angular; we need xpaths below
-        // for the same reason.
+        // This is necessary as the pages are non-angular;
         var driver = browser.driver;
         driver.get(
           general.SERVER_URL_PREFIX + general.SCRIPTS_URL_SLICE +
           TEST_PAGES[i].filename);
 
-        driver.findElement(by.xpath(
-          "//input[@id='embedding-exploration-id']")).sendKeys(explorationId);
-
-        /*
-          "https://stackoverflow.com/questions/34562061/
-          webdriver-click-vs-javascript-click"
-          This doesn't works: 
-          var elem = driver.findElement(
-            by.xpath("//input[@id='embedding-submit-btn'")).click();
-        */
         driver.findElement(
-          by.xpath("//input[@id='embedding-submit-btn']")).click();
+          by.css('#embedding-exploration-id')).sendKeys(explorationId);
+        driver.findElement(
+          by.css('#embedding-submit-btn')).click();
 
         // Test of standard loading (new and old versions)
         browser.switchTo().frame(
           driver.findElement(
-            by.xpath("//div[@class='protractor-test-standard']/iframe")));
+            by.css('.protractor-test-standard iframe')));
         playCountingExploration(3);
         browser.switchTo().defaultContent();
 
         if (TEST_PAGES[i].isVersion1) {
           // Test of deferred loading (old version)
           driver.findElement(
-            by.xpath(
-              "//div[@class='protractor-test-old-version']/oppia/div/button")
+            by.css('.protractor-test-old-version oppia div button')
           ).click();
         }
 
         browser.switchTo().frame(
           driver.findElement(
-            by.xpath("//div[@class='protractor-test-old-version']/iframe")));
+            by.css('.protractor-test-old-version iframe')));
         playCountingExploration(2);
         browser.switchTo().defaultContent();
       }
@@ -236,13 +225,13 @@ describe('Embedding', function() {
         general.SERVER_URL_PREFIX + general.SCRIPTS_URL_SLICE +
         'embedding_tests_dev_i18n_0.0.1.html');
 
-      driver.findElement(by.xpath(
-        "//input[@id='embedding-exploration-id']")).sendKeys(explorationId);
       driver.findElement(
-        by.xpath("//input[@id='embedding-submit-btn']")).click();
+        by.css('#embedding-exploration-id')).sendKeys(explorationId);
+      driver.findElement(
+        by.css('#embedding-submit-btn')).click();
 
-      browser.switchTo().frame(driver.findElement(by.xpath(
-          "//div[@class='protractor-test-embedded-exploration']/iframe")));
+      browser.switchTo().frame(driver.findElement(
+        by.css('.protractor-test-embedded-exploration iframe')));
       general.waitForSystem();
       browser.waitForAngular();
       expect(driver.findElement(by.css('.protractor-test-float-form-input'))
@@ -267,6 +256,14 @@ describe('Embedding', function() {
     checkPlaceholder('Ingresa un número');
 
     users.logout();
-    general.checkForConsoleErrors(['.*idToBeReplaced.*']);
+
+    // This error is to be ignored as 'idToBeReplaced' is not a valid
+    // exploration id. It appers just after the page loads.
+    var errorsToIgnore = new RegExp('http:\/\/localhost:9001\/assets\/' +
+      'scripts\/embedding_tests_dev_i18n_0.0.1.html - Refused to display ' +
+      '\'http:\/\/localhost:9001\/explore\/idToBeReplaced\\?iframed=true&' +
+      'locale=en#version=0.0.1&secret=.*\' in a frame because it set ' +
+      '\'X-Frame-Options\' to \'deny\'.', 'g');
+    general.checkForConsoleErrors([errorsToIgnore]);
   });
 });

--- a/core/tests/protractor/embedding.js
+++ b/core/tests/protractor/embedding.js
@@ -22,11 +22,85 @@ var users = require('../protractor_utils/users.js');
 var AdminPage = require('../protractor_utils/AdminPage.js');
 var editor = require('../protractor_utils/editor.js');
 var ExplorationPlayerPage =
-  require('../protractor_utils/ExplorationPlayerPage.js');
+  require('../protractor_utils/ExplorationPlayerPage.js')
+var workflow = require('../protractor_utils/workflow.js');
 
 describe('Embedding', function() {
   var adminPage = null;
   var explorationPlayerPage = null;
+  var exp_id = null;
+  var createCountingExploration = function (){
+    // Intro
+    editor.setStateName('Intro');
+    editor.setContent(forms.toRichText(
+      'Suppose you were given three balls: one red, one blue, and one ' +
+      'yellow. How many ways are there to arrange them in a straight ' +
+      'line?'
+      )
+    );
+    editor.setInteraction('NumericInput');
+    editor.addResponse('NumericInput', null, 'correct but why', true, 'Equals', 6);
+    editor.addResponse('NumericInput', forms.toRichText('Surely there\'s ' +
+      'at least one? For example, you might have the red ball on the left, ' +
+      'the blue ball in the middle, and the yellow ball on the right. Now try ' +
+      'and find a few more. How many different ways can you find, in total?')
+      , null, false, 'IsLessThanOrEqualTo', 0);
+    editor.setDefaultOutcome(null, 'Not 6', true);
+
+    // correct but why
+    editor.moveToState('correct but why');
+    editor.setContent(forms.toRichText('Right! Why do you think it is 6?'));
+    editor.setInteraction('TextInput', 'Type your answer here.', 5);
+    editor.addResponse('TextInput', forms.toRichText(
+      'Yes, the question is asking for the number of permutations of 3 ' +
+      'different balls, and that is 3! = 3 x 2 x 1. You can think about' +
+      ' this by noticing that there are 3 ways to pick the first ball --' +
+      ' then, once you\'ve done that, there are 2 ways to pick the second,' +
+      ' and the last choice is forced. That\'s 3 x 2 = 6 ways.')
+      , 'END', true, 'Contains', 'permutation');
+    editor.addResponse('TextInput', forms.toRichText(
+      'Yes, the question is asking for the number of permutations of 3 ' +
+      'different balls, and that is 3 factorial, or 3 x 2 x 1. You can ' +
+      'think about this by noticing that there are 3 ways to pick the first' +
+      ' ball -- then, once you\'ve done that, there are 2 ways to pick ' +
+      'the second, and the last choice is forced. That\'s 3 x 2 = 6 ways.')
+      , 'END', false, 'Contains', 'factorial');
+    editor.setDefaultOutcome(forms.toRichText('OK! There are indeed 6 ways ' +
+      'to arrange the balls: there are 3 ways to choose the leftmost one, ' +
+      'and for each of these, there are 2 ways to choose the second one; the ' +
+      'last choice is then forced. This gives 3 x 2 = 6 scenarios. If you do ' +
+      'a quick search for the words \'permutation\' or \'factorial\' on the ' +
+      'Internet, you\'ll also be able to find more information about this ' +
+      'topic. See if you can figure out what the answer for 4 balls is!')
+      , null, false);
+
+    // Not 6
+    editor.moveToState('Not 6');
+    editor.setContent(forms.toRichText('OK, I\'d be interested in seeing what ' +
+      'you came up with; could you list the different ways? Write them as ' +
+      'three-character words, like this: RBY, This means: put the red ball ' +
+      'on the left, the blue ball in the middle, and the yellow ball on the ' +
+      'right. Can you list all the ways you found?'));
+    editor.setInteraction('Continue', 'try again');
+    editor.setDefaultOutcome(null, 'Intro', false);
+
+    // END
+    editor.moveToState('END');
+    editor.setContent(forms.toRichText('Congratulations, you have finished!'));
+    editor.setInteraction('EndExploration');
+
+    // save changes
+    title = 'Protractor Test';
+    category = 'Mathematics';
+    objective = 'learn how to count permutations accurately and systematically';
+    editor.setTitle(title);
+    editor.setCategory(category);
+    editor.setObjective(objective);
+    editor.saveChanges('Done!');
+
+    // publish changes
+    workflow.publishExploration();
+  }
 
   beforeEach(function() {
     adminPage = new AdminPage.AdminPage();
@@ -47,11 +121,11 @@ describe('Embedding', function() {
       browser.waitForAngular();
 
       explorationPlayerPage.expectContentToMatch(
-        forms.toRichText((version === 1) ?
+        forms.toRichText((version === 2) ?
           'Suppose you were given three balls: one red, one blue, and one ' +
           'yellow. How many ways are there to arrange them in a straight ' +
           'line?' :
-          'Version 2'));
+          'Version 3'));
       explorationPlayerPage.submitAnswer('NumericInput', 6);
       explorationPlayerPage.expectContentToMatch(
         forms.toRichText('Right! Why do you think it is 6?'));
@@ -71,86 +145,95 @@ describe('Embedding', function() {
 
     users.createUser('user1@embedding.com', 'user1Embedding');
     users.login('user1@embedding.com', true);
-    adminPage.reloadExploration('protractor_test_1.yaml');
 
-    general.openEditor('12');
-    editor.setContent(forms.toRichText('Version 2'));
-    editor.saveChanges('demonstration edit');
+    // Create exploration.
+    // version 1 is creation of the exploration.
+    workflow.createExploration();
+    general.getExplorationIdFromEditor().then(function(explorationId){
+      exp_id = explorationId;
+      // creates version 2 of the exploration.
+      createCountingExploration();
 
-    for (var i = 0; i < TEST_PAGES.length; i++) {
-      // This is necessary as the pages are non-angular; we need xpaths below
-      // for the same reason.
-      var driver = browser.driver;
-      driver.get(
-        general.SERVER_URL_PREFIX + general.SCRIPTS_URL_SLICE +
-        TEST_PAGES[i].filename);
+      general.openEditor(exp_id);
+      editor.setContent(forms.toRichText('Version 3'));
+      editor.saveChanges('demonstration edit');
 
-      // Test of standard loading (new and old versions)
-      browser.switchTo().frame(
-        driver.findElement(
-          by.xpath("//div[@class='protractor-test-standard']/iframe")));
-      playCountingExploration(2);
-      browser.switchTo().defaultContent();
-
-      if (TEST_PAGES[i].isVersion1) {
-        // Test of deferred loading (old version)
-        driver.findElement(
-          by.xpath(
-            "//div[@class='protractor-test-old-version']/oppia/div/button")
-        ).click();
-      }
-
-      browser.switchTo().frame(
-        driver.findElement(
-          by.xpath("//div[@class='protractor-test-old-version']/iframe")));
-      playCountingExploration(1);
-      browser.switchTo().defaultContent();
-    }
-
-    // Certain events in the exploration playthroughs should trigger hook
-    // functions in the outer page; these send logs to the console which we
-    // now check to ensure that the hooks work correctly.
-    browser.manage().logs().get('browser').then(function(browserLogs) {
-      var embeddingLogs = [];
-      for (var i = 0; i < browserLogs.length; i++) {
-        // We ignore all logs that are not of the desired form.
-        try {
-          var message = browserLogs[i].message;
-          var EMBEDDING_PREFIX = 'Embedding test: ';
-          if (message.indexOf(EMBEDDING_PREFIX) !== -1) {
-            var index = message.indexOf(EMBEDDING_PREFIX);
-            // The "-1" in substring() removes the trailing quotation mark.
-            embeddingLogs.push(message.substring(
-              index + EMBEDDING_PREFIX.length, message.length - 1));
-          }
-        } catch (err) {}
-      }
-
-      // We played the exploration twice for each test page.
-      var expectedLogs = [];
       for (var i = 0; i < TEST_PAGES.length; i++) {
-        if (TEST_PAGES[i].isVersion1) {
-          expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS);
-          expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS);
-        } else {
-          // The two loading events are fired first ...
-          expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[0]);
-          expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[0]);
-          // ... followed by the rest of the events, as each playthrough
-          // occurs.
-          expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[1]);
-          expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[2]);
-          expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[3]);
-          expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[1]);
-          expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[2]);
-          expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[3]);
-        }
-      }
-      expect(embeddingLogs).toEqual(expectedLogs);
-    });
+        // This is necessary as the pages are non-angular; we need xpaths below
+        // for the same reason.
+        var driver = browser.driver;
+        driver.get(
+          general.SERVER_URL_PREFIX + general.SCRIPTS_URL_SLICE +
+          TEST_PAGES[i].filename);
 
-    users.logout();
-    general.checkForConsoleErrors([]);
+        // Test of standard loading (new and old versions)
+        browser.switchTo().frame(
+          driver.findElement(
+            by.xpath("//div[@class='protractor-test-standard']/iframe")));
+
+        playCountingExploration(3);
+        browser.switchTo().defaultContent();
+
+        if (TEST_PAGES[i].isVersion1) {
+          // Test of deferred loading (old version)
+          driver.findElement(
+            by.xpath(
+              "//div[@class='protractor-test-old-version']/oppia/div/button")
+          ).click();
+        }
+
+        browser.switchTo().frame(
+          driver.findElement(
+            by.xpath("//div[@class='protractor-test-old-version']/iframe")));
+        playCountingExploration(2);
+        browser.switchTo().defaultContent();
+      }
+
+      // Certain events in the exploration playthroughs should trigger hook
+      // functions in the outer page; these send logs to the console which we
+      // now check to ensure that the hooks work correctly.
+      browser.manage().logs().get('browser').then(function(browserLogs) {
+        var embeddingLogs = [];
+        for (var i = 0; i < browserLogs.length; i++) {
+          // We ignore all logs that are not of the desired form.
+          try {
+            var message = browserLogs[i].message;
+            var EMBEDDING_PREFIX = 'Embedding test: ';
+            if (message.indexOf(EMBEDDING_PREFIX) !== -1) {
+              var index = message.indexOf(EMBEDDING_PREFIX);
+              // The "-1" in substring() removes the trailing quotation mark.
+              embeddingLogs.push(message.substring(
+                index + EMBEDDING_PREFIX.length, message.length - 1));
+            }
+          } catch (err) {}
+        }
+
+        // We played the exploration twice for each test page.
+        var expectedLogs = [];
+        for (var i = 0; i < TEST_PAGES.length; i++) {
+          if (TEST_PAGES[i].isVersion1) {
+            expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS);
+            expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS);
+          } else {
+            // The two loading events are fired first ...
+            expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[0]);
+            expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[0]);
+            // ... followed by the rest of the events, as each playthrough
+            // occurs.
+            expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[1]);
+            expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[2]);
+            expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[3]);
+            expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[1]);
+            expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[2]);
+            expectedLogs = expectedLogs.concat(PLAYTHROUGH_LOGS[3]);
+          }
+        }
+        expect(embeddingLogs).toEqual(expectedLogs);
+      });
+
+      users.logout();
+      general.checkForConsoleErrors([]);
+    });
   });
 
   it('should use the exploration language as site language.', function() {
@@ -170,19 +253,18 @@ describe('Embedding', function() {
       browser.switchTo().defaultContent();
     };
 
-    users.createUser('embedder2@example.com', 'Embedder2');
+    users.createModerator('embedder2@example.com', 'Embedder2');
     users.login('embedder2@example.com', true);
-    adminPage.reloadExploration('protractor_test_1.yaml');
 
     // Change language to Thai, which is not a supported site language.
-    general.openEditor('12');
+    general.openEditor(exp_id);
     editor.setLanguage('ภาษาไทย');
     editor.saveChanges('Changing the language to a not supported one.');
     // We expect the default language, English
     checkPlaceholder('Type a number');
 
     // Change language to Spanish, which is a supported site language.
-    general.openEditor('12');
+    general.openEditor(exp_id);
     editor.setLanguage('español');
     editor.saveChanges('Changing the language to a supported one.');
     checkPlaceholder('Ingresa un número');

--- a/core/tests/protractor/embedding.js
+++ b/core/tests/protractor/embedding.js
@@ -155,7 +155,8 @@ describe('Embedding', function() {
           var elem = driver.findElement(
             by.xpath("//input[@id='embedding-submit-btn'")).click();
         */
-        driver.executeScript('window.update()');
+        driver.findElement(
+          by.xpath("//input[@id='embedding-submit-btn']")).click();
 
         // Test of standard loading (new and old versions)
         browser.switchTo().frame(
@@ -222,7 +223,7 @@ describe('Embedding', function() {
       });
 
       users.logout();
-      general.checkForConsoleErrors(['.*idToBeReplaced.*']);
+      general.checkForConsoleErrors([]);
     });
   });
 
@@ -237,7 +238,8 @@ describe('Embedding', function() {
 
       driver.findElement(by.xpath(
         "//input[@id='embedding-exploration-id']")).sendKeys(explorationId);
-      driver.executeScript('window.update()');
+      driver.findElement(
+        by.xpath("//input[@id='embedding-submit-btn']")).click();
 
       browser.switchTo().frame(driver.findElement(by.xpath(
           "//div[@class='protractor-test-embedded-exploration']/iframe")));


### PR DESCRIPTION
removed loading of 'protractor_test_1.yaml' from and embedding.js and created an exploration same as that which are actually run in the test.
I had to shift the version numbers by 1 as creating a new exploration is itself the first version.
**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.