### PR TITLE
Fix #4530 : Fixed extra new lines and whitespaces in Multiple choice Options

### DIFF
--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -341,6 +341,28 @@ oppia.filter('normalizeWhitespacePunctuationAndCase', [function() {
   };
 }]);
 
+// Note that this filter removes additional new lines or <p><br></p> tags
+// at the end of the string.
+oppia.filter('removeExtraLines', [function() {
+  return function(string) {
+    if (!angular.isString(string)) {
+      return string;
+    }
+    var BLANK_LINES_TEXT = '<p><br></p>';
+    while (1) {
+      var lastIndex = string.length;
+      if (string.substring(
+           lastIndex - BLANK_LINES_TEXT.length, lastIndex
+          ) === BLANK_LINES_TEXT) {
+        string = string.substring(0, lastIndex - BLANK_LINES_TEXT.length);
+      } else {
+        break;
+      }
+    }
+    return string;
+  };
+}]);
+
 oppia.filter('convertToPlainText', [function() {
   return function(input) {
     var strippedText = input.replace(/(<([^>]+)>)/ig, '');

--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -349,12 +349,15 @@ oppia.filter('removeExtraLines', [function() {
       return string;
     }
     var BLANK_LINES_TEXT = '<p><br></p>';
+    var EMPTY_PARA_TEXT = '<p></p>';
     while (1) {
-      var lastIndex = string.length;
-      if (string.substring(
-           lastIndex - BLANK_LINES_TEXT.length, lastIndex
-          ) === BLANK_LINES_TEXT) {
-        string = string.substring(0, lastIndex - BLANK_LINES_TEXT.length);
+      var endIndex = string.length;
+      var bStr = string.substring(endIndex - BLANK_LINES_TEXT.length, endIndex);
+      var pStr = string.substring(endIndex - EMPTY_PARA_TEXT.length, endIndex);
+      if (bStr === BLANK_LINES_TEXT) {
+        string = string.substring(0, endIndex - BLANK_LINES_TEXT.length);
+      } else if (pStr === EMPTY_PARA_TEXT) {
+        string = string.substring(0, endIndex - EMPTY_PARA_TEXT.length);
       } else {
         break;
       }

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -35,7 +35,8 @@ describe('Testing filters', function() {
     'summarizeNonnegativeNumber',
     'truncateAndCapitalize',
     'capitalize',
-    'stripFormatting'
+    'stripFormatting',
+    'removeExtraLines'
   ];
 
   beforeEach(angular.mock.module('oppia'));
@@ -482,6 +483,22 @@ describe('Testing filters', function() {
       ).toEqual('[Math] Text input [Collapsible] Text input 2 [Image]  ' +
       'Text Input 3');
     }));
+
+  it('should remove extra new lines', inject(function($filter) {
+    var filter = $filter('removeExtraLines');
+
+    expect(filter('<p><br></p>')).toEqual('');
+    expect(filter('<p>abc</p>')).toEqual('<p>abc</p>');
+    expect(filter('<p>abc</p><p><br></p><p>abc</p>')).toEqual(
+      '<p>abc</p><p><br></p><p>abc</p>');
+    expect(filter('<p>abc</p><p><br></p><p>abc</p><p><br></p>')).toEqual(
+      '<p>abc</p><p><br></p><p>abc</p>');
+    expect(filter(
+      '<p>abc</p><p><br></p><p>abc</p><p><br></p><p><br></p>')).toEqual(
+      '<p>abc</p><p><br></p><p>abc</p>');
+    expect(filter(null)).toEqual(null);
+    expect(filter(undefined)).toEqual(undefined);
+  }));
 
   it('should correctly display RTE components in Answer Group Header',
     inject(function($filter) {

--- a/core/templates/dev/head/services/RteHelperService.js
+++ b/core/templates/dev/head/services/RteHelperService.js
@@ -181,7 +181,9 @@ oppia.factory('RteHelperService', [
           });
         });
 
-        return elt.html();
+        text = elt.html();
+        text = $filter('removeExtraLines')(text);
+        return text;
       },
       getRichTextComponents: function() {
         return angular.copy(_RICH_TEXT_COMPONENTS);


### PR DESCRIPTION
This PR fixes #4530 by adding filter to remove new lines occuring at the end of the text. 
Tests for the filters have been written as well.
