### PR TITLE
Fix #4533: Fix word wrap property

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -939,7 +939,7 @@ p {
   margin: 0;
   text-align: left;
   word-spacing: 0;
-  word-break: break-all;
+  word-break: break-word;
 }
 
 .oppia-long-text p {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -939,6 +939,7 @@ p {
   margin: 0;
   text-align: left;
   word-spacing: 0;
+  word-break: break-all;
 }
 
 .oppia-long-text p {


### PR DESCRIPTION
The word wrap property is set to break-all for any paragraph since the editor lengthens in multiple choice interaction as well as item selection interaction. So, instead of making local changes to the interaction, I set the property for any paragraph element.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
