### PR TITLE
Add visualization stats for fractions input interaction.

### DIFF
--- a/extensions/interactions/FractionInput/FractionInput.py
+++ b/extensions/interactions/FractionInput/FractionInput.py
@@ -52,3 +52,14 @@ class FractionInput(base.BaseInteraction):
         },
         'default_value': True
     }]
+
+    _answer_visualization_specs = [{
+        # Table with answer counts for top N answers.
+        'id': 'FrequencyTable',
+        'options': {
+            'column_headers': ['Answer', 'Count'],
+            'title': 'Top answers',
+        },
+        'calculation_id': 'Top10AnswerFrequencies',
+        'show_addressed_info': True,
+    }]


### PR DESCRIPTION
I just found out that we can't see answer stats for the fractions input interaction, so this PR adds them.  Planning to do a hotfix for this.

Note that the stats look terrible atm (the JSON dict is shown rather than the more conventional representation of the fraction) but we don't seem to have the apparatus to show the latter at the moment and this data is important for improving the lessons, so I think we should do this anyway and handle tidying up the visualization later.

**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
