### PR TITLE
Fix #4781: Fixed zoom in Problem with code editor

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -209,14 +209,14 @@ otherwise they will interfere with the iframed conversation skin directive.
     max-width: 560px;
     /* NOTE TO DEVELOPERS: If min-width is changed, max-width in media query
        below should be changed to match. */
-    min-width: 360px;
+    min-width: 447px;
     width: 100%;
     z-index: 3;
   }
 
   /* Some mobile devices have CSS width below 360px, use a responsive min-width
      when under 360px to prevent pushing things offscreen. */
-  @media(max-width: 360px) {
+  @media(max-width: 447px) {
     .conversation-skin-tutor-card-container {
       min-width: 100vw;
     }
@@ -451,6 +451,10 @@ otherwise they will interfere with the iframed conversation skin directive.
     }
     .conversation-skin-oppia-avatar.show-tutor-card:hover {
       opacity: 0.8;
+    }
+
+    .conversation-skin-tutor-card {
+      padding-left: 0px;
     }
   }
 </style>

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -209,14 +209,14 @@ otherwise they will interfere with the iframed conversation skin directive.
     max-width: 560px;
     /* NOTE TO DEVELOPERS: If min-width is changed, max-width in media query
        below should be changed to match. */
-    min-width: 447px;
+    min-width: 360px;
     width: 100%;
     z-index: 3;
   }
 
   /* Some mobile devices have CSS width below 360px, use a responsive min-width
      when under 360px to prevent pushing things offscreen. */
-  @media(max-width: 447px) {
+  @media(max-width: 360px) {
     .conversation-skin-tutor-card-container {
       min-width: 100vw;
     }

--- a/core/templates/dev/head/pages/exploration_player/progress_nav_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/progress_nav_directive.html
@@ -1,3 +1,4 @@
+<!-- 87px is used to move the opppia avatar inside the conversation-skin-tutor-card div (so that it does not goes out of screen during zoom in). -->
 <div layout="row" layout-align="space-between center" style="background-color: white; margin-left: 87px;">
   <!-- Wrapping div on first button keeps the second button right-aligned
     even when the first button is not present. -->

--- a/core/templates/dev/head/pages/exploration_player/progress_nav_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/progress_nav_directive.html
@@ -1,4 +1,4 @@
-<div layout="row" layout-align="space-between center" style="background-color: white;">
+<div layout="row" layout-align="space-between center" style="background-color: white; margin-left: 87px;">
   <!-- Wrapping div on first button keeps the second button right-aligned
     even when the first button is not present. -->
   <div>

--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -101,7 +101,6 @@
 <style>
   .conversation-skin-tutor-card {
     max-width: 100vw;
-    padding-bottom: 18px;
   }
 
   .conversation-skin-instruction-disabled {
@@ -136,7 +135,7 @@
   }
 
   .conversation-skin-tutor-card-top-section {
-    padding: 0 20px;
+    padding: 20px 20px 20px;
   }
 
   .conversation-skin-tutor-card-top-content p:not(:last-child) {
@@ -155,9 +154,8 @@
 
   .conversation-skin-tutor-card,
   .conversation-skin-future-tutor-card {
-    background: #fff;
     border-radius: 2px;
-    padding-top: 20px;
+    padding-left: 87px;
     text-align: left;
   }
 
@@ -180,6 +178,7 @@
   }
 
   .conversation-skin-tutor-card-content {
+    background-color: white;
     word-wrap: break-word;
   }
 
@@ -218,7 +217,7 @@
   .conversation-skin-inline-interaction {
     border-bottom-left-radius: 2px;
     border-bottom-right-radius: 2px;
-    padding: 8px 20px 0;
+    padding: 8px 20px 25px;
     position: relative;
   }
 

--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -152,6 +152,7 @@
     border: 3px solid #f3d140;
   }
 
+  /* 87px is used to move the opppia avatar inside the conversation-skin-tutor-card div (so that it does not goes out of screen during zoom in). */
   .conversation-skin-tutor-card,
   .conversation-skin-future-tutor-card {
     border-radius: 2px;


### PR DESCRIPTION
## Explanation
Fixes #4781: 
Zoom in problem is fixed.
Screenshots are attached below:

Zoom in: 150%

![image](https://user-images.githubusercontent.com/22434689/37056340-241a7352-21aa-11e8-9254-e8745872c95e.png)

Zoom in: 175%

![image](https://user-images.githubusercontent.com/22434689/37056369-3bf9e1c4-21aa-11e8-9f51-e2baaa984ae1.png)


## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
