### PR TITLE
Fix #4428: Block console error message in pencil code editor

### DIFF
--- a/extensions/interactions/PencilCodeEditor/directives/PencilCodeEditor.js
+++ b/extensions/interactions/PencilCodeEditor/directives/PencilCodeEditor.js
@@ -60,6 +60,9 @@ oppia.directive('oppiaInteractivePencilCodeEditor', [
             // screen.
             pce.setupScript([{
               code: [
+                'window.onerror = function() {',
+                '  return true;',
+                '};',
                 'debug.hide();',
                 'window.removeEventListener("error", debug)',
                 '',


### PR DESCRIPTION
Fix #4428:  This PR blocks the console error message from the pencil code editor

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
