### PR TITLE
Fix part of #3905: Add check for break after parens when content spans to multiple lines

### DIFF
--- a/core/controllers/admin_test.py
+++ b/core/controllers/admin_test.py
@@ -93,12 +93,13 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
         self.login(self.ADMIN_EMAIL, is_super_admin=True)
         response = self.testapp.get('/admin')
         csrf_token = self.get_csrf_token_from_response(response)
-        self.post_json('/adminhandler', {
-            'action': 'save_config_properties',
-            'new_config_property_values': {
-                base.BEFORE_END_HEAD_TAG_HOOK.name: new_config_value
-            }
-        }, csrf_token)
+        self.post_json(
+            '/adminhandler', {
+                'action': 'save_config_properties',
+                'new_config_property_values': {
+                    base.BEFORE_END_HEAD_TAG_HOOK.name: new_config_value
+                }
+            }, csrf_token)
 
         response = self.testapp.get('/about')
         self.assertIn(new_config_value, response.body)
@@ -112,11 +113,12 @@ class GenerateDummyExplorationsTest(test_utils.GenericTestBase):
         self.login(self.ADMIN_EMAIL, is_super_admin=True)
         response = self.testapp.get('/admin')
         csrf_token = self.get_csrf_token_from_response(response)
-        self.post_json('/adminhandler', {
-            'action': 'generate_dummy_explorations',
-            'num_dummy_exps_to_generate': 10,
-            'num_dummy_exps_to_publish': 3
-        }, csrf_token)
+        self.post_json(
+            '/adminhandler', {
+                'action': 'generate_dummy_explorations',
+                'num_dummy_exps_to_generate': 10,
+                'num_dummy_exps_to_publish': 3
+            }, csrf_token)
         generated_exps = exp_services.get_all_exploration_summaries()
         published_exps = exp_services.get_recently_published_exp_summaries(5)
         self.assertEqual(len(generated_exps), 10)
@@ -127,11 +129,12 @@ class GenerateDummyExplorationsTest(test_utils.GenericTestBase):
         self.login(self.ADMIN_EMAIL, is_super_admin=True)
         response = self.testapp.get('/admin')
         csrf_token = self.get_csrf_token_from_response(response)
-        self.post_json('/adminhandler', {
-            'action': 'generate_dummy_explorations',
-            'num_dummy_exps_to_generate': 2,
-            'num_dummy_exps_to_publish': 2
-        }, csrf_token)
+        self.post_json(
+            '/adminhandler', {
+                'action': 'generate_dummy_explorations',
+                'num_dummy_exps_to_generate': 2,
+                'num_dummy_exps_to_publish': 2
+            }, csrf_token)
         generated_exps = exp_services.get_all_exploration_summaries()
         published_exps = exp_services.get_recently_published_exp_summaries(5)
         self.assertEqual(len(generated_exps), 2)

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -455,8 +455,9 @@ class BaseHandler(webapp2.RequestHandler):
         if isinstance(exception, self.PageNotFoundException):
             logging.error('Invalid URL requested: %s', self.request.uri)
             self.error(404)
-            self._render_exception(404, {
-                'error': 'Could not find the page %s.' % self.request.uri})
+            self._render_exception(
+                404, {
+                    'error': 'Could not find the page %s.' % self.request.uri})
             return
 
         if isinstance(exception, self.UnauthorizedUserException):

--- a/core/controllers/classifier_test.py
+++ b/core/controllers/classifier_test.py
@@ -99,35 +99,41 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
 
     def test_trained_classifier_handler(self):
         # Normal end-to-end test.
-        self.post_json('/ml/trainedclassifierhandler', self.payload,
-                       expect_errors=False, expected_status_int=200)
+        self.post_json(
+            '/ml/trainedclassifierhandler', self.payload,
+            expect_errors=False, expected_status_int=200)
         classifier_training_jobs = (
             classifier_services.get_classifier_training_jobs(
                 self.exp_id, self.exploration.version, ['Home']))
         self.assertEqual(len(classifier_training_jobs), 1)
 
-        self.assertEqual(classifier_training_jobs[0].classifier_data,
-                         self.classifier_data)
-        self.assertEqual(classifier_training_jobs[0].status,
-                         feconf.TRAINING_JOB_STATUS_COMPLETE)
+        self.assertEqual(
+            classifier_training_jobs[0].classifier_data,
+            self.classifier_data)
+        self.assertEqual(
+            classifier_training_jobs[0].status,
+            feconf.TRAINING_JOB_STATUS_COMPLETE)
 
     def test_error_on_prod_mode_and_default_vm_id(self):
         # Turn off DEV_MODE.
         with self.swap(feconf, 'DEV_MODE', False):
-            self.post_json('/ml/trainedclassifierhandler', self.payload,
-                           expect_errors=True, expected_status_int=401)
+            self.post_json(
+                '/ml/trainedclassifierhandler', self.payload,
+                expect_errors=True, expected_status_int=401)
 
     def test_error_on_different_signatures(self):
         # Altering data to result in different signatures.
         self.payload['message']['job_id'] = 'different_job_id'
-        self.post_json('/ml/trainedclassifierhandler', self.payload,
-                       expect_errors=True, expected_status_int=401)
+        self.post_json(
+            '/ml/trainedclassifierhandler', self.payload,
+            expect_errors=True, expected_status_int=401)
 
     def test_error_on_invalid_message(self):
         # Altering message dict to result in invalid dict.
         self.payload['message']['job_id'] = 1
-        self.post_json('/ml/trainedclassifierhandler', self.payload,
-                       expect_errors=True, expected_status_int=400)
+        self.post_json(
+            '/ml/trainedclassifierhandler', self.payload,
+            expect_errors=True, expected_status_int=400)
 
 
 class NextJobHandlerTest(test_utils.GenericTestBase):
@@ -172,30 +178,35 @@ class NextJobHandlerTest(test_utils.GenericTestBase):
             secret, self.payload['message'])
 
     def test_next_job_handler(self):
-        json_response = self.post_json('/ml/nextjobhandler',
-                                       self.payload, expect_errors=False,
-                                       expected_status_int=200)
+        json_response = self.post_json(
+            '/ml/nextjobhandler',
+            self.payload, expect_errors=False,
+            expected_status_int=200)
         self.assertEqual(json_response, self.expected_response)
         classifier_services.mark_training_jobs_failed([self.job_id])
-        json_response = self.post_json('/ml/nextjobhandler',
-                                       self.payload, expect_errors=False,
-                                       expected_status_int=200)
+        json_response = self.post_json(
+            '/ml/nextjobhandler',
+            self.payload, expect_errors=False,
+            expected_status_int=200)
         self.assertEqual(json_response, {})
 
     def test_error_on_prod_mode_and_default_vm_id(self):
         # Turn off DEV_MODE.
         with self.swap(feconf, 'DEV_MODE', False):
-            self.post_json('/ml/nextjobhandler', self.payload,
-                           expect_errors=True, expected_status_int=401)
+            self.post_json(
+                '/ml/nextjobhandler', self.payload,
+                expect_errors=True, expected_status_int=401)
 
     def test_error_on_modified_message(self):
         # Altering data to result in different signatures.
         self.payload['message'] = 'different'
-        self.post_json('/ml/nextjobhandler', self.payload,
-                       expect_errors=True, expected_status_int=401)
+        self.post_json(
+            '/ml/nextjobhandler', self.payload,
+            expect_errors=True, expected_status_int=401)
 
     def test_error_on_invalid_vm_id(self):
         # Altering vm_id to result in invalid signature.
         self.payload['vm_id'] = 1
-        self.post_json('/ml/nextjobhandler', self.payload,
-                       expect_errors=True, expected_status_int=401)
+        self.post_json(
+            '/ml/nextjobhandler', self.payload,
+            expect_errors=True, expected_status_int=401)

--- a/core/controllers/collection_editor_test.py
+++ b/core/controllers/collection_editor_test.py
@@ -72,22 +72,25 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
         # Check that it is possible to access a page with specific version
         # number.
         response = self.testapp.get(
-            '%s/%s?v=1' % (feconf.COLLECTION_DATA_URL_PREFIX,
-                           self.COLLECTION_ID))
+            '%s/%s?v=1' % (
+                feconf.COLLECTION_DATA_URL_PREFIX,
+                self.COLLECTION_ID))
         self.assertEqual(response.status_int, 200)
 
         # Check that non-editors cannot access the editor page. This is due
         # to them not being whitelisted.
         response = self.testapp.get(
-            '%s/%s' % (feconf.COLLECTION_EDITOR_URL_PREFIX,
-                       self.COLLECTION_ID))
+            '%s/%s' % (
+                feconf.COLLECTION_EDITOR_URL_PREFIX,
+                self.COLLECTION_ID))
         self.assertEqual(response.status_int, 302)
 
         # Check that whitelisted users can access and edit in the editor page.
         self.login(self.EDITOR_EMAIL)
         response = self.testapp.get(
-            '%s/%s' % (feconf.COLLECTION_EDITOR_URL_PREFIX,
-                       self.COLLECTION_ID))
+            '%s/%s' % (
+                feconf.COLLECTION_EDITOR_URL_PREFIX,
+                self.COLLECTION_ID))
         self.assertEqual(response.status_int, 200)
 
         json_response = self.get_json(
@@ -102,8 +105,9 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
         # Check that non-editors cannot access the editor data handler.
         # This is due to them not being whitelisted.
         response = self.testapp.get(
-            '%s/%s' % (feconf.EDITABLE_COLLECTION_DATA_URL_PREFIX,
-                       self.COLLECTION_ID))
+            '%s/%s' % (
+                feconf.EDITABLE_COLLECTION_DATA_URL_PREFIX,
+                self.COLLECTION_ID))
         self.assertEqual(response.status_int, 302)
 
         # Check that whitelisted users can access the data
@@ -111,8 +115,9 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
         self.login(self.EDITOR_EMAIL)
 
         json_response = self.get_json(
-            '%s/%s' % (feconf.EDITABLE_COLLECTION_DATA_URL_PREFIX,
-                       self.COLLECTION_ID))
+            '%s/%s' % (
+                feconf.EDITABLE_COLLECTION_DATA_URL_PREFIX,
+                self.COLLECTION_ID))
         self.assertEqual(self.COLLECTION_ID, json_response['collection']['id'])
         self.logout()
 
@@ -133,14 +138,16 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
 
         # Call get handler to return the csrf token.
         response = self.testapp.get(
-            '%s/%s' % (feconf.COLLECTION_URL_PREFIX,
-                       self.COLLECTION_ID))
+            '%s/%s' % (
+                feconf.COLLECTION_URL_PREFIX,
+                self.COLLECTION_ID))
         csrf_token = self.get_csrf_token_from_response(response)
 
         # Ensure viewers do not have access to the PUT Handler.
         json_response = self.put_json(
-            '%s/%s' % (feconf.EDITABLE_COLLECTION_DATA_URL_PREFIX,
-                       self.COLLECTION_ID),
+            '%s/%s' % (
+                feconf.EDITABLE_COLLECTION_DATA_URL_PREFIX,
+                self.COLLECTION_ID),
             self.json_dict, expect_errors=True,
             csrf_token=csrf_token, expected_status_int=401)
 
@@ -163,13 +170,15 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
 
         # Call get handler to return the csrf token.
         response = self.testapp.get(
-            '%s/%s' % (feconf.COLLECTION_URL_PREFIX,
-                       self.COLLECTION_ID))
+            '%s/%s' % (
+                feconf.COLLECTION_URL_PREFIX,
+                self.COLLECTION_ID))
         csrf_token = self.get_csrf_token_from_response(response)
 
         json_response = self.put_json(
-            '%s/%s' % (feconf.EDITABLE_COLLECTION_DATA_URL_PREFIX,
-                       self.COLLECTION_ID),
+            '%s/%s' % (
+                feconf.EDITABLE_COLLECTION_DATA_URL_PREFIX,
+                self.COLLECTION_ID),
             self.json_dict, csrf_token=csrf_token)
 
         self.assertEqual(self.COLLECTION_ID, json_response['collection']['id'])
@@ -193,14 +202,16 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
             Exception, 'This collection cannot be unpublished.'):
             rights_manager.unpublish_collection(self.owner, collection_id)
         collection_rights = rights_manager.get_collection_rights(collection_id)
-        self.assertEqual(collection_rights.status,
-                         rights_manager.ACTIVITY_STATUS_PUBLIC)
+        self.assertEqual(
+            collection_rights.status,
+            rights_manager.ACTIVITY_STATUS_PUBLIC)
 
         # Check that collection can be unpublished by admin.
         rights_manager.unpublish_collection(self.admin, collection_id)
         collection_rights = rights_manager.get_collection_rights(collection_id)
-        self.assertEqual(collection_rights.status,
-                         rights_manager.ACTIVITY_STATUS_PRIVATE)
+        self.assertEqual(
+            collection_rights.status,
+            rights_manager.ACTIVITY_STATUS_PRIVATE)
 
     def test_get_collection_rights(self):
         whitelisted_usernames = [self.OWNER_USERNAME]
@@ -239,8 +250,8 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
         rights_manager.publish_exploration(self.owner, exploration_id)
         collection = collection_services.get_collection_by_id(collection_id)
         response = self.testapp.get(
-            '%s/%s' % (feconf.COLLECTION_URL_PREFIX,
-                       self.COLLECTION_ID))
+            '%s/%s' % (
+                feconf.COLLECTION_URL_PREFIX, self.COLLECTION_ID))
         csrf_token = self.get_csrf_token_from_response(response)
         response_dict = self.put_json(
             '/collection_editor_handler/publish/%s' % collection_id,
@@ -252,8 +263,7 @@ class CollectionEditorTest(BaseCollectionEditorControllerTest):
         # Login as admin and unpublish the collection.
         self.login(self.ADMIN_EMAIL)
         response = self.testapp.get(
-            '%s/%s' % (feconf.COLLECTION_URL_PREFIX,
-                       self.COLLECTION_ID))
+            '%s/%s' % (feconf.COLLECTION_URL_PREFIX, self.COLLECTION_ID))
         csrf_token = self.get_csrf_token_from_response(response)
         response_dict = self.put_json(
             '/collection_editor_handler/unpublish/%s' % collection_id,

--- a/core/controllers/creator_dashboard_test.py
+++ b/core/controllers/creator_dashboard_test.py
@@ -100,12 +100,13 @@ class CreatorDashboardStatisticsTest(test_utils.GenericTestBase):
         event_services.StartExplorationEventHandler.record(
             exp_id, exp_version, state, self.USER_SESSION_ID, {},
             feconf.PLAY_TYPE_NORMAL)
-        event_services.StatsEventsHandler.record(exp_id, exp_version, {
-            'num_starts': 1,
-            'num_actual_starts': 0,
-            'num_completions': 0,
-            'state_stats_mapping': {}
-        })
+        event_services.StatsEventsHandler.record(
+            exp_id, exp_version, {
+                'num_starts': 1,
+                'num_actual_starts': 0,
+                'num_completions': 0,
+                'state_stats_mapping': {}
+            })
 
     def _rate_exploration(self, exp_id, ratings):
         """Create num_ratings ratings for exploration with exp_id,
@@ -635,25 +636,27 @@ class NotificationsDashboardHandlerTest(test_utils.GenericTestBase):
 
     def _get_recent_notifications_mock_by_viewer(self, unused_user_id):
         """Returns a single feedback thread by VIEWER_ID."""
-        return (100000, [{
-            'activity_id': 'exp_id',
-            'activity_title': 'exp_title',
-            'author_id': self.viewer_id,
-            'last_updated_ms': 100000,
-            'subject': 'Feedback Message Subject',
-            'type': feconf.UPDATE_TYPE_FEEDBACK_MESSAGE,
-        }])
+        return (
+            100000, [{
+                'activity_id': 'exp_id',
+                'activity_title': 'exp_title',
+                'author_id': self.viewer_id,
+                'last_updated_ms': 100000,
+                'subject': 'Feedback Message Subject',
+                'type': feconf.UPDATE_TYPE_FEEDBACK_MESSAGE,
+            }])
 
     def _get_recent_notifications_mock_by_anonymous_user(self, unused_user_id):
         """Returns a single feedback thread by an anonymous user."""
-        return (200000, [{
-            'activity_id': 'exp_id',
-            'activity_title': 'exp_title',
-            'author_id': None,
-            'last_updated_ms': 100000,
-            'subject': 'Feedback Message Subject',
-            'type': feconf.UPDATE_TYPE_FEEDBACK_MESSAGE,
-        }])
+        return (
+            200000, [{
+                'activity_id': 'exp_id',
+                'activity_title': 'exp_title',
+                'author_id': None,
+                'last_updated_ms': 100000,
+                'subject': 'Feedback Message Subject',
+                'type': feconf.UPDATE_TYPE_FEEDBACK_MESSAGE,
+            }])
 
     def test_author_ids_are_handled_correctly(self):
         """Test that author ids are converted into author usernames

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -140,9 +140,10 @@ class EditorTest(BaseEditorControllerTest):
         response = self.testapp.get('/create/%s' % exp_id)
         csrf_token = self.get_csrf_token_from_response(response)
         publish_url = '%s/%s' % (feconf.EXPLORATION_STATUS_PREFIX, exp_id)
-        self.put_json(publish_url, {
-            'make_public': True,
-        }, csrf_token, expect_errors=True, expected_status_int=400)
+        self.put_json(
+            publish_url, {
+                'make_public': True,
+            }, csrf_token, expect_errors=True, expected_status_int=400)
 
         self.logout()
 
@@ -391,18 +392,21 @@ class EditorTest(BaseEditorControllerTest):
             # answer, it will not be returned as potential training data.
             state = exploration_dict['exploration']['states'][state_name]
             answer_group = state['interaction']['answer_groups'][1]
+
             del answer_group['training_data'][1]
-            self.put_json('/createhandler/data/15', {
-                'change_list': [{
-                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                    'state_name': state_name,
-                    'property_name': (
-                        exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS),
-                    'new_value': state['interaction']['answer_groups']
-                }],
-                'commit_message': 'Update confirmed unclassified answers',
-                'version': exploration_dict['version'],
-            }, csrf_token)
+            self.put_json(
+                '/createhandler/data/15', {
+                    'change_list': [{
+                        'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                        'state_name': state_name,
+                        'property_name': (
+                            exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS), # pylint:disable=line-too-long
+                        'new_value': state['interaction']['answer_groups']
+                    }],
+                    'commit_message': 'Update confirmed unclassified answers',
+                    'version': exploration_dict['version'],
+                }, csrf_token)
+
             response_dict = self.get_json(url)
             self.assertEqual(response_dict['unhandled_answers'], [])
 
@@ -873,14 +877,14 @@ class ExplorationDeletionRightsTest(BaseEditorControllerTest):
             # oppia/core/platform/search/gae_search_services.py,
             # not to be checked here (same for admin and moderator).
             self.assertEqual(len(observed_log_messages), 3)
-            self.assertEqual(observed_log_messages[0],
-                             '(%s) %s tried to delete exploration %s' %
-                             (feconf.ROLE_ID_EXPLORATION_EDITOR,
-                              self.owner_id, exp_id))
-            self.assertEqual(observed_log_messages[2],
-                             '(%s) %s deleted exploration %s' %
-                             (feconf.ROLE_ID_EXPLORATION_EDITOR,
-                              self.owner_id, exp_id))
+            self.assertEqual(
+                observed_log_messages[0],
+                '(%s) %s tried to delete exploration %s' %
+                (feconf.ROLE_ID_EXPLORATION_EDITOR, self.owner_id, exp_id))
+            self.assertEqual(
+                observed_log_messages[2],
+                '(%s) %s deleted exploration %s' %
+                (feconf.ROLE_ID_EXPLORATION_EDITOR, self.owner_id, exp_id))
             self.logout()
 
             # Checking for admin.
@@ -894,12 +898,14 @@ class ExplorationDeletionRightsTest(BaseEditorControllerTest):
             self.testapp.delete(
                 '/createhandler/data/%s' % exp_id, expect_errors=True)
             self.assertEqual(len(observed_log_messages), 3)
-            self.assertEqual(observed_log_messages[0],
-                             '(%s) %s tried to delete exploration %s' %
-                             (feconf.ROLE_ID_ADMIN, self.admin_id, exp_id))
-            self.assertEqual(observed_log_messages[2],
-                             '(%s) %s deleted exploration %s' %
-                             (feconf.ROLE_ID_ADMIN, self.admin_id, exp_id))
+            self.assertEqual(
+                observed_log_messages[0],
+                '(%s) %s tried to delete exploration %s' %
+                (feconf.ROLE_ID_ADMIN, self.admin_id, exp_id))
+            self.assertEqual(
+                observed_log_messages[2],
+                '(%s) %s deleted exploration %s' %
+                (feconf.ROLE_ID_ADMIN, self.admin_id, exp_id))
             self.logout()
 
             # Checking for moderator.
@@ -913,14 +919,14 @@ class ExplorationDeletionRightsTest(BaseEditorControllerTest):
             self.testapp.delete(
                 '/createhandler/data/%s' % exp_id, expect_errors=True)
             self.assertEqual(len(observed_log_messages), 3)
-            self.assertEqual(observed_log_messages[0],
-                             '(%s) %s tried to delete exploration %s' %
-                             (feconf.ROLE_ID_MODERATOR,
-                              self.moderator_id, exp_id))
-            self.assertEqual(observed_log_messages[2],
-                             '(%s) %s deleted exploration %s' %
-                             (feconf.ROLE_ID_MODERATOR,
-                              self.moderator_id, exp_id))
+            self.assertEqual(
+                observed_log_messages[0],
+                '(%s) %s tried to delete exploration %s' %
+                (feconf.ROLE_ID_MODERATOR, self.moderator_id, exp_id))
+            self.assertEqual(
+                observed_log_messages[2],
+                '(%s) %s deleted exploration %s' %
+                (feconf.ROLE_ID_MODERATOR, self.moderator_id, exp_id))
             self.logout()
 
 

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -108,10 +108,11 @@ class FeedbackThreadPermissionsTests(test_utils.GenericTestBase):
         thread_url = '%s/%s/%s' % (
             feconf.FEEDBACK_THREAD_URL_PREFIX, self.EXP_ID, 'dummy_thread_id')
 
-        self.post_json(thread_url, {
-            'exploration_id': '0',
-            'text': self.UNICODE_TEST_STRING,
-        }, self.csrf_token, expect_errors=True, expected_status_int=401)
+        self.post_json(
+            thread_url, {
+                'exploration_id': '0',
+                'text': self.UNICODE_TEST_STRING,
+            }, self.csrf_token, expect_errors=True, expected_status_int=401)
 
 
 class FeedbackThreadIntegrationTests(test_utils.GenericTestBase):
@@ -216,11 +217,12 @@ class FeedbackThreadIntegrationTests(test_utils.GenericTestBase):
         # Then, create a new message in that thread.
         thread_url = '%s/%s/%s' % (
             feconf.FEEDBACK_THREAD_URL_PREFIX, self.EXP_ID, thread_id)
-        self.post_json(thread_url, {
-            'updated_status': None,
-            'updated_subject': None,
-            'text': 'Message 1'
-        }, csrf_token)
+        self.post_json(
+            thread_url, {
+                'updated_status': None,
+                'updated_subject': None,
+                'text': 'Message 1'
+            }, csrf_token)
 
         # The resulting thread should contain two messages.
         response_dict = self.get_json(thread_url)
@@ -313,9 +315,10 @@ class FeedbackThreadIntegrationTests(test_utils.GenericTestBase):
             self.login(_get_email(num))
             response = self.testapp.get('/create/%s' % self.EXP_ID)
             csrf_token = self.get_csrf_token_from_response(response)
-            self.post_json(thread_url, {
-                'text': 'New Message %s' % num
-            }, csrf_token)
+            self.post_json(
+                thread_url, {
+                    'text': 'New Message %s' % num
+                }, csrf_token)
             self.logout()
 
         # Get the message list.
@@ -436,11 +439,12 @@ class FeedbackThreadTests(test_utils.GenericTestBase):
         # Now the owner adds a message to the feedback thread.
         thread_url = '%s/%s/%s' % (
             feconf.FEEDBACK_THREAD_URL_PREFIX, self.EXP_ID, thread_id)
-        self.post_json(thread_url, {
-            'updated_status': None,
-            'updated_subject': None,
-            'text': 'Message 1'
-        }, csrf_token)
+        self.post_json(
+            thread_url, {
+                'updated_status': None,
+                'updated_subject': None,
+                'text': 'Message 1'
+            }, csrf_token)
 
         # Both the messages in the thread should have been read by the user.
         self.assertEqual(
@@ -468,11 +472,12 @@ class FeedbackThreadTests(test_utils.GenericTestBase):
         # User adds another message.
         thread_url = '%s/%s/%s' % (
             feconf.FEEDBACK_THREAD_URL_PREFIX, self.EXP_ID, thread_id)
-        self.post_json(thread_url, {
-            'updated_status': None,
-            'updated_subject': None,
-            'text': 'Message 2'
-        }, csrf_token)
+        self.post_json(
+            thread_url, {
+                'updated_status': None,
+                'updated_subject': None,
+                'text': 'Message 2'
+            }, csrf_token)
 
         # Check if the new message is also added to the read list.
         self.assertEqual(
@@ -633,8 +638,9 @@ class SuggestionsIntegrationTests(test_utils.GenericTestBase):
         # Get a suggestion.
         thread_id = threads[0]['thread_id']
         response_dict = self.get_json(
-            '%s/%s/%s' % (feconf.FEEDBACK_THREAD_URL_PREFIX, self.EXP_ID,
-                          thread_id))
+            '%s/%s/%s' % (
+                feconf.FEEDBACK_THREAD_URL_PREFIX, self.EXP_ID,
+                thread_id))
 
         # Suggestion description should be the same as thread subject.
         self.assertEqual(
@@ -667,12 +673,15 @@ class SuggestionsIntegrationTests(test_utils.GenericTestBase):
             status=400, expect_errors=True)
         self.assertEqual(response_dict.status_int, 400)
 
-    def _accept_suggestion(self, thread_id, audio_update_required, csrf_token,
-                           expect_errors=False, expected_status_int=200):
-        with self.swap(exp_domain.Exploration, '_verify_all_states_reachable',
-                       self._return_null):
-            with self.swap(exp_domain.Exploration, '_verify_no_dead_ends',
-                           self._return_null):
+    def _accept_suggestion(
+            self, thread_id, audio_update_required, csrf_token,
+            expect_errors=False, expected_status_int=200):
+        with self.swap(
+            exp_domain.Exploration, '_verify_all_states_reachable',
+            self._return_null):
+            with self.swap(
+                exp_domain.Exploration, '_verify_no_dead_ends',
+                self._return_null):
                 url = '%s/%s/%s' % (
                     feconf.SUGGESTION_ACTION_URL_PREFIX, self.EXP_ID,
                     thread_id)
@@ -684,8 +693,9 @@ class SuggestionsIntegrationTests(test_utils.GenericTestBase):
                     }, csrf_token, expect_errors=expect_errors,
                     expected_status_int=expected_status_int)
 
