### PR TITLE
Remove currently unsupported site languages

### DIFF
--- a/assets/constants.js
+++ b/assets/constants.js
@@ -239,26 +239,17 @@ var constants = {
     "id": "es",
     "text": "Español"
   }, {
-    "id": "hu",
-    "text": "Magyar"
-  }, {
     "id": "pt",
     "text": "Português"
   }, {
     "id": "pt-br",
     "text": "Português (Brasil)"
   }, {
-    "id": "sv",
-    "text": "svenska"
-  }, {
     "id": "ar",
     "text": "العربية"
   }, {
     "id": "kab",
     "text": "Taqbaylit"
-  }, {
-    "id": "mk",
-    "text": "македонски јазик"
   }, {
     "id": "vi",
     "text": "Tiếng Việt"
@@ -268,9 +259,6 @@ var constants = {
   }, {
     "id": "bn",
     "text": "বাংলা"
-  }, {
-    "id": "tr",
-    "text": "Türkçe"
   }, {
     "id": "zh-hans",
     "text": "中文(简体)"

--- a/core/domain/user_jobs_one_off.py
+++ b/core/domain/user_jobs_one_off.py
@@ -49,6 +49,7 @@ class UserContributionsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                 'version_string': item.get_version_string(),
             })
 
+
     @staticmethod
     def reduce(key, version_and_exp_ids):
         """Implements the reduce function for this job."""
@@ -114,7 +115,7 @@ class UserLanguageAuditOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
 
 class UserLanguageResetOneOffJob(jobs.BaseMapReduceOneOffJobManager):
-    """One-off job for reseting the default language preferences of users."""
+    """One-off job for resetting the default language preferences of users."""
 
     @classmethod
     def entity_classes_to_map_over(cls):

--- a/core/domain/user_jobs_one_off.py
+++ b/core/domain/user_jobs_one_off.py
@@ -49,7 +49,6 @@ class UserContributionsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                 'version_string': item.get_version_string(),
             })
 
-
     @staticmethod
     def reduce(key, version_and_exp_ids):
         """Implements the reduce function for this job."""
@@ -71,6 +70,73 @@ class UserContributionsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
             user_services.create_user_contributions(
                 key, list(created_exploration_ids), list(
                     edited_exploration_ids))
+
+
+class UserLanguageAuditOneOffJob(jobs.BaseMapReduceOneOffJobManager):
+    """One-off job for auditing the default language preferences of users."""
+
+    _LANGUAGE_TO_RESET_KEY = 'WOULD_RESET'
+
+    @classmethod
+    def entity_classes_to_map_over(cls):
+        """Return a list of datastore class references to map over."""
+        return [user_models.UserSettingsModel]
+
+    @staticmethod
+    def map(item):
+        """Implements the map function for this job."""
+        if item.preferred_site_language_code in ['hu', 'mk', 'sv', 'tr']:
+            affected_users_key = '%s.%s' % (
+                UserLanguageAuditOneOffJob._LANGUAGE_TO_RESET_KEY,
+                item.preferred_site_language_code)
+            yield (
+                affected_users_key, {
+                    'language_code': item.preferred_site_language_code,
+                    'user_id': item.id
+                })
+        yield (item.preferred_site_language_code, 1)
+
+    @staticmethod
+    def reduce(key_or_language_code, stringified_values):
+        """Implements the reduce function for this job."""
+        if key_or_language_code.startswith(
+                UserLanguageAuditOneOffJob._LANGUAGE_TO_RESET_KEY):
+            affected_users = [
+                ast.literal_eval(stringified_affected_user)
+                for stringified_affected_user in stringified_values]
+            language_code = affected_users[0]['language_code']
+            yield 'Users affected by a reset of %s: %s' % (
+                language_code,
+                [affected_user['user_id'] for affected_user in affected_users])
+        else:
+            yield '%d users are using language: %s' % (
+                len(stringified_values), key_or_language_code)
+
+
+class UserLanguageResetOneOffJob(jobs.BaseMapReduceOneOffJobManager):
+    """One-off job for reseting the default language preferences of users."""
+
+    @classmethod
+    def entity_classes_to_map_over(cls):
+        """Return a list of datastore class references to map over."""
+        return [user_models.UserSettingsModel]
+
+    @staticmethod
+    def map(item):
+        """Implements the map function for this job."""
+        if item.preferred_site_language_code in ['hu', 'mk', 'sv', 'tr']:
+            # Reset the preferred site language for this user to None, which in
+            # turn defaults to English.
+            reset_language_code = item.preferred_site_language_code
+            item.preferred_site_language_code = None
+            item.put()
+            yield ('%s' % reset_language_code, 1)
+
+    @staticmethod
+    def reduce(reset_language_code, language_reset_indicators):
+        """Implements the reduce function for this job."""
+        yield 'Reset %d users for language: %s' % (
+            len(language_reset_indicators), reset_language_code)
 
 
 class UserDefaultDashboardOneOffJob(jobs.BaseMapReduceOneOffJobManager):

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -54,6 +54,8 @@ ONE_OFF_JOB_MANAGERS = [
     user_jobs_one_off.DashboardSubscriptionsOneOffJob,
     user_jobs_one_off.LongUserBiosOneOffJob,
     user_jobs_one_off.UserContributionsOneOffJob,
+    user_jobs_one_off.UserLanguageAuditOneOffJob,
+    user_jobs_one_off.UserLanguageResetOneOffJob,
     user_jobs_one_off.UserDefaultDashboardOneOffJob,
     user_jobs_one_off.UserFirstContributionMsecOneOffJob,
     user_jobs_one_off.UserLastExplorationActivityOneOffJob,


### PR DESCRIPTION
The user experience from removing languages in constants.js is to revert to English. After the reset job is run, we have to run memcache to ensure the languages are actually reset everywhere. Restoring the languages in the future keeps the users on the default setting after the removal job is run.