### PR TITLE
Fix#4864 - On mobile, two icons are visible on the exploration/collection cards at the same time.

### DIFF
--- a/core/templates/dev/head/domain/learner_dashboard/learner_dashboard_icons_directive.html
+++ b/core/templates/dev/head/domain/learner_dashboard/learner_dashboard_icons_directive.html
@@ -5,7 +5,7 @@
    aria-hidden="true"
    uib-tooltip="<['I18N_LIBRARY_ADD_TO_LEARNER_PLAYLIST' | translate]>"
    tooltip-placement="left"></i>
-<div ng-show="isContainerNarrow() && !belongsToLearnerPlaylist()" class="btn-group dropdown oppia-learner-dashboard-icon" uib-dropdown>
+<div ng-show="canActivityBeAddedToLearnerPlaylist(getActivityId()) && isContainerNarrow()" class="btn-group dropdown oppia-learner-dashboard-icon" uib-dropdown>
   <ul style="left:-150px;top:0" class="dropdown-menu" uib-dropdown-menu role="menu" aria-labelledby="single-button">
     <li role="menuitem" ng-click="addToLearnerPlaylist(getActivityId(), getActivityType())">
       <a><['I18N_LIBRARY_ADD_TO_LEARNER_PLAYLIST' | translate]></a>

--- a/core/templates/dev/head/pages/library/ActivityTilesInfinityGridDirective.js
+++ b/core/templates/dev/head/pages/library/ActivityTilesInfinityGridDirective.js
@@ -25,7 +25,7 @@ oppia.directive('activityTilesInfinityGrid', [
         'activity_tiles_infinity_grid_directive.html'),
       controller: [
         '$scope', '$rootScope', 'SearchService', 'WindowDimensionsService',
-        function ($scope, $rootScope, SearchService, WindowDimensionsService) {
+        function($scope, $rootScope, SearchService, WindowDimensionsService) {
           $scope.endOfPageIsReached = false;
           $scope.allActivitiesInOrder = [];
           // Called when the first batch of search results is retrieved from the
@@ -57,7 +57,7 @@ oppia.directive('activityTilesInfinityGrid', [
           $scope.libraryWindowIsNarrow = (
             WindowDimensionsService.getWidth() <= libraryWindowCutoffPx);
 
-          WindowDimensionsService.registerOnResizeHook(function () {
+          WindowDimensionsService.registerOnResizeHook(function() {
             $scope.libraryWindowIsNarrow = (
               WindowDimensionsService.getWidth() <= libraryWindowCutoffPx);
             $scope.$apply();

--- a/core/templates/dev/head/pages/library/ActivityTilesInfinityGridDirective.js
+++ b/core/templates/dev/head/pages/library/ActivityTilesInfinityGridDirective.js
@@ -24,8 +24,8 @@ oppia.directive('activityTilesInfinityGrid', [
         '/pages/library/' +
         'activity_tiles_infinity_grid_directive.html'),
       controller: [
-        '$scope', '$rootScope', 'SearchService',
-        function($scope, $rootScope, SearchService) {
+        '$scope', '$rootScope', 'SearchService', 'WindowDimensionsService',
+        function ($scope, $rootScope, SearchService, WindowDimensionsService) {
           $scope.endOfPageIsReached = false;
           $scope.allActivitiesInOrder = [];
           // Called when the first batch of search results is retrieved from the
@@ -52,6 +52,16 @@ oppia.directive('activityTilesInfinityGrid', [
               });
             }
           };
+
+          var libraryWindowCutoffPx = 530;
+          $scope.libraryWindowIsNarrow = (
+            WindowDimensionsService.getWidth() <= libraryWindowCutoffPx);
+
+          WindowDimensionsService.registerOnResizeHook(function () {
+            $scope.libraryWindowIsNarrow = (
+              WindowDimensionsService.getWidth() <= libraryWindowCutoffPx);
+            $scope.$apply();
+          });
         }
       ]
     };

--- a/core/templates/dev/head/pages/library/activity_tiles_infinity_grid_directive.html
+++ b/core/templates/dev/head/pages/library/activity_tiles_infinity_grid_directive.html
@@ -11,6 +11,7 @@
                              thumbnail-icon-url="activity.thumbnail_icon_url"
                              thumbnail-bg-color="activity.thumbnail_bg_color"
                              show-learner-dashboard-icons-if-possible="true"
+                             container-is-narrow="libraryWindowIsNarrow"
                              style="margin-right: 3px;">
     </collection-summary-tile>
     <exploration-summary-tile ng-if="activity.activity_type === 'exploration'"
@@ -27,6 +28,7 @@
                               is-community-owned="activity.community_owned"
                               is-community-editable="activity.community_editable"
                               show-learner-dashboard-icons-if-possible="true"
+                              container-is-narrow="libraryWindowIsNarrow"
                               class="protractor-test-exp-summary-tile">
     </exploration-summary-tile>
   </div>


### PR DESCRIPTION
Fixes #4864 - On mobile, two icons are visible on the exploration/collection cards at the same time.

Expects to work in this way

- [x]  Check icon if the exploration/collection has been completed.
- [x] Spinner icon if the user is partway through the exploration/collection.
- [x] Ellipses icon if the user has not visited the exploration/collection before.
- [x] Clock icon if the exploration/collection is present in the playlist.