-    def _reject_suggestion(self, thread_id, csrf_token,
-                           expect_errors=False, expected_status_int=200):
+    def _reject_suggestion(
+            self, thread_id, csrf_token,
+            expect_errors=False, expected_status_int=200):
         return self.put_json(
             '%s/%s/%s' % (
                 feconf.SUGGESTION_ACTION_URL_PREFIX, self.EXP_ID, thread_id),

--- a/core/controllers/learner_dashboard.py
+++ b/core/controllers/learner_dashboard.py
@@ -48,9 +48,10 @@ class LearnerDashboardHandler(base.BaseHandler):
     @acl_decorators.can_access_learner_dashboard
     def get(self):
         """Handles GET requests."""
-        (learner_progress, number_of_nonexistent_activities,
-         completed_to_incomplete_collections) = (
-             learner_progress_services.get_activity_progress(self.user_id))
+        (
+            learner_progress, number_of_nonexistent_activities,
+            completed_to_incomplete_collections) = (
+                learner_progress_services.get_activity_progress(self.user_id))
 
         completed_exp_summary_dicts = (
             summary_services.get_displayable_exp_summary_dicts(

--- a/core/controllers/learner_dashboard_test.py
+++ b/core/controllers/learner_dashboard_test.py
@@ -288,11 +288,12 @@ class LearnerDashboardFeedbackThreadHandlerTest(test_utils.GenericTestBase):
         # Add another message.
         thread_url = '%s/%s/%s' % (
             feconf.FEEDBACK_THREAD_URL_PREFIX, self.EXP_ID_1, thread_id)
-        self.post_json(thread_url, {
-            'updated_status': None,
-            'updated_subject': None,
-            'text': 'Message 1'
-        }, self.csrf_token)
+        self.post_json(
+            thread_url, {
+                'updated_status': None,
+                'updated_subject': None,
+                'text': 'Message 1'
+            }, self.csrf_token)
 
         # Again fetch the thread message summary.
         thread_url = '%s/%s/%s' % (

--- a/core/controllers/learner_playlist.py
+++ b/core/controllers/learner_playlist.py
@@ -33,17 +33,20 @@ class LearnerPlaylistHandler(base.BaseHandler):
         belongs_to_subscribed_activities = False
 
         if activity_type == constants.ACTIVITY_TYPE_EXPLORATION:
-            (belongs_to_completed_or_incomplete_list,
-             playlist_limit_exceeded,
-             belongs_to_subscribed_activities) = (
-                 learner_progress_services.add_exp_to_learner_playlist(
-                     self.user_id, activity_id, position_to_be_inserted_in))
+            (
+                belongs_to_completed_or_incomplete_list,
+                playlist_limit_exceeded,
+                belongs_to_subscribed_activities) = (
+                    learner_progress_services.add_exp_to_learner_playlist(
+                        self.user_id, activity_id, position_to_be_inserted_in))
         elif activity_type == constants.ACTIVITY_TYPE_COLLECTION:
-            (belongs_to_completed_or_incomplete_list,
-             playlist_limit_exceeded,
-             belongs_to_subscribed_activities) = (
-                 learner_progress_services.add_collection_to_learner_playlist(
-                     self.user_id, activity_id, position_to_be_inserted_in))
+            (
+                belongs_to_completed_or_incomplete_list,
+                playlist_limit_exceeded,
+                belongs_to_subscribed_activities) = (
+                    learner_progress_services.
+                    add_collection_to_learner_playlist(
+                        self.user_id, activity_id, position_to_be_inserted_in))
 
         self.values.update({
             'belongs_to_completed_or_incomplete_list': (

--- a/core/controllers/library.py
+++ b/core/controllers/library.py
@@ -122,23 +122,26 @@ class LibraryIndexHandler(base.BaseHandler):
             preferred_language_codes = user_settings.preferred_language_codes
 
         if top_rated_activity_summary_dicts:
-            summary_dicts_by_category.insert(0, {
-                'activity_summary_dicts': top_rated_activity_summary_dicts,
-                'categories': [],
-                'header_i18n_id': (
-                    feconf.LIBRARY_CATEGORY_TOP_RATED_EXPLORATIONS),
-                'has_full_results_page': True,
-                'full_results_url': feconf.LIBRARY_TOP_RATED_URL,
-                'protractor_id': 'top-rated',
-            })
+            summary_dicts_by_category.insert(
+                0, {
+                    'activity_summary_dicts': top_rated_activity_summary_dicts,
+                    'categories': [],
+                    'header_i18n_id': (
+                        feconf.LIBRARY_CATEGORY_TOP_RATED_EXPLORATIONS),
+                    'has_full_results_page': True,
+                    'full_results_url': feconf.LIBRARY_TOP_RATED_URL,
+                    'protractor_id': 'top-rated',
+                })
         if featured_activity_summary_dicts:
-            summary_dicts_by_category.insert(0, {
-                'activity_summary_dicts': featured_activity_summary_dicts,
-                'categories': [],
-                'header_i18n_id': feconf.LIBRARY_CATEGORY_FEATURED_ACTIVITIES,
-                'has_full_results_page': False,
-                'full_results_url': None,
-            })
+            summary_dicts_by_category.insert(
+                0, {
+                    'activity_summary_dicts': featured_activity_summary_dicts,
+                    'categories': [],
+                    'header_i18n_id': (
+                        feconf.LIBRARY_CATEGORY_FEATURED_ACTIVITIES),
+                    'has_full_results_page': False,
+                    'full_results_url': None,
+                })
 
         self.values.update({
             'activity_summary_dicts_by_category': (

--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -353,11 +353,12 @@ class ExplorationSummariesHandlerTest(test_utils.GenericTestBase):
     def test_can_get_public_exploration_summaries(self):
         self.login(self.VIEWER_EMAIL)
 
-        response_dict = self.get_json(feconf.EXPLORATION_SUMMARIES_DATA_URL, {
-            'stringified_exp_ids': json.dumps([
-                self.PRIVATE_EXP_ID_EDITOR, self.PUBLIC_EXP_ID_EDITOR,
-                self.PRIVATE_EXP_ID_VIEWER])
-        })
+        response_dict = self.get_json(
+            feconf.EXPLORATION_SUMMARIES_DATA_URL, {
+                'stringified_exp_ids': json.dumps([
+                    self.PRIVATE_EXP_ID_EDITOR, self.PUBLIC_EXP_ID_EDITOR,
+                    self.PRIVATE_EXP_ID_VIEWER])
+            })
         self.assertIn('summaries', response_dict)
 
         summaries = response_dict['summaries']
@@ -371,12 +372,13 @@ class ExplorationSummariesHandlerTest(test_utils.GenericTestBase):
     def test_can_get_editable_private_exploration_summaries(self):
         self.login(self.VIEWER_EMAIL)
 
-        response_dict = self.get_json(feconf.EXPLORATION_SUMMARIES_DATA_URL, {
-            'stringified_exp_ids': json.dumps([
-                self.PRIVATE_EXP_ID_EDITOR, self.PUBLIC_EXP_ID_EDITOR,
-                self.PRIVATE_EXP_ID_VIEWER]),
-            'include_private_explorations': True
-        })
+        response_dict = self.get_json(
+            feconf.EXPLORATION_SUMMARIES_DATA_URL, {
+                'stringified_exp_ids': json.dumps([
+                    self.PRIVATE_EXP_ID_EDITOR, self.PUBLIC_EXP_ID_EDITOR,
+                    self.PRIVATE_EXP_ID_VIEWER]),
+                'include_private_explorations': True
+            })
         self.assertIn('summaries', response_dict)
 
         summaries = response_dict['summaries']
@@ -393,12 +395,13 @@ class ExplorationSummariesHandlerTest(test_utils.GenericTestBase):
             self.editor, self.PRIVATE_EXP_ID_EDITOR, self.viewer_id,
             rights_manager.ROLE_EDITOR)
 
-        response_dict = self.get_json(feconf.EXPLORATION_SUMMARIES_DATA_URL, {
-            'stringified_exp_ids': json.dumps([
-                self.PRIVATE_EXP_ID_EDITOR, self.PUBLIC_EXP_ID_EDITOR,
-                self.PRIVATE_EXP_ID_VIEWER]),
-            'include_private_explorations': True
-        })
+        response_dict = self.get_json(
+            feconf.EXPLORATION_SUMMARIES_DATA_URL, {
+                'stringified_exp_ids': json.dumps([
+                    self.PRIVATE_EXP_ID_EDITOR, self.PUBLIC_EXP_ID_EDITOR,
+                    self.PRIVATE_EXP_ID_VIEWER]),
+                'include_private_explorations': True
+            })
         self.assertIn('summaries', response_dict)
 
         summaries = response_dict['summaries']
@@ -414,12 +417,13 @@ class ExplorationSummariesHandlerTest(test_utils.GenericTestBase):
         self.logout()
 
     def test_cannot_get_private_exploration_summaries_when_logged_out(self):
-        response_dict = self.get_json(feconf.EXPLORATION_SUMMARIES_DATA_URL, {
-            'stringified_exp_ids': json.dumps([
-                self.PRIVATE_EXP_ID_EDITOR, self.PUBLIC_EXP_ID_EDITOR,
-                self.PRIVATE_EXP_ID_VIEWER]),
-            'include_private_explorations': True
-        })
+        response_dict = self.get_json(
+            feconf.EXPLORATION_SUMMARIES_DATA_URL, {
+                'stringified_exp_ids': json.dumps([
+                    self.PRIVATE_EXP_ID_EDITOR, self.PUBLIC_EXP_ID_EDITOR,
+                    self.PRIVATE_EXP_ID_VIEWER]),
+                'include_private_explorations': True
+            })
         self.assertIn('summaries', response_dict)
 
         summaries = response_dict['summaries']

--- a/core/controllers/moderator_test.py
+++ b/core/controllers/moderator_test.py
@@ -77,28 +77,31 @@ class FeaturedActivitiesHandlerTest(test_utils.GenericTestBase):
         csrf_token = self.get_csrf_token_from_response(response)
 
         # Posting a list that includes private activities results in an error.
-        self.post_json('/moderatorhandler/featured', {
-            'featured_activity_reference_dicts': [{
-                'type': 'exploration',
-                'id': self.EXP_ID_2,
-            }],
-        }, csrf_token, expect_errors=True, expected_status_int=400)
-        self.post_json('/moderatorhandler/featured', {
-            'featured_activity_reference_dicts': [{
-                'type': 'exploration',
-                'id': self.EXP_ID_1,
-            }, {
-                'type': 'exploration',
-                'id': self.EXP_ID_2,
-            }],
-        }, csrf_token, expect_errors=True, expected_status_int=400)
+        self.post_json(
+            '/moderatorhandler/featured', {
+                'featured_activity_reference_dicts': [{
+                    'type': 'exploration',
+                    'id': self.EXP_ID_2,
+                }],
+            }, csrf_token, expect_errors=True, expected_status_int=400)
+        self.post_json(
+            '/moderatorhandler/featured', {
+                'featured_activity_reference_dicts': [{
+                    'type': 'exploration',
+                    'id': self.EXP_ID_1,
+                }, {
+                    'type': 'exploration',
+                    'id': self.EXP_ID_2,
+                }],
+            }, csrf_token, expect_errors=True, expected_status_int=400)
 
         # Posting a list that only contains public activities succeeds.
-        self.post_json('/moderatorhandler/featured', {
-            'featured_activity_reference_dicts': [{
-                'type': 'exploration',
-                'id': self.EXP_ID_1,
-            }],
-        }, csrf_token)
+        self.post_json(
+            '/moderatorhandler/featured', {
+                'featured_activity_reference_dicts': [{
+                    'type': 'exploration',
+                    'id': self.EXP_ID_1,
+                }],
+            }, csrf_token)
 
         self.logout()

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -166,16 +166,18 @@ class UsernameCheckHandlerTests(test_utils.GenericTestBase):
         response_dict = self.post_json(
             feconf.USERNAME_CHECK_DATA_URL, {'username': 'abc'},
             csrf_token=csrf_token)
-        self.assertEqual(response_dict, {
-            'username_is_taken': True
-        })
+        self.assertEqual(
+            response_dict, {
+                'username_is_taken': True
+            })
 
         response_dict = self.post_json(
             feconf.USERNAME_CHECK_DATA_URL, {'username': 'def'},
             csrf_token=csrf_token)
-        self.assertEqual(response_dict, {
-            'username_is_taken': False
-        })
+        self.assertEqual(
+            response_dict, {
+                'username_is_taken': False
+            })
 
         response_dict = self.post_json(
             feconf.USERNAME_CHECK_DATA_URL, {'username': '!!!INVALID!!!'},
@@ -595,11 +597,12 @@ class UserContributionsTests(test_utils.GenericTestBase):
             self.EXP_ID_1, user_a_id, end_state_name='End')
         rights_manager.publish_exploration(user_a, self.EXP_ID_1)
 
-        exp_services.update_exploration(user_b_id, self.EXP_ID_1, [{
-            'cmd': 'edit_exploration_property',
-            'property_name': 'objective',
-            'new_value': 'the objective'
-        }], 'Test edit')
+        exp_services.update_exploration(
+            user_b_id, self.EXP_ID_1, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'objective',
+                'new_value': 'the objective'
+            }], 'Test edit')
 
         response_dict = self.get_json(
             '/profilehandler/data/%s' % self.USERNAME_B)
@@ -627,10 +630,11 @@ class SiteLanguageHandlerTests(test_utils.GenericTestBase):
         response = self.testapp.get('/preferences')
         self.assertEqual(response.status_int, 200)
         csrf_token = self.get_csrf_token_from_response(response)
-        self.put_json('/preferenceshandler/data', {
-            'update_type': 'preferred_site_language_code',
-            'data': language_code,
-        }, csrf_token)
+        self.put_json(
+            '/preferenceshandler/data', {
+                'update_type': 'preferred_site_language_code',
+                'data': language_code,
+            }, csrf_token)
 
         preferences = self.get_json('/preferenceshandler/data')
         self.assertIsNotNone(preferences)
@@ -652,10 +656,11 @@ class LongUserBioHandlerTests(test_utils.GenericTestBase):
         response = self.testapp.get('/preferences')
         self.assertEqual(response.status_int, 200)
         csrf_token = self.get_csrf_token_from_response(response)
-        self.put_json('/preferenceshandler/data', {
-            'update_type': 'user_bio',
-            'data': 'I am within 2000 char limit',
-        }, csrf_token)
+        self.put_json(
+            '/preferenceshandler/data', {
+                'update_type': 'user_bio',
+                'data': 'I am within 2000 char limit',
+            }, csrf_token)
         preferences = self.get_json('/preferenceshandler/data')
         self.assertIsNotNone(preferences)
         self.assertEqual(

--- a/core/controllers/question_test.py
+++ b/core/controllers/question_test.py
@@ -137,8 +137,9 @@ class QuestionsHandlersTest(test_utils.GenericTestBase):
             expected_status_int=404)
 
         payload['commit_message'] = 'update title'
-        self.put_json(feconf.QUESTION_DATA_URL, payload, csrf_token,
-                      expect_errors=True, expected_status_int=404)
+        self.put_json(
+            feconf.QUESTION_DATA_URL, payload, csrf_token,
+            expect_errors=True, expected_status_int=404)
 
         self.logout()
         self.login(self.random_email)

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -194,8 +194,9 @@ class ExplorationStateClassifierMappingTests(test_utils.GenericTestBase):
         retrieved_state_classifier_mapping = exploration_dict[
             'state_classifier_mapping']
 
-        self.assertEqual(expected_state_classifier_mapping,
-                         retrieved_state_classifier_mapping)
+        self.assertEqual(
+            expected_state_classifier_mapping,
+            retrieved_state_classifier_mapping)
 
 
 class ExplorationParametersUnitTests(test_utils.GenericTestBase):
@@ -1132,9 +1133,10 @@ class LearnerProgressTest(test_utils.GenericTestBase):
         # Remove one exploration.
         self.testapp.delete(str(
             '%s/%s/%s' %
-            (feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,
-             constants.ACTIVITY_TYPE_EXPLORATION,
-             self.EXP_ID_0)))
+            (
+                feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,
+                constants.ACTIVITY_TYPE_EXPLORATION,
+                self.EXP_ID_0)))
         self.assertEqual(
             learner_progress_services.get_all_incomplete_exp_ids(
                 self.user_id), [self.EXP_ID_1])
@@ -1142,9 +1144,10 @@ class LearnerProgressTest(test_utils.GenericTestBase):
         # Remove another exploration.
         self.testapp.delete(str(
             '%s/%s/%s' %
-            (feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,
-             constants.ACTIVITY_TYPE_EXPLORATION,
-             self.EXP_ID_1)))
+            (
+                feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,
+                constants.ACTIVITY_TYPE_EXPLORATION,
+                self.EXP_ID_1)))
         self.assertEqual(
             learner_progress_services.get_all_incomplete_exp_ids(
                 self.user_id), [])
@@ -1166,9 +1169,10 @@ class LearnerProgressTest(test_utils.GenericTestBase):
         # Remove one collection.
         self.testapp.delete(str(
             '%s/%s/%s' %
-            (feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,
-             constants.ACTIVITY_TYPE_COLLECTION,
-             self.COL_ID_0)))
+            (
+                feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,
+                constants.ACTIVITY_TYPE_COLLECTION,
+                self.COL_ID_0)))
         self.assertEqual(
             learner_progress_services.get_all_incomplete_collection_ids(
                 self.user_id), [self.COL_ID_1])
@@ -1176,9 +1180,10 @@ class LearnerProgressTest(test_utils.GenericTestBase):
         # Remove another collection.
         self.testapp.delete(str(
             '%s/%s/%s' %
-            (feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,
-             constants.ACTIVITY_TYPE_COLLECTION,
-             self.COL_ID_1)))
+            (
+                feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,
+                constants.ACTIVITY_TYPE_COLLECTION,
+                self.COL_ID_1)))
         self.assertEqual(
             learner_progress_services.get_all_incomplete_collection_ids(
                 self.user_id), [])

--- a/core/controllers/resources_test.py
+++ b/core/controllers/resources_test.py
@@ -364,10 +364,11 @@ class AudioHandlerTest(test_utils.GenericTestBase):
         )
         self.logout()
         self.assertEqual(response_dict['status_code'], 400)
-        self.assertEqual(response_dict['error'],
-                         'No filename extension: it should have '
-                         'one of the following extensions: '
-                         '%s' % feconf.ACCEPTED_AUDIO_EXTENSIONS.keys())
+        self.assertEqual(
+            response_dict['error'],
+            'No filename extension: it should have '
+            'one of the following extensions: '
+            '%s' % feconf.ACCEPTED_AUDIO_EXTENSIONS.keys())
 
     def test_exceed_max_length_detected(self):
         """Test that audio file is less than max playback length."""

--- a/core/domain/classifier_domain.py
+++ b/core/domain/classifier_domain.py
@@ -72,9 +72,10 @@ class ClassifierTrainingJob(object):
 
     """
 
-    def __init__(self, job_id, algorithm_id, interaction_id, exp_id,
-                 exp_version, next_scheduled_check_time, state_name, status,
-                 training_data, classifier_data, data_schema_version):
+    def __init__(
+            self, job_id, algorithm_id, interaction_id, exp_id,
+            exp_version, next_scheduled_check_time, state_name, status,
+            training_data, classifier_data, data_schema_version):
         """Constructs a ClassifierTrainingJob domain object.
 
         Args:

--- a/core/domain/classifier_domain_test.py
+++ b/core/domain/classifier_domain_test.py
@@ -69,8 +69,9 @@ class ClassifierTrainingJobDomainTests(test_utils.GenericTestBase):
         }
         observed_training_job = self._get_training_job_from_dict(
             expected_training_job_dict)
-        self.assertDictEqual(expected_training_job_dict,
-                             observed_training_job.to_dict())
+        self.assertDictEqual(
+            expected_training_job_dict,
+            observed_training_job.to_dict())
 
     def test_validation(self):
         """Tests to verify validate method of ClassifierTrainingJob domain."""
@@ -179,8 +180,9 @@ class TrainingJobExplorationMappingDomainTests(test_utils.GenericTestBase):
         }
         observed_mapping = self._get_mapping_from_dict(
             expected_mapping_dict)
-        self.assertDictEqual(expected_mapping_dict,
-                             observed_mapping.to_dict())
+        self.assertDictEqual(
+            expected_mapping_dict,
+            observed_mapping.to_dict())
 
     def test_validation(self):
         """Tests to verify validate method of TrainingJobExplorationMapping

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -230,18 +230,21 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
             state_name, feconf.TRAINING_JOB_STATUS_NEW, {}, 1)
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
-        self.assertEqual(classifier_training_job.algorithm_id,
-                         feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput'][
-                             'algorithm_id'])
+        self.assertEqual(
+            classifier_training_job.algorithm_id,
+            feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput'][
+                'algorithm_id'])
         self.assertEqual(classifier_training_job.interaction_id, interaction_id)
         self.assertEqual(classifier_training_job.exp_id, exp_id)
         self.assertEqual(classifier_training_job.exp_version, 1)
-        self.assertEqual(classifier_training_job.next_scheduled_check_time,
-                         next_scheduled_check_time)
+        self.assertEqual(
+            classifier_training_job.next_scheduled_check_time,
+            next_scheduled_check_time)
         self.assertEqual(classifier_training_job.training_data, [])
         self.assertEqual(classifier_training_job.state_name, state_name)
-        self.assertEqual(classifier_training_job.status,
-                         feconf.TRAINING_JOB_STATUS_NEW)
+        self.assertEqual(
+            classifier_training_job.status,
+            feconf.TRAINING_JOB_STATUS_NEW)
         self.assertEqual(classifier_training_job.classifier_data, {})
         self.assertEqual(classifier_training_job.data_schema_version, 1)
 
@@ -279,15 +282,17 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
 
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
-        self.assertEqual(classifier_training_job.status,
-                         feconf.TRAINING_JOB_STATUS_PENDING)
+        self.assertEqual(
+            classifier_training_job.status,
+            feconf.TRAINING_JOB_STATUS_PENDING)
 
         classifier_services.mark_training_job_complete(job_id)
 
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
-        self.assertEqual(classifier_training_job.status,
-                         feconf.TRAINING_JOB_STATUS_COMPLETE)
+        self.assertEqual(
+            classifier_training_job.status,
+            feconf.TRAINING_JOB_STATUS_COMPLETE)
 
         # Test that invalid status changes cannot be made.
         with self.assertRaisesRegexp(Exception, (
@@ -311,15 +316,17 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
 
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
-        self.assertEqual(classifier_training_job.status,
-                         feconf.TRAINING_JOB_STATUS_NEW)
+        self.assertEqual(
+            classifier_training_job.status,
+            feconf.TRAINING_JOB_STATUS_NEW)
 
         classifier_services.mark_training_job_pending(job_id)
 
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
-        self.assertEqual(classifier_training_job.status,
-                         feconf.TRAINING_JOB_STATUS_PENDING)
+        self.assertEqual(
+            classifier_training_job.status,
+            feconf.TRAINING_JOB_STATUS_PENDING)
 
         # Test that invalid status changes cannot be made.
         with self.assertRaisesRegexp(Exception, (
@@ -343,15 +350,17 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
 
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
-        self.assertEqual(classifier_training_job.status,
-                         feconf.TRAINING_JOB_STATUS_PENDING)
+        self.assertEqual(
+            classifier_training_job.status,
+            feconf.TRAINING_JOB_STATUS_PENDING)
 
         classifier_services.mark_training_jobs_failed([job_id])
 
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
-        self.assertEqual(classifier_training_job.status,
-                         feconf.TRAINING_JOB_STATUS_FAILED)
+        self.assertEqual(
+            classifier_training_job.status,
+            feconf.TRAINING_JOB_STATUS_FAILED)
 
         # Test that invalid status changes cannot be made.
         with self.assertRaisesRegexp(Exception, (

--- a/core/domain/collection_domain.py
+++ b/core/domain/collection_domain.py
@@ -283,9 +283,10 @@ class CollectionNode(object):
 class Collection(object):
     """Domain object for an Oppia collection."""
 
-    def __init__(self, collection_id, title, category, objective,
-                 language_code, tags, schema_version, nodes,
-                 version, created_on=None, last_updated=None):
+    def __init__(
+            self, collection_id, title, category, objective,
+            language_code, tags, schema_version, nodes,
+            version, created_on=None, last_updated=None):
         """Constructs a new collection given all the information necessary to
         represent a collection.
 
