### PR TITLE
Fix part of #4364 : Enhancements to the correctness footer

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/correctness_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/correctness_footer_directive.html
@@ -49,6 +49,220 @@
     -ms-animation-fill-mode: forwards;
   }
 
+  correctness-footer .sprinkle-dot {
+    border-radius: 50%;
+    height: 10px;
+    position: absolute;
+    width: 10px;
+  }
+
+  correctness-footer .dot1 {
+    animation: flasha 1s 10;
+    left: 140px;
+    opacity:0;
+    top: 30px;
+    -webkit-animation: flasha 1s 10;
+  }
+
+  correctness-footer .dot2 {
+    animation: flashb 1s 10;
+    left: 110px;
+    opacity:0;
+    top: 20px;
+    -webkit-animation: flashb 1s 10;
+  }
+
+  correctness-footer .dot3 {
+    animation: flashc 1s 10;
+    left: 130px;
+    opacity:0;
+    top: 5px;
+    -webkit-animation: flashc 1s 10;
+  }
+
+  correctness-footer .dot4 {
+    animation: flashd 1s 10;
+    left: 80px;
+    opacity:0;
+    top: 15px;
+    -webkit-animation: flashd 1s 10;
+  }
+
+  correctness-footer .dot5 {
+    animation: flashb 1s 10;
+    left: 100px;
+    opacity:0;
+    top: 0px;
+    -webkit-animation: flashb 1s 10;
+  }
+
+  correctness-footer .dot6 {
+    animation: flashc 1s 10;
+    left: 120px;
+    opacity:0;
+    top: -15px;
+    -webkit-animation: flashc 1s 10;
+  }
+
+  correctness-footer .dot7 {
+    animation: flashd 1s 10;
+    left: 40px;
+    opacity: 0;
+    top: 5px;
+    -webkit-animation: flashd 1s 10;
+  }
+
+  correctness-footer .dot8 {
+    animation: flasha 1s 10;
+    left: 60px;
+    opacity: 0;
+    top: -10px;
+    -webkit-animation: flasha 1s 10;
+  }
+
+  correctness-footer .dot9 {
+    animation: flashc 1s 10;
+    left: 80px;
+    opacity: 0;
+    top: -25px;
+    -webkit-animation: flashc 1s 10;
+  }
+
+  correctness-footer .dot10 {
+    animation: flashb 1s 10;
+    left: 100px;
+    opacity: 0;
+    top: -40px;
+    -webkit-animation: flashb 1s 10;
+  }
+
+  correctness-footer .dot11 {
+    animation: flashd 1s 10;
+    opacity: 0;
+    right: 140px;
+    top: 30px;
+    -webkit-animation: flashd 1s 10;
+  }
+
+  correctness-footer .dot12 {
+    animation: flashc 1s 10;
+    opacity: 0;
+    right: 110px;
+    top: 20px;
+    -webkit-animation: flashc 1s 10;
+  }
+
+  correctness-footer .dot13 {
+    animation: flasha 1s 10;
+    opacity: 0;
+    right: 130px;
+    top: 5px;
+    -webkit-animation: flasha 1s 10;
+  }
+
+  correctness-footer .dot14 {
+    animation: flashb 1s 10;
+    opacity: 0;
+    right:80px;
+    top: 15px;
+    -webkit-animation: flashb 1s 10;
+  }
+
+  correctness-footer .dot15 {
+    animation: flashb 1s 10;
+    opacity: 0;
+    right: 100px;
+    top: 0px;
+    -webkit-animation: flashb 1s 10;
+  }
+
+  correctness-footer .dot16 {
+    animation: flashd 1s 10;
+    opacity: 0;
+    right: 120px;
+    top: -15px;
+    -webkit-animation: flashd 1s 10;
+  }
+
+  correctness-footer .dot17 {
+    animation: flasha 1s 10;
+    opacity: 0;
+    right: 40px;
+    top: 5px;
+    -webkit-animation: flasha 1s 10;
+  }
+
+  correctness-footer .dot18 {
+    animation: flashc 1s 10;
+    opacity: 0;
+    right: 60px;
+    top: -10px;
+    -webkit-animation: flashc 1s 10;
+  }
+
+  correctness-footer .dot19 {
+    animation: flashb 1s 10;
+    opacity: 0;
+    right: 80px;
+    top: -25px;
+    -webkit-animation: flashb 1s 10;
+  }
+
+  correctness-footer .dot20 {
+    animation: flashd 1s 10;
+    opacity: 0;
+    right: 100px;
+    top: -40px;
+    -webkit-animation: flashd 1s 10;
+  }
+
+  @keyframes flasha {
+    0%  {background-color: red; opacity:0;}
+    50% {background-color: green; opacity:1;}
+    100% {background-color: yellow; opacity:1;}
+}
+
+  @-webkit-keyframes flasha {
+    0%  {background-color: red; opacity:0;}
+    50% {background-color: green; opacity:1;}
+    100% {background-color: pink; opacity:1;}
+  }
+
+  @keyframes flashb {
+    0% {background-color: blue; opacity:1;}
+    50% {background-color: brown; opacity:1;}
+    100% {background-color: black; opacity:0;}
+  }
+
+  @-webkit-keyframes flashb {
+    0% {background-color: blue; opacity:1;}
+    50% {background-color: brown; opacity:1;}
+    100% {background-color: black; opacity:0;}
+  }
+
+  @keyframes flashc {
+    0% {background-color: black; opacity:1;}
+    50% {background-color: red; opacity:1;}
+    100% {background-color: green; opacity:0;}
+  }
+
+  @-webkit-keyframes flashc {
+    0% {background-color: black; opacity:1;}
+    50% {background-color: red; opacity:1;}
+    100% {background-color: green; opacity:0;}
+  }
+
+  @keyframes flashd {
+    0% {background-color: pink; opacity:1;}
+    50% {background-color: blue; opacity:0;}
+    100% {background-color: purple; opacity:1;}
+  }
+
+  @-webkit-keyframes flashd {
+    0% {background-color: pink; opacity:1;}
+    50% {background-color: blue; opacity:0;}
+    100% {background-color: purple; opacity:1;}
+  }
   /* Some mobile devices have CSS width below 360px, use a responsive min-width
      when under 360px to prevent pushing things offscreen. */
   @media(max-width: 360px) {
@@ -59,6 +273,26 @@
 </style>
 
 <div class="inner-container">
+  <div class="sprinkle-dot dot1"></div>
+  <div class="sprinkle-dot dot2"></div>
+  <div class="sprinkle-dot dot3"></div>
+  <div class="sprinkle-dot dot4"></div>
+  <div class="sprinkle-dot dot5"></div>
+  <div class="sprinkle-dot dot6"></div>
+  <div class="sprinkle-dot dot7"></div>
+  <div class="sprinkle-dot dot8"></div>
+  <div class="sprinkle-dot dot9"></div>
+  <div class="sprinkle-dot dot10"></div>
+  <div class="sprinkle-dot dot11"></div>
+  <div class="sprinkle-dot dot12"></div>
+  <div class="sprinkle-dot dot13"></div>
+  <div class="sprinkle-dot dot14"></div>
+  <div class="sprinkle-dot dot15"></div>
+  <div class="sprinkle-dot dot16"></div>
+  <div class="sprinkle-dot dot17"></div>
+  <div class="sprinkle-dot dot18"></div>
+  <div class="sprinkle-dot dot19"></div>
+  <div class="sprinkle-dot dot20"></div>
   <i class="material-icons tick-symbol">&#xE86C;</i>
   <span class="inner-content">CORRECT!</span>
 </div>

--- a/core/templates/dev/head/pages/exploration_player/correctness_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/correctness_footer_directive.html
@@ -57,211 +57,327 @@
   }
 
   correctness-footer .dot1 {
-    animation: flasha 1s 10;
-    left: 140px;
-    opacity:0;
-    top: 30px;
-    -webkit-animation: flasha 1s 10;
+    animation: flasha 2s 1;
+    opacity: 0;
+    -webkit-animation: flasha 2s 1;
   }
 
   correctness-footer .dot2 {
-    animation: flashb 1s 10;
-    left: 110px;
-    opacity:0;
-    top: 20px;
-    -webkit-animation: flashb 1s 10;
+    animation: flashb 2s 1;
+    opacity: 0;
+    -webkit-animation: flashb 2s 1;
   }
 
   correctness-footer .dot3 {
-    animation: flashc 1s 10;
-    left: 130px;
-    opacity:0;
-    top: 5px;
-    -webkit-animation: flashc 1s 10;
+    animation: flashc 2s 1;
+    opacity: 0;
+    -webkit-animation: flashc 2s 1;
   }
 
   correctness-footer .dot4 {
-    animation: flashd 1s 10;
-    left: 80px;
-    opacity:0;
-    top: 15px;
-    -webkit-animation: flashd 1s 10;
+    animation: flashd 2s 1;
+    opacity: 0;
+    -webkit-animation: flashd 2s 1;
   }
 
   correctness-footer .dot5 {
-    animation: flashb 1s 10;
-    left: 100px;
-    opacity:0;
-    top: 0px;
-    -webkit-animation: flashb 1s 10;
+    animation: flashe 2s 1;
+    opacity: 0;
+    -webkit-animation: flashe 2s 1;
   }
 
   correctness-footer .dot6 {
-    animation: flashc 1s 10;
-    left: 120px;
-    opacity:0;
-    top: -15px;
-    -webkit-animation: flashc 1s 10;
+    animation: flashf 2s 1;
+    opacity: 0;
+    -webkit-animation: flashf 2s 1;
   }
 
   correctness-footer .dot7 {
-    animation: flashd 1s 10;
-    left: 40px;
+    animation: flashg 2s 1;
     opacity: 0;
-    top: 5px;
-    -webkit-animation: flashd 1s 10;
+    -webkit-animation: flashg 2s 1;
   }
 
   correctness-footer .dot8 {
-    animation: flasha 1s 10;
-    left: 60px;
+    animation: flashh 2s 1;
     opacity: 0;
-    top: -10px;
-    -webkit-animation: flasha 1s 10;
+    -webkit-animation: flashh 2s 1;
   }
 
   correctness-footer .dot9 {
-    animation: flashc 1s 10;
-    left: 80px;
+    animation: flashi 2s 1;
     opacity: 0;
-    top: -25px;
-    -webkit-animation: flashc 1s 10;
+    -webkit-animation: flashi 2s 1;
   }
 
   correctness-footer .dot10 {
-    animation: flashb 1s 10;
-    left: 100px;
+    animation: flashra 2s 1;
     opacity: 0;
-    top: -40px;
-    -webkit-animation: flashb 1s 10;
+    -webkit-animation: flashra 2s 1;
   }
 
   correctness-footer .dot11 {
-    animation: flashd 1s 10;
+    animation: flashrb 2s 1;
     opacity: 0;
-    right: 140px;
-    top: 30px;
-    -webkit-animation: flashd 1s 10;
+    -webkit-animation: flashrb 2s 1;
   }
 
   correctness-footer .dot12 {
-    animation: flashc 1s 10;
+    animation: flashrc 2s 1;
     opacity: 0;
-    right: 110px;
-    top: 20px;
-    -webkit-animation: flashc 1s 10;
+    -webkit-animation: flashrc 2s 1;
   }
 
   correctness-footer .dot13 {
-    animation: flasha 1s 10;
+    animation: flashrd 2s 1;
     opacity: 0;
-    right: 130px;
-    top: 5px;
-    -webkit-animation: flasha 1s 10;
+    -webkit-animation: flashrd 2s 1;
   }
 
   correctness-footer .dot14 {
-    animation: flashb 1s 10;
+    animation: flashre 2s 1;
     opacity: 0;
-    right:80px;
-    top: 15px;
-    -webkit-animation: flashb 1s 10;
+    -webkit-animation: flashre 2s 1;
   }
 
   correctness-footer .dot15 {
-    animation: flashb 1s 10;
+    animation: flashrf 2s 1;
     opacity: 0;
-    right: 100px;
-    top: 0px;
-    -webkit-animation: flashb 1s 10;
+    -webkit-animation: flashrf 2s 1;
   }
 
   correctness-footer .dot16 {
-    animation: flashd 1s 10;
+    animation: flashrg 2s 1;
     opacity: 0;
-    right: 120px;
-    top: -15px;
-    -webkit-animation: flashd 1s 10;
+    -webkit-animation: flashrg 2s 1;
   }
 
   correctness-footer .dot17 {
-    animation: flasha 1s 10;
+    animation: flashrh 2s 1;
     opacity: 0;
-    right: 40px;
-    top: 5px;
-    -webkit-animation: flasha 1s 10;
+    -webkit-animation: flashrh 2s 1;
   }
 
   correctness-footer .dot18 {
-    animation: flashc 1s 10;
+    animation: flashri 2s 1;
     opacity: 0;
-    right: 60px;
-    top: -10px;
-    -webkit-animation: flashc 1s 10;
-  }
-
-  correctness-footer .dot19 {
-    animation: flashb 1s 10;
-    opacity: 0;
-    right: 80px;
-    top: -25px;
-    -webkit-animation: flashb 1s 10;
-  }
-
-  correctness-footer .dot20 {
-    animation: flashd 1s 10;
-    opacity: 0;
-    right: 100px;
-    top: -40px;
-    -webkit-animation: flashd 1s 10;
+    -webkit-animation: flashri 2s 1;
   }
 
   @keyframes flasha {
-    0%  {background-color: red; opacity:0;}
-    50% {background-color: green; opacity:1;}
-    100% {background-color: yellow; opacity:1;}
-}
-
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50%  {background-color: #800000; opacity:1; top:20px; left:90px;}
+    100% {background-color: #800000; opacity:1; top:-50px; left:20px;}
+  }
   @-webkit-keyframes flasha {
-    0%  {background-color: red; opacity:0;}
-    50% {background-color: green; opacity:1;}
-    100% {background-color: pink; opacity:1;}
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #800000; opacity:1; top:20px; left:90px;}
+    100% {background-color: #800000; opacity:1; top:-50px; left:20px;}
   }
-
   @keyframes flashb {
-    0% {background-color: blue; opacity:1;}
-    50% {background-color: brown; opacity:1;}
-    100% {background-color: black; opacity:0;}
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: red; opacity:1; top:35px; left:55px;}
+    100% {background-color: red; opacity:1; top:-30px; left:-5px;}
   }
-
   @-webkit-keyframes flashb {
-    0% {background-color: blue; opacity:1;}
-    50% {background-color: brown; opacity:1;}
-    100% {background-color: black; opacity:0;}
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: red; opacity:1; top:35px; left:55px;}
+    100% {background-color: red; opacity:1; top:-30px; left:-5px;}
   }
