### PR TITLE
Fix part of #3446: Add frontend validators to CodeRepl Interaction

### DIFF
--- a/extensions/interactions/CodeRepl/directives/CodeReplValidationService.js
+++ b/extensions/interactions/CodeRepl/directives/CodeReplValidationService.js
@@ -57,6 +57,7 @@ oppia.factory('CodeReplValidationService', [
             message: 'PostCode text must be a string.'
           });
         }
+        return warningsList
       },
       getAllWarnings: function(stateName, customizationArgs, answerGroups,
           defaultOutcome) {

--- a/extensions/interactions/CodeRepl/directives/CodeReplValidationService.js
+++ b/extensions/interactions/CodeRepl/directives/CodeReplValidationService.js
@@ -46,7 +46,7 @@ oppia.factory('CodeReplValidationService', [
         if (!angular.isString(preCode)) {
           warningsList.push({
             type: WARNING_TYPES.ERROR,
-            message: 'PreCode text must be a string.'
+            message: 'The pre-code text must be a string.'
           });
         }
 
@@ -54,7 +54,7 @@ oppia.factory('CodeReplValidationService', [
         if (!angular.isString(postCode)) {
           warningsList.push({
             type: WARNING_TYPES.ERROR,
-            message: 'PostCode text must be a string.'
+            message: 'The post-code text must be a string.'
           });
         }
         return warningsList;

--- a/extensions/interactions/CodeRepl/directives/CodeReplValidationService.js
+++ b/extensions/interactions/CodeRepl/directives/CodeReplValidationService.js
@@ -57,7 +57,7 @@ oppia.factory('CodeReplValidationService', [
             message: 'PostCode text must be a string.'
           });
         }
-        return warningsList
+        return warningsList;
       },
       getAllWarnings: function(stateName, customizationArgs, answerGroups,
           defaultOutcome) {

--- a/extensions/interactions/CodeRepl/directives/CodeReplValidationService.js
+++ b/extensions/interactions/CodeRepl/directives/CodeReplValidationService.js
@@ -24,7 +24,7 @@ oppia.factory('CodeReplValidationService', [
         var warningsList = [];
         baseInteractionValidationService.requireCustomizationArguments(
           customizationArgs, ['language', 'placeholder', 'preCode',
-            'postCode']);
+                              'postCode']);
 
         var language = customizationArgs.language.value;
         if (!angular.isString(language)) {

--- a/extensions/interactions/CodeRepl/directives/CodeReplValidationService.js
+++ b/extensions/interactions/CodeRepl/directives/CodeReplValidationService.js
@@ -17,12 +17,46 @@
  */
 
 oppia.factory('CodeReplValidationService', [
-  'baseInteractionValidationService',
-  function(baseInteractionValidationService) {
+  'WARNING_TYPES', 'baseInteractionValidationService',
+  function(WARNING_TYPES, baseInteractionValidationService) {
     return {
       getCustomizationArgsWarnings: function(customizationArgs) {
-        // TODO(juansaba): Implement customization args validations.
-        return [];
+        var warningsList = [];
+        baseInteractionValidationService.requireCustomizationArguments(
+          customizationArgs, ['language', 'placeholder', 'preCode',
+            'postCode']);
+
+        var language = customizationArgs.language.value;
+        if (!angular.isString(language)) {
+          warningsList.push({
+            type: WARNING_TYPES.ERROR,
+            message: 'Programming language name must be a string.'
+          });
+        }
+
+        var placeholder = customizationArgs.placeholder.value;
+        if (!angular.isString(placeholder)) {
+          warningsList.push({
+            type: WARNING_TYPES.ERROR,
+            message: 'Placeholder text must be a string.'
+          });
+        }
+
+        var preCode = customizationArgs.preCode.value;
+        if (!angular.isString(preCode)) {
+          warningsList.push({
+            type: WARNING_TYPES.ERROR,
+            message: 'PreCode text must be a string.'
+          });
+        }
+
+        var postCode = customizationArgs.postCode.value;
+        if (!angular.isString(postCode)) {
+          warningsList.push({
+            type: WARNING_TYPES.ERROR,
+            message: 'PostCode text must be a string.'
+          });
+        }
       },
       getAllWarnings: function(stateName, customizationArgs, answerGroups,
           defaultOutcome) {

--- a/extensions/interactions/CodeRepl/directives/CodeReplValidationServiceSpec.js
+++ b/extensions/interactions/CodeRepl/directives/CodeReplValidationServiceSpec.js
@@ -38,6 +38,22 @@ describe('CodeReplValidationService', function() {
       param_changes: [],
       refresher_exploration_id: null
     });
+
+    customizationArguments = {
+      language: {
+        value: ''
+      },
+      placeholder: {
+        value: ''
+      },
+      preCode: {
+        value: ''
+      },
+      postCode: {
+        value: ''
+      }
+    };
+
     goodAnswerGroups = [agof.createNew([], goodDefaultOutcome, false)];
   }));
 
@@ -45,5 +61,45 @@ describe('CodeReplValidationService', function() {
     var warnings = validatorService.getAllWarnings(
       currentState, {}, goodAnswerGroups, goodDefaultOutcome);
     expect(warnings).toEqual([]);
+  });
+
+  it('should catch non-string value for programming language', function() {
+    customizationArguments.language.value = 1;
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArguments, [], null);
+    expect(warnings).toEqual({
+      type: WARNING_TYPES.ERROR,
+      message: 'Programming language name must be a string.'
+    });
+  });
+
+  it('should catch non-string value for placeholder text', function() {
+    customizationArguments.placeholder.value = 1;
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArguments, [], null);
+    expect(warnings).toEqual({
+      type: WARNING_TYPES.ERROR,
+      message: 'Placeholder text must be a string.'
+    });
+  });
+
+  it('should catch non-string value for preCode text', function() {
+    customizationArguments.preCode.value = 1;
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArguments, [], null);
+    expect(warnings).toEqual({
+      type: WARNING_TYPES.ERROR,
+      message: 'PreCode text must be a string.'
+    });
+  });
+
+  it('should catch non-string value for postCode text', function() {
+    customizationArguments.postCode.value = 1;
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArguments, [], null);
+    expect(warnings).toEqual({
+      type: WARNING_TYPES.ERROR,
+      message: 'PostCode text must be a string.'
+    });
   });
 });

--- a/extensions/interactions/CodeRepl/directives/CodeReplValidationServiceSpec.js
+++ b/extensions/interactions/CodeRepl/directives/CodeReplValidationServiceSpec.js
@@ -14,7 +14,8 @@
 
 describe('CodeReplValidationService', function() {
   var WARNING_TYPES, validatorService;
-  var currentState, goodAnswerGroups, goodDefaultOutcome;
+  var currentState, customizationArguments;
+  var goodAnswerGroups, goodDefaultOutcome;
   var oof, agof;
 
   beforeEach(function() {
@@ -67,39 +68,39 @@ describe('CodeReplValidationService', function() {
     customizationArguments.language.value = 1;
     var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, [], null);
-    expect(warnings).toEqual({
+    expect(warnings).toEqual([{
       type: WARNING_TYPES.ERROR,
       message: 'Programming language name must be a string.'
-    });
+    }]);
   });
 
   it('should catch non-string value for placeholder text', function() {
     customizationArguments.placeholder.value = 1;
     var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, [], null);
-    expect(warnings).toEqual({
+    expect(warnings).toEqual([{
       type: WARNING_TYPES.ERROR,
       message: 'Placeholder text must be a string.'
-    });
+    }]);
   });
 
   it('should catch non-string value for preCode text', function() {
     customizationArguments.preCode.value = 1;
     var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, [], null);
-    expect(warnings).toEqual({
+    expect(warnings).toEqual([{
       type: WARNING_TYPES.ERROR,
       message: 'PreCode text must be a string.'
-    });
+    }]);
   });
 
   it('should catch non-string value for postCode text', function() {
     customizationArguments.postCode.value = 1;
     var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, [], null);
-    expect(warnings).toEqual({
+    expect(warnings).toEqual([{
       type: WARNING_TYPES.ERROR,
       message: 'PostCode text must be a string.'
-    });
+    }]);
   });
 });

