### PR TITLE
Fix #4349: Record leave for refresher exp events

### DIFF
--- a/core/controllers/reader.py
+++ b/core/controllers/reader.py
@@ -437,6 +437,22 @@ class StateCompleteEventHandler(base.BaseHandler):
         self.render_json({})
 
 
+class LeaveForRefresherExpEventHandler(base.BaseHandler):
+    """Tracks a learner leaving an exploration for a refresher exploration."""
+
+    REQUIRE_PAYLOAD_CSRF_CHECK = False
+
+    @acl_decorators.can_play_exploration
+    def post(self, exploration_id):
+        """Handles POST requests."""
+        event_services.LeaveForRefresherExpEventHandler.record(
+            exploration_id, self.payload.get('refresher_exp_id'),
+            self.payload.get('exp_version'), self.payload.get('state_name'),
+            self.payload.get('session_id'),
+            self.payload.get('time_spent_in_state_secs'))
+        self.render_json({})
+
+
 class ClassifyHandler(base.BaseHandler):
     """Stateless handler that performs a classify() operation server-side and
     returns the corresponding classification result, which is a dict containing

--- a/core/domain/event_services.py
+++ b/core/domain/event_services.py
@@ -227,6 +227,20 @@ class StateCompleteEventHandler(BaseEventHandler):
             time_spent_in_state_secs)
 
 
+class LeaveForRefresherExplorationEventHandler(BaseEventHandler):
+    """Event handler for recording leave for refresher exploration events."""
+
+    EVENT_TYPE = feconf.EVENT_TYPE_LEAVE_FOR_REFRESHER_EXP
+
+    @classmethod
+    def _handle_event(
+            cls, exp_id, refresher_exp_id, exp_version, state_name, session_id,
+            time_spent_in_state_secs):
+        stats_models.LeaveForRefresherExplorationEventLogEntryModel.create(
+            exp_id, refresher_exp_id, exp_version, state_name, session_id,
+            time_spent_in_state_secs)
+
+
 class FeedbackThreadCreatedEventHandler(BaseEventHandler):
     """Event handler for recording new feedback thread creation events."""
 

--- a/core/domain/event_services.py
+++ b/core/domain/event_services.py
@@ -227,7 +227,7 @@ class StateCompleteEventHandler(BaseEventHandler):
             time_spent_in_state_secs)
 
 
-class LeaveForRefresherExplorationEventHandler(BaseEventHandler):
+class LeaveForRefresherExpEventHandler(BaseEventHandler):
     """Event handler for recording leave for refresher exploration events."""
 
     EVENT_TYPE = feconf.EVENT_TYPE_LEAVE_FOR_REFRESHER_EXP

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -700,6 +700,52 @@ class StateCompleteEventLogEntryModel(base_models.BaseModel):
         return entity_id
 
 
+class LeaveForRefresherExplorationEventLogEntryModel(base_models.BaseModel):
+    """An event triggered by a student leaving for a refresher exploration."""
+    # ID of exploration currently being played.
+    exp_id = ndb.StringProperty(indexed=True)
+    # ID of the refresher exploration.
+    refresher_exp_id = ndb.StringProperty(indexed=True)
+    # Current version of exploration.
+    exp_version = ndb.IntegerProperty(indexed=True)
+    # Name of current state.
+    state_name = ndb.StringProperty(indexed=True)
+    # ID of current student's session.
+    session_id = ndb.StringProperty(indexed=True)
+    # Time since start of this state before this event occurred (in sec).
+    time_spent_in_state_secs = ndb.FloatProperty()
+    # The version of the event schema used to describe an event of this type.
+    event_schema_version = ndb.IntegerProperty(
+        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
+
+    @classmethod
+    def get_new_event_entity_id(cls, exp_id, session_id):
+        """Generates a unique id for the event model of the form
+        {{random_hash}} from {{timestamp}:{exp_id}:{session_id}}."""
+        timestamp = datetime.datetime.utcnow()
+        return cls.get_new_id('%s:%s:%s' % (
+            utils.get_time_in_millisecs(timestamp),
+            exp_id,
+            session_id))
+
+    @classmethod
+    def create(cls, exp_id, refresher_exp_id, exp_version, state_name,
+               session_id, time_spent_in_state_secs):
+        """Creates a new leave for refresher exploration event."""
+        entity_id = cls.get_new_event_entity_id(
+            exp_id, session_id)
+        leave_for_refresher_exp_entity = cls(
+            id=entity_id,
+            exp_id=exp_id,
+            refresher_exp_id=refresher_exp_id,
+            exp_version=exp_version,
+            state_name=state_name,
+            session_id=session_id,
+            time_spent_in_state_secs=time_spent_in_state_secs)
+        leave_for_refresher_exp_entity.put()
+        return entity_id
+
+
 class ExplorationStatsModel(base_models.BaseModel):
     """Model for storing analytics data for an exploration. This model contains
     statistics data aggregated from version 1 to the version given in the key.

