### PR TITLE
Fix #4559: Write an e2e test to prevent users from getting stuck in non inline interactions

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/progress_nav_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/progress_nav_directive.html
@@ -4,7 +4,7 @@
   <div>
     <!-- ng-if on this second wrapping div because ng-if lags on buttons. -->
     <div ng-if="hasPrevious && !helpCardHasContinueButton">
-      <md-button ng-click="changeCard(activeCardIndex-1)" class="md-raised" style="margin: 0 0 12px 12px;">
+      <md-button ng-click="changeCard(activeCardIndex-1)" class="md-raised protractor-test-back-button" style="margin: 0 0 12px 12px;">
         <i class="material-icons oppia-vcenter" aria-hidden="true">&#xE5C4;</i>
       </div>
     </md-button>

--- a/core/tests/protractor.conf.js
+++ b/core/tests/protractor.conf.js
@@ -63,8 +63,8 @@ exports.config = {
 
     mainEditor: [
       'protractor/editorAndPlayer.js',
-      'protractor/stateEditor.js',
-      'protractor/explorationFeedback.js'
+      //'protractor/stateEditor.js',
+      //'protractor/explorationFeedback.js'
     ],
 
     editorFeatures: [

--- a/core/tests/protractor.conf.js
+++ b/core/tests/protractor.conf.js
@@ -63,8 +63,8 @@ exports.config = {
 
     mainEditor: [
       'protractor/editorAndPlayer.js',
-      //'protractor/stateEditor.js',
-      //'protractor/explorationFeedback.js'
+      'protractor/stateEditor.js',
+      'protractor/explorationFeedback.js'
     ],
 
     editorFeatures: [

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -74,6 +74,7 @@ describe('Full exploration editor', function() {
       by.css('.protractor-test-back-button')).then(function(buttons){
         expect(buttons.length).toBe(0);
       });
+    users.logout();
   });
 
   it('should redirect back to parent exploration correctly when parent id is' +
@@ -126,7 +127,7 @@ describe('Full exploration editor', function() {
     users.logout();
   });
 
-  it('should give option for redirection when author has specified ' +
+  /*it('should give option for redirection when author has specified ' +
       'a refresher exploration Id', function() {
     users.createAndLoginAdminUser('testadm@collections.com', 'testadm');
 
@@ -542,7 +543,7 @@ describe('Full exploration editor', function() {
       editor.setInteraction('EndExploration');
       users.logout();
     });
-  });
+  });*/
 
   afterEach(function() {
     general.checkForConsoleErrors([]);

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -78,7 +78,7 @@ describe('Full exploration editor', function() {
     });
   });
 
-  it('should redirect back to parent exploration correctly when parent id is ' +
+  /*it('should redirect back to parent exploration correctly when parent id is ' +
       'given as query parameter', function() {
     users.createUser('user1@editorAndPlayer.com', 'user1EditorAndPlayer');
     users.login('user1@editorAndPlayer.com');
@@ -544,7 +544,7 @@ describe('Full exploration editor', function() {
       editor.setInteraction('EndExploration');
       users.logout();
     });
-  });
+  });*/
 
   afterEach(function() {
     general.checkForConsoleErrors([]);

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -27,8 +27,6 @@ var ExplorationPlayerPage =
 var CreatorDashboardPage =
   require('../protractor_utils/CreatorDashboardPage.js');
 var LibraryPage = require('../protractor_utils/LibraryPage.js');
-var logicProofUtils = require(
-  '../../../extensions/interactions/LogicProof/protractor.js');
 
 describe('Full exploration editor', function() {
   var explorationPlayerPage = null;
@@ -71,7 +69,7 @@ describe('Full exploration editor', function() {
       by.css('.protractor-test-back-button')).then(function(buttons){
         expect(buttons.length).toBe(1);
       });
-    logicProofUtils.submitAnswer();
+    explorationPlayerPage.submitAnswer('LogicProof');
     element.all(
       by.css('.protractor-test-back-button')).then(function(buttons){
         expect(buttons.length).toBe(0);

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -69,17 +69,17 @@ describe('Full exploration editor', function() {
     explorationPlayerPage.submitAnswer('Continue');
     element.all(
       by.css('.protractor-test-back-button')).then(function(buttons){
-      expect(buttons.length).toBe(1)
-    });
+        expect(buttons.length).toBe(1);
+      });
     logicProofUtils.submitAnswer();
     element.all(
       by.css('.protractor-test-back-button')).then(function(buttons){
-      expect(buttons.length).toBe(0)
-    });
+        expect(buttons.length).toBe(0);
+      });
   });
 
-  /*it('should redirect back to parent exploration correctly when parent id is ' +
-      'given as query parameter', function() {
+  it('should redirect back to parent exploration correctly when parent id is' +
+      ' given as query parameter', function() {
     users.createUser('user1@editorAndPlayer.com', 'user1EditorAndPlayer');
     users.login('user1@editorAndPlayer.com');
 
@@ -544,7 +544,7 @@ describe('Full exploration editor', function() {
       editor.setInteraction('EndExploration');
       users.logout();
     });
-  });*/
+  });
 
   afterEach(function() {
     general.checkForConsoleErrors([]);

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -39,7 +39,7 @@ describe('Full exploration editor', function() {
     creatorDashboardPage = new CreatorDashboardPage.CreatorDashboardPage();
   });
 
-  it('should prevent going back when help card is shown', function(){
+  it('should prevent going back when help card is shown', function() {
     users.createUser('user2@editorAndPlayer.com', 'user2EditorAndPlayer');
     users.login('user2@editorAndPlayer.com');
     workflow.createExploration();

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -74,6 +74,9 @@ describe('Full exploration editor', function() {
       by.css('.protractor-test-back-button')).then(function(buttons){
         expect(buttons.length).toBe(0);
       });
+
+    explorationPlayerPage.clickThroughToNextCard();
+    explorationPlayerPage.expectExplorationToBeOver();
     users.logout();
   });
 

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -127,7 +127,7 @@ describe('Full exploration editor', function() {
     users.logout();
   });
 
-  /*it('should give option for redirection when author has specified ' +
+  it('should give option for redirection when author has specified ' +
       'a refresher exploration Id', function() {
     users.createAndLoginAdminUser('testadm@collections.com', 'testadm');
 
@@ -543,7 +543,7 @@ describe('Full exploration editor', function() {
       editor.setInteraction('EndExploration');
       users.logout();
     });
-  });*/
+  });
 
   afterEach(function() {
     general.checkForConsoleErrors([]);

--- a/extensions/interactions/LogicProof/protractor.js
+++ b/extensions/interactions/LogicProof/protractor.js
@@ -31,8 +31,8 @@ var expectInteractionDetailsToMatch = function(elem) {
 };
 
 var submitAnswer = function() {
-  // TODO: find a way to send keys to the codeRepl. Temporarily pass the
-  // answer as defaultText in the customization args.
+  // TODO: find a way to send keys to the code-mirror element.
+  // Temporarily pass the answer as defaultText in the customization args.
   element(by.css('.oppia-learner-confirm-button')).click();
 };
 

--- a/extensions/interactions/LogicProof/protractor.js
+++ b/extensions/interactions/LogicProof/protractor.js
@@ -1,4 +1,4 @@
-// Copyright 2017 The Oppia Authors. All Rights Reserved.
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ var expectInteractionDetailsToMatch = function(elem) {
   ).toBe(true);
 };
 
-var submitAnswer = function() { 
+var submitAnswer = function() {
   // TODO: find a way to send keys to the codeRepl. Temporarily pass the
   // answer as defaultText in the customization args.
   element(by.css('.oppia-learner-confirm-button')).click();
@@ -44,7 +44,7 @@ var testSuite = [{
   ruleArguments: ['Correct'],
   expectedInteractionDetails: [],
   wrongAnswers: [],
-  correctAnswers: ['']
+  correctAnswers: []
 }];
 
 exports.customizeInteraction = customizeInteraction;

--- a/extensions/interactions/LogicProof/protractor.js
+++ b/extensions/interactions/LogicProof/protractor.js
@@ -1,0 +1,54 @@
+// Copyright 2017 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview End-to-end testing utilities for the LogicProof interaction.
+ */
+
+var objects = require('../../objects/protractor.js');
+
+var customizeInteraction = function(elem, assumption, target, defaultText) {
+  elem.element(by.id('logicQuestionAssumptions')).sendKeys(assumption);
+  elem.element(by.id('logicQuestionTarget')).sendKeys(target);
+  elem.element(by.id('logicQuestionProof')).sendKeys(defaultText);
+};
+
+var expectInteractionDetailsToMatch = function(elem) {
+  expect(
+    elem.element(by.tagName('oppia-interactive-logic-proof')).isPresent()
+  ).toBe(true);
+};
+
+var submitAnswer = function() { 
+  // TODO: find a way to send keys to the codeRepl. Temporarily pass the
+  // answer as defaultText in the customization args.
+  element(by.css('.oppia-learner-confirm-button')).click();
+};
+
+var answerObjectType = 'CheckedProof';
+
+
+var testSuite = [{
+  interactionArguments: ['', '', 'from p we have p'],
+  ruleArguments: ['Correct'],
+  expectedInteractionDetails: [],
+  wrongAnswers: [],
+  correctAnswers: ['']
+}];
+
+exports.customizeInteraction = customizeInteraction;
+exports.expectInteractionDetailsToMatch = expectInteractionDetailsToMatch;
+exports.submitAnswer = submitAnswer;
+exports.answerObjectType = answerObjectType;
+exports.testSuite = testSuite;

--- a/extensions/interactions/LogicProof/protractor.js
+++ b/extensions/interactions/LogicProof/protractor.js
@@ -31,7 +31,7 @@ var expectInteractionDetailsToMatch = function(elem) {
 };
 
 var submitAnswer = function() {
-  // TODO: find a way to send keys to the code-mirror element.
+  // TODO(nithusha21): find a way to send keys to the code-mirror element.
   // Temporarily pass the answer as defaultText in the customization args.
   element(by.css('.oppia-learner-confirm-button')).click();
 };

--- a/extensions/interactions/protractor.js
+++ b/extensions/interactions/protractor.js
@@ -47,7 +47,8 @@ var INTERACTIONS = {
   FractionInput: require('./FractionInput/protractor.js'),
   MultipleChoiceInput: require('./MultipleChoiceInput/protractor.js'),
   NumericInput: require('./NumericInput/protractor.js'),
-  TextInput: require('./TextInput/protractor.js')
+  TextInput: require('./TextInput/protractor.js'),
+  LogicProof: require('./LogicProof/protractor.js')
 };
 
 var getInteraction = function(interactionName) {


### PR DESCRIPTION
This PR fixes #4559 and also adds testing utils for LogicProof interaction. The e2e test adds a continue interaction followed by logic proof. On submitting the answer, the back button is asserted to not be present (this prevents people from getting stuck).

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
