### PR TITLE
Fix #4367 : Prevent null-submission for MathExpressionInput interaction (Upgraded guppy 260da6--->b5055b)

### DIFF
--- a/assets/overrides/guppy/oppia_symbols.json
+++ b/assets/overrides/guppy/oppia_symbols.json
@@ -10,8 +10,9 @@
         "input": 1,
         "keys": ["/"],
         "attrs": {
-        "type": "fraction",
-        "group": "functions"},
+            "type": "fraction",
+            "group": "functions"
+        },
         "args": [{
             "up": "1",
             "down": "2",

--- a/assets/overrides/guppy/oppia_symbols.json
+++ b/assets/overrides/guppy/oppia_symbols.json
@@ -1,17 +1,21 @@
 {
+    "_version": "2.0.0-alpha.2",
+    "_name": "base",
     "frac": {
         "output": {
             "latex": "\\frac{{$1}}{{$2}}",
             "small_latex": "\\frac{{$1}}{{$2}}",
             "text": "({$1})/({$2})"
         },
-        "current": 0,
-        "type": "fraction",
-        "attrs": {
-            "up": [1, 1],
-            "down": [2, 2],
-            "name": ["numerator", "denominator"]
-        }
+        "input":1,
+        "keys":["/"],
+        "attrs":{
+        "type":"fraction",
+        "group":"functions"},
+        "args":[
+        {"up":"1","down":"2","name":"numerator","small":"yes"},
+        {"up":"1","down":"2","delete":"1","name":"denominator","small":"yes"}
+        ]
     },
     "slash": {
         "output": {
@@ -19,13 +23,14 @@
             "small_latex":"\\frac{{$1}}{{$2}}",
             "text":"({$1})/({$2})"
         },
-        "current": 1,
-        "current_type": "token",
-        "type": "fraction",
-        "attrs": {
-            "up": [1, 1],
-            "down": [2, 2],
-            "name": ["numerator", "denominator"]
-        }
+        "input":1,
+        "attrs":{
+            "type":"fraction",
+            "group":"functions"},
+        "keys":["/"],
+        "args":[
+            {"up":"1","down":"2","name":"numerator","small":"yes"},
+            {"up":"1","down":"2","delete":"1","name":"denominator","small":"yes"}
+            ]
     }
 }

--- a/assets/overrides/guppy/oppia_symbols.json
+++ b/assets/overrides/guppy/oppia_symbols.json
@@ -7,30 +7,47 @@
             "small_latex": "\\frac{{$1}}{{$2}}",
             "text": "({$1})/({$2})"
         },
-        "input":1,
-        "keys":["/"],
-        "attrs":{
-        "type":"fraction",
-        "group":"functions"},
-        "args":[
-        {"up":"1","down":"2","name":"numerator","small":"yes"},
-        {"up":"1","down":"2","delete":"1","name":"denominator","small":"yes"}
-        ]
+        "input": 1,
+        "keys": ["/"],
+        "attrs": {
+        "type": "fraction",
+        "group": "functions"},
+        "args": [{
+            "up": "1",
+            "down": "2",
+            "name": "numerator",
+            "small": "yes"
+        }, {
+            "up": "1",
+            "down": "2",
+            "delete": "1",
+            "name": "denominator",
+            "small": "yes"
+        }]
     },
     "slash": {
         "output": {
-            "latex":"\\frac{{$1}}{{$2}}",
-            "small_latex":"\\frac{{$1}}{{$2}}",
-            "text":"({$1})/({$2})"
+            "latex": "\\frac{{$1}}{{$2}}",
+            "small_latex": "\\frac{{$1}}{{$2}}",
+            "text": "({$1})/({$2})"
         },
-        "input":1,
-        "attrs":{
-            "type":"fraction",
-            "group":"functions"},
-        "keys":["/"],
-        "args":[
-            {"up":"1","down":"2","name":"numerator","small":"yes"},
-            {"up":"1","down":"2","delete":"1","name":"denominator","small":"yes"}
-            ]
+        "input": 1,
+        "attrs": {
+            "type": "fraction",
+            "group": "functions"
+        },
+        "keys": ["/"],
+        "args": [{
+            "up": "1",
+            "down": "2",
+            "name": "numerator",
+            "small": "yes"
+        }, {
+            "up": "1",
+            "down": "2",
+            "delete": "1",
+            "name": "denominator",
+            "small": "yes"
+        }]
     }
 }

