### PR TITLE
Fix #4511: Add placeholder in fractions input

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -164,6 +164,7 @@
     "I18N_GET_STARTED_PAGE_PARAGRAPH_9": "When learners go through your exploration, they can send you feedback to alert you to problems or to share ideas for making it better.",
     "I18N_GET_STARTED_PAGE_PARAGRAPH_9_HEADING": "Improve Your Exploration",
     "I18N_GET_STARTED_PAGE_TITLE": "Get Started",
+    "I18N_INTERACTIONS_FRACTIONS_INPUT_PLACEHOLDER": "Enter a fraction in the form n/n or n n/n.",
     "I18N_INTERACTIONS_GRAPH_ADD_EDGE": "Add Edge",
     "I18N_INTERACTIONS_GRAPH_ADD_NODE": "Add Node",
     "I18N_INTERACTIONS_GRAPH_DELETE": "Delete",

--- a/assets/i18n/qqq.json
+++ b/assets/i18n/qqq.json
@@ -164,6 +164,7 @@
 	"I18N_GET_STARTED_PAGE_PARAGRAPH_9": "Text on the Get Started page that explains the process for creating an Oppia activity at a high level.\n{{Identical|Get started}}",
 	"I18N_GET_STARTED_PAGE_PARAGRAPH_9_HEADING": "Paragraph heading on the Get Started page that explains the process for creating an Oppia activity at a high level.\n{{Identical|Get started}}",
 	"I18N_GET_STARTED_PAGE_TITLE": "Title of the Get Started page that explains the process for creating an Oppia activity at a high level.\n{{Identical|Get started}}",
+	"I18N_INTERACTIONS_FRACTIONS_INPUT_PLACEHOLDER": "Text displayed in the fractions interaction input as a placeholder.",
 	"I18N_INTERACTIONS_GRAPH_ADD_EDGE": "Text displayed in a button in a graph interaction inside the graph editor - When the user clicks the button, he can add a new line (edge) to the graph.",
 	"I18N_INTERACTIONS_GRAPH_ADD_NODE": "Text displayed in a button in a graph interaction inside the graph editor - When the user clicks the button, he can add a new dot (node) to the graph.",
 	"I18N_INTERACTIONS_GRAPH_DELETE": "Text displayed in a button in a graph interaction inside the graph editor - When the user clicks the button, he can move then select an element of the graph and delete it.\n{{Identical|Delete}}",

--- a/extensions/interactions/FractionInput/directives/fraction_input_interaction_directive.html
+++ b/extensions/interactions/FractionInput/directives/fraction_input_interaction_directive.html
@@ -1,7 +1,8 @@
 <form ng-disabled="FractionInputForm.$invalid" ng-submit="submitAnswer(answer)" role="form" class="form-horizontal">
   <!-- This ng-form is needed for submitting answer on hitting enter. -->
   <ng-form name="FractionInputForm">
-    <input type="text" name="answer" ng-model="answer" class="form-control">
+    <input type="text" name="answer" ng-model="answer" class="form-control"
+           ng-attr-placeholder="<['I18N_INTERACTIONS_FRACTIONS_INPUT_PLACEHOLDER' | translate]>">
   </ng-form>
 
   <div class="oppia-form-error oppia-fraction-input-error">


### PR DESCRIPTION
Put placeholder text in fractions input and in translation file. 

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
