### PR TITLE
Replaced Content in docstrings

### DIFF
--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -398,7 +398,7 @@ class AudioTranslation(object):
         self.needs_update = needs_update
 
     def validate(self):
-        """Validates properties of the Content.
+        """Validates properties of the AudioTranslation.
 
         Raises:
             ValidationError: One or more attributes of the AudioTranslation are
@@ -1249,8 +1249,8 @@ class State(object):
         """Initializes a State domain object.
 
         Args:
-            content: list(Content). The contents displayed to the reader in
-                this state. This list must have only one element.
+            content: list(SubtitledHtml). The contents displayed to the reader
+            in this state. This list must have only one element.
             param_changes: list(ParamChange). Parameter changes associated with
                 this state.
             interaction: InteractionInstance. The interaction instance
@@ -1336,7 +1336,7 @@ class State(object):
         return False
 
     def update_content(self, content_dict):
-        """Update the list of Content of this state.
+        """Update the list of content of this state.
 
         Args:
             content_dict. dict. The dict representation of SubtitledHtml

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -1249,7 +1249,7 @@ class State(object):
         """Initializes a State domain object.
 
         Args:
-            content: list(SubtitledHtml). The contents displayed to the reader
+            content: SubtitledHtml. The contents displayed to the reader
             in this state. This list must have only one element.
             param_changes: list(ParamChange). Parameter changes associated with
                 this state.

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -1249,8 +1249,8 @@ class State(object):
         """Initializes a State domain object.
 
         Args:
-            content: SubtitledHtml. The contents displayed to the reader
-            in this state. This list must have only one element.
+            content: SubtitledHtml. The contents displayed to the reader in this
+                state.
             param_changes: list(ParamChange). Parameter changes associated with
                 this state.
             interaction: InteractionInstance. The interaction instance
@@ -1282,7 +1282,7 @@ class State(object):
                 are ParamSpec value objects with an object type
                 property(obj_type). It is None if the state belongs to a
                 question.
-            allow_null_interaction. bool. Whether this state's interaction is
+            allow_null_interaction: bool. Whether this state's interaction is
                 allowed to be unspecified.
 
         Raises:
@@ -1336,10 +1336,10 @@ class State(object):
         return False
 
     def update_content(self, content_dict):
-        """Update the list of content of this state.
+        """Update the content of this state.
 
         Args:
-            content_dict. dict. The dict representation of SubtitledHtml
+            content_dict: dict. The dict representation of SubtitledHtml
                 object.
         """
         # TODO(sll): Must sanitize all content in RTE component attrs.
@@ -1349,7 +1349,7 @@ class State(object):
         """Update the param_changes dict attribute.
 
         Args:
-            param_change_dicts. list(dict). List of param_change dicts that
+            param_change_dicts: list(dict). List of param_change dicts that
                 represent ParamChange domain object.
         """
         self.param_changes = [
@@ -1360,7 +1360,7 @@ class State(object):
         """Update the interaction id attribute.
 
         Args:
-            interaction_id. str. The new interaction id to set.
+            interaction_id: str. The new interaction id to set.
         """
         self.interaction.id = interaction_id
         # TODO(sll): This should also clear interaction.answer_groups (except
@@ -1372,7 +1372,7 @@ class State(object):
         """Update the customization_args of InteractionInstance domain object.
 
         Args:
-            customization_args. dict. The new customization_args to set.
+            customization_args: dict. The new customization_args to set.
         """
         self.interaction.customization_args = customization_args
 
@@ -1380,7 +1380,7 @@ class State(object):
         """Update the list of AnswerGroup in IteractioInstancen domain object.
 
         Args:
-            answer_groups_list. list(dict). List of dicts that represent
+            answer_groups_list: list(dict). List of dicts that represent
                 AnswerGroup domain object.
         """
         if not isinstance(answer_groups_list, list):
@@ -1439,7 +1439,7 @@ class State(object):
         """Update the default_outcome of InteractionInstance domain object.
 
         Args:
-            default_outcome_dict. dict. Dict that represents Outcome domain
+            default_outcome_dict: dict. Dict that represents Outcome domain
                 object.
         """
         if default_outcome_dict:
@@ -1459,7 +1459,7 @@ class State(object):
         domain object.
 
         Args:
-            confirmed_unclassified_answers. list(AnswerGroup). The new list of
+            confirmed_unclassified_answers: list(AnswerGroup). The new list of
                 answers which have been confirmed to be associated with the
                 default outcome.
 


### PR DESCRIPTION
Small fixes in docs, the Contetnt object does not (longe?) exists.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
