### PR TITLE
Fix #4566: Dollar formatting issue

### DIFF
--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -240,7 +240,7 @@ oppia.filter('parameterizeRuleDescription', [
           replacementText = inputs[varName];
         }
 
-        if(typeof(replacementText) === 'string') {
+        if(typeof (replacementText) === 'string') {
           // Replacing $ with $$. When this is used in the next replace
           // statement, it will be converted back to $.
           // Also to replace by $$, the appropriate string is $$$$

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -240,7 +240,7 @@ oppia.filter('parameterizeRuleDescription', [
           replacementText = inputs[varName];
         }
 
-        if(typeof (replacementText) === 'string') {
+        if (typeof (replacementText) === 'string') {
           // Replacing $ with $$. When this is used in the next replace
           // statement, it will be converted back to $.
           // Also to replace by $$, the appropriate string is $$$$

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -255,7 +255,7 @@ oppia.filter('parameterizeRuleDescription', [
           varType === 'SetOfNormalizedString') {
           replacementText = inputs[varName];
         } else {
-          throw 'Unknown variable type in rule description';
+          throw Error('Unknown variable type in rule description');
         }
 
         // Replaces all occurances of $ with $$.

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -246,15 +246,21 @@ oppia.filter('parameterizeRuleDescription', [
           }
           replacementText += ']';
         } else if (
-          varType === 'Real' || varType === 'NonnegativeInt') {
+          varType === 'Real' || varType === 'NonnegativeInt' ||
+          varType === 'Int') {
           replacementText = inputs[varName] + '';
-        } else {
+        } else if (
+          varType === 'CodeString' || varType === 'UnicodeString' ||
+          varType === 'LogicErrorCategory' || varType === 'NormalizedString' ||
+          varType === 'SetOfNormalizedString') {
           replacementText = inputs[varName];
+        } else {
+          throw 'Unknown variable type in rule description';
         }
 
         // Replaces all occurances of $ with $$.
         // This makes sure that the next regex matching will yield
-        // the same $ sign pattern as the input
+        // the same $ sign pattern as the input.
         replacementText = replacementText.split('$').join('$$');
 
         description = description.replace(PATTERN, ' ');

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -240,7 +240,14 @@ oppia.filter('parameterizeRuleDescription', [
           replacementText = inputs[varName];
         }
 
-        replacementText = replacementText.replace('$', '$$$$');
+        if(typeof(replacementText) === 'string') {
+          // Replacing $ with $$. When this is used in the next replace
+          // statement, it will be converted back to $.
+          // Also to replace by $$, the appropriate string is $$$$
+          // as $$ -> $
+          replacementText = replacementText.replace('$', '$$$$');
+        }
+
         description = description.replace(PATTERN, ' ');
         finalDescription = finalDescription.replace(PATTERN, replacementText);
       }

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -240,6 +240,7 @@ oppia.filter('parameterizeRuleDescription', [
           replacementText = inputs[varName];
         }
 
+        replacementText = replacementText.replace('$', '$$$$');
         description = description.replace(PATTERN, ' ');
         finalDescription = finalDescription.replace(PATTERN, replacementText);
       }

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -241,12 +241,10 @@ oppia.filter('parameterizeRuleDescription', [
         }
 
         if (typeof (replacementText) === 'string') {
-          // Replacing all occurances of $ with $$.
-          // When this is used in the next replace
-          // statement, it will be converted back to $.
-          // Also to replace by $$, the appropriate string is $$$
-          // as $$ becomes $
-          replacementText = replacementText.replace(/\$/g, '$$$');
+          // Replaces all occurances of $ with $$.
+          // This makes sure that the next regex matching will yield 
+          // the same $ sign pattern as the input 
+          replacementText = replacementText.split('$').join('$$');
         }
 
         description = description.replace(PATTERN, ' ');

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -236,16 +236,26 @@ oppia.filter('parameterizeRuleDescription', [
         } else if (varType === 'Fraction') {
           replacementText = FractionObjectFactory
             .fromDict(inputs[varName]).toString();
+        } else if (varType === 'SetOfUnicodeString') {
+          replacementText = '[';
+          for (var i = 0; i < inputs[varName].length; i++) {
+            if (i !== 0) {
+              replacementText += ', ';
+            }
+            replacementText += inputs[varName][i];
+          }
+          replacementText += ']';
+        } else if (
+          varType === 'Real' || varType === 'NonnegativeInt') {
+          replacementText = inputs[varName] + '';
         } else {
           replacementText = inputs[varName];
         }
 
-        if (typeof (replacementText) === 'string') {
-          // Replaces all occurances of $ with $$.
-          // This makes sure that the next regex matching will yield
-          // the same $ sign pattern as the input
-          replacementText = replacementText.split('$').join('$$');
-        }
+        // Replaces all occurances of $ with $$.
+        // This makes sure that the next regex matching will yield
+        // the same $ sign pattern as the input
+        replacementText = replacementText.split('$').join('$$');
 
         description = description.replace(PATTERN, ' ');
         finalDescription = finalDescription.replace(PATTERN, replacementText);

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -241,11 +241,12 @@ oppia.filter('parameterizeRuleDescription', [
         }
 
         if (typeof (replacementText) === 'string') {
-          // Replacing $ with $$. When this is used in the next replace
+          // Replacing all occurances of $ with $$.
+          // When this is used in the next replace
           // statement, it will be converted back to $.
-          // Also to replace by $$, the appropriate string is $$$$
-          // as $$ -> $
-          replacementText = replacementText.replace('$', '$$$$');
+          // Also to replace by $$, the appropriate string is $$$
+          // as $$ becomes $
+          replacementText = replacementText.replace(/\$/g, '$$$');
         }
 
         description = description.replace(PATTERN, ' ');

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -242,8 +242,8 @@ oppia.filter('parameterizeRuleDescription', [
 
         if (typeof (replacementText) === 'string') {
           // Replaces all occurances of $ with $$.
-          // This makes sure that the next regex matching will yield 
-          // the same $ sign pattern as the input 
+          // This makes sure that the next regex matching will yield
+          // the same $ sign pattern as the input
           replacementText = replacementText.split('$').join('$$');
         }
 

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -573,6 +573,16 @@ describe('Testing filters', function() {
       expect($filter('parameterizeRuleDescription')(ruleMultipleChoice,
         interactionIdMultipleChoice, choicesMultipleChoice)
       ).toEqual('is equal to \'$10 should not become $$10\'');
+
+      choicesMultipleChoice = [
+        {
+          label: '$xyz should not become $$xyz',
+          val: 0
+        }
+      ];
+      expect($filter('parameterizeRuleDescription')(ruleMultipleChoice,
+        interactionIdMultipleChoice, choicesMultipleChoice)
+      ).toEqual('is equal to \'$xyz should not become $$xyz\'');
     }
   ));
 });

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -545,6 +545,21 @@ describe('Testing filters', function() {
         }
       ];
 
+      expect($filter('convertToPlainText')($filter('formatRtePreview')(
+        $filter('parameterizeRuleDescription')(ruleMath, interactionIdMath,
+          choicesMath)))
+      ).toEqual('is ' + 'equal to \'[Math]\'');
+
+      expect($filter('convertToPlainText')($filter('formatRtePreview')(
+        $filter('parameterizeRuleDescription')(ruleMixed, interactionIdMixed,
+        choicesMixed)))
+      ).toEqual('is ' + 'equal to \'[Image] This is a text ' +
+        'input. [Image]  [Link]\'');
+    }
+  ));
+
+  it('should correctly parameterize rule description filter',
+    inject(function($filter) {
       var ruleMultipleChoice = {
         type: 'Equals',
         inputs: {
@@ -558,18 +573,6 @@ describe('Testing filters', function() {
           val: 0
         }
       ];
-
-      expect($filter('convertToPlainText')($filter('formatRtePreview')(
-        $filter('parameterizeRuleDescription')(ruleMath, interactionIdMath,
-          choicesMath)))
-      ).toEqual('is ' + 'equal to \'[Math]\'');
-
-      expect($filter('convertToPlainText')($filter('formatRtePreview')(
-        $filter('parameterizeRuleDescription')(ruleMixed, interactionIdMixed,
-        choicesMixed)))
-      ).toEqual('is ' + 'equal to \'[Image] This is a text ' +
-        'input. [Image]  [Link]\'');
-
       expect($filter('parameterizeRuleDescription')(ruleMultipleChoice,
         interactionIdMultipleChoice, choicesMultipleChoice)
       ).toEqual('is equal to \'$10 should not become $$10\'');
@@ -583,6 +586,5 @@ describe('Testing filters', function() {
       expect($filter('parameterizeRuleDescription')(ruleMultipleChoice,
         interactionIdMultipleChoice, choicesMultipleChoice)
       ).toEqual('is equal to \'$xyz should not become $$xyz\'');
-    }
-  ));
+    }));
 });

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -554,7 +554,7 @@ describe('Testing filters', function() {
       var interactionIdMultipleChoice = 'TextInput';
       var choicesMultipleChoice = [
         {
-          label: '$10 should remain as $10',
+          label: '$10 should not become $$10',
           val: 0
         }
       ];
@@ -572,7 +572,7 @@ describe('Testing filters', function() {
 
       expect($filter('parameterizeRuleDescription')(ruleMultipleChoice,
         interactionIdMultipleChoice, choicesMultipleChoice)
-      ).toEqual('is equal to \'$10 should remain as x0\'');
+      ).toEqual('is equal to \'$10 should not become $$10\'');
     }
   ));
 });

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -545,6 +545,20 @@ describe('Testing filters', function() {
         }
       ];
 
+      var ruleMultipleChoice = {
+        type: 'Equals',
+        inputs: {
+          x: 0
+        }
+      };
+      var interactionIdMultipleChoice = 'TextInput';
+      var choicesMultipleChoice = [
+        {
+          label: '$10 should remain as $10',
+          val: 0
+        }
+      ];
+
       expect($filter('convertToPlainText')($filter('formatRtePreview')(
         $filter('parameterizeRuleDescription')(ruleMath, interactionIdMath,
           choicesMath)))
@@ -555,6 +569,10 @@ describe('Testing filters', function() {
         choicesMixed)))
       ).toEqual('is ' + 'equal to \'[Image] This is a text ' +
         'input. [Image]  [Link]\'');
+
+      expect($filter('parameterizeRuleDescription')(ruleMultipleChoice,
+        interactionIdMultipleChoice, choicesMultipleChoice)
+      ).toEqual('is equal to \'$10 should remain as x0\'');
     }
   ));
 });


### PR DESCRIPTION
Fix #4566. 
$1 was fetting replaced by the group matched from the regex. So the replacement string should have been $$1 which after replace becomes $1 ($$ is changed to $ [ref](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace)).

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
