### PR TITLE
Fix #4531: Change Java prerequisite to v8

### DIFF
--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -33,7 +33,7 @@ fi
 sudo apt-get update
 sudo apt-get install curl
 sudo apt-get install git
-sudo apt-get install openjdk-7-jre
+sudo apt-get install openjdk-8-jre
 sudo apt-get install python-setuptools
 sudo apt-get install python-dev
 sudo apt-get install python-pip


### PR DESCRIPTION
The following updates the prereqs to Java v8. This was minimal as Travis already uses Java 8 in automated tests.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
