### PR TITLE
Fixes issue  #4562 : Overlapping line numbers and text in Code Editor

### DIFF
--- a/extensions/interactions/CodeRepl/directives/CodeRepl.js
+++ b/extensions/interactions/CodeRepl/directives/CodeRepl.js
@@ -59,12 +59,12 @@ oppia.directive('oppiaInteractiveCodeRepl', [
           // Make sure $scope.preCode ends with a newline:
           if ($scope.preCode.trim().length === 0) {
             $scope.preCode = '';
-          } else if (!$scope.preCode.slice(-1) === '\n') {
+          } else if ($scope.preCode.slice(-1) !== '\n') {
             $scope.preCode += '\n';
           }
 
           // Make sure $scope.placeholder ends with a newline.
-          if (!$scope.placeholder.slice(-1) === '\n') {
+          if ($scope.placeholder.slice(-1) !== '\n') {
             $scope.placeholder += '\n';
           }
 


### PR DESCRIPTION
**Fix for issue #4562**

The fix is to correct the conditional statements.