### PR TITLE
Added domain objects and services for Skills: Milestone 1.2 (Part 2)

### DIFF
--- a/core/domain/collection_services.py
+++ b/core/domain/collection_services.py
@@ -65,7 +65,7 @@ def _migrate_collection_contents_to_latest_schema(
 
     Args:
         versioned_collection_contents: A dict with two keys:
-          - schema_version: str. The schema version for the collection.
+          - schema_version: int. The schema version for the collection.
           - collection_contents: dict. The dict comprising the collection
               contents.
 
@@ -93,7 +93,7 @@ def _get_collection_memcache_key(collection_id, version=None):
 
     Args:
         collection_id: str. ID of the collection.
-        version: str. Schema version of the collection.
+        version: int. Schema version of the collection.
 
     Returns:
         str. The memcache key of the collection.
@@ -193,7 +193,7 @@ def get_collection_by_id(collection_id, strict=True, version=None):
         collection_id: str. ID of the collection.
         strict: bool. Whether to fail noisily if no collection with the given
             id exists in the datastore.
-        version: str or None. The version number of the collection to be
+        version: int or None. The version number of the collection to be
             retrieved. If it is None, the latest version will be retrieved.
 
     Returns:

--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -25,9 +25,9 @@ SKILL_PROPERTY_LANGUAGE_CODE = 'language_code'
 SKILL_CONTENTS_PROPERTY_EXPLANATION = 'explanation'
 SKILL_CONTENTS_PROPERTY_WORKED_EXAMPLES = 'worked_examples'
 
-SKILL_MISCONCEPTIONS_PROPERTY_TAG_NAME = 'tag_name'
-SKILL_MISCONCEPTIONS_PROPERTY_DESCRIPTION = 'description'
-SKILL_MISCONCEPTIONS_PROPERTY_DEFAULT_FEEDBACK = 'default_feedback'
+SKILL_MISCONCEPTIONS_PROPERTY_NAME = 'name'
+SKILL_MISCONCEPTIONS_PROPERTY_NOTES = 'notes'
+SKILL_MISCONCEPTIONS_PROPERTY_FEEDBACK = 'feedback'
 
 # These take additional 'property_name' and 'new_value' parameters and,
 # optionally, 'old_value'.
@@ -52,9 +52,9 @@ class SkillChange(object):
         SKILL_CONTENTS_PROPERTY_WORKED_EXAMPLES)
 
     SKILL_MISCONCEPTIONS_PROPERTIES = (
-        SKILL_MISCONCEPTIONS_PROPERTY_TAG_NAME,
-        SKILL_MISCONCEPTIONS_PROPERTY_DESCRIPTION,
-        SKILL_MISCONCEPTIONS_PROPERTY_DEFAULT_FEEDBACK
+        SKILL_MISCONCEPTIONS_PROPERTY_NAME,
+        SKILL_MISCONCEPTIONS_PROPERTY_NOTES,
+        SKILL_MISCONCEPTIONS_PROPERTY_FEEDBACK
     )
 
     def __init__(self, change_dict):
@@ -80,16 +80,14 @@ class SkillChange(object):
         self.cmd = change_dict['cmd']
 
         if self.cmd == CMD_ADD_SKILL_MISCONCEPTION:
-            self.tag_name = change_dict['tag_name']
-            self.description = change_dict['description']
-            self.default_feedback = change_dict['default_feedback']
+            self.misconception_id = change_dict['id']
         elif self.cmd == CMD_DELETE_SKILL_MISCONCEPTION:
-            self.tag_name = change_dict['tag_name']
+            self.misconception_id = change_dict['id']
         elif self.cmd == CMD_UPDATE_SKILL_MISCONCEPTIONS_PROPERTY:
             if (change_dict['property_name'] not in
                     self.SKILL_MISCONCEPTIONS_PROPERTIES):
                 raise Exception('Invalid change_dict: %s' % change_dict)
-            self.tag_name = change_dict['tag_name']
+            self.misconception_id = change_dict['id']
             self.property_name = change_dict['property_name']
             self.new_value = change_dict['new_value']
             self.old_value = change_dict['old_value']
@@ -115,19 +113,21 @@ class Misconception(object):
     """
 
     def __init__(
-            self, tag_name, description, default_feedback):
+            self, id, name, notes, feedback):
         """Initializes a Misconception domain object.
 
         Args:
-            tag_name: str. The unique name for each misconception.
-            description: str. General advice for creators about the
+            id: str. The unique id of each misconception.
+            name: str. The name of the misconception.
+            notes: str. General advice for creators about the
                 misconception (including examples) and general notes.
-            default_feedback: str. This can auto-populate the feedback field
+            feedback: str. This can auto-populate the feedback field
                 when an answer group has been tagged with a misconception.
         """
-        self.tag_name = tag_name
-        self.description = description
-        self.default_feedback = default_feedback
+        self.id = id
+        self.name = name
+        self.notes = notes
+        self.feedback = feedback
 
     def to_dict(self):
         """Returns a dict representing this Misconception domain object.
@@ -136,14 +136,15 @@ class Misconception(object):
             A dict, mapping all fields of Misconception instance.
         """
         return {
-            'tag_name': self.tag_name,
-            'description': self.description,
-            'default_feedback': self.default_feedback
+            'id': self.id,
+            'name': self.name,
+            'notes': self.notes,
+            'feedback': self.feedback
         }
 
     @classmethod
     def from_dict(cls, misconception_dict):
-        """Return a Misconception domain object from a dict.
+        """Returns a Misconception domain object from a dict.
 
         Args:
             misconception_dict: dict. The dict representation of
@@ -153,8 +154,8 @@ class Misconception(object):
             Misconception. The corresponding Misconception domain object.
         """
         misconception = cls(
-            misconception_dict['tag_name'], misconception_dict['description'],
-            misconception_dict['default_feedback'])
+            misconception_dict['id'], misconception_dict['name'],
+            misconception_dict['notes'], misconception_dict['feedback'])
 
         return misconception
 
@@ -167,8 +168,7 @@ class SkillContents(object):
 
         Args:
             explanation: str. An explanation on how to apply the skill.
