### PR TITLE
Fix #4683: Altered positioning of help card to make it appropriate

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/SupplementalCardDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/SupplementalCardDirective.js
@@ -85,7 +85,7 @@ oppia.directive('supplementalCard', [
           $scope.getHelpCardBottomPosition = function() {
             var helpCard = $('.conversation-skin-help-card');
             var container = $('.conversation-skin-supplemental-card-container');
-            return Math.max(container.height() - helpCard.height()/2, 0);
+            return Math.max(container.height() - helpCard.height() / 2, 0);
           };
 
           $scope.submitAnswer = function(answer, interactionRulesService) {

--- a/core/templates/dev/head/pages/exploration_player/SupplementalCardDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/SupplementalCardDirective.js
@@ -67,7 +67,7 @@ oppia.directive('supplementalCard', [
 
           // We use the max because the height property of the help card is
           // unstable while animating, causing infinite digest errors.
-          maxHelpCardHeightSeen = 0;
+          var maxHelpCardHeightSeen = 0;
           $scope.clearHelpCard = function() {
             $scope.helpCardHtml = null;
             $scope.helpCardHasContinueButton = false;

--- a/core/templates/dev/head/pages/exploration_player/SupplementalCardDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/SupplementalCardDirective.js
@@ -67,7 +67,7 @@ oppia.directive('supplementalCard', [
 
           // We use the max because the height property of the help card is
           // unstable while animating, causing infinite digest errors.
-          var maxHelpCardHeightSeen = 0;
+          maxHelpCardHeightSeen = 0;
           $scope.clearHelpCard = function() {
             $scope.helpCardHtml = null;
             $scope.helpCardHasContinueButton = false;
@@ -80,6 +80,12 @@ oppia.directive('supplementalCard', [
               maxHelpCardHeightSeen = helpCard.height();
             }
             return maxHelpCardHeightSeen > $(window).height() - 100;
+          };
+
+          $scope.getHelpCardBottomPosition = function() {
+            var helpCard = $('.conversation-skin-help-card');
+            var container = $('.conversation-skin-supplemental-card-container');
+            return Math.max(container.height() - helpCard.height()/2, 0);
           };
 
           $scope.submitAnswer = function(answer, interactionRulesService) {

--- a/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
@@ -1,6 +1,6 @@
 <div class="conversation-skin-supplemental-card">
-  <div ng-if="helpCardHtml" class="conversation-skin-help-card"
-       ng-class="{'help-card-standard': isHelpCardTall(), 'help-card-fixed': !isHelpCardTall()}" >
+  <div ng-if="helpCardHtml" class="conversation-skin-help-card help-card-standard"
+       ng-style="!isHelpCardTall() ? {'top': getHelpCardBottomPosition()} : {}">
     <img class="conversation-skin-oppia-avatar"
          ng-src="<[::OPPIA_AVATAR_IMAGE_URL]>" alt="">
     <button type="button" class="conversation-skin-close-help-card-button"
@@ -45,15 +45,9 @@
   }
 
   .help-card-standard {
-    top: 100px;
     /* Use margin-bottom to make sure the help card doesn't get hidden behind the footer. */
     margin-bottom: 80px;
     position: absolute;
-  }
-
-  .help-card-fixed {
-    bottom: 50px;
-    position: fixed;
   }
 
   .conversation-skin-help-card .conversation-skin-oppia-avatar {


### PR DESCRIPTION
Fix #4683. I have added a function that returns the top position of the help card. This function will return a minimum value of 0 so it will at least be aligned to the top of the supplemental interaction card (and the page will expand below). If the card is not that big, it is centered about the bottom edge of the image. Does this look ok? 
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