--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -1,8 +1,8 @@
-<link rel="stylesheet" href="/third_party/static/guppy-260da6/build/guppy.min.css">
-<script src="/third_party/static/guppy-260da6/build/guppy.min.js"></script>
+<link rel="stylesheet" href="/third_party/static/guppy-b5055b/build/guppy-default.min.css">
+<script type="text/javascript" src="/third_party/static/guppy-b5055b/build/guppy.min.js"></script>
 
-<script>
-  Guppy.get_symbols(['builtins', '/third_party/static/guppy-260da6/sym/symbols.json']);
+<script type="text/javascript">
+Guppy.init({"path":"/third_party/static/guppy-b5055b/build",symbols:['/third_party/static/guppy-b5055b/sym/symbols.json','/assets/overrides/guppy/oppia_symbols.json']});
 </script>
 
 <style>

--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -2,7 +2,7 @@
 <script type="text/javascript" src="/third_party/static/guppy-b5055b/build/guppy.min.js"></script>
 
 <script type="text/javascript">
-Guppy.init({"path":"/third_party/static/guppy-b5055b/build",symbols:['/third_party/static/guppy-b5055b/sym/symbols.json','/assets/overrides/guppy/oppia_symbols.json']});
+Guppy.init({"path":"/third_party/static/guppy-b5055b/build"});
 </script>
 
 <style>

--- a/extensions/dependencies/guppy.html
+++ b/extensions/dependencies/guppy.html
@@ -2,7 +2,9 @@
 <script type="text/javascript" src="/third_party/static/guppy-b5055b/build/guppy.min.js"></script>
 
 <script type="text/javascript">
-Guppy.init({"path":"/third_party/static/guppy-b5055b/build"});
+  Guppy.init({
+    "path": "/third_party/static/guppy-b5055b/build"
+  });
 </script>
 
 <style>

