### PR TITLE
Fixes #4055: Removes redundant css selector from conversation_skin_directive.html

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2164,8 +2164,8 @@ pre.oppia-pre-wrapped-text {
 
 /* These rules must be kept in sync with corresponding rules in
    pages/exploration_player/conversation_skin_directive.html
-   (those with '.rte-viewer > p' selectors specifying
-    the same line-height, margin-top and margin-bottom attributes)
+   (those with '.rte-viewer > p' selectors specifying the same
+   line-height, margin-top and margin-bottom attributes)
 */
 .oppia-rte-editor > p,
 .oppia-rte-content > div > p {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2164,10 +2164,7 @@ pre.oppia-pre-wrapped-text {
 
 /* These rules must be kept in sync with corresponding rules in
    pages/exploration_player/conversation_skin_directive.html
-   (those with '.conversation-skin-tutor-card-top-content > p,
-   .conversation-skin-oppia-feedback-content > p,
-   .conversation-skin-learner-answer-content > p,
-   .conversation-skin-help-card-content > p' selectors specifying
+   (those with '.rte-viewer > p' selectors specifying
     the same line-height, margin-top and margin-bottom attributes)
 */
 .oppia-rte-editor > p,

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -5,7 +5,7 @@
 <div class="conversation-skin-future-tutor-card" aria-hidden="true">
   <div class="conversation-skin-tutor-card-content">
     <div class="conversation-skin-tutor-card-top-section">
-      <div class="conversation-skin-tutor-card-top-content"
+      <div class="rte-viewer conversation-skin-tutor-card-top-content"
            angular-html-bind="upcomingContentHtml">
       </div>
     </div>
@@ -243,30 +243,19 @@ otherwise they will interfere with the iframed conversation skin directive.
        .form-control.oppia-rte-content > div > p' selectors specifying
       the same line-height, margin-top and margin-bottom attributes)
   */
-  .conversation-skin-oppia-feedback-content > p,
-  .conversation-skin-learner-answer-content > p,
-  .conversation-skin-help-card-content > p {
+  .rte-viewer > p {
     line-height: 28px;
     margin-bottom: 18px;
     margin-top: 18px;
   }
-  .conversation-skin-tutor-card-top-content > p:first-child,
-  .conversation-skin-oppia-feedback-content > p:first-child,
-  .conversation-skin-learner-answer-content > p:first-child,
-  .conversation-skin-help-card-content > p:first-child {
+  .rte-viewer > p:first-child {
     margin-top: 0px;
   }
-  .conversation-skin-tutor-card-top-content > p:last-child,
-  .conversation-skin-oppia-feedback-content > p:last-child,
-  .conversation-skin-learner-answer-content > p:last-child,
-  .conversation-skin-help-card-content > p:last-child {
+  .rte-viewer > p:last-child {
     margin-bottom: 0px;
   }
 
-  .conversation-skin-tutor-card-top-content,
-  .conversation-skin-oppia-feedback-content,
-  .conversation-skin-learner-answer-content,
-  .conversation-skin-help-card-content {
+  .rte-viewer {
     border-radius: 2px;
     display: inline-block;
     max-width: 100%;

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -5,7 +5,7 @@
 <div class="conversation-skin-future-tutor-card" aria-hidden="true">
   <div class="conversation-skin-tutor-card-content">
     <div class="conversation-skin-tutor-card-top-section">
-      <div class="conversation-skin-tutor-card-top-content" angular-html-bind="upcomingContentHtml">
+      <div class="rte-viewer conversation-skin-tutor-card-top-content" angular-html-bind="upcomingContentHtml">
       </div>
     </div>
     <div ng-if="upcomingInlineInteractionHtml">
@@ -396,33 +396,21 @@ directive. -->
       the same line-height, margin-top and margin-bottom attributes)
   */
 
-  .conversation-skin-tutor-card-top-content > p,
-  .conversation-skin-oppia-feedback-content > p,
-  .conversation-skin-learner-answer-content > p,
-  .conversation-skin-help-card-content > p {
+  .rte-viewer > p {
     line-height: 28px;
     margin-bottom: 18px;
     margin-top: 18px;
   }
 
-  .conversation-skin-tutor-card-top-content > p:first-child,
-  .conversation-skin-oppia-feedback-content > p:first-child,
-  .conversation-skin-learner-answer-content > p:first-child,
-  .conversation-skin-help-card-content > p:first-child {
+  .rte-viewer > p:first-child {
     margin-top: 0;
   }
 
-  .conversation-skin-tutor-card-top-content > p:last-child,
-  .conversation-skin-oppia-feedback-content > p:last-child,
-  .conversation-skin-learner-answer-content > p:last-child,
-  .conversation-skin-help-card-content > p:last-child {
+  .rte-viewer > p:last-child {
     margin-bottom: 0;
   }
 
-  .conversation-skin-tutor-card-top-content,
-  .conversation-skin-oppia-feedback-content,
-  .conversation-skin-learner-answer-content,
-  .conversation-skin-help-card-content {
+  .rte-viewer {
     border-radius: 2px;
     display: inline-block;
     max-width: 100%;

--- a/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
@@ -4,16 +4,16 @@
     <div ng-if="getShortAnswerHtml()"
          popover-placement="bottom" uib-popover-template="'popover/answer'"
          popover-trigger="click" style="cursor: pointer;">
-      <div class="conversation-skin-learner-answer-content" angular-html-bind="getShortAnswerHtml()">
+      <div class="rte-viewer conversation-skin-learner-answer-content" angular-html-bind="getShortAnswerHtml()">
       </div>
     </div>
     <div ng-if="!getShortAnswerHtml()">
-      <div class="conversation-skin-learner-answer-content" angular-html-bind="getAnswerHtml()">
+      <div class="rte-viewer conversation-skin-learner-answer-content" angular-html-bind="getAnswerHtml()">
       </div>
     </div>
   </div>
   <div ng-if="data.isHint">
-    <div class="conversation-skin-learner-answer-content">
+    <div class="rte-viewer conversation-skin-learner-answer-content">
       <[data.learnerInput | translate]>
     </div>
   </div>
@@ -29,7 +29,7 @@
     <span id="<[getInputResponsePairId()]>"></span>
     <div ng-if="data.oppiaResponse !== null"
          angular-html-bind="data.oppiaResponse"
-         class="conversation-skin-oppia-feedback-content protractor-test-conversation-feedback"
+         class="rte-viewer conversation-skin-oppia-feedback-content protractor-test-conversation-feedback"
          ng-class="getFeedbackAudioHighlightClass()">
     </div>
 </div>

--- a/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
@@ -7,7 +7,7 @@
             ng-click="clearHelpCard()" ng-if="!helpCardHasContinueButton">
       <i class="material-icons md-18">&#xE5CD;</i>
     </button>
-    <div class="conversation-skin-help-card-content" angular-html-bind="helpCardHtml" ng-class="getFeedbackAudioHighlightClass()"></div>
+    <div class="rte-viewer conversation-skin-help-card-content" angular-html-bind="helpCardHtml" ng-class="getFeedbackAudioHighlightClass()"></div>
     <br>
     <continue-button ng-if="helpCardHasContinueButton"
                      focus-on="<[::CONTINUE_BUTTON_FOCUS_LABEL]>"

--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -6,7 +6,7 @@
     <div class="conversation-skin-tutor-card-top-section">
       <img class="conversation-skin-oppia-avatar"
            ng-src="<[OPPIA_AVATAR_IMAGE_URL]>" alt="">
-      <div class="conversation-skin-tutor-card-top-content"
+      <div class="rte-viewer conversation-skin-tutor-card-top-content"
            ng-class="getContentAudioHighlightClass()"
            focus-on="<[getContentFocusLabel($index)]>">
         <div class="protractor-test-conversation-content"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation

- Removes redundant css selector from conversation_skin_directive.html
- Fix part of #4055 
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
