### PR TITLE
Fix #4612: organised promises

### DIFF
--- a/core/tests/protractor/collections.js
+++ b/core/tests/protractor/collections.js
@@ -65,66 +65,70 @@ describe('Collections', function() {
       );
       general.getExplorationIdFromEditor().then(function(expId) {
         secondExplorationId = expId;
-      });
-      workflow.createAndPublishExploration(
-        'Third Exploration',
-        'Languages',
-        'Third Test Exploration.'
-      );
-      general.getExplorationIdFromEditor().then(function(expId) {
-        thirdExplorationId = expId;
-      });
-      workflow.createAndPublishExploration(
-        'Fourth Exploration',
-        'Languages',
-        'Fourth Test Exploration.'
-      );
-      general.getExplorationIdFromEditor().then(function(expId) {
-        fourthExplorationId = expId;
-      });
-      // Create searchable explorations.
-      workflow.createAndPublishExploration(
-        'The Lazy Magician',
-        'Algorithms',
-        'discover the binary search algorithm'
-      );
-      workflow.createAndPublishExploration(
-        'Root Linear Coefficient Theorem',
-        'Algebra',
-        'discover the Root Linear Coefficient Theorem'
-      );
-      workflow.createAndPublishExploration(
-        'Test Exploration',
-        'Languages',
-        'discover the Protractor Testing'
-      );
-      users.logout();
+        workflow.createAndPublishExploration(
+          'Third Exploration',
+          'Languages',
+          'Third Test Exploration.'
+        );
+        general.getExplorationIdFromEditor().then(function(expId) {
+          thirdExplorationId = expId;
+          workflow.createAndPublishExploration(
+            'Fourth Exploration',
+            'Languages',
+            'Fourth Test Exploration.'
+          );
+          general.getExplorationIdFromEditor().then(function(expId) {
+            fourthExplorationId = expId;
+            // Create searchable explorations.
+            workflow.createAndPublishExploration(
+              'The Lazy Magician',
+              'Algorithms',
+              'discover the binary search Algorithms'
+            );
+            workflow.createAndPublishExploration(
+              'Root Linear Coefficient Theorem',
+              'Algebra',
+              'discover the Root Linear Coefficient Theorem'
+            );
+            workflow.createAndPublishExploration(
+              'Test Exploration',
+              'Languages',
+              'discover the Protractor Testing'
+            );
+            users.logout();
 
-      users.login('player@collections.com');
-      browser.get(general.SERVER_URL_PREFIX);
-      var dropdown = element(by.css('.protractor-test-profile-dropdown'));
-      browser.actions().mouseMove(dropdown).perform();
-      dropdown.element(by.css('.protractor-test-dashboard-link')).click();
-      browser.waitForAngular();
-      creatorDashboardPage.clickCreateActivityButton();
-      creatorDashboardPage.clickCreateCollectionButton();
-      browser.getCurrentUrl().then(function(url) {
-        var pathname = url.split('/');
-        //in the url a # is added at the end that is not part of collection ID
-        collectionId = pathname[5].slice(0, -1);
+            users.login('player@collections.com');
+            browser.get(general.SERVER_URL_PREFIX);
+            var dropdown = element(by.css(
+              '.protractor-test-profile-dropdown'));
+            browser.actions().mouseMove(dropdown).perform();
+            dropdown.element(by.css(
+              '.protractor-test-dashboard-link')).click();
+            browser.waitForAngular();
+            creatorDashboardPage.clickCreateActivityButton();
+            creatorDashboardPage.clickCreateCollectionButton();
+            browser.getCurrentUrl().then(function(url) {
+              var pathname = url.split('/');
+              // in the url a # is added at the end that
+              // is not part of collection ID
+              collectionId = pathname[5].slice(0, -1);
+              browser.waitForAngular();
+              // Add existing explorations.
+              collectionEditor.addExistingExploration(firstExplorationId);
+              collectionEditor.saveDraft();
+              collectionEditor.closeSaveModal();
+              collectionEditor.publishCollection();
+              collectionEditor.setTitle('Test Collection 2');
+              collectionEditor.setObjective(
+                'This is the second test collection.');
+              collectionEditor.setCategory('Algebra');
+              collectionEditor.saveChanges();
+              browser.waitForAngular();
+              users.logout();
+            });
+          });
+        });
       });
-      browser.waitForAngular();
-      // Add existing explorations.
-      collectionEditor.addExistingExploration(firstExplorationId);
-      collectionEditor.saveDraft();
-      collectionEditor.closeSaveModal();
-      collectionEditor.publishCollection();
-      collectionEditor.setTitle('Test Collection 2');
-      collectionEditor.setObjective('This is the second test collection.');
-      collectionEditor.setCategory('Algebra');
-      collectionEditor.saveChanges();
-      browser.waitForAngular();
-      users.logout();
     });
   });
 

