### PR TITLE
Fix #4714: Alignment of button and text in exploration setting 

### DIFF
--- a/core/templates/dev/head/components/attribution_guide/attribution_guide_directive.html
+++ b/core/templates/dev/head/components/attribution_guide/attribution_guide_directive.html
@@ -1,5 +1,5 @@
 <div class="oppia-cc-icon oppia-transition-200" ng-if="!isMobileDevice">
-  <div style="height: 1px; width: 1px;" class="protractor-test-neutral-element"></div>
+  <div style="height: 3px; width: 3px;" class="protractor-test-neutral-element"></div>
 
   <a class="oppia-attribution-image-link" rel="license" href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">
     <img alt="Creative Commons License" style="border-width: 0; height: 24px;" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png">

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4876,27 +4876,27 @@ md-card.preview-conversation-skin-supplemental-card {
   color: rgba(255,255,255,1);
 }
 
-.oppia-on-off-switch-switch {
+.oppia-on-off-switch {
   position: relative;
   width: 70px;
 }
-.oppia-on-off-switch-switch-checkbox {
+.oppia-on-off-switch-checkbox {
   display: none;
 }
-.oppia-on-off-switch-switch-label {
+.oppia-on-off-switch-label {
   border: 2px solid #999999;
   border-radius: 20px;
   cursor: pointer;
   display: block;
   overflow: hidden;
 }
-.oppia-on-off-switch-switch-inner {
+.oppia-on-off-switch-inner {
   display: block;
   margin-left: -100%;
   transition: margin 0.3s ease-in 0s;
   width: 200%;
 }
-.oppia-on-off-switch-switch-inner:before, .oppia-on-off-switch-switch-inner:after {
+.oppia-on-off-switch-inner:before, .oppia-on-off-switch-inner:after {
   box-sizing: border-box;
   color: white;
   display: block;
@@ -4909,20 +4909,20 @@ md-card.preview-conversation-skin-supplemental-card {
   padding: 0;
   width: 50%;
 }
-.oppia-on-off-switch-switch-inner:before {
+.oppia-on-off-switch-inner:before {
   background-color: #04857C;
   color: #FFFFFF;
   content: "ON";
   padding-left: 10px;
 }
-.oppia-on-off-switch-switch-inner:after {
+.oppia-on-off-switch-inner:after {
   background-color: #EEEEEE;
   color: #999999;
   content: "OFF";
   padding-right: 10px;
   text-align: right;
 }
-.oppia-on-off-switch-switch-switch {
+.oppia-on-off-switch-main {
   background: #FFFFFF;
   border: 2px solid #999999;
   border-radius: 20px;
@@ -4935,11 +4935,11 @@ md-card.preview-conversation-skin-supplemental-card {
   transition: all 0.3s ease-in 0s;
   width: 18px;
 }
-.oppia-on-off-switch-switch-checkbox:checked + .oppia-on-off-switch-switch-label .oppia-on-off-switch-switch-inner {
+.oppia-on-off-switch-checkbox:checked + .oppia-on-off-switch-label .oppia-on-off-switch-inner {
   margin-left: 0;
 }
-.oppia-on-off-switch-switch-checkbox:checked + .oppia-on-off-switch-switch-label .oppia-on-off-switch-switch-switch {
-  right: 0px;
+.oppia-on-off-switch-checkbox:checked + .oppia-on-off-switch-label .oppia-on-off-switch-main {
+  right: 0;
 }
 
 /*

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4876,6 +4876,72 @@ md-card.preview-conversation-skin-supplemental-card {
   color: rgba(255,255,255,1);
 }
 
+.oppia-on-off-switch-switch {
+  position: relative;
+  width: 70px;
+}
+.oppia-on-off-switch-switch-checkbox {
+  display: none;
+}
+.oppia-on-off-switch-switch-label {
+  border: 2px solid #999999;
+  border-radius: 20px;
+  cursor: pointer;
+  display: block;
+  overflow: hidden;
+}
+.oppia-on-off-switch-switch-inner {
+  display: block;
+  margin-left: -100%;
+  transition: margin 0.3s ease-in 0s;
+  width: 200%;
+}
+.oppia-on-off-switch-switch-inner:before, .oppia-on-off-switch-switch-inner:after {
+  box-sizing: border-box;
+  color: white;
+  display: block;
+  font-family: "Capriola", "Roboto", Arial, sans-serif;
+  font-size: 12px;
+  font-weight: bold;
+  float: left;
+  height: 20px;
+  line-height: 20px;
+  padding: 0;
+  width: 50%;
+}
+.oppia-on-off-switch-switch-inner:before {
+  background-color: #04857C;
+  color: #FFFFFF;
+  content: "ON";
+  padding-left: 10px;
+}
+.oppia-on-off-switch-switch-inner:after {
+  background-color: #EEEEEE;
+  color: #999999;
+  content: "OFF";
+  padding-right: 10px;
+  text-align: right;
+}
+.oppia-on-off-switch-switch-switch {
+  background: #FFFFFF;
+  border: 2px solid #999999;
+  border-radius: 20px;
+  bottom: 0;
+  display: block;
+  margin: 3.5px;
+  position: absolute;
+  right: 41px;
+  top: 0;
+  transition: all 0.3s ease-in 0s;
+  width: 18px;
+}
+.oppia-on-off-switch-switch-checkbox:checked + .oppia-on-off-switch-switch-label .oppia-on-off-switch-switch-inner {
+  margin-left: 0;
+}
+.oppia-on-off-switch-switch-checkbox:checked + .oppia-on-off-switch-switch-label .oppia-on-off-switch-switch-switch {
+  right: 0px;
+}
+
 /*
   about/learners/creators media queries
 */

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1,12 +1,9 @@
 /*
   Copyright 2014 The Oppia Authors. All Rights Reserved.
-
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-
       http://www.apache.org/licenses/LICENSE-2.0
-
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -1192,7 +1189,6 @@ textarea {
 }
 /*
   This is needed for proper display of tabs. See
-
   https://github.com/angular-ui/bootstrap/commit/8620aedba99b05822311
 */
 .navbar-nav, .uib-pagination {

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -158,7 +158,7 @@
             </label>
             <span class="col-lg-2 col-md-2 col-sm-2">
               <div class="oppia-on-off-switch-switch">
-                <input type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="parameter-switch" ng-click="enableParameters()">
+                <input type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox protractor-test-enable-parameters" id="parameter-switch" ng-click="enableParameters()">
                 <label class="oppia-on-off-switch-switch-label" for="parameter-switch">
                   <span class="oppia-on-off-switch-switch-inner"></span>
                   <span class="oppia-on-off-switch-switch-switch"></span>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -158,7 +158,7 @@
             </label>
             <span class="col-lg-2 col-md-2 col-sm-2">
               <div class="oppia-on-off-switch">
-                <input span ng-if="areParametersEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox protractor-test-enable-parameters" id="parameter-switch" ng-click="enableParameters()" checked disabled>
+                <input span ng-if="areParametersEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox" id="parameter-switch" checked disabled>
                 <input span ng-if="!areParametersEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox protractor-test-enable-parameters" id="parameter-switch" ng-click="enableParameters()">
                 <label class="oppia-on-off-switch-label" for="parameter-switch">
                   <span class="oppia-on-off-switch-inner"></span>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -153,82 +153,64 @@
       <div class="row">
         <div class="col-lg-12 col-md-12 col-sm-12">
           <div role="form" class="form-horizontal">
-            <label for="enableParameters" class="col-lg-12 col-md-12 col-sm-12">
+            <label for="enableParameters" class="col-lg-10 col-md-10 col-sm-10">
               Parameters
             </label>
+            <span class="col-lg-2 col-md-2 col-sm-2">
+              <div class="oppia-on-off-switch-switch">
+                <input type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="parameter-switch" ng-click="enableParameters()">
+                <label class="oppia-on-off-switch-switch-label" for="parameter-switch">
+                  <span class="oppia-on-off-switch-switch-inner"></span>
+                  <span class="oppia-on-off-switch-switch-switch"></span>
+                </label>
+              </div>
+            </span>
             <span class="col-lg-12 col-md-12 col-sm-12 help-block" style="font-size: smaller;">
-              Parameters are
-              <span ng-if="!areParametersEnabled()">
-                disabled.
-              </span>
-              <span ng-if="areParametersEnabled()">
-                enabled.
-              </span>
               Parameters are values that change as the learner moves between cards (<a href="http://oppia.github.io/#/Parameters" target="_blank">more info</a>).
             </span>
-            <span class="col-lg-12 col-md-12 col-sm-12">
-              <button type="button" class="btn btn-default protractor-test-enable-parameters" ng-click="enableParameters()" ng-if="!areParametersEnabled()">
-                Enable
-              </button>
-              <span ng-if="areParametersEnabled()">
-                Enabled
-              </span>
-            </span>
           </div>
         </div>
       </div>
-      <br>
+      <hr>
       <div class="row">
         <div class="col-lg-12 col-md-12 col-sm-12">
           <div role="form" class="form-horizontal">
-            <label for="enableAutomaticTextToSpeech" class="col-lg-12 col-md-12 col-sm-12">
+            <label for="enableAutomaticTextToSpeech" class="col-lg-10 col-md-10 col-sm-10">
               Automatic Text-to-speech
             </label>
-            <span ng-if="!isAutomaticTextToSpeechEnabled()" class="col-lg-12 col-md-12 col-sm-12 help-block" style="font-size: smaller;">
-              Automatic text-to-speech is disabled. It generates audio from your content for learners to listen to.
+            <span class="col-lg-2 col-md-2 col-sm-2">
+              <div class="oppia-on-off-switch-switch">
+                <input type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="text-speech-switch" ng-click="toggleAutomaticTextToSpeech()" checked>
+                <label class="oppia-on-off-switch-switch-label" for="text-speech-switch">
+                  <span class="oppia-on-off-switch-switch-inner"></span>
+                  <span class="oppia-on-off-switch-switch-switch"></span>
+                </label>
+              </div>
             </span>
-            <span ng-if="isAutomaticTextToSpeechEnabled()" class="col-lg-12 col-md-12 col-sm-12 help-block" style="font-size: smaller;">
-              Automatic text-to-speech is enabled. It generates audio from your content for learners to listen to. It is recommended that you disable this feature if creating an exploration whose content consists of multiple languages.
-            </span>
-            <span class="col-lg-12 col-md-12 col-sm-12">
-              <button type="button" class="btn btn-default protractor-test-enable-automatic-text-to-speech" ng-click="toggleAutomaticTextToSpeech()">
-                <span ng-if="!isAutomaticTextToSpeechEnabled()">
-                  Enable
-                </span>
-                <span ng-if="isAutomaticTextToSpeechEnabled()">
-                  Disable
-                </span>
-              </button>
+            <span class="col-lg-12 col-md-12 col-sm-12 help-block" style="font-size: smaller;">
+              Automatic text-to-speech generates audio from your content for learners to listen to. It is recommended that you disable this feature if creating an exploration whose content consists of multiple languages.
             </span>
           </div>
         </div>
       </div>
-      <br>
+      <hr>
       <div class="row">
         <div class="col-lg-12 col-md-12 col-sm-12">
           <div role="form" class="form-horizontal">
-            <label for="enableCorrectnessFeedback" class="col-lg-12 col-md-12 col-sm-12">
+            <label for="enableCorrectnessFeedback" class="col-lg-10 col-md-10 col-sm-10">
               Correctness Feedback
             </label>
-            <span class="col-lg-12 col-md-12 col-sm-12 help-block" style="font-size: smaller;">
-              This feature is
-              <span ng-if="!isCorrectnessFeedbackEnabled()">
-                disabled.
-              </span>
-              <span ng-if="isCorrectnessFeedbackEnabled()">
-                enabled.
-              </span>
-              This allows the user to categorise answer groups as correct or incorrect.
+            <span class="col-lg-2 col-md-2 col-sm-2">
+              <div class="oppia-on-off-switch-switch">
+                <input type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="correctness-switch" ng-click="toggleCorrectnessFeedback()">
+                <label class="oppia-on-off-switch-switch-label" for="correctness-switch">
+                  <span class="oppia-on-off-switch-switch-inner"></span>
+                  <span class="oppia-on-off-switch-switch-switch"></span>
+                </label>
+              </div>
             </span>
-            <span class="col-lg-12 col-md-12 col-sm-12">
-              <button type="button" class="btn btn-default" ng-click="toggleCorrectnessFeedback()">
-                <span ng-if="!isCorrectnessFeedbackEnabled()">
-                  Enable
-                </span>
-                <span ng-if="isCorrectnessFeedbackEnabled()">
-                  Disable
-                </span>
-              </button>
+            <span class="col-lg-12 col-md-12 col-sm-12 help-block" style="font-size: smaller;">
+              Correctness feedback allows the user to categorise answer groups as correct or incorrect.
             </span>
           </div>
         </div>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -159,8 +159,8 @@
             <span class="col-lg-2 col-md-2 col-sm-2">
               <div class="oppia-on-off-switch">
                 <input span ng-if="areParametersEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox" id="parameter-switch" checked disabled>
-                <input span ng-if="!areParametersEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox protractor-test-enable-parameters" id="parameter-switch" ng-click="enableParameters()">
-                <label class="oppia-on-off-switch-label" for="parameter-switch">
+                <input span ng-if="!areParametersEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox" id="parameter-switch" ng-click="enableParameters()">
+                <label class="oppia-on-off-switch-label protractor-test-enable-parameters" for="parameter-switch">
                   <span class="oppia-on-off-switch-inner"></span>
                   <span class="oppia-on-off-switch-main"></span>
                 </label>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -158,7 +158,8 @@
             </label>
             <span class="col-lg-2 col-md-2 col-sm-2">
               <div class="oppia-on-off-switch-switch">
-                <input type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox protractor-test-enable-parameters" id="parameter-switch" ng-click="enableParameters()">
+                <input span ng-if="areParametersEnabled()" type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox protractor-test-enable-parameters" id="parameter-switch" ng-click="enableParameters()" checked>
+                <input span ng-if="!areParametersEnabled()" type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox protractor-test-enable-parameters" id="parameter-switch" ng-click="enableParameters()">
                 <label class="oppia-on-off-switch-switch-label" for="parameter-switch">
                   <span class="oppia-on-off-switch-switch-inner"></span>
                   <span class="oppia-on-off-switch-switch-switch"></span>
@@ -180,7 +181,8 @@
             </label>
             <span class="col-lg-2 col-md-2 col-sm-2">
               <div class="oppia-on-off-switch-switch">
-                <input type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="text-speech-switch" ng-click="toggleAutomaticTextToSpeech()" checked>
+                <input type="checkbox" ng-if="isAutomaticTextToSpeechEnabled()" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="text-speech-switch" ng-click="toggleAutomaticTextToSpeech()" checked>
+                <input type="checkbox" ng-if="!isAutomaticTextToSpeechEnabled()" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="text-speech-switch" ng-click="toggleAutomaticTextToSpeech()">
                 <label class="oppia-on-off-switch-switch-label" for="text-speech-switch">
                   <span class="oppia-on-off-switch-switch-inner"></span>
                   <span class="oppia-on-off-switch-switch-switch"></span>
@@ -202,7 +204,8 @@
             </label>
             <span class="col-lg-2 col-md-2 col-sm-2">
               <div class="oppia-on-off-switch-switch">
-                <input type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="correctness-switch" ng-click="toggleCorrectnessFeedback()">
+                <input type="checkbox" ng-if="!isCorrectnessFeedbackEnabled()" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="correctness-switch" ng-click="toggleCorrectnessFeedback()">
+                <input type="checkbox" ng-if="isCorrectnessFeedbackEnabled()" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="correctness-switch" ng-click="toggleCorrectnessFeedback()" checked>
                 <label class="oppia-on-off-switch-switch-label" for="correctness-switch">
                   <span class="oppia-on-off-switch-switch-inner"></span>
                   <span class="oppia-on-off-switch-switch-switch"></span>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -153,18 +153,10 @@
       <div class="row">
         <div class="col-lg-12 col-md-12 col-sm-12">
           <div role="form" class="form-horizontal">
-            <label for="enableParameters" class="col-lg-2 col-md-2 col-sm-2">
+            <label for="enableParameters" class="col-lg-12 col-md-12 col-sm-12">
               Parameters
             </label>
-            <span class="col-lg-2 col-md-2 col-sm-2">
-              <button type="button" class="btn btn-default protractor-test-enable-parameters" ng-click="enableParameters()" ng-if="!areParametersEnabled()">
-                Enable
-              </button>
-              <span ng-if="areParametersEnabled()">
-                Enabled
-              </span>
-            </span>
-            <span class="col-lg-8 col-md-8 col-sm-8 help-block" style="font-size: smaller;">
+            <span class="col-lg-12 col-md-12 col-sm-12 help-block" style="font-size: smaller;">
               Parameters are
               <span ng-if="!areParametersEnabled()">
                 disabled.
@@ -174,17 +166,32 @@
               </span>
               Parameters are values that change as the learner moves between cards (<a href="http://oppia.github.io/#/Parameters" target="_blank">more info</a>).
             </span>
+            <span class="col-lg-12 col-md-12 col-sm-12">
+              <button type="button" class="btn btn-default protractor-test-enable-parameters" ng-click="enableParameters()" ng-if="!areParametersEnabled()">
+                Enable
+              </button>
+              <span ng-if="areParametersEnabled()">
+                Enabled
+              </span>
+            </span>
           </div>
         </div>
       </div>
+      <br>
       <div class="row">
         <div class="col-lg-12 col-md-12 col-sm-12">
           <div role="form" class="form-horizontal">
-            <label for="enableAutomaticTextToSpeech" class="col-lg-2 col-md-2 col-sm-2">
+            <label for="enableAutomaticTextToSpeech" class="col-lg-12 col-md-12 col-sm-12">
               Automatic Text-to-speech
             </label>
-            <span class="col-lg-2 col-md-2 col-sm-2">
-              <button type="button" class="btn btn-default protractor-test-enable-automatic-text-to-speech" ng-click="toggleAutomaticTextToSpeech()" style="margin-top: 16px">
+            <span ng-if="!isAutomaticTextToSpeechEnabled()" class="col-lg-12 col-md-12 col-sm-12 help-block" style="font-size: smaller;">
+              Automatic text-to-speech is disabled. It generates audio from your content for learners to listen to.
+            </span>
+            <span ng-if="isAutomaticTextToSpeechEnabled()" class="col-lg-12 col-md-12 col-sm-12 help-block" style="font-size: smaller;">
+              Automatic text-to-speech is enabled. It generates audio from your content for learners to listen to. It is recommended that you disable this feature if creating an exploration whose content consists of multiple languages.
+            </span>
+            <span class="col-lg-12 col-md-12 col-sm-12">
+              <button type="button" class="btn btn-default protractor-test-enable-automatic-text-to-speech" ng-click="toggleAutomaticTextToSpeech()">
                 <span ng-if="!isAutomaticTextToSpeechEnabled()">
                   Enable
                 </span>
@@ -193,32 +200,17 @@
                 </span>
               </button>
             </span>
-            <span ng-if="!isAutomaticTextToSpeechEnabled()" class="col-lg-8 col-md-8 col-sm-8 help-block" style="font-size: smaller;">
-              Automatic text-to-speech is disabled. It generates audio from your content for learners to listen to.
-            </span>
-            <span ng-if="isAutomaticTextToSpeechEnabled()" class="col-lg-8 col-md-8 col-sm-8 help-block" style="font-size: smaller;">
-              Automatic text-to-speech is enabled. It generates audio from your content for learners to listen to. It is recommended that you disable this feature if creating an exploration whose content consists of multiple languages.
-            </span>
           </div>
         </div>
       </div>
+      <br>
       <div class="row">
         <div class="col-lg-12 col-md-12 col-sm-12">
           <div role="form" class="form-horizontal">
-            <label for="enableCorrectnessFeedback" class="col-lg-2 col-md-2 col-sm-2">
+            <label for="enableCorrectnessFeedback" class="col-lg-12 col-md-12 col-sm-12">
               Correctness Feedback
             </label>
-            <span class="col-lg-2 col-md-2 col-sm-2">
-              <button type="button" class="btn btn-default" ng-click="toggleCorrectnessFeedback()" style="margin-top: 16px">
-                <span ng-if="!isCorrectnessFeedbackEnabled()">
-                  Enable
-                </span>
-                <span ng-if="isCorrectnessFeedbackEnabled()">
-                  Disable
-                </span>
-              </button>
-            </span>
-            <span class="col-lg-8 col-md-8 col-sm-8 help-block" style="font-size: smaller;">
+            <span class="col-lg-12 col-md-12 col-sm-12 help-block" style="font-size: smaller;">
               This feature is
               <span ng-if="!isCorrectnessFeedbackEnabled()">
                 disabled.
@@ -227,6 +219,16 @@
                 enabled.
               </span>
               This allows the user to categorise answer groups as correct or incorrect.
+            </span>
+            <span class="col-lg-12 col-md-12 col-sm-12">
+              <button type="button" class="btn btn-default" ng-click="toggleCorrectnessFeedback()">
+                <span ng-if="!isCorrectnessFeedbackEnabled()">
+                  Enable
+                </span>
+                <span ng-if="isCorrectnessFeedbackEnabled()">
+                  Disable
+                </span>
+              </button>
             </span>
           </div>
         </div>

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -157,12 +157,12 @@
               Parameters
             </label>
             <span class="col-lg-2 col-md-2 col-sm-2">
-              <div class="oppia-on-off-switch-switch">
-                <input span ng-if="areParametersEnabled()" type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox protractor-test-enable-parameters" id="parameter-switch" ng-click="enableParameters()" checked>
-                <input span ng-if="!areParametersEnabled()" type="checkbox" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox protractor-test-enable-parameters" id="parameter-switch" ng-click="enableParameters()">
-                <label class="oppia-on-off-switch-switch-label" for="parameter-switch">
-                  <span class="oppia-on-off-switch-switch-inner"></span>
-                  <span class="oppia-on-off-switch-switch-switch"></span>
+              <div class="oppia-on-off-switch">
+                <input span ng-if="areParametersEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox protractor-test-enable-parameters" id="parameter-switch" ng-click="enableParameters()" checked disabled>
+                <input span ng-if="!areParametersEnabled()" type="checkbox" class="oppia-on-off-switch-checkbox protractor-test-enable-parameters" id="parameter-switch" ng-click="enableParameters()">
+                <label class="oppia-on-off-switch-label" for="parameter-switch">
+                  <span class="oppia-on-off-switch-inner"></span>
+                  <span class="oppia-on-off-switch-main"></span>
                 </label>
               </div>
             </span>
@@ -180,12 +180,12 @@
               Automatic Text-to-speech
             </label>
             <span class="col-lg-2 col-md-2 col-sm-2">
-              <div class="oppia-on-off-switch-switch">
-                <input type="checkbox" ng-if="isAutomaticTextToSpeechEnabled()" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="text-speech-switch" ng-click="toggleAutomaticTextToSpeech()" checked>
-                <input type="checkbox" ng-if="!isAutomaticTextToSpeechEnabled()" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="text-speech-switch" ng-click="toggleAutomaticTextToSpeech()">
-                <label class="oppia-on-off-switch-switch-label" for="text-speech-switch">
-                  <span class="oppia-on-off-switch-switch-inner"></span>
-                  <span class="oppia-on-off-switch-switch-switch"></span>
+              <div class="oppia-on-off-switch">
+                <input type="checkbox" ng-if="isAutomaticTextToSpeechEnabled()" class="oppia-on-off-switch-checkbox" id="text-speech-switch" ng-click="toggleAutomaticTextToSpeech()" checked>
+                <input type="checkbox" ng-if="!isAutomaticTextToSpeechEnabled()" class="oppia-on-off-switch-checkbox" id="text-speech-switch" ng-click="toggleAutomaticTextToSpeech()">
+                <label class="oppia-on-off-switch-label" for="text-speech-switch">
+                  <span class="oppia-on-off-switch-inner"></span>
+                  <span class="oppia-on-off-switch-main"></span>
                 </label>
               </div>
             </span>
@@ -203,12 +203,12 @@
               Correctness Feedback
             </label>
             <span class="col-lg-2 col-md-2 col-sm-2">
-              <div class="oppia-on-off-switch-switch">
-                <input type="checkbox" ng-if="!isCorrectnessFeedbackEnabled()" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="correctness-switch" ng-click="toggleCorrectnessFeedback()">
-                <input type="checkbox" ng-if="isCorrectnessFeedbackEnabled()" name="oppia-on-off-switch-switch" class="oppia-on-off-switch-switch-checkbox" id="correctness-switch" ng-click="toggleCorrectnessFeedback()" checked>
-                <label class="oppia-on-off-switch-switch-label" for="correctness-switch">
-                  <span class="oppia-on-off-switch-switch-inner"></span>
-                  <span class="oppia-on-off-switch-switch-switch"></span>
+              <div class="oppia-on-off-switch">
+                <input type="checkbox" ng-if="!isCorrectnessFeedbackEnabled()" class="oppia-on-off-switch-checkbox" id="correctness-switch" ng-click="toggleCorrectnessFeedback()">
+                <input type="checkbox" ng-if="isCorrectnessFeedbackEnabled()" class="oppia-on-off-switch-checkbox" id="correctness-switch" ng-click="toggleCorrectnessFeedback()" checked>
+                <label class="oppia-on-off-switch-label" for="correctness-switch">
+                  <span class="oppia-on-off-switch-inner"></span>
+                  <span class="oppia-on-off-switch-main"></span>
                 </label>
               </div>
             </span>


### PR DESCRIPTION
## Explanation
Fixes #4714 
Implemented the solution of having the heading, button and text in separate lines as discussed in the issue thread.

## Screenshots
**Desktop view**
![alignment-fix-desktop](https://user-images.githubusercontent.com/24409931/37534427-d184d4ca-296a-11e8-97fd-21cab24e20e7.png)

**Mobile view**
![alignment-fix-mobile](https://user-images.githubusercontent.com/24409931/37534428-d221756e-296a-11e8-86cb-355aa6fffec4.png)