### PR TITLE
Fix #4542: Moves the position of NodeErrorMessage tooltip.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_graph_visualization_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_graph_visualization_directive.html
@@ -104,7 +104,7 @@ with the same id on the page. -->
                       ng-attr-x="<[node.x0]>" ng-attr-y="<[node.y0 - 8]>"
                       ng-attr-transform="<[getHighlightTransform(node.x0, node.y0)]>"
                       uib-tooltip="<[getNodeErrorMessage(node.label)]>"
-                      tooltip-placement="bottom" tooltip-animation="true"
+                      tooltip-placement="top" tooltip-animation="true"
                       tooltip-append-to-body="true">
                 </rect>
                 <text fill="firebrick" text-anchor="middle" ng-attr-x="<[node.x0 + 11]>"


### PR DESCRIPTION
Fix #4542 

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