--- a/core/tests/protractor/collections.js
+++ b/core/tests/protractor/collections.js
@@ -65,70 +65,66 @@ describe('Collections', function() {
       );
       general.getExplorationIdFromEditor().then(function(expId) {
         secondExplorationId = expId;
-        workflow.createAndPublishExploration(
-          'Third Exploration',
-          'Languages',
-          'Third Test Exploration.'
-        );
-        general.getExplorationIdFromEditor().then(function(expId) {
-          thirdExplorationId = expId;
-          workflow.createAndPublishExploration(
-            'Fourth Exploration',
-            'Languages',
-            'Fourth Test Exploration.'
-          );
-          general.getExplorationIdFromEditor().then(function(expId) {
-            fourthExplorationId = expId;
-            // Create searchable explorations.
-            workflow.createAndPublishExploration(
-              'The Lazy Magician',
-              'Algorithms',
-              'discover the binary search Algorithms'
-            );
-            workflow.createAndPublishExploration(
-              'Root Linear Coefficient Theorem',
-              'Algebra',
-              'discover the Root Linear Coefficient Theorem'
-            );
-            workflow.createAndPublishExploration(
-              'Test Exploration',
-              'Languages',
-              'discover the Protractor Testing'
-            );
-            users.logout();
-
-            users.login('player@collections.com');
-            browser.get(general.SERVER_URL_PREFIX);
-            var dropdown = element(by.css(
-              '.protractor-test-profile-dropdown'));
-            browser.actions().mouseMove(dropdown).perform();
-            dropdown.element(by.css(
-              '.protractor-test-dashboard-link')).click();
-            browser.waitForAngular();
-            creatorDashboardPage.clickCreateActivityButton();
-            creatorDashboardPage.clickCreateCollectionButton();
-            browser.getCurrentUrl().then(function(url) {
-              var pathname = url.split('/');
-              // in the url a # is added at the end that
-              // is not part of collection ID
-              collectionId = pathname[5].slice(0, -1);
-              browser.waitForAngular();
-              // Add existing explorations.
-              collectionEditor.addExistingExploration(firstExplorationId);
-              collectionEditor.saveDraft();
-              collectionEditor.closeSaveModal();
-              collectionEditor.publishCollection();
-              collectionEditor.setTitle('Test Collection 2');
-              collectionEditor.setObjective(
-                'This is the second test collection.');
-              collectionEditor.setCategory('Algebra');
-              collectionEditor.saveChanges();
-              browser.waitForAngular();
-              users.logout();
-            });
-          });
-        });
       });
+      workflow.createAndPublishExploration(
+        'Third Exploration',
+        'Languages',
+        'Third Test Exploration.'
+      );
+      general.getExplorationIdFromEditor().then(function(expId) {
+        thirdExplorationId = expId;
+      });
+      workflow.createAndPublishExploration(
+        'Fourth Exploration',
+        'Languages',
+        'Fourth Test Exploration.'
+      );
+      general.getExplorationIdFromEditor().then(function(expId) {
+        fourthExplorationId = expId;
+      });
+      // Create searchable explorations.
+      workflow.createAndPublishExploration(
+        'The Lazy Magician',
+        'Algorithms',
+        'discover the binary search algorithm'
+      );
+      workflow.createAndPublishExploration(
+        'Root Linear Coefficient Theorem',
+        'Algebra',
+        'discover the Root Linear Coefficient Theorem'
+      );
+      workflow.createAndPublishExploration(
+        'Test Exploration',
+        'Languages',
+        'discover the Protractor Testing'
+      );
+      users.logout();
+
+      users.login('player@collections.com');
+      browser.get(general.SERVER_URL_PREFIX);
+      var dropdown = element(by.css('.protractor-test-profile-dropdown'));
+      browser.actions().mouseMove(dropdown).perform();
+      dropdown.element(by.css('.protractor-test-dashboard-link')).click();
+      browser.waitForAngular();
+      creatorDashboardPage.clickCreateActivityButton();
+      creatorDashboardPage.clickCreateCollectionButton();
+      browser.getCurrentUrl().then(function(url) {
+        var pathname = url.split('/');
+        //in the url a # is added at the end that is not part of collection ID
+        collectionId = pathname[5].slice(0, -1);
+      });
+      browser.waitForAngular();
+      // Add existing explorations.
+      collectionEditor.addExistingExploration(firstExplorationId);
+      collectionEditor.saveDraft();
+      collectionEditor.closeSaveModal();
+      collectionEditor.publishCollection();
+      collectionEditor.setTitle('Test Collection 2');
+      collectionEditor.setObjective('This is the second test collection.');
+      collectionEditor.setCategory('Algebra');
+      collectionEditor.saveChanges();
+      browser.waitForAngular();
+      users.logout();
     });
   });
 
