### PR TITLE
Fix #4641: Added new fractions rule to check if fractional part exactly equals

### DIFF
--- a/extensions/interactions/FractionInput/directives/FractionInput.js
+++ b/extensions/interactions/FractionInput/directives/FractionInput.js
@@ -229,6 +229,11 @@ oppia.factory('fractionInputRulesService', [
       HasNoFractionalPart: function(answer) {
         return answer.numerator === 0;
       },
+      HasFractionalPartExactlyEqualTo: function(answer, inputs) {
+        return (
+          answer.numerator === inputs.f.numerator &&
+          answer.denominator === inputs.f.denominator);
+      },
     };
   }
 ]);

--- a/extensions/interactions/FractionInput/directives/FractionInputRulesServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputRulesServiceSpec.js
@@ -57,6 +57,15 @@ describe('Fraction Input rules service', function() {
     x: 20
   };
 
+  var FRACTIONAL_RULE_INPUT = {
+    f: {
+      isNegative: false,
+      wholeNumber: 0,
+      numerator: 2,
+      denominator: 4
+    }
+  };
+
   it('should have a correct \'equivalence\' rule', function() {
     expect(firs.IsEquivalentTo(
       createNegativeFractionDict(1, 8, 4), RULE_INPUT)).toBe(false);
@@ -163,5 +172,16 @@ describe('Fraction Input rules service', function() {
       createPositiveFractionDict(1, 0, 1))).toBe(true);
     expect(firs.HasNoFractionalPart(
       createPositiveFractionDict(1, 8, 4))).toBe(false);
+  });
+
+  it('should check if \'fractional part is exactly equal\' rule', function() {
+    expect(firs.HasFractionalPartExactlyEqualTo(
+      createPositiveFractionDict(1, 1, 2), FRACTIONAL_RULE_INPUT)).toBe(false);
+    expect(firs.HasFractionalPartExactlyEqualTo(
+      createPositiveFractionDict(1, 2, 4), FRACTIONAL_RULE_INPUT)).toBe(true);
+    expect(firs.HasFractionalPartExactlyEqualTo(
+      createPositiveFractionDict(1, 5, 6), FRACTIONAL_RULE_INPUT)).toBe(false);
+    expect(firs.HasFractionalPartExactlyEqualTo(
+      createPositiveFractionDict(6, 2, 4), FRACTIONAL_RULE_INPUT)).toBe(true);
   });
 });

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationService.js
@@ -95,7 +95,7 @@ oppia.factory('FractionInputValidationService', [
         };
 
         var ranges = [];
-        var denominators = [];
+        var matchedDenominators = [];
 
         for (var i = 0; i < answerGroups.length; i++) {
           var rules = answerGroups[i].rules;
@@ -110,7 +110,7 @@ oppia.factory('FractionInputValidationService', [
               ubi: false,
             };
 
-            var denominator = {
+            var matchedDenominator = {
               answerGroupIndex: i + 1,
               ruleIndex: j + 1,
               denominator: null,
@@ -208,7 +208,7 @@ oppia.factory('FractionInputValidationService', [
                       'should be greater than zero.')
                   });
                 }
-                denominator.denominator = rule.inputs.x;
+                matchedDenominator.denominator = rule.inputs.x;
                 break;
               case 'HasFractionalPartExactlyEqualTo':
                 if (rule.inputs.f.wholeNumber !== 0) {
@@ -263,26 +263,27 @@ oppia.factory('FractionInputValidationService', [
               }
             }
 
-            for (var k = 0; k < denominators.length; k++) {
-              if (denominators[k].denominator !== null &&
+            for (var k = 0; k < matchedDenominators.length; k++) {
+              if (matchedDenominators[k].denominator !== null &&
                 rule.type === 'HasFractionalPartExactlyEqualTo') {
-                if (denominators[k].denominator ===
+                if (matchedDenominators[k].denominator ===
                   rule.inputs.f.denominator) {
                   warningsList.push({
                     type: WARNING_TYPES.ERROR,
                     message: (
                       'Rule ' + (j + 1) + ' from answer group ' +
                       (i + 1) + ' will never be matched because it ' +
-                      'is made redundant by rule ' + denominators[k].ruleIndex +
-                      ' from answer group ' + denominators[k].answerGroupIndex +
-                      '.')
+                      'is made redundant by rule ' +
+                      matchedDenominators[k].ruleIndex +
+                      ' from answer group ' +
+                      matchedDenominators[k].answerGroupIndex + '.')
                   });
                 }
               }
             }
 
             ranges.push(range);
-            denominators.push(denominator);
+            matchedDenominators.push(matchedDenominator);
           }
         }
 

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
@@ -164,6 +164,34 @@ describe('FractionInputValidationService', function() {
       }
     });
 
+    HasFractionalPartExactlyEqualToTwoFifthsRule = rof.createFromBackendDict({
+      rule_type: 'HasFractionalPartExactlyEqualTo',
+      inputs: {
+        f: createFractionDict(false, 0, 2, 5)
+      }
+    });
+
+    HasFractionalPartExactlyEqualToOneAndHalfRule = rof.createFromBackendDict({
+      rule_type: 'HasFractionalPartExactlyEqualTo',
+      inputs: {
+        f: createFractionDict(false, 1, 1, 2)
+      }
+    });
+
+    HasFractionalPartExactlyEqualToNegativeValue = rof.createFromBackendDict({
+      rule_type: 'HasFractionalPartExactlyEqualTo',
+      inputs: {
+        f: createFractionDict(true, 0, 1, 2)
+      }
+    });
+
+    HasFractionalPartExactlyEqualToThreeHalfs = rof.createFromBackendDict({
+      rule_type: 'HasFractionalPartExactlyEqualTo',
+      inputs: {
+        f: createFractionDict(false, 0, 3, 2)
+      }
+    });
+
     answerGroups = [agof.createNew(
       [equalsOneRule, lessThanTwoRule],
       goodDefaultOutcome,
@@ -404,5 +432,63 @@ describe('FractionInputValidationService', function() {
       currentState, customizationArgs, answerGroups,
       goodDefaultOutcome);
     expect(warnings).toEqual([]);
+  });
+
+  it('should correctly check validity of HasFractionalPartExactlyEqualTo rule',
+    function() {
+    customizationArgs.requireSimplestForm = false;
+    answerGroups[0].rules = [HasFractionalPartExactlyEqualToOneAndHalfRule];
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([{
+      type: WARNING_TYPES.ERROR,
+      message: (
+        'Rule 1 from answer group 1 is invalid as ' +
+        'integer part should be zero')
+    }]);
+
+    customizationArgs.allowImproperFraction = false;
+    answerGroups[0].rules = [HasFractionalPartExactlyEqualToThreeHalfs];
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([{
+      type: WARNING_TYPES.ERROR,
+      message: (
+        'Rule 1 from answer group 1 is invalid as ' +
+        'improper fractions are not allowed')
+    }]);
+
+    answerGroups[0].rules = [HasFractionalPartExactlyEqualToNegativeValue];
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([{
+      type: WARNING_TYPES.ERROR,
+      message: (
+        'Rule 1 from answer group 1 is invalid as ' +
+        'sign should be positive')
+    }]);
+
+    customizationArgs.allowImproperFraction = true;
+    answerGroups[0].rules = [HasFractionalPartExactlyEqualToTwoFifthsRule];
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([]);
+
+    answerGroups[1] = angular.copy(answerGroups[0]);
+    answerGroups[0].rules = [denominatorEqualsFiveRule];
+    answerGroups[1].rules = [HasFractionalPartExactlyEqualToTwoFifthsRule];
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([{
+      type: WARNING_TYPES.ERROR,
+      message: (
+        'Rule 1 from answer group 2 will never be matched because it ' +
+        'is made redundant by rule 1 from answer group 1.')
+    }]);
   });
 });

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
@@ -490,5 +490,5 @@ describe('FractionInputValidationService', function() {
           'Rule 1 from answer group 2 will never be matched because it ' +
           'is made redundant by rule 1 from answer group 1.')
       }]);