@@ -1059,11 +1060,12 @@ class Collection(object):
 class CollectionSummary(object):
     """Domain object for an Oppia collection summary."""
 
-    def __init__(self, collection_id, title, category, objective, language_code,
-                 tags, status, community_owned, owner_ids, editor_ids,
-                 viewer_ids, contributor_ids, contributors_summary, version,
-                 node_count, collection_model_created_on,
-                 collection_model_last_updated):
+    def __init__(
+            self, collection_id, title, category, objective, language_code,
+            tags, status, community_owned, owner_ids, editor_ids,
+            viewer_ids, contributor_ids, contributors_summary, version,
+            node_count, collection_model_created_on,
+            collection_model_last_updated):
         """Constructs a CollectionSummary domain object.
 
         Args:

--- a/core/domain/collection_jobs_one_off.py
+++ b/core/domain/collection_jobs_one_off.py
@@ -48,8 +48,9 @@ class CollectionMigrationJob(jobs.BaseMapReduceOneOffJobManager):
     @staticmethod
     def map(item):
         if item.deleted:
-            yield (CollectionMigrationJob._DELETED_KEY,
-                   'Encountered deleted collection.')
+            yield (
+                CollectionMigrationJob._DELETED_KEY,
+                'Encountered deleted collection.')
             return
 
         # Note: the read will bring the collection up to the newest version.
@@ -59,8 +60,9 @@ class CollectionMigrationJob(jobs.BaseMapReduceOneOffJobManager):
         except Exception as e:
             logging.error(
                 'Collection %s failed validation: %s' % (item.id, e))
-            yield (CollectionMigrationJob._ERROR_KEY,
-                   'Collection %s failed validation: %s' % (item.id, e))
+            yield (
+                CollectionMigrationJob._ERROR_KEY,
+                'Collection %s failed validation: %s' % (item.id, e))
             return
 
         # Write the new collection into the datastore if it's different from
@@ -76,8 +78,9 @@ class CollectionMigrationJob(jobs.BaseMapReduceOneOffJobManager):
                 feconf.MIGRATION_BOT_USERNAME, item.id, commit_cmds,
                 'Update collection schema version to %d.' % (
                     feconf.CURRENT_COLLECTION_SCHEMA_VERSION))
-            yield (CollectionMigrationJob._MIGRATED_KEY,
-                   'Collection successfully migrated.')
+            yield (
+                CollectionMigrationJob._MIGRATED_KEY,
+                'Collection successfully migrated.')
 
     @staticmethod
     def reduce(key, values):

--- a/core/domain/collection_services.py
+++ b/core/domain/collection_services.py
@@ -799,11 +799,12 @@ def save_new_collection(committer_id, collection):
     """
     commit_message = (
         'New collection created with title \'%s\'.' % collection.title)
-    _create_collection(committer_id, collection, commit_message, [{
-        'cmd': CMD_CREATE_NEW,
-        'title': collection.title,
-        'category': collection.category,
-    }])
+    _create_collection(
+        committer_id, collection, commit_message, [{
+            'cmd': CMD_CREATE_NEW,
+            'title': collection.title,
+            'category': collection.category,
+        }])
 
 
 def delete_collection(committer_id, collection_id, force_deletion=False):
@@ -1098,11 +1099,12 @@ def save_new_collection_from_yaml(committer_id, yaml_content, collection_id):
         'New collection created from YAML file with title \'%s\'.'
         % collection.title)
 
-    _create_collection(committer_id, collection, commit_message, [{
-        'cmd': CMD_CREATE_NEW,
-        'title': collection.title,
-        'category': collection.category,
-    }])
+    _create_collection(
+        committer_id, collection, commit_message, [{
+            'cmd': CMD_CREATE_NEW,
+            'title': collection.title,
+            'category': collection.category,
+        }])
 
     return collection
 

--- a/core/domain/collection_services_test.py
+++ b/core/domain/collection_services_test.py
@@ -243,8 +243,9 @@ class CollectionProgressUnitTests(CollectionServicesUnitTests):
         completion_model = self._get_progress_model(
             self.owner_id, self.COL_ID_0)
         self.assertIsNotNone(completion_model)
-        self.assertEqual(completion_model.completed_explorations, [
-            self.EXP_ID_0])
+        self.assertEqual(
+            completion_model.completed_explorations, [
+                self.EXP_ID_0])
 
         # If the same exploration is completed again within the context of this
         # collection, it should not be duplicated.
@@ -252,8 +253,9 @@ class CollectionProgressUnitTests(CollectionServicesUnitTests):
             self.owner_id, self.COL_ID_0, self.EXP_ID_0)
         completion_model = self._get_progress_model(
             self.owner_id, self.COL_ID_0)
-        self.assertEqual(completion_model.completed_explorations, [
-            self.EXP_ID_0])
+        self.assertEqual(
+            completion_model.completed_explorations, [
+                self.EXP_ID_0])
 
         # If the same exploration and another are completed within the context
         # of a different collection, it shouldn't affect this one.
@@ -264,8 +266,9 @@ class CollectionProgressUnitTests(CollectionServicesUnitTests):
             self.owner_id, self.COL_ID_1, self.EXP_ID_1)
         completion_model = self._get_progress_model(
             self.owner_id, self.COL_ID_0)
-        self.assertEqual(completion_model.completed_explorations, [
-            self.EXP_ID_0])
+        self.assertEqual(
+            completion_model.completed_explorations, [
+                self.EXP_ID_0])
 
         # If two more explorations are completed, they are recorded in the
         # order they are completed.
@@ -275,8 +278,9 @@ class CollectionProgressUnitTests(CollectionServicesUnitTests):
             self.owner_id, self.COL_ID_0, self.EXP_ID_1)
         completion_model = self._get_progress_model(
             self.owner_id, self.COL_ID_0)
-        self.assertEqual(completion_model.completed_explorations, [
-            self.EXP_ID_0, self.EXP_ID_2, self.EXP_ID_1])
+        self.assertEqual(
+            completion_model.completed_explorations, [
+                self.EXP_ID_0, self.EXP_ID_2, self.EXP_ID_1])
 
 
 class CollectionSummaryQueriesUnitTests(CollectionServicesUnitTests):
@@ -506,16 +510,19 @@ class CollectionCreateAndDeleteUnitTests(CollectionServicesUnitTests):
             _count_at_least_editable_collection_summaries(self.owner_id), 0)
 
         # But the models still exist in the backend.
-        self.assertIn(self.COLLECTION_ID, [
-            collection.id
-            for collection in collection_models.CollectionModel.get_all(
-                include_deleted=True)])
+        self.assertIn(
+            self.COLLECTION_ID, [
+                collection.id
+                for collection in collection_models.CollectionModel.get_all(
+                    include_deleted=True)])
 
         # The collection summary is deleted, however.
-        self.assertNotIn(self.COLLECTION_ID, [
-            collection.id
-            for collection in collection_models.CollectionSummaryModel.get_all(
-                include_deleted=True)])
+        self.assertNotIn(
+            self.COLLECTION_ID, [
+                collection.id
+                for collection in
+                collection_models.CollectionSummaryModel.get_all(
+                    include_deleted=True)])
 
     def test_hard_deletion_of_collections(self):
         """Test that hard deletion of collections works correctly."""
@@ -534,10 +541,11 @@ class CollectionCreateAndDeleteUnitTests(CollectionServicesUnitTests):
             _count_at_least_editable_collection_summaries(self.owner_id), 0)
 
         # The collection model has been purged from the backend.
-        self.assertNotIn(self.COLLECTION_ID, [
-            collection.id
-            for collection in collection_models.CollectionModel.get_all(
-                include_deleted=True)])
+        self.assertNotIn(
+            self.COLLECTION_ID, [
+                collection.id
+                for collection in collection_models.CollectionModel.get_all(
+                    include_deleted=True)])
 
     def test_summaries_of_hard_deleted_collections(self):
         """Test that summaries of hard deleted collections are
@@ -555,10 +563,12 @@ class CollectionCreateAndDeleteUnitTests(CollectionServicesUnitTests):
             _count_at_least_editable_collection_summaries(self.owner_id), 0)
 
         # The collection summary model has been purged from the backend.
-        self.assertNotIn(self.COLLECTION_ID, [
-            collection.id
-            for collection in collection_models.CollectionSummaryModel.get_all(
-                include_deleted=True)])
+        self.assertNotIn(
+            self.COLLECTION_ID, [
+                collection.id
+                for collection in
+                collection_models.CollectionSummaryModel.get_all(
+                    include_deleted=True)])
 
     def test_collections_are_removed_from_index_when_deleted(self):
         """Tests that deleted collections are removed from the search index."""
@@ -623,8 +633,9 @@ class CollectionCreateAndDeleteUnitTests(CollectionServicesUnitTests):
             collection_services.get_collection_summary_by_id(
                 self.COLLECTION_ID))
 
-        self.assertEqual(retrieved_collection_summary.contributor_ids,
-                         [self.owner_id])
+        self.assertEqual(
+            retrieved_collection_summary.contributor_ids,
+            [self.owner_id])
         self.assertEqual(retrieved_collection_summary.title, 'A new title')
         self.assertEqual(
             retrieved_collection_summary.category, 'A new category')
@@ -1394,9 +1405,10 @@ class CollectionSearchTests(CollectionServicesUnitTests):
             return ids
 
         add_docs_counter = test_utils.CallCounter(mock_add_documents_to_index)
-        add_docs_swap = self.swap(gae_search_services,
-                                  'add_documents_to_index',
-                                  add_docs_counter)
+        add_docs_swap = self.swap(
+            gae_search_services,
+            'add_documents_to_index',
+            add_docs_counter)
 
         for ind in xrange(5):
             self.save_new_valid_collection(
@@ -1515,19 +1527,22 @@ class CollectionSummaryTests(CollectionServicesUnitTests):
          # Have Bob update that collection. Version 2.
         collection_services.update_collection(
             bob_id, self.COLLECTION_ID, changelist_cmds, 'Changed title.')
-        self._check_contributors_summary(self.COLLECTION_ID,
-                                         {albert_id: 1, bob_id: 1})
+        self._check_contributors_summary(
+            self.COLLECTION_ID,
+            {albert_id: 1, bob_id: 1})
         # Have Bob update that collection. Version 3.
         collection_services.update_collection(
             bob_id, self.COLLECTION_ID, changelist_cmds, 'Changed title.')
-        self._check_contributors_summary(self.COLLECTION_ID,
-                                         {albert_id: 1, bob_id: 2})
+        self._check_contributors_summary(
+            self.COLLECTION_ID,
+            {albert_id: 1, bob_id: 2})
 
         # Have Albert update that collection. Version 4.
         collection_services.update_collection(
             albert_id, self.COLLECTION_ID, changelist_cmds, 'Changed title.')
-        self._check_contributors_summary(self.COLLECTION_ID,
-                                         {albert_id: 2, bob_id: 2})
+        self._check_contributors_summary(
+            self.COLLECTION_ID,
+            {albert_id: 2, bob_id: 2})
 
         # TODO(madiyar): uncomment after revert_collection implementation
         # Have Albert revert to version 3. Version 5

--- a/core/domain/config_domain.py
+++ b/core/domain/config_domain.py
@@ -171,10 +171,11 @@ class ConfigProperty(object):
             model_instance = config_models.ConfigPropertyModel(
                 id=self.name)
         model_instance.value = value
-        model_instance.commit(committer_id, [{
-            'cmd': CMD_CHANGE_PROPERTY_VALUE,
-            'new_value': value
-        }])
+        model_instance.commit(
+            committer_id, [{
+                'cmd': CMD_CHANGE_PROPERTY_VALUE,
+                'new_value': value
+            }])
 
         # Set value in memcache.
         memcache_services.set_multi({

--- a/core/domain/email_jobs_one_off_test.py
+++ b/core/domain/email_jobs_one_off_test.py
@@ -53,8 +53,9 @@ class EmailHashRegenerationOneOffJobTests(test_utils.GenericTestBase):
 
         generate_constant_hash_ctx = self.swap(
             email_models.SentEmailModel, '_generate_hash',
-            types.MethodType(_generate_hash_for_tests,
-                             email_models.SentEmailModel))
+            types.MethodType(
+                _generate_hash_for_tests,
+                email_models.SentEmailModel))
 
         with generate_constant_hash_ctx:
             email_models.SentEmailModel.create(

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -415,10 +415,11 @@ class SignupEmailTests(test_utils.GenericTestBase):
             response = self.testapp.get(feconf.SIGNUP_URL)
             csrf_token = self.get_csrf_token_from_response(response)
 
-            self.post_json(feconf.SIGNUP_DATA_URL, {
-                'agreed_to_terms': True,
-                'username': self.EDITOR_USERNAME
-            }, csrf_token=csrf_token)
+            self.post_json(
+                feconf.SIGNUP_DATA_URL, {
+                    'agreed_to_terms': True,
+                    'username': self.EDITOR_USERNAME
+                }, csrf_token=csrf_token)
 
             # Check that no email was sent.
             messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)
@@ -445,10 +446,11 @@ class SignupEmailTests(test_utils.GenericTestBase):
             csrf_token = self.get_csrf_token_from_response(response)
 
             # No user-facing error should surface.
-            self.post_json(feconf.SIGNUP_DATA_URL, {
-                'agreed_to_terms': True,
-                'username': self.EDITOR_USERNAME
-            }, csrf_token=csrf_token)
+            self.post_json(
+                feconf.SIGNUP_DATA_URL, {
+                    'agreed_to_terms': True,
+                    'username': self.EDITOR_USERNAME
+                }, csrf_token=csrf_token)
 
             # However, an error should be recorded in the logs.
             self.assertEqual(log_new_error_counter.times_called, 1)
@@ -491,10 +493,11 @@ class SignupEmailTests(test_utils.GenericTestBase):
             csrf_token = self.get_csrf_token_from_response(response)
 
             # No user-facing error should surface.
-            self.post_json(feconf.SIGNUP_DATA_URL, {
-                'agreed_to_terms': True,
-                'username': self.EDITOR_USERNAME
-            }, csrf_token=csrf_token)
+            self.post_json(
+                feconf.SIGNUP_DATA_URL, {
+                    'agreed_to_terms': True,
+                    'username': self.EDITOR_USERNAME
+                }, csrf_token=csrf_token)
 
             # However, an error should be recorded in the logs.
             self.assertEqual(log_new_error_counter.times_called, 1)
@@ -535,10 +538,11 @@ class SignupEmailTests(test_utils.GenericTestBase):
             csrf_token = self.get_csrf_token_from_response(response)
 
             # No user-facing error should surface.
-            self.post_json(feconf.SIGNUP_DATA_URL, {
-                'agreed_to_terms': True,
-                'username': self.EDITOR_USERNAME
-            }, csrf_token=csrf_token)
+            self.post_json(
+                feconf.SIGNUP_DATA_URL, {
+                    'agreed_to_terms': True,
+                    'username': self.EDITOR_USERNAME
+                }, csrf_token=csrf_token)
 
             # However, an error should be recorded in the logs.
             self.assertEqual(log_new_error_counter.times_called, 1)
@@ -565,10 +569,11 @@ class SignupEmailTests(test_utils.GenericTestBase):
             response = self.testapp.get(feconf.SIGNUP_URL)
             csrf_token = self.get_csrf_token_from_response(response)
 
-            self.post_json(feconf.SIGNUP_DATA_URL, {
-                'agreed_to_terms': True,
-                'username': self.EDITOR_USERNAME
-            }, csrf_token=csrf_token)
+            self.post_json(
+                feconf.SIGNUP_DATA_URL, {
+                    'agreed_to_terms': True,
+                    'username': self.EDITOR_USERNAME
+                }, csrf_token=csrf_token)
 
             # Check that an email was sent with the correct content.
             messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)
@@ -597,20 +602,22 @@ class SignupEmailTests(test_utils.GenericTestBase):
             response = self.testapp.get(feconf.SIGNUP_URL)
             csrf_token = self.get_csrf_token_from_response(response)
 
-            self.post_json(feconf.SIGNUP_DATA_URL, {
-                'agreed_to_terms': True,
-                'username': self.EDITOR_USERNAME
-            }, csrf_token=csrf_token)
+            self.post_json(
+                feconf.SIGNUP_DATA_URL, {
+                    'agreed_to_terms': True,
+                    'username': self.EDITOR_USERNAME
+                }, csrf_token=csrf_token)
 
             # Check that an email was sent.
             messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)
             self.assertEqual(1, len(messages))
 
             # Send a second POST request.
-            self.post_json(feconf.SIGNUP_DATA_URL, {
-                'agreed_to_terms': True,
-                'username': self.EDITOR_USERNAME
-            }, csrf_token=csrf_token)
+            self.post_json(
+                feconf.SIGNUP_DATA_URL, {
+                    'agreed_to_terms': True,
+                    'username': self.EDITOR_USERNAME
+                }, csrf_token=csrf_token)
 
             # Check that no new email was sent.
             messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)
@@ -644,10 +651,11 @@ class SignupEmailTests(test_utils.GenericTestBase):
             self.assertEqual(0, len(messages))
 
             # Redo the signup process with a good username.
-            self.post_json(feconf.SIGNUP_DATA_URL, {
-                'agreed_to_terms': True,
-                'username': self.EDITOR_USERNAME
-            }, csrf_token=csrf_token)
+            self.post_json(
+                feconf.SIGNUP_DATA_URL, {
+                    'agreed_to_terms': True,
+                    'username': self.EDITOR_USERNAME
+                }, csrf_token=csrf_token)
 
             # Check that a new email was sent.
             messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)
@@ -672,10 +680,11 @@ class SignupEmailTests(test_utils.GenericTestBase):
             response = self.testapp.get(feconf.SIGNUP_URL)
             csrf_token = self.get_csrf_token_from_response(response)
 
-            self.post_json(feconf.SIGNUP_DATA_URL, {
-                'agreed_to_terms': True,
-                'username': self.EDITOR_USERNAME
-            }, csrf_token=csrf_token)
+            self.post_json(
+                feconf.SIGNUP_DATA_URL, {
+                    'agreed_to_terms': True,
+                    'username': self.EDITOR_USERNAME
+                }, csrf_token=csrf_token)
 
             # Check that a new email was sent.
             messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)
@@ -737,8 +746,9 @@ class DuplicateEmailTests(test_utils.GenericTestBase):
 
         self.generate_hash_ctx = self.swap(
             email_models.SentEmailModel, '_generate_hash',
-            types.MethodType(_generate_hash_for_tests,
-                             email_models.SentEmailModel))
+            types.MethodType(
+                _generate_hash_for_tests,
+                email_models.SentEmailModel))
 
     def test_send_email_does_not_resend_if_same_hash_exists(self):
         can_send_emails_ctx = self.swap(
@@ -1834,8 +1844,8 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
         # Both users have disabled all emails globally, therefore they
         # should not receive any emails.
         for user_id in user_ids:
-            user_services.update_email_preferences(user_id, True, True, False,
-                                                   True)
+            user_services.update_email_preferences(
+                user_id, True, True, False, True)
 
         self.assertListEqual(email_manager.can_users_receive_thread_email(
             user_ids, exp_id, True), [False, False])
@@ -1849,8 +1859,8 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
             user_ids[0], exp_id, mute_feedback_notifications=False)
         user_services.set_email_preferences_for_exploration(
             user_ids[1], exp_id, mute_suggestion_notifications=False)
-        user_services.update_email_preferences(user_id, True, True, False,
-                                               True)
+        user_services.update_email_preferences(
+            user_id, True, True, False, True)
         self.assertListEqual(email_manager.can_users_receive_thread_email(
             user_ids, exp_id, True), [False, False])
         self.assertTrue(email_manager.can_users_receive_thread_email(
@@ -1859,8 +1869,8 @@ class EmailPreferencesTests(test_utils.GenericTestBase):
         # Both user have enabled all emails globally, therefore they should
         # receive all emails.
         for user_id in user_ids:
-            user_services.update_email_preferences(user_id, True, True, True,
-                                                   True)
+            user_services.update_email_preferences(
+                user_id, True, True, True, True)
 
         self.assertListEqual(email_manager.can_users_receive_thread_email(
             user_ids, exp_id, True), [True, True])

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -523,11 +523,13 @@ class SubtitledHtml(object):
         Returns:
             SubtitledHtml. The corresponding SubtitledHtml domain object.
         """
-        return cls(subtitled_html_dict['html'], {
-            language_code: AudioTranslation.from_dict(audio_translation_dict)
-            for language_code, audio_translation_dict in
-            subtitled_html_dict['audio_translations'].iteritems()
-        })
+        return cls(
+            subtitled_html_dict['html'], {
+                language_code: AudioTranslation.from_dict(
+                    audio_translation_dict)
+                for language_code, audio_translation_dict in
+                subtitled_html_dict['audio_translations'].iteritems()
+            })
 
     def validate(self):
         """Validates properties of the SubtitledHtml.
@@ -948,8 +950,9 @@ class Solution(object):
     to progress to the next card and explanation is an HTML string containing
     an explanation for the solution.
     """
-    def __init__(self, interaction_id, answer_is_exclusive,
-                 correct_answer, explanation):
+    def __init__(
+            self, interaction_id, answer_is_exclusive,
+            correct_answer, explanation):
         """Constructs a Solution domain object.
 
         Args:
@@ -1240,8 +1243,9 @@ class State(object):
         'solution': None,
     }
 
-    def __init__(self, content, param_changes, interaction,
-                 classifier_model_id=None):
+    def __init__(
+            self, content, param_changes, interaction,
+            classifier_model_id=None):
         """Initializes a State domain object.
 
         Args:
@@ -1647,12 +1651,13 @@ class ExplorationVersionsDiff(object):
 class Exploration(object):
     """Domain object for an Oppia exploration."""
 
-    def __init__(self, exploration_id, title, category, objective,
-                 language_code, tags, blurb, author_notes,
-                 states_schema_version, init_state_name, states_dict,
-                 param_specs_dict, param_changes_list, version,
-                 auto_tts_enabled, correctness_feedback_enabled,
-                 created_on=None, last_updated=None):
+    def __init__(
+            self, exploration_id, title, category, objective,
+            language_code, tags, blurb, author_notes,
+            states_schema_version, init_state_name, states_dict,
+            param_specs_dict, param_changes_list, version,
+            auto_tts_enabled, correctness_feedback_enabled,
+            created_on=None, last_updated=None):
         """Initializes an Exploration domain object.
 
         Args:
@@ -3944,13 +3949,14 @@ class Exploration(object):
 class ExplorationSummary(object):
     """Domain object for an Oppia exploration summary."""
 
-    def __init__(self, exploration_id, title, category, objective,
-                 language_code, tags, ratings, scaled_average_rating, status,
-                 community_owned, owner_ids, editor_ids,
-                 viewer_ids, contributor_ids, contributors_summary, version,
-                 exploration_model_created_on,
-                 exploration_model_last_updated,
-                 first_published_msec):
+    def __init__(
+            self, exploration_id, title, category, objective,
+            language_code, tags, ratings, scaled_average_rating, status,
+            community_owned, owner_ids, editor_ids,
+            viewer_ids, contributor_ids, contributors_summary, version,
+            exploration_model_created_on,
+            exploration_model_last_updated,
+            first_published_msec):
         """Initializes a ExplorationSummary domain object.
 
         Args:

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -58,9 +58,10 @@ class ExplorationVersionsDiffDomainUnitTests(test_utils.GenericTestBase):
 
         self.assertEqual(exp_versions_diff.added_state_names, [])
         self.assertEqual(exp_versions_diff.deleted_state_names, [])
