### PR TITLE
Fix #4549 - Fixed the position of code editor

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -233,8 +233,7 @@ otherwise they will interfere with the iframed conversation skin directive.
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.24), 0 1px 3px rgba(0, 0, 0, 0.12);
     flex-shrink: 1;
     margin-left: 12px;
-    max-width: 1000px;
-    min-width: 560px;
+    width: 650px;
     position: relative;
     z-index: 2;
   }


### PR DESCRIPTION
This PR fixes #4549.

**Checklist**
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
