### PR TITLE
Fix #4924: Fixed exploration count error.

### DIFF
--- a/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
+++ b/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
@@ -141,7 +141,7 @@ oppia.controller('LearnerDashboard', [
       return $scope.completedExplorationsList.slice(
         startCompletedExpIndex, Math.min(
           startCompletedExpIndex + $scope.PAGE_SIZE,
-          $scope.completedExplorationsList.length))
+          $scope.completedExplorationsList.length));
     };
 
     $scope.showUsernamePopover = function(subscriberUsername) {

--- a/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
+++ b/core/templates/dev/head/pages/learner_dashboard/LearnerDashboard.js
@@ -137,6 +137,13 @@ oppia.controller('LearnerDashboard', [
       return ($window.innerWidth < 500);
     };
 
+    $scope.getVisibleExplorationList = function(startCompletedExpIndex) {
+      return $scope.completedExplorationsList.slice(
+        startCompletedExpIndex, Math.min(
+          startCompletedExpIndex + $scope.PAGE_SIZE,
+          $scope.completedExplorationsList.length))
+    };
+
     $scope.showUsernamePopover = function(subscriberUsername) {
       // The popover on the subscription card is only shown if the length of
       // the subscriber username is greater than 10 and the user hovers over
@@ -187,7 +194,7 @@ oppia.controller('LearnerDashboard', [
       } else if (section === LEARNER_DASHBOARD_SECTION_I18N_IDS.COMPLETED) {
         if (subsection === LEARNER_DASHBOARD_SUBSECTION_I18N_IDS.EXPLORATIONS) {
           if ($scope.startCompletedExpIndex +
-            $scope.PAGE_SIZE <= $scope.startCompletedExpIndex.length) {
+            $scope.PAGE_SIZE <= $scope.completedExplorationsList.length) {
             $scope.startCompletedExpIndex += $scope.PAGE_SIZE;
           }
         } else if (

--- a/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
+++ b/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
@@ -298,7 +298,7 @@
               </div>
             </md-card>
 
-            <div ng-repeat="tile in completedExplorationsList | orderBy:getValueOfExplorationSortKey:isCurrentExpSortDescending track by tile.id"
+            <div ng-repeat="tile in getVisibleExplorationList(startCompletedExpIndex) | orderBy:getValueOfExplorationSortKey:isCurrentExpSortDescending track by tile.id"
                  style="display: inline-block; margin-left: 1px;">
               <exploration-summary-tile
                                       exploration-id="tile.id"


### PR DESCRIPTION
Now, restricted the completed section to only show 8 explorations at a time, with the overflow visible on clicking the left or right arrows.
Also, this is the last blocking bug before this release.