### PR TITLE
Playthrough Visualisation: Milestone 1.2 (Part 1)

### DIFF
--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -431,6 +431,18 @@ class ExplorationIssues(object):
         self.id = exp_id
         self.unresolved_issues = unresolved_issues
 
+    @classmethod
+    def create_default(cls, exp_id):
+        """Creates a default ExplorationIssues domain object.
+
+        Args:
+            exp_id: str. ID of the exploration.
+
+        Returns:
+            ExplorationIssues. The exploration issues domain object.
+        """
+        return cls(exp_id, [])
+
     def to_dict(self):
         """Returns a dict representation of the ExplorationIssues domain object.
 

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -271,6 +271,11 @@ class StateStatsTests(test_utils.GenericTestBase):
 class ExplorationIssuesTests(test_utils.GenericTestBase):
     """Tests the ExplorationIssues domain object."""
 
+    def test_create_default(self):
+        exp_issues = stats_domain.ExplorationIssues.create_default('exp_id1')
+        self.assertEqual(exp_issues.id, 'exp_id1')
+        self.assertEqual(exp_issues.unresolved_issues, [])
+
     def test_to_dict(self):
         exp_issues = stats_domain.ExplorationIssues(
             'exp_id1', [{

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -61,11 +61,11 @@ class ExplorationIssuesModelCreatorOneOffJob(
                 exp_issues_model.put()
             yield(
                 exploration_model.id,
-                'ExplorationIssuesModel created for %s' % exploration_model.id)
+                'ExplorationIssuesModel created')
 
     @staticmethod
     def reduce(exp_id, values):
-        yield(values)
+        yield "%s: %s" % (exp_id, values)
 
 
 class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -59,10 +59,13 @@ class ExplorationIssuesModelCreatorOneOffJob(
             else:
                 exp_issues_model.unresolved_issues = []
                 exp_issues_model.put()
+            yield(
+                exploration_model.id,
+                'ExplorationIssuesModel created for %s' % exploration_model.id)
 
     @staticmethod
     def reduce(exp_id, values):
-        pass
+        yield(values)
 
 
 class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -34,6 +34,37 @@ import feconf
 ])
 
 
+class ExplorationIssuesModelCreatorOneOffJob(
+        jobs.BaseMapReduceOneOffJobManager):
+    """A one-off job for creating a default ExplorationIsssues model instance
+    for all the explorations in the datastore. If an ExplorationIssues model
+    already exists for an exploration, it is refreshed to a default instance.
+    """
+
+    @classmethod
+    def entity_classes_to_map_over(cls):
+        return [exp_models.ExplorationModel]
+
+    @staticmethod
+    def map(exploration_model):
+        if not exploration_model.deleted:
+            exp_issues_model = stats_models.ExplorationIssuesModel.get(
+                exploration_model.id, strict=False)
+            if not exp_issues_model:
+                exp_issues_default = (
+                    stats_domain.ExplorationIssues.create_default(
+                        exploration_model.id))
+                stats_models.ExplorationIssuesModel.create(
+                    exp_issues_default.id, exp_issues_default.unresolved_issues)
+            else:
+                exp_issues_model.unresolved_issues = []
+                exp_issues_model.put()
+
+    @staticmethod
+    def reduce(exp_id, values):
+        pass
+
+
 class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     """A one-off job for recomputing creator statistics from the events
     in the datastore. Should only be run in events of data corruption.

--- a/core/domain/stats_jobs_one_off_test.py
+++ b/core/domain/stats_jobs_one_off_test.py
@@ -28,6 +28,70 @@ import feconf
     [models.NAMES.exploration, models.NAMES.statistics])
 
 