-            worked_examples: list(str). A list of worked out examples of the
-                skill.
+            worked_examples: list(str). A list of worked examples for the skill.
         """
         self.explanation = explanation
         self.worked_examples = worked_examples
@@ -220,10 +220,6 @@ class Skill(object):
                 associated with the skill.
             skill_contents: SkillContents. The object representing the contents
                 of the skill.
-            created_on: datetime.datetime. Date and time when the skill is
-                created.
-            last_updated: datetime.datetime. Date and time when the
-                skill was last updated.
             misconceptions_schema_version: int. The schema version for the
                 misconceptions object.
             skill_contents_schema_version: int. The schema version for the
@@ -231,6 +227,10 @@ class Skill(object):
             language_code: str. The ISO 639-1 code for the language this
                 skill is written in.
             version: int. The version of the skill.
+            created_on: datetime.datetime. Date and time when the skill is
+                created.
+            last_updated: datetime.datetime. Date and time when the
+                skill was last updated.
         """
         self.id = skill_id
         self.description = description
@@ -316,7 +316,7 @@ class Skill(object):
         Args:
             versioned_misconceptions: dict. A dict with two keys:
                 - schema_version: str. The schema version for the
-                    skill_contents dict.
+                    misconceptions dict.
                 - misconceptions: list(dict). The list of dicts comprising the
                     misconceptions of the skill.
             current_version: int. The current schema version of misconceptions.

--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -113,18 +113,18 @@ class Misconception(object):
     """
 
     def __init__(
-            self, id, name, notes, feedback):
+            self, misconception_id, name, notes, feedback):
         """Initializes a Misconception domain object.
 
         Args:
-            id: str. The unique id of each misconception.
+            misconception_id: str. The unique id of each misconception.
             name: str. The name of the misconception.
             notes: str. General advice for creators about the
                 misconception (including examples) and general notes.
             feedback: str. This can auto-populate the feedback field
                 when an answer group has been tagged with a misconception.
         """
-        self.id = id
+        self.id = misconception_id
         self.name = name
         self.notes = notes
         self.feedback = feedback

--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -1,0 +1,380 @@
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Domain objects relating to skills."""
+
+from constants import constants
+import feconf
+
+# Do not modify the values of these constants. This is to preserve backwards
+# compatibility with previous change dicts.
+SKILL_PROPERTY_DESCRIPTION = 'description'
+SKILL_PROPERTY_LANGUAGE_CODE = 'language_code'
+
+SKILL_CONTENTS_PROPERTY_EXPLANATION = 'explanation'
+SKILL_CONTENTS_PROPERTY_WORKED_EXAMPLES = 'worked_examples'
+
+SKILL_MISCONCEPTIONS_PROPERTY_TAG_NAME = 'tag_name'
+SKILL_MISCONCEPTIONS_PROPERTY_DESCRIPTION = 'description'
+SKILL_MISCONCEPTIONS_PROPERTY_DEFAULT_FEEDBACK = 'default_feedback'
+
+# These take additional 'property_name' and 'new_value' parameters and,
+# optionally, 'old_value'.
+CMD_UPDATE_SKILL_PROPERTY = 'update_skill_property'
+CMD_UPDATE_SKILL_CONTENTS_PROPERTY = 'update_skill_contents_property'
+CMD_UPDATE_SKILL_MISCONCEPTIONS_PROPERTY = (
+    'update_skill_misconceptions_property')
+
+CMD_ADD_SKILL_MISCONCEPTION = 'add_skill_misconception'
+CMD_DELETE_SKILL_MISCONCEPTION = 'delete_skill_misconception'
+
+CMD_CREATE_NEW = 'create_new'
+
+
+class SkillChange(object):
+    """Domain object for changes made to skill object."""
+    SKILL_PROPERTIES = (
+        SKILL_PROPERTY_DESCRIPTION, SKILL_PROPERTY_LANGUAGE_CODE)
+
+    SKILL_CONTENTS_PROPERTIES = (
+        SKILL_CONTENTS_PROPERTY_EXPLANATION,
+        SKILL_CONTENTS_PROPERTY_WORKED_EXAMPLES)
+
+    SKILL_MISCONCEPTIONS_PROPERTIES = (
+        SKILL_MISCONCEPTIONS_PROPERTY_TAG_NAME,
+        SKILL_MISCONCEPTIONS_PROPERTY_DESCRIPTION,
+        SKILL_MISCONCEPTIONS_PROPERTY_DEFAULT_FEEDBACK
+    )
+
+    def __init__(self, change_dict):
+        """Initialize a SkillChange object from a dict.
+
+        Args:
+            change_dict: dict. Represents a command. It should have a 'cmd'
+                key, and one or more other keys. The keys depend on what the
+                value for 'cmd' is. The possible values for 'cmd' are listed
+                below, together with the other keys in the dict:
+                - 'update_skill_property' (with property_name, new_value
+                and old_value)
+                - 'update_skill_contents_property' (with property_name,
+                new_value and old_value)
+                - 'update_skill_misconceptions_property' (with property_name,
+                new_value and old_value)
+
+        Raises:
+            Exception: The given change dict is not valid.
+        """
+        if 'cmd' not in change_dict:
+            raise Exception('Invalid change_dict: %s' % change_dict)
+        self.cmd = change_dict['cmd']
+
+        if self.cmd == CMD_ADD_SKILL_MISCONCEPTION:
+            self.tag_name = change_dict['tag_name']
+            self.description = change_dict['description']
+            self.default_feedback = change_dict['default_feedback']
+        elif self.cmd == CMD_DELETE_SKILL_MISCONCEPTION:
+            self.tag_name = change_dict['tag_name']
+        elif self.cmd == CMD_UPDATE_SKILL_MISCONCEPTIONS_PROPERTY:
+            if (change_dict['property_name'] not in
+                    self.SKILL_MISCONCEPTIONS_PROPERTIES):
+                raise Exception('Invalid change_dict: %s' % change_dict)
+            self.tag_name = change_dict['tag_name']
+            self.property_name = change_dict['property_name']
+            self.new_value = change_dict['new_value']
+            self.old_value = change_dict['old_value']
+        elif self.cmd == CMD_UPDATE_SKILL_PROPERTY:
+            if change_dict['property_name'] not in self.SKILL_PROPERTIES:
+                raise Exception('Invalid change_dict: %s' % change_dict)
+            self.property_name = change_dict['property_name']
+            self.new_value = change_dict['new_value']
+            self.old_value = change_dict['old_value']
+        elif self.cmd == CMD_UPDATE_SKILL_CONTENTS_PROPERTY:
+            if (change_dict['property_name'] not in
+                    self.SKILL_CONTENTS_PROPERTIES):
+                raise Exception('Invalid change_dict: %s' % change_dict)
+            self.property_name = change_dict['property_name']
+            self.new_value = change_dict['new_value']
+            self.old_value = change_dict['old_value']
+        else:
+            raise Exception('Invalid change_dict: %s' % change_dict)
+
+
+class Misconception(object):
+    """Domain object describing a skill misconception.
+    """
+
+    def __init__(
+            self, tag_name, description, default_feedback):
+        """Initializes a Misconception domain object.
+
+        Args:
+            tag_name: str. The unique name for each misconception.
+            description: str. General advice for creators about the
+                misconception (including examples) and general notes.
+            default_feedback: str. This can auto-populate the feedback field
+                when an answer group has been tagged with a misconception.
+        """
+        self.tag_name = tag_name
+        self.description = description
+        self.default_feedback = default_feedback
+
+    def to_dict(self):
+        """Returns a dict representing this Misconception domain object.
+
+        Returns:
+            A dict, mapping all fields of Misconception instance.
+        """
+        return {
+            'tag_name': self.tag_name,
+            'description': self.description,
+            'default_feedback': self.default_feedback
+        }
+
+    @classmethod
+    def from_dict(cls, misconception_dict):
+        """Return a Misconception domain object from a dict.
+
+        Args:
+            misconception_dict: dict. The dict representation of
+                Misconception object.
+
+        Returns:
+            Misconception. The corresponding Misconception domain object.
+        """
+        misconception = cls(
+            misconception_dict['tag_name'], misconception_dict['description'],
+            misconception_dict['default_feedback'])
+
+        return misconception
+
+
+class SkillContents(object):
+    """Domain object representing the skill_contents dict."""
+
+    def __init__(self, explanation, worked_examples):
+        """Constructs a SkillContents domain object.
+
+        Args:
+            explanation: str. An explanation on how to apply the skill.
+            worked_examples: list(str). A list of worked out examples of the
+                skill.
+        """
+        self.explanation = explanation
+        self.worked_examples = worked_examples
+
+    def to_dict(self):
+        """Returns a dict representing this SkillContents domain object.
+
+        Returns:
+            A dict, mapping all fields of SkillContents instance.
+        """
+        return {
+            'explanation': self.explanation,
+            'worked_examples': self.worked_examples
+        }
+
+    @classmethod
+    def from_dict(cls, skill_contents_dict):
+        """Return a SkillContents domain object from a dict.
+
+        Args:
+            skill_contents_dict: dict. The dict representation of
+                SkillContents object.
+
+        Returns:
+            SkillContents. The corresponding SkillContents domain object.
+        """
+        skill_contents = cls(
+            skill_contents_dict['explanation'],
+            skill_contents_dict['worked_examples']
+        )
+
+        return skill_contents
+
+
+class Skill(object):
+    """Domain object for an Oppia Skill."""
+
+    def __init__(
+            self, skill_id, description, misconceptions,
+            skill_contents, misconceptions_schema_version,
+            skill_contents_schema_version, language_code, version,
+            created_on=None, last_updated=None):
+        """Constructs a Skill domain object.
+
+        Args:
+            skill_id: str. The unique ID of the skill.
+            description: str. Describes the observable behaviour of the skill.
+            misconceptions: list(Misconception). The list of misconceptions
+                associated with the skill.
+            skill_contents: SkillContents. The object representing the contents
+                of the skill.
+            created_on: datetime.datetime. Date and time when the skill is
+                created.
+            last_updated: datetime.datetime. Date and time when the
+                skill was last updated.
+            misconceptions_schema_version: int. The schema version for the
+                misconceptions object.
+            skill_contents_schema_version: int. The schema version for the
+                skill_contents object.
+            language_code: str. The ISO 639-1 code for the language this
+                skill is written in.
+            version: int. The version of the skill.
+        """
+        self.id = skill_id
+        self.description = description
+        self.misconceptions = misconceptions
+        self.skill_contents = skill_contents
+        self.misconceptions_schema_version = misconceptions_schema_version
+        self.skill_contents_schema_version = skill_contents_schema_version
+        self.language_code = language_code
+        self.created_on = created_on
+        self.last_updated = last_updated
+        self.version = version
+
+    def to_dict(self):
+        """Returns a dict representing this Skill domain object.
+
+        Returns:
+            A dict, mapping all fields of Skill instance.
+        """
+        return {
+            'id': self.id,
+            'description': self.description,
+            'misconceptions': [
+                misconception.to_dict()
+                for misconception in self.misconceptions],
+            'skill_contents': self.skill_contents.to_dict(),
+            'language_code': self.language_code,
+            'misconceptions_schema_version': self.misconceptions_schema_version,
+            'skill_contents_schema_version': self.skill_contents_schema_version,
+            'version': self.version
+        }
+
+    @classmethod
+    def create_default_skill(cls, skill_id):
+        """Returns a skill domain object with default values. This is for
+        the frontend where a default blank skill would be shown to the user
+        when the skill is created for the first time.
+
+        Args:
+            skill_id: str. The unique id of the skill.
+
+        Returns:
+            Skill. The Skill domain object with the default values.
+        """
+        skill_contents = SkillContents(feconf.DEFAULT_SKILL_EXPLANATION, [])
+        return cls(
+            skill_id, feconf.DEFAULT_SKILL_DESCRIPTION, [], skill_contents,
+            feconf.CURRENT_MISCONCEPTIONS_SCHEMA_VERSION,
+            feconf.CURRENT_SKILL_CONTENTS_SCHEMA_VERSION,
+            constants.DEFAULT_LANGUAGE_CODE, 0)
+
+    @classmethod
+    def update_skill_contents_from_model(
+            cls, versioned_skill_contents, current_version):
+        """Converts the skill_contents blob contained in the given
+        versioned_skill_contents dict from current_version to
+        current_version + 1. Note that the versioned_skill_contents being
+        passed in is modified in-place.
+
+        Args:
+            versioned_skill_contents: dict. A dict with two keys:
+                - schema_version: str. The schema version for the
+                    skill_contents dict.
+                - skill_contents: dict. The dict comprising the skill
+                    contents.
+            current_version: int. The current schema version of skill_contents.
+        """
+        versioned_skill_contents['schema_version'] = current_version + 1
+
+        conversion_fn = getattr(
+            cls, '_convert_skill_contents_v%s_dict_to_v%s_dict' % (
+                current_version, current_version + 1))
+        versioned_skill_contents['skill_contents'] = conversion_fn(
+            versioned_skill_contents['skill_contents'])
+
+    @classmethod
+    def update_misconceptions_from_model(
+            cls, versioned_misconceptions, current_version):
+        """Converts the misconceptions blob contained in the given
+        versioned_misconceptions dict from current_version to
+        current_version + 1. Note that the versioned_misconceptions being
+        passed in is modified in-place.
+
+        Args:
+            versioned_misconceptions: dict. A dict with two keys:
+                - schema_version: str. The schema version for the
+                    skill_contents dict.
+                - misconceptions: list(dict). The list of dicts comprising the
+                    misconceptions of the skill.
+            current_version: int. The current schema version of misconceptions.
+        """
+        versioned_misconceptions['schema_version'] = current_version + 1
+
+        conversion_fn = getattr(
+            cls, '_convert_misconception_v%s_dict_to_v%s_dict' % (
+                current_version, current_version + 1))
+
+        updated_misconceptions = []
+        for misconception in versioned_misconceptions['misconceptions']:
+            updated_misconceptions.append(conversion_fn(misconception))
+
+        versioned_misconceptions['misconceptions'] = updated_misconceptions
+
+
+class SkillSummary(object):
+    """Domain object for Skill Summary."""
+
+    def __init__(
+            self, skill_id, description, language_code, version,
+            misconception_count, skill_model_created_on,
+            skill_model_last_updated):
+        """Constructs a SkillSummary domain object.
+
+        Args:
+            skill_id: str. The unique id of the skill.
+            description: str. The short description of the skill.
+            language_code: str. The language code of the skill.
+            version: int. The version of the skill.
+            misconception_count: int. The number of misconceptions associated
+                with the skill.
+            skill_model_created_on: datetime.datetime. Date and time when
+                the skill model is created.
+            skill_model_last_updated: datetime.datetime. Date and time
+                when the skill model was last updated.
+        """
+        self.id = skill_id
+        self.description = description
+        self.language_code = language_code
+        self.version = version
+        self.misconception_count = misconception_count
+        self.skill_model_created_on = skill_model_created_on
+        self.skill_model_last_updated = skill_model_last_updated
+
+    def to_dict(self):
+        """Returns a dictionary representation of this domain object.
+
+        Returns:
+            dict. A dict representing this SkillSummary object.
+        """
+        return {
+            'id': self.id,
+            'description': self.description,
+            'language_code': self.language_code,
+            'version': self.version,
+            'misconception_count': self.misconception_count,
+            'skill_model_created_on': self.skill_model_created_on,
+            'skill_model_last_updated': self.skill_model_last_updated
+        }

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -24,6 +24,7 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
     """Test the skill domain object."""
 
     SKILL_ID = 'skill_id'
