### PR TITLE
Fix #5000 add check for response status in get_json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,24 +16,24 @@ branches:
 
 env:
   matrix:
-    - RUN_LINT=true
-    - RUN_FRONTEND_TESTS=true
+    # - RUN_LINT=true
+    # - RUN_FRONTEND_TESTS=true
     - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=false EXCLUDE_LOAD_TESTS=true
     # TODO(sll): Reinstate this when we can get it to run in reasonable time.
     # - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=true
     # TODO(sll): Reinstate this when the load tests are more reliable.
     # - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=true EXCLUDE_LOAD_TESTS=false
-    - RUN_E2E_TESTS_ACCESSIBILITY=true
-    - RUN_E2E_TESTS_COLLECTIONS=true
-    - RUN_E2E_TESTS_EDITOR_AND_PLAYER=true
-    - RUN_E2E_TESTS_STATE_EDITOR=true
-    - RUN_E2E_TESTS_EDITOR_FEATURES=true
-    - RUN_E2E_TESTS_EMBEDDING=true
-    - RUN_E2E_TESTS_EXTENSIONS=true
+    # - RUN_E2E_TESTS_ACCESSIBILITY=true
+    # - RUN_E2E_TESTS_COLLECTIONS=true
+    # - RUN_E2E_TESTS_EDITOR_AND_PLAYER=true
+    # - RUN_E2E_TESTS_STATE_EDITOR=true
+    # - RUN_E2E_TESTS_EDITOR_FEATURES=true
+    # - RUN_E2E_TESTS_EMBEDDING=true
+    # - RUN_E2E_TESTS_EXTENSIONS=true
     # TODO(sll): Reinstate this once the tests for the learner dashboard are fixed.
     # - RUN_E2E_TESTS_LEARNER_DASHBOARD=true
-    - RUN_E2E_TESTS_LIBRARY=true
-    - RUN_E2E_TESTS_USERS=true
+    # - RUN_E2E_TESTS_LIBRARY=true
+    # - RUN_E2E_TESTS_USERS=true
 
 matrix:
   allow_failures: []

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,24 +16,24 @@ branches:
 
 env:
   matrix:
-    # - RUN_LINT=true
-    # - RUN_FRONTEND_TESTS=true
+    - RUN_LINT=true
+    - RUN_FRONTEND_TESTS=true
     - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=false EXCLUDE_LOAD_TESTS=true
     # TODO(sll): Reinstate this when we can get it to run in reasonable time.
     # - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=true
     # TODO(sll): Reinstate this when the load tests are more reliable.
     # - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=true EXCLUDE_LOAD_TESTS=false
-    # - RUN_E2E_TESTS_ACCESSIBILITY=true
-    # - RUN_E2E_TESTS_COLLECTIONS=true
-    # - RUN_E2E_TESTS_EDITOR_AND_PLAYER=true
-    # - RUN_E2E_TESTS_STATE_EDITOR=true
-    # - RUN_E2E_TESTS_EDITOR_FEATURES=true
-    # - RUN_E2E_TESTS_EMBEDDING=true
-    # - RUN_E2E_TESTS_EXTENSIONS=true
+    - RUN_E2E_TESTS_ACCESSIBILITY=true
+    - RUN_E2E_TESTS_COLLECTIONS=true
+    - RUN_E2E_TESTS_EDITOR_AND_PLAYER=true
+    - RUN_E2E_TESTS_STATE_EDITOR=true
+    - RUN_E2E_TESTS_EDITOR_FEATURES=true
+    - RUN_E2E_TESTS_EMBEDDING=true
+    - RUN_E2E_TESTS_EXTENSIONS=true
     # TODO(sll): Reinstate this once the tests for the learner dashboard are fixed.
     # - RUN_E2E_TESTS_LEARNER_DASHBOARD=true
-    # - RUN_E2E_TESTS_LIBRARY=true
-    # - RUN_E2E_TESTS_USERS=true
+    - RUN_E2E_TESTS_LIBRARY=true
+    - RUN_E2E_TESTS_USERS=true
 
 matrix:
   allow_failures: []

