### PR TITLE
Add a dot to mark previous answer in ImageRegion when no highlighting

### DIFF
--- a/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
+++ b/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
@@ -110,11 +110,11 @@ oppia.directive('oppiaInteractiveImageClickInput', [
             };
             if ($scope.lastAnswer) {
               answer.left =
-                $scope.lastAnswer.clickPosition[0]*image.width() +
+                $scope.lastAnswer.clickPosition[0] * image.width() +
                 image.offset().left -
                 image.parent().offset().left - 5;
               answer.top =
-                $scope.lastAnswer.clickPosition[1]*image.height() +
+                $scope.lastAnswer.clickPosition[1] * image.height() +
                 image.offset().top -
                 image.parent().offset().top - 5;
             }

--- a/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
+++ b/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
@@ -122,6 +122,9 @@ oppia.directive('oppiaInteractiveImageClickInput', [
           };
           $scope.onMousemoveImage = function(event) {
             if (!$scope.interactionIsActive) {
+              $scope.lastAnswer = {
+                clickPosition: [$scope.mouseX, $scope.mouseY]
+              };
               return;
             }
             var image = $($element).find('.oppia-image-click-img');
@@ -133,11 +136,6 @@ oppia.directive('oppiaInteractiveImageClickInput', [
             $scope.updateCurrentlyHoveredRegions();
           };
           $scope.onClickImage = function() {
-            if (!$scope.lastAnswer) {
-              $scope.lastAnswer = {
-                clickPosition: [$scope.mouseX, $scope.mouseY]
-              };
-            }
             $scope.onSubmit({
               answer: {
                 clickPosition: [$scope.mouseX, $scope.mouseY],

--- a/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
+++ b/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
@@ -52,6 +52,9 @@ oppia.directive('oppiaInteractiveImageClickInput', [
           $scope.mouseX = 0;
           $scope.mouseY = 0;
           $scope.interactionIsActive = ($scope.getLastAnswer() === null);
+          if (!$scope.interactionIsActive) {
+            $scope.lastAnswer = $scope.getLastAnswer();
+          }
 
           $scope.currentlyHoveredRegions = [];
           $scope.allRegions = imageAndRegions.labeledRegions;
@@ -99,6 +102,24 @@ oppia.directive('oppiaInteractiveImageClickInput', [
           $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.interactionIsActive = false;
           });
+          $scope.getDotLocation = function() {
+            var image = $($element).find('.oppia-image-click-img');
+            var answer = {
+              left: null,
+              top: null
+            };
+            if ($scope.lastAnswer) {
+              answer.left =
+                $scope.lastAnswer.clickPosition[0]*image.width() +
+                image.offset().left -
+                image.parent().offset().left - 5;
+              answer.top =
+                $scope.lastAnswer.clickPosition[1]*image.height() +
+                image.offset().top -
+                image.parent().offset().top - 5;
+            }
+            return answer;
+          };
           $scope.onMousemoveImage = function(event) {
             if (!$scope.interactionIsActive) {
               return;
@@ -112,6 +133,9 @@ oppia.directive('oppiaInteractiveImageClickInput', [
             $scope.updateCurrentlyHoveredRegions();
           };
           $scope.onClickImage = function() {
+            $scope.lastAnswer = {
+              clickPosition: [$scope.mouseX, $scope.mouseY]
+            };
             $scope.onSubmit({
               answer: {
                 clickPosition: [$scope.mouseX, $scope.mouseY],

--- a/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
+++ b/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
@@ -133,9 +133,11 @@ oppia.directive('oppiaInteractiveImageClickInput', [
             $scope.updateCurrentlyHoveredRegions();
           };
           $scope.onClickImage = function() {
-            $scope.lastAnswer = {
-              clickPosition: [$scope.mouseX, $scope.mouseY]
-            };
+            if (!$scope.lastAnswer) {
+              $scope.lastAnswer = {
+                clickPosition: [$scope.mouseX, $scope.mouseY]
+              };
+            }
             $scope.onSubmit({
               answer: {
                 clickPosition: [$scope.mouseX, $scope.mouseY],

--- a/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
+++ b/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
@@ -104,21 +104,21 @@ oppia.directive('oppiaInteractiveImageClickInput', [
           });
           $scope.getDotLocation = function() {
             var image = $($element).find('.oppia-image-click-img');
-            var answer = {
+            var dotLocation = {
               left: null,
               top: null
             };
             if ($scope.lastAnswer) {
-              answer.left =
+              dotLocation.left =
                 $scope.lastAnswer.clickPosition[0] * image.width() +
                 image.offset().left -
                 image.parent().offset().left - 5;
-              answer.top =
+              dotLocation.top =
                 $scope.lastAnswer.clickPosition[1] * image.height() +
                 image.offset().top -
                 image.parent().offset().top - 5;
             }
-            return answer;
+            return dotLocation;
           };
           $scope.onMousemoveImage = function(event) {
             if (!$scope.interactionIsActive) {

--- a/extensions/interactions/ImageClickInput/directives/image_click_input_interaction_directive.html
+++ b/extensions/interactions/ImageClickInput/directives/image_click_input_interaction_directive.html
@@ -44,4 +44,17 @@
            z-index: 10;">
     </div>
   </div>
+  <div ng-if="!highlightRegionsOnHover && !interactionIsActive"
+       style="
+       border-radius: 50%;
+       width: 10px;
+       height: 10px;
+       background: red;
+       border: 1px solid #000;
+       z-index: 10;
+       position: absolute;
+       display: inline;
+       left: <[getDotLocation().left]>px;
+       top: <[getDotLocation().top]>px;">
+  </div>
 </div>


### PR DESCRIPTION
Added another circular div that is positioned at the point where the user clicked for correct answer.

**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