+    MISCONCEPTION_ID = 'misconception_id'
 
     def test_create_default_skill(self):
         """Test the create_default_skill function.
@@ -48,7 +49,7 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
         }
         self.assertEqual(skill.to_dict(), expected_skill_dict)
 
-    def test_export_import(self):
+    def test_conversion_to_and_from_dict(self):
         """Test that to_dict and from_dict preserve all data within a
         skill_contents and misconception object.
         """
@@ -59,7 +60,7 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
             skill_contents_dict)
 
         misconceptions = skill_domain.Misconception(
-            'Tag Name', 'Description', 'Feedback')
+            self.MISCONCEPTION_ID, 'Tag Name', 'Description', 'Feedback')
         misconceptions_dict = misconceptions.to_dict()
         misconceptions_from_dict = skill_domain.Misconception.from_dict(
             misconceptions_dict)

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -1,0 +1,71 @@
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for skill domain objects and methods defined on them."""
+
+from constants import constants
+from core.domain import skill_domain
+from core.tests import test_utils
+import feconf
+
+
+class SkillDomainUnitTests(test_utils.GenericTestBase):
+    """Test the skill domain object."""
+
+    SKILL_ID = 'skill_id'
+
+    def test_create_default_skill(self):
+        """Test the create_default_skill function.
+        """
+        skill = skill_domain.Skill.create_default_skill(self.SKILL_ID)
+        skill_contents = skill_domain.SkillContents(
+            feconf.DEFAULT_SKILL_EXPLANATION, [])
+        expected_skill_dict = {
+            'id': self.SKILL_ID,
+            'description': feconf.DEFAULT_SKILL_DESCRIPTION,
+            'misconceptions': [],
+            'skill_contents': {
+                'explanation': feconf.DEFAULT_SKILL_EXPLANATION,
+                'worked_examples': []
+            },
+            'misconceptions_schema_version': (
+                feconf.CURRENT_MISCONCEPTIONS_SCHEMA_VERSION
+            ),
+            'skill_contents_schema_version': (
+                feconf.CURRENT_SKILL_CONTENTS_SCHEMA_VERSION
+            ),
+            'language_code': constants.DEFAULT_LANGUAGE_CODE,
+            'version': 0
+        }
+        self.assertEqual(skill.to_dict(), expected_skill_dict)
+
+    def test_export_import(self):
+        """Test that to_dict and from_dict preserve all data within a
+        skill_contents and misconception object.
+        """
+        skill_contents = skill_domain.SkillContents(
+            'Explanation', ['example_1'])
+        skill_contents_dict = skill_contents.to_dict()
+        skill_contents_from_dict = skill_domain.SkillContents.from_dict(
+            skill_contents_dict)
+
+        misconceptions = skill_domain.Misconception(
+            'Tag Name', 'Description', 'Feedback')
+        misconceptions_dict = misconceptions.to_dict()
+        misconceptions_from_dict = skill_domain.Misconception.from_dict(
+            misconceptions_dict)
+        self.assertEqual(
+            skill_contents_from_dict.to_dict(), skill_contents_dict)
+        self.assertEqual(
+            misconceptions_from_dict.to_dict(), misconceptions_dict)

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -29,8 +29,6 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
         """Test the create_default_skill function.
         """
         skill = skill_domain.Skill.create_default_skill(self.SKILL_ID)
