### PR TITLE
Fix:#4634 Deleting imageInteraction should delete the responses.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/InteractionDetailsCacheService.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/InteractionDetailsCacheService.js
@@ -29,6 +29,9 @@ oppia.factory('InteractionDetailsCacheService', [function() {
     contains: function(interactionId) {
       return _cache.hasOwnProperty(interactionId);
     },
+    removeDetails: function (interactionId) {
+      delete _cache[interactionId];
+    },
     set: function(interactionId, interactionCustomizationArgs) {
       _cache[interactionId] = {
         customization: angular.copy(interactionCustomizationArgs)

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateInteraction.js
@@ -348,7 +348,8 @@ oppia.controller('StateInteraction', [
         stateInteractionIdService.displayed = null;
         stateCustomizationArgsService.displayed = {};
         stateSolutionService.displayed = null;
-
+        InteractionDetailsCacheService.removeDetails(
+          stateInteractionIdService.savedMemento);
         stateInteractionIdService.saveDisplayedValue();
         stateCustomizationArgsService.saveDisplayedValue();
         stateSolutionService.saveDisplayedValue();

--- a/extensions/objects/templates/image_with_regions_editor.html
+++ b/extensions/objects/templates/image_with_regions_editor.html
@@ -14,7 +14,7 @@
     ng-mousemove="onSvgMouseMove($event)"
     ng-mouseup="onSvgMouseUp($event)">
     <image ng-href="<[getPreviewUrl($parent.$parent.value.imagePath)]>"
-      xlink:href = ""
+      xlink:href=""
       x="0"
       y="0"
       ng-attr-height="<[getImageHeight()]>"

--- a/extensions/objects/templates/image_with_regions_editor.html
+++ b/extensions/objects/templates/image_with_regions_editor.html
@@ -13,7 +13,8 @@
     ng-mousedown="onSvgMouseDown($event)"
     ng-mousemove="onSvgMouseMove($event)"
     ng-mouseup="onSvgMouseUp($event)">
-    <image xlink:href="<[getPreviewUrl($parent.$parent.value.imagePath)]>"
+    <image ng-href="<[getPreviewUrl($parent.$parent.value.imagePath)]>"
+      xlink:href = ""
       x="0"
       y="0"
       ng-attr-height="<[getImageHeight()]>"


### PR DESCRIPTION
Fixes #4634 

@seanlip @DubeySandeep  1.I am removing the details of the interaction from cache on deletion of interaction in  InteractionDetailsCacheService.
2.About the console error in the image interaction issue can be fixed by adding ng-href,have a look at these links for more.
[here](https://github.com/angular/angular.js/issues/7697) and [here for demo](http://jsbin.com/sigoleya/1/edit?html,css,js,output),let me know if any changes to be made.
Thanks
