### PR TITLE
Fix part of #3950: replace Jinja in state_editor_responses.html

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
@@ -29,6 +29,8 @@ oppia.controller('StateResponses', [
       ExplorationContextService, TrainingDataService,
       stateCustomizationArgsService, PLACEHOLDER_OUTCOME_DEST,
       INTERACTION_SPECS, UrlInterpolationService, AnswerGroupObjectFactory) {
+    $scope.SHOW_TRAINABLE_UNRESOLVED_ANSWERS = (
+      GLOBALS.SHOW_TRAINABLE_UNRESOLVED_ANSWERS);
     $scope.EditorStateService = EditorStateService;
 
     $scope.dragDotsImgUrl = UrlInterpolationService.getStaticImageUrl(

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
@@ -101,6 +101,7 @@
         + Teach Oppia
       </button>
     </div>
+    
   </md-card>
   <md-card style="margin: 0px; padding: 0px;">
     <div ng-if="EditabilityService.isEditableOutsideTutorialMode() && !isCurrentInteractionLinear()">

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
@@ -95,15 +95,13 @@
     </div>
   </md-card>
 
-{% if SHOW_TRAINABLE_UNRESOLVED_ANSWERS %}
-  <md-card style="margin: 20px 0px; padding: 0px;" ng-if="isCurrentInteractionTrainable()">
+  <md-card style="margin: 20px 0px; padding: 0px;" ng-if="SHOW_TRAINABLE_UNRESOLVED_ANSWERS && isCurrentInteractionTrainable()">
     <div ng-if="EditabilityService.isEditableOutsideTutorialMode() && !isCurrentInteractionLinear()">
       <button type="button" class="btn btn-default btn-lg oppia-add-response-button protractor-test-open-teach-modal" ng-click="openTeachOppiaModal()">
         + Teach Oppia
       </button>
     </div>
   </md-card>
-{% endif %}
   <md-card style="margin: 0px; padding: 0px;">
     <div ng-if="EditabilityService.isEditableOutsideTutorialMode() && !isCurrentInteractionLinear()">
       <button type="button" class="btn btn-default btn-lg oppia-add-response-button protractor-test-open-add-response-modal" ng-click="openAddAnswerGroupModal()">

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
@@ -102,7 +102,7 @@
       </button>
     </div>
   </md-card>
-  
+
   <md-card style="margin: 0px; padding: 0px;">
     <div ng-if="EditabilityService.isEditableOutsideTutorialMode() && !isCurrentInteractionLinear()">
       <button type="button" class="btn btn-default btn-lg oppia-add-response-button protractor-test-open-add-response-modal" ng-click="openAddAnswerGroupModal()">

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/state_editor_responses.html
@@ -101,8 +101,8 @@
         + Teach Oppia
       </button>
     </div>
-    
   </md-card>
+  
   <md-card style="margin: 0px; padding: 0px;">
     <div ng-if="EditabilityService.isEditableOutsideTutorialMode() && !isCurrentInteractionLinear()">
       <button type="button" class="btn btn-default btn-lg oppia-add-response-button protractor-test-open-add-response-modal" ng-click="openAddAnswerGroupModal()">


### PR DESCRIPTION
This PR removes the use of Jinja template `{% if SHOW_TRAINABLE_UNRESOLVED_ANSWERS %}` in exploration_editor/editor_tab/state_editor_responses.html to Angular style

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