@@ -138,9 +134,11 @@ describe('Collections', function() {
     var dropdown = element(by.css('.protractor-test-profile-dropdown'));
     browser.actions().mouseMove(dropdown).perform();
     dropdown.element(by.css('.protractor-test-dashboard-link')).click();
+    general.waitForSystem();
     browser.waitForAngular();
     creatorDashboardPage.clickCreateActivityButton();
     creatorDashboardPage.clickCreateCollectionButton();
+    general.waitForSystem();
     browser.waitForAngular();
     // Add existing explorations.
     collectionEditor.addExistingExploration(firstExplorationId);

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -75,18 +75,18 @@ describe('Full exploration editor', function() {
           browser.getCurrentUrl().then(function(url) {
             var currentExplorationId = url.split('/')[4].split('?')[0];
             expect(currentExplorationId).toBe(parentId2);
-          });
 
-          explorationPlayerPage.clickOnSummaryTileAtEnd();
+            explorationPlayerPage.clickOnSummaryTileAtEnd();
 
-          browser.getCurrentUrl().then(function(url) {
-            currentExplorationId = url.split('/')[4];
-            expect(currentExplorationId).toBe(parentId1);
+            browser.getCurrentUrl().then(function(url) {
+              currentExplorationId = url.split('/')[4];
+              expect(currentExplorationId).toBe(parentId1);
+              users.logout();
+            });
           });
         });
       });
     });
-    users.logout();
   });
 
   it('should give option for redirection when author has specified ' +
@@ -196,36 +196,36 @@ describe('Full exploration editor', function() {
       browser.waitForAngular();
       general.getExplorationIdFromPlayer().then(function(currentId) {
         expect(currentId).toEqual(refresherExplorationId);
-      });
-      general.waitForSystem();
-      explorationPlayerPage.clickOnSummaryTileAtEnd();
-      browser.waitForAngular();
-      explorationPlayerPage.submitAnswer('MultipleChoiceInput', 'Incorrect');
-      general.waitForSystem();
-      explorationPlayerPage.clickCancelRedirectionButton();
-      browser.waitForAngular();
-      explorationPlayerPage.expectContentToMatch(
-        forms.toRichText('Parent Exploration Content'));
-      explorationPlayerPage.submitAnswer('MultipleChoiceInput', 'Correct');
-      browser.waitForAngular();
+        general.waitForSystem();
+        explorationPlayerPage.clickOnSummaryTileAtEnd();
+        browser.waitForAngular();
+        explorationPlayerPage.submitAnswer('MultipleChoiceInput', 'Incorrect');
+        general.waitForSystem();
+        explorationPlayerPage.clickCancelRedirectionButton();
+        browser.waitForAngular();
+        explorationPlayerPage.expectContentToMatch(
+          forms.toRichText('Parent Exploration Content'));
+        explorationPlayerPage.submitAnswer('MultipleChoiceInput', 'Correct');
+        browser.waitForAngular();
 
-      browser.get('/search/find?q=');
-      element.all(by.css(
-        '.protractor-test-collection-summary-tile-title')).first().click();
-      element.all(by.css(
-        '.protractor-test-collection-exploration')).first().click();
-      explorationPlayerPage.submitAnswer('MultipleChoiceInput', 'Incorrect');
-      general.waitForSystem();
-      explorationPlayerPage.clickConfirmRedirectionButton();
-      browser.waitForAngular();
-      // Check the current url to see if collection_id is present in it.
-      browser.getCurrentUrl().then(function(url) {
-        var pathname = url.split('/');
-        expect(
-          pathname[4].split('?')[1].split('=')[0]).toEqual('collection_id');
+        browser.get('/search/find?q=');
+        element.all(by.css(
+          '.protractor-test-collection-summary-tile-title')).first().click();
+        element.all(by.css(
+          '.protractor-test-collection-exploration')).first().click();
+        explorationPlayerPage.submitAnswer('MultipleChoiceInput', 'Incorrect');
+        general.waitForSystem();
+        explorationPlayerPage.clickConfirmRedirectionButton();
+        browser.waitForAngular();
+        // Check the current url to see if collection_id is present in it.
+        browser.getCurrentUrl().then(function(url) {
+          var pathname = url.split('/');
+          expect(
+            pathname[4].split('?')[1].split('=')[0]).toEqual('collection_id');
+          general.waitForSystem();
+          users.logout();
+        });
       });
-      general.waitForSystem();
-      users.logout();
     });
   });
 