-  });
+    });
 });

--- a/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
+++ b/extensions/interactions/FractionInput/directives/FractionInputValidationServiceSpec.js
@@ -436,59 +436,59 @@ describe('FractionInputValidationService', function() {
 
   it('should correctly check validity of HasFractionalPartExactlyEqualTo rule',
     function() {
-    customizationArgs.requireSimplestForm = false;
-    answerGroups[0].rules = [HasFractionalPartExactlyEqualToOneAndHalfRule];
-    var warnings = validatorService.getAllWarnings(
-      currentState, customizationArgs, answerGroups,
-      goodDefaultOutcome);
-    expect(warnings).toEqual([{
-      type: WARNING_TYPES.ERROR,
-      message: (
-        'Rule 1 from answer group 1 is invalid as ' +
-        'integer part should be zero')
-    }]);
+      customizationArgs.requireSimplestForm = false;
+      answerGroups[0].rules = [HasFractionalPartExactlyEqualToOneAndHalfRule];
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArgs, answerGroups,
+        goodDefaultOutcome);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: (
+          'Rule 1 from answer group 1 is invalid as ' +
+          'integer part should be zero')
+      }]);
 
-    customizationArgs.allowImproperFraction = false;
-    answerGroups[0].rules = [HasFractionalPartExactlyEqualToThreeHalfs];
-    var warnings = validatorService.getAllWarnings(
-      currentState, customizationArgs, answerGroups,
-      goodDefaultOutcome);
-    expect(warnings).toEqual([{
-      type: WARNING_TYPES.ERROR,
-      message: (
-        'Rule 1 from answer group 1 is invalid as ' +
-        'improper fractions are not allowed')
-    }]);
+      customizationArgs.allowImproperFraction = false;
+      answerGroups[0].rules = [HasFractionalPartExactlyEqualToThreeHalfs];
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArgs, answerGroups,
+        goodDefaultOutcome);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: (
+          'Rule 1 from answer group 1 is invalid as ' +
+          'improper fractions are not allowed')
+      }]);
 
