### PR TITLE
Fix #4501: Changed rule description for HasNoFractionalPart

### DIFF
--- a/extensions/interactions/rule_templates.json
+++ b/extensions/interactions/rule_templates.json
@@ -53,7 +53,7 @@
       "description": "has integer part equal to {{x|Int}}"
     },
     "HasNoFractionalPart": {
-      "description": "is an integer"
+      "description": "has no fractional part"
     }
   },
   "GraphInput": {


### PR DESCRIPTION
Changed the rule description for HasNoFractionalPart rule in Fractions Interaction. 
Fixes #4501.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
