### PR TITLE
Ensure 'Return to Library' button always shows for explorations completed outside a collection.

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -117,9 +117,6 @@
       <div ng-if="collectionSummary" class="conversation-skin-back-to-collection-container">
         <a ng-href="/collection/<[collectionId]>" class="conversation-skin-back-to-collection" translate="I18N_PLAYER_BACK_TO_COLLECTION"></a>
       </div>
-      <div ng-if="!collectionSummary" class="conversation-skin-back-to-collection-container">
-        <a ng-href="/library" class="conversation-skin-back-to-collection" translate="I18N_PLAYER_RETURN_TO_LIBRARY"></a>
-      </div>
     </div>
 
     <div ng-if="collectionSummary && recommendedExplorationSummaries.length === 0">
@@ -139,6 +136,10 @@
         </collection-summary-tile>
       </div>
     </div>
+  </div>
+
+  <div ng-if="!collectionSummary" class="conversation-skin-back-to-collection-container">
+    <a ng-href="/library" class="conversation-skin-back-to-collection" translate="I18N_PLAYER_RETURN_TO_LIBRARY"></a>
   </div>
 </div>
 


### PR DESCRIPTION
Fix that the 'Return to Library' button does not show up when finishing explorations outside a collection unless there are recommended explorations. Verified that this works for both cases when there are and are not recommended explorations, both for logged in and guest collection exploration flows.