### PR TITLE
Add more detailed logging for StateIdMapping one off job. Add realtime logging to build script when deploying.

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -365,7 +365,7 @@ class ExplorationStateIdMappingJob(jobs.BaseMapReduceOneOffJobManager):
         try:
             exploration = exp_services.get_exploration_from_model(item)
         except Exception as e:
-            yield ('ERROR with exp_id %s' % item.id, str(e))
+            yield ('ERROR get_exp_from_model: exp_id %s' % item.id, str(e))
             return
 
         explorations = []
@@ -382,7 +382,9 @@ class ExplorationStateIdMappingJob(jobs.BaseMapReduceOneOffJobManager):
                     exp_services.get_multiple_explorations_by_version(
                         exploration.id, versions))
             except Exception as e:
-                yield ('ERROR with exp_id %s' % item.id, str(e))
+                yield (
+                    'ERROR get_multiple_exp_by_version exp_id %s' % item.id,
+                    str(e))
                 return
 
         # Append latest exploration to the list of explorations.
@@ -420,7 +422,10 @@ class ExplorationStateIdMappingJob(jobs.BaseMapReduceOneOffJobManager):
                     exp_services.create_and_save_state_id_mapping_model(
                         exploration, change_list)
             except Exception as e:
-                yield ('ERROR with exp_id %s' % item.id, str(e))
+                yield (
+                    'ERROR with exp_id %s version %s' % (
+                        item.id, exploration.version),
+                    str(e))
                 return
 
         yield (exploration.id, exploration.version)

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -221,9 +221,21 @@ def _execute_deployment():
         print 'Preprocessing release...'
         preprocess_release()
 
-        # Do a build; ensure there are no errors.
+        # Do a build, while outputting to the terminal.
         print 'Building and minifying scripts...'
-        subprocess.check_output(['python', 'scripts/build.py'])
+        build_process = subprocess.Popen(
+            ['python', 'scripts/build.py', '--prod_env'],
+            stdout=subprocess.PIPE)
+        while True:
+            line = build_process.stdout.readline().strip()
+            if not line:
+                break
+            print line
+
+        # Wait for process to terminate, then check return code.
+        build_process.communicate()
+        if build_process.returncode > 0:
+            raise Exception('Build failed.')
 
         # Deploy to GAE.
         subprocess.check_output([APPCFG_PATH, 'update', '.'])


### PR DESCRIPTION
The error messages in StateIdMapping one off job are indistinguishable, so I made them different to help with identifying errors. @prasanna08 PTAL.

@vojtechjelinek -- I also found that subprocess.check_output() in deploy.py doesn't print anything to the console when the build.py script gets run, so I added realtime logging (and also the --prod_env flag). PTAL at that part.

If you could review this ASAP, that would be great since this is needed for the upcoming release.

Thanks!

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.