### PR TITLE
Add translator role for the exploration (M1.1 Lesson translation dashboard)

### DIFF
--- a/core/domain/acl_decorators.py
+++ b/core/domain/acl_decorators.py
@@ -438,6 +438,34 @@ def can_edit_exploration(handler):
     return test_can_edit
 
 
+def can_translate_exploration(handler):
+    """Decorator to check whether the user can translate given exploration."""
+
+    def test_can_translate(self, exploration_id, **kwargs):
+        """Checks if the user can translate the exploration.
+
+        Args:
+            exploration_id: str. The exploration id.
+        """
+        if not self.user_id:
+            raise base.UserFacingExceptions.NotLoggedInException
+
+        exploration_rights = rights_manager.get_exploration_rights(
+            exploration_id)
+        if exploration_rights is None:
+            raise base.UserFacingExceptions.PageNotFoundException
+
+        if rights_manager.check_can_translate_activity(
+                self.user, exploration_rights):
+            return handler(self, exploration_id, **kwargs)
+        else:
+            raise base.UserFacingExceptions.UnauthorizedUserException(
+                'You do not have credentials to translate this exploration.')
+    test_can_translate.__wrapped__ = True
+
+    return test_can_translate
+
+
 def can_delete_exploration(handler):
     """Decorator to check whether user can delete exploration."""
 

--- a/core/domain/acl_decorators_test.py
+++ b/core/domain/acl_decorators_test.py
@@ -50,7 +50,7 @@ class PlayExplorationDecoratorTest(test_utils.GenericTestBase):
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
         self.set_admins([self.ADMIN_USERNAME])
         self.owner = user_services.UserActionsInfo(self.owner_id)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<exploration_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
@@ -61,31 +61,36 @@ class PlayExplorationDecoratorTest(test_utils.GenericTestBase):
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
 
     def test_guest_can_access_published_exploration(self):
-        response = self.get_json('/mock/%s' % self.published_exp_id)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.published_exp_id)
         self.assertEqual(response['exploration_id'], self.published_exp_id)
 
     def test_guest_cannot_access_private_exploration(self):
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 404)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                expected_status_int=404)
 
     def test_admin_can_access_private_exploration(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.get_json('/mock/%s' % self.private_exp_id)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
     def test_owner_can_access_private_exploration(self):
         self.login(self.OWNER_EMAIL)
-        response = self.get_json('/mock/%s' % self.private_exp_id)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
         self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
     def test_logged_in_user_cannot_access_not_owned_exploration(self):
         self.login(self.user_email)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 404)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                expected_status_int=404)
         self.logout()
 
 
@@ -114,7 +119,7 @@ class PlayCollectionDecoratorTest(test_utils.GenericTestBase):
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
         self.set_admins([self.ADMIN_USERNAME])
         self.owner = user_services.UserActionsInfo(self.owner_id)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<collection_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
@@ -132,31 +137,36 @@ class PlayCollectionDecoratorTest(test_utils.GenericTestBase):
         rights_manager.publish_collection(self.owner, self.published_col_id)
 
     def test_guest_can_access_published_collection(self):
-        response = self.get_json('/mock/%s' % self.published_col_id)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.published_col_id)
         self.assertEqual(response['collection_id'], self.published_col_id)
 
     def test_guest_cannot_access_private_collection(self):
-        response = self.testapp.get(
-            '/mock/%s' % self.private_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 404)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_col_id, expect_errors=True,
+                expected_status_int=404)
 
     def test_admin_can_access_private_collection(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.get_json('/mock/%s' % self.private_col_id)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_col_id)
         self.assertEqual(response['collection_id'], self.private_col_id)
         self.logout()
 
     def test_owner_can_access_private_collection(self):
         self.login(self.OWNER_EMAIL)
-        response = self.get_json('/mock/%s' % self.private_col_id)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_col_id)
         self.assertEqual(response['collection_id'], self.private_col_id)
         self.logout()
 
     def test_logged_in_user_cannot_access_not_owned_private_collection(self):
         self.login(self.user_email)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 404)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_col_id, expect_errors=True,
+                expected_status_int=404)
         self.logout()
 
 
@@ -188,7 +198,7 @@ class EditCollectionDecoratorTest(test_utils.GenericTestBase):
         self.set_moderators([self.MODERATOR_USERNAME])
         self.set_collection_editors([self.OWNER_USERNAME])
         self.owner = user_services.UserActionsInfo(self.owner_id)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<collection_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
@@ -206,43 +216,46 @@ class EditCollectionDecoratorTest(test_utils.GenericTestBase):
         rights_manager.publish_collection(self.owner, self.published_col_id)
 
     def test_guest_is_redirected_to_login_page(self):