-
   @keyframes flashc {
-    0% {background-color: black; opacity:1;}
-    50% {background-color: red; opacity:1;}
-    100% {background-color: green; opacity:0;}
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50%  {background-color: #b30000; opacity:1; top:0px; left:65px;}
+    100% {background-color: #b30000; opacity:1; top: -65px; left: 0px;}
   }
-
   @-webkit-keyframes flashc {
-    0% {background-color: black; opacity:1;}
-    50% {background-color: red; opacity:1;}
-    100% {background-color: green; opacity:0;}
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50%  {background-color: #b30000; opacity:1; top:0px; left:65px;}
+    100% {background-color: #b30000; opacity:1; top: -65px; left: 0px;}
   }
-
   @keyframes flashd {
-    0% {background-color: pink; opacity:1;}
-    50% {background-color: blue; opacity:0;}
-    100% {background-color: purple; opacity:1;}
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: yellow; opacity:1; top:30px; left:25px;}
+    100% {background-color: yellow; opacity:1; top:-35px; left:-35px;}
   }
-
   @-webkit-keyframes flashd {
-    0% {background-color: pink; opacity:1;}
-    50% {background-color: blue; opacity:0;}
-    100% {background-color: purple; opacity:1;}
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: yellow; opacity:1; top:30px; left:25px;}
+    100% {background-color: yellow; opacity:1; top:-35px; left:-35px;}
+  }
+  @keyframes flashe {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #00ffff; opacity:1; top:15px; left:40px;}
+    100% {background-color: #00ffff; opacity:1; top:-50px; left:-20px;}
+  }
+  @-webkit-keyframes flashe {
+    0% {opacity:0;}
+    50% {background-color: #00ffff; opacity:1; top:15px; left:40px;}
+    100% {background-color: #00ffff; opacity:1; top:-50px; left:-20px;}
+  }
+  @keyframes flashf {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50%  {background-color: #00ffff; opacity:1; top:30px; left:-15px;}
+    100% {background-color: #00ffff; opacity:1; top: -35px; left: -60px;}
+  }
+  @-webkit-keyframes flashf {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50%  {background-color: #00ffff; opacity:1; top:30px; left:-15px;}
+    100% {background-color: #00ffff; opacity:1; top: -35px; left: -60px;}
+  }
+  @keyframes flashg {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #330000; opacity:1; top:5px; left:10px;}
+    100% {background-color: #330000; opacity:1; top:-50px;left:-50px;}
+  }
+  @-webkit-keyframes flashg {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #330000; opacity:1; top:5px; left:10px;}
+    100% {background-color: #330000; opacity:1; top:-50px;left:-50px;}
+  }
+  @keyframes flashh {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #00ffff; opacity:1; top:-10px; left:40px;}
+    100% {background-color: #00ffff; opacity:1; top:-70px;left: -20px;}
+  }
+  @-webkit-keyframes flashh {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #00ffff; opacity:1; top:-10px; left:40px;}
+    100% {background-color: #00ffff; opacity:1; top:-70px;left: -20px;}
+  }
+  @keyframes flashi {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #b34700; opacity:1; top:-20px; left:-20px;}
+    100% {background-color: #b34700; opacity:1; top:-80px;left: -80px;}
+  }
+  @-webkit-keyframes flashi {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #b34700; opacity:1; top:-20px; left:-20px;}
+    100% {background-color: #b34700 opacity:1; top:-80px;left: -80px;}
+  }
+  @keyframes flashra {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50%  {background-color: #800000; opacity:1; top:20px; right:90px;}
+    100% {background-color: #800000; opacity:1; top:-50px; right:20px;}
+  }
+  @-webkit-keyframes flashra {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #800000; opacity:1; top:20px; right:90px;}
+    100% {background-color: #800000; opacity:1; top:-50px; right:20px;}
+  }
+  @keyframes flashrb {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: red; opacity:1; top:35px; right:55px;}
+    100% {background-color: red; opacity:1; top:-30px; right:-5px;}
+  }
+  @-webkit-keyframes flashrb {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: red; opacity:1; top:35px; right:55px;}
+    100% {background-color: red; opacity:1; top:-30px; right:-5px;}
+  }
+  @keyframes flashrc {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50%  {background-color: #b30000; opacity:1; top:0px; right:65px;}
+    100% {background-color: #b30000; opacity:1; top: -65px; right: 0px;}
+  }
+  @-webkit-keyframes flashrc {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50%  {background-color: #b30000; opacity:1; top:0px; right:65px;}
+    100% {background-color: #b30000; opacity:1; top: -65px; right: 0px;}
+  }
+  @keyframes flashrd {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: yellow; opacity:1; top:30px; right:25px;}
+    100% {background-color: yellow; opacity:1; top:-35px; right:-35px;}
+  }
+  @-webkit-keyframes flashrd {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: yellow; opacity:1; top:30px; right:25px;}
+    100% {background-color: yellow; opacity:1; top:-35px; right:-35px;}
+  }
+  @keyframes flashre {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #00ffff; opacity:1; top:15px; right:40px;}
+    100% {background-color: #00ffff; opacity:1; top:-50px; right:-20px;}
+  }
+  @-webkit-keyframes flashre {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #00ffff; opacity:1; top:15px; right:40px;}
+    100% {background-color: #00ffff; opacity:1; top:-50px; right:-20px;}
+  }
+  @keyframes flashrf {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50%  {background-color: #00ffff; opacity:1; top:30px; right:-15px;}
+    100% {background-color: #00ffff; opacity:1; top: -35px; right: -60px;}
+  }
+  @-webkit-keyframes flashrf {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50%  {background-color: #00ffff; opacity:1; top:30px; right:-15px;}
+    100% {background-color: #00ffff; opacity:1; top: -35px; right: -60px;}
+  }
+  @keyframes flashrg {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #330000; opacity:1; top:5px; right:10px;}
+    100% {background-color: #330000; opacity:1; top:-50px;right:-50px;}
+  }
+  @-webkit-keyframes flashrg {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #330000; opacity:1; top:5px; right:10px;}
+    100% {background-color: #330000; opacity:1; top:-50px;right:-50px;}
+  }
+  @keyframes flashrh {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #00ffff; opacity:1; top:-10px; right:40px;}
+    100% {background-color: #00ffff; opacity:1; top:-70px;right: -20px;}
+  }
+  @-webkit-keyframes flashrh {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #00ffff; opacity:1; top:-10px; right:40px;}
+    100% {background-color: #00ffff; opacity:1; top:-70px;right: -20px;}
+  }
+  @keyframes flashri {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #b34700; opacity:1; top:-20px; right:-20px;}
+    100% {background-color: #b34700; opacity:1; top:-80px;right: -80px;}
+  }
+  @-webkit-keyframes flashri {
+    0% {opacity:0;}
+    49% {opacity:0;}
+    50% {background-color: #b34700; opacity:1; top:-20px; right:-20px;}
+    100% {background-color: #b34700 opacity:1; top:-80px;right: -80px;}
   }
   /* Some mobile devices have CSS width below 360px, use a responsive min-width
      when under 360px to prevent pushing things offscreen. */
@@ -291,8 +407,6 @@
   <div class="sprinkle-dot dot16"></div>
   <div class="sprinkle-dot dot17"></div>
   <div class="sprinkle-dot dot18"></div>
-  <div class="sprinkle-dot dot19"></div>
-  <div class="sprinkle-dot dot20"></div>
   <i class="material-icons tick-symbol">&#xE86C;</i>
   <span class="inner-content">CORRECT!</span>
 </div>


### PR DESCRIPTION

## Explanation
Fixes part of #4364: Adds sprinkles to correctness footer.
Here is a video of the same:
![footer](https://user-images.githubusercontent.com/22434689/36952232-f965a316-2032-11e8-91ed-aa132a4f13bd.gif)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