--- a/core/tests/protractor/editorAndPlayer.js
+++ b/core/tests/protractor/editorAndPlayer.js
@@ -97,6 +97,7 @@ describe('Full exploration editor', function() {
     var dropdown = element(by.css('.protractor-test-profile-dropdown'));
     browser.actions().mouseMove(dropdown).perform();
     dropdown.element(by.css('.protractor-test-dashboard-link')).click();
+    general.waitForSystem();
     browser.waitForAngular();
     creatorDashboardPage.clickCreateActivityButton();
     creatorDashboardPage.clickCreateExplorationButton();
@@ -115,6 +116,7 @@ describe('Full exploration editor', function() {
       dropdown = element(by.css('.protractor-test-profile-dropdown'));
       browser.actions().mouseMove(dropdown).perform();
       dropdown.element(by.css('.protractor-test-dashboard-link')).click();
+      general.waitForSystem();
       browser.waitForAngular();
       creatorDashboardPage.clickCreateActivityButton();
       creatorDashboardPage.clickCreateExplorationButton();
@@ -144,6 +146,7 @@ describe('Full exploration editor', function() {
       dropdown = element(by.css('.protractor-test-profile-dropdown'));
       browser.actions().mouseMove(dropdown).perform();
       dropdown.element(by.css('.protractor-test-dashboard-link')).click();
+      general.waitForSystem();
       browser.waitForAngular();
       creatorDashboardPage.clickCreateActivityButton();
       creatorDashboardPage.clickCreateExplorationButton();
@@ -173,9 +176,11 @@ describe('Full exploration editor', function() {
       dropdown = element(by.css('.protractor-test-profile-dropdown'));
       browser.actions().mouseMove(dropdown).perform();
       dropdown.element(by.css('.protractor-test-dashboard-link')).click();
+      general.waitForSystem();
       browser.waitForAngular();
       creatorDashboardPage.clickCreateActivityButton();
       creatorDashboardPage.clickCreateCollectionButton();
+      general.waitForSystem();
       browser.waitForAngular();
       collectionEditor.searchForAndAddExistingExploration(
         'Parent Exploration in collection');
@@ -193,6 +198,7 @@ describe('Full exploration editor', function() {
       explorationPlayerPage.submitAnswer('MultipleChoiceInput', 'Incorrect');
       general.waitForSystem();
       explorationPlayerPage.clickConfirmRedirectionButton();
+      general.waitForSystem();
       browser.waitForAngular();
       general.getExplorationIdFromPlayer().then(function(currentId) {
         expect(currentId).toEqual(refresherExplorationId);
@@ -216,6 +222,7 @@ describe('Full exploration editor', function() {
         explorationPlayerPage.submitAnswer('MultipleChoiceInput', 'Incorrect');
         general.waitForSystem();
         explorationPlayerPage.clickConfirmRedirectionButton();
+        general.waitForSystem();
         browser.waitForAngular();
         // Check the current url to see if collection_id is present in it.
         browser.getCurrentUrl().then(function(url) {

--- a/core/tests/protractor/suggestions.js
+++ b/core/tests/protractor/suggestions.js
@@ -78,19 +78,19 @@ describe('Suggestions on Explorations', function() {
     editor.getSuggestionThreads().then(function(threads) {
       expect(threads.length).toEqual(1);
       expect(threads[0]).toMatch(suggestionDescription);
+      editor.acceptSuggestion(suggestionDescription);
+
+      editor.navigateToPreviewTab();
+      explorationPlayerPage.expectContentToMatch(forms.toRichText(suggestion));
+      users.logout();
+
+      // Student logs in and plays the exploration, finds the updated content
+      users.login('user3@ExplorationSuggestions.com');
+      libraryPage.get();
+      libraryPage.playExploration(EXPLORATION_TITLE);
+      explorationPlayerPage.expectContentToMatch(forms.toRichText(suggestion));
+      users.logout();
     });
-    editor.acceptSuggestion(suggestionDescription);
-
-    editor.navigateToPreviewTab();
-    explorationPlayerPage.expectContentToMatch(forms.toRichText(suggestion));
-    users.logout();
-
-    // Student logs in and plays the exploration, finds the updated content
-    users.login('user3@ExplorationSuggestions.com');
-    libraryPage.get();
-    libraryPage.playExploration(EXPLORATION_TITLE);
-    explorationPlayerPage.expectContentToMatch(forms.toRichText(suggestion));
-    users.logout();
   });
 
   afterEach(function() {


### PR DESCRIPTION
Testing e2e test for mainEditor and misc suite by organising promises.
Aim is to fix 'document unloaded' error for protractor tests.

**Checklist**
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
