### PR TITLE
Generalized Review System: Milestone 1 - Changes to suggestion_domain

### DIFF
--- a/core/domain/suggestion_domain.py
+++ b/core/domain/suggestion_domain.py
@@ -40,23 +40,10 @@ class BaseSuggestion(object):
         score_category: str. The scoring category for the suggestion.
     """
 
-    def __init__(
-            self, suggestion_id, suggestion_type, target_type, target_id,
-            target_version_at_submission, status, author_id,
-            assigned_reviewer_id, final_reviewer_id, change_cmd,
-            score_category):
+    def __init__(self):
         """Initializes a Suggestion object."""
-        self.suggestion_id = suggestion_id
-        self.suggestion_type = suggestion_type
-        self.target_type = target_type
-        self.target_id = target_id
-        self.target_version_at_submission = target_version_at_submission
-        self.status = status
-        self.author_id = author_id
-        self.assigned_reviewer_id = assigned_reviewer_id
-        self.final_reviewer_id = final_reviewer_id
-        self.change_cmd = change_cmd
-        self.score_category = score_category
+        raise NotImplementedError(
+            'Subclasses of BaseSuggestion should implement __init__.')
 
     def to_dict(self):
         """Returns a dict representation of a suggestion object.
@@ -79,63 +66,57 @@ class BaseSuggestion(object):
         }
 
     @classmethod
-    def from_dict(cls, suggestion_dict):
-        """Return a Suggestion object of type from a dict.
-
-        Args:
-            suggestion_dict: dict. The dict representation of the suggestion.
-
-        Returns:
-            BaseSuggestion. The corresponding Suggestion domain object.
-        """
-        suggestion = cls(
-            suggestion_dict['suggestion_id'],
-            suggestion_dict['suggestion_type'], suggestion_dict['target_type'],
-            suggestion_dict['target_id'],
-            suggestion_dict['target_version_at_submission'],
-            suggestion_dict['status'], suggestion_dict['author_id'],
-            suggestion_dict['assigned_reviewer_id'],
-            suggestion_dict['final_reviewer_id'], suggestion_dict['change_cmd'],
-            suggestion_dict['score_category'])
-
-        return suggestion
+    def from_dict(cls):
+        """Return a Suggestion object of type from a dict."""
+        raise NotImplementedError(
+            'Subclasses of BaseSuggestion should implement from_dict.')
 
     def validate(self):
         """Validates the suggestion object. Each subclass must implement
         this function
         """
-        pass
+        raise NotImplementedError(
+            'Subclasses of BaseSuggestion should implement validate.')
 
     def accept(self):
         """Accepts the suggestion. Each subclass must implement this function.
         """
-        pass
+        raise NotImplementedError(
+            'Subclasses of BaseSuggestion should implement accept.')
 
 
 class SuggestionEditStateContent(BaseSuggestion):
-    """Domain object for a suggestion of type SUGGESTION_EDIT_STATE_CONTENT."""
+    """Domain object for a suggestion of type
+    SUGGESTION_TYPE_EDIT_STATE_CONTENT.
+    """
 
     def __init__(
             self, suggestion_id, target_id, target_version_at_submission,
             status, author_id, assigned_reviewer_id, final_reviewer_id,
             change_cmd, score_category):
         """Initializes a Suggestion object of type
-        SUGGESTION_EDIT_STATE_CONTENT.
+        SUGGESTION_TYPE_EDIT_STATE_CONTENT.
         """
-        super(SuggestionEditStateContent, self).__init__(
-            suggestion_id, suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
-            suggestion_models.TARGET_TYPE_EXPLORATION, target_id,
-            target_version_at_submission, status, author_id,
-            assigned_reviewer_id, final_reviewer_id, change_cmd,
-            score_category)
+        self.suggestion_id = suggestion_id
+        self.suggestion_type = (
+            suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT)
+        self.target_type = suggestion_models.TARGET_TYPE_EXPLORATION
+        self.target_id = target_id
+        self.target_version_at_submission = target_version_at_submission
+        self.status = status
+        self.author_id = author_id
+        self.assigned_reviewer_id = assigned_reviewer_id
+        self.final_reviewer_id = final_reviewer_id
+        self.change_cmd = change_cmd
+        self.score_category = score_category
 
     def validate(self):