-        skill_contents = skill_domain.SkillContents(
-            feconf.DEFAULT_SKILL_EXPLANATION, [])
         expected_skill_dict = {
             'id': self.SKILL_ID,
             'description': feconf.DEFAULT_SKILL_DESCRIPTION,

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -1,0 +1,331 @@
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Commands that can be used to operate on skills.
+"""
+
+import copy
+
+from core.domain import skill_domain
+from core.platform import models
+import feconf
+
+(skill_models,) = models.Registry.import_models([models.NAMES.skill])
+datastore_services = models.Registry.import_datastore_services()
+memcache_services = models.Registry.import_memcache_services()
+
+
+def _migrate_skill_contents_to_latest_schema(versioned_skill_contents):
+    """Holds the responsibility of performing a step-by-step, sequential update
+    of the skill contents structure based on the schema version of the input
+    skill contents dictionary. If the current skill_contents schema changes, a
+    new conversion function must be added and some code appended to this
+    function to account for that new version.
+
+    Args:
+        versioned_skill_contents: A dict with two keys:
+          - schema_version: str. The schema version for the skill_contents dict.
+          - skill_contents: dict. The dict comprising the skill contents.
+
+    Raises:
+        Exception: The schema version of the skill_contents is outside of what
+        is supported at present.
+    """
+    skill_contents_schema_version = versioned_skill_contents['schema_version']
+    if not (1 <= skill_contents_schema_version
+            <= feconf.CURRENT_SKILL_CONTENTS_SCHEMA_VERSION):
+        raise Exception(
+            'Sorry, we can only process v1-v%d skill schemas at '
+            'present.' % feconf.CURRENT_SKILL_CONTENTS_SCHEMA_VERSION)
+
+    while (skill_contents_schema_version <
+           feconf.CURRENT_SKILL_CONTENTS_SCHEMA_VERSION):
+        skill_domain.Skill.update_skill_contents_from_model(
+            versioned_skill_contents, skill_contents_schema_version)
+        skill_contents_schema_version += 1
+
+
+def _migrate_misconceptions_to_latest_schema(versioned_misconceptions):
+    """Holds the responsibility of performing a step-by-step, sequential update
+    of the misconceptions structure based on the schema version of the input
+    misconceptions dictionary. If the current misconceptions schema changes, a
+    new conversion function must be added and some code appended to this
+    function to account for that new version.
+
+    Args:
+        versioned_misconceptions: A dict with two keys:
+          - schema_version: str. The schema version for the skill_contents dict.
+          - misconceptions: list(dict). The list of dicts comprising the skill
+              misconceptions.
+
+    Raises:
+        Exception: The schema version of misconceptions is outside of what
+        is supported at present.
+    """
+    misconception_schema_version = versioned_misconceptions['schema_version']
+    if not (1 <= misconception_schema_version
+            <= feconf.CURRENT_MISCONCEPTIONS_SCHEMA_VERSION):
+        raise Exception(
+            'Sorry, we can only process v1-v%d misconception schemas at '
+            'present.' % feconf.CURRENT_MISCONCEPTIONS_SCHEMA_VERSION)
+
+    while (misconception_schema_version <
+           feconf.CURRENT_MISCONCEPTIONS_SCHEMA_VERSION):
+        skill_domain.Skill.update_misconceptions_from_model(
+            versioned_misconceptions, misconception_schema_version)
+        misconception_schema_version += 1
+
+
+# Repository GET methods.
+def _get_skill_memcache_key(skill_id, version=None):
+    """Returns a memcache key for the skill.
+
+    Args:
+        skill_id: str. ID of the skill.
+        version: str. Schema version of the skill.
+
+    Returns:
+        str. The memcache key of the skill.
+    """
+    if version:
+        return 'skill-version:%s:%s' % (skill_id, version)
+    else:
+        return 'skill:%s' % skill_id
+
+
+def get_skill_from_model(skill_model, run_conversion=True):
+    """Returns a skill domain object given a skill model loaded
+    from the datastore.
+
+    Args:
+        skill_model: SkillModel. The skill model loaded from the
+            datastore.
+        run_conversion: bool. If true, the the skill's schema version will
+            be checked against the current schema version. If they do not match,
+            the skill will be automatically updated to the latest schema
+            version.
+
+    Returns:
+        skill. A Skill domain object corresponding to the given
+        skill model.
+    """
+
+    # Ensure the original skill model does not get altered.
+    versioned_skill_contents = {
+        'schema_version': skill_model.skill_contents_schema_version,
+        'skill_contents': copy.deepcopy(skill_model.skill_contents)
+    }
+
+    versioned_misconceptions = {
+        'schema_version': skill_model.misconceptions_schema_version,
+        'misconceptions': copy.deepcopy(skill_model.misconceptions)
+    }
+
+    # Migrate the skill if it is not using the latest schema version.
+    if (run_conversion and skill_model.skill_contents_schema_version !=
+            feconf.CURRENT_SKILL_CONTENTS_SCHEMA_VERSION):
+        _migrate_skill_contents_to_latest_schema(versioned_skill_contents)
+
+    if (run_conversion and skill_model.misconceptions_schema_version !=
+            feconf.CURRENT_MISCONCEPTIONS_SCHEMA_VERSION):
+        _migrate_misconceptions_to_latest_schema(versioned_misconceptions)
+
+    return skill_domain.Skill(
+        skill_model.id, skill_model.description,
+        [
+            skill_domain.Misconception.from_dict(misconception)
+            for misconception in versioned_misconceptions['misconceptions']
+        ], skill_domain.SkillContents.from_dict(
+            versioned_skill_contents['skill_contents']),
+        versioned_misconceptions['schema_version'],
+        versioned_skill_contents['schema_version'],
+        skill_model.language_code,
+        skill_model.version, skill_model.created_on,
+        skill_model.last_updated)
+
+
+def get_skill_summary_from_model(skill_summary_model):
+    """Returns a domain object for an Oppia skill summary given a
+    skill summary model.
+
+    Args:
+        skill_summary_model: SkillSummaryModel.
+
+    Returns:
+        SkillSummary.
+    """
+    return skill_domain.SkillSummary(
+        skill_summary_model.id, skill_summary_model.description,
+        skill_summary_model.language_code,
+        skill_summary_model.version,
+        skill_summary_model.misconception_count,
+        skill_summary_model.skill_model_created_on,
+        skill_summary_model.skill_model_last_updated
+    )
+
+
+def get_skill_by_id(skill_id, strict=True, version=None):
+    """Returns a domain object representing a skill.
+
+    Args:
+        skill_id: str. ID of the skill.
+        strict: bool. Whether to fail noisily if no skill with the given
+            id exists in the datastore.
+        version: str or None. The version number of the skill to be
+            retrieved. If it is None, the latest version will be retrieved.
+
+    Returns:
+        Skill or None. The domain object representing a skill with the
+        given id, or None if it does not exist.
+    """
+    skill_memcache_key = _get_skill_memcache_key(
+        skill_id, version=version)
+    memcached_skill = memcache_services.get_multi(
+        [skill_memcache_key]).get(skill_memcache_key)
+
+    if memcached_skill is not None:
+        return memcached_skill
+    else:
+        skill_model = skill_models.SkillModel.get(
+            skill_id, strict=strict, version=version)
+        if skill_model:
+            skill = get_skill_from_model(skill_model)
+            memcache_services.set_multi({skill_memcache_key: skill})
+            return skill
+        else:
+            return None
+
+
+def get_skill_summary_by_id(skill_id):
+    """Returns a domain object representing a skill summary.
+
+    Args:
+        skill_id: str. ID of the skill summary.
+
+    Returns:
+        SkillSummary. The skill summary domain object corresponding to
+        a skill with the given skill_id.
+    """
+    skill_summary_model = skill_models.SkillSummaryModel.get(
+        skill_id)
+    if skill_summary_model:
+        skill_summary = get_skill_summary_from_model(
+            skill_summary_model)
+        return skill_summary
+    else:
+        return None
+
+
+def get_new_skill_id():
+    """Returns a new skill id.
+
+    Returns:
+        str. A new skill id.
+    """
+    return skill_models.SkillModel.get_new_id('')
+
+
+def _create_skill(committer_id, skill, commit_message, commit_cmds):
+    """Creates a new skill.
+
+    Args:
+        committer_id: str. ID of the committer.
+        skill: Skill. The skill domain object.
+        commit_message: str. A description of changes made to the skill.
+        commit_cmds: list(dict). A list of change commands made to the given
+            skill.
+    """
+    model = skill_models.SkillModel(
+        id=skill.id,
+        description=skill.description,
+        language_code=skill.language_code,
+        misconceptions=[
+            misconception.to_dict()
+            for misconception in skill.misconceptions
+        ],
+        skill_contents=skill.skill_contents.to_dict(),
+        misconceptions_schema_version=skill.misconceptions_schema_version,
+        skill_contents_schema_version=skill.skill_contents_schema_version
+    )
+    model.commit(committer_id, commit_message, commit_cmds)
+    skill.version += 1
+    create_skill_summary(skill.id)
+
+
+def save_new_skill(committer_id, skill):
+    """Saves a new skill.
+
+    Args:
+        committer_id: str. ID of the committer.
+        skill: Skill. Skill to be saved.
+    """
+    commit_message = 'New skill created.'
+    _create_skill(
+        committer_id, skill, commit_message, [{
+            'cmd': skill_domain.CMD_CREATE_NEW
+        }])
+
+
+def compute_summary_of_skill(skill):
+    """Create a SkillSummary domain object for a given Skill domain
+    object and return it.
+
+    Args:
+        skill_id: str. ID of the skill.
+
+    Returns:
+        SkillSummary. The computed summary for the given skill.
+    """
+    skill_model_misconception_count = len(skill.misconceptions)
+    skill_summary = skill_domain.SkillSummary(
+        skill.id, skill.description, skill.language_code,
+        skill.version, skill_model_misconception_count,
+        skill.created_on, skill.last_updated
+    )
+
+    return skill_summary
+
+
+def create_skill_summary(skill_id):
+    """Creates and stores a summary of the given skill.
+
+    Args:
+        skill_id: str. ID of the skill.
+    """
+    skill = get_skill_by_id(skill_id)
+    skill_summary = compute_summary_of_skill(skill)
+    save_skill_summary(skill_summary)
+
+
+def save_skill_summary(skill_summary):
+    """Save a skill summary domain object as a SkillSummaryModel
+    entity in the datastore.
+
+    Args:
+        skill_summary: The skill summary object to be saved in the
+            datastore.
+    """
+    skill_summary_model = skill_models.SkillSummaryModel(
+        id=skill_summary.id,
+        description=skill_summary.description,
+        language_code=skill_summary.language_code,
+        version=skill_summary.version,
+        misconception_count=skill_summary.misconception_count,
+        skill_model_last_updated=(
+            skill_summary.skill_model_last_updated),
+        skill_model_created_on=(
+            skill_summary.skill_model_created_on)
+    )
+
+    skill_summary_model.put()

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -35,7 +35,7 @@ def _migrate_skill_contents_to_latest_schema(versioned_skill_contents):
 
     Args:
         versioned_skill_contents: A dict with two keys:
-          - schema_version: str. The schema version for the skill_contents dict.
+          - schema_version: int. The schema version for the skill_contents dict.
           - skill_contents: dict. The dict comprising the skill contents.
 
     Raises:
@@ -65,7 +65,7 @@ def _migrate_misconceptions_to_latest_schema(versioned_misconceptions):
 
     Args:
         versioned_misconceptions: A dict with two keys:
-          - schema_version: str. The schema version for the skill_contents dict.
+          - schema_version: int. The schema version for the misconceptions dict.
           - misconceptions: list(dict). The list of dicts comprising the skill
               misconceptions.
 
@@ -93,7 +93,7 @@ def _get_skill_memcache_key(skill_id, version=None):
 
     Args:
         skill_id: str. ID of the skill.
-        version: str. Schema version of the skill.
+        version: int or None. Schema version of the skill.
 
     Returns:
         str. The memcache key of the skill.
@@ -182,7 +182,7 @@ def get_skill_by_id(skill_id, strict=True, version=None):
         skill_id: str. ID of the skill.
         strict: bool. Whether to fail noisily if no skill with the given
             id exists in the datastore.
-        version: str or None. The version number of the skill to be
+        version: int or None. The version number of the skill to be
             retrieved. If it is None, the latest version will be retrieved.
 
     Returns:
@@ -282,7 +282,7 @@ def compute_summary_of_skill(skill):
     object and return it.
 
     Args:
-        skill_id: str. ID of the skill.
+        skill: Skill. The skill object, for which the summary is to be computed.
 
     Returns:
         SkillSummary. The computed summary for the given skill.

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -27,13 +27,14 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
 
     SKILL_ID = None
     USER_ID = 'user'
+    MISCONCEPTION_ID = 'misconception_id'
 
     def setUp(self):
         super(SkillServicesUnitTests, self).setUp()
         skill_contents = skill_domain.SkillContents(
             'Explanation', ['Example 1'])
         misconceptions = [skill_domain.Misconception(
-            'tag_name', 'description', 'default_feedback')]
+            self.MISCONCEPTION_ID, 'name', 'description', 'default_feedback')]
         self.SKILL_ID = skill_services.get_new_skill_id()
         self.skill = self.save_new_skill(
             self.SKILL_ID, self.USER_ID, 'Description', misconceptions,

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -1,0 +1,89 @@
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests the methods defined in skill services."""
+
+from core.domain import skill_domain
+from core.domain import skill_services
+from core.platform import models
+from core.tests import test_utils
+
+(skill_models,) = models.Registry.import_models([models.NAMES.skill])
+
+
+class SkillServicesUnitTests(test_utils.GenericTestBase):
+    """Test the skill services module."""
+
+    SKILL_ID = None
+    USER_ID = 'user'
+
+    def setUp(self):
+        super(SkillServicesUnitTests, self).setUp()
+        skill_contents = skill_domain.SkillContents(
+            'Explanation', ['Example 1'])
+        misconceptions = [skill_domain.Misconception(
+            'tag_name', 'description', 'default_feedback')]
+        self.SKILL_ID = skill_services.get_new_skill_id()
+        self.skill = self.save_new_skill(
+            self.SKILL_ID, self.USER_ID, 'Description', misconceptions,
+            skill_contents
+        )
+
+    def test_compute_summary(self):
+        skill_summary = skill_services.compute_summary_of_skill(self.skill)
+
+        self.assertEqual(skill_summary.id, self.SKILL_ID)
+        self.assertEqual(skill_summary.description, 'Description')
+        self.assertEqual(skill_summary.misconception_count, 1)
+
+    def test_get_new_skill_id(self):
+        new_skill_id = skill_services.get_new_skill_id()
+
+        self.assertEqual(len(new_skill_id), 12)
+        self.assertEqual(skill_models.SkillModel.get_by_id(new_skill_id), None)
+
+    def test_get_skill_from_model(self):
+        skill_model = skill_models.SkillModel.get(self.SKILL_ID)
+        skill = skill_services.get_skill_from_model(skill_model)
+
+        self.assertEqual(skill.to_dict(), self.skill.to_dict())
+
+    def test_get_skill_summary_from_model(self):
+        skill_summary_model = skill_models.SkillSummaryModel.get(self.SKILL_ID)
+        skill_summary = skill_services.get_skill_summary_from_model(
+            skill_summary_model)
+
+        self.assertEqual(skill_summary.id, self.SKILL_ID)
+        self.assertEqual(skill_summary.description, 'Description')
+        self.assertEqual(skill_summary.misconception_count, 1)
+
+    def test_get_skill_by_id(self):
+        expected_skill = self.skill.to_dict()
+        skill = skill_services.get_skill_by_id(self.SKILL_ID)
+        self.assertEqual(skill.to_dict(), expected_skill)
+
+    def test_commit_log_entry(self):
+        skill_commit_log_entry = (
+            skill_models.SkillCommitLogEntryModel.get_commit(self.SKILL_ID, 1)
+        )
+        self.assertEqual(skill_commit_log_entry.commit_type, 'create')
+        self.assertEqual(skill_commit_log_entry.skill_id, self.SKILL_ID)
+        self.assertEqual(skill_commit_log_entry.user_id, self.USER_ID)
+
+    def test_get_skill_summary_by_id(self):
+        skill_summary = skill_services.get_skill_summary_by_id(self.SKILL_ID)
+
+        self.assertEqual(skill_summary.id, self.SKILL_ID)
+        self.assertEqual(skill_summary.description, 'Description')
+        self.assertEqual(skill_summary.misconception_count, 1)

--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -234,7 +234,7 @@ class Story(object):
         Args:
             story_id: str. The unique ID of the story.
             title: str. The title of the story.
-            description: str. The high level desscription of the story.
+            description: str. The high level description of the story.
             notes: str. A set of notes, that describe the characters,
                 main storyline, and setting.
             story_contents: StoryContents. The StoryContents instance

--- a/core/domain/story_services.py
+++ b/core/domain/story_services.py
@@ -246,7 +246,7 @@ def compute_summary_of_story(story):
     object and return it.
 
     Args:
-        story_id: str. ID of the story.
+        story: Story. The story object, for which the summary is to be computed.
 
     Returns:
         StorySummary. The computed summary for the given story.

--- a/core/storage/base_model/gae_models.py
+++ b/core/storage/base_model/gae_models.py
@@ -262,7 +262,7 @@ class BaseCommitLogEntryModel(BaseModel):
             entity_id: str. The ID of the construct corresponding to this
                 commit log entry model (e.g. the exp_id for an exploration,
                 the story_id for a story, etc.).
-            version: int. The version number of the model after the commit. 
+            version: int. The version number of the model after the commit.
             committer_id: str. The user_id of the user who committed the
                 change.
             committer_username: str. The username of the user who committed the

--- a/core/storage/base_model/gae_models.py
+++ b/core/storage/base_model/gae_models.py
@@ -259,6 +259,10 @@ class BaseCommitLogEntryModel(BaseModel):
         construct with the common fields filled.
 
         Args:
+            entity_id: str. The ID of the construct corresponding to this
+                commit log entry model (e.g. the exp_id for an exploration,
+                the story_id for a story, etc.).
+            version: int. The version number of the model after the commit. 
             committer_id: str. The user_id of the user who committed the
                 change.
             committer_username: str. The username of the user who committed the

--- a/core/storage/skill/gae_models.py
+++ b/core/storage/skill/gae_models.py
@@ -15,10 +15,12 @@
 """Models for storing the skill data models."""
 
 from core.platform import models
+import feconf
 
 from google.appengine.ext import ndb
 
-(base_models,) = models.Registry.import_models([models.NAMES.base_model])
+(base_models, user_models,) = models.Registry.import_models([
+    models.NAMES.base_model, models.NAMES.user])
 
 
 class SkillSnapshotMetadataModel(base_models.BaseSnapshotMetadataModel):
@@ -56,6 +58,41 @@ class SkillModel(base_models.VersionedModel):
         required=True, indexed=True)
     # A dict representing the skill contents.
     skill_contents = ndb.JsonProperty(indexed=False)
