### PR TITLE
Fix part of #3905: Add checks for correct docstring style.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -5,6 +5,11 @@
 [GENERAL]
 init-hook='import sys; sys.path.append("../oppia_tools/google_appengine_1.9.50/google_appengine")'
 
+[MASTER]
+
+# Checks for correct docstring style
+load-plugins=pylint.extensions.docstyle
+
 [BASIC]
 
 # Regular expression which should only match correct function names

--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -218,8 +218,7 @@ class AdminHandler(base.BaseHandler):
 
     def _generate_dummy_explorations(
             self, num_dummy_exps_to_generate, num_dummy_exps_to_publish):
-        """
-        Generates and publishes the given number of dummy explorations.
+        """Generates and publishes the given number of dummy explorations.
 
         Args:
             num_dummy_exps_to_generate: int. Count of dummy explorations to

--- a/core/domain/html_cleaner_test.py
+++ b/core/domain/html_cleaner_test.py
@@ -129,7 +129,7 @@ class HtmlStripperUnitTests(test_utils.GenericTestBase):
 
 
 class RteComponentExtractorUnitTests(test_utils.GenericTestBase):
-    '''Test the RTE component extractor.'''
+    """Test the RTE component extractor."""
 
     def test_get_rte_components(self):
         test_data = (

--- a/core/domain/user_jobs_continuous.py
+++ b/core/domain/user_jobs_continuous.py
@@ -433,7 +433,8 @@ class UserStatsAggregator(jobs.BaseContinuousComputationManager):
     # Public query method.
     @classmethod
     def get_dashboard_stats(cls, user_id):
-        """
+        """Returns the dashboard stats associated with the given user_id.
+
         Args:
             user_id: str. The ID of the user.
 

--- a/scripts/release_info.py
+++ b/scripts/release_info.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Script that simplifies releases by collecting various information.
 Should be run from the oppia root dir.

--- a/scripts/release_info.py
+++ b/scripts/release_info.py
@@ -13,8 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Script that simplifies releases by collecting various information.
+
+"""Script that simplifies releases by collecting various information.
 Should be run from the oppia root dir.
 """
 import collections


### PR DESCRIPTION
This PR adds checks for correct """ quotes and non-empty first line  for docstrings.

**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.