### PR TITLE
Fix #4190: Add try and except blocks at probable error generating lines in ExplorationStateIdMapping job

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -362,7 +362,12 @@ class ExplorationStateIdMappingJob(jobs.BaseMapReduceOneOffJobManager):
         if item.deleted:
             return
 
-        exploration = exp_services.get_exploration_from_model(item)
+        try:
+            exploration = exp_services.get_exploration_from_model(item)
+        except Exception as e:
+            yield ('ERROR with exp_id %s' % item.id, str(e))
+            return
+
         explorations = []
 
         # Fetch all versions of the exploration, if they exist.
@@ -401,15 +406,23 @@ class ExplorationStateIdMappingJob(jobs.BaseMapReduceOneOffJobManager):
                 return
 
             change_list = snapshot['commit_cmds']
-            # Check if commit is to revert the exploration.
-            if change_list and change_list[0]['cmd'].endswith(
-                    'revert_version_number'):
-                reverted_version = change_list[0]['version_number']
-                exp_services.create_and_save_state_id_mapping_model_for_reverted_exploration( # pylint: disable=line-too-long
-                    exploration.id, exploration.version - 1, reverted_version)
-            else:
-                exp_services.create_and_save_state_id_mapping_model(
-                    exploration, change_list)
+
+            try:
+                # Check if commit is to revert the exploration.
+                if change_list and change_list[0]['cmd'].endswith(
+                        'revert_version_number'):
+                    reverted_version = change_list[0]['version_number']
+                    # pylint: disable=line-too-long
+                    exp_services.create_and_save_state_id_mapping_model_for_reverted_exploration(
+                        exploration.id, exploration.version - 1, reverted_version)
+                    # pylint: enable=line-too-long
+                else:
+                    exp_services.create_and_save_state_id_mapping_model(
+                        exploration, change_list)
+            except Exception as e:
+                yield ('ERROR with exp_id %s' % item.id, str(e))
+                return
+
         yield (exploration.id, exploration.version)
 
     @staticmethod


### PR DESCRIPTION
This adds probable fixes at some code (as suggested by @pranavsid98) in ExplorationStateIdMappingJob which may be generating errors when running production code.
/cc @BenHenning @seanlip 