### PR TITLE
Fix:#4721:The text in the tooltip is not completely visible in case of the leftmost collection.

### DIFF
--- a/core/templates/dev/head/domain/learner_dashboard/learner_dashboard_icons_directive.html
+++ b/core/templates/dev/head/domain/learner_dashboard/learner_dashboard_icons_directive.html
@@ -1,5 +1,5 @@
 <i class="oppia-learner-dashboard-icon fa fa-clock-o"
-   ng-show="canActivityBeAddedToLearnerPlaylist(getActivityId())"
+   ng-show="false"
    ng-click="addToLearnerPlaylist(getActivityId(), getActivityType())"
    ng-mouseenter="setHoverState(true)" ng-mouseleave="setHoverState(false)"
    aria-hidden="true"
@@ -19,15 +19,15 @@
    uib-tooltip="<['I18N_LIBRARY_ACTIVITY_COMPLETED_ICON' | translate]>"
    tooltip-placement="left"></i>
 <i class="oppia-learner-dashboard-icon fa fa-spinner"
-   ng-if="belongsToIncompleteActivities()"
+   ng-if="true"
    aria-hidden="true"
    tooltip-append-to-body="true"
    tooltip-class="library-incomplete-activity-tooltip"
    uib-tooltip="<['I18N_LIBRARY_INCOMPLETE_ACTIVITY_ICON' | translate]>"
    tooltip-placement="left"></i>
 <style>
-   .library-incomplete-activity-tooltip .tooltip-inner {
-        max-width: none;
-        white-space: nowrap;
-    }
+  .library-incomplete-activity-tooltip .tooltip-inner {
+    max-width: none;
+    white-space: nowrap;
+  }
 </style>

--- a/core/templates/dev/head/domain/learner_dashboard/learner_dashboard_icons_directive.html
+++ b/core/templates/dev/head/domain/learner_dashboard/learner_dashboard_icons_directive.html
@@ -21,5 +21,13 @@
 <i class="oppia-learner-dashboard-icon fa fa-spinner"
    ng-if="belongsToIncompleteActivities()"
    aria-hidden="true"
+   tooltip-append-to-body="true"
+   tooltip-class="library-incomplete-activity-tooltip"
    uib-tooltip="<['I18N_LIBRARY_INCOMPLETE_ACTIVITY_ICON' | translate]>"
    tooltip-placement="left"></i>
+<style>
+   .library-incomplete-activity-tooltip .tooltip-inner {
+        max-width: none;
+        white-space: nowrap;
+    }
+</style>

--- a/core/templates/dev/head/domain/learner_dashboard/learner_dashboard_icons_directive.html
+++ b/core/templates/dev/head/domain/learner_dashboard/learner_dashboard_icons_directive.html
@@ -1,5 +1,5 @@
 <i class="oppia-learner-dashboard-icon fa fa-clock-o"
-   ng-show="false"
+   ng-show="canActivityBeAddedToLearnerPlaylist(getActivityId())"
    ng-click="addToLearnerPlaylist(getActivityId(), getActivityType())"
    ng-mouseenter="setHoverState(true)" ng-mouseleave="setHoverState(false)"
    aria-hidden="true"
@@ -19,7 +19,7 @@
    uib-tooltip="<['I18N_LIBRARY_ACTIVITY_COMPLETED_ICON' | translate]>"
    tooltip-placement="left"></i>
 <i class="oppia-learner-dashboard-icon fa fa-spinner"
-   ng-if="true"
+   ng-if="belongsToIncompleteActivities()"
    aria-hidden="true"
    tooltip-append-to-body="true"
    tooltip-class="library-incomplete-activity-tooltip"


### PR DESCRIPTION
Fixes #4721 : The text in the tooltip is not completely visible in case of the leftmost collection.
 
Previously there was no space for the the tooltip to show,that's why it is getting clipped off like this
![image](https://user-images.githubusercontent.com/17567875/36620208-f5b951bc-1917-11e8-906e-cea8b096e563.png)
So I did appended the tooltip the body so it gets enough space to display complete text.
Added css properties to make sure that it shows the text inside it in a single line.
I have added a class for the tooltip because the tooltip is appended to body and setting the style to `.tooltip-inner` with body as css selector is not a good idea.So I have added a class and using it as a css selector to make sure that the changes are scoped to that tooltip only.

preview after the fix - 
(PC)
![image](https://user-images.githubusercontent.com/17567875/36620382-d0cfadd2-1918-11e8-88bf-390ba1d81b1f.png)
(Mobile)
![image](https://user-images.githubusercontent.com/17567875/36620488-50b2342a-1919-11e8-947d-edda7a3295a8.png)

**EDIT:**
Text not limited to single line will look like this-
![image](https://user-images.githubusercontent.com/17567875/36620846-0983a7f8-191b-11e8-9422-fb55c6086426.png)
