### PR TITLE
Fix cut-off ratings at end of exploration.

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -350,6 +350,7 @@ otherwise they will interfere with the iframed conversation skin directive.
 
   .conversation-skin-final-ratings {
     text-align: center;
+    margin-bottom: 60px;
   }
   .conversation-skin-final-ratings-header {
     color: #064b46;


### PR DESCRIPTION
Fix #4455: Added a margin to the bottom of the ratings so it isn't hidden behind the footer.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
