### PR TITLE
Fix #4880: Adjusted the position of correctness footer

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/correctness_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/correctness_footer_directive.html
@@ -20,6 +20,9 @@
     text-align: center;
   }
 
+  correctness-footer .inner-container-alignment {
+    padding-left: 60px;
+  }
   correctness-footer .tick-symbol {
     font-size: 50px;
   }
@@ -386,27 +389,36 @@
       min-width: 100vw;
     }
   }
-</style>
 
-<div class="inner-container">
-  <div class="sprinkle-dot dot1"></div>
-  <div class="sprinkle-dot dot2"></div>
-  <div class="sprinkle-dot dot3"></div>
-  <div class="sprinkle-dot dot4"></div>
-  <div class="sprinkle-dot dot5"></div>
-  <div class="sprinkle-dot dot6"></div>
-  <div class="sprinkle-dot dot7"></div>
-  <div class="sprinkle-dot dot8"></div>
-  <div class="sprinkle-dot dot9"></div>
-  <div class="sprinkle-dot dot10"></div>
-  <div class="sprinkle-dot dot11"></div>
-  <div class="sprinkle-dot dot12"></div>
-  <div class="sprinkle-dot dot13"></div>
-  <div class="sprinkle-dot dot14"></div>
-  <div class="sprinkle-dot dot15"></div>
-  <div class="sprinkle-dot dot16"></div>
-  <div class="sprinkle-dot dot17"></div>
-  <div class="sprinkle-dot dot18"></div>
-  <i class="material-icons tick-symbol">&#xE86C;</i>
-  <span class="inner-content">CORRECT!</span>
+  @media(max-width: 959px) {
+    correctness-footer .inner-container-alignment {
+      padding-left: 0px;
+      padding-right: 30px;
+    }
+  }
+
+</style>
+<div class="inner-container-alignment">
+  <div class="inner-container">
+    <div class="sprinkle-dot dot1"></div>
+    <div class="sprinkle-dot dot2"></div>
+    <div class="sprinkle-dot dot3"></div>
+    <div class="sprinkle-dot dot4"></div>
+    <div class="sprinkle-dot dot5"></div>
+    <div class="sprinkle-dot dot6"></div>
+    <div class="sprinkle-dot dot7"></div>
+    <div class="sprinkle-dot dot8"></div>
+    <div class="sprinkle-dot dot9"></div>
+    <div class="sprinkle-dot dot10"></div>
+    <div class="sprinkle-dot dot11"></div>
+    <div class="sprinkle-dot dot12"></div>
+    <div class="sprinkle-dot dot13"></div>
+    <div class="sprinkle-dot dot14"></div>
+    <div class="sprinkle-dot dot15"></div>
+    <div class="sprinkle-dot dot16"></div>
+    <div class="sprinkle-dot dot17"></div>
+    <div class="sprinkle-dot dot18"></div>
+    <i class="material-icons tick-symbol">&#xE86C;</i>
+    <span class="inner-content">CORRECT!</span>
+  </div>
 </div>

--- a/core/templates/dev/head/pages/exploration_player/correctness_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/correctness_footer_directive.html
@@ -13,7 +13,7 @@
     height: 60px;
     line-height: normal;
     margin: 0 auto;
-    max-width: 560px;
+    max-width: 475px;
     min-width: 360px;
     padding-top: 5px;
     position: relative;
@@ -22,6 +22,7 @@
 
   correctness-footer .inner-container-alignment {
     padding-left: 60px;
+    padding-right: 0px;
   }
   correctness-footer .tick-symbol {
     font-size: 50px;
@@ -394,6 +395,10 @@
     correctness-footer .inner-container-alignment {
       padding-left: 0px;
       padding-right: 30px;
+    }
+
+    correctness-footer .inner-container {
+      max-width: 560px;
     }
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #4880.
Here is a screenshot after adjusting the position of footer:

![selection_083](https://user-images.githubusercontent.com/22434689/38747635-203d581c-3f69-11e8-8bb7-3af20f38df05.png)

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
