### PR TITLE
Fix#4875 - Removed dead zone

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -4230,7 +4230,7 @@ md-card.preview-conversation-skin-supplemental-card {
 
 .oppia-dashboard-statistics-card-link {
   background: white;
-  height: 25.5%;
+  height: 34%;
   opacity: 0;
   position: absolute;
   width: 184px;
@@ -4333,8 +4333,9 @@ md-card.preview-conversation-skin-supplemental-card {
 
 .oppia-dashboard-card-view-item .exp-private-text {
   font-size: 13px;
-  margin: 0.5em;
-  padding: 0.2em;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  padding-top: 0.8em;
 }
 
 .oppia-dashboard-card-view-item .metrics {


### PR DESCRIPTION
## Explanation
Fixes #4875.
I have removed the white space that was present in the white area that was present in the image shown in the issue. Here is the screenshot after that:

![selection_082](https://user-images.githubusercontent.com/22434689/38704473-173bce92-3ec4-11e8-8d61-5f533611d80e.png)

I had tested this now, and there is no area that is unclickable.
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