-        self.assertEqual(exp_versions_diff.old_to_new_state_names, {
-            'Home': 'Renamed state'
-        })
+        self.assertEqual(
+            exp_versions_diff.old_to_new_state_names, {
+                'Home': 'Renamed state'
+            })
         self.exploration.version += 1
 
         # Add a state.
@@ -699,14 +700,16 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(
             utils.ValidationError, 'Expected language code to be a string'
             ):
-            with self.swap(subtitled_html, 'audio_translations',
-                           {20: audio_translation}):
+            with self.swap(
+                subtitled_html, 'audio_translations',
+                {20: audio_translation}):
                 subtitled_html.validate()
         with self.assertRaisesRegexp(
             utils.ValidationError, 'Unrecognized language code'
             ):
-            with self.swap(subtitled_html, 'audio_translations',
-                           {'invalid-code': audio_translation}):
+            with self.swap(
+                subtitled_html, 'audio_translations',
+                {'invalid-code': audio_translation}):
                 subtitled_html.validate()
 
     def test_get_trainable_states_dict(self):
@@ -3352,9 +3355,10 @@ class StateIdMappingTests(test_utils.GenericTestBase):
                     'state_name': 'new state',
                 }], 'Add state name')
 
-            exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
-                'cmd': exp_domain.CMD_DELETE_STATE,
-                'state_name': 'new state',
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_DELETE_STATE,
+                    'state_name': 'new state',
                 }], 'delete state')
 
         new_exploration = exp_services.get_exploration_by_id(self.EXP_ID)
@@ -3380,11 +3384,12 @@ class StateIdMappingTests(test_utils.GenericTestBase):
                     'state_name': 'new state',
                 }], 'Add state name')
 
-            exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
-                'cmd': exp_domain.CMD_RENAME_STATE,
-                'old_state_name': 'new state',
-                'new_state_name': 'state',
-            }], 'Change state name')
+            exp_services.update_exploration(
+                self.owner_id, self.EXP_ID, [{
+                    'cmd': exp_domain.CMD_RENAME_STATE,
+                    'old_state_name': 'new state',
+                    'new_state_name': 'state',
+                }], 'Change state name')
 
         new_exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         new_mapping = exp_services.get_state_id_mapping(

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -967,11 +967,12 @@ def save_new_exploration(committer_id, exploration):
     commit_message = (
         ('New exploration created with title \'%s\'.' % exploration.title)
         if exploration.title else 'New exploration created.')
-    _create_exploration(committer_id, exploration, commit_message, [{
-        'cmd': CMD_CREATE_NEW,
-        'title': exploration.title,
-        'category': exploration.category,
-    }])
+    _create_exploration(
+        committer_id, exploration, commit_message, [{
+            'cmd': CMD_CREATE_NEW,
+            'title': exploration.title,
+            'category': exploration.category,
+        }])
     user_services.add_created_exploration_id(committer_id, exploration.id)
     user_services.add_edited_exploration_id(committer_id, exploration.id)
     user_services.record_user_created_an_exploration(committer_id)
@@ -1500,11 +1501,12 @@ def save_new_exploration_from_yaml_and_assets(
         'New exploration created from YAML file with title \'%s\'.'
         % exploration.title)
 
-    _create_exploration(committer_id, exploration, create_commit_message, [{
-        'cmd': CMD_CREATE_NEW,
-        'title': exploration.title,
-        'category': exploration.category,
-    }])
+    _create_exploration(
+        committer_id, exploration, create_commit_message, [{
+            'cmd': CMD_CREATE_NEW,
+            'title': exploration.title,
+            'category': exploration.category,
+        }])
 
     for (asset_filename, asset_content) in assets_list:
         fs = fs_domain.AbstractFileSystem(

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1307,10 +1307,11 @@ class UpdateStateTests(ExplorationServicesUnitTests):
 
         self.assertNotIn('new state', exploration.states)
 
-        exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
-            'cmd': exp_domain.CMD_ADD_STATE,
-            'state_name': 'new state',
-        }], 'Add state name')
+        exp_services.update_exploration(
+            self.owner_id, self.EXP_ID, [{
+                'cmd': exp_domain.CMD_ADD_STATE,
+                'state_name': 'new state',
+            }], 'Add state name')
 
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         self.assertIn('new state', exploration.states)
@@ -1321,11 +1322,12 @@ class UpdateStateTests(ExplorationServicesUnitTests):
 
         self.assertIn(feconf.DEFAULT_INIT_STATE_NAME, exploration.states)
 
-        exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
-            'cmd': exp_domain.CMD_RENAME_STATE,
-            'old_state_name': feconf.DEFAULT_INIT_STATE_NAME,
-            'new_state_name': 'state',
-        }], 'Change state name')
+        exp_services.update_exploration(
+            self.owner_id, self.EXP_ID, [{
+                'cmd': exp_domain.CMD_RENAME_STATE,
+                'old_state_name': feconf.DEFAULT_INIT_STATE_NAME,
+                'new_state_name': 'state',
+            }], 'Change state name')
 
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         self.assertIn('state', exploration.states)
@@ -1338,11 +1340,12 @@ class UpdateStateTests(ExplorationServicesUnitTests):
         self.assertNotIn(u'¡Hola! αβγ', exploration.states)
         self.assertIn(feconf.DEFAULT_INIT_STATE_NAME, exploration.states)
 
-        exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
-            'cmd': exp_domain.CMD_RENAME_STATE,
-            'old_state_name': feconf.DEFAULT_INIT_STATE_NAME,
-            'new_state_name': u'¡Hola! αβγ',
-        }], 'Change state name')
+        exp_services.update_exploration(
+            self.owner_id, self.EXP_ID, [{
+                'cmd': exp_domain.CMD_RENAME_STATE,
+                'old_state_name': feconf.DEFAULT_INIT_STATE_NAME,
+                'new_state_name': u'¡Hola! αβγ',
+            }], 'Change state name')
 
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         self.assertIn(u'¡Hola! αβγ', exploration.states)
@@ -1352,18 +1355,20 @@ class UpdateStateTests(ExplorationServicesUnitTests):
         """Test deleting a state name."""
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)
 
-        exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
-            'cmd': exp_domain.CMD_ADD_STATE,
-            'state_name': 'new state',
-        }], 'Add state name')
+        exp_services.update_exploration(
+            self.owner_id, self.EXP_ID, [{
+                'cmd': exp_domain.CMD_ADD_STATE,
+                'state_name': 'new state',
+            }], 'Add state name')
 
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)
 
         self.assertIn('new state', exploration.states)
 
-        exp_services.update_exploration(self.owner_id, self.EXP_ID, [{
-            'cmd': exp_domain.CMD_DELETE_STATE,
-            'state_name': 'new state',
+        exp_services.update_exploration(
+            self.owner_id, self.EXP_ID, [{
+                'cmd': exp_domain.CMD_DELETE_STATE,
+                'state_name': 'new state',
             }], 'delete state')
 
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)
@@ -2143,9 +2148,10 @@ class ExplorationSearchTests(ExplorationServicesUnitTests):
             return ids
 
         add_docs_counter = test_utils.CallCounter(mock_add_documents_to_index)
-        add_docs_swap = self.swap(search_services,
-                                  'add_documents_to_index',
-                                  add_docs_counter)
+        add_docs_swap = self.swap(
+            search_services,
+            'add_documents_to_index',
+            add_docs_counter)
 
         for i in xrange(5):
             self.save_new_valid_exploration(
@@ -2320,8 +2326,8 @@ class ExplorationSummaryTests(ExplorationServicesUnitTests):
                 'property_name': 'title',
                 'new_value': 'Exploration 1 title'
             }], 'Changed title.')
-        self._check_contributors_summary(self.EXP_ID_1,
-                                         {albert_id: 1, bob_id: 1})
+        self._check_contributors_summary(
+            self.EXP_ID_1, {albert_id: 1, bob_id: 1})
         # Have Bob update that exploration. Version 3.
         exp_services.update_exploration(
             bob_id, self.EXP_ID_1, [{
@@ -2329,8 +2335,8 @@ class ExplorationSummaryTests(ExplorationServicesUnitTests):
                 'property_name': 'title',
                 'new_value': 'Exploration 1 title'
             }], 'Changed title.')
-        self._check_contributors_summary(self.EXP_ID_1,
-                                         {albert_id: 1, bob_id: 2})
+        self._check_contributors_summary(
+            self.EXP_ID_1, {albert_id: 1, bob_id: 2})
 
         # Have Albert update that exploration. Version 4.
         exp_services.update_exploration(
@@ -2339,13 +2345,13 @@ class ExplorationSummaryTests(ExplorationServicesUnitTests):
                 'property_name': 'title',
                 'new_value': 'Exploration 1 title'
             }], 'Changed title.')
-        self._check_contributors_summary(self.EXP_ID_1,
-                                         {albert_id: 2, bob_id: 2})
+        self._check_contributors_summary(
+            self.EXP_ID_1, {albert_id: 2, bob_id: 2})
 
         # Have Albert revert to version 3. Version 5.
         exp_services.revert_exploration(albert_id, self.EXP_ID_1, 4, 3)
-        self._check_contributors_summary(self.EXP_ID_1,
-                                         {albert_id: 1, bob_id: 2})
+        self._check_contributors_summary(
+            self.EXP_ID_1, {albert_id: 1, bob_id: 2})
 
 
 class ExplorationSummaryGetTests(ExplorationServicesUnitTests):
@@ -2838,8 +2844,9 @@ class SuggestionActionUnitTests(test_utils.GenericTestBase):
             self.EXP_ID1, self.editor_id)
         self.save_new_valid_exploration(self.EXP_ID2, self.editor_id)
         self.initial_state_name = exploration.init_state_name
-        with self.swap(feedback_models.FeedbackThreadModel,
-                       'generate_new_thread_id', self._generate_thread_id):
+        with self.swap(
+            feedback_models.FeedbackThreadModel,
+            'generate_new_thread_id', self._generate_thread_id):
             feedback_services.create_suggestion(
                 self.EXP_ID1, self.user_id, 3, self.initial_state_name,
                 'description', 'new text')
@@ -2848,10 +2855,12 @@ class SuggestionActionUnitTests(test_utils.GenericTestBase):
                 'description', 'new text')
 
     def test_accept_suggestion_valid_suggestion(self):
-        with self.swap(exp_services, '_is_suggestion_valid',
-                       self._return_true):
-            with self.swap(exp_services, 'update_exploration',
-                           self._check_commit_message):
+        with self.swap(
+            exp_services, '_is_suggestion_valid',
+            self._return_true):
+            with self.swap(
+                exp_services, 'update_exploration',
+                self._check_commit_message):
                 exp_services.accept_suggestion(
                     self.editor_id, self.THREAD_ID1, self.EXP_ID1,
                     self.COMMIT_MESSAGE, False)
@@ -2865,8 +2874,9 @@ class SuggestionActionUnitTests(test_utils.GenericTestBase):
         self.assertEqual(last_message.text, 'Suggestion accepted.')
 
     def test_accept_suggestion_invalid_suggestion(self):