-        """Validates a suggestion object of type SUGGESTION_EDIT_STATE_CONTENT.
+        """Validates a suggestion object of type
+        SUGGESTION_TYPE_EDIT_STATE_CONTENT.
 
         Returns:
             bool. The validity of the suggestion object.
         """
-        super(SuggestionEditStateContent, self).validate()
         states = exp_services.get_exploration_by_id(self.target_id).states
         if self.change_cmd['state_name'] not in states:
             return False
@@ -173,18 +154,6 @@ class SuggestionEditStateContent(BaseSuggestion):
 
         return suggestion
 
-suggestion_type_domain_class_mapping = {
-    suggestion_models.SUGGESTION_EDIT_STATE_CONTENT: SuggestionEditStateContent
+SUGGESTION_TYPE_TO_DOMAIN_CLASS = {
+    suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT: SuggestionEditStateContent
 }
-
-
-def get_model_corresponding_to_suggestion(suggestion_type):
-    """Gets the domain class for the given suggestion_type.
-
-    Args:
-        suggestion_type: str. The type of suggestion.
-
-    Returns:
-        The appropriate subclass of BaseSuggestion class.
-    """
-    return suggestion_type_domain_class_mapping[suggestion_type]

--- a/core/domain/suggestion_domain.py
+++ b/core/domain/suggestion_domain.py
@@ -19,6 +19,7 @@ from core.platform import models
 
 (suggestion_models,) = models.Registry.import_models([models.NAMES.suggestion])
 
+
 class BaseSuggestion(object):
     """Domain object for a suggestion.
 
@@ -79,7 +80,8 @@ class BaseSuggestion(object):
 
     def validate(self):
         """Validates the suggestion object. Each subclass must implement
-        this function"""
+        this function
+        """
         pass
 
 
@@ -128,3 +130,12 @@ class SuggestionEditStateContent(BaseSuggestion):
         if self.change_cmd['state_name'] not in states:
             return False
         return True
+
+
+suggestion_type_domain_class_mapping = {
+    suggestion_models.SUGGESTION_EDIT_STATE_CONTENT: SuggestionEditStateContent
+}
+
+
+def get_model_corresponding_to_suggestion(suggestion):
+    return suggestion_type_domain_class_mapping[suggestion.suggestion_type]

--- a/core/domain/suggestion_domain.py
+++ b/core/domain/suggestion_domain.py
@@ -137,5 +137,13 @@ suggestion_type_domain_class_mapping = {
 }
 
 
-def get_model_corresponding_to_suggestion(suggestion):
-    return suggestion_type_domain_class_mapping[suggestion.suggestion_type]
+def get_model_corresponding_to_suggestion(suggestion_type):
+    """Gets the domain class for the given suggestion_type.
+
+    Args:
+        suggestion_type: str. The type of suggestion.
+
+    Returns:
+        The appropriate subclass of BaseSuggestion class.
+    """
+    return suggestion_type_domain_class_mapping[suggestion_type]

--- a/core/domain/suggestion_domain.py
+++ b/core/domain/suggestion_domain.py
@@ -82,8 +82,8 @@ class BaseSuggestion(object):
                 are invalid.
         """
         if (
-            self.suggestion_type not in
-            suggestion_models.SUGGESTION_TYPE_CHOICES):
+                self.suggestion_type not in
+                suggestion_models.SUGGESTION_TYPE_CHOICES):
             raise utils.ValidationError(
                 'Expected suggestion_type to be among allowed choices, '
                 'recieved %s' % self.suggestion_type)
