### PR TITLE
Fix #4295: Added slider for audio bar

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
@@ -182,8 +182,8 @@ oppia.directive('audioBar', [
 
           $scope.track = {             
             progress: function(progress) {
-              if (arguments.length){
-                AudioPlayerService.setProgress(progress * 1.0 / 100);
+              if (angular.isDefined(progress)) {
+                AudioPlayerService.setProgress(progress / 100);
                 return progress;
               } else {
                 return AudioPlayerService.getProgress() * 100;

--- a/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
@@ -73,14 +73,6 @@ oppia.directive('audioBar', [
               $scope.languagesInExploration.length > 0);
           };
 
-          $scope.getProgressBarMode = function() {
-            if ($scope.audioLoadingIndicatorIsShown) {
-              return 'indeterminate';
-            } else {
-              return 'determinate';
-            }
-          };
-
           $scope.onNewLanguageSelected = function() {
             AudioTranslationLanguageService.setCurrentAudioLanguageCode(
               $scope.selectedLanguage.value);
@@ -184,6 +176,17 @@ oppia.directive('audioBar', [
               if (audioTranslation) {
                 playPauseUploadedAudioTranslation(
                   getCurrentAudioLanguageCode());
+              }
+            }
+          };
+
+          $scope.track = {             
+            progress: function(progress) {
+              if (arguments.length){
+                AudioPlayerService.setProgress(progress * 1.0 / 100);
+                return progress;
+              } else {
+                return AudioPlayerService.getProgress() * 100;
               }
             }
           };

--- a/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
@@ -6,7 +6,7 @@
          ng-class="{'fa-ellipsis-h': audioLoadingIndicatorIsShown, 'fa-play': !isAudioPlaying(), 'fa-pause': isAudioPlaying(), 'audio-controls-audio-not-available': !isAudioAvailableInCurrentLanguage() || audioIsLoading}"
          uib-tooltip="<[!isAudioAvailableInCurrentLanguage() ? ('I18N_PLAYER_AUDIO_NOT_AVAILABLE_IN' | translate:{languageDescription:getCurrentAudioLanguageDescription()}) : '']>"
          tooltip-append-to-body="true" tooltip-placement="right"></i>
-      <div class="slider-section" ng-if="hasPressedPlayButtonAtLeastOnce">
+      <div class="audio-bar slider-section" ng-if="hasPressedPlayButtonAtLeastOnce">
         <md-slider ng-model="track.progress" ng-model-options="{ getterSetter: true }" aria-label="audio-slider">
         </md-slider>
         <span ng-if="audioLoadingIndicatorIsShown && !doesCurrentAudioTranslationNeedUpdate()" class="audio-controls-message" translate="I18N_PLAYER_AUDIO_LOADING_AUDIO"></span>
@@ -27,24 +27,24 @@
 
 <style>
 
-  md-slider {
+  .audio-bar md-slider {
     height: 5px;
   }
 
-  md-slider.md-default-theme .md-track-fill {
+  .audio-bar md-slider.md-default-theme .md-track-fill {
     background-color: #009688;
   }
 
-  md-slider.md-default-theme .md-thumb:after {
+  .audio-bar md-slider.md-default-theme .md-thumb:after {
     border-color: #009688;
     background-color: #009688;
   }
 
-  md-slider .md-track-container {
+  .audio-bar md-slider .md-track-container {
     top: 5px;
   }
 
-  md-slider .md-thumb-container {
+  .audio-bar md-slider .md-thumb-container {
     top: -17px;
   }
 

--- a/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/audio_bar_directive.html
@@ -6,8 +6,9 @@
          ng-class="{'fa-ellipsis-h': audioLoadingIndicatorIsShown, 'fa-play': !isAudioPlaying(), 'fa-pause': isAudioPlaying(), 'audio-controls-audio-not-available': !isAudioAvailableInCurrentLanguage() || audioIsLoading}"
          uib-tooltip="<[!isAudioAvailableInCurrentLanguage() ? ('I18N_PLAYER_AUDIO_NOT_AVAILABLE_IN' | translate:{languageDescription:getCurrentAudioLanguageDescription()}) : '']>"
          tooltip-append-to-body="true" tooltip-placement="right"></i>
-      <div class="progress-bar-section" ng-if="hasPressedPlayButtonAtLeastOnce">
-        <md-progress-linear md-mode="<[getProgressBarMode()]>" value="<[AudioPlayerService.getProgress() * 100]>"></md-progress-linear>
+      <div class="slider-section" ng-if="hasPressedPlayButtonAtLeastOnce">
+        <md-slider ng-model="track.progress" ng-model-options="{ getterSetter: true }" aria-label="audio-slider">
+        </md-slider>
         <span ng-if="audioLoadingIndicatorIsShown && !doesCurrentAudioTranslationNeedUpdate()" class="audio-controls-message" translate="I18N_PLAYER_AUDIO_LOADING_AUDIO"></span>
         <span ng-if="isAudioAvailableInCurrentLanguage() && doesCurrentAudioTranslationNeedUpdate()" class="audio-controls-message" translate="I18N_PLAYER_AUDIO_MIGHT_NOT_MATCH_TEXT"></span>
         <!--Filler space for message-->
@@ -26,8 +27,25 @@
 
 <style>
 
-  md-progress-linear.md-default-theme .md-bar {
+  md-slider {
+    height: 5px;
+  }
+
+  md-slider.md-default-theme .md-track-fill {
     background-color: #009688;
+  }
+
+  md-slider.md-default-theme .md-thumb:after {
+    border-color: #009688;
+    background-color: #009688;
+  }
+
+  md-slider .md-track-container {
+    top: 5px;
+  }
+
+  md-slider .md-thumb-container {
+    top: -17px;
   }
 
   .audio-header .fa-sort-up, .audio-header .fa-sort-down {
@@ -112,7 +130,7 @@
     padding-left: 3px;
   }
 
-  .progress-bar-section {
+  .slider-section {
     display: inline-block;
     margin: 0 auto;
     padding: 0 4px;

--- a/core/templates/dev/head/services/AudioPlayerService.js
+++ b/core/templates/dev/head/services/AudioPlayerService.js
@@ -110,6 +110,11 @@ oppia.factory('AudioPlayerService', [
         }
         return _currentTrack.progress;
       },
+      setProgress: function(progress) {
+        if(_currentTrack) {
+          _currentTrack.progress = progress;
+        }
+      },
       isPlaying: function() {
         return Boolean(_currentTrack && !_currentTrack.paused);
       },

--- a/core/templates/dev/head/services/AudioPlayerService.js
+++ b/core/templates/dev/head/services/AudioPlayerService.js
@@ -111,7 +111,7 @@ oppia.factory('AudioPlayerService', [
         return _currentTrack.progress;
       },
       setProgress: function(progress) {
-        if(_currentTrack) {
+        if (_currentTrack) {
           _currentTrack.progress = progress;
         }
       },


### PR DESCRIPTION
This PR changes the progress bar in the audio bar to a slider. Audio's progress property is used as ``ng-model`` for the slider.
**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