-        with self.swap(exp_services, '_is_suggestion_valid',
-                       self._return_false):
+        with self.swap(
+            exp_services, '_is_suggestion_valid',
+            self._return_false):
             with self.assertRaisesRegexp(
                 Exception,
                 'Invalid suggestion: The state for which it was made '
@@ -2881,8 +2891,8 @@ class SuggestionActionUnitTests(test_utils.GenericTestBase):
         self.assertEqual(thread.status, feedback_models.STATUS_CHOICES_OPEN)
 
     def test_accept_suggestion_empty_commit_message(self):
-        with self.assertRaisesRegexp(Exception,
-                                     'Commit message cannot be empty.'):
+        with self.assertRaisesRegexp(
+            Exception, 'Commit message cannot be empty.'):
             exp_services.accept_suggestion(
                 self.editor_id, self.THREAD_ID1, self.EXP_ID2,
                 self.EMPTY_COMMIT_MESSAGE, False)
@@ -2893,8 +2903,9 @@ class SuggestionActionUnitTests(test_utils.GenericTestBase):
 
     def test_accept_suggestion_that_has_already_been_handled(self):
         exception_message = 'Suggestion has already been accepted/rejected'
-        with self.swap(exp_services, '_is_suggestion_handled',
-                       self._return_true):
+        with self.swap(
+            exp_services, '_is_suggestion_handled',
+            self._return_true):
             with self.assertRaisesRegexp(Exception, exception_message):
                 exp_services.accept_suggestion(
                     self.editor_id, self.THREAD_ID1, self.EXP_ID2,
@@ -2906,13 +2917,15 @@ class SuggestionActionUnitTests(test_utils.GenericTestBase):
         thread = feedback_models.FeedbackThreadModel.get(
             feedback_models.FeedbackThreadModel.generate_full_thread_id(
                 self.EXP_ID2, self.THREAD_ID1))
-        self.assertEqual(thread.status,
-                         feedback_models.STATUS_CHOICES_IGNORED)
+        self.assertEqual(
+            thread.status,
+            feedback_models.STATUS_CHOICES_IGNORED)
 
     def test_reject_suggestion_that_has_already_been_handled(self):
         exception_message = 'Suggestion has already been accepted/rejected'
-        with self.swap(exp_services, '_is_suggestion_handled',
-                       self._return_true):
+        with self.swap(
+            exp_services, '_is_suggestion_handled',
+            self._return_true):
             with self.assertRaisesRegexp(Exception, exception_message):
                 exp_services.reject_suggestion(
                     self.editor_id, self.THREAD_ID1, self.EXP_ID2)
@@ -3010,8 +3023,8 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
         self.assertEqual(exp_user_data.exploration_id, self.EXP_ID1)
         self.assertEqual(
             exp_user_data.draft_change_list, self.NEW_CHANGELIST)
-        self.assertEqual(exp_user_data.draft_change_list_last_updated,
-                         self.NEWER_DATETIME)
+        self.assertEqual(
+            exp_user_data.draft_change_list_last_updated, self.NEWER_DATETIME)
         self.assertEqual(exp_user_data.draft_change_list_exp_version, 5)
         self.assertEqual(exp_user_data.draft_change_list_id, 3)
 
@@ -3038,8 +3051,8 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
         self.assertEqual(exp_user_data.exploration_id, self.EXP_ID3)
         self.assertEqual(
             exp_user_data.draft_change_list, self.NEW_CHANGELIST)
-        self.assertEqual(exp_user_data.draft_change_list_last_updated,
-                         self.NEWER_DATETIME)
+        self.assertEqual(
+            exp_user_data.draft_change_list_last_updated, self.NEWER_DATETIME)
         self.assertEqual(exp_user_data.draft_change_list_exp_version, 5)
         self.assertEqual(exp_user_data.draft_change_list_id, 1)
 

--- a/core/domain/feedback_domain.py
+++ b/core/domain/feedback_domain.py
@@ -39,9 +39,10 @@ class FeedbackThread(object):
             was last updated.
     """
 
-    def __init__(self, full_thread_id, exploration_id, state_name,
-                 original_author_id, status, subject, summary, has_suggestion,
-                 message_count, created_on, last_updated):
+    def __init__(
+            self, full_thread_id, exploration_id, state_name,
+            original_author_id, status, subject, summary, has_suggestion,
+            message_count, created_on, last_updated):
         """Initializes a FeedbackThread object."""
 
         self.id = full_thread_id
@@ -160,9 +161,10 @@ class FeedbackMessage(object):
         received_via_email: bool. Whether the feedback was received via email.
     """
 
-    def __init__(self, full_message_id, full_thread_id, message_id, author_id,
-                 updated_status, updated_subject, text, created_on,
-                 last_updated, received_via_email):
+    def __init__(
+            self, full_message_id, full_thread_id, message_id, author_id,
+            updated_status, updated_subject, text, created_on,
+            last_updated, received_via_email):
         self.id = full_message_id
         self.full_thread_id = full_thread_id
         self.message_id = message_id
@@ -250,8 +252,9 @@ class Suggestion(object):
         suggestion_html: str. The state's suggested content.
         """
 
-    def __init__(self, full_thread_id, author_id, exploration_id,
-                 exploration_version, state_name, description, suggestion_html):
+    def __init__(
+            self, full_thread_id, author_id, exploration_id,
+            exploration_version, state_name, description, suggestion_html):
         """Initializes a Suggestion object."""
         self.id = full_thread_id
         self.author_id = author_id

--- a/core/domain/feedback_domain_test.py
+++ b/core/domain/feedback_domain_test.py
@@ -51,8 +51,8 @@ class FeedbackThreadDomainUnitTests(test_utils.GenericTestBase):
             expected_thread_dict['state_name'], self.viewer_id,
             expected_thread_dict['status'], expected_thread_dict['subject'],
             expected_thread_dict['summary'], False, 1, fake_date, fake_date)
-        self.assertDictEqual(expected_thread_dict,
-                             observed_thread.to_dict())
+        self.assertDictEqual(
+            expected_thread_dict, observed_thread.to_dict())
 
     def test_get_exp_id_from_full_thread_id(self):
         observed_exp_id = (
@@ -119,8 +119,8 @@ class FeedbackMessageDomainUnitTests(test_utils.GenericTestBase):
             self.owner_id, expected_message_dict['updated_status'],
             expected_message_dict['updated_subject'],
             expected_message_dict['text'], fake_date, fake_date, False)
-        self.assertDictEqual(expected_message_dict,
-                             observed_message.to_dict())
+        self.assertDictEqual(
+            expected_message_dict, observed_message.to_dict())
 
 
 class FeedbackAnalyticsDomainUnitTests(test_utils.GenericTestBase):
@@ -161,8 +161,8 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
             expected_suggestion_dict['state_name'],
             expected_suggestion_dict['description'],
             expected_suggestion_dict['suggestion_html'])
-        self.assertDictEqual(expected_suggestion_dict,
-                             observed_suggestion.to_dict())
+        self.assertDictEqual(
+            expected_suggestion_dict, observed_suggestion.to_dict())
 
 
 class FeedbackMessageReferenceDomainTests(test_utils.GenericTestBase):

--- a/core/domain/feedback_jobs_continuous_test.py
+++ b/core/domain/feedback_jobs_continuous_test.py
@@ -69,8 +69,8 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
                 taskqueue_services.QUEUE_NAME_CONTINUOUS_JOBS), 1)
         self.process_and_flush_pending_tasks()
 
-    def _run_job_and_check_results(self, exp_id,
-                                   expected_thread_analytics_dict):
+    def _run_job_and_check_results(
+            self, exp_id, expected_thread_analytics_dict):
         self._run_job()
         self.assertEqual(
             ModifiedFeedbackAnalyticsAggregator.get_thread_analytics(
@@ -144,10 +144,11 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
         with self._get_swap_context():
             exp_id = 'eid'
             self.save_new_valid_exploration(exp_id, 'owner')
-            self._run_job_and_check_results(exp_id, {
-                'num_open_threads': 0,
-                'num_total_threads': 0,
-            })
+            self._run_job_and_check_results(
+                exp_id, {
+                    'num_open_threads': 0,
+                    'num_total_threads': 0,
+                })
 
     def test_single_thread_single_exp(self):
         with self._get_swap_context():
@@ -159,10 +160,11 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
             thread.exploration_id = exp_id
             thread.put()
 
-            self._run_job_and_check_results(exp_id, {
-                'num_open_threads': 1,
-                'num_total_threads': 1,
-            })
+            self._run_job_and_check_results(
+                exp_id, {
+                    'num_open_threads': 1,
+                    'num_total_threads': 1,
+                })
 
     def test_multiple_threads_single_exp(self):
         with self._get_swap_context():
@@ -179,10 +181,11 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
             thread_2.exploration_id = exp_id
             thread_2.put()
 
-            self._run_job_and_check_results(exp_id, {
-                'num_open_threads': 2,
-                'num_total_threads': 2,
-            })
+            self._run_job_and_check_results(
+                exp_id, {
+                    'num_open_threads': 2,
+                    'num_total_threads': 2,
+                })
 
     def test_multiple_threads_multiple_exp(self):
         with self._get_swap_context():
@@ -271,10 +274,11 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
             thread_1.put()
 
             # Start job.
-            self._run_job_and_check_results(exp_id, {
-                'num_open_threads': 1,
-                'num_total_threads': 1,
-            })
+            self._run_job_and_check_results(
+                exp_id, {
+                    'num_open_threads': 1,
+                    'num_total_threads': 1,
+                })
 
             # Stop job.
             ModifiedFeedbackAnalyticsAggregator.stop_computation(user_id)
@@ -289,10 +293,11 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
             thread.put()
 
             # Restart job.
-            self._run_job_and_check_results(exp_id, {
-                'num_open_threads': 0,
-                'num_total_threads': 1,
-            })
+            self._run_job_and_check_results(
+                exp_id, {
+                    'num_open_threads': 0,
+                    'num_total_threads': 1,
+                })
 
     def test_thread_closed_reopened_again(self):
         with self._get_swap_context():
@@ -307,10 +312,11 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
             thread_1.put()
 
             # Start job.
-            self._run_job_and_check_results(exp_id, {
-                'num_open_threads': 1,
-                'num_total_threads': 1,
-            })
+            self._run_job_and_check_results(
+                exp_id, {
+                    'num_open_threads': 1,
+                    'num_total_threads': 1,
+                })
 
             # Stop job.
             ModifiedFeedbackAnalyticsAggregator.stop_computation(user_id)
@@ -325,10 +331,11 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
             thread.put()
 
             # Restart job.
-            self._run_job_and_check_results(exp_id, {
-                'num_open_threads': 0,
-                'num_total_threads': 1,
-            })
+            self._run_job_and_check_results(
+                exp_id, {
+                    'num_open_threads': 0,
+                    'num_total_threads': 1,
+                })
 
             # Stop job.
             ModifiedFeedbackAnalyticsAggregator.stop_computation(user_id)
@@ -343,10 +350,11 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
             thread.put()
 
             # Restart job.
-            self._run_job_and_check_results(exp_id, {
-                'num_open_threads': 1,
-                'num_total_threads': 1,
-            })
+            self._run_job_and_check_results(
+                exp_id, {
+                    'num_open_threads': 1,
+                    'num_total_threads': 1,
+                })
 
     def test_thread_closed_status_changed(self):
         with self._get_swap_context():
@@ -361,10 +369,11 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
             thread_1.put()
 
             # Start job.
-            self._run_job_and_check_results(exp_id, {
-                'num_open_threads': 1,
-                'num_total_threads': 1,
-            })
+            self._run_job_and_check_results(
+                exp_id, {
+                    'num_open_threads': 1,
+                    'num_total_threads': 1,
+                })
 
             # Stop job.
             ModifiedFeedbackAnalyticsAggregator.stop_computation(user_id)
@@ -379,10 +388,11 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
             thread.put()
 
             # Restart job.
-            self._run_job_and_check_results(exp_id, {
-                'num_open_threads': 0,
-                'num_total_threads': 1,
-            })
+            self._run_job_and_check_results(
+                exp_id, {
+                    'num_open_threads': 0,
+                    'num_total_threads': 1,
+                })
 
             # Stop job.
             ModifiedFeedbackAnalyticsAggregator.stop_computation(user_id)
@@ -397,10 +407,11 @@ class FeedbackAnalyticsAggregatorUnitTests(test_utils.GenericTestBase):
             thread.put()
 
             # Restart job.
-            self._run_job_and_check_results(exp_id, {
-                'num_open_threads': 0,
-                'num_total_threads': 1,
-            })
+            self._run_job_and_check_results(
+                exp_id, {
+                    'num_open_threads': 0,
+                    'num_total_threads': 1,
+                })
 
 
 class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
@@ -425,10 +436,11 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             exp_id = 'eid'
             self.save_new_valid_exploration(exp_id, 'owner')
 
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 0,
-                'num_total_threads': 0,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 0,
+                    'num_total_threads': 0,
+                })
 
     def test_single_thread_single_exp(self):
         with self._get_swap_context():
@@ -441,10 +453,11 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             feedback_services.create_thread(
                 exp_id, 'a_state_name', None, 'a subject', 'some text')
 
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 1,
-                'num_total_threads': 1,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 1,
+                    'num_total_threads': 1,
+                })
 
     def test_multiple_threads_single_exp(self):
         with self._get_swap_context():
@@ -459,10 +472,11 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             feedback_services.create_thread(
                 exp_id, 'a_state_name', None, 'a subject', 'some text')
 
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 2,
-                'num_total_threads': 2,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 2,
+                    'num_total_threads': 2,
+                })
 
     def test_multiple_threads_multiple_exp(self):
         with self._get_swap_context():
@@ -483,14 +497,16 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             feedback_services.create_thread(
                 exp_id_2, 'a_state_name', None, 'a subject', 'some text')
 
-            self._flush_tasks_and_check_analytics(exp_id_1, {
-                'num_open_threads': 2,
-                'num_total_threads': 2,
-            })
-            self._flush_tasks_and_check_analytics(exp_id_2, {
-                'num_open_threads': 2,
-                'num_total_threads': 2,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id_1, {
+                    'num_open_threads': 2,
+                    'num_total_threads': 2,
+                })
+            self._flush_tasks_and_check_analytics(
+                exp_id_2, {
+                    'num_open_threads': 2,
+                    'num_total_threads': 2,
+                })
 
     def test_thread_closed_job_running(self):
         with self._get_swap_context():
@@ -502,10 +518,11 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             self.process_and_flush_pending_tasks()
             feedback_services.create_thread(
                 exp_id, 'a_state_name', None, 'a subject', 'some text')
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 1,
-                'num_total_threads': 1,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 1,
+                    'num_total_threads': 1,
+                })
 
             # Trigger close event.
             threadlist = feedback_services.get_all_threads(exp_id, False)
@@ -513,10 +530,11 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             feedback_services.create_message(
                 exp_id, thread_id, 'author',
                 feedback_models.STATUS_CHOICES_FIXED, None, 'some text')
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 0,
-                'num_total_threads': 1,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 0,
+                    'num_total_threads': 1,
+                })
 
     def test_thread_closed_reopened_again(self):
         with self._get_swap_context():
@@ -529,10 +547,11 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             feedback_services.create_thread(
                 exp_id, 'a_state_name', None, 'a subject', 'some text')
 
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 1,
-                'num_total_threads': 1,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 1,
+                    'num_total_threads': 1,
+                })
 
             # Trigger close event.
             threadlist = feedback_services.get_all_threads(exp_id, False)
@@ -540,10 +559,11 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             feedback_services.create_message(
                 exp_id, thread_id, 'author',
                 feedback_models.STATUS_CHOICES_FIXED, None, 'some text')
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 0,
-                'num_total_threads': 1,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 0,
+                    'num_total_threads': 1,
+                })
 
             # Trigger reopen event.
             threadlist = feedback_services.get_all_threads(exp_id, False)
@@ -551,10 +571,11 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             feedback_services.create_message(
                 exp_id, thread_id, 'author',
                 feedback_models.STATUS_CHOICES_OPEN, None, 'some text')
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 1,
-                'num_total_threads': 1,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 1,
+                    'num_total_threads': 1,
+                })
 
     def test_thread_closed_status_changed(self):
         with self._get_swap_context():
@@ -567,10 +588,11 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             feedback_services.create_thread(
                 exp_id, 'a_state_name', None, 'a subject', 'some text')
 
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 1,
-                'num_total_threads': 1,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 1,
+                    'num_total_threads': 1,
+                })
 
             # Trigger close event.
             threadlist = feedback_services.get_all_threads(exp_id, False)
@@ -578,10 +600,11 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             feedback_services.create_message(
                 exp_id, thread_id, 'author',
                 feedback_models.STATUS_CHOICES_FIXED, None, 'some text')
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 0,
-                'num_total_threads': 1,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 0,
+                    'num_total_threads': 1,
+                })
 
             # Trigger thread status change event.
             threadlist = feedback_services.get_all_threads(exp_id, False)
@@ -589,10 +612,11 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
             feedback_services.create_message(
                 exp_id, thread_id, 'author',
                 feedback_models.STATUS_CHOICES_IGNORED, None, 'some text')
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 0,
-                'num_total_threads': 1,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 0,
+                    'num_total_threads': 1,
+                })
 
     def test_realtime_with_batch_computation(self):
         with self._get_swap_context():
@@ -617,15 +641,17 @@ class RealtimeFeedbackAnalyticsUnitTests(test_utils.GenericTestBase):
                 self.count_jobs_in_taskqueue(
                     taskqueue_services.QUEUE_NAME_CONTINUOUS_JOBS), 0)
 
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 1,
-                'num_total_threads': 1,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 1,
+                    'num_total_threads': 1,
+                })
 
             # Create another thread but don't start job.
             feedback_services.create_thread(
                 exp_id, 'a_state_name', None, 'a subject', 'some text')
-            self._flush_tasks_and_check_analytics(exp_id, {
-                'num_open_threads': 2,
-                'num_total_threads': 2,
-            })
+            self._flush_tasks_and_check_analytics(
+                exp_id, {
+                    'num_open_threads': 2,
+                    'num_total_threads': 2,
+                })

--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -60,13 +60,14 @@ class FeedbackThreadMessagesCountOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                 'number of messages.' % (
                     key, len(message_ids), next_message_id))
 
-            yield ('error', {
-                'subject': thread.subject,
-                'exploration_id': exploration_id,
-                'thread_id': thread_id,
-                'next_message_id': next_message_id,
-                'message_count': len(message_ids)
-            })
+            yield (
+                'error', {
+                    'subject': thread.subject,
+                    'exploration_id': exploration_id,
+                    'thread_id': thread_id,
+                    'next_message_id': next_message_id,
+                    'message_count': len(message_ids)
+                })
 
 
 class FeedbackSubjectOneOffJob(jobs.BaseMapReduceOneOffJobManager):

--- a/core/domain/feedback_services.py
+++ b/core/domain/feedback_services.py
@@ -180,8 +180,8 @@ def create_message(
             exploration_id, thread_id, author_id, message_id)
 
 
-def update_messages_read_by_the_user(user_id, exploration_id, thread_id,
-                                     message_ids):
+def update_messages_read_by_the_user(
+        user_id, exploration_id, thread_id, message_ids):
     """Replaces the list of message ids read by the message ids given to the
     function.
 
@@ -204,8 +204,8 @@ def update_messages_read_by_the_user(user_id, exploration_id, thread_id,
     feedback_thread_user_model.put()
 
 
-def add_message_id_to_read_by_list(exploration_id, thread_id,
-                                   user_id, message_id):
+def add_message_id_to_read_by_list(
+        exploration_id, thread_id, user_id, message_id):
     """Adds the message id to the list of message ids read by the user.
 
     Args:
@@ -352,8 +352,9 @@ def get_total_open_threads(feedback_thread_analytics):
         feedback.num_open_threads for feedback in feedback_thread_analytics)
 
 
-def create_suggestion(exploration_id, author_id, exploration_version,
-                      state_name, description, suggestion_content):
+def create_suggestion(
+        exploration_id, author_id, exploration_version,
+        state_name, description, suggestion_content):
     """Creates a new SuggestionModel and the corresponding FeedbackThreadModel
     domain object.
 

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -151,8 +151,9 @@ class SuggestionQueriesUnitTests(test_utils.GenericTestBase):
             thread.put()
 
     def test_create_and_get_suggestion(self):
-        with self.swap(feedback_models.FeedbackThreadModel,
-                       'generate_new_thread_id', self._generate_thread_id):
+        with self.swap(
+            feedback_models.FeedbackThreadModel,
+            'generate_new_thread_id', self._generate_thread_id):
             feedback_services.create_suggestion(
                 self.EXP_ID2, self.user_id, 3, 'state_name', 'description', '')
         suggestion = feedback_services.get_suggestion(
@@ -281,8 +282,8 @@ class FeedbackThreadUnitTests(test_utils.GenericTestBase):
 
         threads = feedback_services.get_threads(self.EXP_ID_1)
         self.assertEqual(1, len(threads))
-        self.assertDictContainsSubset(self.EXPECTED_THREAD_DICT,
-                                      threads[0].to_dict())
+        self.assertDictContainsSubset(
+            self.EXPECTED_THREAD_DICT, threads[0].to_dict())
 
     def test_get_all_threads(self):
         # Create an anonymous feedback thread.
@@ -292,8 +293,8 @@ class FeedbackThreadUnitTests(test_utils.GenericTestBase):
 
         threads = feedback_services.get_all_threads(self.EXP_ID_1, False)
         self.assertEqual(1, len(threads))
-        self.assertDictContainsSubset(self.EXPECTED_THREAD_DICT,
-                                      threads[0].to_dict())
+        self.assertDictContainsSubset(
+            self.EXPECTED_THREAD_DICT, threads[0].to_dict())
 
         self.EXPECTED_THREAD_DICT_VIEWER['original_author_username'] = (
             self.VIEWER_USERNAME)
@@ -306,8 +307,8 @@ class FeedbackThreadUnitTests(test_utils.GenericTestBase):
 
         threads = feedback_services.get_all_threads(self.EXP_ID_1, False)
         self.assertEqual(2, len(threads))
-        self.assertDictContainsSubset(self.EXPECTED_THREAD_DICT_VIEWER,
-                                      threads[1].to_dict())
+        self.assertDictContainsSubset(
+            self.EXPECTED_THREAD_DICT_VIEWER, threads[1].to_dict())
 
     def test_get_total_open_threads_before_job_run(self):
         self.assertEqual(feedback_services.get_total_open_threads(

--- a/core/domain/learner_progress_domain.py
+++ b/core/domain/learner_progress_domain.py
@@ -20,10 +20,11 @@
 class LearnerProgress(object):
     """Domain object for the progress of the learner."""
 
-    def __init__(self, incomplete_exp_summaries,
-                 incomplete_collection_summaries, completed_exp_summaries,
-                 completed_collection_summaries, exploration_playlist,
-                 collection_playlist):
+    def __init__(
+            self, incomplete_exp_summaries,
+            incomplete_collection_summaries, completed_exp_summaries,
+            completed_collection_summaries, exploration_playlist,
+            collection_playlist):
         """Constructs a LearnerProgress domain object.
 
         Args:

--- a/core/domain/learner_progress_services.py
+++ b/core/domain/learner_progress_services.py
@@ -350,9 +350,10 @@ def add_collection_to_learner_playlist(
     else:
         belongs_to_completed_or_incomplete_list = True
 
-    return (belongs_to_completed_or_incomplete_list,
-            playlist_limit_exceeded,
-            belongs_to_subscribed_activities)
+    return (
+        belongs_to_completed_or_incomplete_list,
+        playlist_limit_exceeded,
+        belongs_to_subscribed_activities)
 
 
 def add_exp_to_learner_playlist(
@@ -395,13 +396,14 @@ def add_exp_to_learner_playlist(
     else:
         belongs_to_completed_or_incomplete_list = True
 
-    return (belongs_to_completed_or_incomplete_list,
-            playlist_limit_exceeded,
-            belongs_to_subscribed_activities)
+    return (
+        belongs_to_completed_or_incomplete_list,
+        playlist_limit_exceeded,
+        belongs_to_subscribed_activities)
 
 
-def _remove_activity_ids_from_playlist(user_id, exploration_ids,
-                                       collection_ids):
+def _remove_activity_ids_from_playlist(
+        user_id, exploration_ids, collection_ids):
     """Removes the explorations and collections from the playlist of the user.
 
     Args:
@@ -466,8 +468,8 @@ def remove_collection_from_completed_list(user_id, collection_id):
             _save_completed_activities(activities_completed)
 
 
-def _remove_activity_ids_from_completed_list(user_id, exploration_ids,
-                                             collection_ids):
+def _remove_activity_ids_from_completed_list(
+        user_id, exploration_ids, collection_ids):
     """Removes the explorations and collections from the completed list of the
     learner.
 
@@ -587,8 +589,8 @@ def get_all_completed_exp_ids(user_id):
         return []
 
 
-def _get_filtered_completed_exp_summaries(exploration_summaries,
-                                          exploration_ids):
+def _get_filtered_completed_exp_summaries(
+        exploration_summaries, exploration_ids):
     """Returns a list of summaries of the completed exploration ids and the
     ids of explorations that are no longer present.
 
@@ -641,8 +643,8 @@ def get_all_completed_collection_ids(user_id):
         return []
 
 
-def _get_filtered_completed_collection_summaries(user_id, collection_summaries,
-                                                 collection_ids):
+def _get_filtered_completed_collection_summaries(
+        user_id, collection_summaries, collection_ids):
     """Returns a list of summaries of the completed collection ids, the ids
     of collections that are no longer present and the summaries of the
     collections being shifted to the incomplete section on account of new
@@ -694,9 +696,10 @@ def _get_filtered_completed_collection_summaries(user_id, collection_summaries,
                 filtered_completed_collection_summaries.append(
                     collection_summary)
 
-    return (filtered_completed_collection_summaries,
-            nonexistent_completed_collection_ids,
-            completed_to_incomplete_collections)
+    return (
+        filtered_completed_collection_summaries,
+        nonexistent_completed_collection_ids,
+        completed_to_incomplete_collections)
 
 
 def get_all_incomplete_exp_ids(user_id):
@@ -723,8 +726,8 @@ def get_all_incomplete_exp_ids(user_id):
         return []
 
 
-def _get_filtered_incomplete_exp_summaries(exploration_summaries,
-                                           exploration_ids):
+def _get_filtered_incomplete_exp_summaries(
+        exploration_summaries, exploration_ids):
     """Returns a list of summaries of the incomplete exploration ids and the ids
     of explorations that are no longer present.
 
@@ -776,8 +779,8 @@ def get_all_incomplete_collection_ids(user_id):
         return []
 
 
-def _get_filtered_incomplete_collection_summaries(collection_summaries,
-                                                  collection_ids):
+def _get_filtered_incomplete_collection_summaries(
+        collection_summaries, collection_ids):
     """Returns a list of summaries of the incomplete collection ids and the ids
     of collections that are no longer present.
 
@@ -803,12 +806,13 @@ def _get_filtered_incomplete_collection_summaries(collection_summaries,
         else:
             filtered_incomplete_collection_summaries.append(collection_summary)
 
-    return (filtered_incomplete_collection_summaries,
-            nonexistent_incomplete_collection_ids)
+    return (
+        filtered_incomplete_collection_summaries,
+        nonexistent_incomplete_collection_ids)
 
 
-def _get_filtered_exp_playlist_summaries(exploration_summaries,
-                                         exploration_ids):
+def _get_filtered_exp_playlist_summaries(
+        exploration_summaries, exploration_ids):
     """Returns a list of summaries of the explorations in the learner playlist
     and the ids of explorations that are no longer present.
 
@@ -837,8 +841,8 @@ def _get_filtered_exp_playlist_summaries(exploration_summaries,
     return filtered_exp_playlist_summaries, nonexistent_playlist_exp_ids
 
 
-def _get_filtered_collection_playlist_summaries(collection_summaries,
-                                                collection_ids):
+def _get_filtered_collection_playlist_summaries(
+        collection_summaries, collection_ids):
     """Returns a list of summaries of the collections in the learner playlist
     and the ids of collections that are no longer present.
 
@@ -864,8 +868,9 @@ def _get_filtered_collection_playlist_summaries(collection_summaries,
         else:
             filtered_collection_playlist_summaries.append(collection_summary)
 
-    return (filtered_collection_playlist_summaries,
-            nonexistent_playlist_collection_ids)
+    return (
+        filtered_collection_playlist_summaries,
+        nonexistent_playlist_collection_ids)
 
 
 def get_collection_summary_dicts(collection_summaries):
@@ -1047,11 +1052,13 @@ def get_activity_progress(user_id):
         _get_filtered_completed_exp_summaries(
             completed_exp_summaries, completed_exploration_ids))
 
-    (filtered_completed_collection_summaries,
-     nonexistent_completed_collection_ids,
-     completed_to_incomplete_collection_summaries) = (
-         _get_filtered_completed_collection_summaries(
-             user_id, completed_collection_summaries, completed_collection_ids))
+    (
+        filtered_completed_collection_summaries,
+        nonexistent_completed_collection_ids,
+        completed_to_incomplete_collection_summaries) = (
+            _get_filtered_completed_collection_summaries(
+                user_id, completed_collection_summaries,
+                completed_collection_ids))
 
     completed_to_incomplete_collection_titles = []
     for collection_summary in completed_to_incomplete_collection_summaries:
@@ -1060,19 +1067,21 @@ def get_activity_progress(user_id):
             collection_summary.title)
         incomplete_collection_ids.append(collection_summary.id)
 
-    (filtered_incomplete_collection_summaries,
-     nonexistent_incomplete_collection_ids) = (
-         _get_filtered_incomplete_collection_summaries(
-             incomplete_collection_summaries, incomplete_collection_ids))
+    (
+        filtered_incomplete_collection_summaries,
+        nonexistent_incomplete_collection_ids) = (
+            _get_filtered_incomplete_collection_summaries(
+                incomplete_collection_summaries, incomplete_collection_ids))
 
     filtered_exp_playlist_summaries, nonexistent_playlist_exp_ids = (
         _get_filtered_exp_playlist_summaries(
             exploration_playlist_summaries, exploration_playlist_ids))
 
-    (filtered_collection_playlist_summaries,
-     nonexistent_playlist_collection_ids) = (
-         _get_filtered_collection_playlist_summaries(
-             collection_playlist_summaries, collection_playlist_ids))
+    (
+        filtered_collection_playlist_summaries,
+        nonexistent_playlist_collection_ids) = (
+            _get_filtered_collection_playlist_summaries(
+                collection_playlist_summaries, collection_playlist_ids))
 
     number_of_nonexistent_activities = {
         'incomplete_explorations': len(nonexistent_incomplete_exp_ids),
@@ -1101,5 +1110,6 @@ def get_activity_progress(user_id):
         filtered_exp_playlist_summaries,
         filtered_collection_playlist_summaries)
 
-    return (learner_progress, number_of_nonexistent_activities,
-            completed_to_incomplete_collection_titles)
+    return (
+        learner_progress, number_of_nonexistent_activities,
+        completed_to_incomplete_collection_titles)

--- a/core/domain/learner_progress_services_test.py
+++ b/core/domain/learner_progress_services_test.py
@@ -126,8 +126,8 @@ class LearnerProgressTests(test_utils.GenericTestBase):
             'version': incomplete_exploration_user_model.last_played_exp_version
         }
 
-    def _check_if_exp_details_match(self, actual_details,
-                                    details_fetched_from_model):
+    def _check_if_exp_details_match(
+            self, actual_details, details_fetched_from_model):
         self.assertEqual(
             actual_details['state_name'],
             details_fetched_from_model['state_name'])

--- a/core/domain/moderator_services.py
+++ b/core/domain/moderator_services.py
@@ -22,8 +22,8 @@ import feconf
 taskqueue_services = models.Registry.import_taskqueue_services()
 
 
-def enqueue_flag_exploration_email_task(exploration_id, report_text,
-                                        reporter_id):
+def enqueue_flag_exploration_email_task(
+        exploration_id, report_text, reporter_id):
     """Adds a 'send flagged exploration email' task into taskqueue."""
     payload = {
         'exploration_id': exploration_id,

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -100,8 +100,9 @@ class Question(object):
             question is written in.
     """
 
-    def __init__(self, question_id, title, question_data,
-                 question_data_schema_version, language_code):
+    def __init__(
+            self, question_id, title, question_data,
+            question_data_schema_version, language_code):
         """Constructs a Question domain object.
 
         Args:

--- a/core/domain/question_services.py
+++ b/core/domain/question_services.py
@@ -43,10 +43,11 @@ def _create_new_question(committer_id, question, commit_message):
         language_code=question.language_code,
     )
 
-    model.commit(committer_id, commit_message, [{
-        'cmd': CMD_CREATE_NEW,
-        'title': question.title
-    }])
+    model.commit(
+        committer_id, commit_message, [{
+            'cmd': CMD_CREATE_NEW,
+            'title': question.title
+        }])
     return model.id
 
 

--- a/core/domain/question_services_test.py
+++ b/core/domain/question_services_test.py
@@ -81,8 +81,9 @@ class QuestionServicesUnitTest(test_utils.GenericTestBase):
 
         self.assertEqual(model.title, title)
         self.assertEqual(model.question_data, question_data)
-        self.assertEqual(model.question_data_schema_version,
-                         question_data_schema_version)
+        self.assertEqual(
+            model.question_data_schema_version,
+            question_data_schema_version)
         self.assertEqual(model.language_code, language_code)
 
     def test_delete_question(self):
@@ -125,6 +126,7 @@ class QuestionServicesUnitTest(test_utils.GenericTestBase):
         model = question_models.QuestionModel.get(question_id)
         self.assertEqual(model.title, 'ABC')
         self.assertEqual(model.question_data, question_data)
-        self.assertEqual(model.question_data_schema_version,
-                         question_data_schema_version)
+        self.assertEqual(
+            model.question_data_schema_version,
+            question_data_schema_version)
         self.assertEqual(model.language_code, language_code)

--- a/core/domain/recommendations_jobs_one_off.py
+++ b/core/domain/recommendations_jobs_one_off.py
@@ -72,10 +72,11 @@ class ExplorationRecommendationsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                         compared_exp_summary.owner_ids,
                         compared_exp_summary.status))
                 if similarity_score >= SIMILARITY_SCORE_THRESHOLD:
-                    yield (exp_summary_id, {
-                        'similarity_score': similarity_score,
-                        'exp_id': compared_exp_id
-                    })
+                    yield (
+                        exp_summary_id, {
+                            'similarity_score': similarity_score,
+                            'exp_id': compared_exp_id
+                        })
 
     @staticmethod
     def reduce(key, stringified_values):

--- a/core/domain/rights_manager.py
+++ b/core/domain/rights_manager.py
@@ -60,10 +60,11 @@ class ActivityRights(object):
     exploration or a collection).
     """
 
-    def __init__(self, exploration_id, owner_ids, editor_ids, viewer_ids,
-                 community_owned=False, cloned_from=None,
-                 status=ACTIVITY_STATUS_PRIVATE,
-                 viewable_if_private=False, first_published_msec=None):
+    def __init__(
+            self, exploration_id, owner_ids, editor_ids, viewer_ids,
+            community_owned=False, cloned_from=None,
+            status=ACTIVITY_STATUS_PRIVATE,
+            viewable_if_private=False, first_published_msec=None):
         self.id = exploration_id
         self.owner_ids = owner_ids
         self.editor_ids = editor_ids
@@ -852,8 +853,9 @@ def _assign_role(
         'new_role': new_role
     }]
 
-    _save_activity_rights(committer_id, activity_rights, activity_type,
-                          commit_message, commit_cmds)
+    _save_activity_rights(
+        committer_id, activity_rights, activity_type,
+        commit_message, commit_cmds)
     _update_activity_summary(activity_type, activity_rights)
 
 

--- a/core/domain/rights_manager_test.py
+++ b/core/domain/rights_manager_test.py
@@ -456,9 +456,10 @@ class CollectionRightsTests(test_utils.GenericTestBase):
             self.user_a, self.COLLECTION_ID, self.user_id_b,
             rights_manager.ROLE_EDITOR)
 
-        self.assertListEqual(['A'],
-                             rights_manager.get_collection_owner_names(
-                                 self.COLLECTION_ID))
+        self.assertListEqual(
+            ['A'],
+            rights_manager.get_collection_owner_names(
+                self.COLLECTION_ID))
         collection_rights = rights_manager.get_collection_rights(
             self.COLLECTION_ID)
 
@@ -470,9 +471,10 @@ class CollectionRightsTests(test_utils.GenericTestBase):
     def test_newly_created_collection(self):
         self.save_new_default_collection(self.COLLECTION_ID, self.user_id_a)
 
-        self.assertListEqual(['A'],
-                             rights_manager.get_collection_owner_names(
-                                 self.COLLECTION_ID))
+        self.assertListEqual(
+            ['A'],
+            rights_manager.get_collection_owner_names(
+                self.COLLECTION_ID))
         collection_rights = rights_manager.get_collection_rights(
             self.COLLECTION_ID)
 
@@ -530,9 +532,10 @@ class CollectionRightsTests(test_utils.GenericTestBase):
             rights_manager.ROLE_EDITOR)
 
         # Ensure User A is the only user in the owner names list.
-        self.assertListEqual(['A'],
-                             rights_manager.get_collection_owner_names(
-                                 self.COLLECTION_ID))
+        self.assertListEqual(
+            ['A'],
+            rights_manager.get_collection_owner_names(
+                self.COLLECTION_ID))
         collection_rights = rights_manager.get_collection_rights(
             self.COLLECTION_ID)
 

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -409,9 +409,10 @@ class StateStats(object):
 class StateAnswers(object):
     """Domain object containing answers submitted to an exploration state."""
 
-    def __init__(self, exploration_id, exploration_version, state_name,
-                 interaction_id, submitted_answer_list,
-                 schema_version=feconf.CURRENT_STATE_ANSWERS_SCHEMA_VERSION):
+    def __init__(
+            self, exploration_id, exploration_version, state_name,
+            interaction_id, submitted_answer_list,
+            schema_version=feconf.CURRENT_STATE_ANSWERS_SCHEMA_VERSION):
         """Constructs a StateAnswers domain object.
 
         Args:
@@ -497,10 +498,11 @@ class SubmittedAnswer(object):
     # referenced in future migration or mapreduce jobs, or they may be removed
     # without warning or migration.
 
-    def __init__(self, answer, interaction_id, answer_group_index,
-                 rule_spec_index, classification_categorization, params,
-                 session_id, time_spent_in_sec, rule_spec_str=None,
-                 answer_str=None):
+    def __init__(
+            self, answer, interaction_id, answer_group_index,
+            rule_spec_index, classification_categorization, params,
+            session_id, time_spent_in_sec, rule_spec_str=None,
+            answer_str=None):
         self.answer = answer
         self.interaction_id = interaction_id
         self.answer_group_index = answer_group_index
@@ -797,8 +799,9 @@ class StateAnswersCalcOutput(object):
     """Domain object that represents output of calculations operating on
     state answers.
     """
-    def __init__(self, exploration_id, exploration_version, state_name,
-                 interaction_id, calculation_id, calculation_output):
+    def __init__(
+            self, exploration_id, exploration_version, state_name,
+            interaction_id, calculation_id, calculation_output):
         """Initialize domain object for state answers calculation output.
 
         Args:

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -284,30 +284,32 @@ class StateAnswersTests(test_utils.GenericTestBase):
                     rule_spec_str='rule spec str2', answer_str='answer str2')])
         submitted_answer_dict_list = (
             state_answers.get_submitted_answer_dict_list())
-        self.assertEqual(submitted_answer_dict_list, [{
-            'answer': 'Text',
-            'interaction_id': 'TextInput',
-            'answer_group_index': 0,
-            'rule_spec_index': 1,
-            'classification_categorization': exp_domain.EXPLICIT_CLASSIFICATION,
-            'params': {},
-            'session_id': 'sess',
-            'time_spent_in_sec': 10.5,
-            'rule_spec_str': 'rule spec str1',
-            'answer_str': 'answer str1'
-        }, {
-            'answer': 'Other text',
-            'interaction_id': 'TextInput',
-            'answer_group_index': 1,
-            'rule_spec_index': 0,
-            'classification_categorization': (
-                exp_domain.DEFAULT_OUTCOME_CLASSIFICATION),
-            'params': {},
-            'session_id': 'sess',
-            'time_spent_in_sec': 7.5,
-            'rule_spec_str': 'rule spec str2',
-            'answer_str': 'answer str2'
-        }])
+        self.assertEqual(
+            submitted_answer_dict_list, [{
+                'answer': 'Text',
+                'interaction_id': 'TextInput',
+                'answer_group_index': 0,
+                'rule_spec_index': 1,
+                'classification_categorization': (
+                    exp_domain.EXPLICIT_CLASSIFICATION),
+                'params': {},
+                'session_id': 'sess',
+                'time_spent_in_sec': 10.5,
+                'rule_spec_str': 'rule spec str1',
+                'answer_str': 'answer str1'
+            }, {
+                'answer': 'Other text',
+                'interaction_id': 'TextInput',
+                'answer_group_index': 1,
+                'rule_spec_index': 0,
+                'classification_categorization': (
+                    exp_domain.DEFAULT_OUTCOME_CLASSIFICATION),
+                'params': {},
+                'session_id': 'sess',
+                'time_spent_in_sec': 7.5,
+                'rule_spec_str': 'rule spec str2',
+                'answer_str': 'answer str2'
+            }])
 
 
 class StateAnswersValidationTests(test_utils.GenericTestBase):

--- a/core/domain/stats_jobs_continuous_test.py
+++ b/core/domain/stats_jobs_continuous_test.py
@@ -763,14 +763,16 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
             calculation_output_second = (
                 common_elements_calc_output_model.calculation_output)
 
-            self.assertEqual(calculation_output_first, [{
-                'answer': ['answer1', 'answer2'],
-                'frequency': 1
-            }])
-            self.assertEqual(calculation_output_second, [{
-                'answer': 'answer1',
-                'frequency': 1
-            }, {
-                'answer': 'answer2',
-                'frequency': 1
-            }])
+            self.assertEqual(
+                calculation_output_first, [{
+                    'answer': ['answer1', 'answer2'],
+                    'frequency': 1
+                }])
+            self.assertEqual(
+                calculation_output_second, [{
+                    'answer': 'answer1',
+                    'frequency': 1
+                }, {
+                    'answer': 'answer2',
+                    'frequency': 1
+                }])

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -54,53 +54,59 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
         if item.event_schema_version != 2:
             return
         if isinstance(item, stats_models.StateCompleteEventLogEntryModel):
-            yield (item.exp_id,
-                   {
-                       'event_type': feconf.EVENT_TYPE_STATE_COMPLETED,
-                       'version': item.exp_version,
-                       'state_name': item.state_name
-                   })
+            yield (
+                item.exp_id,
+                {
+                    'event_type': feconf.EVENT_TYPE_STATE_COMPLETED,
+                    'version': item.exp_version,
+                    'state_name': item.state_name
+                })
         elif isinstance(
                 item, stats_models.AnswerSubmittedEventLogEntryModel):
-            yield (item.exp_id,
-                   {
-                       'event_type': feconf.EVENT_TYPE_ANSWER_SUBMITTED,
-                       'version': item.exp_version,
-                       'state_name': item.state_name,
-                       'is_feedback_useful': item.is_feedback_useful
-                   })
+            yield (
+                item.exp_id,
+                {
+                    'event_type': feconf.EVENT_TYPE_ANSWER_SUBMITTED,
+                    'version': item.exp_version,
+                    'state_name': item.state_name,
+                    'is_feedback_useful': item.is_feedback_useful
+                })
         elif isinstance(item, stats_models.StateHitEventLogEntryModel):
-            yield (item.exploration_id,
-                   {
-                       'event_type': feconf.EVENT_TYPE_STATE_HIT,
-                       'version': item.exploration_version,
-                       'state_name': item.state_name,
-                       'session_id': item.session_id
-                   })
+            yield (
+                item.exploration_id,
+                {
+                    'event_type': feconf.EVENT_TYPE_STATE_HIT,
+                    'version': item.exploration_version,
+                    'state_name': item.state_name,
+                    'session_id': item.session_id
+                })
         elif isinstance(item, stats_models.SolutionHitEventLogEntryModel):
-            yield (item.exp_id,
-                   {
-                       'event_type': feconf.EVENT_TYPE_SOLUTION_HIT,
-                       'version': item.exp_version,
-                       'state_name': item.state_name,
-                       'session_id': item.session_id
-                   })
+            yield (
+                item.exp_id,
+                {
+                    'event_type': feconf.EVENT_TYPE_SOLUTION_HIT,
+                    'version': item.exp_version,
+                    'state_name': item.state_name,
+                    'session_id': item.session_id
+                })
         elif isinstance(
                 item, stats_models.ExplorationActualStartEventLogEntryModel):
-            yield (item.exp_id,
-                   {
-                       'event_type': feconf.EVENT_TYPE_ACTUAL_START_EXPLORATION,
-                       'version': item.exp_version,
-                       'state_name': item.state_name
-                   })
+            yield (
+                item.exp_id,
+                {
+                    'event_type': feconf.EVENT_TYPE_ACTUAL_START_EXPLORATION,
+                    'version': item.exp_version,
+                    'state_name': item.state_name
+                })
         elif isinstance(
                 item, stats_models.CompleteExplorationEventLogEntryModel):
-            yield (item.exploration_id,
-                   {
-                       'event_type': feconf.EVENT_TYPE_COMPLETE_EXPLORATION,
-                       'version': item.exploration_version,
-                       'state_name': item.state_name
-                   })
+            yield (
+                item.exploration_id,
+                {
+                    'event_type': feconf.EVENT_TYPE_COMPLETE_EXPLORATION,
+                    'version': item.exploration_version,
+                    'state_name': item.state_name
+                })
 
     @staticmethod
     def reduce(exp_id, values):
@@ -354,13 +360,14 @@ class StatisticsAuditV1(jobs.BaseMapReduceOneOffJobManager):
             } for state_name in item.state_stats_mapping
         }
 