--- a/core/storage/statistics/gae_models_test.py
+++ b/core/storage/statistics/gae_models_test.py
@@ -116,6 +116,27 @@ class StateCompleteEventLogEntryModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(event_model.time_spent_in_state_secs, 0.0)
 
 
+class LeaveForRefresherExplorationEventLogEntryModelUnitTests(
+        test_utils.GenericTestBase):
+    """Test the LeaveForRefresherExplorationEventLogEntryModel class."""
+
+    def test_create_and_get_event_models(self):
+        event_id = (
+            stat_models.LeaveForRefresherExplorationEventLogEntryModel.create(
+                'exp_id1', 'exp_id2', 1, 'state_name1', 'session_id1', 0.0))
+
+        event_model = (
+            stat_models.LeaveForRefresherExplorationEventLogEntryModel.get(
+                event_id))
+
+        self.assertEqual(event_model.exp_id, 'exp_id1')
+        self.assertEqual(event_model.refresher_exp_id, 'exp_id2')
+        self.assertEqual(event_model.exp_version, 1)
+        self.assertEqual(event_model.state_name, 'state_name1')
+        self.assertEqual(event_model.session_id, 'session_id1')
+        self.assertEqual(event_model.time_spent_in_state_secs, 0.0)
+
+
 class CompleteExplorationEventLogEntryModelUnitTests(
         test_utils.GenericTestBase):
     """Test the CompleteExplorationEventLogEntryModel class."""

--- a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
@@ -652,7 +652,7 @@ oppia.directive('conversationSkin', [
                               }
                             );
                           ExplorationPlayerService.recordLeftForRefresherExp(
-                            newStateName, refresherExpId);
+                            newStateName, refresherExplorationId);
                         }
                       });
                     }

--- a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js
@@ -651,6 +651,8 @@ oppia.directive('conversationSkin', [
                                   true;
                               }
                             );
+                          ExplorationPlayerService.recordLeftForRefresherExp(
+                            newStateName, refresherExpId);
                         }
                       });
                     }

--- a/core/templates/dev/head/pages/exploration_player/PlayerServices.js
+++ b/core/templates/dev/head/pages/exploration_player/PlayerServices.js
@@ -479,6 +479,12 @@ oppia.factory('ExplorationPlayerService', [
           StatsReportingService.recordSolutionHit(stateName);
         }
       },
+      recordLeftForRefresherExp: function(stateName, refresherExpId) {
+        if (!_editorPreviewMode) {
+          StatsReportingService.recordLeftForRefresherExp(
+            stateName, refresherExpId);
+        }
+      },
       // Returns whether the screen is wide enough to fit two
       // cards (e.g., the tutor and supplemental cards) side-by-side.
       canWindowShowTwoCards: function() {

--- a/core/templates/dev/head/pages/exploration_player/StatsReportingService.js
+++ b/core/templates/dev/head/pages/exploration_player/StatsReportingService.js
@@ -23,7 +23,8 @@ oppia.constant('STATS_EVENT_TYPES', {
   EVENT_TYPE_STATE_HIT: 'state_hit',
   EVENT_TYPE_STATE_COMPLETED: 'state_complete',
   EVENT_TYPE_ANSWER_SUBMITTED: 'answer_submitted',
-  EVENT_TYPE_SOLUTION_HIT: 'solution_hit'
+  EVENT_TYPE_SOLUTION_HIT: 'solution_hit',
+  EVENT_TYPE_LEAVE_FOR_REFRESHER_EXP: 'leave_for_refresher_exp',
 });
 
 oppia.constant('STATS_REPORTING_URLS', {
@@ -39,6 +40,8 @@ oppia.constant('STATS_REPORTING_URLS', {
   EXPLORATION_ACTUALLY_STARTED: (
     '/explorehandler/exploration_actual_start_event/<exploration_id>'),
   SOLUTION_HIT: '/explorehandler/solution_hit_event/<exploration_id>',
+  LEAVE_FOR_REFRESHER_EXP: (
+    '/explorehandler/leave_for_refresher_exp_event/<exploration_id>'),
   STATS_EVENTS: '/explorehandler/stats_events/<exploration_id>'
 });
 
@@ -183,6 +186,15 @@ oppia.factory('StatsReportingService', [
 
         $http.post(getFullStatsUrl('SOLUTION_HIT'), {
           exploration_version: explorationVersion,
+          state_name: stateName,
+          session_id: sessionId,
+          time_spent_in_state_secs: stateStopwatch.getTimeInSecs()
+        });
+      },
+      recordLeaveForRefresherExp: function(stateName, refresherExpId) {
+        $http.post(getFullStatsUrl('LEAVE_FOR_REFRESHER_EXP'), {
+          exploration_version: explorationVersion,
+          refresher_exp_id: refresherExpId,
           state_name: stateName,
           session_id: sessionId,
           time_spent_in_state_secs: stateStopwatch.getTimeInSecs()

--- a/feconf.py
+++ b/feconf.py
@@ -622,6 +622,7 @@ EVENT_TYPE_NEW_THREAD_CREATED = 'feedback_thread_created'
 EVENT_TYPE_THREAD_STATUS_CHANGED = 'feedback_thread_status_changed'
 EVENT_TYPE_RATE_EXPLORATION = 'rate_exploration'
 EVENT_TYPE_SOLUTION_HIT = 'solution_hit'
+EVENT_TYPE_LEAVE_FOR_REFRESHER_EXP = 'leave_for_refresher_exp'
 # The values for these event types should be left as-is for backwards
 # compatibility.
 EVENT_TYPE_START_EXPLORATION = 'start'

--- a/main.py
+++ b/main.py
@@ -317,6 +317,9 @@ URLS = MAPREDUCE_HANDLERS + [
         r'/explorehandler/state_complete_event/<exploration_id>',
         reader.StateCompleteEventHandler),
     get_redirect_route(
+        r'/explorehandler/leave_for_refresher_exp_event/<exploration_id>',
+        reader.LeaveForRefresherExpEventHandler),
+    get_redirect_route(
         r'/explorehandler/answer_submitted_event/<exploration_id>',
         reader.AnswerSubmittedEventHandler),
     get_redirect_route(


### PR DESCRIPTION
#4349 

This PR records an additional event model in the event of a student leaving for a refresher exploration.

@seanlip PTAL.