### PR TITLE
Fix #1494:Can't see videos in Tabs.

### DIFF
--- a/extensions/rich_text_components/Tabs/directives/TabsDirective.js
+++ b/extensions/rich_text_components/Tabs/directives/TabsDirective.js
@@ -34,3 +34,17 @@ oppia.directive('oppiaNoninteractiveTabs', [
     };
   }
 ]);
+
+oppia.directive('bindHtmlCompile', ['$compile', function ($compile) {
+  return {
+    restrict: 'A',
+    link: function (scope, element, attrs) {
+      scope.$watch(function () {
+        return scope.$eval(attrs.bindHtmlCompile);
+      }, function (value) {
+        element.html(value);
+        $compile(element.contents())(scope);
+      });
+    }
+  };
+}]);

--- a/extensions/rich_text_components/Tabs/directives/TabsDirective.js
+++ b/extensions/rich_text_components/Tabs/directives/TabsDirective.js
@@ -34,17 +34,3 @@ oppia.directive('oppiaNoninteractiveTabs', [
     };
   }
 ]);
-
-oppia.directive('bindHtmlCompile', ['$compile', function ($compile) {
-  return {
-    restrict: 'A',
-    link: function (scope, element, attrs) {
-      scope.$watch(function () {
-        return scope.$eval(attrs.bindHtmlCompile);
-      }, function (value) {
-        element.html(value);
-        $compile(element.contents())(scope);
-      });
-    }
-  };
-}]);

--- a/extensions/rich_text_components/Tabs/directives/tabs_directive.html
+++ b/extensions/rich_text_components/Tabs/directives/tabs_directive.html
@@ -1,7 +1,7 @@
 <uib-tabset>
   <uib-tab ng-repeat="tabContent in tabContents" heading="<[tabContent.title]>">
     <br>
-    <span bind-html-compile="tabContent.content"></span>
+    <span angular-html-bind="tabContent.content"></span>
   </uib-tab>
 </uib-tabset>
 

--- a/extensions/rich_text_components/Tabs/directives/tabs_directive.html
+++ b/extensions/rich_text_components/Tabs/directives/tabs_directive.html
@@ -1,7 +1,7 @@
 <uib-tabset>
   <uib-tab ng-repeat="tabContent in tabContents" heading="<[tabContent.title]>">
     <br>
-    <span ng-bind-html="tabContent.content"></span>
+    <span bind-html-compile="tabContent.content"></span>
   </uib-tab>
 </uib-tabset>
 


### PR DESCRIPTION
Fixes #1494:Can't see videos in Tabs.

In tabs_directive we are currently using ng-bind-html.But ng-bind-html is just outputting the html.So,It will not work in the case if there are any directives inside it(like non-interaction-image),so we have to call $compile on the trusted HTML , so that it will re-evaluate the directives in the html.
After fix:
![ve](https://user-images.githubusercontent.com/17567875/36634396-171255cc-19ca-11e8-9890-75711b1ab4b0.png)
