### PR TITLE
Allow ExplorationStateIdMappingJob to overwrite StateIdMapping models

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -421,19 +421,11 @@ class ExplorationStateIdMappingJob(jobs.BaseMapReduceOneOffJobManager):
                         exp_services.generate_state_id_mapping_model(
                             exploration, change_list))
 
-                # pylint: disable=protected-access
-                instance_id = (
-                    exp_models.StateIdMappingModel._generate_instance_id(
-                        exploration.id, exploration.version))
-                # pylint: enable=protected-access
-
-                state_id_mapping_model = exp_models.StateIdMappingModel(
-                    id=instance_id,
-                    exploration_id=state_id_mapping.exploration_id,
-                    exploration_version=state_id_mapping.exploration_version,
-                    state_names_to_ids=state_id_mapping.state_names_to_ids,
-                    largest_state_id_used=(
-                        state_id_mapping.largest_state_id_used))
+                state_id_mapping_model = exp_models.StateIdMappingModel.create(
+                    state_id_mapping.exploration_id,
+                    state_id_mapping.exploration_version,
+                    state_id_mapping.state_names_to_ids,
+                    state_id_mapping.largest_state_id_used, overwrite=True)
                 state_id_mapping_model.put()
 
             except Exception as e:

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -676,8 +676,7 @@ class ExplorationStateIdMappingJobTest(test_utils.GenericTestBase):
         job_id = exp_jobs_one_off.ExplorationStateIdMappingJob.create_new()
         exp_jobs_one_off.ExplorationStateIdMappingJob.enqueue(job_id)
 
-        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
-            self.process_and_flush_pending_tasks()
+        self.process_and_flush_pending_tasks()
 
         expected_mapping = {
             exploration.init_state_name: 0
@@ -714,8 +713,7 @@ class ExplorationStateIdMappingJobTest(test_utils.GenericTestBase):
         job_id = exp_jobs_one_off.ExplorationStateIdMappingJob.create_new()
         exp_jobs_one_off.ExplorationStateIdMappingJob.enqueue(job_id)
 
-        with self.swap(feconf, 'ENABLE_STATE_ID_MAPPING', True):
-            self.process_and_flush_pending_tasks()
+        self.process_and_flush_pending_tasks()
 
         expected_mapping = {
             exploration.init_state_name: 0

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -609,7 +609,7 @@ class StateIdMappingModel(base_models.BaseModel):
     @classmethod
     def create(
             cls, exp_id, exp_version, state_names_to_ids,
-            largest_state_id_used):
+            largest_state_id_used, overwrite=False):
         """Creates a new instance of state id mapping model.
 
         Args:
@@ -618,12 +618,14 @@ class StateIdMappingModel(base_models.BaseModel):
             state_names_to_ids: dict. A dict storing state name to ids mapping.
             largest_state_id_used: int. The largest integer so far that has been
                 used as a state ID for this exploration.
+            overwrite: bool. Whether overwriting of an existing model should
+                be allowed.
 
         Returns:
             StateIdMappingModel. Instance of the state id mapping model.
         """
         instance_id = cls._generate_instance_id(exp_id, exp_version)
-        if cls.get_by_id(instance_id):
+        if not overwrite and cls.get_by_id(instance_id):
             raise Exception(
                 'State id mapping model already exists for exploration %s,'
                 ' version %d' % (exp_id, exp_version))


### PR DESCRIPTION
Fixes ExplorationStateIdMappingJob so that it can overwrite StateIdMapping models and directly bypass `model already exists` check.