### PR TITLE
Fix #4857: Fixed feedback message status behaviour

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/feedback_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/feedback_tab.html
@@ -123,7 +123,7 @@
           </span>
         </div>
 
-        <div style="color:#ff0000; margin-top: 7px;" ng-if="tmpMessage.status === 'ignored' || tmpMessage.status === 'not_actionable'">
+        <div style="color:#ff0000; margin-top: 7px;" ng-if="!tmpMessage.text && (tmpMessage.status === 'ignored' || tmpMessage.status === 'not_actionable')">
           <i class="material-icons">&#xE88F;</i>
           <span>Please specify a reason for setting the status to <[getHumanReadableStatus(tmpMessage.status)]>.</span>
         </div>


### PR DESCRIPTION
Fixes #4857 
## Explanation  
Added an if condition to the info message so that it displays only when the message box is empty. This bug was also present for "Not actionable" status and that is fixed with this change as well.
## Screenshot
![pic1](https://user-images.githubusercontent.com/24409931/38514690-7facf978-3c4f-11e8-8b63-46d8218f2bc9.png)