-    answerGroups[0].rules = [HasFractionalPartExactlyEqualToNegativeValue];
-    var warnings = validatorService.getAllWarnings(
-      currentState, customizationArgs, answerGroups,
-      goodDefaultOutcome);
-    expect(warnings).toEqual([{
-      type: WARNING_TYPES.ERROR,
-      message: (
-        'Rule 1 from answer group 1 is invalid as ' +
-        'sign should be positive')
-    }]);
+      answerGroups[0].rules = [HasFractionalPartExactlyEqualToNegativeValue];
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArgs, answerGroups,
+        goodDefaultOutcome);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: (
+          'Rule 1 from answer group 1 is invalid as ' +
+          'sign should be positive')
+      }]);
 
-    customizationArgs.allowImproperFraction = true;
-    answerGroups[0].rules = [HasFractionalPartExactlyEqualToTwoFifthsRule];
-    var warnings = validatorService.getAllWarnings(
-      currentState, customizationArgs, answerGroups,
-      goodDefaultOutcome);
-    expect(warnings).toEqual([]);
+      customizationArgs.allowImproperFraction = true;
+      answerGroups[0].rules = [HasFractionalPartExactlyEqualToTwoFifthsRule];
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArgs, answerGroups,
+        goodDefaultOutcome);
+      expect(warnings).toEqual([]);
 
-    answerGroups[1] = angular.copy(answerGroups[0]);
-    answerGroups[0].rules = [denominatorEqualsFiveRule];
-    answerGroups[1].rules = [HasFractionalPartExactlyEqualToTwoFifthsRule];
-    var warnings = validatorService.getAllWarnings(
-      currentState, customizationArgs, answerGroups,
-      goodDefaultOutcome);
-    expect(warnings).toEqual([{
-      type: WARNING_TYPES.ERROR,
-      message: (
-        'Rule 1 from answer group 2 will never be matched because it ' +
-        'is made redundant by rule 1 from answer group 1.')
-    }]);
+      answerGroups[1] = angular.copy(answerGroups[0]);
+      answerGroups[0].rules = [denominatorEqualsFiveRule];
+      answerGroups[1].rules = [HasFractionalPartExactlyEqualToTwoFifthsRule];
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArgs, answerGroups,
+        goodDefaultOutcome);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: (
+          'Rule 1 from answer group 2 will never be matched because it ' +
+          'is made redundant by rule 1 from answer group 1.')
+      }]);
   });
 });

--- a/extensions/interactions/rule_templates.json
+++ b/extensions/interactions/rule_templates.json
@@ -54,6 +54,9 @@
     },
     "HasNoFractionalPart": {
       "description": "has no fractional part"
+    },
+    "HasFractionalPartExactlyEqualTo": {
+      "description": "has fractional part exatly equal to {{f|Fraction}}"
     }
   },
   "GraphInput": {

--- a/extensions/interactions/rule_templates.json
+++ b/extensions/interactions/rule_templates.json
@@ -56,7 +56,7 @@
       "description": "has no fractional part"
     },
     "HasFractionalPartExactlyEqualTo": {
-      "description": "has fractional part exatly equal to {{f|Fraction}}"
+      "description": "has fractional part exactly equal to {{f|Fraction}}"
     }
   },
   "GraphInput": {


### PR DESCRIPTION
Fix #4641. Added a new rule to fractions interaction that allows you to check if fractional part exactly equals a value. Appropriate karma tests have been added. 

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
