### PR TITLE
Fix #4870: Made edits to the fractions landing page

### DIFF
--- a/core/controllers/custom_landing_pages.py
+++ b/core/controllers/custom_landing_pages.py
@@ -31,7 +31,7 @@ class FractionLandingPage(base.BaseHandler):
         viewer_type = self.request.get('viewerType')
 
         if not viewer_type:
-            viewer_type = 'student'
+            viewer_type = 'teacher'
             self.redirect('/fractions?viewerType=%s' % viewer_type)
 
         self.render_template(

--- a/core/templates/dev/head/pages/landing/fractions/landing_page_student.html
+++ b/core/templates/dev/head/pages/landing/fractions/landing_page_student.html
@@ -16,7 +16,7 @@
               <img ng-src="<[getStaticImageUrl('/fractions_landing/student/hero_bakery_combined_mobile.png')]>" class="oppia-fractions-landing-image oppia-fractions-landing-image-mobile" alt="">
             </div>
             <div class="col-sm-6 col-sm-pull-6">
-              <h2 class="oppia-fractions-landing-h2">Jump into our interactive lessons and get the help you need to tackle the material.</h2>
+              <h2 class="oppia-fractions-landing-h2">Jump into our free interactive lessons and get the help you need to tackle the material.</h2>
               <button class="btn oppia-fractions-landing-get-started" ng-click="onClickGetStartedButton('student')">Get Started</button>
               <button class="btn oppia-fractions-landing-learn-more" ng-click="onClickLearnMoreButton()">Learn More</button>
             </div>
@@ -354,7 +354,7 @@
     .oppia-fractions-landing-image-mobile {
       display: none;
     }
-    @media screen and (max-width: 900px) {
+    @media screen and (max-width: 768px) {
       .oppia-fractions-landing-section-inner,
       .oppia-fractions-landing-section {
         height: auto;

--- a/core/templates/dev/head/pages/landing/fractions/landing_page_teacher.html
+++ b/core/templates/dev/head/pages/landing/fractions/landing_page_teacher.html
@@ -16,7 +16,7 @@
               <img ng-src="<[getStaticImageUrl('/fractions_landing/student/hero_bakery_combined_mobile.png')]>" class="oppia-fractions-landing-image oppia-fractions-landing-image-mobile" alt="">
             </div>
             <div class="col-sm-6 col-sm-pull-6">
-              <h2 class="oppia-fractions-landing-h2">Get your students started with our interactive lessons and get the help they need to tackle the material.</h2>
+              <h2 class="oppia-fractions-landing-h2">Get your students and kids started with our free interactive lessons and get the help they need to tackle the material.</h2>
               <button class="btn oppia-fractions-landing-get-started" ng-click="onClickGetStartedButton('teacher')">Get Started</button>
               <button class="btn oppia-fractions-landing-learn-more" ng-click="onClickLearnMoreButton()">Learn More</button>
             </div>
@@ -149,7 +149,7 @@
               <img ng-src="<[getStaticImageUrl('/fractions_landing/teachers/story_otter_combined.png')]>" class="oppia-fractions-landing-image" alt="">
             </div>
             <div class="col-sm-6 col-sm-pull-6">
-              <h2 class="oppia-fractions-landing-h2" style="color: #FFFFFF">Students are guided through explorations with targeted feedback and immersive storytelling.
+              <h2 class="oppia-fractions-landing-h2" style="color: #FFFFFF">Students are guided through explorations with personalized feedback and immersive storytelling.
               <br><br>We’ll make sure they’re not confused along the way with helpful hints at every step.
               </h2>
             </div>
@@ -169,7 +169,7 @@
             </div>
             <div class="col-sm-6">
               <h2 class="oppia-fractions-landing-h2" style="color: #242424; text-align: right; right: 80px">With Oppia, we make it easy to go through the lessons and learn something new!
-                <br><br>Students get to work through stories and apply their knowledge to real-world problems.
+                <br><br>Students and kids get to work through stories and apply their knowledge to real-world problems.
               </h2>
             </div>
           </div>
@@ -179,8 +179,8 @@
 
     <div class="oppia-fractions-landing-section text-center" style="background-color: #afd2eb">
       <div class="oppia-fractions-landing-section-inner">
-        <h1 class="oppia-fractions-landing-h1" style="text-align: center; padding-left: 0px; padding-bottom: 10px">Imagine what your students could learn today</h1>
-        <h2 class="oppia-fractions-landing-h2 oppia-fractions-landing-centered-h2" style="text-align: center; width: 50%;">Fractions are important to learn, and with our lessons your student can improve a lot!</h2>
+        <h1 class="oppia-fractions-landing-h1" style="text-align: center; padding-left: 0px; padding-bottom: 10px; margin-left: 20%; margin-right: 20%">Imagine what your students and kids could learn today</h1>
+        <h2 class="oppia-fractions-landing-h2 oppia-fractions-landing-centered-h2" style="text-align: center; width: 50%;">Fractions are important to learn, and with our lessons your students and kids can improve a lot!</h2>
         <div style="position: absolute; top: 40%">
           <div class="oppia-fractions-landing-background-icon-row">
             <img ng-src="<[getStaticSubjectImageUrl('Humor')]>" class="oppia-fractions-landing-background-icon" alt="">
@@ -260,7 +260,7 @@
       position: relative;
     }
     .oppia-fractions-landing-h1 {
-      font-size: 2.4em;
+      font-size: 1.8em;
       left: 10%;
       margin: 0px;
       padding-left: 90px;
@@ -276,7 +276,7 @@
       position: relative;
     }
     .oppia-fractions-landing-h2{
-      font-size: 1.6em;
+      font-size: 1.4em;
       left: 80px;
       line-height: 1.6em;
       position: relative;
@@ -293,12 +293,12 @@
     .oppia-fractions-landing-get-started {
       border-radius: 0;
       font-family: "Capriola", "Roboto", Arial, sans-serif;
-      font-size: 1.6em;
+      font-size: 1.2em;
       height: 56px;
       position: relative;
       text-align: center;
       text-transform: uppercase;
-      width: 45%;
+      width: 38%;
       z-index: 20;
     }
     .oppia-fractions-landing-get-started {
@@ -355,7 +355,7 @@
     .oppia-fractions-landing-image-mobile {
       display: none;
     }
-    @media screen and (max-width: 900px) {
+    @media screen and (max-width: 768px) {
       .oppia-fractions-landing-section-inner,
       .oppia-fractions-landing-section {
         height: auto;


### PR DESCRIPTION

## Explanation
Fixed #4870. Made edits as per comments from the first user testing results of the fractions landing pages.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