@@ -134,8 +134,8 @@ class BaseSuggestion(object):
                     self.score_category))
 
         if (
-            not suggestion_models.SCORE_CATEGORY_DELIMITER in
-            self.score_category):
+                not suggestion_models.SCORE_CATEGORY_DELIMITER in
+                self.score_category):
             raise utils.ValidationError(
                 'Expected score_category to be of the form'
                 ' score_type%sscore_sub_type, recieved %s' %
@@ -143,9 +143,9 @@ class BaseSuggestion(object):
                     self.score_category))
 
         if (
-            self.score_category.split(
-                suggestion_models.SCORE_CATEGORY_DELIMITER)[0] not in
-            suggestion_models.SCORE_TYPE_CHOICES):
+                self.score_category.split(
+                    suggestion_models.SCORE_CATEGORY_DELIMITER)[0] not in
+                suggestion_models.SCORE_TYPE_CHOICES):
             raise utils.ValidationError(
                 'Expected the first part of score_category to be among allowed'
                 ' choices, recieved %s' % self.score_category.split(
@@ -163,7 +163,7 @@ class SuggestionEditStateContent(BaseSuggestion):
     SUGGESTION_TYPE_EDIT_STATE_CONTENT.
     """
 
-    def __init__(
+    def __init__( # pylint: disable=super-init-not-called
             self, suggestion_id, target_id, target_version_at_submission,
             status, author_id, assigned_reviewer_id, final_reviewer_id,
             change_cmd, score_category):
@@ -206,8 +206,8 @@ class SuggestionEditStateContent(BaseSuggestion):
                 'Expected change_cmd to contain a property_name key')
 
         if (
-            self.change_cmd['property_name'] !=
-            exp_domain.STATE_PROPERTY_CONTENT):
+                self.change_cmd['property_name'] !=
+                exp_domain.STATE_PROPERTY_CONTENT):
             raise utils.ValidationError(
                 'Expected property_name to be %s, recieved %s' % (
                     exp_domain.STATE_PROPERTY_CONTENT,
@@ -255,6 +255,7 @@ class SuggestionEditStateContent(BaseSuggestion):
 
         return suggestion
 
+
 SUGGESTION_TYPE_TO_DOMAIN_CLASS = {
-    suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT: SuggestionEditStateContent
+    suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT: SuggestionEditStateContent # pylint: disable=line-too-long
 }

--- a/core/domain/suggestion_domain_test.py
+++ b/core/domain/suggestion_domain_test.py
@@ -84,7 +84,7 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
     def test_from_dict_suggestion_edit_state_content(self):
         observed_suggestion = (
             suggestion_domain.SuggestionEditStateContent.from_dict(
-            self.suggestion_dict))
+                self.suggestion_dict))
         self.assertDictEqual(
             observed_suggestion.to_dict(), self.suggestion_dict)
         self.assertIsInstance(

--- a/core/domain/suggestion_domain_test.py
+++ b/core/domain/suggestion_domain_test.py
@@ -71,6 +71,12 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
         self.assertDictEqual(
             observed_suggestion.to_dict(), expected_suggestion_dict)
 
+    def test_from_dict_base_suggestion(self):
+        observed_suggestion = suggestion_domain.BaseSuggestion.from_dict(
+            self.suggestion_dict)
+        self.assertDictEqual(
+            observed_suggestion.to_dict(), self.suggestion_dict)
+
     def test_get_model_corresponding_to_suggestion(self):
         self.assertEqual(
             suggestion_domain.get_model_corresponding_to_suggestion(
@@ -91,6 +97,15 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
 
         self.assertDictEqual(
             observed_suggestion.to_dict(), expected_suggestion_dict)
+
+    def test_from_dict_suggestion_edit_state_content(self):
+        observed_suggestion = (
+            suggestion_domain.SuggestionEditStateContent.from_dict(
+            self.suggestion_dict))
+        self.assertDictEqual(
+            observed_suggestion.to_dict(), self.suggestion_dict)
+        self.assertIsInstance(
+            observed_suggestion, suggestion_domain.SuggestionEditStateContent)
 
     class MockExploration(object):
         """Mocks an exploration. To be used only for testing."""

--- a/core/domain/suggestion_domain_test.py
+++ b/core/domain/suggestion_domain_test.py
@@ -72,21 +72,9 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
             observed_suggestion.to_dict(), expected_suggestion_dict)
 
     def test_get_model_corresponding_to_suggestion(self):
-        expected_suggestion_dict = self.suggestion_dict
-
-        observed_suggestion = suggestion_domain.BaseSuggestion(
-            expected_suggestion_dict['suggestion_id'],
-            expected_suggestion_dict['suggestion_type'],
-            expected_suggestion_dict['target_type'],
-            expected_suggestion_dict['target_id'],
-            expected_suggestion_dict['target_version_at_submission'],
-            expected_suggestion_dict['status'], self.author_id,
-            self.assigned_reviewer_id, self.reviewer_id,
-            expected_suggestion_dict['change_cmd'],
-            expected_suggestion_dict['score_category'])
         self.assertEqual(
             suggestion_domain.get_model_corresponding_to_suggestion(
-                observed_suggestion.suggestion_type),
+                suggestion_models.SUGGESTION_EDIT_STATE_CONTENT),
             suggestion_domain.SuggestionEditStateContent)
 
     def test_create_suggestion_edit_state_content(self):

--- a/core/domain/suggestion_domain_test.py
+++ b/core/domain/suggestion_domain_test.py
@@ -14,10 +14,12 @@
 
 """Tests for suggestion domain objects."""
 
+from core.domain import exp_domain
 from core.domain import exp_services
 from core.domain import suggestion_domain
 from core.platform import models
 from core.tests import test_utils
+import utils
 
 (suggestion_models,) = models.Registry.import_models([models.NAMES.suggestion])
 
@@ -108,6 +110,8 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
     def test_validate_suggestion_edit_state_content(self):
         expected_suggestion_dict = self.suggestion_dict
         expected_suggestion_dict['change_cmd'] = {
+            'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+            'property_name': exp_domain.STATE_PROPERTY_CONTENT,
             'state_name': 'state_1'
         }
         suggestion = suggestion_domain.SuggestionEditStateContent(
@@ -122,9 +126,11 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
         with self.swap(
             exp_services, 'get_exploration_by_id',
             self.mock_get_exploration_by_id):
-            self.assertTrue(suggestion.validate())
+            suggestion.validate()
 
         expected_suggestion_dict['change_cmd'] = {
+            'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+            'property_name': exp_domain.STATE_PROPERTY_CONTENT,
             'state_name': 'state_unknown'
         }
         suggestion = suggestion_domain.SuggestionEditStateContent(
@@ -138,4 +144,7 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
         with self.swap(
             exp_services, 'get_exploration_by_id',
             self.mock_get_exploration_by_id):
-            self.assertFalse(suggestion.validate())
+            with self.assertRaisesRegexp(
+                utils.ValidationError, 'Expected state_unknown to be a valid '
+                                       'state name'):
+                suggestion.validate()

--- a/core/domain/suggestion_domain_test.py
+++ b/core/domain/suggestion_domain_test.py
@@ -71,6 +71,24 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
         self.assertDictEqual(
             observed_suggestion.to_dict(), expected_suggestion_dict)
 
+    def test_get_model_corresponding_to_suggestion(self):
+        expected_suggestion_dict = self.suggestion_dict
+
+        observed_suggestion = suggestion_domain.BaseSuggestion(
+            expected_suggestion_dict['suggestion_id'],
+            expected_suggestion_dict['suggestion_type'],
+            expected_suggestion_dict['target_type'],
+            expected_suggestion_dict['target_id'],
+            expected_suggestion_dict['target_version_at_submission'],
+            expected_suggestion_dict['status'], self.author_id,
+            self.assigned_reviewer_id, self.reviewer_id,
+            expected_suggestion_dict['change_cmd'],
+            expected_suggestion_dict['score_category'])
+        self.assertEqual(
+            suggestion_domain.get_model_corresponding_to_suggestion(
+                observed_suggestion.suggestion_type),
+            suggestion_domain.SuggestionEditStateContent)
+
     def test_create_suggestion_edit_state_content(self):
         expected_suggestion_dict = self.suggestion_dict
 
@@ -85,7 +103,6 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
 
         self.assertDictEqual(
             observed_suggestion.to_dict(), expected_suggestion_dict)
-
 
     class MockExploration(object):
         """Mocks an exploration. To be used only for testing."""

--- a/core/domain/suggestion_domain_test.py
+++ b/core/domain/suggestion_domain_test.py
@@ -41,7 +41,7 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
             self.ASSIGNED_REVIEWER_EMAIL)
         self.suggestion_dict = {
             'suggestion_id': 'exploration.exp1.thread1',
-            'suggestion_type': suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
+            'suggestion_type': suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT, # pylint: disable=line-too-long
             'target_type': suggestion_models.TARGET_TYPE_EXPLORATION,
             'target_id': 'exp1',
             'target_version_at_submission': 1,
@@ -53,35 +53,16 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
             'score_category': 'translation.English'
         }
 
-    def test_to_dict_base_suggestion(self):
+    def test_base_class_methods_raises_error(self):
+        with self.assertRaisesRegexp(
+            NotImplementedError,
+            'Subclasses of BaseSuggestion should implement __init__.'):
+            suggestion_domain.BaseSuggestion()
 
-        expected_suggestion_dict = self.suggestion_dict
-
-        observed_suggestion = suggestion_domain.BaseSuggestion(
-            expected_suggestion_dict['suggestion_id'],
-            expected_suggestion_dict['suggestion_type'],
-            expected_suggestion_dict['target_type'],
-            expected_suggestion_dict['target_id'],
-            expected_suggestion_dict['target_version_at_submission'],
-            expected_suggestion_dict['status'], self.author_id,
-            self.assigned_reviewer_id, self.reviewer_id,
-            expected_suggestion_dict['change_cmd'],
-            expected_suggestion_dict['score_category'])
-
-        self.assertDictEqual(
-            observed_suggestion.to_dict(), expected_suggestion_dict)
-
-    def test_from_dict_base_suggestion(self):
-        observed_suggestion = suggestion_domain.BaseSuggestion.from_dict(
-            self.suggestion_dict)
-        self.assertDictEqual(
-            observed_suggestion.to_dict(), self.suggestion_dict)
-
-    def test_get_model_corresponding_to_suggestion(self):
-        self.assertEqual(
-            suggestion_domain.get_model_corresponding_to_suggestion(
-                suggestion_models.SUGGESTION_EDIT_STATE_CONTENT),
-            suggestion_domain.SuggestionEditStateContent)
+        with self.assertRaisesRegexp(
+            NotImplementedError,
+            'Subclasses of BaseSuggestion should implement from_dict.'):
+            suggestion_domain.BaseSuggestion.from_dict()
 
     def test_create_suggestion_edit_state_content(self):
         expected_suggestion_dict = self.suggestion_dict

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -16,23 +16,13 @@
 subclasses for each type of suggestion
 """
 
+from constants import constants
 from core.domain import exp_domain
 from core.domain import exp_services
 from core.platform import models
 import utils
 
 (suggestion_models,) = models.Registry.import_models([models.NAMES.suggestion])
-
-ALL_CATEGORIES = ['Algebra', 'Algorithms', 'Architecture', 'Arithmetic',
-                  'Art', 'Astronomy', 'Biology', 'Business', 'Calculus',
-                  'Chemistry', 'Combinatorics', 'Computing', 'Economics',
-                  'Education', 'Engineering', 'English', 'Environment',
-                  'Gaulish', 'Geography', 'Geometry', 'Government',
-                  'Graph Theory', 'History', 'Languages', 'Latin', 'Law',
-                  'Logic', 'Mathematics', 'Medicine', 'Music', 'Philosophy',
-                  'Physics', 'Poetry', 'Probability', 'Programming', 'Puzzles',
-                  'Reading', 'Spanish', 'Sport', 'Statistics', 'Trigonometry',
-                  'Welcome']
 
 
 class BaseSuggestion(object):
@@ -85,6 +75,25 @@ class BaseSuggestion(object):
         """Return a Suggestion object of type from a dict."""
         raise NotImplementedError(
             'Subclasses of BaseSuggestion should implement from_dict.')
+
+    def get_score_type(self):
+        """Returns the first part of the score category.
+
+        Returns:
+            str. The first part of the score category.
+        """
+        return self.score_category.split(
+            suggestion_models.SCORE_CATEGORY_DELIMITER)[0]
+
+    def get_score_sub_type(self):
+        """Returns the second part of the score category.
+
+        Returns:
+            str. The second part of the score category.
+        """
+        return self.score_category.split(
+            suggestion_models.SCORE_CATEGORY_DELIMITER)[1]
+
 
     def validate(self):
         """Validates the BaseSuggestion object. Each subclass must implement
@@ -167,14 +176,10 @@ class BaseSuggestion(object):
                     self.score_category))
 
 
-        if (
-                self.score_category.split(
-                    suggestion_models.SCORE_CATEGORY_DELIMITER)[0] not in
-                suggestion_models.SCORE_TYPE_CHOICES):
+        if self.get_score_type() not in suggestion_models.SCORE_TYPE_CHOICES:
             raise utils.ValidationError(
                 'Expected the first part of score_category to be among allowed'
-                ' choices, received %s' % self.score_category.split(
-                    suggestion_models.SCORE_CATEGORY_DELIMITER)[0])
+                ' choices, received %s' % self.get_score_type())
 
     def accept(self):
         """Accepts the suggestion. Each subclass must implement this function.
@@ -218,24 +223,17 @@ class SuggestionEditStateContent(BaseSuggestion):
         """
         super(SuggestionEditStateContent, self).validate()
 
-        if (
-                self.score_category.split(
-                    suggestion_models.SCORE_CATEGORY_DELIMITER)[0] !=
-                suggestion_models.SCORE_TYPE_CONTENT):
+        if self.get_score_type() != suggestion_models.SCORE_TYPE_CONTENT:
             raise utils.ValidationError(
                 'Expected the first part of score_category to be %s '
                 ', received %s' % (
                     suggestion_models.SCORE_TYPE_CONTENT,
-                    self.score_category.split(
-                        suggestion_models.SCORE_CATEGORY_DELIMITER)[0]))
-        if (
-                self.score_category.split(
-                    suggestion_models.SCORE_CATEGORY_DELIMITER)[1] not in
-                ALL_CATEGORIES):
+                    self.get_score_type()))
+
+        if self.get_score_sub_type() not in constants.ALL_CATEGORIES:
             raise utils.ValidationError(
                 'Expected the second part of score_category to be a valid'
-                ' category, received %s' % self.score_category.split(
-                    suggestion_models.SCORE_CATEGORY_DELIMITER)[1])
+                ' category, received %s' % self.get_score_sub_type())
 
         if 'cmd' not in self.change_cmd:
             raise utils.ValidationError(

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Registry for Oppia suggestions. Contains a BaseSuggestion class and
-subclasses for each type of suggestion
+subclasses for each type of suggestion.
 """
 
 from constants import constants

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -162,18 +162,18 @@ class BaseSuggestion(object):
                 self.score_category):
             raise utils.ValidationError(
                 'Expected score_category to be of the form'
-                ' score_type%sscore_sub_type, received %s' %
-                suggestion_models.SCORE_CATEGORY_DELIMITER, type(
-                    self.score_category))
+                ' score_type%sscore_sub_type, received %s' % (
+                suggestion_models.SCORE_CATEGORY_DELIMITER,
+                self.score_category))
 
         if (
                 len(self.score_category.split(
                     suggestion_models.SCORE_CATEGORY_DELIMITER))) != 2:
             raise utils.ValidationError(
                 'Expected score_category to be of the form'
-                ' score_type%sscore_sub_type, received %s' %
-                suggestion_models.SCORE_CATEGORY_DELIMITER, type(
-                    self.score_category))
+                ' score_type%sscore_sub_type, received %s' % (
+                suggestion_models.SCORE_CATEGORY_DELIMITER,
+                self.score_category))
 
 
         if self.get_score_type() not in suggestion_models.SCORE_TYPE_CHOICES:

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -215,7 +215,7 @@ class SuggestionEditStateContent(BaseSuggestion):
         """
         super(SuggestionEditStateContent, self).validate()
 
-         if (
+        if (
                 self.score_category.split(
                     suggestion_models.SCORE_CATEGORY_DELIMITER)[0] !=
                 suggestion_models.SCORE_TYPE_CONTENT):

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -163,8 +163,8 @@ class BaseSuggestion(object):
             raise utils.ValidationError(
                 'Expected score_category to be of the form'
                 ' score_type%sscore_sub_type, received %s' % (
-                suggestion_models.SCORE_CATEGORY_DELIMITER,
-                self.score_category))
+                    suggestion_models.SCORE_CATEGORY_DELIMITER,
+                    self.score_category))
 
         if (
                 len(self.score_category.split(
@@ -172,8 +172,8 @@ class BaseSuggestion(object):
             raise utils.ValidationError(
                 'Expected score_category to be of the form'
                 ' score_type%sscore_sub_type, received %s' % (
-                suggestion_models.SCORE_CATEGORY_DELIMITER,
-                self.score_category))
+                    suggestion_models.SCORE_CATEGORY_DELIMITER,
+                    self.score_category))
 
 
         if self.get_score_type() not in suggestion_models.SCORE_TYPE_CHOICES:

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -34,6 +34,7 @@ ALL_CATEGORIES = ['Algebra', 'Algorithms', 'Architecture', 'Arithmetic',
                   'Reading', 'Spanish', 'Sport', 'Statistics', 'Trigonometry',
                   'Welcome']
 
+
 class BaseSuggestion(object):
     """Base class for a suggestion.
 

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -24,13 +24,15 @@ import utils
 (suggestion_models,) = models.Registry.import_models([models.NAMES.suggestion])
 
 ALL_CATEGORIES = ['Algebra', 'Algorithms', 'Architecture', 'Arithmetic',
-    'Art', 'Astronomy', 'Biology', 'Business', 'Calculus', 'Chemistry',
-    'Combinatorics', 'Computing', 'Economics', 'Education', 'Engineering',
-    'English', 'Environment', 'Gaulish', 'Geography', 'Geometry', 'Government',
-    'Graph Theory', 'History', 'Languages', 'Latin', 'Law', 'Logic',
-    'Mathematics', 'Medicine', 'Music', 'Philosophy', 'Physics', 'Poetry',
-    'Probability', 'Programming', 'Puzzles', 'Reading', 'Spanish', 'Sport',
-    'Statistics', 'Trigonometry', 'Welcome']
+                  'Art', 'Astronomy', 'Biology', 'Business', 'Calculus',
+                  'Chemistry', 'Combinatorics', 'Computing', 'Economics',
+                  'Education', 'Engineering', 'English', 'Environment',
+                  'Gaulish', 'Geography', 'Geometry', 'Government',
+                  'Graph Theory', 'History', 'Languages', 'Latin', 'Law',
+                  'Logic', 'Mathematics', 'Medicine', 'Music', 'Philosophy',
+                  'Physics', 'Poetry', 'Probability', 'Programming', 'Puzzles',
+                  'Reading', 'Spanish', 'Sport', 'Statistics', 'Trigonometry',
+                  'Welcome']
 
 class BaseSuggestion(object):
     """Base class for a suggestion.
@@ -224,15 +226,14 @@ class SuggestionEditStateContent(BaseSuggestion):
                 ', received %s' % (
                     suggestion_models.SCORE_TYPE_CONTENT,
                     self.score_category.split(
-                    suggestion_models.SCORE_CATEGORY_DELIMITER)[0]))
+                        suggestion_models.SCORE_CATEGORY_DELIMITER)[0]))
         if (
                 self.score_category.split(
                     suggestion_models.SCORE_CATEGORY_DELIMITER)[1] not in
                 ALL_CATEGORIES):
             raise utils.ValidationError(
                 'Expected the second part of score_category to be a valid'
-                ' category, received %s' %
-                    self.score_category.split(
+                ' category, received %s' % self.score_category.split(
                     suggestion_models.SCORE_CATEGORY_DELIMITER)[1])
 
         if 'cmd' not in self.change_cmd:

--- a/core/domain/suggestion_registry_test.py
+++ b/core/domain/suggestion_registry_test.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for suggestion domain objects."""
+"""Tests for suggestion registry classes."""
 
 from core.domain import exp_domain
 from core.domain import exp_services