--- a/core/controllers/email_dashboard_test.py
+++ b/core/controllers/email_dashboard_test.py
@@ -92,28 +92,26 @@ class EmailDashboardDataHandlerTests(test_utils.GenericTestBase):
         self.login(self.SUBMITTER_EMAIL)
         csrf_token = self.get_csrf_token_from_response(
             self.testapp.get('/emaildashboard'))
-        with self.assertRaisesRegexp(Exception, '400 Invalid input for query.'):
-            self.post_json(
-                '/emaildashboarddatahandler', {
-                    'data': {
-                        'has_not_logged_in_for_n_days': 2,
-                        'inactive_in_last_n_days': 5,
-                        'created_at_least_n_exps': 1,
-                        'created_fewer_than_n_exps': None,
-                        'edited_at_least_n_exps': None,
-                        'fake_key': 2
-                    }}, csrf_token)
+        self.post_json(
+            '/emaildashboarddatahandler', {
+                'data': {
+                    'has_not_logged_in_for_n_days': 2,
+                    'inactive_in_last_n_days': 5,
+                    'created_at_least_n_exps': 1,
+                    'created_fewer_than_n_exps': 'None',
+                    'edited_at_least_n_exps': None,
+                    'fake_key': 2
+                }}, csrf_token, expect_errors=True, expected_status_int=400)
 
-        with self.assertRaisesRegexp(Exception, '400 Invalid input for query.'):
-            self.post_json(
-                '/emaildashboarddatahandler', {
-                    'data': {
-                        'has_not_logged_in_for_n_days': 2,
-                        'inactive_in_last_n_days': 5,
-                        'created_at_least_n_exps': 'invalid_value',
-                        'created_fewer_than_n_exps': 'None',
-                        'edited_at_least_n_exps': None
-                    }}, csrf_token)
+        self.post_json(
+            '/emaildashboarddatahandler', {
+                'data': {
+                    'has_not_logged_in_for_n_days': 2,
+                    'inactive_in_last_n_days': 5,
+                    'created_at_least_n_exps': 'invalid_value',
+                    'created_fewer_than_n_exps': 'None',
+                    'edited_at_least_n_exps': None
+                }}, csrf_token, expect_errors=True, expected_status_int=400)
         self.logout()
 
 

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -420,6 +420,9 @@ tags: []
         # the response. However this expected status is verified only when
         # expect_errors=False. For other situations we need to explicitly check
         # the status.
+        # Reference URL:
+        # https://github.com/Pylons/webtest/blob/
+        # bf77326420b628c9ea5431432c7e171f88c5d874/webtest/app.py#L1119
         self.assertEqual(json_response.status_int, expected_status_int)
         return self._parse_json_response(
             json_response, expect_errors=expect_errors)
@@ -438,6 +441,9 @@ tags: []
         # the response. However this expected status is verified only when
         # expect_errors=False. For other situations we need to explicitly check
         # the status.
