### PR TITLE
Fix #4663: Added CSS to fix overflowing content out of modal.

### DIFF
--- a/extensions/visualizations/enumerated_frequency_table_directive.html
+++ b/extensions/visualizations/enumerated_frequency_table_directive.html
@@ -1,5 +1,10 @@
 <strong><[options.title]></strong>
 <table class="table">
+  <colgroup>
+    <col span="1" style="width: 75%;">
+    <col span="1" style="width: 10%;">
+    <col span="1" style="width: 15%;">
+  </colgroup>
   <tr>
     <th><[options.column_headers[0]]></th>
     <th><[options.column_headers[1]]></th>
@@ -28,9 +33,11 @@
   }
   oppia-visualization-enumerated-frequency-table table {
     margin-top: 12px;
+    table-layout: fixed;
   }
   oppia-visualization-enumerated-frequency-table table td:first-child {
     width: 60%;
+    word-wrap: break-word;
   }
   oppia-visualization-enumerated-frequency-table table.item {
     margin-top: 8px;

--- a/extensions/visualizations/frequency_table_directive.html
+++ b/extensions/visualizations/frequency_table_directive.html
@@ -18,8 +18,10 @@
 <style>
   oppia-visualization-frequency-table table {
     margin-top: 12px;
+    table-layout: fixed;
   }
   oppia-visualization-frequency-table table td:first-child {
     width: 60%;
+    word-wrap: break-word;
   }
 </style>

--- a/extensions/visualizations/frequency_table_directive.html
+++ b/extensions/visualizations/frequency_table_directive.html
@@ -1,8 +1,8 @@
 <strong><[options.title]></strong>
 <table class="table">
   <colgroup>
-    <col span="1" style="width: 70%;">
-    <col span="1" style="width: 15%;">
+    <col span="1" style="width: 75%;">
+    <col span="1" style="width: 10%;">
     <col span="1" style="width: 15%;">
   </colgroup>
   <tr>

--- a/extensions/visualizations/frequency_table_directive.html
+++ b/extensions/visualizations/frequency_table_directive.html
@@ -1,13 +1,28 @@
-<strong><[options.title]></strong>
+<strong>
+  <[options.title]>
+</strong>
 <table class="table">
+  <colgroup>
+    <col span="1" style="width: 70%;">
+    <col span="1" style="width: 15%;">
+    <col span="1" style="width: 15%;">
+  </colgroup>
   <tr>
-    <th><[options.column_headers[0]]></th>
-    <th><[options.column_headers[1]]></th>
+    <th>
+      <[options.column_headers[0]]>
+    </th>
+    <th>
+      <[options.column_headers[1]]>
+    </th>
     <th ng-if="isAddressed !== null">Addressed specifically?</th>
   </tr>
   <tr ng-repeat="row in data track by $index">
-    <td><[row.answer]></td>
-    <td><[row.frequency]></td>
+    <td>
+      <[row.answer]>
+    </td>
+    <td>
+      <[row.frequency]>
+    </td>
     <td ng-if="isAddressed !== null">
       <span ng-if="isAddressed[$index]">Yes</span>
       <span ng-if="!isAddressed[$index]">No</span>
@@ -20,6 +35,7 @@
     margin-top: 12px;
     table-layout: fixed;
   }
+
   oppia-visualization-frequency-table table td:first-child {
     width: 60%;
     word-wrap: break-word;

--- a/extensions/visualizations/frequency_table_directive.html
+++ b/extensions/visualizations/frequency_table_directive.html
@@ -1,6 +1,4 @@
-<strong>
-  <[options.title]>
-</strong>
+<strong><[options.title]></strong>
 <table class="table">
   <colgroup>
     <col span="1" style="width: 70%;">
@@ -8,21 +6,13 @@
     <col span="1" style="width: 15%;">
   </colgroup>
   <tr>
-    <th>
-      <[options.column_headers[0]]>
-    </th>
-    <th>
-      <[options.column_headers[1]]>
-    </th>
+    <th><[options.column_headers[0]]></th>
+    <th><[options.column_headers[1]]></th>
     <th ng-if="isAddressed !== null">Addressed specifically?</th>
   </tr>
   <tr ng-repeat="row in data track by $index">
-    <td>
-      <[row.answer]>
-    </td>
-    <td>
-      <[row.frequency]>
-    </td>
+    <td><[row.answer]></td>
+    <td><[row.frequency]></td>
     <td ng-if="isAddressed !== null">
       <span ng-if="isAddressed[$index]">Yes</span>
       <span ng-if="!isAddressed[$index]">No</span>
@@ -35,7 +25,6 @@
     margin-top: 12px;
     table-layout: fixed;
   }
-
   oppia-visualization-frequency-table table td:first-child {
     width: 60%;
     word-wrap: break-word;


### PR DESCRIPTION
This PR fixes #4663.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
