### PR TITLE
WIP: Fixes #857: Updating rules when an option is deleted

### DIFF
--- a/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
+++ b/core/templates/dev/head/components/forms/schema_editors/SchemaBasedListEditorDirective.js
@@ -17,12 +17,12 @@
  */
 
 oppia.directive('schemaBasedListEditor', [
-  'SchemaDefaultValueService',
+  'SchemaDefaultValueService', 'ResponsesService',
   'NestedDirectivesRecursionTimeoutPreventionService',
   'FocusManagerService', 'SchemaUndefinedLastElementService',
   'IdGenerationService', 'UrlInterpolationService',
   function(
-      SchemaDefaultValueService,
+      SchemaDefaultValueService, ResponsesService,
       NestedDirectivesRecursionTimeoutPreventionService,
       FocusManagerService, SchemaUndefinedLastElementService,
       IdGenerationService, UrlInterpolationService) {
@@ -141,7 +141,7 @@ oppia.directive('schemaBasedListEditor', [
           };
 
           var deleteEmptyElements = function() {
-            for (var i = 0; i < $scope.localValue.length - 1; i++) {
+            for ( var i = 0; i < $scope.localValue.length - 1; i++) {
               if ($scope.localValue[i].length === 0) {
                 $scope.deleteElement(i);
                 i--;
@@ -200,6 +200,17 @@ oppia.directive('schemaBasedListEditor', [
           $scope.deleteElement = function(index) {
             // Need to let the RTE know that HtmlContent has been changed.
             $scope.$broadcast('externalHtmlContentChange');
+            var answerGroups = ResponsesService.getAnswerGroups();
+            for (var i = 0; i < answerGroups.length; i++) {
+              var rules = answerGroups[i].rules;
+              for (var j = 0; j < rules.length; j++) {
+                if (index < rules[j].inputs.x) {
+                  ResponsesService.reduceRuleIndexByOne(i, j);
+                } else if (index === rules[j].inputs.x) {
+                  ResponsesService.makeRuleInvalid(i, j);
+                }
+              }
+            }
             $scope.localValue.splice(index, 1);
           };
         } else {

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/ResponsesService.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/ResponsesService.js
@@ -98,7 +98,6 @@ oppia.factory('ResponsesService', [
 
     var _updateAnswerGroup = function(index, updates) {
       var answerGroup = _answerGroups[index];
-      console.log(answerGroup.rules);
       if (updates.hasOwnProperty('rules')) {
         answerGroup.rules = updates.rules;
       }
@@ -156,13 +155,13 @@ oppia.factory('ResponsesService', [
       } else {
         _answerGroups[answerGroupIndex].rules[ruleIndex].inputs.x--;
       }
-      // _saveAnswerGroups(_answerGroups);
+      _saveAnswerGroups(_answerGroups);
     };
 
     var _makeRuleInvalid = function(answerGroupIndex, ruleIndex) {
       _answerGroups[answerGroupIndex].rules[ruleIndex].inputs.x =
         _answerChoices.length;
-      // _saveAnswerGroups(_answerGroups);
+      _saveAnswerGroups(_answerGroups);
     };
 
     return {

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/ResponsesService.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/ResponsesService.js
@@ -98,6 +98,7 @@ oppia.factory('ResponsesService', [
 
     var _updateAnswerGroup = function(index, updates) {
       var answerGroup = _answerGroups[index];
+      console.log(answerGroup.rules);
       if (updates.hasOwnProperty('rules')) {
         answerGroup.rules = updates.rules;
       }
@@ -146,6 +147,22 @@ oppia.factory('ResponsesService', [
         _confirmedUnclassifiedAnswersMemento = angular.copy(
           newConfirmedUnclassifiedAnswers);
       }
+    };
+
+    var _reduceRuleIndexByOne = function(answerGroupIndex, ruleIndex) {
+      if (_answerGroups[answerGroupIndex].rules[ruleIndex].inputs.x === 0) {
+        _answerGroups[answerGroupIndex].rules[ruleIndex].inputs.x =
+          _answerChoices.length;
+      } else {
+        _answerGroups[answerGroupIndex].rules[ruleIndex].inputs.x--;
+      }
+      // _saveAnswerGroups(_answerGroups);
+    };
+
+    var _makeRuleInvalid = function(answerGroupIndex, ruleIndex) {
+      _answerGroups[answerGroupIndex].rules[ruleIndex].inputs.x =
+        _answerChoices.length;
+      // _saveAnswerGroups(_answerGroups);
     };
 
     return {
@@ -345,6 +362,12 @@ oppia.factory('ResponsesService', [
       },
       getConfirmedUnclassifiedAnswers: function() {
         return angular.copy(_confirmedUnclassifiedAnswers);
+      },
+      reduceRuleIndexByOne: function(answerGroupIndex, ruleIndex) {
+        return _reduceRuleIndexByOne(answerGroupIndex, ruleIndex);
+      },
+      makeRuleInvalid: function(answerGroupIndex, ruleIndex) {
+        return _makeRuleInvalid(answerGroupIndex, ruleIndex);
       },
       // This registers the change to the handlers in the list of changes, and
       // also updates the states object in ExplorationStatesService.


### PR DESCRIPTION
Fixes #857
Currently the rules aren't updated as a multiple choice option is deleted.
What I'm achieving with this PR is:
- When an option is deleted, a function is triggered that checks for each rule and the deleted option.
- When the deleted option index:
  - is less than any of the rules index, it reduces the rule index by one as other options' rules are decreased.
  - is equal to the rule index, it sets the rule index to the options' length, which in turns makes it invalid.
