### PR TITLE
Fix part of #3550: Move translation check from footer to header

### DIFF
--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -37,7 +37,6 @@ oppia.directive('topNavigationBar', [
           if (GLOBALS.userIsLoggedIn && GLOBALS.preferredSiteLanguageCode) {
             $translate.use(GLOBALS.preferredSiteLanguageCode);
           }
-
           var NAV_MODE_SIGNUP = 'signup';
           var NAV_MODES_WITH_CUSTOM_LOCAL_NAV = [
             'create', 'explore', 'collection'];

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -27,13 +27,18 @@ oppia.directive('topNavigationBar', [
         '/components/top_navigation_bar/' +
         'top_navigation_bar_directive.html'),
       controller: [
-        '$scope', '$http', '$window', '$timeout',
+        '$scope', '$http', '$window', '$timeout', '$translate',
         'SidebarStatusService', 'LABEL_FOR_CLEARING_FOCUS',
         'siteAnalyticsService', 'WindowDimensionsService', 'DebouncerService',
         function(
-            $scope, $http, $window, $timeout,
+            $scope, $http, $window, $timeout, $translate,
             SidebarStatusService, LABEL_FOR_CLEARING_FOCUS,
             siteAnalyticsService, WindowDimensionsService, DebouncerService) {
+          if (GLOBALS.userIsLoggedIn && GLOBALS.preferredSiteLanguageCode) {
+            $cookies.remove('NG_TRANSLATE_LANG_KEY', {path: '/'});
+            $translate.use(GLOBALS.preferredSiteLanguageCode);
+          }
+
           var NAV_MODE_SIGNUP = 'signup';
           var NAV_MODES_WITH_CUSTOM_LOCAL_NAV = [
             'create', 'explore', 'collection'];

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -34,11 +34,7 @@ oppia.directive('topNavigationBar', [
             $scope, $http, $window, $timeout, $translate, $cookies,
             SidebarStatusService, LABEL_FOR_CLEARING_FOCUS,
             siteAnalyticsService, WindowDimensionsService, DebouncerService) {
-          $cookies.remove('NG_TRANSLATE_LANG_KEY');
-          $cookies.put('test', 'value', {path: '/'});
-          console.log("tsss");
           if (GLOBALS.userIsLoggedIn && GLOBALS.preferredSiteLanguageCode) {
-            //$cookies.remove('NG_TRANSLATE_LANG_KEY', {path: '/'});
             $translate.use(GLOBALS.preferredSiteLanguageCode);
           }
 

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -27,15 +27,18 @@ oppia.directive('topNavigationBar', [
         '/components/top_navigation_bar/' +
         'top_navigation_bar_directive.html'),
       controller: [
-        '$scope', '$http', '$window', '$timeout', '$translate',
+        '$scope', '$http', '$window', '$timeout', '$translate', '$cookies',
         'SidebarStatusService', 'LABEL_FOR_CLEARING_FOCUS',
         'siteAnalyticsService', 'WindowDimensionsService', 'DebouncerService',
         function(
-            $scope, $http, $window, $timeout, $translate,
+            $scope, $http, $window, $timeout, $translate, $cookies,
             SidebarStatusService, LABEL_FOR_CLEARING_FOCUS,
             siteAnalyticsService, WindowDimensionsService, DebouncerService) {
+          $cookies.remove('NG_TRANSLATE_LANG_KEY');
+          $cookies.put('test', 'value', {path: '/'});
+          console.log("tsss");
           if (GLOBALS.userIsLoggedIn && GLOBALS.preferredSiteLanguageCode) {
-            $cookies.remove('NG_TRANSLATE_LANG_KEY', {path: '/'});
+            //$cookies.remove('NG_TRANSLATE_LANG_KEY', {path: '/'});
             $translate.use(GLOBALS.preferredSiteLanguageCode);
           }
 

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -27,11 +27,11 @@ oppia.directive('topNavigationBar', [
         '/components/top_navigation_bar/' +
         'top_navigation_bar_directive.html'),
       controller: [
-        '$scope', '$http', '$window', '$timeout', '$translate', '$cookies',
+        '$scope', '$http', '$window', '$timeout', '$translate',
         'SidebarStatusService', 'LABEL_FOR_CLEARING_FOCUS',
         'siteAnalyticsService', 'WindowDimensionsService', 'DebouncerService',
         function(
-            $scope, $http, $window, $timeout, $translate, $cookies,
+            $scope, $http, $window, $timeout, $translate,
             SidebarStatusService, LABEL_FOR_CLEARING_FOCUS,
             siteAnalyticsService, WindowDimensionsService, DebouncerService) {
           if (GLOBALS.userIsLoggedIn && GLOBALS.preferredSiteLanguageCode) {

--- a/core/templates/dev/head/i18n.js
+++ b/core/templates/dev/head/i18n.js
@@ -71,8 +71,7 @@ oppia.controller('I18nFooter', [
         // path each time a non-logged-in user changes their site language.
         $cookies.put(
           'NG_TRANSLATE_LANG_KEY',
-          '"' + $scope.currentLanguageCode + '"');
-      }
+          '"' + $scope.currentLanguageCode + '"',  {path: '/'});      }
     };
   }
 ]);

--- a/core/templates/dev/head/i18n.js
+++ b/core/templates/dev/head/i18n.js
@@ -44,9 +44,6 @@ oppia.controller('I18nFooter', [
     var preferencesDataUrl = '/preferenceshandler/data';
     var siteLanguageUrl = '/save_site_language';
     $scope.supportedSiteLanguages = constants.SUPPORTED_SITE_LANGUAGES;
-    if (GLOBALS.userIsLoggedIn && GLOBALS.preferredSiteLanguageCode) {
-      $translate.use(GLOBALS.preferredSiteLanguageCode);
-    }
 
     // The $timeout seems to be necessary for the dropdown to show anything
     // at the outset, if the default language is not English.
@@ -72,6 +69,7 @@ oppia.controller('I18nFooter', [
         // to change; in such cases, the user's preferences are not picked up by
         // other pages. To avoid this, we manually set the cookie using the '/'
         // path each time a non-logged-in user changes their site language.
+        $cookies.remove('NG_TRANSLATE_LANG_KEY', {path: '/'});
         $cookies.put(
           'NG_TRANSLATE_LANG_KEY',
           '"' + $scope.currentLanguageCode + '"', {path: '/'});

--- a/core/templates/dev/head/i18n.js
+++ b/core/templates/dev/head/i18n.js
@@ -69,10 +69,9 @@ oppia.controller('I18nFooter', [
         // to change; in such cases, the user's preferences are not picked up by
         // other pages. To avoid this, we manually set the cookie using the '/'
         // path each time a non-logged-in user changes their site language.
-        $cookies.remove('NG_TRANSLATE_LANG_KEY', {path: '/'});
         $cookies.put(
           'NG_TRANSLATE_LANG_KEY',
-          '"' + $scope.currentLanguageCode + '"', {path: '/'});
+          '"' + $scope.currentLanguageCode + '"');
       }
     };
   }

--- a/core/templates/dev/head/i18n.js
+++ b/core/templates/dev/head/i18n.js
@@ -71,7 +71,8 @@ oppia.controller('I18nFooter', [
         // path each time a non-logged-in user changes their site language.
         $cookies.put(
           'NG_TRANSLATE_LANG_KEY',
-          '"' + $scope.currentLanguageCode + '"',  {path: '/'});      }
+          '"' + $scope.currentLanguageCode + '"', {path: '/'});
+      }
     };
   }
 ]);


### PR DESCRIPTION
Fix part of 3550

## Explanation

After many attempts, I could not figure out why the learner views, creator views, and collection view have duplicate NG_TRANSLATE_LANG_KEY cookies. I believe it has something to do with the path. One interesting observation is that if you console.log the cookie inside the top nav directive, and then console.log cookie after a timeout of 100ms, you see that the duplicate cookie is being set from somewhere else, but I just can't find where this happens.

I find that when I try to remove the cookies manually before doing the translation check, this actually makes the exploration view, collection view translations work properly, but this breaks the library, about, donate, etc. pages. One dirty fix would be to specify when to manually remove the duplicate cookie on each page, but it would be much better to find the root cause.

Anyways, this PR moves the translation check from the footer to the header, as the header is on every page whereas the footer isn't. As such, pages without a footer weren't capturing the language changes. The problem should now be localized to the case when a guest changes from the library to collection or exploration view.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
