### PR TITLE
Add build before frontend tests

### DIFF
--- a/core/tests/karma.conf.js
+++ b/core/tests/karma.conf.js
@@ -1,7 +1,7 @@
 var argv = require('yargs').argv;
-var isMinificationNeeded = (argv.minify === 'True');
+var prodEnv = (argv.prod_env === 'True');
 var generatedJs = 'third_party/generated/js/third_party.js';
-if (isMinificationNeeded) {
+if (prodEnv) {
   generatedJs = (
     'backend_prod_files/third_party/generated/js/third_party.min.js');
 }

--- a/core/tests/karma.conf.js
+++ b/core/tests/karma.conf.js
@@ -2,7 +2,8 @@ var argv = require('yargs').argv;
 var isMinificationNeeded = (argv.minify === 'True');
 var generatedJs = 'third_party/generated/js/third_party.js';
 if (isMinificationNeeded) {
-  generatedJs = 'third_party/generated/js/third_party.min.js';
+  generatedJs = (
+    'backend_prod_files/third_party/generated/js/third_party.min.js');
 }
 
 module.exports = function(config) {

--- a/scripts/run_frontend_tests.sh
+++ b/scripts/run_frontend_tests.sh
@@ -59,14 +59,14 @@ echo ""
 echo ""
 echo "  Running test in development environment"
 echo ""
-
+$PYTHON_CMD scripts/build.py
 $XVFB_PREFIX $NODE_MODULE_DIR/karma/bin/karma start core/tests/karma.conf.js
 
 if [ "$RUN_MINIFIED_TESTS" = "true" ]; then
   echo ""
   echo "  Running test in production environment"
   echo ""
-
+  $PYTHON_CMD scripts/build.py --prod_env
   $XVFB_PREFIX $NODE_MODULE_DIR/karma/bin/karma start core/tests/karma.conf.js --minify=True
 fi
 

--- a/scripts/run_frontend_tests.sh
+++ b/scripts/run_frontend_tests.sh
@@ -67,7 +67,7 @@ if [ "$RUN_MINIFIED_TESTS" = "true" ]; then
   echo "  Running test in production environment"
   echo ""
   $PYTHON_CMD scripts/build.py --prod_env
-  $XVFB_PREFIX $NODE_MODULE_DIR/karma/bin/karma start core/tests/karma.conf.js --minify=True
+  $XVFB_PREFIX $NODE_MODULE_DIR/karma/bin/karma start core/tests/karma.conf.js --prod_env=True
 fi
 
 echo Done!


### PR DESCRIPTION
## Explanation
Executes build before running frontend tests. Uses correct file for production frontend tests. The build for frontend test could be simplified (we need just the third_party.min.js not all files build) but since #4941 is blocked by this and I don't have enough time now, I will create an issue and implement it later.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
