### PR TITLE
Fix #4617: Fixed the weird behaviour of red dot in editor mode

### DIFF
--- a/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
+++ b/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
@@ -99,8 +99,17 @@ oppia.directive('oppiaInteractiveImageClickInput', [
               return 'inline';
             }
           };
+          $scope.getDotDisplay = function() {
+            if (ExplorationContextService.getEditorTabContext() === 'editor') {
+              return 'none';
+            }
+            return 'inline';
+          };
           $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.interactionIsActive = false;
+            $scope.lastAnswer = {
+              clickPosition: [$scope.mouseX, $scope.mouseY]
+            };
           });
           $scope.getDotLocation = function() {
             var image = $($element).find('.oppia-image-click-img');
@@ -122,9 +131,6 @@ oppia.directive('oppiaInteractiveImageClickInput', [
           };
           $scope.onMousemoveImage = function(event) {
             if (!$scope.interactionIsActive) {
-              $scope.lastAnswer = {
-                clickPosition: [$scope.mouseX, $scope.mouseY]
-              };
               return;
             }
             var image = $($element).find('.oppia-image-click-img');

--- a/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
+++ b/extensions/interactions/ImageClickInput/directives/ImageClickInput.js
@@ -23,11 +23,11 @@
 oppia.directive('oppiaInteractiveImageClickInput', [
   '$sce', 'HtmlEscaperService', 'ExplorationContextService',
   'imageClickInputRulesService', 'UrlInterpolationService',
-  'EVENT_NEW_CARD_AVAILABLE',
+  'EVENT_NEW_CARD_AVAILABLE', 'EDITOR_TAB_CONTEXT',
   function(
       $sce, HtmlEscaperService, ExplorationContextService,
       imageClickInputRulesService, UrlInterpolationService,
-      EVENT_NEW_CARD_AVAILABLE) {
+      EVENT_NEW_CARD_AVAILABLE, EDITOR_TAB_CONTEXT) {
     return {
       restrict: 'E',
       scope: {
@@ -100,7 +100,8 @@ oppia.directive('oppiaInteractiveImageClickInput', [
             }
           };
           $scope.getDotDisplay = function() {
-            if (ExplorationContextService.getEditorTabContext() === 'editor') {
+            if (ExplorationContextService.getEditorTabContext() ===
+                EDITOR_TAB_CONTEXT.EDITOR) {
               return 'none';
             }
             return 'inline';

--- a/extensions/interactions/ImageClickInput/directives/image_click_input_interaction_directive.html
+++ b/extensions/interactions/ImageClickInput/directives/image_click_input_interaction_directive.html
@@ -53,7 +53,7 @@
        border: 1px solid #000;
        z-index: 10;
        position: absolute;
-       display: inline;
+       display: <[getDotDisplay()]>;
        left: <[getDotLocation().left]>px;
        top: <[getDotLocation().top]>px;">
   </div>


### PR DESCRIPTION
Fixed the sudden appearance of red dot just after clicking right answer and the display of the dot even in editor view just after preview.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