+
+    def _trusted_commit(
+            self, committer_id, commit_type, commit_message, commit_cmds):
+        """Record the event to the commit log after the model commit.
+
+        Note that this extends the superclass method.
+
+        Args:
+            committer_id: str. The user_id of the user who committed the
+                change.
+            commit_type: str. The type of commit. Possible values are in
+                core.storage.base_models.COMMIT_TYPE_CHOICES.
+            commit_message: str. The commit description message.
+            commit_cmds: list(dict). A list of commands, describing changes
+                made in this model, which should give sufficient information to
+                reconstruct the commit. Each dict always contains:
+                    cmd: str. Unique command.
+                and then additional arguments for that command.
+        """
+        super(SkillModel, self)._trusted_commit(
+            committer_id, commit_type, commit_message, commit_cmds)
+
+        committer_user_settings_model = (
+            user_models.UserSettingsModel.get_by_id(committer_id))
+        committer_username = (
+            committer_user_settings_model.username
+            if committer_user_settings_model else '')
+
+        skill_commit_log_entry = SkillCommitLogEntryModel.create(
+            self.id, self.version, committer_id, committer_username,
+            commit_type, commit_message, commit_cmds,
+            feconf.ACTIVITY_STATUS_PUBLIC, False
+        )
+        skill_commit_log_entry.skill_id = self.id
+        skill_commit_log_entry.put_async()
 
 
 class SkillCommitLogEntryModel(base_models.BaseCommitLogEntryModel):
