### PR TITLE
Fix #4590: Fixes dropdown overlap with feedback editor

### DIFF
--- a/core/templates/dev/head/components/forms/html_select_directive.html
+++ b/core/templates/dev/head/components/forms/html_select_directive.html
@@ -3,7 +3,7 @@
     <div class="oppia-html-select-selection-element" angular-html-bind="options[getSelectionIndex()].val"></div>
     <span class="caret oppia-html-select-selection-caret"></span>
   </button>
-  <ul uib-dropdown-menu style="width: inherit;">
+  <ul uib-dropdown-menu class="oppia-dropdown-menu" style="width: inherit;">
     <li ng-repeat="choice in options">
       <a class="oppia-html-select-option protractor-test-html-select-option" angular-html-bind="choice.val" ng-click="select(choice.id)">
       </a>
@@ -46,5 +46,8 @@
   .oppia-html-select .oppia-html-select-option oppia-noninteractive-image {
     display: inline-block;
     margin-bottom: 0;
+  }
+  .oppia-dropdown-menu {
+    position: relative;
   }
 </style>


### PR DESCRIPTION
Dropdown position is set to relative to prevent overlap with feedback editor.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
