### PR TITLE
Update text of refresher exploration modal.

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/refresher_exploration_confirmation_modal_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/refresher_exploration_confirmation_modal_directive.html
@@ -16,9 +16,9 @@
 
 <div class="modal-body">
   <span class="oppia-learner-refresher-exploration-confirmation-body">
-    It looks like you're having some trouble answering the question.
-    Would you like to try a different exploration to refresh your memory, and
-    return here after you've completed that?
+    It looks like you're having some trouble with this question. Would you
+    like to try a short exploration to refresh your memory, and return
+    here after you've completed that?
   </span>
 </div>
 


### PR DESCRIPTION
This is a small wording change intended to emphasize that refresher explorations are _short_.

If you'd like to see this functionality in action, try [this exploration](https://www.oppia.org/explore/MjZzEVOG47_1) and get one of the initial questions wrong.

**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.