@@ -100,6 +137,8 @@ class SkillSummaryModel(base_models.BaseModel):
 
     # The description of the skill.
     description = ndb.StringProperty(required=True, indexed=True)
+    # The number of misconceptions associated with the skill.
+    misconception_count = ndb.IntegerProperty(required=True, indexed=True)
     # The ISO 639-1 code for the language this skill is written in.
     language_code = ndb.StringProperty(required=True, indexed=True)
     # Time when the skill model was last updated (not to be

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -31,6 +31,8 @@ from core.domain import collection_services
 from core.domain import exp_domain
 from core.domain import exp_services
 from core.domain import rights_manager
+from core.domain import skill_domain
+from core.domain import skill_services
 from core.domain import story_domain
 from core.domain import story_services
 from core.domain import user_services
@@ -886,7 +888,7 @@ tags: []
             story_id: str. ID for the story to be created.
             owner_id: str. The user_id of the creator of the story.
             title: str. The title of the story.
-            description: str. The high level desscription of the story.
+            description: str. The high level description of the story.
             notes: str. A set of notes, that describe the characters,
                 main storyline, and setting.
             story_contents: StoryContents. A StoryContents object containing the
@@ -903,6 +905,34 @@ tags: []
         )
         story_services.save_new_story(owner_id, story)
         return story
