### PR TITLE
Fix #4493: Update collection_player.html to properly pass along collection ID to the exploration summary tile.

### DIFF
--- a/core/templates/dev/head/pages/collection_player/collection_player.html
+++ b/core/templates/dev/head/pages/collection_player/collection_player.html
@@ -317,7 +317,7 @@
             <div ng-class="{'oppia-activity-summary-tile-mobile-background-mask': explorationCardIsShown}" ng-click="closeOnClickingOutside()">
               <exploration-summary-tile ng-if="explorationCardIsShown"
                                         ng-click="onClickStopPropagation($event)"
-                                        collection-id="getCollectionId()"
+                                        collection-id="collectionId"
                                         exploration-id="currentExplorationId"
                                         exploration-title="summaryToPreview.title"
                                         last-updated-msec="summaryToPreview.last_updated_msec"
@@ -347,7 +347,7 @@
           </div>
         </md-card>
         <exploration-summary-tile ng-if="explorationCardIsShown"
-                                  collection-id="getCollectionId()"
+                                  collection-id="collectionId"
                                   exploration-id="currentExplorationId"
                                   exploration-title="summaryToPreview.title"
                                   last-updated-msec="summaryToPreview.last_updated_msec"


### PR DESCRIPTION
See #4493 and #4494 for context, but overall this PR fixes a bug in ``collection_player.html`` where the collection ID was trying to be passed to exploration summary tiles by calling a non-existent ``getCollectionId()`` method. This does not resolve in errors since non-defined types are treated as undefined by default. Moreover, this became worse once a mobile-only version of the collection player was added since the collection ID passed to the summary tile is needed by the client to actually enter an exploration in the context of a collection. Without a collection context, finishing the exploration does not provide the proper return-to-collection behavior expected.

There's no clear way to me to add tests for this. I tested manually both on web (in mobile view) and on mobile to ensure the issue is fixed.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