-        response = self.testapp.get(
-            '/mock/%s' % self.published_col_id, expect_errors=True)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.mock_testapp.get(
+                '/mock/%s' % self.published_col_id, expect_errors=True)
         self.assertEqual(response.status_int, 302)
 
     def test_normal_user_cannot_edit_collection(self):
         self.login(self.user_email)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_col_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
     def test_owner_can_edit_owned_collection(self):
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_col_id)
+        self.assertEqual(response['collection_id'], self.private_col_id)
         self.logout()
 
     def test_moderator_cannot_edit_private_collection(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_col_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
     def test_moderator_can_edit_public_collection(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.published_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.published_col_id)
+        self.assertEqual(response['collection_id'], self.published_col_id)
         self.logout()
 
     def test_admin_can_edit_any_private_collection(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_col_id)
+        self.assertEqual(response['collection_id'], self.private_col_id)
         self.logout()
 
 
@@ -252,6 +265,9 @@ class CreateExplorationDecoratorTest(test_utils.GenericTestBase):
     user_email = 'user@example.com'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_create_exploration
         def get(self):
             self.render_json({'success': True})
@@ -261,26 +277,28 @@ class CreateExplorationDecoratorTest(test_utils.GenericTestBase):
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
         self.signup(self.user_email, self.username)
         self.set_banned_users([self.username])
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/create', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
 
     def test_banned_user_cannot_create_exploration(self):
         self.login(self.user_email)
-        response = self.testapp.get('/mock/create', expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/create', expect_errors=True, expected_status_int=401)
         self.logout()
 
     def test_normal_user_can_create_exploration(self):
         self.login(self.EDITOR_EMAIL)
-        response = self.testapp.get('/mock/create', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/create')
+        self.assertEqual(response['success'], True)
         self.logout()
 
     def test_guest_user_is_redirected_to_login_page(self):
-        response = self.testapp.get(
-            '/mock/create', expect_errors=True)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.mock_testapp.get('/mock/create', expect_errors=True)
         self.assertEqual(response.status_int, 302)
 
 
@@ -290,6 +308,9 @@ class CreateCollectionDecoratorTest(test_utils.GenericTestBase):
     user_email = 'user@example.com'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_create_collection
         def get(self):
             self.render_json({'success': True})
@@ -301,31 +322,35 @@ class CreateCollectionDecoratorTest(test_utils.GenericTestBase):
         self.signup(self.ADMIN_EMAIL, self.ADMIN_USERNAME)
         self.set_collection_editors([self.username])
         self.set_admins([self.ADMIN_USERNAME])
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/create', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
 
     def test_guest_user_is_redirected_to_login_page(self):
-        response = self.testapp.get('/mock/create', expect_errors=True)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.mock_testapp.get('/mock/create', expect_errors=True)
         self.assertEqual(response.status_int, 302)
 
     def test_normal_user_cannot_create_collection(self):
         self.login(self.EDITOR_EMAIL)
-        response = self.testapp.get('/mock/create', expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/create', expect_errors=True, expected_status_int=401)
         self.logout()
 
     def test_collection_editor_can_create_collection(self):
         self.login(self.user_email)
-        response = self.testapp.get('/mock/create', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/create')
+        self.assertEqual(response['success'], True)
         self.logout()
 
     def test_admins_can_create_collection(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get('/mock/create', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/create')
+        self.assertEqual(response['success'], True)
         self.logout()
 
 
@@ -336,6 +361,8 @@ class AccessCreatorDashboardTest(test_utils.GenericTestBase):
 
     class MockHandler(base.BaseHandler):
 
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_access_creator_dashboard
         def get(self):
             self.render_json({'success': True})
@@ -345,21 +372,23 @@ class AccessCreatorDashboardTest(test_utils.GenericTestBase):
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
         self.signup(self.user_email, self.username)
         self.set_banned_users([self.username])
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/access', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
 
     def test_banned_user_cannot_access_editor_dashboard(self):
         self.login(self.user_email)
-        response = self.testapp.get('/mock/access', expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/access', expect_errors=True, expected_status_int=401)
         self.logout()
 
     def test_normal_user_can_access_editor_dashboard(self):
         self.login(self.EDITOR_EMAIL)
-        response = self.testapp.get('/mock/access', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/access')
+        self.assertEqual(response['success'], True)
 
 
 class CommentOnFeedbackTest(test_utils.GenericTestBase):
@@ -368,6 +397,9 @@ class CommentOnFeedbackTest(test_utils.GenericTestBase):
     private_exp_id = 'exp_1'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_comment_on_feedback_thread
         def get(self, exploration_id):
             self.render_json({'exploration_id': exploration_id})
@@ -381,7 +413,7 @@ class CommentOnFeedbackTest(test_utils.GenericTestBase):
         self.set_moderators([self.MODERATOR_USERNAME])
         self.set_admins([self.ADMIN_USERNAME])
         self.owner = user_services.UserActionsInfo(self.owner_id)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<exploration_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
@@ -393,36 +425,41 @@ class CommentOnFeedbackTest(test_utils.GenericTestBase):
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
 
     def test_guest_cannot_comment_on_feedback_threads(self):
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.mock_testapp.get(
+                '/mock/%s' % self.private_exp_id, expect_errors=True)
         self.assertEqual(response.status_int, 302)
 
     def test_owner_can_comment_on_feedback_for_private_exploration(self):
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
+        self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
     def test_moderator_can_comment_on_feeback_public_exploration(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.published_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.published_exp_id)
+        self.assertEqual(response['exploration_id'], self.published_exp_id)
         self.logout()
 
     def test_admin_can_comment_on_feeback_private_exploration(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
+        self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
 
 class ManageEmailDashboardTest(test_utils.GenericTestBase):
     """Tests for can_manage_email_dashboard decorator."""
+    query_id = 'query_id'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_manage_email_dashboard
         def get(self):
             return self.render_json({'success': 1})
@@ -438,7 +475,7 @@ class ManageEmailDashboardTest(test_utils.GenericTestBase):
         self.signup(self.MODERATOR_EMAIL, self.MODERATOR_USERNAME)
         self.set_admins([self.ADMIN_USERNAME])
         self.set_moderators([self.MODERATOR_USERNAME])
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [
                 webapp2.Route('/mock/', self.MockHandler),
                 webapp2.Route('/mock/<query_id>', self.MockHandler)
@@ -448,24 +485,33 @@ class ManageEmailDashboardTest(test_utils.GenericTestBase):
 
     def test_moderator_cannot_access_email_dashboard(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get('/mock/', expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/', expect_errors=True, expected_status_int=401)
         self.logout()
 
     def test_admin_can_access_email_dashboard(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get('/mock/', expect_errors=True)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/')
+        self.assertEqual(response['success'], 1)
+
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.mock_testapp.put('/mock/%s' % self.query_id)
         self.assertEqual(response.status_int, 200)
-        response = self.testapp.put('/mock/one', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        self.logout()
 
 
 class RateExplorationTest(test_utils.GenericTestBase):
     """Tests for can_rate_exploration decorator."""
     username = 'user'
     user_email = 'user@example.com'
+    exp_id = 'exp_id'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_rate_exploration
         def get(self, exploration_id):
             self.render_json({'exploration_id': exploration_id})
@@ -473,19 +519,22 @@ class RateExplorationTest(test_utils.GenericTestBase):
     def setUp(self):
         super(RateExplorationTest, self).setUp()
         self.signup(self.user_email, self.username)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<exploration_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
 
     def test_guest_cannot_give_rating(self):
-        response = self.testapp.get('/mock/exp', expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.exp_id, expect_errors=True,
+                expected_status_int=401)
 
     def test_normal_user_can_give_rating(self):
         self.login(self.user_email)
-        response = self.testapp.get('/mock/exp', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.exp_id)
+        self.assertEqual(response['exploration_id'], self.exp_id)
         self.logout()
 
 
@@ -494,6 +543,9 @@ class AccessModeratorPageTest(test_utils.GenericTestBase):
     user_email = 'user@example.com'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_access_moderator_page
         def get(self):
             return self.render_json({'success': 1})
@@ -503,21 +555,22 @@ class AccessModeratorPageTest(test_utils.GenericTestBase):
         self.signup(self.ADMIN_EMAIL, self.ADMIN_USERNAME)
         self.signup(self.user_email, self.username)
         self.set_admins([self.ADMIN_USERNAME])
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
 
     def test_normal_user_cannot_access_moderator_page(self):
         self.login(self.user_email)
-        response = self.testapp.get('/mock/', expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json('/mock/', expect_errors=True, expected_status_int=401)
         self.logout()
 
     def test_admin_can_access_moderator_page(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get('/mock/', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/')
+        self.assertEqual(response['success'], 1)
         self.logout()
 
 
@@ -525,8 +578,12 @@ class FlagExplorationTest(test_utils.GenericTestBase):
     """Tests for can_flag_exploration decorator."""
     username = 'user'
     user_email = 'user@example.com'
+    exp_id = 'exp_id'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_flag_exploration
         def get(self, exploration_id):
             self.render_json({'exploration_id': exploration_id})
@@ -534,19 +591,22 @@ class FlagExplorationTest(test_utils.GenericTestBase):
     def setUp(self):
         super(FlagExplorationTest, self).setUp()
         self.signup(self.user_email, self.username)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<exploration_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
 
     def test_guest_cannot_flag_exploration(self):
-        response = self.testapp.get('/mock/exp', expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.exp_id, expect_errors=True,
+                expected_status_int=401)
 
     def test_normal_user_can_flag_exploration(self):
         self.login(self.user_email)
-        response = self.testapp.get('/mock/exp', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.exp_id)
+        self.assertEqual(response['exploration_id'], self.exp_id)
         self.logout()
 
 
@@ -556,6 +616,9 @@ class SubscriptionToUsersTest(test_utils.GenericTestBase):
     user_email = 'user@example.com'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_subscribe_to_users
         def get(self):
             self.render_json({'success': True})
@@ -563,19 +626,20 @@ class SubscriptionToUsersTest(test_utils.GenericTestBase):
     def setUp(self):
         super(SubscriptionToUsersTest, self).setUp()
         self.signup(self.user_email, self.username)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
 
     def test_guest_cannot_subscribe_to_users(self):
-        response = self.testapp.get('/mock/', expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json('/mock/', expect_errors=True, expected_status_int=401)
 
     def test_normal_user_can_subscribe_to_users(self):
         self.login(self.user_email)
-        response = self.testapp.get('/mock/', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/')
+        self.assertEqual(response['success'], True)
         self.logout()
 
 
@@ -585,6 +649,9 @@ class SendModeratorEmailsTest(test_utils.GenericTestBase):
     user_email = 'user@example.com'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_send_moderator_emails
         def get(self):
             return self.render_json({'success': 1})
@@ -594,21 +661,22 @@ class SendModeratorEmailsTest(test_utils.GenericTestBase):
         self.signup(self.ADMIN_EMAIL, self.ADMIN_USERNAME)
         self.signup(self.user_email, self.username)
         self.set_admins([self.ADMIN_USERNAME])
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
 
     def test_normal_user_cannot_send_moderator_emails(self):
         self.login(self.user_email)
-        response = self.testapp.get('/mock/', expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json('/mock/', expect_errors=True, expected_status_int=401)
         self.logout()
 
     def test_admin_can_send_moderator_emails(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get('/mock/', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/')
+        self.assertEqual(response['success'], 1)
         self.logout()
 
 
@@ -621,6 +689,9 @@ class TranslateExplorationTest(test_utils.GenericTestBase):
     private_exp_id = 'exp_1'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_translate_exploration
         def get(self, exploration_id):
             self.render_json({'exploration_id': exploration_id})
@@ -638,7 +709,7 @@ class TranslateExplorationTest(test_utils.GenericTestBase):
         self.set_admins([self.ADMIN_USERNAME])
         self.set_banned_users([self.username])
         self.owner = user_services.UserActionsInfo(self.owner_id)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<exploration_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
@@ -653,44 +724,46 @@ class TranslateExplorationTest(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_translate_exploration(self):
         self.login(self.user_email)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
     def test_owner_can_translate_exploration(self):
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
+        self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
     def test_moderator_can_translate_public_exploration(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.published_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.published_exp_id)
+        self.assertEqual(response['exploration_id'], self.published_exp_id)
         self.logout()
 
     def test_moderator_cannot_translate_private_exploration(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
-    def test_admin_can_edit_private_exploration(self):
+    def test_admin_can_translate_private_exploration(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
+        self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
     def test_translator_can_translate_assigned_exploration(self):
         self.login(self.TRANSLATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.published_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.published_exp_id)
+        self.assertEqual(response['exploration_id'], self.published_exp_id)
         self.logout()
 
 
@@ -702,6 +775,9 @@ class EditExplorationTest(test_utils.GenericTestBase):
     private_exp_id = 'exp_1'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_edit_exploration
         def get(self, exploration_id):
             self.render_json({'exploration_id': exploration_id})
@@ -717,7 +793,7 @@ class EditExplorationTest(test_utils.GenericTestBase):
         self.set_admins([self.ADMIN_USERNAME])
         self.set_banned_users([self.username])
         self.owner = user_services.UserActionsInfo(self.owner_id)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<exploration_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
@@ -729,37 +805,39 @@ class EditExplorationTest(test_utils.GenericTestBase):
 
     def test_banned_user_cannot_edit_exploration(self):
         self.login(self.user_email)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
     def test_owner_can_edit_exploration(self):
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
+        self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
     def test_moderator_can_edit_public_exploration(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.published_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.published_exp_id)
+        self.assertEqual(response['exploration_id'], self.published_exp_id)
         self.logout()
 
     def test_moderator_cannot_edit_private_exploration(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
     def test_admin_can_edit_private_exploration(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
+        self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
 
@@ -772,6 +850,9 @@ class ManageOwnProfileTest(test_utils.GenericTestBase):
     user_email = 'user@example.com'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_manage_own_profile
         def get(self):
             return self.render_json({'success': 1})
@@ -781,21 +862,24 @@ class ManageOwnProfileTest(test_utils.GenericTestBase):
         self.signup(self.banned_user_email, self.banned_user)
         self.signup(self.user_email, self.username)
         self.set_banned_users([self.banned_user])
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
 
     def test_banned_user_cannot_update_preferences(self):
         self.login(self.banned_user_email)
-        response = self.testapp.get('/mock/', expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/', expect_errors=True, expected_status_int=401)
         self.logout()
 
     def test_normal_user_can_manage_preferences(self):
         self.login(self.user_email)
-        response = self.testapp.get('/mock/', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/')
+        self.assertEqual(response['success'], 1)
+        self.logout()
 
 
 class DeleteExplorationTest(test_utils.GenericTestBase):
@@ -804,6 +888,9 @@ class DeleteExplorationTest(test_utils.GenericTestBase):
     published_exp_id = 'exp_1'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_delete_exploration
         def get(self, exploration_id):
             self.render_json({'exploration_id': exploration_id})
@@ -815,7 +902,7 @@ class DeleteExplorationTest(test_utils.GenericTestBase):
         self.set_moderators([self.MODERATOR_USERNAME])
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
         self.owner = user_services.UserActionsInfo(self.owner_id)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<exploration_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
@@ -827,30 +914,32 @@ class DeleteExplorationTest(test_utils.GenericTestBase):
 
     def test_owner_can_delete_owned_private_exploration(self):
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
+        self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
     def test_moderator_can_delete_published_exploration(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.published_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.published_exp_id)
+        self.assertEqual(response['exploration_id'], self.published_exp_id)
         self.logout()
 
     def test_owner_cannot_delete_published_exploration(self):
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.published_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.published_exp_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
     def test_moderator_cannot_delete_private_exploration(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
 
@@ -860,8 +949,12 @@ class SuggestChangesTest(test_utils.GenericTestBase):
     user_email = 'user@example.com'
     banned_username = 'banneduser'
     banned_user_email = 'banned@example.com'
+    exploration_id = 'exp_id'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_suggest_changes_to_exploration
         def get(self, exploration_id):
             self.render_json({'exploration_id': exploration_id})
@@ -871,21 +964,24 @@ class SuggestChangesTest(test_utils.GenericTestBase):
         self.signup(self.user_email, self.username)
         self.signup(self.banned_user_email, self.banned_username)
         self.set_banned_users([self.banned_username])
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<exploration_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
 
     def test_banned_user_cannot_suggest_changes(self):
         self.login(self.banned_user_email)
-        response = self.testapp.get('/mock/exp', expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.exploration_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
     def test_normal_user_can_suggest_changes(self):
         self.login(self.user_email)
-        response = self.testapp.get('/mock/exp', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.exploration_id)
+        self.assertEqual(response['exploration_id'], self.exploration_id)
         self.logout()
 
 
@@ -895,6 +991,9 @@ class PublishExplorationTest(test_utils.GenericTestBase):
     public_exp_id = 'exp_1'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_publish_exploration
         def get(self, exploration_id):
             self.render_json({'exploration_id': exploration_id})
@@ -908,7 +1007,7 @@ class PublishExplorationTest(test_utils.GenericTestBase):
         self.set_admins([self.ADMIN_USERNAME])
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
         self.owner = user_services.UserActionsInfo(self.owner_id)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<exploration_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
@@ -920,30 +1019,33 @@ class PublishExplorationTest(test_utils.GenericTestBase):
 
     def test_owner_can_publish_owned_exploration(self):
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
+        self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
     def test_already_published_exploration_cannot_be_published(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.public_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.public_exp_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
     def test_moderator_cannot_publish_private_exploration(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                expected_status_int=401)
+        self.logout()
 
     def test_admin_can_publish_any_exploration(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
-        self.logout()
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
+        self.assertEqual(response['exploration_id'], self.private_exp_id)
+
 
 
 class ModifyExplorationRolesTest(test_utils.GenericTestBase):
@@ -951,6 +1053,9 @@ class ModifyExplorationRolesTest(test_utils.GenericTestBase):
     private_exp_id = 'exp_0'
 
     class MockHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_modify_exploration_roles
         def get(self, exploration_id):
             self.render_json({'exploration_id': exploration_id})
@@ -963,7 +1068,7 @@ class ModifyExplorationRolesTest(test_utils.GenericTestBase):
         self.set_moderators([self.MODERATOR_USERNAME])
         self.set_admins([self.ADMIN_USERNAME])
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/<exploration_id>', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
@@ -972,23 +1077,24 @@ class ModifyExplorationRolesTest(test_utils.GenericTestBase):
 
     def test_owner_can_modify_exploration_roles(self):
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
+        self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
     def test_moderator_cannot_modify_roles_of_unowned_exploration(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
     def test_admin_can_modify_roles_of_any_exploration(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get(
-            '/mock/%s' % self.private_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock/%s' % self.private_exp_id)
+        self.assertEqual(response['exploration_id'], self.private_exp_id)
         self.logout()
 
 
@@ -1003,11 +1109,17 @@ class CollectionPublishStatusTest(test_utils.GenericTestBase):
     private_col_id = 'col_id_2'
 
     class MockPublishHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_publish_collection
         def get(self, collection_id):
             return self.render_json({'collection_id': collection_id})
 
     class MockUnpublishHandler(base.BaseHandler):
+
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_unpublish_collection
         def get(self, collection_id):
             return self.render_json({'collection_id': collection_id})
@@ -1023,7 +1135,7 @@ class CollectionPublishStatusTest(test_utils.GenericTestBase):
         self.set_moderators([self.MODERATOR_USERNAME])
         self.set_collection_editors([self.OWNER_USERNAME])
         self.owner = user_services.UserActionsInfo(self.owner_id)
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [
                 webapp2.Route(
                     '/mock_publish/<collection_id>', self.MockPublishHandler),
@@ -1048,37 +1160,40 @@ class CollectionPublishStatusTest(test_utils.GenericTestBase):
 
     def test_owner_can_publish_collection(self):
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.get(
-            '/mock_publish/%s' % self.private_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock_publish/%s' % self.private_col_id)
+        self.assertEqual(response['collection_id'], self.private_col_id)
         self.logout()
 
     def test_owner_cannot_unpublish_public_collection(self):
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.get(
-            '/mock_unpublish/%s' % self.published_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock_unpublish/%s' % self.published_col_id,
+                expect_errors=True, expected_status_int=401)
         self.logout()
 
     def test_moderator_can_unpublish_public_collection(self):
         self.login(self.MODERATOR_EMAIL)
-        response = self.testapp.get(
-            '/mock_unpublish/%s' % self.published_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json(
+                '/mock_unpublish/%s' % self.published_col_id)
+        self.assertEqual(response['collection_id'], self.published_col_id)
         self.logout()
 
     def test_admin_can_publish_any_collection(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get(
-            '/mock_publish/%s' % self.private_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.get_json('/mock_publish/%s' % self.private_col_id)
+        self.assertEqual(response['collection_id'], self.private_col_id)
         self.logout()
 
     def test_admin_cannot_publish_already_published_collection(self):
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.get(
-            '/mock_publish/%s' % self.published_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock_publish/%s' % self.published_col_id, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
 
@@ -1092,6 +1207,8 @@ class AccessLearnerDashboardDecoratorTest(test_utils.GenericTestBase):
 
     class MockHandler(base.BaseHandler):
 
+        GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
         @acl_decorators.can_access_learner_dashboard
         def get(self):
             return self.render_json({})
@@ -1101,21 +1218,22 @@ class AccessLearnerDashboardDecoratorTest(test_utils.GenericTestBase):
         self.signup(self.user_email, self.user)
         self.signup(self.banned_user_email, self.banned_user)
         self.set_banned_users([self.banned_user])
-        self.testapp = webtest.TestApp(webapp2.WSGIApplication(
+        self.mock_testapp = webtest.TestApp(webapp2.WSGIApplication(
             [webapp2.Route('/mock/', self.MockHandler)],
             debug=feconf.DEBUG,
         ))
 
     def test_banned_user_is_redirected(self):
         self.login(self.banned_user_email)
-        response = self.testapp.get('/mock/', expect_errors=True)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            response = self.mock_testapp.get('/mock/', expect_errors=True)
         self.assertEqual(response.status_int, 302)
         self.logout()
 
     def test_exploration_editor_can_access_learner_dashboard(self):
         self.login(self.user_email)
-        response = self.testapp.get('/mock/', expect_errors=True)
-        self.assertEqual(response.status_int, 200)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json('/mock/')
         self.logout()
 
 
@@ -1128,6 +1246,7 @@ class EditTopicDecoratorTest(test_utils.GenericTestBase):
     topic_id = 'topic_1'
 
     class MockHandler(base.BaseHandler):
+
         GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
 
         @acl_decorators.can_edit_topic

--- a/core/domain/acl_decorators_test.py
+++ b/core/domain/acl_decorators_test.py
@@ -216,9 +216,8 @@ class EditCollectionDecoratorTest(test_utils.GenericTestBase):
         rights_manager.publish_collection(self.owner, self.published_col_id)
 
     def test_guest_is_redirected_to_login_page(self):
-        with self.swap(self, 'testapp', self.mock_testapp):
-            response = self.mock_testapp.get(
-                '/mock/%s' % self.published_col_id, expect_errors=True)
+        response = self.mock_testapp.get(
+            '/mock/%s' % self.published_col_id, expect_errors=True)
         self.assertEqual(response.status_int, 302)
 
     def test_normal_user_cannot_edit_collection(self):
@@ -297,8 +296,7 @@ class CreateExplorationDecoratorTest(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_is_redirected_to_login_page(self):
-        with self.swap(self, 'testapp', self.mock_testapp):
-            response = self.mock_testapp.get('/mock/create', expect_errors=True)
+        response = self.mock_testapp.get('/mock/create', expect_errors=True)
         self.assertEqual(response.status_int, 302)
 
 
@@ -328,8 +326,7 @@ class CreateCollectionDecoratorTest(test_utils.GenericTestBase):
         ))
 
     def test_guest_user_is_redirected_to_login_page(self):
-        with self.swap(self, 'testapp', self.mock_testapp):
-            response = self.mock_testapp.get('/mock/create', expect_errors=True)
+        response = self.mock_testapp.get('/mock/create', expect_errors=True)
         self.assertEqual(response.status_int, 302)
 
     def test_normal_user_cannot_create_collection(self):
@@ -425,9 +422,8 @@ class CommentOnFeedbackTest(test_utils.GenericTestBase):
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
 
     def test_guest_cannot_comment_on_feedback_threads(self):
-        with self.swap(self, 'testapp', self.mock_testapp):
-            response = self.mock_testapp.get(
-                '/mock/%s' % self.private_exp_id, expect_errors=True)
+        response = self.mock_testapp.get(
+            '/mock/%s' % self.private_exp_id, expect_errors=True)
         self.assertEqual(response.status_int, 302)
 
     def test_owner_can_comment_on_feedback_for_private_exploration(self):
@@ -687,8 +683,10 @@ class TranslateExplorationTest(test_utils.GenericTestBase):
     user_email = 'user@example.com'
     banned_username = 'banneduser'
     banned_user_email = 'banneduser@example.com'
-    published_exp_id = 'exp_0'
-    private_exp_id = 'exp_1'
+    published_exp_id_1 = 'exp_1'
+    published_exp_id_2 = 'exp_2'
+    private_exp_id_1 = 'exp_3'
+    private_exp_id_2 = 'exp_4'
 
     class MockHandler(base.BaseHandler):
 
@@ -717,72 +715,93 @@ class TranslateExplorationTest(test_utils.GenericTestBase):
             debug=feconf.DEBUG,
         ))
         self.save_new_valid_exploration(
-            self.published_exp_id, self.owner_id)
+            self.published_exp_id_1, self.owner_id)
         self.save_new_valid_exploration(
-            self.private_exp_id, self.owner_id)
-        rights_manager.publish_exploration(self.owner, self.published_exp_id)
+            self.published_exp_id_2, self.owner_id)
+        self.save_new_valid_exploration(
+            self.private_exp_id_1, self.owner_id)
+        self.save_new_valid_exploration(
+            self.private_exp_id_2, self.owner_id)
+        rights_manager.publish_exploration(self.owner, self.published_exp_id_1)
+        rights_manager.publish_exploration(self.owner, self.published_exp_id_2)
 
         rights_manager.assign_role_for_exploration(
-            self.owner, self.published_exp_id, self.translator_id, self.role)
+            self.owner, self.published_exp_id_1, self.translator_id, self.role)
         rights_manager.assign_role_for_exploration(
-            self.owner, self.private_exp_id, self.translator_id, self.role)
+            self.owner, self.private_exp_id_1, self.translator_id, self.role)
 
     def test_banned_user_cannot_translate_exploration(self):
         self.login(self.banned_user_email)
         with self.swap(self, 'testapp', self.mock_testapp):
             self.get_json(
-                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                '/mock/%s' % self.private_exp_id_1, expect_errors=True,
                 expected_status_int=401)
         self.logout()
 
     def test_owner_can_translate_exploration(self):
         self.login(self.OWNER_EMAIL)
         with self.swap(self, 'testapp', self.mock_testapp):
-            response = self.get_json('/mock/%s' % self.private_exp_id)
-        self.assertEqual(response['exploration_id'], self.private_exp_id)
+            response = self.get_json('/mock/%s' % self.private_exp_id_1)
+        self.assertEqual(response['exploration_id'], self.private_exp_id_1)
         self.logout()
 
     def test_moderator_can_translate_public_exploration(self):
         self.login(self.MODERATOR_EMAIL)
         with self.swap(self, 'testapp', self.mock_testapp):
-            response = self.get_json('/mock/%s' % self.published_exp_id)
-        self.assertEqual(response['exploration_id'], self.published_exp_id)
+            response = self.get_json('/mock/%s' % self.published_exp_id_1)
+        self.assertEqual(response['exploration_id'], self.published_exp_id_1)
         self.logout()
 
     def test_moderator_cannot_translate_private_exploration(self):
         self.login(self.MODERATOR_EMAIL)
         with self.swap(self, 'testapp', self.mock_testapp):
             self.get_json(
-                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                '/mock/%s' % self.private_exp_id_1, expect_errors=True,
                 expected_status_int=401)
         self.logout()
 
     def test_admin_can_translate_private_exploration(self):
         self.login(self.ADMIN_EMAIL)
         with self.swap(self, 'testapp', self.mock_testapp):
-            response = self.get_json('/mock/%s' % self.private_exp_id)
-        self.assertEqual(response['exploration_id'], self.private_exp_id)
+            response = self.get_json('/mock/%s' % self.private_exp_id_1)
+        self.assertEqual(response['exploration_id'], self.private_exp_id_1)
         self.logout()
 
-    def test_translator_can_translate_assigned_public_exploration(self):
+    def test_translator_can_only_translate_assigned_public_exploration(self):
         self.login(self.TRANSLATOR_EMAIL)
+        # Checking translator can translate assigned public exploration.
         with self.swap(self, 'testapp', self.mock_testapp):
-            response = self.get_json('/mock/%s' % self.published_exp_id)
-        self.assertEqual(response['exploration_id'], self.published_exp_id)
+            response = self.get_json('/mock/%s' % self.published_exp_id_1)
+        self.assertEqual(response['exploration_id'], self.published_exp_id_1)
+
+        # Checking translator cannot translate public exploration which he/she
+        # is not assigned for.
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.published_exp_id_2, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
-    def test_translator_can_translate_assigned_private_exploration(self):
+    def test_translator_can_only_translate_assigned_private_exploration(self):
         self.login(self.TRANSLATOR_EMAIL)
+        # Checking translator can translate assigned private exploration.
         with self.swap(self, 'testapp', self.mock_testapp):
-            response = self.get_json('/mock/%s' % self.private_exp_id)
-        self.assertEqual(response['exploration_id'], self.private_exp_id)
+            response = self.get_json('/mock/%s' % self.private_exp_id_1)
+        self.assertEqual(response['exploration_id'], self.private_exp_id_1)
+
+        # Checking translator cannot translate private exploration which he/she
+        # is not assigned for.
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.private_exp_id_2, expect_errors=True,
+                expected_status_int=401)
         self.logout()
 
     def test_user_without_translator_role_of_exploration_cannot_translate_public_exploration(self): # pylint: disable=line-too-long
         self.login(self.user_email)
         with self.swap(self, 'testapp', self.mock_testapp):
             self.get_json(
-                '/mock/%s' % self.published_exp_id, expect_errors=True,
+                '/mock/%s' % self.published_exp_id_1, expect_errors=True,
                 expected_status_int=401)
         self.logout()
 
@@ -790,7 +809,7 @@ class TranslateExplorationTest(test_utils.GenericTestBase):
         self.login(self.user_email)
         with self.swap(self, 'testapp', self.mock_testapp):
             self.get_json(
-                '/mock/%s' % self.private_exp_id, expect_errors=True,
+                '/mock/%s' % self.private_exp_id_1, expect_errors=True,
                 expected_status_int=401)
         self.logout()
 
@@ -1253,8 +1272,7 @@ class AccessLearnerDashboardDecoratorTest(test_utils.GenericTestBase):
 
     def test_banned_user_is_redirected(self):
         self.login(self.banned_user_email)
-        with self.swap(self, 'testapp', self.mock_testapp):
-            response = self.mock_testapp.get('/mock/', expect_errors=True)
+        response = self.mock_testapp.get('/mock/', expect_errors=True)
         self.assertEqual(response.status_int, 302)
         self.logout()
 

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -3955,7 +3955,7 @@ class ExplorationSummary(object):
     def __init__(
             self, exploration_id, title, category, objective,
             language_code, tags, ratings, scaled_average_rating, status,
-            community_owned, owner_ids, editor_ids,
+            community_owned, owner_ids, editor_ids, translator_ids,
             viewer_ids, contributor_ids, contributors_summary, version,
             exploration_model_created_on,
             exploration_model_last_updated,
@@ -3981,6 +3981,8 @@ class ExplorationSummary(object):
                 this exploration.
             editor_ids: list(str). List of the users ids who have access to
                 edit this exploration.
+            translator_ids: list(str). List of the users ids who have access to
+                translate this exploration.
             viewer_ids: list(str). List of the users ids who have access to
                 view this exploration.
             contributor_ids: list(str). List of the users ids of the user who
@@ -4008,6 +4010,7 @@ class ExplorationSummary(object):
         self.community_owned = community_owned
         self.owner_ids = owner_ids
         self.editor_ids = editor_ids
+        self.translator_ids = translator_ids
         self.viewer_ids = viewer_ids
         self.contributor_ids = contributor_ids
         self.contributors_summary = contributors_summary

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -146,6 +146,7 @@ class ExpSummariesCreationOneOffJobTest(test_utils.GenericTestBase):
                     exp_rights_model.community_owned,
                     exp_rights_model.owner_ids,
                     exp_rights_model.editor_ids,
+                    exp_rights_model.translator_ids,
                     exp_rights_model.viewer_ids,
                     [admin_id],
                     {admin_id: 1},
@@ -167,6 +168,9 @@ class ExpSummariesCreationOneOffJobTest(test_utils.GenericTestBase):
                 if exp_rights_model.editor_ids:
                     expected_job_output[exp_id].editor_ids = (
                         exp_rights_model.editor_ids)
+                if exp_rights_model.translator_ids:
+                    expected_job_output[exp_id].translator_ids = (
+                        exp_rights_model.translator_ids)
                 if exp_rights_model.viewer_ids:
                     expected_job_output[exp_id].viewer_ids = (
                         exp_rights_model.viewer_ids)
@@ -191,7 +195,7 @@ class ExpSummariesCreationOneOffJobTest(test_utils.GenericTestBase):
             simple_props = ['id', 'title', 'category', 'objective',
                             'language_code', 'tags', 'ratings', 'status',
                             'community_owned', 'owner_ids',
-                            'editor_ids', 'viewer_ids',
+                            'editor_ids', 'translator_ids', 'viewer_ids',
                             'contributor_ids', 'contributors_summary',
                             'version', 'exploration_model_created_on']
             for exp_id in actual_job_output:

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -194,7 +194,7 @@ def get_exploration_summary_from_model(exp_summary_model):
         exp_summary_model.ratings, exp_summary_model.scaled_average_rating,
         exp_summary_model.status, exp_summary_model.community_owned,
         exp_summary_model.owner_ids, exp_summary_model.editor_ids,
-        exp_summary_model.viewer_ids,
+        exp_summary_model.translator_ids, exp_summary_model.viewer_ids,
         exp_summary_model.contributor_ids,
         exp_summary_model.contributors_summary, exp_summary_model.version,
         exp_summary_model.exploration_model_created_on,
@@ -1260,8 +1260,8 @@ def compute_summary_of_exploration(exploration, contributor_id_to_add):
         exploration.objective, exploration.language_code,
         exploration.tags, ratings, scaled_average_rating, exp_rights.status,
         exp_rights.community_owned, exp_rights.owner_ids,
-        exp_rights.editor_ids, exp_rights.viewer_ids, contributor_ids,
-        contributors_summary, exploration.version,
+        exp_rights.editor_ids, exp_rights.translator_ids, exp_rights.viewer_ids,
+        contributor_ids, contributors_summary, exploration.version,
         exploration_model_created_on, exploration_model_last_updated,
         first_published_msec)
 
@@ -1322,6 +1322,7 @@ def save_exploration_summary(exp_summary):
         community_owned=exp_summary.community_owned,
         owner_ids=exp_summary.owner_ids,
         editor_ids=exp_summary.editor_ids,
+        translator_ids=exp_summary.translator_ids,
         viewer_ids=exp_summary.viewer_ids,
         contributor_ids=exp_summary.contributor_ids,
         contributors_summary=exp_summary.contributors_summary,

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -61,14 +61,17 @@ class ExplorationServicesUnitTests(test_utils.GenericTestBase):
 
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
+        self.translator_id = self.get_user_id_from_email(self.TRANSLATOR_EMAIL)
         self.viewer_id = self.get_user_id_from_email(self.VIEWER_EMAIL)
 
         user_services.create_new_user(self.owner_id, self.OWNER_EMAIL)
         user_services.create_new_user(self.editor_id, self.EDITOR_EMAIL)
+        user_services.create_new_user(self.translator_id, self.TRANSLATOR_EMAIL)
         user_services.create_new_user(self.viewer_id, self.VIEWER_EMAIL)
 
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
+        self.signup(self.TRANSLATOR_EMAIL, self.TRANSLATOR_USERNAME)
         self.signup(self.VIEWER_EMAIL, self.VIEWER_USERNAME)
         self.signup(self.ADMIN_EMAIL, self.ADMIN_USERNAME)
 
@@ -2445,7 +2448,7 @@ class ExplorationSummaryGetTests(ExplorationServicesUnitTests):
                 'A category', 'An objective', 'en', [],
                 feconf.get_empty_ratings(), feconf.EMPTY_SCALED_AVERAGE_RATING,
                 rights_manager.ACTIVITY_STATUS_PUBLIC,
-                False, [self.albert_id], [], [], [self.albert_id],
+                False, [self.albert_id], [], [], [], [self.albert_id],
                 {self.albert_id: 1},
                 self.EXPECTED_VERSION_2,
                 actual_summaries[self.EXP_ID_2].exploration_model_created_on,
@@ -2460,7 +2463,7 @@ class ExplorationSummaryGetTests(ExplorationServicesUnitTests):
                         'language_code', 'tags', 'ratings',
                         'scaled_average_rating', 'status',
                         'community_owned', 'owner_ids',
-                        'editor_ids', 'viewer_ids',
+                        'editor_ids', 'translator_ids', 'viewer_ids',
                         'contributor_ids', 'version',
                         'exploration_model_created_on',
                         'exploration_model_last_updated']
@@ -2477,8 +2480,8 @@ class ExplorationSummaryGetTests(ExplorationServicesUnitTests):
                 self.EXP_ID_1, 'Exploration 1 title',
                 'A category', 'An objective', 'en', [],
                 feconf.get_empty_ratings(), feconf.EMPTY_SCALED_AVERAGE_RATING,
-                rights_manager.ACTIVITY_STATUS_PRIVATE,
-                False, [self.albert_id], [], [], [self.albert_id, self.bob_id],
+                rights_manager.ACTIVITY_STATUS_PRIVATE, False,
+                [self.albert_id], [], [], [], [self.albert_id, self.bob_id],
                 {self.albert_id: 1, self.bob_id: 1}, self.EXPECTED_VERSION_1,
                 actual_summaries[self.EXP_ID_1].exploration_model_created_on,
                 actual_summaries[self.EXP_ID_1].exploration_model_last_updated,
@@ -2489,7 +2492,7 @@ class ExplorationSummaryGetTests(ExplorationServicesUnitTests):
                 'A category', 'An objective', 'en', [],
                 feconf.get_empty_ratings(), feconf.EMPTY_SCALED_AVERAGE_RATING,
                 rights_manager.ACTIVITY_STATUS_PUBLIC,
-                False, [self.albert_id], [], [], [self.albert_id],
+                False, [self.albert_id], [], [], [], [self.albert_id],
                 {self.albert_id: 1}, self.EXPECTED_VERSION_2,
                 actual_summaries[self.EXP_ID_2].exploration_model_created_on,
                 actual_summaries[self.EXP_ID_2].exploration_model_last_updated,
@@ -2503,8 +2506,9 @@ class ExplorationSummaryGetTests(ExplorationServicesUnitTests):
         simple_props = ['id', 'title', 'category', 'objective',
                         'language_code', 'tags', 'ratings', 'status',
                         'community_owned', 'owner_ids',
-                        'editor_ids', 'viewer_ids', 'contributor_ids',
-                        'version', 'exploration_model_created_on',
+                        'editor_ids', 'translator_ids', 'viewer_ids',
+                        'contributor_ids', 'version',
+                        'exploration_model_created_on',
                         'exploration_model_last_updated']
         for exp_id in actual_summaries:
             for prop in simple_props:

--- a/core/domain/rights_manager.py
+++ b/core/domain/rights_manager.py
@@ -175,7 +175,7 @@ class ActivityRights(object):
             user_id: str or None. Id of the user.
 
         Returns:
-            bool. Whether user is an activity owners.
+            bool. Whether user is an activity owner.
         """
         return bool(user_id in self.owner_ids)
 
@@ -186,7 +186,7 @@ class ActivityRights(object):
             user_id: str or None. Id of the user.
 
         Returns:
-            bool. Whether user is an activity editors.
+            bool. Whether user is an activity editor.
         """
         return bool(user_id in self.editor_ids)
 

--- a/core/domain/rights_manager.py
+++ b/core/domain/rights_manager.py
@@ -107,6 +107,8 @@ class ActivityRights(object):
         editor_translator = set(self.editor_ids).intersection(
             set(self.translator_ids))
         editor_viewer = set(self.editor_ids).intersection(set(self.viewer_ids))
+        translator_viewer = set(self.editor_ids).intersection(
+            set(self.viewer_ids))
         if owner_editor:
             raise utils.ValidationError(
                 'A user cannot be both an owner and an editor: %s' %
@@ -127,6 +129,10 @@ class ActivityRights(object):
             raise utils.ValidationError(
                 'A user cannot be both an editor and a viewer: %s' %
                 editor_viewer)
+        if translator_viewer:
+            raise utils.ValidationError(
+                'A user cannot be both a translator and a viewer: %s' %
+                translator_viewer)
 
     def to_dict(self):
         """Returns a dict suitable for use by the frontend.
@@ -169,7 +175,7 @@ class ActivityRights(object):
             user_id: str or None. Id of the user.
 
         Returns:
-            bool. Whether user is in activity owners.
+            bool. Whether user is an activity owners.
         """
         return bool(user_id in self.owner_ids)
 
@@ -180,7 +186,7 @@ class ActivityRights(object):
             user_id: str or None. Id of the user.
 
         Returns:
-            bool. Whether user is in activity editors.
+            bool. Whether user is an activity editors.
         """
         return bool(user_id in self.editor_ids)
 
@@ -191,7 +197,7 @@ class ActivityRights(object):
             user_id: str or None. Id of the user.
 
         Returns:
-            bool. Whether user is in activity translator.
+            bool. Whether user is an activity translator.
         """
         return bool(user_id in self.translator_ids)
 
@@ -202,7 +208,7 @@ class ActivityRights(object):
             user_id: str or None. Id of the user.
 
         Returns:
-            bool. Whether user is in activity viewers of.
+            bool. Whether user is an activity viewer.
         """
         return bool(user_id in self.viewer_ids)
 

--- a/core/domain/rights_manager.py
+++ b/core/domain/rights_manager.py
@@ -48,6 +48,7 @@ ACTIVITY_STATUS_PUBLIC = feconf.ACTIVITY_STATUS_PUBLIC
 
 ROLE_OWNER = 'owner'
 ROLE_EDITOR = 'editor'
+ROLE_TRANSLATOR = 'translator'
 ROLE_VIEWER = 'viewer'
 ROLE_NONE = 'none'
 
@@ -61,13 +62,14 @@ class ActivityRights(object):
     """
 
     def __init__(
-            self, exploration_id, owner_ids, editor_ids, viewer_ids,
-            community_owned=False, cloned_from=None,
-            status=ACTIVITY_STATUS_PRIVATE,
-            viewable_if_private=False, first_published_msec=None):
+            self, exploration_id, owner_ids, editor_ids, translator_ids,
+            viewer_ids, community_owned=False, cloned_from=None,
+            status=ACTIVITY_STATUS_PRIVATE, viewable_if_private=False,
+            first_published_msec=None):
         self.id = exploration_id
         self.owner_ids = owner_ids
         self.editor_ids = editor_ids
+        self.translator_ids = translator_ids
         self.viewer_ids = viewer_ids
         self.community_owned = community_owned
         self.cloned_from = cloned_from
@@ -79,15 +81,16 @@ class ActivityRights(object):
         """Validates an ActivityRights object.
 
         Raises:
-          utils.ValidationError: if any of the owners, editors and viewers
-          lists overlap, or if a community-owned exploration has owners,
-          editors or viewers specified.
+          utils.ValidationError: if any of the owners, editors, translators and
+          viewers lists overlap, or if a community-owned exploration has owners,
+          editors, translators or viewers specified.
         """
         if self.community_owned:
-            if self.owner_ids or self.editor_ids or self.viewer_ids:
+            if (self.owner_ids or self.editor_ids or self.translator_ids or
+                    self.viewer_ids):
                 raise utils.ValidationError(
                     'Community-owned explorations should have no owners, '
-                    'editors or viewers specified.')
+                    'editors, translators or viewers specified.')
 
         if self.community_owned and self.status == ACTIVITY_STATUS_PRIVATE:
             raise utils.ValidationError(
@@ -98,19 +101,31 @@ class ActivityRights(object):
                 'Public explorations should have no viewers specified.')
 
         owner_editor = set(self.owner_ids).intersection(set(self.editor_ids))
+        owner_translator = set(self.owner_ids).intersection(
+            set(self.translator_ids))
         owner_viewer = set(self.owner_ids).intersection(set(self.viewer_ids))
+        editor_translator = set(self.editor_ids).intersection(
+            set(self.translator_ids))
         editor_viewer = set(self.editor_ids).intersection(set(self.viewer_ids))
         if owner_editor:
             raise utils.ValidationError(
                 'A user cannot be both an owner and an editor: %s' %
                 owner_editor)
+        if owner_translator:
+            raise utils.ValidationError(
+                'A user cannot be both an owner and a translator: %s' %
+                owner_translator)
         if owner_viewer:
             raise utils.ValidationError(
                 'A user cannot be both an owner and a viewer: %s' %
                 owner_viewer)
+        if editor_translator:
+            raise utils.ValidationError(
+                'A user cannot be both an editor and a translator: %s' %
+                editor_translator)
         if editor_viewer:
             raise utils.ValidationError(
-                'A user cannot be both an owner and an editor: %s' %
+                'A user cannot be both an editor and a viewer: %s' %
                 editor_viewer)
 
     def to_dict(self):
@@ -127,6 +142,7 @@ class ActivityRights(object):
                 'community_owned': True,
                 'owner_names': [],
                 'editor_names': [],
+                'translator_names': [],
                 'viewer_names': [],
                 'viewable_if_private': self.viewable_if_private,
             }
@@ -139,6 +155,8 @@ class ActivityRights(object):
                     self.owner_ids),
                 'editor_names': user_services.get_human_readable_user_ids(
                     self.editor_ids),
+                'translator_names': user_services.get_human_readable_user_ids(
+                    self.translator_ids),
                 'viewer_names': user_services.get_human_readable_user_ids(
                     self.viewer_ids),
                 'viewable_if_private': self.viewable_if_private,
@@ -165,6 +183,17 @@ class ActivityRights(object):
             bool. Whether user is in activity editors.
         """
         return bool(user_id in self.editor_ids)
+
+    def is_translator(self, user_id):
+        """Checks whether given user is translator of activity.
+
+        Args:
+            user_id: str or None. Id of the user.
+
+        Returns:
+            bool. Whether user is in activity translator.
+        """
+        return bool(user_id in self.translator_ids)
 
     def is_viewer(self, user_id):
         """Checks whether given user is viewer of activity.
@@ -211,6 +240,7 @@ def get_activity_rights_from_model(activity_rights_model, activity_type):
         activity_rights_model.id,
         activity_rights_model.owner_ids,
         activity_rights_model.editor_ids,
+        activity_rights_model.translator_ids,
         activity_rights_model.viewer_ids,
         community_owned=activity_rights_model.community_owned,
         cloned_from=(
@@ -250,6 +280,7 @@ def _save_activity_rights(
     model.owner_ids = activity_rights.owner_ids
     model.editor_ids = activity_rights.editor_ids
     model.viewer_ids = activity_rights.viewer_ids
+    model.translator_ids = activity_rights.translator_ids
     model.community_owned = activity_rights.community_owned
     model.status = activity_rights.status
     model.viewable_if_private = activity_rights.viewable_if_private
@@ -344,13 +375,14 @@ def create_new_exploration_rights(exploration_id, committer_id):
         committer_id: str. ID of the committer.
     """
     exploration_rights = ActivityRights(
-        exploration_id, [committer_id], [], [])
+        exploration_id, [committer_id], [], [], [])
     commit_cmds = [{'cmd': CMD_CREATE_NEW}]
 
     exp_models.ExplorationRightsModel(
         id=exploration_rights.id,
         owner_ids=exploration_rights.owner_ids,
         editor_ids=exploration_rights.editor_ids,
+        translator_ids=exploration_rights.translator_ids,
         viewer_ids=exploration_rights.viewer_ids,
         community_owned=exploration_rights.community_owned,
         status=exploration_rights.status,
@@ -457,13 +489,15 @@ def create_new_collection_rights(collection_id, committer_id):
         collection_id: str. ID of the collection.
         committer_id: str. ID of the committer.
     """
-    collection_rights = ActivityRights(collection_id, [committer_id], [], [])
+    collection_rights = ActivityRights(
+        collection_id, [committer_id], [], [], [])
     commit_cmds = [{'cmd': CMD_CREATE_NEW}]
 
     collection_models.CollectionRightsModel(
         id=collection_rights.id,
         owner_ids=collection_rights.owner_ids,
         editor_ids=collection_rights.editor_ids,
+        translator_ids=collection_rights.translator_ids,
         viewer_ids=collection_rights.viewer_ids,
         community_owned=collection_rights.community_owned,
         status=collection_rights.status,
@@ -586,6 +620,7 @@ def check_can_access_activity(user, activity_rights):
             activity_rights.is_viewer(user.user_id) or
             activity_rights.is_owner(user.user_id) or
             activity_rights.is_editor(user.user_id) or
+            activity_rights.is_translator(user.user_id) or
             activity_rights.viewable_if_private)
 
 
@@ -609,6 +644,41 @@ def check_can_edit_activity(user, activity_rights):
 
     if (activity_rights.is_owner(user.user_id) or
             activity_rights.is_editor(user.user_id)):
+        return True
+
+    if (activity_rights.community_owned or
+            (role_services.ACTION_EDIT_ANY_ACTIVITY in user.actions)):
+        return True
+
+    if (activity_rights.is_published() and
+            (role_services.ACTION_EDIT_ANY_PUBLIC_ACTIVITY in
+             user.actions)):
+        return True
+
+    return False
+
+
+def check_can_translate_activity(user, activity_rights):
+    """Checks whether the user can translate given activity.
+
+    Args:
+        user: UserActionsInfo. Object having user_id, role and actions for
+            given user.
+        activity_rights: ActivityRights or None. Rights object for the given
+            activity.
+
+    Returns:
+        bool. Whether the given user can translate this activity.
+    """
+    if activity_rights is None:
+        return False
+
+    if role_services.ACTION_EDIT_OWNED_ACTIVITY not in user.actions:
+        return False
+
+    if (activity_rights.is_owner(user.user_id) or
+            activity_rights.is_editor(user.user_id) or
+            activity_rights.is_translator(user.user_id)):
         return True
 
     if (activity_rights.community_owned or
@@ -770,6 +840,7 @@ def _assign_role(
         new_role: str. The name of the new role: One of
             ROLE_OWNER
             ROLE_EDITOR
+            ROLE_TRANSLATOR
             ROLE_VIEWER
         activity_id: str. ID of the activity.
         activity_type: str. The type of activity. Possible values:
@@ -780,7 +851,9 @@ def _assign_role(
         Exception. The committer does not have rights to modify a role.
         Exception. The user already owns the activity.
         Exception. The user can already edit the activity.
+        Exception. The user can already translate the activity.
         Exception. The activity is already publicly editable.
+        Exception. The activity is already publicly translatable.
         Exception. The user can already view the activity.
         Exception. The activity is already publicly viewable.
         Exception. The role is invalid.
@@ -811,6 +884,9 @@ def _assign_role(
         if assignee_id in activity_rights.editor_ids:
             activity_rights.editor_ids.remove(assignee_id)
             old_role = ROLE_EDITOR
+        if assignee_id in activity_rights.translator_ids:
+            activity_rights.translator_ids.remove(assignee_id)
+            old_role = ROLE_TRANSLATOR
 
     elif new_role == ROLE_EDITOR:
         if (activity_rights.is_editor(assignee_id) or
@@ -823,6 +899,27 @@ def _assign_role(
                 'Community-owned %ss can be edited by anyone.' % activity_type)
 
         activity_rights.editor_ids.append(assignee_id)
+
+        if assignee_id in activity_rights.translator_ids:
+            activity_rights.translator_ids.remove(assignee_id)
+            old_role = ROLE_TRANSLATOR
+
+        if assignee_id in activity_rights.viewer_ids:
+            activity_rights.viewer_ids.remove(assignee_id)
+            old_role = ROLE_VIEWER
+
+    elif new_role == ROLE_TRANSLATOR:
+        if (activity_rights.is_editor(assignee_id) or
+                activity_rights.is_translator(assignee_id) or
+                activity_rights.is_owner(assignee_id)):
+            raise Exception(
+                'This user already can translate this %s.' % activity_type)
+        if activity_rights.community_owned:
+            raise Exception(
+                'Community-owned %ss can be translated by anyone.' %
+                activity_type)
+
+        activity_rights.translator_ids.append(assignee_id)
 
         if assignee_id in activity_rights.viewer_ids:
             activity_rights.viewer_ids.remove(assignee_id)
@@ -1010,6 +1107,7 @@ def assign_role_for_exploration(
         new_role: str. The name of the new role: One of
             ROLE_OWNER
             ROLE_EDITOR
+            ROLE_TRANSLATOR
 
     Raises:
         Exception. This could potentially throw an exception from
@@ -1018,7 +1116,7 @@ def assign_role_for_exploration(
     _assign_role(
         committer, assignee_id, new_role, exploration_id,
         constants.ACTIVITY_TYPE_EXPLORATION)
-    if new_role in [ROLE_OWNER, ROLE_EDITOR]:
+    if new_role in [ROLE_OWNER, ROLE_EDITOR, ROLE_TRANSLATOR]:
         subscription_services.subscribe_to_exploration(
             assignee_id, exploration_id)
 

--- a/core/domain/rights_manager_test.py
+++ b/core/domain/rights_manager_test.py
@@ -34,6 +34,7 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
         self.signup('c@example.com', 'C')
         self.signup('d@example.com', 'D')
         self.signup('e@example.com', 'E')
+        self.signup('f@example.com', 'F')
         self.signup(self.ADMIN_EMAIL, username=self.ADMIN_USERNAME)
         self.signup(self.MODERATOR_EMAIL, username=self.MODERATOR_USERNAME)
 
@@ -42,6 +43,7 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
         self.user_id_c = self.get_user_id_from_email('c@example.com')
         self.user_id_d = self.get_user_id_from_email('d@example.com')
         self.user_id_e = self.get_user_id_from_email('e@example.com')
+        self.user_id_f = self.get_user_id_from_email('f@example.com')
         self.user_id_admin = self.get_user_id_from_email(self.ADMIN_EMAIL)
         self.user_id_moderator = self.get_user_id_from_email(
             self.MODERATOR_EMAIL)
@@ -53,6 +55,7 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
         self.user_c = user_services.UserActionsInfo(self.user_id_c)
         self.user_d = user_services.UserActionsInfo(self.user_id_d)
         self.user_e = user_services.UserActionsInfo(self.user_id_e)
+        self.user_f = user_services.UserActionsInfo(self.user_id_f)
         self.user_admin = user_services.UserActionsInfo(self.user_id_admin)
         self.user_moderator = user_services.UserActionsInfo(
             self.user_id_moderator)
@@ -81,6 +84,8 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             self.user_a, exp_rights))
         self.assertTrue(rights_manager.check_can_edit_activity(
             self.user_a, exp_rights))
+        self.assertTrue(rights_manager.check_can_translate_activity(
+            self.user_a, exp_rights))
         self.assertFalse(rights_manager.check_can_delete_activity(
             self.user_a, exp_rights))
 
@@ -88,12 +93,16 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             self.user_admin, exp_rights))
         self.assertTrue(rights_manager.check_can_edit_activity(
             self.user_admin, exp_rights))
+        self.assertTrue(rights_manager.check_can_translate_activity(
+            self.user_admin, exp_rights))
         self.assertTrue(rights_manager.check_can_delete_activity(
             self.user_admin, exp_rights))
 
         self.assertTrue(rights_manager.check_can_access_activity(
             self.user_moderator, exp_rights))
         self.assertTrue(rights_manager.check_can_edit_activity(
+            self.user_moderator, exp_rights))
+        self.assertTrue(rights_manager.check_can_translate_activity(
             self.user_moderator, exp_rights))
         self.assertTrue(rights_manager.check_can_delete_activity(
             self.user_moderator, exp_rights))
@@ -110,6 +119,8 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             self.user_a, exp_rights))
         self.assertTrue(rights_manager.check_can_edit_activity(
             self.user_a, exp_rights))
+        self.assertTrue(rights_manager.check_can_translate_activity(
+            self.user_a, exp_rights))
         self.assertFalse(rights_manager.check_can_delete_activity(
             self.user_a, exp_rights))
 
@@ -117,12 +128,16 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             self.user_admin, exp_rights))
         self.assertTrue(rights_manager.check_can_edit_activity(
             self.user_admin, exp_rights))
+        self.assertTrue(rights_manager.check_can_translate_activity(
+            self.user_admin, exp_rights))
         self.assertTrue(rights_manager.check_can_delete_activity(
             self.user_admin, exp_rights))
 
         self.assertTrue(rights_manager.check_can_access_activity(
             self.user_moderator, exp_rights))
         self.assertTrue(rights_manager.check_can_edit_activity(
+            self.user_moderator, exp_rights))
+        self.assertTrue(rights_manager.check_can_translate_activity(
             self.user_moderator, exp_rights))
         self.assertTrue(rights_manager.check_can_delete_activity(
             self.user_moderator, exp_rights))
@@ -149,6 +164,8 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             self.user_a, exp_rights))
         self.assertTrue(rights_manager.check_can_edit_activity(
             self.user_a, exp_rights))
+        self.assertTrue(rights_manager.check_can_translate_activity(
+            self.user_a, exp_rights))
         self.assertTrue(rights_manager.check_can_delete_activity(
             self.user_a, exp_rights))
 
@@ -156,6 +173,8 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             self.user_admin, exp_rights))
         self.assertTrue(rights_manager.check_can_edit_activity(
             self.user_admin, exp_rights))
+        self.assertTrue(rights_manager.check_can_translate_activity(
+            self.user_admin, exp_rights))
         self.assertTrue(rights_manager.check_can_delete_activity(
             self.user_admin, exp_rights))
 
@@ -163,12 +182,16 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             self.user_moderator, exp_rights))
         self.assertFalse(rights_manager.check_can_edit_activity(
             self.user_moderator, exp_rights))
+        self.assertFalse(rights_manager.check_can_translate_activity(
+            self.user_moderator, exp_rights))
         self.assertFalse(rights_manager.check_can_delete_activity(
             self.user_moderator, exp_rights))
 
         self.assertFalse(rights_manager.check_can_access_activity(
             self.user_b, exp_rights))
         self.assertFalse(rights_manager.check_can_edit_activity(
+            self.user_b, exp_rights))
+        self.assertFalse(rights_manager.check_can_translate_activity(
             self.user_b, exp_rights))
         self.assertFalse(rights_manager.check_can_delete_activity(
             self.user_b, exp_rights))
@@ -182,6 +205,8 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             self.user_b, exp_rights))
         self.assertFalse(rights_manager.check_can_edit_activity(
             self.user_b, exp_rights))
+        self.assertFalse(rights_manager.check_can_translate_activity(
+            self.user_b, exp_rights))
         self.assertFalse(rights_manager.check_can_delete_activity(
             self.user_b, exp_rights))
 
@@ -193,6 +218,36 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
         self.assertTrue(rights_manager.check_can_access_activity(
             self.user_b, exp_rights))
         self.assertTrue(rights_manager.check_can_edit_activity(
+            self.user_b, exp_rights))
+        self.assertTrue(rights_manager.check_can_translate_activity(
+            self.user_b, exp_rights))
+        self.assertFalse(rights_manager.check_can_delete_activity(
+            self.user_b, exp_rights))
+
+    def test_inviting_translator_to_exploration(self):
+        exp = exp_domain.Exploration.create_default_exploration(self.EXP_ID)
+        exp_services.save_new_exploration(self.user_id_a, exp)
+        exp_rights = rights_manager.get_exploration_rights(self.EXP_ID)
+
+        self.assertFalse(rights_manager.check_can_access_activity(
+            self.user_b, exp_rights))
+        self.assertFalse(rights_manager.check_can_edit_activity(
+            self.user_b, exp_rights))
+        self.assertFalse(rights_manager.check_can_translate_activity(
+            self.user_b, exp_rights))
+        self.assertFalse(rights_manager.check_can_delete_activity(
+            self.user_b, exp_rights))
+
+        rights_manager.assign_role_for_exploration(
+            self.user_a, self.EXP_ID, self.user_id_b,
+            rights_manager.ROLE_TRANSLATOR)
+        exp_rights = rights_manager.get_exploration_rights(self.EXP_ID)
+
+        self.assertTrue(rights_manager.check_can_access_activity(
+            self.user_b, exp_rights))
+        self.assertFalse(rights_manager.check_can_edit_activity(
+            self.user_b, exp_rights))
+        self.assertTrue(rights_manager.check_can_translate_activity(
             self.user_b, exp_rights))
         self.assertFalse(rights_manager.check_can_delete_activity(
             self.user_b, exp_rights))
@@ -206,6 +261,8 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             self.user_b, exp_rights))
         self.assertFalse(rights_manager.check_can_edit_activity(
             self.user_b, exp_rights))
+        self.assertFalse(rights_manager.check_can_translate_activity(
+            self.user_b, exp_rights))
         self.assertFalse(rights_manager.check_can_delete_activity(
             self.user_b, exp_rights))
 
@@ -218,6 +275,8 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             self.user_b, exp_rights))
         self.assertFalse(rights_manager.check_can_edit_activity(
             self.user_b, exp_rights))
+        self.assertFalse(rights_manager.check_can_translate_activity(
+            self.user_b, exp_rights))
         self.assertFalse(rights_manager.check_can_delete_activity(
             self.user_b, exp_rights))
 
@@ -228,6 +287,15 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
         rights_manager.assign_role_for_exploration(
             self.user_a, self.EXP_ID, self.user_id_b,
             rights_manager.ROLE_VIEWER)
+
+        with self.assertRaisesRegexp(Exception, 'Could not assign new role.'):
+            rights_manager.assign_role_for_exploration(
+                self.user_b, self.EXP_ID, self.user_id_c,
+                rights_manager.ROLE_VIEWER)
+
+        rights_manager.assign_role_for_exploration(
+            self.user_a, self.EXP_ID, self.user_id_b,
+            rights_manager.ROLE_TRANSLATOR)
 
         with self.assertRaisesRegexp(Exception, 'Could not assign new role.'):
             rights_manager.assign_role_for_exploration(
@@ -255,6 +323,9 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             rights_manager.ROLE_EDITOR)
         rights_manager.assign_role_for_exploration(
             self.user_b, self.EXP_ID, self.user_id_e,
+            rights_manager.ROLE_TRANSLATOR)
+        rights_manager.assign_role_for_exploration(
+            self.user_b, self.EXP_ID, self.user_id_f,
             rights_manager.ROLE_VIEWER)
 
     def test_publishing_and_unpublishing_exploration(self):
@@ -347,6 +418,10 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
             self.user_a, self.EXP_ID, self.user_id_c,
             rights_manager.ROLE_EDITOR)
 
+        rights_manager.assign_role_for_exploration(
+            self.user_a, self.EXP_ID, self.user_id_d,
+            rights_manager.ROLE_TRANSLATOR)
+
         exp_rights = rights_manager.get_exploration_rights(self.EXP_ID)
 
         self.assertTrue(exp_rights.is_owner(self.user_id_a))
@@ -355,6 +430,9 @@ class ExplorationRightsTests(test_utils.GenericTestBase):
         self.assertFalse(exp_rights.is_viewer(self.user_id_a))
         self.assertFalse(exp_rights.is_owner(self.user_id_b))
         self.assertFalse(exp_rights.is_editor(self.user_id_b))
+        self.assertTrue(exp_rights.is_translator(self.user_id_d))
+        self.assertFalse(exp_rights.is_translator(self.user_id_b))
+
 
     def test_get_multiple_exploration_rights(self):
         exp_ids = ['exp1', 'exp2', 'exp3', 'exp4']

--- a/core/domain/search_services_test.py
+++ b/core/domain/search_services_test.py
@@ -36,14 +36,17 @@ class SearchServicesUnitTests(test_utils.GenericTestBase):
 
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
+        self.translator_id = self.get_user_id_from_email(self.TRANSLATOR_EMAIL)
         self.viewer_id = self.get_user_id_from_email(self.VIEWER_EMAIL)
 
         user_services.create_new_user(self.owner_id, self.OWNER_EMAIL)
         user_services.create_new_user(self.editor_id, self.EDITOR_EMAIL)
+        user_services.create_new_user(self.translator_id, self.TRANSLATOR_EMAIL)
         user_services.create_new_user(self.viewer_id, self.VIEWER_EMAIL)
 
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
+        self.signup(self.TRANSLATOR_EMAIL, self.TRANSLATOR_USERNAME)
         self.signup(self.VIEWER_EMAIL, self.VIEWER_USERNAME)
         self.signup(self.ADMIN_EMAIL, self.ADMIN_USERNAME)
 
@@ -233,8 +236,8 @@ class SearchServicesUnitTests(test_utils.GenericTestBase):
 
         def mock_get_rights(unused_collection_id):
             return rights_manager.ActivityRights(
-                self.COLLECTION_ID,
-                [self.owner_id], [self.editor_id], [self.viewer_id],
+                self.COLLECTION_ID, [self.owner_id], [self.editor_id],
+                [self.translator_id], [self.viewer_id],
                 status=rights_manager.ACTIVITY_STATUS_PRIVATE
             )
 
@@ -276,8 +279,8 @@ class SearchServicesUnitTests(test_utils.GenericTestBase):
 
         def mock_get_rights(unused_exp_id):
             return rights_manager.ActivityRights(
-                self.EXP_ID,
-                [self.owner_id], [self.editor_id], [self.viewer_id],
+                self.EXP_ID, [self.owner_id], [self.editor_id],
+                [self.translator_id], [self.viewer_id],
                 status=rights_manager.ACTIVITY_STATUS_PRIVATE
             )
 

--- a/core/storage/collection/gae_models.py
+++ b/core/storage/collection/gae_models.py
@@ -147,6 +147,8 @@ class CollectionRightsModel(base_models.VersionedModel):
     owner_ids = ndb.StringProperty(indexed=True, repeated=True)
     # The user_ids of users who are allowed to edit this collection.
     editor_ids = ndb.StringProperty(indexed=True, repeated=True)
+    # The user_ids of users who are allowed to translate this collection.
+    translator_ids = ndb.StringProperty(indexed=True, repeated=True)
     # The user_ids of users who are allowed to view this collection.
     viewer_ids = ndb.StringProperty(indexed=True, repeated=True)
 

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -176,6 +176,8 @@ class ExplorationRightsModel(base_models.VersionedModel):
     owner_ids = ndb.StringProperty(indexed=True, repeated=True)
     # The user_ids of users who are allowed to edit this exploration.
     editor_ids = ndb.StringProperty(indexed=True, repeated=True)
+    # The user_ids of users who are allowed to translate this exploration.
+    translator_ids = ndb.StringProperty(indexed=True, repeated=True)
     # The user_ids of users who are allowed to view this exploration.
     viewer_ids = ndb.StringProperty(indexed=True, repeated=True)
 
@@ -464,6 +466,8 @@ class ExpSummaryModel(base_models.BaseModel):
     owner_ids = ndb.StringProperty(indexed=True, repeated=True)
     # The user_ids of users who are allowed to edit this exploration.
     editor_ids = ndb.StringProperty(indexed=True, repeated=True)
+    # The user_ids of users who are allowed to translate this exploration.
+    translator_ids = ndb.StringProperty(indexed=True, repeated=True)
     # The user_ids of users who are allowed to view this exploration.
     viewer_ids = ndb.StringProperty(indexed=True, repeated=True)
     # The user_ids of users who have contributed (humans who have made a
@@ -527,6 +531,7 @@ class ExpSummaryModel(base_models.BaseModel):
         ).filter(
             ndb.OR(ExpSummaryModel.owner_ids == user_id,
                    ExpSummaryModel.editor_ids == user_id,
+                   ExpSummaryModel.translator_ids == user_id,
                    ExpSummaryModel.viewer_ids == user_id)
         ).filter(
             ExpSummaryModel.deleted == False  # pylint: disable=singleton-comparison

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -136,6 +136,8 @@ class TestBase(unittest.TestCase):
     OWNER_USERNAME = 'owner'
     EDITOR_EMAIL = 'editor@example.com'
     EDITOR_USERNAME = 'editor'
+    TRANSLATOR_EMAIL = 'translator@example.com'
+    TRANSLATOR_USERNAME = 'translator'
     VIEWER_EMAIL = 'viewer@example.com'
     VIEWER_USERNAME = 'viewer'
     NEW_USER_EMAIL = 'new.user@example.com'


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
- Milestone 1.1:  
  - Adding “translator” role for the exploration.
  - Adding new entity translator_ids in ExplorationSummary and ActivityRights object.
  - Adding `translator_ids` in ExplorationSummaryModel and ExplorationRightsModel.
  - Writing @acl_decorators for can_translate_exploration.


## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
