### PR TITLE
Fix #3983: Reorder tabs in Learner Dashboard 

### DIFF
--- a/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
+++ b/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
@@ -86,6 +86,24 @@
            style="min-width: 200px;">
         <md-card class="oppia-learner-dashboard-main-menu">
           <h4 class="oppia-learner-dashboard-menu"
+              ng-class="{'oppia-learner-dashboard-section-active': activeSection === LEARNER_DASHBOARD_SECTION_I18N_IDS.PLAYLIST}"
+              ng-click="setActiveSection(LEARNER_DASHBOARD_SECTION_I18N_IDS.PLAYLIST)">
+            <span translate="<[LEARNER_DASHBOARD_SECTION_I18N_IDS.PLAYLIST]>"></span>
+            <span class="caret"></span>
+          </h4>
+          <div ng-show="activeSection === LEARNER_DASHBOARD_SECTION_I18N_IDS.PLAYLIST" class="menu-sub-section">
+            <div class="oppia-learner-dashboard-submenu"
+                 ng-class="{'oppia-learner-dashboard-sub-section-active': activeSubsection === LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.EXPLORATIONS}"
+                 ng-click="setActiveSubsection(LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.EXPLORATIONS)"
+                 translate="I18N_DASHBOARD_EXPLORATIONS">
+            </div>
+            <div class="oppia-learner-dashboard-submenu protractor-test-playlist-collection-section"
+                 ng-class="{'oppia-learner-dashboard-sub-section-active': activeSubsection === LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.COLLECTIONS}"
+                 ng-click="setActiveSubsection(LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.COLLECTIONS)"
+                 translate="I18N_DASHBOARD_COLLECTIONS">
+            </div>
+          </div>
+          <h4 class="oppia-learner-dashboard-menu"
               ng-class="{'oppia-learner-dashboard-section-active': activeSection === LEARNER_DASHBOARD_SECTION_I18N_IDS.INCOMPLETE}"
               ng-click="setActiveSection(LEARNER_DASHBOARD_SECTION_I18N_IDS.INCOMPLETE)">
             <span translate="<[LEARNER_DASHBOARD_SECTION_I18N_IDS.INCOMPLETE]>"></span>
@@ -132,24 +150,6 @@
             <span translate="<[LEARNER_DASHBOARD_SECTION_I18N_IDS.FEEDBACK]>"></span>
             <span ng-if="numberOfUnreadThreads !== 0">(<[numberOfUnreadThreads]>)</span>
           </h4>
-          <h4 class="oppia-learner-dashboard-menu"
-              ng-class="{'oppia-learner-dashboard-section-active': activeSection === LEARNER_DASHBOARD_SECTION_I18N_IDS.PLAYLIST}"
-              ng-click="setActiveSection(LEARNER_DASHBOARD_SECTION_I18N_IDS.PLAYLIST)">
-            <span translate="<[LEARNER_DASHBOARD_SECTION_I18N_IDS.PLAYLIST]>"></span>
-            <span class="caret"></span>
-          </h4>
-          <div ng-show="activeSection === LEARNER_DASHBOARD_SECTION_I18N_IDS.PLAYLIST" class="menu-sub-section">
-            <div class="oppia-learner-dashboard-submenu"
-                 ng-class="{'oppia-learner-dashboard-sub-section-active': activeSubsection === LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.EXPLORATIONS}"
-                 ng-click="setActiveSubsection(LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.EXPLORATIONS)"
-                 translate="I18N_DASHBOARD_EXPLORATIONS">
-            </div>
-            <div class="oppia-learner-dashboard-submenu protractor-test-playlist-collection-section"
-                 ng-class="{'oppia-learner-dashboard-sub-section-active': activeSubsection === LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.COLLECTIONS}"
-                 ng-click="setActiveSubsection(LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.COLLECTIONS)"
-                 translate="I18N_DASHBOARD_COLLECTIONS">
-            </div>
-          </div>
         </md-card>
       </div>
 


### PR DESCRIPTION
Fixes #3983 : Reorder the tabs in the Learner Dashboard to make them more intuitive.

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