-        yield (item.exp_id, {
-            'exp_version': item.exp_version,
-            'num_starts_v1': item.num_starts_v1,
-            'num_completions_v1': item.num_completions_v1,
-            'num_actual_starts_v1': item.num_actual_starts_v1,
-            'state_stats_mapping': reduced_state_stats_mapping
-        })
+        yield (
+            item.exp_id, {
+                'exp_version': item.exp_version,
+                'num_starts_v1': item.num_starts_v1,
+                'num_completions_v1': item.num_completions_v1,
+                'num_actual_starts_v1': item.num_actual_starts_v1,
+                'state_stats_mapping': reduced_state_stats_mapping
+            })
 
     @staticmethod
     def reduce(exp_id, stringified_values):
@@ -519,12 +526,13 @@ class StatisticsAudit(jobs.BaseMapReduceOneOffJobManager):
         # This is short hand for making sure we get ones updated most recently.
         else:
             if item.exploration_id is not None:
-                yield (item.exploration_id, {
-                    'version': item.version,
-                    'starts': item.num_starts,
-                    'completions': item.num_completions,
-                    'state_hit': item.state_hit_counts
-                })
+                yield (
+                    item.exploration_id, {
+                        'version': item.version,
+                        'starts': item.num_starts,
+                        'completions': item.num_completions,
+                        'state_hit': item.state_hit_counts
+                    })
 
     @staticmethod
     def reduce(key, stringified_values):

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -1152,34 +1152,37 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
     def _rename_state(
             self, new_state_name, exp_id=TEXT_INPUT_EXP_ID,
             state_name=INIT_STATE_NAME):
-        exp_services.update_exploration(self.owner_id, exp_id, [{
-            'cmd': exp_domain.CMD_RENAME_STATE,
-            'old_state_name': state_name,
-            'new_state_name': new_state_name
-        }], 'Update state name')
+        exp_services.update_exploration(
+            self.owner_id, exp_id, [{
+                'cmd': exp_domain.CMD_RENAME_STATE,
+                'old_state_name': state_name,
+                'new_state_name': new_state_name
+            }], 'Update state name')
 
     def _change_state_interaction_id(
             self, interaction_id, exp_id=TEXT_INPUT_EXP_ID,
             state_name=INIT_STATE_NAME):
-        exp_services.update_exploration(self.owner_id, exp_id, [{
-            'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-            'state_name': state_name,
-            'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
-            'new_value': interaction_id
-        }], 'Update state interaction ID')
+        exp_services.update_exploration(
+            self.owner_id, exp_id, [{
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'state_name': state_name,
+                'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
+                'new_value': interaction_id
+            }], 'Update state interaction ID')
 
     def _change_state_content(
             self, new_content, exp_id=TEXT_INPUT_EXP_ID,
             state_name=INIT_STATE_NAME):
-        exp_services.update_exploration(self.owner_id, exp_id, [{
-            'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-            'state_name': state_name,
-            'property_name': exp_domain.STATE_PROPERTY_CONTENT,
-            'new_value': {
-                'html': new_content,
-                'audio_translations': {},
-            }
-        }], 'Change content description')
+        exp_services.update_exploration(
+            self.owner_id, exp_id, [{
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'state_name': state_name,
+                'property_name': exp_domain.STATE_PROPERTY_CONTENT,
+                'new_value': {
+                    'html': new_content,
+                    'audio_translations': {},
+                }
+            }], 'Change content description')
 
     def setUp(self):
         super(AnswerVisualizationsTests, self).setUp()
@@ -1237,10 +1240,11 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
 
             visualization = visualizations[0]
             self.assertEqual(visualization['id'], 'FrequencyTable')
-            self.assertEqual(visualization['data'], [{
-                'answer': 'Answer A',
-                'frequency': 1
-            }])
+            self.assertEqual(
+                visualization['data'], [{
+                    'answer': 'Answer A',
+                    'frequency': 1
+                }])
 
     def test_has_vis_info_for_exp_with_many_answers_for_one_calculation(self):
         with self._get_swap_context():
@@ -1256,16 +1260,17 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             visualization = visualizations[0]
             self.assertEqual(visualization['id'], 'FrequencyTable')
             # Ties will appear in same order they are submitted in.
-            self.assertEqual(visualization['data'], [{
-                'answer': 'Answer A',
-                'frequency': 3
-            }, {
-                'answer': 'Answer C',
-                'frequency': 1
-            }, {
-                'answer': 'Answer B',
-                'frequency': 1
-            }])
+            self.assertEqual(
+                visualization['data'], [{
+                    'answer': 'Answer A',
+                    'frequency': 3
+                }, {
+                    'answer': 'Answer C',
+                    'frequency': 1
+                }, {
+                    'answer': 'Answer B',
+                    'frequency': 1
+                }])
 
     def test_has_vis_info_for_each_calculation_for_multi_calc_exp(self):
         with self._get_swap_context():
@@ -1288,16 +1293,17 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             self.assertEqual(
                 top_answers_visualization['options']['column_headers'],
                 ['Answer', 'Count'])
-            self.assertEqual(top_answers_visualization['data'], [{
-                'answer': ['A', 'B'],
-                'frequency': 3
-            }, {
-                'answer': ['A'],
-                'frequency': 2
-            }, {
-                'answer': ['C', 'A'],
-                'frequency': 1
-            }])
+            self.assertEqual(
+                top_answers_visualization['data'], [{
+                    'answer': ['A', 'B'],
+                    'frequency': 3
+                }, {
+                    'answer': ['A'],
+                    'frequency': 2
+                }, {
+                    'answer': ['C', 'A'],
+                    'frequency': 1
+                }])
 
             common_elements_visualization = visualizations[1]
             self.assertEqual(
@@ -1308,16 +1314,17 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
 
             common_visualization_data = (
                 common_elements_visualization['data'])
-            self.assertEqual(common_visualization_data, [{
-                'answer': 'A',
-                'frequency': 6
-            }, {
-                'answer': 'B',
-                'frequency': 3
-            }, {
-                'answer': 'C',
-                'frequency': 1
-            }])
+            self.assertEqual(
+                common_visualization_data, [{
+                    'answer': 'A',
+                    'frequency': 6
+                }, {
+                    'answer': 'B',
+                    'frequency': 3
+                }, {
+                    'answer': 'C',
+                    'frequency': 1
+                }])
 
     def test_retrieves_latest_vis_info_with_rounds_of_calculations(self):
         with self._get_swap_context():
@@ -1333,13 +1340,14 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
 
             visualization = visualizations[0]
             # The latest data should include all submitted answers.
-            self.assertEqual(visualization['data'], [{
-                'answer': 'Answer A',
-                'frequency': 2
-            }, {
-                'answer': 'Answer C',
-                'frequency': 1
-            }])
+            self.assertEqual(
+                visualization['data'], [{
+                    'answer': 'Answer A',
+                    'frequency': 2
+                }, {
+                    'answer': 'Answer C',
+                    'frequency': 1
+                }])
 
     def test_retrieves_vis_info_across_multiple_exploration_versions(self):
         with self._get_swap_context():
@@ -1356,13 +1364,14 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
 
             visualization = visualizations[0]
             # The latest data should include all submitted answers.
-            self.assertEqual(visualization['data'], [{
-                'answer': 'Answer A',
-                'frequency': 2
-            }, {
-                'answer': 'Answer B',
-                'frequency': 1
-            }])
+            self.assertEqual(
+                visualization['data'], [{
+                    'answer': 'Answer A',
+                    'frequency': 2
+                }, {
+                    'answer': 'Answer B',
+                    'frequency': 1
+                }])
 
     def test_no_vis_info_for_exp_with_new_state_name_before_calculations(self):
         with self._get_swap_context():

--- a/core/domain/subscription_services_test.py
+++ b/core/domain/subscription_services_test.py
@@ -335,10 +335,11 @@ class SubscriptionsTest(test_utils.GenericTestBase):
         # If the collection author adds the exploration to his/her collection,
         # the collection author should not be subscribed to the exploration nor
         # should the exploration author be subscribed to the collection.
-        collection_services.update_collection(self.owner_id, COLLECTION_ID, [{
-            'cmd': collection_domain.CMD_ADD_COLLECTION_NODE,
-            'exploration_id': EXP_ID
-        }], 'Add new exploration to collection.')
+        collection_services.update_collection(
+            self.owner_id, COLLECTION_ID, [{
+                'cmd': collection_domain.CMD_ADD_COLLECTION_NODE,
+                'exploration_id': EXP_ID
+            }], 'Add new exploration to collection.')
 
         # Ensure subscriptions are as expected.
         self.assertEqual(
@@ -399,8 +400,8 @@ class UserSubscriptionsTest(test_utils.GenericTestBase):
             [self.owner_id])
 
         # Subscribe another creator.
-        subscription_services.subscribe_to_creator(USER_ID_2,
-                                                   self.owner_id)
+        subscription_services.subscribe_to_creator(
+            USER_ID_2, self.owner_id)
         self.assertEqual(
             self._get_all_subscribers_of_creators(self.owner_id),
             [USER_ID, USER_ID_2])

--- a/core/domain/summary_services_test.py
+++ b/core/domain/summary_services_test.py
@@ -197,8 +197,8 @@ class ExplorationDisplayableSummariesTest(
             'title': u'Exploration 2 Albert title',
         }
         self.assertIn('last_updated_msec', displayable_summaries[0])
-        self.assertDictContainsSubset(expected_summary,
-                                      displayable_summaries[0])
+        self.assertDictContainsSubset(
+            expected_summary, displayable_summaries[0])
 
     def test_get_public_and_filtered_private_summary_dicts_for_creator(self):
         # If a new exploration is created by another user (Bob) and not public,
@@ -251,10 +251,11 @@ class LibraryGroupsTest(exp_services_test.ExplorationServicesUnitTests):
         self.login(self.ADMIN_EMAIL, is_super_admin=True)
         response = self.testapp.get('/admin')
         csrf_token = self.get_csrf_token_from_response(response)
-        self.post_json('/adminhandler', {
-            'action': 'reload_exploration',
-            'exploration_id': '2'
-        }, csrf_token)
+        self.post_json(
+            '/adminhandler', {
+                'action': 'reload_exploration',
+                'exploration_id': '2'
+            }, csrf_token)
         self.logout()
 
     def test_get_library_groups(self):
@@ -726,8 +727,8 @@ class RecentlyPublishedExplorationDisplayableSummariesTest(
         - (7) Admin user is set up.
         """
 
-        super(RecentlyPublishedExplorationDisplayableSummariesTest,
-              self).setUp()
+        super(
+            RecentlyPublishedExplorationDisplayableSummariesTest, self).setUp()
 
         self.admin_id = self.get_user_id_from_email(self.ADMIN_EMAIL)
         self.albert_id = self.get_user_id_from_email(self.ALBERT_EMAIL)
@@ -907,25 +908,30 @@ class CollectionNodeMetadataDictsTest(
         self.albert = user_services.UserActionsInfo(self.albert_id)
         self.bob = user_services.UserActionsInfo(self.bob_id)
 
-        self.save_new_valid_exploration(self.EXP_ID1, self.albert_id,
-                                        title='Exploration 1 Albert title',
-                                        objective='An objective 1')
+        self.save_new_valid_exploration(
+            self.EXP_ID1, self.albert_id,
+            title='Exploration 1 Albert title',
+            objective='An objective 1')
 
-        self.save_new_valid_exploration(self.EXP_ID2, self.albert_id,
-                                        title='Exploration 2 Albert title',
-                                        objective='An objective 2')
+        self.save_new_valid_exploration(
+            self.EXP_ID2, self.albert_id,
+            title='Exploration 2 Albert title',
+            objective='An objective 2')
 
-        self.save_new_valid_exploration(self.EXP_ID3, self.albert_id,
-                                        title='Exploration 3 Albert title',
-                                        objective='An objective 3')
+        self.save_new_valid_exploration(
+            self.EXP_ID3, self.albert_id,
+            title='Exploration 3 Albert title',
+            objective='An objective 3')
 
-        self.save_new_valid_exploration(self.EXP_ID4, self.bob_id,
-                                        title='Exploration 4 Bob title',
-                                        objective='An objective 4')
+        self.save_new_valid_exploration(
+            self.EXP_ID4, self.bob_id,
+            title='Exploration 4 Bob title',
+            objective='An objective 4')
 
-        self.save_new_valid_exploration(self.EXP_ID5, self.albert_id,
-                                        title='Exploration 5 Albert title',
-                                        objective='An objective 5')
+        self.save_new_valid_exploration(
+            self.EXP_ID5, self.albert_id,
+            title='Exploration 5 Albert title',
+            objective='An objective 5')
 
         rights_manager.publish_exploration(self.albert, self.EXP_ID1)
         rights_manager.publish_exploration(self.albert, self.EXP_ID2)

--- a/core/domain/user_domain.py
+++ b/core/domain/user_domain.py
@@ -77,8 +77,8 @@ class UserExplorationPrefs(object):
             muted suggestion emails.
     """
 
-    def __init__(self, mute_feedback_notifications,
-                 mute_suggestion_notifications):
+    def __init__(
+            self, mute_feedback_notifications, mute_suggestion_notifications):
         """Constructs a UserExplorationPrefs domain object.
 
         Args:
@@ -116,8 +116,9 @@ class UserExplorationPrefs(object):
 class ExpUserLastPlaythrough(object):
     """Domain object for an exploration last playthrough model."""
 
-    def __init__(self, user_id, exploration_id, last_played_exp_version,
-                 last_updated, last_played_state_name):
+    def __init__(
+            self, user_id, exploration_id, last_played_exp_version,
+            last_updated, last_played_state_name):
         self.id = '%s.%s' % (user_id, exploration_id)
         self.user_id = user_id
         self.exploration_id = exploration_id
@@ -125,8 +126,8 @@ class ExpUserLastPlaythrough(object):
         self.last_updated = last_updated
         self.last_played_state_name = last_played_state_name
 
-    def update_last_played_information(self, last_played_exp_version,
-                                       last_played_state_name):
+    def update_last_played_information(
+            self, last_played_exp_version, last_played_state_name):
         """Updates the last playthrough information of the user.
 
         Args:
@@ -142,8 +143,8 @@ class ExpUserLastPlaythrough(object):
 class IncompleteActivities(object):
     """Domain object for the incomplete activities model."""
 
-    def __init__(self, user_id, exploration_ids,
-                 collection_ids):
+    def __init__(
+            self, user_id, exploration_ids, collection_ids):
         self.id = user_id
         self.exploration_ids = exploration_ids
         self.collection_ids = collection_ids
@@ -172,8 +173,8 @@ class IncompleteActivities(object):
 class CompletedActivities(object):
     """Domain object for the activities completed by learner model."""
 
-    def __init__(self, user_id, exploration_ids,
-                 collection_ids):
+    def __init__(
+            self, user_id, exploration_ids, collection_ids):
         self.id = user_id
         self.exploration_ids = exploration_ids
         self.collection_ids = collection_ids
@@ -202,8 +203,8 @@ class CompletedActivities(object):
 class LearnerPlaylist(object):
     """Domain object for the learner playlist model."""
 
-    def __init__(self, user_id, exploration_ids,
-                 collection_ids):
+    def __init__(
+            self, user_id, exploration_ids, collection_ids):
         self.id = user_id
         self.exploration_ids = exploration_ids
         self.collection_ids = collection_ids
@@ -217,7 +218,8 @@ class LearnerPlaylist(object):
                 play later list.
             position_to_be_inserted: The position at which it is to be inserted.
         """
-        self.exploration_ids.insert(position_to_be_inserted, exploration_id)
+        self.exploration_ids.insert(
+            position_to_be_inserted, exploration_id)
 
     def add_exploration_id_to_list(self, exploration_id):
         """Inserts the exploration id at the end of the list.

--- a/core/domain/user_jobs_continuous.py
+++ b/core/domain/user_jobs_continuous.py
@@ -275,16 +275,17 @@ class RecentUpdatesMRJobManager(
                 feedback_models.FeedbackMessageModel.get_most_recent_message(
                     exp_id, thread_id))
 
-            yield (reducer_key, {
-                'type': feconf.UPDATE_TYPE_FEEDBACK_MESSAGE,
-                'activity_id': last_message.exploration_id,
-                'activity_title': exp_models.ExplorationModel.get_by_id(
-                    last_message.exploration_id).title,
-                'author_id': last_message.author_id,
-                'last_updated_ms': utils.get_time_in_millisecs(
-                    last_message.created_on),
-                'subject': last_message.get_thread_subject(),
-            })
+            yield (
+                reducer_key, {
+                    'type': feconf.UPDATE_TYPE_FEEDBACK_MESSAGE,
+                    'activity_id': last_message.exploration_id,
+                    'activity_title': exp_models.ExplorationModel.get_by_id(
+                        last_message.exploration_id).title,
+                    'author_id': last_message.author_id,
+                    'last_updated_ms': utils.get_time_in_millisecs(
+                        last_message.created_on),
+                    'subject': last_message.get_thread_subject(),
+                })
 
     @staticmethod
     def reduce(key, stringified_values):

--- a/core/domain/user_jobs_continuous_test.py
+++ b/core/domain/user_jobs_continuous_test.py
@@ -383,14 +383,16 @@ class RecentUpdatesAggregatorUnitTests(test_utils.GenericTestBase):
                     exp_last_updated_ms))
 
             # User A sees A's commit and B's feedback thread.
-            self.assertEqual(recent_notifications_for_user_a, [
-                expected_thread_notification,
-                expected_creation_notification
-            ])
+            self.assertEqual(
+                recent_notifications_for_user_a, [
+                    expected_thread_notification,
+                    expected_creation_notification
+                ])
             # User B sees only her feedback thread, but no commits.
-            self.assertEqual(recent_notifications_for_user_b, [
-                expected_thread_notification,
-            ])
+            self.assertEqual(
+                recent_notifications_for_user_b, [
+                    expected_thread_notification,
+                ])
 
     def test_subscribing_to_exploration_subscribes_to_its_feedback_threads(
             self):