-from core.domain import suggestion_domain
+from core.domain import suggestion_registry
 from core.platform import models
 from core.tests import test_utils
 import utils
@@ -24,7 +24,7 @@ import utils
 (suggestion_models,) = models.Registry.import_models([models.NAMES.suggestion])
 
 
-class SuggestionDomainUnitTests(test_utils.GenericTestBase):
+class SuggestionRegistryUnitTests(test_utils.GenericTestBase):
     """Tests for the suggestion class."""
 
     AUTHOR_EMAIL = 'author@example.com'
@@ -32,7 +32,7 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
     ASSIGNED_REVIEWER_EMAIL = 'assigned_reviewer@example.com'
 
     def setUp(self):
-        super(SuggestionDomainUnitTests, self).setUp()
+        super(SuggestionRegistryUnitTests, self).setUp()
 
         self.signup(self.AUTHOR_EMAIL, 'author')
         self.author_id = self.get_user_id_from_email(self.AUTHOR_EMAIL)
@@ -43,7 +43,8 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
             self.ASSIGNED_REVIEWER_EMAIL)
         self.suggestion_dict = {
             'suggestion_id': 'exploration.exp1.thread1',
-            'suggestion_type': suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT, # pylint: disable=line-too-long
+            'suggestion_type': (
+                suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT),
             'target_type': suggestion_models.TARGET_TYPE_EXPLORATION,
             'target_id': 'exp1',
             'target_version_at_submission': 1,
@@ -52,24 +53,24 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
             'final_reviewer_id': self.reviewer_id,
             'assigned_reviewer_id': self.assigned_reviewer_id,
             'change_cmd': {},
-            'score_category': 'translation.English'
+            'score_category': 'content.Algebra'
         }
 
     def test_base_class_methods_raises_error(self):
         with self.assertRaisesRegexp(
             NotImplementedError,
             'Subclasses of BaseSuggestion should implement __init__.'):
