### PR TITLE
Fix #4317: Hides the back button if a help window with a continue button is shown

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/progress_nav_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/progress_nav_directive.html
@@ -3,7 +3,7 @@
     even when the first button is not present. -->
   <div>
     <!-- ng-if on this second wrapping div because ng-if lags on buttons. -->
-    <div ng-if="hasPrevious">
+    <div ng-if="hasPrevious && !helpCardHasContinueButton">
       <md-button ng-click="changeCard(activeCardIndex-1)" class="md-raised" style="margin: 0 0 12px 12px;">
         <i class="material-icons oppia-vcenter" aria-hidden="true">&#xE5C4;</i>
       </div>


### PR DESCRIPTION
Hi @seanlip and @DubeySandeep could you let me know if this is a reasonable fix for #4317? 

What happens currently: On any interaction that triggers the help card, If the help card is currently shown with a continue button the back button is hidden. This prevents this situation from arising and the learner is forced to go forward. On returning to this interaction using the back buttons however he can navigate backwards. 

I'll continue to fix the other PR on this same issue to finish up an e2e test that makes sure this functionality is preserved. 

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