@@ -448,15 +450,17 @@ class RecentUpdatesAggregatorUnitTests(test_utils.GenericTestBase):
                     exp_last_updated_ms))
 
             # User A sees A's commit and B's feedback thread.
-            self.assertEqual(recent_notifications_for_user_a, [
-                expected_thread_notification,
-                expected_creation_notification
-            ])
+            self.assertEqual(
+                recent_notifications_for_user_a, [
+                    expected_thread_notification,
+                    expected_creation_notification
+                ])
             # User B sees A's commit and B's feedback thread.
-            self.assertEqual(recent_notifications_for_user_b, [
-                expected_thread_notification,
-                expected_creation_notification,
-            ])
+            self.assertEqual(
+                recent_notifications_for_user_b, [
+                    expected_thread_notification,
+                    expected_creation_notification,
+                ])
 
     def test_basic_computation_for_collections(self):
         with self._get_test_context():

--- a/core/domain/user_jobs_one_off.py
+++ b/core/domain/user_jobs_one_off.py
@@ -43,10 +43,12 @@ class UserContributionsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     @staticmethod
     def map(item):
         """Implements the map function for this job."""
-        yield (item.committer_id, {
-            'exploration_id': item.get_unversioned_instance_id(),
-            'version_string': item.get_version_string(),
-        })
+        yield (
+            item.committer_id, {
+                'exploration_id': item.get_unversioned_instance_id(),
+                'version_string': item.get_version_string(),
+            })
+
 
     @staticmethod
     def reduce(key, version_and_exp_ids):
@@ -165,25 +167,28 @@ class DashboardSubscriptionsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
         """Implements the map function for this job."""
         if isinstance(item, feedback_models.FeedbackMessageModel):
             if item.author_id:
-                yield (item.author_id, {
-                    'type': 'feedback',
-                    'id': item.thread_id
-                })
+                yield (
+                    item.author_id, {
+                        'type': 'feedback',
+                        'id': item.thread_id
+                    })
         elif isinstance(item, exp_models.ExplorationRightsModel):
             if item.deleted:
                 return
 
             if not item.community_owned:
                 for owner_id in item.owner_ids:
-                    yield (owner_id, {
-                        'type': 'exploration',
-                        'id': item.id
-                    })
+                    yield (
+                        owner_id, {
+                            'type': 'exploration',
+                            'id': item.id
+                        })
                 for editor_id in item.editor_ids:
-                    yield (editor_id, {
-                        'type': 'exploration',
-                        'id': item.id
-                    })
+                    yield (
+                        editor_id, {
+                            'type': 'exploration',
+                            'id': item.id
+                        })
             else:
                 # Go through the history.
                 current_version = item.version
@@ -193,15 +198,17 @@ class DashboardSubscriptionsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
                     if not model.community_owned:
                         for owner_id in model.owner_ids:
-                            yield (owner_id, {
-                                'type': 'exploration',
-                                'id': item.id
-                            })
+                            yield (
+                                owner_id, {
+                                    'type': 'exploration',
+                                    'id': item.id
+                                })
                         for editor_id in model.editor_ids:
-                            yield (editor_id, {
-                                'type': 'exploration',
-                                'id': item.id
-                            })
+                            yield (
+                                editor_id, {
+                                    'type': 'exploration',
+                                    'id': item.id
+                                })
         elif isinstance(item, collection_models.CollectionRightsModel):
             # NOTE TO DEVELOPERS: Although the code handling subscribing to
             # collections is very similar to the code above for explorations,
@@ -215,15 +222,17 @@ class DashboardSubscriptionsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
             if not item.community_owned:
                 for owner_id in item.owner_ids:
-                    yield (owner_id, {
-                        'type': 'collection',
-                        'id': item.id
-                    })
+                    yield (
+                        owner_id, {
+                            'type': 'collection',
+                            'id': item.id
+                        })
                 for editor_id in item.editor_ids:
-                    yield (editor_id, {
-                        'type': 'collection',
-                        'id': item.id
-                    })
+                    yield (
+                        editor_id, {
+                            'type': 'collection',
+                            'id': item.id
+                        })
             else:
                 # Go through the history.
                 current_version = item.version
@@ -234,15 +243,17 @@ class DashboardSubscriptionsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
                     if not model.community_owned:
                         for owner_id in model.owner_ids:
-                            yield (owner_id, {
-                                'type': 'collection',
-                                'id': item.id
-                            })
+                            yield (
+                                owner_id, {
+                                    'type': 'collection',
+                                    'id': item.id
+                                })
                         for editor_id in model.editor_ids:
-                            yield (editor_id, {
-                                'type': 'collection',
-                                'id': item.id
-                            })
+                            yield (
+                                editor_id, {
+                                    'type': 'collection',
+                                    'id': item.id
+                                })
 
     @staticmethod
     def reduce(key, stringified_values):

--- a/core/domain/user_jobs_one_off_test.py
+++ b/core/domain/user_jobs_one_off_test.py
@@ -84,20 +84,22 @@ class UserContributionsOneOffJobTests(test_utils.GenericTestBase):
         self.save_new_valid_exploration(
             self.EXP_ID_1, self.user_b_id, end_state_name='End')
 
-        exp_services.update_exploration(self.user_c_id, self.EXP_ID_1, [{
-            'cmd': 'edit_exploration_property',
-            'property_name': 'objective',
-            'new_value': 'the objective'
-        }], 'Test edit')
+        exp_services.update_exploration(
+            self.user_c_id, self.EXP_ID_1, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'objective',
+                'new_value': 'the objective'
+            }], 'Test edit')
 
         self.save_new_valid_exploration(
             self.EXP_ID_2, self.user_d_id, end_state_name='End')
 
-        exp_services.update_exploration(self.user_d_id, self.EXP_ID_2, [{
-            'cmd': 'edit_exploration_property',
-            'property_name': 'objective',
-            'new_value': 'the objective'
-        }], 'Test edit')
+        exp_services.update_exploration(
+            self.user_d_id, self.EXP_ID_2, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'objective',
+                'new_value': 'the objective'
+            }], 'Test edit')
 
     def test_null_case(self):
         """Tests the case where user has no created or edited explorations."""
@@ -758,9 +760,10 @@ class DashboardStatsOneOffJobTests(test_utils.GenericTestBase):
         self.assertEquals(
             user_services.get_last_week_dashboard_stats(self.owner_id), None)
 
-        with self.swap(user_services,
-                       'get_current_date_as_string',
-                       self._mock_get_current_date_as_string):
+        with self.swap(
+            user_services,
+            'get_current_date_as_string',
+            self._mock_get_current_date_as_string):
             self._run_one_off_job()
 
         weekly_stats = user_services.get_weekly_dashboard_stats(self.owner_id)
@@ -777,23 +780,26 @@ class DashboardStatsOneOffJobTests(test_utils.GenericTestBase):
             expected_results_list[0])
 
     def test_weekly_stats_if_no_explorations(self):
-        (user_jobs_continuous_test.ModifiedUserStatsAggregator.
-         start_computation())
+        (
+            user_jobs_continuous_test.ModifiedUserStatsAggregator.
+            start_computation())
         self.process_and_flush_pending_tasks()
 
-        with self.swap(user_services,
-                       'get_current_date_as_string',
-                       self._mock_get_current_date_as_string):
+        with self.swap(
+            user_services,
+            'get_current_date_as_string',
+            self._mock_get_current_date_as_string):
             self._run_one_off_job()
 
         weekly_stats = user_services.get_weekly_dashboard_stats(self.owner_id)
-        self.assertEqual(weekly_stats, [{
-            self._mock_get_current_date_as_string(): {
-                'num_ratings': 0,
-                'average_ratings': None,
-                'total_plays': 0
-            }
-        }])
+        self.assertEqual(
+            weekly_stats, [{
+                self._mock_get_current_date_as_string(): {
+                    'num_ratings': 0,
+                    'average_ratings': None,
+                    'total_plays': 0
+                }
+            }])
 
     def test_weekly_stats_for_single_exploration(self):
         exploration = self.save_new_valid_exploration(
@@ -802,30 +808,34 @@ class DashboardStatsOneOffJobTests(test_utils.GenericTestBase):
         init_state_name = exploration.init_state_name
         self._record_play(exp_id, init_state_name)
         self._rate_exploration('user1', exp_id, 5)
-        event_services.StatsEventsHandler.record(self.EXP_ID_1, 1, {
-            'num_starts': 1,
-            'num_actual_starts': 0,
-            'num_completions': 0,
-            'state_stats_mapping': {}
-        })
+        event_services.StatsEventsHandler.record(
+            self.EXP_ID_1, 1, {
+                'num_starts': 1,
+                'num_actual_starts': 0,
+                'num_completions': 0,
+                'state_stats_mapping': {}
+            })
 
-        (user_jobs_continuous_test.ModifiedUserStatsAggregator.
-         start_computation())
+        (
+            user_jobs_continuous_test.ModifiedUserStatsAggregator.
+            start_computation())
         self.process_and_flush_pending_tasks()
 
-        with self.swap(user_services,
-                       'get_current_date_as_string',
-                       self._mock_get_current_date_as_string):
+        with self.swap(
+            user_services,
+            'get_current_date_as_string',
+            self._mock_get_current_date_as_string):
             self._run_one_off_job()
 
         weekly_stats = user_services.get_weekly_dashboard_stats(self.owner_id)
-        self.assertEqual(weekly_stats, [{
-            self._mock_get_current_date_as_string(): {
-                'num_ratings': 1,
-                'average_ratings': 5.0,
-                'total_plays': 1
-            }
-        }])
+        self.assertEqual(
+            weekly_stats, [{
+                self._mock_get_current_date_as_string(): {
+                    'num_ratings': 1,
+                    'average_ratings': 5.0,
+                    'total_plays': 1
+                }
+            }])
 
     def test_weekly_stats_for_multiple_explorations(self):
         exploration_1 = self.save_new_valid_exploration(
@@ -838,30 +848,34 @@ class DashboardStatsOneOffJobTests(test_utils.GenericTestBase):
         self._record_play(exp_id_1, init_state_name_1)
         self._rate_exploration('user1', exp_id_1, 5)
         self._rate_exploration('user2', exp_id_2, 4)
-        event_services.StatsEventsHandler.record(self.EXP_ID_1, 1, {
-            'num_starts': 1,
-            'num_actual_starts': 0,
-            'num_completions': 0,
-            'state_stats_mapping': {}
-        })
+        event_services.StatsEventsHandler.record(
+            self.EXP_ID_1, 1, {
+                'num_starts': 1,
+                'num_actual_starts': 0,
+                'num_completions': 0,
+                'state_stats_mapping': {}
+            })
 
-        (user_jobs_continuous_test.ModifiedUserStatsAggregator.
-         start_computation())
+        (
+            user_jobs_continuous_test.ModifiedUserStatsAggregator.
+            start_computation())
         self.process_and_flush_pending_tasks()
 
-        with self.swap(user_services,
-                       'get_current_date_as_string',
-                       self._mock_get_current_date_as_string):
+        with self.swap(
+            user_services,
+            'get_current_date_as_string',
+            self._mock_get_current_date_as_string):
             self._run_one_off_job()
 
         weekly_stats = user_services.get_weekly_dashboard_stats(self.owner_id)
-        self.assertEqual(weekly_stats, [{
-            self._mock_get_current_date_as_string(): {
-                'num_ratings': 2,
-                'average_ratings': 4.5,
-                'total_plays': 1
-            }
-        }])
+        self.assertEqual(
+            weekly_stats, [{
+                self._mock_get_current_date_as_string(): {
+                    'num_ratings': 2,
+                    'average_ratings': 4.5,
+                    'total_plays': 1
+                }
+            }])
 
     def test_stats_for_multiple_weeks(self):
         exploration = self.save_new_valid_exploration(
@@ -871,48 +885,55 @@ class DashboardStatsOneOffJobTests(test_utils.GenericTestBase):
         self._rate_exploration('user1', exp_id, 4)
         self._record_play(exp_id, init_state_name)
         self._record_play(exp_id, init_state_name)
-        event_services.StatsEventsHandler.record(self.EXP_ID_1, 1, {
-            'num_starts': 2,
-            'num_actual_starts': 0,
-            'num_completions': 0,
-            'state_stats_mapping': {}
-        })
+        event_services.StatsEventsHandler.record(
+            self.EXP_ID_1, 1, {
+                'num_starts': 2,
+                'num_actual_starts': 0,
+                'num_completions': 0,
+                'state_stats_mapping': {}
+            })
 
-        (user_jobs_continuous_test.ModifiedUserStatsAggregator.
-         start_computation())
+        (
+            user_jobs_continuous_test.ModifiedUserStatsAggregator.
+            start_computation())
         self.process_and_flush_pending_tasks()
 
-        with self.swap(user_services,
-                       'get_current_date_as_string',
-                       self._mock_get_current_date_as_string):
+        with self.swap(
+            user_services,
+            'get_current_date_as_string',
+            self._mock_get_current_date_as_string):
             self._run_one_off_job()
 
         weekly_stats = user_services.get_weekly_dashboard_stats(self.owner_id)
-        self.assertEqual(weekly_stats, [{
-            self._mock_get_current_date_as_string(): {
-                'num_ratings': 1,
-                'average_ratings': 4.0,
-                'total_plays': 2
-            }
-        }])
+        self.assertEqual(
+            weekly_stats, [{
+                self._mock_get_current_date_as_string(): {
+                    'num_ratings': 1,
+                    'average_ratings': 4.0,
+                    'total_plays': 2
+                }
+            }])
 
-        (user_jobs_continuous_test.ModifiedUserStatsAggregator.
-         stop_computation(self.owner_id))
+        (
+            user_jobs_continuous_test.ModifiedUserStatsAggregator.
+            stop_computation(self.owner_id))
         self.process_and_flush_pending_tasks()
 
         self._rate_exploration('user2', exp_id, 2)
 
-        (user_jobs_continuous_test.ModifiedUserStatsAggregator.
-         start_computation())
+        (
+            user_jobs_continuous_test.ModifiedUserStatsAggregator.
+            start_computation())
         self.process_and_flush_pending_tasks()
 
         def _mock_get_date_after_one_week():
             """Returns the date of the next week."""
             return self.DATE_AFTER_ONE_WEEK
 
-        with self.swap(user_services,
-                       'get_current_date_as_string',
-                       _mock_get_date_after_one_week):
+        with self.swap(
+            user_services,
+            'get_current_date_as_string',
+            _mock_get_date_after_one_week):
             self._run_one_off_job()
 
         expected_results_list = [
@@ -1120,11 +1141,12 @@ class UserLastExplorationActivityOneOffJobTests(test_utils.GenericTestBase):
             self.exp_id, self.owner_id, end_state_name='End')
         self.logout()
         self.login(self.EDITOR_EMAIL)
-        exp_services.update_exploration(self.editor_id, self.exp_id, [{
-            'cmd': 'edit_exploration_property',
-            'property_name': 'objective',
-            'new_value': 'the objective'
-        }], 'Test edit')
+        exp_services.update_exploration(
+            self.editor_id, self.exp_id, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'objective',
+                'new_value': 'the objective'
+            }], 'Test edit')
         self.logout()
 
         user_settings = user_services.get_user_settings(self.editor_id)
@@ -1147,18 +1169,20 @@ class UserLastExplorationActivityOneOffJobTests(test_utils.GenericTestBase):
         self.login(self.OWNER_EMAIL)
         self.save_new_valid_exploration(
             self.exp_id, self.owner_id, end_state_name='End')
-        exp_services.update_exploration(self.owner_id, self.exp_id, [{
-            'cmd': 'edit_exploration_property',
-            'property_name': 'objective',
-            'new_value': 'the objective'
-        }], 'Test edit')
+        exp_services.update_exploration(
+            self.owner_id, self.exp_id, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'objective',
+                'new_value': 'the objective'
+            }], 'Test edit')
         self.logout()
         self.login(self.EDITOR_EMAIL)
-        exp_services.update_exploration(self.editor_id, self.exp_id, [{
-            'cmd': 'edit_exploration_property',
-            'property_name': 'objective',
-            'new_value': 'new objective'
-        }], 'Test edit new')
+        exp_services.update_exploration(
+            self.editor_id, self.exp_id, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'objective',
+                'new_value': 'new objective'
+            }], 'Test edit new')
         self.logout()
 
         user_settings = user_services.get_user_settings(self.owner_id)

--- a/core/domain/user_query_jobs_one_off_test.py
+++ b/core/domain/user_query_jobs_one_off_test.py
@@ -87,20 +87,22 @@ class UserQueryJobOneOffTests(test_utils.GenericTestBase):
         self.save_new_valid_exploration(
             self.EXP_ID_1, self.user_b_id, end_state_name='End')
 
-        exp_services.update_exploration(self.user_c_id, self.EXP_ID_1, [{
-            'cmd': 'edit_exploration_property',
-            'property_name': 'objective',
-            'new_value': 'the objective'
-        }], 'Test edit')
+        exp_services.update_exploration(
+            self.user_c_id, self.EXP_ID_1, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'objective',
+                'new_value': 'the objective'
+            }], 'Test edit')
 
         self.save_new_valid_exploration(
             self.EXP_ID_2, self.user_d_id, end_state_name='End')
 
-        exp_services.update_exploration(self.user_d_id, self.EXP_ID_2, [{
-            'cmd': 'edit_exploration_property',
-            'property_name': 'objective',
-            'new_value': 'the objective'
-        }], 'Test edit')
+        exp_services.update_exploration(
+            self.user_d_id, self.EXP_ID_2, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'objective',
+                'new_value': 'the objective'
+            }], 'Test edit')
 
         self.save_new_valid_exploration(
             self.EXP_ID_3, self.user_e_id, end_state_name='End')

