### PR TITLE
Fix #3977: Added tooltip for Collections in Learner Dashboard

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -244,6 +244,7 @@
     "I18N_LEARNER_DASHBOARD_SUGGESTION_NO_CURRENT_STATE": "Oops! This state no longer exists!",
     "I18N_LEARNER_DASHBOARD_SUGGESTION_SUGGESTED_STATE_CONTENT_HEADER": "Suggested:",
     "I18N_LEARNER_DASHBOARD_SUGGESTION_TEXT": "Suggestion",
+    "I18N_LEARNER_DASHBOARD_TOOLTIP": "Collections are multiple related explorations that are intended to be completed in a sequence.",
     "I18N_LEARNER_DASHBOARD_VIEW_SUGGESTION": "View Suggestion",
     "I18N_LIBRARY_ACTIVITY_COMPLETED_ICON": "You have completed this",
     "I18N_LIBRARY_ACTIVITY_IN_LEARNER_PLAYLIST": "Already added to playlist",

--- a/assets/i18n/qqq.json
+++ b/assets/i18n/qqq.json
@@ -244,6 +244,7 @@
 	"I18N_LEARNER_DASHBOARD_SUGGESTION_NO_CURRENT_STATE": "Text that appears in the learner dashboard when a suggestion is opened. It denotes that the state for which the suggestion is suggested no longer exists.",
 	"I18N_LEARNER_DASHBOARD_SUGGESTION_SUGGESTED_STATE_CONTENT_HEADER": "Text that appears in the learner dashboard when a suggestion is opened. It is the header for the box which shows the suggested content of the state in a suggestion.",
 	"I18N_LEARNER_DASHBOARD_SUGGESTION_TEXT": "Text displayed in the learner dashboard. It appears in the thread summary, when last message sent in the thread is a suggestion.",
+	"I18N_LEARNER_DASHBOARD_TOOLTIP": "Text for the tooltip that appears on hovering over the info icon next to collections text",
 	"I18N_LEARNER_DASHBOARD_VIEW_SUGGESTION": "The name of a button in the learner dashboard. On clicking it the contents of the suggestion are viewable.",
 	"I18N_LIBRARY_ACTIVITY_COMPLETED_ICON": "Text that appears on hovering over the completed icon that appears on top of the activity cards. It indicates to the user that he/she has completed the activity.",
 	"I18N_LIBRARY_ACTIVITY_IN_LEARNER_PLAYLIST": "Text that appears on hovering over the playlist icon that appears on top of the activity cards. It indicates to the user that the activity is already there on his/her list of activities to play later.",

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -5043,12 +5043,12 @@ md-card.preview-conversation-skin-supplemental-card {
   width: 1px;
 }
 
-.oppia-tooltip {
+.oppia-dashboard-tooltip {
   display: inline-block;
   position: relative;
 }
 
-.oppia-tooltip-text {
+.oppia-dashboard-tooltip-text {
   background-color: #009688;
   border-radius: 6px;
   bottom: 97%;
@@ -5063,7 +5063,7 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 
 @media screen and (max-width: 800px) {
-  .oppia-tooltip-text::after {
+  .oppia-dashboard-tooltip-text::after {
     border-color: #009688 transparent transparent transparent;
     border-style: solid;
     border-width: 5px;
@@ -5073,11 +5073,11 @@ md-card.preview-conversation-skin-supplemental-card {
     position: absolute;
     top: 100%;
   }
-  .oppia-tooltip-text {
+  .oppia-dashboard-tooltip-text {
     width: 90%;
   }
 }
 
-.oppia-tooltip:hover + .oppia-tooltip-text {
+.oppia-dashboard-tooltip:hover + .oppia-dashboard-tooltip-text {
   visibility: visible;
 }

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -5062,17 +5062,7 @@ md-card.preview-conversation-skin-supplemental-card {
   z-index: 1;
 }
 
-@media screen and (max-width: 800px) {
-  .oppia-dashboard-tooltip-text::after {
-    border-color: #009688 transparent transparent transparent;
-    border-style: solid;
-    border-width: 5px;
-    content: "";
-    left: 50%;
-    margin-left: -5px;
-    position: absolute;
-    top: 100%;
-  }
+@media screen and (max-width: 500px) {
   .oppia-dashboard-tooltip-text {
     width: 90%;
   }

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -5042,3 +5042,42 @@ md-card.preview-conversation-skin-supplemental-card {
   padding: 0;
   width: 1px;
 }
+
+.oppia-tooltip {
+  display: inline-block;
+  position: relative;
+}
+
+.oppia-tooltip-text {
+  background-color: #009688;
+  border-radius: 6px;
+  bottom: 97%;
+  color: #fff;
+  font-size: 0.6em;
+  padding: 5px;
+  position: absolute;
+  text-align: center;
+  visibility: hidden;
+  width: auto;
+  z-index: 1;
+}
+
+@media screen and (max-width: 800px) {
+  .oppia-tooltip-text::after {
+    border-color: #009688 transparent transparent transparent;
+    border-style: solid;
+    border-width: 5px;
+    content: "";
+    left: 50%;
+    margin-left: -5px;
+    position: absolute;
+    top: 100%;
+  }
+  .oppia-tooltip-text {
+    width: 90%;
+  }
+}
+
+.oppia-tooltip:hover + .oppia-tooltip-text {
+  visibility: visible;
+}

--- a/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
+++ b/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
@@ -163,8 +163,8 @@
                     style="margin: 0 1px;">
               </span>
               <span translate="<[activeSubsection]>"></span>
-              <i ng-if="activeSubsection === LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.COLLECTIONS" class="oppia-tooltip material-icons">info</i>
-              <span class="oppia-tooltip-text">Collections are multiple related explorations that are intended to be completed in a sequence.</span>
+              <i ng-if="activeSubsection === LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.COLLECTIONS" class="oppia-dashboard-tooltip material-icons">info</i>
+              <span class="oppia-dashboard-tooltip-text" translate="I18N_LEARNER_DASHBOARD_TOOLTIP"></span>
             </span>
           </span>
 

--- a/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
+++ b/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
@@ -163,6 +163,8 @@
                     style="margin: 0 1px;">
               </span>
               <span translate="<[activeSubsection]>"></span>
+              <i ng-if="activeSubsection === LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.COLLECTIONS" class="oppia-tooltip material-icons">info</i>
+              <span class="oppia-tooltip-text">Collections are multiple related explorations that are intended to be completed in a sequence.</span>
             </span>
           </span>
 


### PR DESCRIPTION
This PR fixes #3977 

## Explanation
Added a hoverable help icon with a tool-tip next to the "collections" in the learner's dashboard to explain what a collection is. I chose to not add the bottom arrow in larger displays due to frequent misalignment with the Collection text.

## Screenshots
**Mobile**
![01](https://user-images.githubusercontent.com/24409931/38369220-da138ca4-3904-11e8-9ffc-ec295ccfab8a.png)

**Tablet**
![02](https://user-images.githubusercontent.com/24409931/38369222-dbe0957c-3904-11e8-86f0-5db2636a8874.png)

**Laptop**
![03](https://user-images.githubusercontent.com/24409931/38369228-ddcc174e-3904-11e8-9010-248bd7b23035.png)