+        # Reference URL:
+        # https://github.com/Pylons/webtest/blob/
+        # bf77326420b628c9ea5431432c7e171f88c5d874/webtest/app.py#L1119
         self.assertEqual(json_response.status_int, expected_status_int)
 
         return self._parse_json_response(
@@ -502,7 +508,8 @@ tags: []
         # expect_errors=False. For other situations we need to explicitly check
         # the status.
         # Reference URL:
-        # https://docs.pylonsproject.org/projects/webtest/en/latest/api.html
+        # https://github.com/Pylons/webtest/blob/
+        # bf77326420b628c9ea5431432c7e171f88c5d874/webtest/app.py#L1119
         self.assertEqual(json_response.status_int, expected_status_int)
         return self._parse_json_response(
             json_response, expect_errors=expect_errors)

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -422,7 +422,7 @@ tags: []
         # the status.
         # Reference URL:
         # https://github.com/Pylons/webtest/blob/
-        # bf77326420b628c9ea5431432c7e171f88c5d874/webtest/app.py#L1119
+        # bf77326420b628c9ea5431432c7e171f88c5d874/webtest/app.py#L1119 .
         self.assertEqual(json_response.status_int, expected_status_int)
         return self._parse_json_response(
             json_response, expect_errors=expect_errors)
@@ -443,7 +443,7 @@ tags: []
         # the status.
         # Reference URL:
         # https://github.com/Pylons/webtest/blob/
-        # bf77326420b628c9ea5431432c7e171f88c5d874/webtest/app.py#L1119
+        # bf77326420b628c9ea5431432c7e171f88c5d874/webtest/app.py#L1119 .
         self.assertEqual(json_response.status_int, expected_status_int)
 
         return self._parse_json_response(
@@ -509,7 +509,7 @@ tags: []
         # the status.
         # Reference URL:
         # https://github.com/Pylons/webtest/blob/
-        # bf77326420b628c9ea5431432c7e171f88c5d874/webtest/app.py#L1119
+        # bf77326420b628c9ea5431432c7e171f88c5d874/webtest/app.py#L1119 .
         self.assertEqual(json_response.status_int, expected_status_int)
         return self._parse_json_response(
             json_response, expect_errors=expect_errors)

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -448,7 +448,8 @@ tags: []
             upload_files=None, headers=None):
         json_response = app.post(
             str(url), data, expect_errors=expect_errors,
-            upload_files=upload_files, headers=headers)
+            upload_files=upload_files, headers=headers,
+            status=expected_status_int)
         return json_response
 
     def post_email(

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -416,6 +416,10 @@ tags: []
             url, params, expect_errors=expect_errors,
             status=expected_status_int)
 
+        # Testapp takes in a status parameter which is the expected status of
+        # the response. However this expected status is verified only when
+        # expect_errors=False. For other situations we need to explicitly check
+        # the status.
         self.assertEqual(json_response.status_int, expected_status_int)
         return self._parse_json_response(
             json_response, expect_errors=expect_errors)
@@ -430,6 +434,11 @@ tags: []
         json_response = self._send_post_request(
             self.testapp, url, data, expect_errors, expected_status_int,
             upload_files)
+        # Testapp takes in a status parameter which is the expected status of
+        # the response. However this expected status is verified only when
+        # expect_errors=False. For other situations we need to explicitly check
+        # the status.
+        self.assertEqual(json_response.status_int, expected_status_int)
 
         return self._parse_json_response(
             json_response, expect_errors=expect_errors)
@@ -440,7 +449,6 @@ tags: []
         json_response = app.post(
             str(url), data, expect_errors=expect_errors,
             upload_files=upload_files, headers=headers)
-        self.assertEqual(json_response.status_int, expected_status_int)
         return json_response
 
     def post_email(
@@ -488,6 +496,10 @@ tags: []
         json_response = self.testapp.put(
             str(url), data, expect_errors=expect_errors)
 
+        # Testapp takes in a status parameter which is the expected status of
+        # the response. However this expected status is verified only when
+        # expect_errors=False. For other situations we need to explicitly check
+        # the status.
         self.assertEqual(json_response.status_int, expected_status_int)
         return self._parse_json_response(
             json_response, expect_errors=expect_errors)

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -501,6 +501,8 @@ tags: []
         # the response. However this expected status is verified only when
         # expect_errors=False. For other situations we need to explicitly check
         # the status.
+        # Reference URL:
+        # https://docs.pylonsproject.org/projects/webtest/en/latest/api.html
         self.assertEqual(json_response.status_int, expected_status_int)
         return self._parse_json_response(
             json_response, expect_errors=expect_errors)

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -415,6 +415,8 @@ tags: []
         json_response = self.testapp.get(
             url, params, expect_errors=expect_errors,
             status=expected_status_int)
+
+        self.assertEqual(json_response.status_int, expected_status_int)
         return self._parse_json_response(
             json_response, expect_errors=expect_errors)
 


### PR DESCRIPTION
## Explanation
Fix #5000 

Want to audit all locations where the tests fail after this change. Will fix them and then request for review.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
