### PR TITLE
Only attach onended property of audio if current track is not null.

### DIFF
--- a/core/templates/dev/head/services/AudioPlayerService.js
+++ b/core/templates/dev/head/services/AudioPlayerService.js
@@ -35,19 +35,21 @@ oppia.factory('AudioPlayerService', [
             _currentTrack = ngAudio.load(blobUrl);
             _currentTrackFilename = filename;
 
-            // ngAudio doesn't seem to be provide any way of detecting
+            // ngAudio doesn't seem to provide any way of detecting
             // when native audio object has finished loading. It seems
             // that after creating an ngAudio object, the native audio
             // object is asynchronously loaded. So we use a timeout
             // to grab native audio.
             // TODO(tjiang11): Look for a better way to handle this.
             $timeout(function() {
-              _currentTrack.audio.onended = function() {
-                _currentTrack = null;
-                _currentTrackFilename = null;
-                AudioTranslationManagerService
-                  .clearSecondaryAudioTranslations();
-              };
+              if (_currentTrack !== null) {
+                _currentTrack.audio.onended = function() {
+                  _currentTrack = null;
+                  _currentTrackFilename = null;
+                  AudioTranslationManagerService
+                    .clearSecondaryAudioTranslations();
+                };
+              }
             }, 100);
 
             successCallback();


### PR DESCRIPTION
This is an attempt to fix a front-end error in production where the client tries to read the property 'audio' of null in AudioBarDirective. I'm having trouble seeing how this is happening at all, since in that same code segment a few lines before _currentTrack is being assigned an immediate value. 

I suspect it's possible that somehow in the small frame between when _currentTrack gets set with a value and when the $timeout function executes, _currentTrack is being set to null via some other means, such as the clearing of the audioplayerservice when a new card is loaded. If this is the case, then we don't want to execute the $timeout function as _currentTrack would be null, causing the error.