### PR TITLE
Fix #4567: Changed condition to check range enclosed criteria, edited existing test

### DIFF
--- a/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
@@ -81,6 +81,19 @@ oppia.factory('FractionInputValidationService', [
             upperBoundConditionIsSatisfied;
         };
 
+        var shouldCheckRangeCriteria = function(rule1, rule2) {
+          if (
+            (rule1.type === 'IsExactlyEqualTo' &&
+            rule2.type === 'IsExactlyEqualTo') ||
+            (rule1.type === 'IsExactlyEqualTo' &&
+            rule2.type === 'IsEquivalentTo') ||
+            (rule1.type === 'IsExactlyEqualTo' &&
+            rule2.type === 'IsEquivalentToAndInSimplestForm')) {
+            return false;
+          }
+          return true;
+        };
+
         var ranges = [];
         for (var i = 0; i < answerGroups.length; i++) {
           var rules = answerGroups[i].rules;
@@ -194,8 +207,7 @@ oppia.factory('FractionInputValidationService', [
               if (isEnclosedBy(range, ranges[k])) {
                 var rule2 = answerGroups[ranges[k].answerGroupIndex - 1]
                   .rules[ranges[k].ruleIndex - 1];
-                if (rule.type !== 'IsExactlyEqualTo' ||
-                  rule2.type !== 'IsExactlyEqualTo') {
+                if (shouldCheckRangeCriteria(rule2, rule)) {
                   warningsList.push({
                     type: WARNING_TYPES.ERROR,
                     message: (

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
@@ -81,14 +81,14 @@ oppia.factory('FractionInputValidationService', [
             upperBoundConditionIsSatisfied;
         };
 
-        var shouldCheckRangeCriteria = function(rule1, rule2) {
+        var shouldCheckRangeCriteria = function(earlierRule, laterRule) {
           if (
-            (rule1.type === 'IsExactlyEqualTo' &&
-            rule2.type === 'IsExactlyEqualTo') ||
-            (rule1.type === 'IsExactlyEqualTo' &&
-            rule2.type === 'IsEquivalentTo') ||
-            (rule1.type === 'IsExactlyEqualTo' &&
-            rule2.type === 'IsEquivalentToAndInSimplestForm')) {
+            (earlierRule.type === 'IsExactlyEqualTo' &&
+            laterRule.type === 'IsExactlyEqualTo') ||
+            (earlierRule.type === 'IsExactlyEqualTo' &&
+            laterRule.type === 'IsEquivalentTo') ||
+            (earlierRule.type === 'IsExactlyEqualTo' &&
+            laterRule.type === 'IsEquivalentToAndInSimplestForm')) {
             return false;
           }
           return true;
@@ -205,9 +205,9 @@ oppia.factory('FractionInputValidationService', [
             }
             for (var k = 0; k < ranges.length; k++) {
               if (isEnclosedBy(range, ranges[k])) {
-                var rule2 = answerGroups[ranges[k].answerGroupIndex - 1]
+                var earlierRule = answerGroups[ranges[k].answerGroupIndex - 1]
                   .rules[ranges[k].ruleIndex - 1];
-                if (shouldCheckRangeCriteria(rule2, rule)) {
+                if (shouldCheckRangeCriteria(earlierRule, rule)) {
                   warningsList.push({
                     type: WARNING_TYPES.ERROR,
                     message: (

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
@@ -143,6 +143,20 @@ describe('FractionInputValidationService', function() {
       }
     });
 
+    exactlyEqualToTwoByFour = rof.createFromBackendDict({
+      rule_type: 'IsExactlyEqualTo',
+      inputs: {
+        f: createFractionDict(false, 0, 2, 4)
+      }
+    });
+
+    equivalentToHalf = rof.createFromBackendDict({
+      rule_type: 'IsEquivalentTo',
+      inputs: {
+        f: createFractionDict(false, 0, 1, 2)
+      }
+    });
+
     zeroDenominatorRule = rof.createFromBackendDict({
       rule_type: 'HasDenominatorEqualTo',
       inputs: {
@@ -190,8 +204,22 @@ describe('FractionInputValidationService', function() {
     }]);
   });
 
-  it('should catch identical rules as redundant', function() {
+  it('should not catch equals followed by equivalent as redundant', function() {
     answerGroups[0].rules = [equalsOneRule, equivalentToOneRule];
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([]);
+
+    answerGroups[0].rules = [equalsOneRule, equivalentToOneAndSimplestFormRule];
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([]);
+  });
+
+  it('should catch identical rules as redundant', function() {
+    answerGroups[0].rules = [equivalentToOneAndSimplestFormRule, equalsOneRule];
     var warnings = validatorService.getAllWarnings(
       currentState, customizationArgs, answerGroups,
       goodDefaultOutcome);
@@ -200,7 +228,8 @@ describe('FractionInputValidationService', function() {
       message: 'Rule 2 from answer group 1 will never be matched ' +
         'because it is made redundant by rule 1 from answer group 1.'
     }]);
-    answerGroups[0].rules = [equalsOneRule, equivalentToOneAndSimplestFormRule];
+
+    answerGroups[0].rules = [equivalentToOneAndSimplestFormRule, equalsOneRule];
     var warnings = validatorService.getAllWarnings(
       currentState, customizationArgs, answerGroups,
       goodDefaultOutcome);

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
@@ -204,7 +204,7 @@ describe('FractionInputValidationService', function() {
     expect(warnings).toEqual([]);
   });
 
-  it('should catch equivalent followed by equals same number' +
+  it('should catch equivalent followed by equals same value' +
     'as redundant', function() {
     answerGroups[0].rules = [equivalentToOneRule, equalsOneRule];
     var warnings = validatorService.getAllWarnings(

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
@@ -143,20 +143,6 @@ describe('FractionInputValidationService', function() {
       }
     });
 
-    exactlyEqualToTwoByFour = rof.createFromBackendDict({
-      rule_type: 'IsExactlyEqualTo',
-      inputs: {
-        f: createFractionDict(false, 0, 2, 4)
-      }
-    });
-
-    equivalentToHalf = rof.createFromBackendDict({
-      rule_type: 'IsEquivalentTo',
-      inputs: {
-        f: createFractionDict(false, 0, 1, 2)
-      }
-    });
-
     zeroDenominatorRule = rof.createFromBackendDict({
       rule_type: 'HasDenominatorEqualTo',
       inputs: {
@@ -219,7 +205,7 @@ describe('FractionInputValidationService', function() {
   });
 
   it('should catch identical rules as redundant', function() {
-    answerGroups[0].rules = [equivalentToOneAndSimplestFormRule, equalsOneRule];
+    answerGroups[0].rules = [equivalentToOneRule, equalsOneRule];
     var warnings = validatorService.getAllWarnings(
       currentState, customizationArgs, answerGroups,
       goodDefaultOutcome);

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
@@ -204,7 +204,8 @@ describe('FractionInputValidationService', function() {
     expect(warnings).toEqual([]);
   });
 
-  it('should catch identical rules as redundant', function() {
+  it('should catch equivalent followed by equals same number' +
+    'as redundant', function() {
     answerGroups[0].rules = [equivalentToOneRule, equalsOneRule];
     var warnings = validatorService.getAllWarnings(
       currentState, customizationArgs, answerGroups,


### PR DESCRIPTION
Fixes #4567. I have proceeded as per my comment https://github.com/oppia/oppia/issues/4567#issuecomment-359165619. I have edited 2 existing karma tests and tested the situation mentioned in the issue and the reverse(ie, equivalent to 1/2 followed by equals 1/2 should show a warning).
 
**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
