### PR TITLE
Fixes alignment of the correctness footer

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/correctness_footer_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/correctness_footer_directive.html
@@ -13,7 +13,7 @@
     height: 60px;
     line-height: normal;
     margin: 0 auto;
-    max-width: 475px;
+    max-width: 560px;
     min-width: 360px;
     padding-top: 5px;
     position: relative;
@@ -21,8 +21,8 @@
   }
 
   correctness-footer .inner-container-alignment {
-    padding-left: 60px;
-    padding-right: 0px;
+    padding-left: 0px;
+    padding-right: 30px;
   }
   correctness-footer .tick-symbol {
     font-size: 50px;

--- a/extensions/interactions/ItemSelectionInput/static/item_selection_input.css
+++ b/extensions/interactions/ItemSelectionInput/static/item_selection_input.css
@@ -33,7 +33,7 @@ md-checkbox.item-selection-input-checkbox .md-label {
   width: 100%;
 }
 .item-selection-input-container {
-  margin-bottom: 5px;
+  padding-bottom: 5px;
 }
 
 .item-selection-input-container md-input-group.md-default-theme label {


### PR DESCRIPTION
## Explanation
While fixing issue #4902, the alignment of the correctness footer was affected. This PR fixes the alignment. Please add this to the current release.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
