### PR TITLE
Fix #4430: fixed weird graph edge weight input

### DIFF
--- a/extensions/interactions/GraphInput/directives/GraphInput.js
+++ b/extensions/interactions/GraphInput/directives/GraphInput.js
@@ -293,6 +293,8 @@ oppia.directive('graphViz', [
 
           $scope.VERTEX_RADIUS = graphDetailService.VERTEX_RADIUS;
           $scope.EDGE_WIDTH = graphDetailService.EDGE_WIDTH;
+          $scope.selectedEdgeWeightValue = 0;
+          $scope.shouldShowWrongWeightWarning = false;
 
           $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             $scope.state.currentMode = null;
@@ -643,6 +645,9 @@ oppia.directive('graphViz', [
 
           var beginEditEdgeWeight = function(index) {
             $scope.state.selectedEdge = index;
+            $scope.selectedEdgeWeightValue = (
+              $scope.graph.edges[$scope.state.selectedEdge].weight);
+            $scope.shouldShowWrongWeightWarning = false;
             FocusManagerService.setFocus('edgeWeightEditBegun');
           };
 
@@ -698,10 +703,28 @@ oppia.directive('graphViz', [
             if ($scope.state.selectedEdge === null) {
               return '';
             }
-            if (angular.isDefined(weight) && angular.isNumber(weight)) {
-              $scope.graph.edges[$scope.state.selectedEdge].weight = weight;
+            if (weight === null) {
+              $scope.selectedEdgeWeightValue = '';
             }
-            return $scope.graph.edges[$scope.state.selectedEdge].weight;
+            if (angular.isNumber(weight)) {
+              $scope.selectedEdgeWeightValue = weight;
+            }
+            return $scope.selectedEdgeWeightValue;
+          };
+
+          $scope.isValidEdgeWeight = function() {
+            if (!angular.isNumber($scope.selectedEdgeWeightValue)) {
+              return false;
+            }
+            return true;
+          };
+
+          $scope.onUpdateEdgeWeight = function() {
+            if (angular.isNumber($scope.selectedEdgeWeightValue)) {
+              $scope.graph.edges[$scope.state.selectedEdge].weight = (
+                $scope.selectedEdgeWeightValue);
+            }
+            $scope.state.selectedEdge = null;
           };
 
           // Styling functions

--- a/extensions/interactions/GraphInput/directives/GraphInput.js
+++ b/extensions/interactions/GraphInput/directives/GraphInput.js
@@ -713,10 +713,7 @@ oppia.directive('graphViz', [
           };
 
           $scope.isValidEdgeWeight = function() {
-            if (!angular.isNumber($scope.selectedEdgeWeightValue)) {
-              return false;
-            }
-            return true;
+            return angular.isNumber($scope.selectedEdgeWeightValue);
           };
 
           $scope.onUpdateEdgeWeight = function() {

--- a/extensions/interactions/GraphInput/directives/graph_viz_directive.html
+++ b/extensions/interactions/GraphInput/directives/graph_viz_directive.html
@@ -133,7 +133,8 @@
     <md-button class="md-raised" ng-click="state.selectedVertex = null;" translate="I18N_INTERACTIONS_GRAPH_UPDATE_LABEL"></md-button>
   </div>
   <div ng-if="state.selectedEdge !== null && graph.isWeighted && canEditEdgeWeight">
-    <input type="number" ng-model="selectedEdgeWeight" ng-model-options="{getterSetter: true}" focus-on="edgeWeightEditBegun"></input>
-    <md-button class="md-raised" ng-click="state.selectedEdge = null;" translate="I18N_INTERACTIONS_GRAPH_UPDATE_WEIGHT"></md-button>
+    <input type="number" ng-model="selectedEdgeWeight" ng-model-options="{getterSetter: true}" focus-on="edgeWeightEditBegun" ng-style="shouldShowWrongWeightWarning ? {'border': '1px solid red'}: {}" ng-blur="shouldShowWrongWeightWarning = !isValidEdgeWeight()" ng-focus="shouldShowWrongWeightWarning = false"></input>
+    <md-button class="md-raised" ng-click="onUpdateEdgeWeight()" translate="I18N_INTERACTIONS_GRAPH_UPDATE_WEIGHT"></md-button>
+
   </div>
 </div>

--- a/extensions/interactions/GraphInput/directives/graph_viz_directive.html
+++ b/extensions/interactions/GraphInput/directives/graph_viz_directive.html
@@ -135,6 +135,5 @@
   <div ng-if="state.selectedEdge !== null && graph.isWeighted && canEditEdgeWeight">
     <input type="number" ng-model="selectedEdgeWeight" ng-model-options="{getterSetter: true}" focus-on="edgeWeightEditBegun" ng-style="shouldShowWrongWeightWarning ? {'border': '1px solid red'}: {}" ng-blur="shouldShowWrongWeightWarning = !isValidEdgeWeight()" ng-focus="shouldShowWrongWeightWarning = false"></input>
     <md-button class="md-raised" ng-click="onUpdateEdgeWeight()" translate="I18N_INTERACTIONS_GRAPH_UPDATE_WEIGHT"></md-button>
-
   </div>
 </div>


### PR DESCRIPTION
Fixes #4430. Allows the edge weight input to become ''. A red border appears if the input is invalid and the text box is not in focus. Upon trying to submit an empty input for the edge weight, the old value is retained. 
PTAL @seanlip 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
