### PR TITLE
Fix git push error when branch has same name as directory.

### DIFF
--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -104,6 +104,9 @@ def _git_diff_name_status(left, right, diff_filter=''):
     if diff_filter:
         git_cmd.append('--diff-filter={}'.format(diff_filter))
     git_cmd.extend([left, right])
+    # append -- to avoid conflict between branch and directory name
+    # more here https://stackoverflow.com/questions/26349191
+    git_cmd.append('--')
     out, err = _start_subprocess_for_result(git_cmd)
     if not err:
         file_list = []

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -68,7 +68,8 @@ class ChangedBranch(object):
     def __enter__(self):
         if not self.is_same_branch:
             try:
-                subprocess.check_output(['git', 'checkout', self.new_branch])
+                subprocess.check_output(
+                    ['git', 'checkout', self.new_branch, '--'])
             except subprocess.CalledProcessError:
                 print ('\nCould not change branch to %s. This is most probably '
                        'because you are in a dirty state. Change manually to '
@@ -78,7 +79,7 @@ class ChangedBranch(object):
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if not self.is_same_branch:
-            subprocess.check_output(['git', 'checkout', self.old_branch])
+            subprocess.check_output(['git', 'checkout', self.old_branch, '--'])
 
 
 def _start_subprocess_for_result(cmd):

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -105,8 +105,8 @@ def _git_diff_name_status(left, right, diff_filter=''):
     if diff_filter:
         git_cmd.append('--diff-filter={}'.format(diff_filter))
     git_cmd.extend([left, right])
-    # append -- to avoid conflict between branch and directory name
-    # more here https://stackoverflow.com/questions/26349191
+    # Append -- to avoid conflicts between branch and directory name.
+    # More here: https://stackoverflow.com/questions/26349191
     git_cmd.append('--')
     out, err = _start_subprocess_for_result(git_cmd)
     if not err:


### PR DESCRIPTION
## Explanation
When the git branch has the same name as some folder in Oppia project root folder (in my case _build_), the git can't recognize if we mean branch or folder. This problem is solved by adding `--` between branch names and folder names, for example: `git log <branch_name> -- <folder_name>`. Both parts can be empty, so when we want only to specify some branch name we write `git log <branch_name> --`.

We use git commands in some places in pre_push_hook.py, so I have added `--` to this places.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