+
+    def save_new_skill(
+            self, skill_id, owner_id,
+            description, misconceptions, skill_contents,
+            language_code=constants.DEFAULT_LANGUAGE_CODE):
+        """Creates an Oppia Skill and saves it.
+
+        Args:
+            skill_id: str. ID for the skill to be created.
+            owner_id: str. The user_id of the creator of the skill.
+            description: str. The description of the skill.
+            skill_contents: SkillContents. A SkillContents object containing the
+                explanation and examples of the skill.
+            misconceptions: list(Misconception). A list of Misconception objects
+                that contains the various misconceptions of the skill.
+            language_code: str. The ISO 639-1 code for the language this
+                skill is written in.
+
+        Returns:
+            Skill. A newly-created skill.
+        """
+        skill = skill_domain.Skill(
+            skill_id, description, misconceptions, skill_contents,
+            feconf.CURRENT_MISCONCEPTIONS_SCHEMA_VERSION,
+            feconf.CURRENT_SKILL_CONTENTS_SCHEMA_VERSION, language_code, 0
+        )
+        skill_services.save_new_skill(owner_id, skill)
+        return skill
 
     def get_updated_param_dict(
             self, param_dict, param_changes, exp_param_specs):

--- a/feconf.py
+++ b/feconf.py
@@ -165,8 +165,14 @@ CURRENT_EXPLORATION_STATES_SCHEMA_VERSION = 19
 # number must be changed.
 CURRENT_COLLECTION_SCHEMA_VERSION = 6
 
-# The current version of story schema.
+# The current version of story contents dict in the story schema.
 CURRENT_STORY_CONTENTS_SCHEMA_VERSION = 1
+
+# The current version of skill contents dict in the skill schema.
+CURRENT_SKILL_CONTENTS_SCHEMA_VERSION = 1
+
+# The current version of misconceptions dict in the skill schema.
+CURRENT_MISCONCEPTIONS_SCHEMA_VERSION = 1
 
 # The current version of the question schema.
 CURRENT_QUESTION_SCHEMA_VERSION = 1
@@ -216,6 +222,11 @@ DEFAULT_STORY_TITLE = ''
 DEFAULT_STORY_DESCRIPTION = ''
 # Default notes for a newly-minted story.
 DEFAULT_STORY_NOTES = ''
+
+# Default description for a newly-minted skill.
+DEFAULT_SKILL_DESCRIPTION = ''
+# Default explanation for a newly-minted skill.
+DEFAULT_SKILL_EXPLANATION = ''
 
 # Default ID of VM which is used for training classifier.
 DEFAULT_VM_ID = 'vm_default'


### PR DESCRIPTION
In this PR, the skill_domain.py and skill_services.py files have been created with create_skill and get_skill functionalities with their corresponding tests.
