### PR TITLE
Fix #4496: Set error page footer to relative position

### DIFF
--- a/core/templates/dev/head/pages/error/error.html
+++ b/core/templates/dev/head/pages/error/error.html
@@ -64,11 +64,8 @@
       font-weight: 700;
     }
     @media screen and (min-width: 768px) {
-      .oppia-error-page-main-content {
-        margin-bottom: 250px;
-      }
       .oppia-footer {
-        position: absolute;
+        position: relative;
       }
     }
   </style>


### PR DESCRIPTION
Fixes the footer so that it changes position relative to the error message length. This was tested on desktop, tablet, and mobile view and the text was not hidden. 

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
