### PR TITLE
Fix part of #3446: Add frontend validators to End Exploration. 

### DIFF
--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
@@ -31,7 +31,7 @@ oppia.factory('EndExplorationValidationService', [
         if (!angular.isArray(recommendedExplorationIds)) {
           warningsList.push({
             type: WARNING_TYPES.ERROR,
-            message: 'Set of recommended exploration IDs must be a list.'
+            message: 'Set of recommended exploration IDs must be list.'
           });
         }
         for (var i = 0; i < recommendedExplorationIds.length; i++) {

--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
@@ -27,11 +27,19 @@ oppia.factory('EndExplorationValidationService', [
 
         var recommendedExplorationIds = (
             customizationArgs.recommendedExplorationIds.value);
+
+        if(!angular.isArray(recommendedExplorationIds)) {
+          warningsList.push({
+            type: WARNING_TYPES.ERROR,
+            message: 'Set of recommended exploration IDs must be in list ' +
+              'format.'
+          });
+        }
         for (var i = 0; i < recommendedExplorationIds.length; i++) {
           if (!angular.isString(recommendedExplorationIds[i])) {
             warningsList.push({
               type: WARNING_TYPES.ERROR,
-              message: 'Recommended Exploration ID must be a string.'
+              message: 'Recommended exploration ID must be a string.'
             });
           }
         }

--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
@@ -26,7 +26,7 @@ oppia.factory('EndExplorationValidationService', [
           customizationArgs, ['recommendedExplorationIds']);
 
         var recommendedExplorationIds = (
-            customizationArgs.recommendedExplorationIds.value);
+          customizationArgs.recommendedExplorationIds.value);
 
         if (!angular.isArray(recommendedExplorationIds)) {
           warningsList.push({

--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
@@ -28,7 +28,7 @@ oppia.factory('EndExplorationValidationService', [
         var recommendedExplorationIds = (
             customizationArgs.recommendedExplorationIds.value);
 
-        if(!angular.isArray(recommendedExplorationIds)) {
+        if (!angular.isArray(recommendedExplorationIds)) {
           warningsList.push({
             type: WARNING_TYPES.ERROR,
             message: 'Set of recommended exploration IDs must be in list ' +

--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
@@ -21,10 +21,21 @@ oppia.factory('EndExplorationValidationService', [
   function(WARNING_TYPES, baseInteractionValidationService) {
     return {
       getCustomizationArgsWarnings: function(customizationArgs) {
+        var warningsList = [];
         baseInteractionValidationService.requireCustomizationArguments(
           customizationArgs, ['recommendedExplorationIds']);
-        // TODO(juansaba): Implement customization args validations.
-        return [];
+
+        var recommendedExplorationIds = (
+            customizationArgs.recommendedExplorationIds.value);
+        for (var i = 0; i < recommendedExplorationIds.length; i++) {
+          if (!angular.isString(recommendedExplorationIds[i])) {
+            warningsList.push({
+              type: WARNING_TYPES.ERROR,
+              message: 'Recommended Exploration ID must be a string.'
+            });
+          }
+        }
+        return warningsList;
       },
       getAllWarnings: function(
           stateName, customizationArgs, answerGroups, defaultOutcome) {

--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationService.js
@@ -31,8 +31,7 @@ oppia.factory('EndExplorationValidationService', [
         if (!angular.isArray(recommendedExplorationIds)) {
           warningsList.push({
             type: WARNING_TYPES.ERROR,
-            message: 'Set of recommended exploration IDs must be in list ' +
-              'format.'
+            message: 'Set of recommended exploration IDs must be a list.'
           });
         }
         for (var i = 0; i < recommendedExplorationIds.length; i++) {

--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
@@ -115,7 +115,18 @@ describe('EndExplorationValidationService', function() {
         currentState, customizationArguments, [], null);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
-        message: 'Recommended Exploration ID must be a string.'
+        message: 'Recommended exploration ID must be a string.'
       }]);
     });
+
+  it('should have warnings for non-list format of recommended exploration IDs',
+    function() {
+      customizationArguments.recommendedExplorationIds.value = 'ExpID0';
+      warnings = validatorService.getAllWarnings(
+        currentState, customizationArguments, [], null);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: 'Set of recommended exploration IDs must be in list format.'
+      }]);
+    })
 });

--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
@@ -126,7 +126,7 @@ describe('EndExplorationValidationService', function() {
         currentState, customizationArguments, [], null);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
-        message: 'Set of recommended exploration IDs must be a list.'
+        message: 'Set of recommended exploration IDs must be list.'
       }]);
     });
 });

--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
@@ -107,4 +107,15 @@ describe('EndExplorationValidationService', function() {
       currentState, customizationArguments, [], null);
     expect(warnings).toEqual([]);
   });
+
+  it('should catch non-string value for recommended exploration ID',
+    function() {
+      customizationArguments.recommendedExplorationIds.value = [1];
+      warnings = validatorService.getAllWarnings(
+        currentState, customizationArguments, [], null);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: 'Recommended Exploration ID must be a string.'
+      }]);
+    });
 });

--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
@@ -23,7 +23,7 @@ describe('EndExplorationValidationService', function() {
     module('oppia');
   });
 
-  beforeEach(inject(function($rootScope, $controller, $injector) {
+  beforeEach(inject(function($injector) {
     validatorService = $injector.get('EndExplorationValidationService');
     WARNING_TYPES = $injector.get('WARNING_TYPES');
 

--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
@@ -126,7 +126,7 @@ describe('EndExplorationValidationService', function() {
         currentState, customizationArguments, [], null);
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
-        message: 'Set of recommended exploration IDs must be in list format.'
+        message: 'Set of recommended exploration IDs must be a list.'
       }]);
     });
 });

--- a/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
+++ b/extensions/interactions/EndExploration/directives/EndExplorationValidationServiceSpec.js
@@ -128,5 +128,5 @@ describe('EndExplorationValidationService', function() {
         type: WARNING_TYPES.ERROR,
         message: 'Set of recommended exploration IDs must be in list format.'
       }]);
-    })
+    });
 });


### PR DESCRIPTION
This PR adds frontend validators for unicode Exploration IDs in End Exploration.

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