-            suggestion_domain.BaseSuggestion()
+            suggestion_registry.BaseSuggestion()
 
         with self.assertRaisesRegexp(
             NotImplementedError,
             'Subclasses of BaseSuggestion should implement from_dict.'):
-            suggestion_domain.BaseSuggestion.from_dict()
+            suggestion_registry.BaseSuggestion.from_dict()
 
     def test_create_suggestion_edit_state_content(self):
         expected_suggestion_dict = self.suggestion_dict
 
-        observed_suggestion = suggestion_domain.SuggestionEditStateContent(
+        observed_suggestion = suggestion_registry.SuggestionEditStateContent(
             expected_suggestion_dict['suggestion_id'],
             expected_suggestion_dict['target_id'],
             expected_suggestion_dict['target_version_at_submission'],
@@ -83,12 +84,12 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
 
     def test_from_dict_suggestion_edit_state_content(self):
         observed_suggestion = (
-            suggestion_domain.SuggestionEditStateContent.from_dict(
+            suggestion_registry.SuggestionEditStateContent.from_dict(
                 self.suggestion_dict))
         self.assertDictEqual(
             observed_suggestion.to_dict(), self.suggestion_dict)
         self.assertIsInstance(
-            observed_suggestion, suggestion_domain.SuggestionEditStateContent)
+            observed_suggestion, suggestion_registry.SuggestionEditStateContent)
 
     class MockExploration(object):
         """Mocks an exploration. To be used only for testing."""
@@ -114,7 +115,7 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
             'property_name': exp_domain.STATE_PROPERTY_CONTENT,
             'state_name': 'state_1'
         }
-        suggestion = suggestion_domain.SuggestionEditStateContent(
+        suggestion = suggestion_registry.SuggestionEditStateContent(
             expected_suggestion_dict['suggestion_id'],
             expected_suggestion_dict['target_id'],
             expected_suggestion_dict['target_version_at_submission'],
@@ -133,7 +134,7 @@ class SuggestionDomainUnitTests(test_utils.GenericTestBase):
             'property_name': exp_domain.STATE_PROPERTY_CONTENT,
             'state_name': 'state_unknown'
         }
-        suggestion = suggestion_domain.SuggestionEditStateContent(
+        suggestion = suggestion_registry.SuggestionEditStateContent(
             expected_suggestion_dict['suggestion_id'],
             expected_suggestion_dict['target_id'],
             expected_suggestion_dict['target_version_at_submission'],

--- a/core/domain/suggestion_registry_test.py
+++ b/core/domain/suggestion_registry_test.py
@@ -82,6 +82,22 @@ class SuggestionRegistryUnitTests(test_utils.GenericTestBase):
         self.assertDictEqual(
             observed_suggestion.to_dict(), expected_suggestion_dict)
 
+    def test_get_score_part_helper_methods(self):
+        expected_suggestion_dict = self.suggestion_dict
+
+        suggestion = suggestion_registry.SuggestionEditStateContent(
+            expected_suggestion_dict['suggestion_id'],
+            expected_suggestion_dict['target_id'],
+            expected_suggestion_dict['target_version_at_submission'],
+            expected_suggestion_dict['status'], self.author_id,
+            self.assigned_reviewer_id, self.reviewer_id,
+            expected_suggestion_dict['change_cmd'],
+            expected_suggestion_dict['score_category'])
+
+        self.assertEqual(suggestion.get_score_type(), 'content')
+        self.assertEqual(suggestion.get_score_sub_type(), 'Algebra')
+
+
     def test_from_dict_suggestion_edit_state_content(self):
         observed_suggestion = (
             suggestion_registry.SuggestionEditStateContent.from_dict(

--- a/core/storage/suggestion/gae_models.py
+++ b/core/storage/suggestion/gae_models.py
@@ -48,16 +48,16 @@ STATUS_CHOICES = [
 ]
 
 # Constants defining various suggestion types.
-SUGGESTION_EDIT_STATE_CONTENT = 'edit_exploration_state_content'
+SUGGESTION_TYPE_EDIT_STATE_CONTENT = 'edit_exploration_state_content'
 
 SUGGESTION_TYPE_CHOICES = [
-    SUGGESTION_EDIT_STATE_CONTENT
+    SUGGESTION_TYPE_EDIT_STATE_CONTENT
 ]
 
 # Defines what is the minimum role required to review suggestions
 # of a particular type.
 SUGGESTION_MINIMUM_ROLE_FOR_REVIEW = {
-    SUGGESTION_EDIT_STATE_CONTENT: feconf.ROLE_ID_EXPLORATION_EDITOR
+    SUGGESTION_TYPE_EDIT_STATE_CONTENT: feconf.ROLE_ID_EXPLORATION_EDITOR
 }
 
 # Constants defining various contribution types.

--- a/core/storage/suggestion/gae_models_test.py
+++ b/core/storage/suggestion/gae_models_test.py
@@ -36,35 +36,35 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
     def setUp(self):
         super(SuggestionModelUnitTests, self).setUp()
         suggestion_models.SuggestionModel.create(
-            suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
+            suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_IN_REVIEW, 'author_1',
             'reviewer_1', 'reviewer_1', self.change_cmd, self.score_category,
             'exploration.exp1.thread_1')
         suggestion_models.SuggestionModel.create(
-            suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
+            suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_ACCEPTED, 'author_2',
             'reviewer_2', 'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp1.thread_2')
         suggestion_models.SuggestionModel.create(
-            suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
+            suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_ACCEPTED, 'author_2',
             'reviewer_3', 'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp1.thread_3')
         suggestion_models.SuggestionModel.create(
-            suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
+            suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_REJECTED, 'author_2',
             'reviewer_2', 'reviewer_3', self.change_cmd, self.score_category,
             'exploration.exp1.thread_4')
         suggestion_models.SuggestionModel.create(
-            suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
+            suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_REJECTED, 'author_3',
@@ -78,7 +78,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
 
     def test_create_new_object_succesfully(self):
         suggestion_models.SuggestionModel.create(
-            suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
+            suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_IN_REVIEW, 'author_3',
@@ -93,7 +93,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
 
         self.assertEqual(
             observed_suggestion_model.suggestion_type,
-            suggestion_models.SUGGESTION_EDIT_STATE_CONTENT)
+            suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT)
         self.assertEqual(
             observed_suggestion_model.target_type,
             suggestion_models.TARGET_TYPE_EXPLORATION)
@@ -119,7 +119,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             Exception, 'There is already a suggestion with the given id: '
                        'exploration.exp1.thread_1'):
             suggestion_models.SuggestionModel.create(
-                suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
+                suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
                 suggestion_models.TARGET_TYPE_EXPLORATION,
                 self.target_id, self.target_version_at_submission,
                 suggestion_models.STATUS_IN_REVIEW, 'author_3',
@@ -129,7 +129,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
     def test_get_suggestions_by_type(self):
         self.assertEqual(
             len(suggestion_models.SuggestionModel.get_suggestions_by_type(
-                suggestion_models.SUGGESTION_EDIT_STATE_CONTENT)), 5)
+                suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT)), 5)
         with self.assertRaisesRegexp(
             Exception, 'Value \'invalid_suggestion_type\' for property'
                        ' suggestion_type is not an allowed choice'):


### PR DESCRIPTION
## Explanation
Reference: https://github.com/oppia/oppia/pull/4982#discussion_r191069473

As noted that the validation can be kept specific to a type of suggestion by creating sub classes of a BaseSuggestion class for various types of suggestions. This PR implements a SuggestionEditStateContent class which is a sub class of BaseSuggestion. 

PTAL @anmolshkl and @seanlip 

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