--- a/extensions/interactions/CodeRepl/directives/CodeReplValidationServiceSpec.js
+++ b/extensions/interactions/CodeRepl/directives/CodeReplValidationServiceSpec.js
@@ -60,7 +60,8 @@ describe('CodeReplValidationService', function() {
 
   it('should be able to perform basic validation', function() {
     var warnings = validatorService.getAllWarnings(
-      currentState, {}, goodAnswerGroups, goodDefaultOutcome);
+      currentState, customizationArguments, goodAnswerGroups,
+      goodDefaultOutcome);
     expect(warnings).toEqual([]);
   });
 

--- a/extensions/interactions/CodeRepl/directives/CodeReplValidationServiceSpec.js
+++ b/extensions/interactions/CodeRepl/directives/CodeReplValidationServiceSpec.js
@@ -91,7 +91,7 @@ describe('CodeReplValidationService', function() {
       currentState, customizationArguments, [], null);
     expect(warnings).toEqual([{
       type: WARNING_TYPES.ERROR,
-      message: 'PreCode text must be a string.'
+      message: 'The pre-code text must be a string.'
     }]);
   });
 
@@ -101,7 +101,7 @@ describe('CodeReplValidationService', function() {
       currentState, customizationArguments, [], null);
     expect(warnings).toEqual([{
       type: WARNING_TYPES.ERROR,
-      message: 'PostCode text must be a string.'
+      message: 'The post-code text must be a string.'
     }]);
   });
 });


### PR DESCRIPTION
This PR adds frontend validators for unicode customization arg specs in Code Editor Interaction.

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
