### PR TITLE
Remove reference to master branch from CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,4 @@
-This file contains a summary of changes to the Oppia code base. For a full changelog, please see
-
-    https://github.com/oppia/oppia/commits/master
+This file contains a summary of changes to the Oppia code base.
 
 v2.6.2 (20 Mar 2018)
 --------------------


### PR DESCRIPTION
Removes the reference to https://github.com/oppia/oppia/commits/master from the CHANGELOG now that we don't have a master branch anymore.

We could update this to refer to ``develop`` instead, but that may includes commits not yet part of the true changelog. There doesn't seem to be a good way to show the latest release branch (best we can do is show the latest release, e.g. https://github.com/oppia/oppia/releases/latest). It seems better just to remove the suggestion altogether.