### PR TITLE
Fix #4488: Make audio bar expand button bigger on mobile, and hide on scroll down.

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
@@ -121,14 +121,14 @@ oppia.directive('audioBar', [
             var scrollTop = $(this).scrollTop();
             var audioHeader = angular.element($('.audio-header:first'));
             if (scrollTop > lastScrollTop) {
-              audioHeader.addClass('nav-up');
+              audioHeader.addClass('audio-bar-nav-up');
               if (!$scope.audioBarIsExpanded) {
-                audioHeader.addClass('nav-hidden');
+                audioHeader.addClass('audio-bar-nav-hidden');
               }
             } else if (scrollTop === 0 ||
                        scrollTop + $(window).height() < $(document).height()) {
-              audioHeader.removeClass('nav-up');
-              audioHeader.removeClass('nav-hidden');
+              audioHeader.removeClass('audio-bar-nav-up');
+              audioHeader.removeClass('audio-bar-nav-hidden');
             }
             lastScrollTop = scrollTop;
           };

--- a/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
@@ -122,9 +122,13 @@ oppia.directive('audioBar', [
             var audioHeader = angular.element($('.audio-header:first'));
             if (scrollTop > lastScrollTop) {
               audioHeader.addClass('nav-up');
+              if (!$scope.audioBarIsExpanded) {
+                audioHeader.addClass('nav-hidden');
+              }
             } else if (scrollTop === 0 ||
                        scrollTop + $(window).height() < $(document).height()) {
               audioHeader.removeClass('nav-up');
+              audioHeader.removeClass('nav-hidden');
             }
             lastScrollTop = scrollTop;
           };

--- a/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
@@ -120,11 +120,11 @@
     width: 50%;
   }
 
-  .nav-up {
+  .audio-bar-nav-up {
     margin-top: -186px;
   }
 
-  .nav-hidden {
+  .audio-bar-nav-hidden {
     margin-top: -270px;
   }
 

--- a/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
@@ -20,7 +20,7 @@
     </div>
   </div>
   <div class="audio-collapse-button audio-toggle-button" ng-if="audioBarIsExpanded" ng-click="collapseAudioBar()"><i class="fa fa-sort-up"></i></div>
-  <div class="audio-expand-button audio-toggle-button" ng-if="!audioBarIsExpanded" ng-click="expandAudioBar()"><span translate="I18N_PLAYER_AUDIO_EXPAND_TEXT"></span> <i class="fa fa-sort-down"></i></div>
+  <div class="audio-expand-button audio-toggle-button" ng-if="!audioBarIsExpanded" ng-click="expandAudioBar()"><span class="audio-expand-button-text" translate="I18N_PLAYER_AUDIO_EXPAND_TEXT"></span> <i class="audio-expand-icon fa fa-sort-down"></i></div>
 </div>
 
 <style>
@@ -122,6 +122,23 @@
 
   .nav-up {
     margin-top: -186px;
+  }
+
+  .nav-hidden {
+    margin-top: -270px;
+  }
+
+  @media screen and (max-width: 959px) {
+    .audio-expand-button {
+      height: 40px;
+      width: 120px;
+      text-transform: capitalize;
+    }
+
+    .audio-expand-button-text, .audio-expand-icon {
+      font-size: 20px;
+      line-height: 1.9em;
+    }
   }
 
 </style>

--- a/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
@@ -130,14 +130,14 @@
 
   @media screen and (max-width: 959px) {
     .audio-expand-button {
-      height: 40px;
-      width: 120px;
+      height: 32px;
+      width: 100px;
       text-transform: capitalize;
     }
 
     .audio-expand-button-text, .audio-expand-icon {
-      font-size: 20px;
-      line-height: 1.9em;
+      font-size: 18px;
+      line-height: 1.7em;
     }
   }
 


### PR DESCRIPTION
I made the audio bar expand button bigger and hid it while scrolling down. Not sure if this is the right fix, just did it to see how it looks. The problem also remains that the collapse button is too small.

![image](https://user-images.githubusercontent.com/11807091/34966552-37f8093e-fa22-11e7-957f-9a2fa97c26c6.png)

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
