### PR TITLE
Fix part of #4367: Added null submit checks for set input interaction

### DIFF
--- a/extensions/interactions/SetInput/directives/SetInput.js
+++ b/extensions/interactions/SetInput/directives/SetInput.js
@@ -64,6 +64,15 @@ oppia.directive('oppiaInteractiveSetInput', [
             return false;
           };
 
+          var hasBlankOption = function(answer) {
+            for (var i = 0; i < answer.length; i++) {
+              if (answer[i] === '') {
+                return true;
+              }
+            }
+            return false;
+          };
+
           $scope.submitAnswer = function(answer) {
             if (hasDuplicates(answer)) {
               $scope.errorMessage = (
@@ -78,20 +87,23 @@ oppia.directive('oppiaInteractiveSetInput', [
           };
 
           $scope.isAnswerValid = function() {
-            return ($scope.answer.length > 0);
+            return ($scope.answer.length > 0 &&
+              !hasBlankOption($scope.answer));
           };
 
           $scope.$on(EVENT_PROGRESS_NAV_SUBMITTED, function() {
             $scope.submitAnswer($scope.answer);
           });
 
+          // Third parameter is set to true to enable deep watching.
+          // https://stackoverflow.com/questions/14712089/
           $scope.$watch(function() {
             return $scope.answer;
           }, function() {
             $scope.setAnswerValidity({
               answerValidity: $scope.isAnswerValid()
             });
-          });
+          }, true);
         }
       ]
     };

--- a/extensions/interactions/SetInput/directives/SetInput.js
+++ b/extensions/interactions/SetInput/directives/SetInput.js
@@ -65,12 +65,9 @@ oppia.directive('oppiaInteractiveSetInput', [
           };
 
           var hasBlankOption = function(answer) {
-            for (var i = 0; i < answer.length; i++) {
-              if (answer[i] === '') {
-                return true;
-              }
-            }
-            return false;
+            return answer.some(function(element) {
+              return (element === '');
+            });
           };
 
           $scope.submitAnswer = function(answer) {


### PR DESCRIPTION
## Explanation
Added null submit checks for set input interaction (part of #4367). The watch wasn't detecting changes in an array and I found that a third parameter should be enabled in $watch for [deep watching](https://stackoverflow.com/questions/14712089/how-to-deep-watch-an-array-in-angularjs). Now the submit button changes as per the rules. PTAL @seanlip. Thanks

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