--- a/core/domain/user_services.py
+++ b/core/domain/user_services.py
@@ -1344,8 +1344,8 @@ def create_user_contributions(
     return user_contributions
 
 
-def update_user_contributions(user_id, created_exploration_ids,
-                              edited_exploration_ids):
+def update_user_contributions(
+        user_id, created_exploration_ids, edited_exploration_ids):
     """Updates an existing UserContributionsModel with new calculated
     contributions.
 

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -749,12 +749,13 @@ class UserDashboardStatsTests(test_utils.GenericTestBase):
         event_services.StartExplorationEventHandler.record(
             self.EXP_ID, 1, init_state_name, self.USER_SESSION_ID, {},
             feconf.PLAY_TYPE_NORMAL)
-        event_services.StatsEventsHandler.record(self.EXP_ID, 1, {
-            'num_starts': 1,
-            'num_actual_starts': 0,
-            'num_completions': 0,
-            'state_stats_mapping': {}
-        })
+        event_services.StatsEventsHandler.record(
+            self.EXP_ID, 1, {
+                'num_starts': 1,
+                'num_actual_starts': 0,
+                'num_completions': 0,
+                'state_stats_mapping': {}
+            })
         self.assertEquals(
             user_jobs_continuous.UserStatsAggregator.get_dashboard_stats(
                 self.owner_id),
@@ -787,9 +788,10 @@ class UserDashboardStatsTests(test_utils.GenericTestBase):
         self.assertEquals(
             user_services.get_last_week_dashboard_stats(self.owner_id), None)
 
-        with self.swap(user_services,
-                       'get_current_date_as_string',
-                       self._mock_get_current_date_as_string):
+        with self.swap(
+            user_services,
+            'get_current_date_as_string',
+            self._mock_get_current_date_as_string):
             user_services.update_dashboard_stats_log(self.owner_id)
 
         self.assertEquals(
@@ -808,12 +810,13 @@ class UserDashboardStatsTests(test_utils.GenericTestBase):
         event_services.StartExplorationEventHandler.record(
             self.EXP_ID, 1, init_state_name, self.USER_SESSION_ID, {},
             feconf.PLAY_TYPE_NORMAL)
-        event_services.StatsEventsHandler.record(self.EXP_ID, 1, {
-            'num_starts': 1,
-            'num_actual_starts': 0,
-            'num_completions': 0,
-            'state_stats_mapping': {}
-        })
+        event_services.StatsEventsHandler.record(
+            self.EXP_ID, 1, {
+                'num_starts': 1,
+                'num_actual_starts': 0,
+                'num_completions': 0,
+                'state_stats_mapping': {}
+            })
 
         self.assertEquals(
             user_services.get_weekly_dashboard_stats(self.owner_id), None)
@@ -829,9 +832,10 @@ class UserDashboardStatsTests(test_utils.GenericTestBase):
         self.assertEquals(
             user_services.get_last_week_dashboard_stats(self.owner_id), None)
 
-        with self.swap(user_services,
-                       'get_current_date_as_string',
-                       self._mock_get_current_date_as_string):
+        with self.swap(
+            user_services,
+            'get_current_date_as_string',
+            self._mock_get_current_date_as_string):
             user_services.update_dashboard_stats_log(self.owner_id)
 
         self.assertEquals(
@@ -995,21 +999,23 @@ class LastExplorationEditedIntegrationTests(test_utils.GenericTestBase):
         editor_settings = user_services.get_user_settings(self.editor_id)
         self.assertIsNone(editor_settings.last_edited_an_exploration)
 
-        exp_services.update_exploration(self.editor_id, self.EXP_ID, [{
-            'cmd': 'edit_exploration_property',
-            'property_name': 'objective',
-            'new_value': 'the objective'
-        }], 'Test edit')
+        exp_services.update_exploration(
+            self.editor_id, self.EXP_ID, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'objective',
+                'new_value': 'the objective'
+            }], 'Test edit')
 
         editor_settings = user_services.get_user_settings(self.editor_id)
         self.assertIsNotNone(editor_settings.last_edited_an_exploration)
 
     def test_last_exp_edit_time_gets_updated(self):
-        exp_services.update_exploration(self.editor_id, self.EXP_ID, [{
-            'cmd': 'edit_exploration_property',
-            'property_name': 'objective',
-            'new_value': 'the objective'
-        }], 'Test edit')
+        exp_services.update_exploration(
+            self.editor_id, self.EXP_ID, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'objective',
+                'new_value': 'the objective'
+            }], 'Test edit')
 
         # Decrease last exploration edited time by 13 hours.
         user_settings = user_services.get_user_settings(self.editor_id)
@@ -1024,11 +1030,12 @@ class LastExplorationEditedIntegrationTests(test_utils.GenericTestBase):
         self.assertIsNotNone(previous_last_edited_an_exploration)
 
         # The editor edits the exploration 13 hours after it was created.
-        exp_services.update_exploration(self.editor_id, self.EXP_ID, [{
-            'cmd': 'edit_exploration_property',
-            'property_name': 'objective',
-            'new_value': 'new objective'
-        }], 'Test edit 2')
+        exp_services.update_exploration(
+            self.editor_id, self.EXP_ID, [{
+                'cmd': 'edit_exploration_property',
+                'property_name': 'objective',
+                'new_value': 'new objective'
+            }], 'Test edit 2')
 
         # Make sure last exploration edited time gets updated.
         editor_settings = user_services.get_user_settings(self.editor_id)

--- a/core/jobs_test.py
+++ b/core/jobs_test.py
@@ -734,9 +734,10 @@ class StartExplorationMRJobManager(
     def map(item):
         current_class = StartExplorationMRJobManager
         if current_class._entity_created_before_job_queued(item):  # pylint: disable=protected-access
-            yield (item.exploration_id, {
-                'event_type': item.event_type,
-            })
+            yield (
+                item.exploration_id, {
+                    'event_type': item.event_type,
+                })
 
     @staticmethod
     def reduce(key, stringified_values):

--- a/core/storage/activity/gae_models_test.py
+++ b/core/storage/activity/gae_models_test.py
@@ -50,7 +50,8 @@ class ActivityListModelTest(test_utils.GenericTestBase):
         featured_model_instance = (
             activity_models.ActivityReferencesModel.get_or_create('featured'))
         self.assertEqual(featured_model_instance.id, 'featured')
-        self.assertEqual(featured_model_instance.activity_references, [{
-            'type': constants.ACTIVITY_TYPE_EXPLORATION,
-            'id': '0',
-        }])
+        self.assertEqual(
+            featured_model_instance.activity_references, [{
+                'type': constants.ACTIVITY_TYPE_EXPLORATION,
+                'id': '0',
+            }])

--- a/core/storage/classifier/gae_models.py
+++ b/core/storage/classifier/gae_models.py
@@ -294,9 +294,10 @@ class TrainingJobExplorationMappingModel(base_models.BaseModel):
         mapping_models = []
         mapping_ids = []
         for job_exploration_mapping in job_exploration_mappings:
-            instance_id = cls._generate_id(job_exploration_mapping.exp_id,
-                                           job_exploration_mapping.exp_version,
-                                           job_exploration_mapping.state_name)
+            instance_id = cls._generate_id(
+                job_exploration_mapping.exp_id,
+                job_exploration_mapping.exp_version,
+                job_exploration_mapping.state_name)
             mapping_instance = cls(
                 id=instance_id, exp_id=job_exploration_mapping.exp_id,
                 exp_version=job_exploration_mapping.exp_version,

--- a/core/storage/classifier/gae_models_test.py
+++ b/core/storage/classifier/gae_models_test.py
@@ -45,10 +45,12 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(training_job.exp_id, 'exp_id1')
         self.assertEqual(training_job.exp_version, 1)
         self.assertEqual(training_job.state_name, 'state_name2')
-        self.assertEqual(training_job.status,
-                         feconf.TRAINING_JOB_STATUS_NEW)
-        self.assertEqual(training_job.training_data,
-                         [{'answer_group_index': 1, 'answers': ['a1', 'a2']}])
+        self.assertEqual(
+            training_job.status,
+            feconf.TRAINING_JOB_STATUS_NEW)
+        self.assertEqual(
+            training_job.training_data,
+            [{'answer_group_index': 1, 'answers': ['a1', 'a2']}])
         self.assertEqual(training_job.classifier_data, None)
         self.assertEqual(training_job.data_schema_version, 1)
 
@@ -85,15 +87,19 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(training_jobs[0].interaction_id, 'TextInput')
         self.assertEqual(training_jobs[0].exp_id, 'exp_id1')
         self.assertEqual(training_jobs[0].exp_version, 1)
-        self.assertEqual(training_jobs[0].next_scheduled_check_time,
-                         next_scheduled_check_time)
+        self.assertEqual(
+            training_jobs[0].next_scheduled_check_time,
+            next_scheduled_check_time)
         self.assertEqual(training_jobs[0].state_name, 'state_name2')
-        self.assertEqual(training_jobs[0].status,
-                         feconf.TRAINING_JOB_STATUS_NEW)
-        self.assertEqual(training_jobs[0].training_data,
-                         [{'answer_group_index': 1, 'answers': ['a1', 'a2']}])
-        self.assertEqual(training_jobs[1].status,
-                         feconf.TRAINING_JOB_STATUS_PENDING)
+        self.assertEqual(
+            training_jobs[0].status,
+            feconf.TRAINING_JOB_STATUS_NEW)
+        self.assertEqual(
+            training_jobs[0].training_data,
+            [{'answer_group_index': 1, 'answers': ['a1', 'a2']}])
+        self.assertEqual(
+            training_jobs[1].status,
+            feconf.TRAINING_JOB_STATUS_PENDING)
         self.assertEqual(more, False)
         self.assertEqual(cursor is not None, True)
 
@@ -133,33 +139,39 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
 
         training_job1 = (
             classifier_models.ClassifierTrainingJobModel.get(job_ids[0]))
-        self.assertEqual(training_job1.algorithm_id,
-                         feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput'][
-                             'algorithm_id'])
-        self.assertEqual(training_job1.interaction_id,
-                         'TextInput')
+        self.assertEqual(
+            training_job1.algorithm_id,
+            feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput'][
+                'algorithm_id'])
+        self.assertEqual(
+            training_job1.interaction_id,
+            'TextInput')
         self.assertEqual(training_job1.exp_id, '1')
         self.assertEqual(training_job1.exp_version, 1)
         self.assertEqual(training_job1.training_data, [])
         self.assertEqual(training_job1.state_name, 'Home')
-        self.assertEqual(training_job1.status,
-                         feconf.TRAINING_JOB_STATUS_NEW)
+        self.assertEqual(
+            training_job1.status,
+            feconf.TRAINING_JOB_STATUS_NEW)
         self.assertEqual(training_job1.classifier_data, None)
         self.assertEqual(training_job1.data_schema_version, 1)
 
         training_job2 = (
             classifier_models.ClassifierTrainingJobModel.get(job_ids[1]))
-        self.assertEqual(training_job2.algorithm_id,
-                         feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput'][
-                             'algorithm_id'])
-        self.assertEqual(training_job2.interaction_id,
-                         'TextInput')
+        self.assertEqual(
+            training_job2.algorithm_id,
+            feconf.INTERACTION_CLASSIFIER_MAPPING['TextInput'][
+                'algorithm_id'])
+        self.assertEqual(
+            training_job2.interaction_id,
+            'TextInput')
         self.assertEqual(training_job2.exp_id, '1')
         self.assertEqual(training_job2.exp_version, 2)
         self.assertEqual(training_job2.training_data, [])
         self.assertEqual(training_job2.state_name, 'Home')
-        self.assertEqual(training_job2.status,
-                         feconf.TRAINING_JOB_STATUS_NEW)
+        self.assertEqual(
+            training_job2.status,
+            feconf.TRAINING_JOB_STATUS_NEW)
         self.assertEqual(training_job2.classifier_data, None)
         self.assertEqual(training_job2.data_schema_version, 1)
 

--- a/core/storage/email/gae_models.py
+++ b/core/storage/email/gae_models.py
@@ -160,8 +160,9 @@ class SentEmailModel(base_models.BaseModel):
             if not isinstance(sent_datetime_lower_bound, datetime.datetime):
                 raise Exception(
                     'Expected datetime, received %s of type %s' %
-                    (sent_datetime_lower_bound,
-                     type(sent_datetime_lower_bound)))
+                    (
+                        sent_datetime_lower_bound,
+                        type(sent_datetime_lower_bound)))
 
         query = cls.query().filter(cls.email_hash == email_hash)
 

--- a/core/storage/email/gae_models_test.py
+++ b/core/storage/email/gae_models_test.py
@@ -37,8 +37,9 @@ class SentEmailModelUnitTests(test_utils.GenericTestBase):
 
         self.generate_constant_hash_ctx = self.swap(
             email_models.SentEmailModel, '_generate_hash',
-            types.MethodType(_generate_hash_for_tests,
-                             email_models.SentEmailModel))
+            types.MethodType(
+                _generate_hash_for_tests,
+                email_models.SentEmailModel))
 
     def test_saved_model_can_be_retrieved_with_same_hash(self):
         with self.generate_constant_hash_ctx:

--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -603,8 +603,9 @@ class SuggestionModel(base_models.BaseModel):
         return '.'.join([exploration_id, thread_id])
 
     @classmethod
-    def create(cls, exploration_id, thread_id, author_id, exploration_version,
-               state_name, description, suggestion_html):
+    def create(
+            cls, exploration_id, thread_id, author_id, exploration_version,
+            state_name, description, suggestion_html):
         """Creates a new SuggestionModel entry.
 
         Args:

--- a/core/storage/feedback/gae_models_test.py
+++ b/core/storage/feedback/gae_models_test.py
@@ -165,10 +165,11 @@ class SuggestionModelTest(test_utils.GenericTestBase):
         self.assertEqual(suggestion.exploration_version, 1)
         self.assertEqual(suggestion.state_name, 'state_name')
         self.assertEqual(suggestion.description, 'description')
-        self.assertEqual(suggestion.state_content, {
-            'type': 'text',
-            'value': 'suggestion_text',
-        })
+        self.assertEqual(
+            suggestion.state_content, {
+                'type': 'text',
+                'value': 'suggestion_text',
+            })
 
     def test_create_suggestion_fails_if_thread_already_has_suggestion(self):
         with self.assertRaisesRegexp(Exception, 'There is already a feedback '

--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -34,6 +34,7 @@ class QuestionModelUnitTests(test_utils.GenericTestBase):
 
         self.assertEqual(question_model.title, title)
         self.assertEqual(question_model.question_data, question_data)
-        self.assertEqual(question_model.question_data_schema_version,
-                         question_data_schema_version)
+        self.assertEqual(
+            question_model.question_data_schema_version,
+            question_data_schema_version)
         self.assertEqual(question_model.language_code, language_code)

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -98,8 +98,9 @@ class AnswerSubmittedEventLogEntryModel(base_models.BaseModel):
             session_id))
 
     @classmethod
-    def create(cls, exp_id, exp_version, state_name, session_id,
-               time_spent_in_state_secs, is_feedback_useful):
+    def create(
+            cls, exp_id, exp_version, state_name, session_id,
+            time_spent_in_state_secs, is_feedback_useful):
         """Creates a new answer submitted event."""
         entity_id = cls.get_new_event_entity_id(
             exp_id, session_id)
@@ -186,8 +187,9 @@ class SolutionHitEventLogEntryModel(base_models.BaseModel):
             session_id))
 
     @classmethod
-    def create(cls, exp_id, exp_version, state_name, session_id,
-               time_spent_in_state_secs):
+    def create(
+            cls, exp_id, exp_version, state_name, session_id,
+            time_spent_in_state_secs):
         """Creates a new solution hit event."""
         entity_id = cls.get_new_event_entity_id(
             exp_id, session_id)
@@ -262,8 +264,9 @@ class StartExplorationEventLogEntryModel(base_models.BaseModel):
             session_id))
 
     @classmethod
-    def create(cls, exp_id, exp_version, state_name, session_id,
-               params, play_type, unused_version=1):
+    def create(
+            cls, exp_id, exp_version, state_name, session_id,
+            params, play_type, unused_version=1):
         """Creates a new start exploration event and then writes it to
         the datastore.
 
@@ -372,8 +375,9 @@ class MaybeLeaveExplorationEventLogEntryModel(base_models.BaseModel):
             session_id))
 
     @classmethod
-    def create(cls, exp_id, exp_version, state_name, session_id,
-               client_time_spent_in_secs, params, play_type):
+    def create(
+            cls, exp_id, exp_version, state_name, session_id,
+            client_time_spent_in_secs, params, play_type):
         """Creates a new leave exploration event and then writes it
         to the datastore.
 
@@ -476,8 +480,9 @@ class CompleteExplorationEventLogEntryModel(base_models.BaseModel):
             session_id))
 
     @classmethod
-    def create(cls, exp_id, exp_version, state_name, session_id,
-               client_time_spent_in_secs, params, play_type):
+    def create(
+            cls, exp_id, exp_version, state_name, session_id,
+            client_time_spent_in_secs, params, play_type):
         """Creates a new exploration completion event and then writes it
         to the datastore.
 
@@ -688,8 +693,9 @@ class StateCompleteEventLogEntryModel(base_models.BaseModel):
             session_id))
 
     @classmethod
-    def create(cls, exp_id, exp_version, state_name, session_id,
-               time_spent_in_state_secs):
+    def create(
+            cls, exp_id, exp_version, state_name, session_id,
+            time_spent_in_state_secs):
         """Creates a new state complete event."""
         entity_id = cls.get_new_event_entity_id(
             exp_id, session_id)
@@ -734,8 +740,9 @@ class LeaveForRefresherExplorationEventLogEntryModel(base_models.BaseModel):
             session_id))
 
     @classmethod
-    def create(cls, exp_id, refresher_exp_id, exp_version, state_name,
-               session_id, time_spent_in_state_secs):
+    def create(
+            cls, exp_id, refresher_exp_id, exp_version, state_name,
+            session_id, time_spent_in_state_secs):
         """Creates a new leave for refresher exploration event."""
         entity_id = cls.get_new_event_entity_id(
             exp_id, session_id)
@@ -1402,8 +1409,9 @@ class StateAnswersCalcOutputModel(base_models.BaseMapReduceBatchResultsModel):
                     state_name.encode('utf-8'), calculation_id))
 
     @classmethod
-    def get_model(cls, exploration_id, exploration_version, state_name,
-                  calculation_id):
+    def get_model(
+            cls, exploration_id, exploration_version, state_name,
+            calculation_id):
         """Gets entity instance corresponding to the given exploration state.
 
         Args:
@@ -1423,8 +1431,9 @@ class StateAnswersCalcOutputModel(base_models.BaseMapReduceBatchResultsModel):
         return instance
 
     @classmethod
-    def _get_entity_id(cls, exploration_id, exploration_version, state_name,
-                       calculation_id):
+    def _get_entity_id(
+            cls, exploration_id, exploration_version, state_name,
+            calculation_id):
         """Returns entity_id corresponding to the given exploration state.
 
         Args:

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -120,8 +120,9 @@ class ExplorationUserDataModelTest(test_utils.GenericTestBase):
         self.assertEqual(retrieved_object.rated_on, self.DATETIME_OBJECT)
         self.assertEqual(
             retrieved_object.draft_change_list, {'new_content': {}})
-        self.assertEqual(retrieved_object.draft_change_list_last_updated,
-                         self.DATETIME_OBJECT)
+        self.assertEqual(
+            retrieved_object.draft_change_list_last_updated,
+            self.DATETIME_OBJECT)
         self.assertEqual(retrieved_object.draft_change_list_exp_version, 3)
         self.assertEqual(retrieved_object.draft_change_list_id, 1)
 

--- a/core/tests/performance_framework/perf_services.py
+++ b/core/tests/performance_framework/perf_services.py
@@ -285,8 +285,8 @@ class SeleniumPerformanceDataFetcher(object):
         self._wait_until_page_load_is_finished()
         resulting_url = driver.current_url
 
-        if resulting_url == '%s%s' % (self.BASE_URL,
-                                      feconf.CREATOR_DASHBOARD_URL):
+        if resulting_url == '%s%s' % (
+                self.BASE_URL, feconf.CREATOR_DASHBOARD_URL):
             return False
 
         return True

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -501,13 +501,14 @@ tags: []
             response = self.testapp.get(feconf.SIGNUP_URL)
             self.assertEqual(response.status_int, 200)
             csrf_token = self.get_csrf_token_from_response(response)
-            response = self.testapp.post(feconf.SIGNUP_DATA_URL, {
-                'csrf_token': csrf_token,
-                'payload': json.dumps({
-                    'username': username,
-                    'agreed_to_terms': True
+            response = self.testapp.post(
+                feconf.SIGNUP_DATA_URL, {
+                    'csrf_token': csrf_token,
+                    'payload': json.dumps({
+                        'username': username,
+                        'agreed_to_terms': True
+                    })
                 })
-            })
             self.assertEqual(response.status_int, 200)
         self.logout()
 
@@ -520,12 +521,13 @@ tags: []
         self.login('tmpsuperadmin@example.com', is_super_admin=True)
         response = self.testapp.get('/admin')
         csrf_token = self.get_csrf_token_from_response(response)
-        self.post_json('/adminhandler', {
-            'action': 'save_config_properties',
-            'new_config_property_values': {
-                config_obj.name: new_config_value,
-            }
-        }, csrf_token)
+        self.post_json(
+            '/adminhandler', {
+                'action': 'save_config_properties',
+                'new_config_property_values': {
+                    config_obj.name: new_config_value,
+                }
+            }, csrf_token)
         self.logout()
 
         self._restore_stashed_user_env()
@@ -542,10 +544,11 @@ tags: []
         self.login('tmpsuperadmin@example.com', is_super_admin=True)
         response = self.testapp.get('/admin')
         csrf_token = self.get_csrf_token_from_response(response)
-        self.post_json('/adminrolehandler', {
-            'username': username,
-            'role': user_role
-        }, csrf_token)
+        self.post_json(
+            '/adminrolehandler', {
+                'username': username,
+                'role': user_role
+            }, csrf_token)
         self.logout()
 
         self._restore_stashed_user_env()
@@ -700,11 +703,12 @@ tags: []
         rights_manager.create_new_exploration_rights(exp_id, user_id)
 
         commit_message = 'New exploration created with title \'%s\'.' % title
-        exp_model.commit(user_id, commit_message, [{
-            'cmd': 'create_new',
-            'title': 'title',
-            'category': 'category',
-        }])
+        exp_model.commit(
+            user_id, commit_message, [{
+                'cmd': 'create_new',
+                'title': 'title',
+                'category': 'category',
+            }])
         exp_rights = exp_models.ExplorationRightsModel.get_by_id(exp_id)
         exp_summary_model = exp_models.ExpSummaryModel(
             id=exp_id,

--- a/extensions/interactions/base_test.py
+++ b/extensions/interactions/base_test.py
@@ -155,24 +155,25 @@ class InteractionUnitTests(test_utils.GenericTestBase):
             'default_outcome_heading', 'can_have_solution',
             'show_generic_submit_button'])
         self.assertEqual(interaction_dict['id'], TEXT_INPUT_ID)
-        self.assertEqual(interaction_dict['customization_arg_specs'], [{
-            'name': 'placeholder',
-            'description': 'Placeholder text (optional)',
-            'schema': {'type': 'unicode'},
-            'default_value': '',
-        }, {
-            'name': 'rows',
-            'description': 'Height (in rows)',
-            'schema': {
-                'type': 'int',
-                'validators': [{
-                    'id': 'is_at_least', 'min_value': 1
-                }, {
-                    'id': 'is_at_most', 'max_value': 200
-                }]
-            },
-            'default_value': 1,
-        }])
+        self.assertEqual(
+            interaction_dict['customization_arg_specs'], [{
+                'name': 'placeholder',
+                'description': 'Placeholder text (optional)',
+                'schema': {'type': 'unicode'},
+                'default_value': '',
+            }, {
+                'name': 'rows',
+                'description': 'Height (in rows)',
+                'schema': {
+                    'type': 'int',
+                    'validators': [{
+                        'id': 'is_at_least', 'min_value': 1
+                    }, {
+                        'id': 'is_at_most', 'max_value': 200
+                    }]
+                },
+                'default_value': 1,
+            }])
 
     def test_interaction_rules(self):
         def _check_num_interaction_rules(interaction_id, expected_num):

--- a/scripts/build_test.py
+++ b/scripts/build_test.py
@@ -37,15 +37,17 @@ class BuildTests(test_utils.GenericTestBase):
         # pylint: enable=protected-access
 
     def test_is_file_hash_provided_to_frontend(self):
-        with self.swap(build, 'FILEPATHS_PROVIDED_TO_FRONTEND',
-                       ('path/to/file.js', 'path/to/file.html', 'file.js')):
+        with self.swap(
+            build, 'FILEPATHS_PROVIDED_TO_FRONTEND',
+            ('path/to/file.js', 'path/to/file.html', 'file.js')):
             self.assertTrue(
                 build.is_file_hash_provided_to_frontend('path/to/file.js'))
             self.assertTrue(
                 build.is_file_hash_provided_to_frontend('path/to/file.html'))
             self.assertTrue(build.is_file_hash_provided_to_frontend('file.js'))
-        with self.swap(build, 'FILEPATHS_PROVIDED_TO_FRONTEND',
-                       ('path/to/*', '*.js', '*_end.html')):
+        with self.swap(
+            build, 'FILEPATHS_PROVIDED_TO_FRONTEND',
+            ('path/to/*', '*.js', '*_end.html')):
             self.assertTrue(
                 build.is_file_hash_provided_to_frontend('path/to/file.js'))
             self.assertTrue(
@@ -64,13 +66,16 @@ class BuildTests(test_utils.GenericTestBase):
             hashes = {'path/to/file.js': '123456',
                       'path/file.min.js': '123456'}
             filtered_hashes = build.filter_hashes(hashes)
-            self.assertEquals(filtered_hashes['/path/to/file.js'],
-                              hashes['path/to/file.js'])
-            self.assertEquals(filtered_hashes['/path/file.min.js'],
-                              hashes['path/file.min.js'])
+            self.assertEquals(
+                filtered_hashes['/path/to/file.js'],
+                hashes['path/to/file.js'])
+            self.assertEquals(
+                filtered_hashes['/path/file.min.js'],
+                hashes['path/file.min.js'])
 
-        with self.swap(build, 'FILEPATHS_PROVIDED_TO_FRONTEND',
-                       ('test_path/*', 'path/to/file.js')):
+        with self.swap(
+            build, 'FILEPATHS_PROVIDED_TO_FRONTEND',
+            ('test_path/*', 'path/to/file.js')):
             hashes = {'path/to/file.js': '123456',
                       'test_path/to/file.html': '123456',
                       'test_path/to/file.js': 'abcdef',

--- a/scripts/custom_lint_checks_test.py
+++ b/scripts/custom_lint_checks_test.py
@@ -19,6 +19,7 @@
 
 import os
 import sys
+import tempfile
 import unittest
 
 _PARENT_DIR = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
@@ -77,3 +78,50 @@ class ExplicitKwargsCheckerTest(unittest.TestCase):
         ):
             checker_test_object.checker.visit_call(
                 func_call_node_three)
+
+
+class HangingIndentCheckerTest(unittest.TestCase):
+
+    def test_finds_hanging_indent(self):
+        checker_test_object = testutils.CheckerTestCase()
+        checker_test_object.CHECKER_CLASS = (
+            custom_lint_checks.HangingIndentChecker)
+        checker_test_object.setup_method()
+        node1 = astroid.scoped_nodes.Module(name='test', doc='Custom test')
+        temp_file = tempfile.NamedTemporaryFile()
+        filename = temp_file.name
+        with open(filename, 'w') as tmp:
+            tmp.write(
+                """self.post_json('/ml/trainedclassifierhandler', self.payload,
+                expect_errors=True, expected_status_int=401)
+                """)
+        node1.file = filename
+        node1.path = filename
+
+        checker_test_object.checker.process_module(node1)
+
+        with checker_test_object.assertAddsMessages(
+            testutils.Message(
+                msg_id='no-break-after-hanging-indent',
+                line=1
+            ),
+        ):
+            temp_file.close()
+
+        node2 = astroid.scoped_nodes.Module(name='test', doc='Custom test')
+
+        temp_file = tempfile.NamedTemporaryFile()
+        filename = temp_file.name
+        with open(filename, 'w') as tmp:
+            tmp.write(
+                """master_translation_dict = json.loads(
+                utils.get_file_contents(os.path.join(
+                os.getcwd(), 'assets', 'i18n', 'en.json')))
+                """)
+        node2.file = filename
+        node2.path = filename
+
+        checker_test_object.checker.process_module(node2)
+
+        with checker_test_object.assertNoMessages():
+            temp_file.close()

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -295,8 +295,8 @@ def _get_all_files_in_directory(dir_path, excluded_glob_patterns):
     return files_in_directory
 
 
-def _lint_js_files(node_path, eslint_path, files_to_lint, stdout,
-                   result):
+def _lint_js_files(
+        node_path, eslint_path, files_to_lint, stdout, result):
     """Prints a list of lint errors in the given list of JavaScript files.
 
     Args:
@@ -532,8 +532,9 @@ def _pre_commit_linter(all_files):
     linting_processes = []
     js_stdout = multiprocessing.Queue()
     linting_processes.append(multiprocessing.Process(
-        target=_lint_js_files, args=(node_path, eslint_path, js_files_to_lint,
-                                     js_stdout, js_result)))
+        target=_lint_js_files, args=(
+            node_path, eslint_path, js_files_to_lint,
+            js_stdout, js_result)))
 
     py_result = multiprocessing.Queue()
     linting_processes.append(multiprocessing.Process(

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -40,8 +40,8 @@ import sys
 # pylint: enable=wrong-import-order
 
 
-GitRef = collections.namedtuple('GitRef', ['local_ref', 'local_sha1',
-                                           'remote_ref', 'remote_sha1'])
+GitRef = collections.namedtuple(
+    'GitRef', ['local_ref', 'local_sha1', 'remote_ref', 'remote_sha1'])
 FileDiff = collections.namedtuple('FileDiff', ['status', 'name'])
 
 # git hash of /dev/null, refers to an 'empty' commit.
@@ -186,13 +186,13 @@ def _collect_files_being_pushed(ref_list, remote):
         else:
             # Get the difference to origin/develop instead.
             try:
-                modified_files = _compare_to_remote(remote, branch,
-                                                    remote_branch='develop')
+                modified_files = _compare_to_remote(
+                    remote, branch, remote_branch='develop')
             except ValueError:
                 # give up, return all files in repo.
                 try:
-                    modified_files = _git_diff_name_status(GIT_NULL_COMMIT,
-                                                           sha1)
+                    modified_files = _git_diff_name_status(
+                        GIT_NULL_COMMIT, sha1)
                 except ValueError as e:
                     print e.message
                     sys.exit(1)

--- a/scripts/release_info.py
+++ b/scripts/release_info.py
@@ -98,8 +98,8 @@ def _gather_logs(start, stop='HEAD'):
         list[Log]: List of Logs
 
     """
-    get_logs_cmd = GIT_CMD_GET_LOGS_FORMAT_STRING.format(GROUP_SEP, start,
-                                                         stop)
+    get_logs_cmd = GIT_CMD_GET_LOGS_FORMAT_STRING.format(
+        GROUP_SEP, start, stop)
     out = _run_cmd(get_logs_cmd).split('\x00')
     if len(out) == 1 and out[0] == '':
         return []

--- a/utils_test.py
+++ b/utils_test.py
@@ -246,7 +246,8 @@ class UtilsTests(test_utils.GenericTestBase):
         test_set = {utils.get_hashable_value(json1)}
         self.assertIn(utils.get_hashable_value(json1_deepcopy), test_set)
         test_set.add(utils.get_hashable_value(json2))
-        self.assertEqual(test_set, {
-            utils.get_hashable_value(json1_deepcopy),
-            utils.get_hashable_value(json2_deepcopy),
-        })
+        self.assertEqual(
+            test_set, {
+                utils.get_hashable_value(json1_deepcopy),
+                utils.get_hashable_value(json2_deepcopy),
+            })


### PR DESCRIPTION
## Explanantion

Fix part of #3905: This PR adds a pylint plugin to check for a break after parens when content spans to multiple lines.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
