### PR TITLE
Fix #4486: Changed width of audio selection dropdown to not cut out text on phones

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
@@ -16,7 +16,7 @@
       <select class="audio-language-select"
               ng-model="selectedLanguage.value"
               ng-options="o.value as o.displayed for o in languagesInExploration"
-              ng-style="hasPressedPlayButtonAtLeastOnce ? {'width': '36%'} : {'width': '60%'}"
+              ng-style="hasPressedPlayButtonAtLeastOnce ? {'width': '30%'} : {'width': '60%'}"
               ng-change="onNewLanguageSelected()"></select>
     </div>
   </div>
@@ -110,7 +110,6 @@
     font-size: 15px;
     margin-left: 5px;
     padding-left: 3px;
-    width: 36%;
   }
 
   .progress-bar-section {

--- a/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
@@ -16,6 +16,7 @@
       <select class="audio-language-select"
               ng-model="selectedLanguage.value"
               ng-options="o.value as o.displayed for o in languagesInExploration"
+              ng-style="hasPressedPlayButtonAtLeastOnce ? {'width': '36%'} : {'width': '50%'}"
               ng-change="onNewLanguageSelected()"></select>
     </div>
   </div>

--- a/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
@@ -16,7 +16,7 @@
       <select class="audio-language-select"
               ng-model="selectedLanguage.value"
               ng-options="o.value as o.displayed for o in languagesInExploration"
-              ng-style="hasPressedPlayButtonAtLeastOnce ? {'width': '36%'} : {'width': '50%'}"
+              ng-style="hasPressedPlayButtonAtLeastOnce ? {'width': '36%'} : {'width': '60%'}"
               ng-change="onNewLanguageSelected()"></select>
     </div>
   </div>


### PR DESCRIPTION
Fixes #4486 . Changed the width of the audio selection dropdown if the progress bar is not shown to use the extra space also instead of cutting out some of the text on the dropdown.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
