### PR TITLE
[WIP] Fix for #4317: Adding testing utils for LogicProof Interaction

### DIFF
--- a/core/tests/protractor.conf.js
+++ b/core/tests/protractor.conf.js
@@ -74,7 +74,7 @@ exports.config = {
     ],
 
     extensions: [
-      //'protractor/richTextComponents.js',
+      'protractor/richTextComponents.js',
       'protractor/interactions.js'
     ],
 

--- a/core/tests/protractor.conf.js
+++ b/core/tests/protractor.conf.js
@@ -74,7 +74,7 @@ exports.config = {
     ],
 
     extensions: [
-      'protractor/richTextComponents.js',
+      //'protractor/richTextComponents.js',
       'protractor/interactions.js'
     ],
 

--- a/extensions/interactions/LogicProof/protractor.js
+++ b/extensions/interactions/LogicProof/protractor.js
@@ -1,0 +1,52 @@
+// Copyright 2017 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview End-to-end testing utilities for the LogicProof interaction.
+ */
+
+var objects = require('../../objects/protractor.js');
+
+var customizeInteraction = function(elem, assumption, target, defaultText) {
+  elem.element(by.id('logicQuestionAssumptions')).sendKeys(assumption);
+  elem.element(by.id('logicQuestionTarget')).sendKeys(target);
+  elem.element(by.id('logicQuestionProof')).sendKeys(defaultText);
+};
+
+var expectInteractionDetailsToMatch = function(elem) {
+  expect(
+    elem.element(by.tagName('oppia-interactive-logic-proof')).isPresent()
+  ).toBe(true);
+};
+
+var submitAnswer = function(elem, answer) {
+  elem.element(by.className('oppia-learner-confirm-button')).click();
+};
+
+var answerObjectType = 'CheckedProof';
+
+
+var testSuite = [{
+  interactionArguments: ['', '', 'from p we have p'],
+  ruleArguments: ['Correct'],
+  expectedInteractionDetails: [],
+  wrongAnswers: [],
+  correctAnswers: ['']
+}];
+
+exports.customizeInteraction = customizeInteraction;
+exports.expectInteractionDetailsToMatch = expectInteractionDetailsToMatch;
+exports.submitAnswer = submitAnswer;
+exports.answerObjectType = answerObjectType;
+exports.testSuite = testSuite;

--- a/extensions/interactions/LogicProof/protractor.js
+++ b/extensions/interactions/LogicProof/protractor.js
@@ -31,7 +31,7 @@ var expectInteractionDetailsToMatch = function(elem) {
 };
 
 var submitAnswer = function(elem, answer) {
-  elem.element(by.className('oppia-learner-confirm-button')).click();
+  element(by.css('.oppia-learner-confirm-button')).click();
 };
 
 var answerObjectType = 'CheckedProof';

--- a/extensions/interactions/protractor.js
+++ b/extensions/interactions/protractor.js
@@ -47,7 +47,8 @@ var INTERACTIONS = {
   FractionInput: require('./FractionInput/protractor.js'),
   MultipleChoiceInput: require('./MultipleChoiceInput/protractor.js'),
   NumericInput: require('./NumericInput/protractor.js'),
-  TextInput: require('./TextInput/protractor.js')
+  TextInput: require('./TextInput/protractor.js'),
+  LogicProof: require('./LogicProof/protractor.js')
 };
 
 var getInteraction = function(interactionName) {

--- a/extensions/interactions/protractor.js
+++ b/extensions/interactions/protractor.js
@@ -43,12 +43,11 @@
  */
 
 var INTERACTIONS = {
-  /*Continue: require('./Continue/protractor.js'),
+  Continue: require('./Continue/protractor.js'),
   FractionInput: require('./FractionInput/protractor.js'),
   MultipleChoiceInput: require('./MultipleChoiceInput/protractor.js'),
   NumericInput: require('./NumericInput/protractor.js'),
-  TextInput: require('./TextInput/protractor.js'),*/
-  LogicProof: require('./LogicProof/protractor.js')
+  TextInput: require('./TextInput/protractor.js')
 };
 
 var getInteraction = function(interactionName) {

--- a/extensions/interactions/protractor.js
+++ b/extensions/interactions/protractor.js
@@ -43,11 +43,12 @@
  */
 
 var INTERACTIONS = {
-  Continue: require('./Continue/protractor.js'),
+  /*Continue: require('./Continue/protractor.js'),
   FractionInput: require('./FractionInput/protractor.js'),
   MultipleChoiceInput: require('./MultipleChoiceInput/protractor.js'),
   NumericInput: require('./NumericInput/protractor.js'),
-  TextInput: require('./TextInput/protractor.js')
+  TextInput: require('./TextInput/protractor.js'),*/
+  LogicProof: require('./LogicProof/protractor.js')
 };
 
 var getInteraction = function(interactionName) {


### PR DESCRIPTION
This is step 1 towards fixing #4317. I have added the testing utils for LogicProof Interaction. Have one issue here which I would like some help to fix. When added into the interactions to be tested using interactions.js (by adding into extensions/interactions/protractor.js). The test seems to progress correctly and everything happens as expected. But at the end it errors with 
`Expected '' to equal 'yes'.`. It shows this even after logging out successfully. 

Further tasks to be completed: 
- [ ] use this testing util to build an e2e test to guard against the situation mentioned in #4317 
- [ ] make sure you fix the issue by passing the e2e test.

PTAL @kevinlee12 and @aks681 
**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