--- a/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
+++ b/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
@@ -154,6 +154,11 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
                 $scope.$apply();
               },
               ready: function() {
+                var oppiaSymbolsUrl = UrlInterpolationService.getStaticAssetUrl(
+                  '/overrides/guppy/oppia_symbols.json');
+                Guppy.init({
+                  symbols:['/third_party/static/guppy-b5055b/sym/symbols.json',
+                           oppiaSymbolsUrl]});
                 $scope.setAnswerValidity({
                   answerValidity: false
                 });

--- a/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
+++ b/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
@@ -45,6 +45,11 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
             EVENT_PROGRESS_NAV_SUBMITTED) {
           var guppyDivElt = $element[0].querySelector('.guppy-div');
 
+          //Dynamically assigns a unique id to the guppy-div
+          guppyDivElt.setAttribute(
+            'id', 'guppy_' + (Object.keys(Guppy.instances).length).toString());
+          var guppyDivId = guppyDivElt.id;
+
           /**
            * Adds a button overlay and invisible text field used to bring up
            * the keyboard on mobile devices.
@@ -130,30 +135,46 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
               setGuppyContentFromInput();
             });
           };
+          var guppyInstance = new Guppy(guppyDivId, {
+            settings:{
+              empty_content:
+              '\\color{grey}{\\text{\\small{Type a formula here.}}}',
+              buttons:[]
+            },
+            events:{
+              done:function(e){
+                $scope.submitAnswer();
+              },
+              change:function(e) {
+                $scope.setAnswerValidity({
+                  answerValidity: $scope.isCurrentAnswerValid()
+                });
+                // Need to manually trigger the digest cycle
+                // to make any 'watchers' aware of changes in answer.
+                $scope.$apply();
+              },
+              ready: function() {
+                $scope.setAnswerValidity({
+                  answerValidity: false
+                });
 
-          var guppyInstance = new Guppy(guppyDivElt, {
-            empty_content: (
-              '\\color{grey}{\\text{\\small{Type a formula here.}}}'),
-            ready_callback: function() {
-              Guppy.get_symbols(
-                UrlInterpolationService.getStaticAssetUrl(
-                  '/overrides/guppy/oppia_symbols.json'));
-
-              if (DeviceInfoService.isMobileUserAgent() &&
-                DeviceInfoService.hasTouchEvents()) {
-                $scope.mobileOverlayIsShown = true;
-                // Wait for the scope change to apply. Since we interact with
-                // the DOM elements, they need to be added by angular before
-                // the function is called. Timeout of 0 to wait until the end
-                // of the current digest cycle, false to not start a new digest
-                // cycle. A new cycle is not needed since no angular variables
-                // are changed within the function.
-                $timeout(makeGuppyMobileFriendly, 0, false);
+                if (DeviceInfoService.isMobileUserAgent() &&
+                  DeviceInfoService.hasTouchEvents()) {
+                  $scope.mobileOverlayIsShown = true;
+                  // Wait for the scope change to apply. Since we interact with
+                  // the DOM elements, they need to be added by angular before
+                  // the function is called. Timeout of 0 to wait
+                  // until the end of the current digest cycle,
+                  // false to not start a new digest cycle.
+                  // A new cycle is not needed since no angular variables
+                  // are changed within the function.
+                  $timeout(makeGuppyMobileFriendly, 0, false);
+                }
               }
             }
           });
-          var guppyDivId = guppyInstance.editor.id;
 
+          guppyInstance.render();
           var labelForFocusTarget = $attrs.labelForFocusTarget || null;
 
           $scope.$on('focusOn', function(e, name) {
@@ -168,9 +189,7 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
             }
           });
 
-          guppyInstance.done_callback = function() {
-            $scope.submitAnswer();
-          };
+
 
           var answer = {
             ascii: '',
@@ -178,9 +197,9 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
           };
 
           $scope.isCurrentAnswerValid = function() {
-            var latexAnswer = Guppy.instances[guppyDivId].get_content('latex');
+            var latexAnswer = guppyInstance.latex();
             try {
-              MathExpression.fromLatex(answer.latex);
+              MathExpression.fromLatex(latexAnswer);
             } catch (e) {
               return false;
             }
@@ -189,13 +208,11 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
           };
 
           $scope.submitAnswer = function() {
-            answer.ascii = Guppy.instances[guppyDivId].get_content('text');
-            answer.latex = Guppy.instances[guppyDivId].get_content('latex');
-
             if (!$scope.isCurrentAnswerValid()) {
               return;
             }
-
+            answer.latex = guppyInstance.latex();
+            answer.ascii = guppyInstance.text();
             $scope.onSubmit({
               answer: answer,
               rulesService: mathExpressionInputRulesService

--- a/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
+++ b/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
@@ -49,7 +49,7 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
           guppyDivElt.setAttribute(
             'id', 'guppy_' + (Math.floor(Math.random() * 10000)).toString());
           var guppyDivId = guppyDivElt.id;
-                    /**
+          /**
            * Adds a button overlay and invisible text field used to bring up
            * the keyboard on mobile devices.
            *

--- a/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
+++ b/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
@@ -49,8 +49,7 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
           guppyDivElt.setAttribute(
             'id', 'guppy_' + (Math.floor(Math.random() * 10000)).toString());
           var guppyDivId = guppyDivElt.id;
-
-          /**
+                    /**
            * Adds a button overlay and invisible text field used to bring up
            * the keyboard on mobile devices.
            *
@@ -193,8 +192,6 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
               guppyInstance.deactivate();
             }
           });
-
-
 
           var answer = {
             ascii: '',

--- a/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
+++ b/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
@@ -134,6 +134,11 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
               setGuppyContentFromInput();
             });
           };
+          var oppiaSymbolsUrl = UrlInterpolationService.getStaticAssetUrl(
+            '/overrides/guppy/oppia_symbols.json');
+          Guppy.init({
+            symbols: ['/third_party/static/guppy-b5055b/sym/symbols.json',
+                      oppiaSymbolsUrl]});
           var guppyInstance = new Guppy(guppyDivId, {
             settings: {
               empty_content: (
@@ -153,11 +158,6 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
                 $scope.$apply();
               },
               ready: function() {
-                var oppiaSymbolsUrl = UrlInterpolationService.getStaticAssetUrl(
-                  '/overrides/guppy/oppia_symbols.json');
-                Guppy.init({
-                  symbols: ['/third_party/static/guppy-b5055b/sym/symbols.json',
-                            oppiaSymbolsUrl]});
                 $scope.setAnswerValidity({
                   answerValidity: false
                 });

--- a/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
+++ b/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
@@ -47,7 +47,7 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
 
           // Dynamically assigns a unique id to the guppy-div
           guppyDivElt.setAttribute(
-            'id', 'guppy_' + (Math.floor(Math.random() * 10000)).toString());
+            'id', 'guppy_' + Math.floor(Math.random() * 100000000));
           var guppyDivId = guppyDivElt.id;
           /**
            * Adds a button overlay and invisible text field used to bring up
@@ -142,7 +142,7 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
           var guppyInstance = new Guppy(guppyDivId, {
             settings: {
               empty_content: (
-              '\\color{grey}{\\text{\\small{Type a formula here.}}}'),
+                '\\color{grey}{\\text{\\small{Type a formula here.}}}'),
               buttons: []
             },
             events: {

--- a/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
+++ b/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
@@ -47,7 +47,7 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
 
           // Dynamically assigns a unique id to the guppy-div
           guppyDivElt.setAttribute(
-            'id', 'guppy_' + (Object.keys(Guppy.instances).length).toString());
+            'id', 'guppy_' + (Math.floor(Math.random() * 10000)).toString());
           var guppyDivId = guppyDivElt.id;
 
           /**

--- a/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
+++ b/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
@@ -45,7 +45,7 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
             EVENT_PROGRESS_NAV_SUBMITTED) {
           var guppyDivElt = $element[0].querySelector('.guppy-div');
 
-          //Dynamically assigns a unique id to the guppy-div
+          // Dynamically assigns a unique id to the guppy-div
           guppyDivElt.setAttribute(
             'id', 'guppy_' + (Object.keys(Guppy.instances).length).toString());
           var guppyDivId = guppyDivElt.id;
@@ -136,16 +136,16 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
             });
           };
           var guppyInstance = new Guppy(guppyDivId, {
-            settings:{
-              empty_content:
-              '\\color{grey}{\\text{\\small{Type a formula here.}}}',
-              buttons:[]
+            settings: {
+              empty_content: (
+              '\\color{grey}{\\text{\\small{Type a formula here.}}}'),
+              buttons: []
             },
-            events:{
-              done:function(e){
+            events: {
+              done: function(e) {
                 $scope.submitAnswer();
               },
-              change:function(e) {
+              change: function(e) {
                 $scope.setAnswerValidity({
                   answerValidity: $scope.isCurrentAnswerValid()
                 });
@@ -157,8 +157,8 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
                 var oppiaSymbolsUrl = UrlInterpolationService.getStaticAssetUrl(
                   '/overrides/guppy/oppia_symbols.json');
                 Guppy.init({
-                  symbols:['/third_party/static/guppy-b5055b/sym/symbols.json',
-                           oppiaSymbolsUrl]});
+                  symbols: ['/third_party/static/guppy-b5055b/sym/symbols.json',
+                            oppiaSymbolsUrl]});
                 $scope.setAnswerValidity({
                   answerValidity: false
                 });

--- a/manifest.json
+++ b/manifest.json
@@ -256,11 +256,11 @@
         }
       },
       "guppy": {
-        "version": "260da662c907e95f3da0a335c896fe9621fc165d",
+        "version": "b5055b963fdbea5c6c1e92dbf58fdaf3ea0cd8ba",
         "downloadFormat": "zip",
-        "url": "https://github.com/daniel3735928559/guppy/archive/260da662c907e95f3da0a335c896fe9621fc165d.zip",
+        "url": "https://github.com/daniel3735928559/guppy/archive/b5055b963fdbea5c6c1e92dbf58fdaf3ea0cd8ba.zip",
         "rootDirPrefix": "guppy-",
-        "targetDir": "guppy-260da6"
+        "targetDir": "guppy-b5055b"
       },
       "hammerJs": {
         "version": "2.0.4",


### PR DESCRIPTION
Fixed: Null submissions for math expression input interaction

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
