### PR TITLE
Revert "Fixes #4530: Removes spaces and new lines from end of string in RTE. (#4748)"

### DIFF
--- a/core/templates/dev/head/filters.js
+++ b/core/templates/dev/head/filters.js
@@ -345,55 +345,25 @@ oppia.filter('normalizeWhitespacePunctuationAndCase', [function() {
   };
 }]);
 
-// Filter that targets to remove occurrence of blank lines, empty paragraphs
-// and spaces at the end of string. It'll remove <p></p>, <p><br></p>, spaces
-// and &nbsp; occurrences from the end of the string.
-oppia.filter('removeExtraLinesAndSpace', [function() {
+// Note that this filter removes additional new lines or <p><br></p> tags
+// at the end of the string.
+oppia.filter('removeExtraLines', [function() {
   return function(string) {
     if (!angular.isString(string)) {
       return string;
     }
     var BLANK_LINES_TEXT = '<p><br></p>';
     var EMPTY_PARA_TEXT = '<p></p>';
-    var BLANK_CHAR = ' ';
-    var BREAK_LINE_TAG = '<br>';
-    var SPACE_ENTITY = '&nbsp;';
     while (1) {
-      var lastIndexOfClosingTag = string.lastIndexOf('<');
-      if (string[lastIndexOfClosingTag - 1] !== BLANK_CHAR &&
-          string.substring(
-            lastIndexOfClosingTag - BREAK_LINE_TAG.length, lastIndexOfClosingTag
-          ) !== BREAK_LINE_TAG &&
-          string.substring(
-            lastIndexOfClosingTag - SPACE_ENTITY.length, lastIndexOfClosingTag
-          ) !== SPACE_ENTITY) {
+      var endIndex = string.length;
+      var bStr = string.substring(endIndex - BLANK_LINES_TEXT.length, endIndex);
+      var pStr = string.substring(endIndex - EMPTY_PARA_TEXT.length, endIndex);
+      if (bStr === BLANK_LINES_TEXT) {
+        string = string.substring(0, endIndex - BLANK_LINES_TEXT.length);
+      } else if (pStr === EMPTY_PARA_TEXT) {
+        string = string.substring(0, endIndex - EMPTY_PARA_TEXT.length);
+      } else {
         break;
-      }
-      while (1) {
-        var lng = string.lastIndexOf('<');
-        if (string[lastIndexOfClosingTag - 1] === BLANK_CHAR) {
-          string = string.substring(0, lastIndexOfClosingTag - 1) + '</p>';
-        } else if (
-          string.substring(
-            lastIndexOfClosingTag - SPACE_ENTITY.length, lastIndexOfClosingTag
-          ) === SPACE_ENTITY) {
-          string = string.substring(
-            0, lastIndexOfClosingTag - SPACE_ENTITY.length) + '</p>';
-        } else {
-          break;
-        }
-      }
-      while (1) {
-        var endIdx = string.length;
-        var bStr = string.substring(endIdx - BLANK_LINES_TEXT.length, endIdx);
-        var pStr = string.substring(endIdx - EMPTY_PARA_TEXT.length, endIdx);
-        if (bStr === BLANK_LINES_TEXT) {
-          string = string.substring(0, endIdx - BLANK_LINES_TEXT.length);
-        } else if (pStr === EMPTY_PARA_TEXT) {
-          string = string.substring(0, endIdx - EMPTY_PARA_TEXT.length);
-        } else {
-          break;
-        }
       }
     }
     return string;

--- a/core/templates/dev/head/filtersSpec.js
+++ b/core/templates/dev/head/filtersSpec.js
@@ -37,7 +37,7 @@ describe('Testing filters', function() {
     'capitalize',
     'stripFormatting',
     'getAbbreviatedText',
-    'removeExtraLinesAndSpace'
+    'removeExtraLines'
   ];
 
   beforeEach(angular.mock.module('oppia'));
@@ -510,8 +510,8 @@ describe('Testing filters', function() {
       'Text Input 3');
     }));
 
-  it('should remove extra new lines and spaces', inject(function($filter) {
-    var filter = $filter('removeExtraLinesAndSpace');
+  it('should remove extra new lines', inject(function($filter) {
+    var filter = $filter('removeExtraLines');
 
     expect(filter('<p><br></p>')).toEqual('');
     expect(filter('<p>abc</p>')).toEqual('<p>abc</p>');
@@ -522,15 +522,6 @@ describe('Testing filters', function() {
     expect(filter(
       '<p>abc</p><p><br></p><p>abc</p><p><br></p><p><br></p>')).toEqual(
       '<p>abc</p><p><br></p><p>abc</p>');
-    expect(filter(
-      '<p>test</p><p><br></p><p>&nbsp;test</p><p><br></p><p>&nbsp; &nbsp;</p>'))
-      .toEqual('<p>test</p><p><br></p><p>&nbsp;test</p>');
-    expect(filter(
-      '<p>test</p><p><br></p><p>&nbsp;test</p><p>&nbsp;&nbsp;</p>')).toEqual(
-      '<p>test</p><p><br></p><p>&nbsp;test</p>');
-    expect(filter(
-      '<p>test</p><p><br></p><p>&nbsp;test</p><p>&nbsp; &nbsp;</p>')).toEqual(
-      '<p>test</p><p><br></p><p>&nbsp;test</p>');
     expect(filter(null)).toEqual(null);
     expect(filter(undefined)).toEqual(undefined);
   }));

--- a/core/templates/dev/head/services/RteHelperService.js
+++ b/core/templates/dev/head/services/RteHelperService.js
@@ -182,7 +182,7 @@ oppia.factory('RteHelperService', [
         });
 
         text = elt.html();
-        text = $filter('removeExtraLinesAndSpace')(text);
+        text = $filter('removeExtraLines')(text);
         return text;
       },
       getRichTextComponents: function() {


### PR DESCRIPTION
This reverts commit c95abcc912ce0e09f5c7767779b5488de81d4fbc. See comments on #4748 for rationale.

@BenHenning please note that this needs to be cherry-picked into 2.6.2.

Thanks!