### PR TITLE
Fix #4582: Prevent supplemental help card from being cut off.

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/SupplementalCardDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/SupplementalCardDirective.js
@@ -65,21 +65,21 @@ oppia.directive('supplementalCard', [
 
           $scope.windowDimensionsService = WindowDimensionsService;
 
+          // We use the max because the height property of the help card is
+          // unstable while animating, causing infinite digest errors.
+          var maxHelpCardHeightSeen = 0;
           $scope.clearHelpCard = function() {
             $scope.helpCardHtml = null;
             $scope.helpCardHasContinueButton = false;
+            maxHelpCardHeightSeen = 0;
           };
 
-          $scope.canWindowShowTwoCards = function() {
-            return ExplorationPlayerService.canWindowShowTwoCards();
-          };
-
-          $scope.isWindowTall = function() {
-            var supplemental = $('.conversation-skin-supplemental-card');
-            var scrollBottom = $(window).scrollTop() + $(window).height();
-            var supplementalBottom = supplemental.offset().top +
-                                     supplemental.height();
-            return scrollBottom - supplementalBottom > 50;
+          $scope.isHelpCardTall = function() {
+            var helpCard = $('.conversation-skin-help-card');
+            if (helpCard.height() > maxHelpCardHeightSeen) {
+              maxHelpCardHeightSeen = helpCard.height();
+            }
+            return maxHelpCardHeightSeen > $(window).height() - 100;
           };
 
           $scope.submitAnswer = function(answer, interactionRulesService) {

--- a/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
@@ -1,6 +1,6 @@
 <div class="conversation-skin-supplemental-card">
   <div ng-if="helpCardHtml" class="conversation-skin-help-card"
-       ng-class="{'help-card-standard': isWindowTall(), 'help-card-fixed': !isWindowTall() || !canWindowShowTwoCards()}" >
+       ng-class="{'help-card-standard': isHelpCardTall(), 'help-card-fixed': !isHelpCardTall()}" >
     <img class="conversation-skin-oppia-avatar"
          ng-src="<[::OPPIA_AVATAR_IMAGE_URL]>" alt="">
     <button type="button" class="conversation-skin-close-help-card-button"
@@ -45,7 +45,9 @@
   }
 
   .help-card-standard {
-    bottom: -50px;
+    top: 100px;
+    /* Use margin-bottom to make sure the help card doesn't get hidden behind the footer. */
+    margin-bottom: 80px;
     position: absolute;
   }
 


### PR DESCRIPTION
Fix #4582

I'm not sure exactly what the intent of the original isWindowTall() method was, but anyways I edited it for it to represent just whether the help card is tall in relation to the window, and used that as a metric to decide how to place the card.