### PR TITLE
Fixes part of #4057: Add test for EditabilityService

### DIFF
--- a/core/templates/dev/head/services/EditabilityServiceSpec.js
+++ b/core/templates/dev/head/services/EditabilityServiceSpec.js
@@ -1,0 +1,50 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for EditabilityService.
+ */
+
+describe('EditabilityService', function() {
+  var EditabilityService = null;
+
+  beforeEach(module('oppia'));
+
+  beforeEach(inject(function($injector) {
+    EditabilityService = $injector.get('EditabilityService');
+  }));
+
+  it('should allow to edit an exploration after the tutorial ends', function() {
+    EditabilityService.onEndTutorial();
+    EditabilityService.markEditable();
+    expect(EditabilityService.isEditable()).toBe(true);
+  });
+
+  it('should allow to edit an exploration outside the tutorial mode',
+    function() {
+      EditabilityService.markEditable();
+      expect(EditabilityService.isEditableOutsideTutorialMode()).toBe(true);
+    });
+
+  it('should not allow to edit an exploration during tutorial mode',
+    function() {
+      EditabilityService.onStartTutorial();
+      expect(EditabilityService.isEditable()).toBe(false);
+    });
+
+  it('should not allow to edit an uneditable exploration', function() {
+    EditabilityService.markNotEditable();
+    expect(EditabilityService.isEditable()).toBe(false);
+  });
+});


### PR DESCRIPTION
Fix part of #4057 . Add test for EditabilityService.  

## Explanation

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
