### PR TITLE
Fix #4656: Fix spacing around links in rte

### DIFF
--- a/extensions/rich_text_components/Link/directives/LinkDirective.js
+++ b/extensions/rich_text_components/Link/directives/LinkDirective.js
@@ -51,6 +51,9 @@ oppia.directive('oppiaNoninteractiveLink', [
             if ($scope.text) {
               $scope.showUrlInTooltip = true;
             }
+            else {
+              $scope.text = $scope.url;
+            }
           }
 
           // This following check disbales the link in Editor being caught

--- a/extensions/rich_text_components/Link/directives/LinkDirective.js
+++ b/extensions/rich_text_components/Link/directives/LinkDirective.js
@@ -50,8 +50,7 @@ oppia.directive('oppiaNoninteractiveLink', [
             // have an empty 'text' value.
             if ($scope.text) {
               $scope.showUrlInTooltip = true;
-            }
-            else {
+            } else {
               $scope.text = $scope.url;
             }
           }

--- a/extensions/rich_text_components/Link/directives/link_directive.html
+++ b/extensions/rich_text_components/Link/directives/link_directive.html
@@ -1,7 +1,5 @@
 <!--
   The extra comments in this file are needed to prevent extra whitespace from
   being added before and after the link. See http://stackoverflow.com/q/5078239
--->
-<a ng-if="showUrlInTooltip" href="<[url]>" target="_blank" uib-tooltip="<[url]>" tabindex="<[tabIndexVal]>"><[text]></a><!--
---><a ng-if="!showUrlInTooltip" href="<[url]>" target="_blank" tabindex="<[tabIndexVal]>"><[url]></a><!--
+--><a href="<[url]>" target="_blank" uib-tooltip="<[url]>" tabindex="<[tabIndexVal]>" tooltip-enable="showUrlInTooltip"><[text]></a><!--
 -->


### PR DESCRIPTION
## Explanation
Fixes #4656: Since there were two ``a`` tags with ``ng-if``, a comment was being added by default, so to adjust the comments, a single tag is used with ``tooltip-enable`` and the ``text`` is modified accordingly in JS.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
