### PR TITLE
Fix #2915: fixes sidebar breaking on mobile

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1064,6 +1064,7 @@ textarea {
 }
 
 .oppia-sidebar-menu-open .oppia-sidebar-menu {
+  height: 100vh;
   box-shadow: 1px 0 3px rgba(0,0,0,0.12), 1px 0 2px rgba(0,0,0,0.24);
   overflow-y: scroll;
   -ms-transform: translate(0, 0);

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1064,8 +1064,8 @@ textarea {
 }
 
 .oppia-sidebar-menu-open .oppia-sidebar-menu {
-  height: 100vh;
   box-shadow: 1px 0 3px rgba(0,0,0,0.12), 1px 0 2px rgba(0,0,0,0.24);
+  height: 110vh;
   overflow-y: scroll;
   -ms-transform: translate(0, 0);
   -webkit-transform: translate3d(0, 0, 0);


### PR DESCRIPTION


## Explanation
Fixes #2915: Sidebar breaking is fixed. I have tested on both Android and iOS and it works well. I referred this link: https://developers.google.com/web/updates/2016/12/url-bar-resizing for the fix.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