+class ExplorationIssuesModelCreatorOneOffJobTest(test_utils.GenericTestBase):
+    exp_id1 = 'exp_id1'
+    exp_id2 = 'exp_id2'
+
+    def setUp(self):
+        super(ExplorationIssuesModelCreatorOneOffJobTest, self).setUp()
+        self.exp1 = self.save_new_valid_exploration(self.exp_id1, 'owner')
+        self.exp2 = self.save_new_valid_exploration(self.exp_id2, 'owner')
+
+    def test_default_job_execution(self):
+        job_id = (
+            stats_jobs_one_off.ExplorationIssuesModelCreatorOneOffJob.create_new()) # pylint: disable=line-too-long
+        stats_jobs_one_off.ExplorationIssuesModelCreatorOneOffJob.enqueue(
+            job_id)
+
+        self.assertEqual(
+            self.count_jobs_in_taskqueue(
+                taskqueue_services.QUEUE_NAME_ONE_OFF_JOBS), 1)
+        self.process_and_flush_pending_tasks()
+
+        exp_issues1 = stats_models.ExplorationIssuesModel.get(self.exp_id1)
+        self.assertEqual(exp_issues1.id, self.exp_id1)
+        self.assertEqual(exp_issues1.unresolved_issues, [])
+
+        exp_issues2 = stats_models.ExplorationIssuesModel.get(self.exp_id2)
+        self.assertEqual(exp_issues2.id, self.exp_id2)
+        self.assertEqual(exp_issues2.unresolved_issues, [])
+
+    def test_with_existing_exp_issues_instance(self):
+        stats_models.ExplorationIssuesModel.create(
+            self.exp_id1,
+            [{
+                'issue_type': 'EarlyQuit',
+                'issue_customization_args': {
+                    'state_name': {
+                        'value': 'state_name1'
+                    },
+                    'time_spent_in_exp_in_msecs': {
+                        'value': 200
+                    }
+                },
+                'playthrough_ids': ['playthrough_id1']
+            }]
+        )
+
+        job_id = (
+            stats_jobs_one_off.ExplorationIssuesModelCreatorOneOffJob.create_new()) # pylint: disable=line-too-long
+        stats_jobs_one_off.ExplorationIssuesModelCreatorOneOffJob.enqueue(
+            job_id)
+
+        self.assertEqual(
+            self.count_jobs_in_taskqueue(
+                taskqueue_services.QUEUE_NAME_ONE_OFF_JOBS), 1)
+        self.process_and_flush_pending_tasks()
+
+        exp_issues1 = stats_models.ExplorationIssuesModel.get(self.exp_id1)
+        self.assertEqual(exp_issues1.id, self.exp_id1)
+        self.assertEqual(exp_issues1.unresolved_issues, [])
+
+        exp_issues2 = stats_models.ExplorationIssuesModel.get(self.exp_id2)
+        self.assertEqual(exp_issues2.id, self.exp_id2)
+        self.assertEqual(exp_issues2.unresolved_issues, [])
+
+
 class RecomputeStateCompleteStatisticsTest(test_utils.GenericTestBase):
     exp_id = 'exp_id'
     state_b = 'b'

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -47,6 +47,7 @@ ONE_OFF_JOB_MANAGERS = [
     feedback_jobs_one_off.FeedbackThreadMessagesCountOneOffJob,
     feedback_jobs_one_off.FeedbackSubjectOneOffJob,
     recommendations_jobs_one_off.ExplorationRecommendationsOneOffJob,
+    stats_jobs_one_off.ExplorationIssuesModelCreatorOneOffJob,
     stats_jobs_one_off.RecomputeStatisticsOneOffJob,
     stats_jobs_one_off.StatisticsAuditV1,
     stats_jobs_one_off.StatisticsAudit,


### PR DESCRIPTION
This PR implements Milestone 1.1 of the Playthrough Visualisation project (can be found at [Learner Playthrough Visualization](https://docs.google.com/document/d/1PsGV3Ll-hhdCLaYlq3BwwAVdrnwgne26wapX4RFeA28/edit?ts=5ade8311) ).

The following features are implemented in this PR:

- One off job along with tests for creating default ExplorationIssuesModel instances for all explorations in the datastore.

@seanlip @brianrodri PTAL!

Thanks a lot