### PR TITLE
Fix part of #3836: Milestone 1, introduce new calculation to aggregate top unresolved answers.

### DIFF
--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -968,3 +968,28 @@ class StateAnswerStatisticsHandler(EditorHandler):
             'answers': stats_services.get_top_state_answer_stats_multi(
                 exploration_id, current_exploration.states)
         })
+
+
+class TopUnresolvedAnswersHandler(EditorHandler):
+    """Returns a list of top N unresolved answers."""
+
+    @acl_decorators.can_edit_exploration
+    def get(self):
+        """Handles GET requests for unresolved answers."""
+        try:
+            exploration_id = self.payload.get('exploration_id')
+            state_name = self.payload.get('state_name')
+        except utils.ValidationError as e:
+            # We leave any pre-existing draft changes in the datastore.
+            raise self.InvalidInputException(e)
+
+        try:
+            unresolved_answers_with_frequency = (
+                stats_services.get_top_state_unresolved_answers(
+                    exploration_id, state_name))
+        except Exception:
+            raise self.PageNotFoundException
+
+        self.render_json({
+            'unresolved_answers': unresolved_answers_with_frequency
+        })

--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -979,9 +979,8 @@ class TopUnresolvedAnswersHandler(EditorHandler):
         try:
             exploration_id = self.payload.get('exploration_id')
             state_name = self.payload.get('state_name')
-        except utils.ValidationError as e:
-            # We leave any pre-existing draft changes in the datastore.
-            raise self.InvalidInputException(e)
+        except Exception:
+            raise self.PageNotFoundException
 
         try:
             unresolved_answers_with_frequency = (

--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -974,20 +974,16 @@ class TopUnresolvedAnswersHandler(EditorHandler):
     """Returns a list of top N unresolved answers."""
 
     @acl_decorators.can_edit_exploration
-    def get(self):
+    def get(self, exploration_id):
         """Handles GET requests for unresolved answers."""
         try:
-            exploration_id = self.payload.get('exploration_id')
             state_name = self.payload.get('state_name')
         except Exception:
             raise self.PageNotFoundException
 
-        try:
-            unresolved_answers_with_frequency = (
-                stats_services.get_top_state_unresolved_answers(
-                    exploration_id, state_name))
-        except Exception:
-            raise self.PageNotFoundException
+        unresolved_answers_with_frequency = (
+            stats_services.get_top_state_unresolved_answers(
+                exploration_id, state_name))
 
         self.render_json({
             'unresolved_answers': unresolved_answers_with_frequency

--- a/core/domain/stats_jobs_continuous.py
+++ b/core/domain/stats_jobs_continuous.py
@@ -246,6 +246,10 @@ class InteractionAnswerSummariesMRJobManager(
             'submitted_answer_list': submitted_answer_list
         }
 
+        # NOTE: The answers stored in submitted_answers_list must be sorted
+        # according to the chronological order of their submission otherwise
+        # TopNUnresolvedAnswersByFrequency calculation will output invalid
+        # results.
         state_answers_models = stats_models.StateAnswersModel.get_multi(
             item_ids)
         for state_answers_model in state_answers_models:

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -623,6 +623,29 @@ def get_top_state_answer_stats(exploration_id, state_name):
     ]
 
 
+def get_top_state_unresolved_answers(exploration_id, state_name):
+    """Fetches the top unresolved answers for the given state_name in the
+    corresponding exploration. Only answers that occur with frequency >=
+    STATE_ANSWER_STATS_MIN_FREQUENCY are returned.
+
+    Args:
+        exploration_id: str. The exploration ID.
+        state_name: str. The name of the state to fetch answers for.
+
+    Returns:
+        list(*). A list of the top 10 answers, sorted by decreasing frequency.
+    """
+    calculation_output = (
+        _get_calc_output(
+            exploration_id, state_name, 'TopNUnresolvedAnswersByFrequency')
+        .calculation_output.to_raw_type())
+    return [
+        {'answer': output['answer'], 'frequency': output['frequency']}
+        for output in calculation_output
+        if output['frequency'] >= feconf.STATE_ANSWER_STATS_MIN_FREQUENCY
+    ]
+
+
 def get_top_state_answer_stats_multi(exploration_id, state_names):
     """Fetches the top (at most) 10 answers from each given state_name in the
     corresponding exploration. Only answers that occur with frequency >=

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -480,6 +480,11 @@ def get_visualizations_info(exp_id, state_name, interaction_id):
         if calc_output_domain_object is None:
             continue
 
+        # Don't show top unresolved answers calculation ouutput in stats of
+        # exploration.
+        if calculation_id == 'TopNUnresolvedAnswersByFrequency':
+            continue
+
         # If the output was associated with a different interaction ID, skip the
         # results. This filtering step is needed since the same calculation_id
         # can be shared across multiple interaction types.

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -470,6 +470,11 @@ def get_visualizations_info(exp_id, state_name, interaction_id):
 
     calculation_ids_to_outputs = {}
     for calculation_id in calculation_ids:
+        # Don't show top unresolved answers calculation ouutput in stats of
+        # exploration.
+        if calculation_id == 'TopNUnresolvedAnswersByFrequency':
+            continue
+
         # This is None if the calculation job has not yet been run for this
         # state.
         calc_output_domain_object = _get_calc_output(
@@ -478,11 +483,6 @@ def get_visualizations_info(exp_id, state_name, interaction_id):
         # If the calculation job has not yet been run for this state, we simply
         # exclude the corresponding visualization results.
         if calc_output_domain_object is None:
-            continue
-
-        # Don't show top unresolved answers calculation ouutput in stats of
-        # exploration.
-        if calculation_id == 'TopNUnresolvedAnswersByFrequency':
             continue
 
         # If the output was associated with a different interaction ID, skip the

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -1261,7 +1261,9 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             self._record_answer('Answer A')
             self._run_answer_summaries_aggregator()
             visualizations = self._get_visualizations()
-            self.assertEqual(len(visualizations), 1)
+            # There are two visualizations for TextInput. One for top answers
+            # and second is for top unresolved answers.
+            self.assertEqual(len(visualizations), 2)
 
             visualization = visualizations[0]
             self.assertEqual(
@@ -1273,7 +1275,10 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             self._record_answer('Answer A')
             self._run_answer_summaries_aggregator()
             visualizations = self._get_visualizations()
-            self.assertEqual(len(visualizations), 1)
+
+            # There are two visualizations for TextInput. One for top answers
+            # and second is for top unresolved answers.
+            self.assertEqual(len(visualizations), 2)
 
             visualization = visualizations[0]
             self.assertEqual(visualization['id'], 'FrequencyTable')
@@ -1292,7 +1297,9 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             self._record_answer('Answer A')
             self._run_answer_summaries_aggregator()
             visualizations = self._get_visualizations()
-            self.assertEqual(len(visualizations), 1)
+            # There are two visualizations for TextInput. One for top answers
+            # and second is for top unresolved answers.
+            self.assertEqual(len(visualizations), 2)
 
             visualization = visualizations[0]
             self.assertEqual(visualization['id'], 'FrequencyTable')
@@ -1373,7 +1380,9 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             self._record_answer('Answer A')
             self._rerun_answer_summaries_aggregator()
             visualizations = self._get_visualizations()
-            self.assertEqual(len(visualizations), 1)
+            # There are two visualizations for TextInput. One for top answers
+            # and second is for top unresolved answers.
+            self.assertEqual(len(visualizations), 2)
 
             visualization = visualizations[0]
             # The latest data should include all submitted answers.
@@ -1397,7 +1406,9 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
 
             self._run_answer_summaries_aggregator()
             visualizations = self._get_visualizations()
-            self.assertEqual(len(visualizations), 1)
+            # There are two visualizations for TextInput. One for top answers
+            # and second is for top unresolved answers.
+            self.assertEqual(len(visualizations), 2)
 
             visualization = visualizations[0]
             # The latest data should include all submitted answers.

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -1505,6 +1505,8 @@ class StateAnswersStatisticsTest(test_utils.GenericTestBase):
         self.assertEqual(
             self.count_jobs_in_taskqueue(
                 taskqueue_services.QUEUE_NAME_CONTINUOUS_JOBS), 0)
+        ModifiedInteractionAnswerSummariesAggregator.stop_computation(
+            feconf.SYSTEM_COMMITTER_ID)
 
     def setUp(self):
         super(StateAnswersStatisticsTest, self).setUp()
@@ -1541,6 +1543,20 @@ class StateAnswersStatisticsTest(test_utils.GenericTestBase):
                 {'answer': 'A', 'frequency': 2},
                 {'answer': 'C', 'frequency': 1},
                 {'answer': 'E', 'frequency': 1}
+            ])
+
+        self._record_answer(
+            'A', classification_category=exp_domain.EXPLICIT_CLASSIFICATION)
+        self._record_answer(
+            'E', classification_category=exp_domain.EXPLICIT_CLASSIFICATION)
+        self._run_answer_summaries_aggregator()
+
+        with self.swap(feconf, 'STATE_ANSWER_STATS_MIN_FREQUENCY', 1):
+            state_answers_stats = self._get_top_state_unresolved_answer_stats()
+
+        self.assertEqual(
+            state_answers_stats, [
+                {'answer': 'C', 'frequency': 1}
             ])
 
     def test_get_top_state_answer_stats(self):

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -1464,6 +1464,11 @@ class StateAnswersStatisticsTest(test_utils.GenericTestBase):
             self, exp_id=EXP_ID, state_name=STATE_NAMES[0]):
         return stats_services.get_top_state_answer_stats(exp_id, state_name)
 
+    def _get_top_state_unresolved_answer_stats(
+            self, exp_id=EXP_ID, state_name=STATE_NAMES[0]):
+        return stats_services.get_top_state_unresolved_answers(
+            exp_id, state_name)
+
     def _get_top_state_answer_stats_multi(
             self, exp_id=EXP_ID, state_names=None):
         if not state_names:
@@ -1472,12 +1477,13 @@ class StateAnswersStatisticsTest(test_utils.GenericTestBase):
             exp_id, state_names)
 
     def _record_answer(
-            self, answer, exp_id=EXP_ID, state_name=STATE_NAMES[0]):
+            self, answer, exp_id=EXP_ID, state_name=STATE_NAMES[0],
+            classification_category=exp_domain.EXPLICIT_CLASSIFICATION):
         exploration = exp_services.get_exploration_by_id(exp_id)
         interaction_id = exploration.states[state_name].interaction.id
         event_services.AnswerSubmissionEventHandler.record(
             exp_id, exploration.version, state_name, interaction_id, 0, 0,
-            exp_domain.EXPLICIT_CLASSIFICATION, 'sid1', 10.0, {}, answer)
+            classification_category, 'sid1', 10.0, {}, answer)
 
     def _run_answer_summaries_aggregator(self):
         ModifiedInteractionAnswerSummariesAggregator.start_computation()
@@ -1496,6 +1502,35 @@ class StateAnswersStatisticsTest(test_utils.GenericTestBase):
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
         self.save_new_linear_exp_with_state_names_and_interactions(
             self.EXP_ID, self.owner_id, self.STATE_NAMES, ['TextInput'])
+
+    def test_get_top_state_unresolved_answer_stats(self):
+        self._record_answer(
+            'A', classification_category=exp_domain.EXPLICIT_CLASSIFICATION)
+        self._record_answer(
+            'B', classification_category=exp_domain.EXPLICIT_CLASSIFICATION)
+        self._record_answer(
+            'C', classification_category=exp_domain.STATISTICAL_CLASSIFICATION)
+        self._record_answer(
+            'A', classification_category=exp_domain.STATISTICAL_CLASSIFICATION)
+        self._record_answer(
+            'D',
+            classification_category=exp_domain.DEFAULT_OUTCOME_CLASSIFICATION)
+        self._record_answer(
+            'E',
+            classification_category=exp_domain.DEFAULT_OUTCOME_CLASSIFICATION)
+        self._record_answer(
+            'D', classification_category=exp_domain.EXPLICIT_CLASSIFICATION)
+        self._run_answer_summaries_aggregator()
+
+        with self.swap(feconf, 'STATE_ANSWER_STATS_MIN_FREQUENCY', 1):
+            state_answers_stats = self._get_top_state_unresolved_answer_stats()
+
+        self.assertEqual(
+            state_answers_stats, [
+                {'answer': 'A', 'frequency': 2},
+                {'answer': 'C', 'frequency': 1},
+                {'answer': 'E', 'frequency': 1}
+            ])
 
     def test_get_top_state_answer_stats(self):
         self._record_answer('A')

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -1262,8 +1262,9 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             self._run_answer_summaries_aggregator()
             visualizations = self._get_visualizations()
             # There are two visualizations for TextInput. One for top answers
-            # and second is for top unresolved answers.
-            self.assertEqual(len(visualizations), 2)
+            # and second is for top unresolved answers but top unresolved
+            # answers visualization is not shown as part of exploration stats.
+            self.assertEqual(len(visualizations), 1)
 
             visualization = visualizations[0]
             self.assertEqual(
@@ -1277,8 +1278,9 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             visualizations = self._get_visualizations()
 
             # There are two visualizations for TextInput. One for top answers
-            # and second is for top unresolved answers.
-            self.assertEqual(len(visualizations), 2)
+            # and second is for top unresolved answers but top unresolved
+            # answers visualization is not shown as part of exploration stats.
+            self.assertEqual(len(visualizations), 1)
 
             visualization = visualizations[0]
             self.assertEqual(visualization['id'], 'FrequencyTable')
@@ -1298,8 +1300,9 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             self._run_answer_summaries_aggregator()
             visualizations = self._get_visualizations()
             # There are two visualizations for TextInput. One for top answers
-            # and second is for top unresolved answers.
-            self.assertEqual(len(visualizations), 2)
+            # and second is for top unresolved answers but top unresolved
+            # answers visualization is not shown as part of exploration stats.
+            self.assertEqual(len(visualizations), 1)
 
             visualization = visualizations[0]
             self.assertEqual(visualization['id'], 'FrequencyTable')
@@ -1328,7 +1331,7 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             visualizations = sorted(
                 self._get_visualizations(exp_id=self.SET_INPUT_EXP_ID),
                 key=operator.itemgetter('data'))
-            self.assertEqual(len(visualizations), 2)
+            self.assertEqual(len(visualizations), 1)
 
             # Use options to distinguish between the two visualizations, since
             # both are FrequencyTable.
@@ -1381,8 +1384,9 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             self._rerun_answer_summaries_aggregator()
             visualizations = self._get_visualizations()
             # There are two visualizations for TextInput. One for top answers
-            # and second is for top unresolved answers.
-            self.assertEqual(len(visualizations), 2)
+            # and second is for top unresolved answers but top unresolved
+            # answers visualization is not shown as part of exploration stats.
+            self.assertEqual(len(visualizations), 1)
 
             visualization = visualizations[0]
             # The latest data should include all submitted answers.
@@ -1407,8 +1411,9 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             self._run_answer_summaries_aggregator()
             visualizations = self._get_visualizations()
             # There are two visualizations for TextInput. One for top answers
-            # and second is for top unresolved answers.
-            self.assertEqual(len(visualizations), 2)
+            # and second is for top unresolved answers but top unresolved
+            # answers visualization is not shown as part of exploration stats.
+            self.assertEqual(len(visualizations), 1)
 
             visualization = visualizations[0]
             # The latest data should include all submitted answers.

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -1331,7 +1331,7 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
             visualizations = sorted(
                 self._get_visualizations(exp_id=self.SET_INPUT_EXP_ID),
                 key=operator.itemgetter('data'))
-            self.assertEqual(len(visualizations), 1)
+            self.assertEqual(len(visualizations), 2)
 
             # Use options to distinguish between the two visualizations, since
             # both are FrequencyTable.

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -1244,6 +1244,10 @@ class StateAnswersModel(base_models.BaseModel):
 
     # List of answer dicts, each of which is stored as JSON blob. The content
     # of answer dicts is specified in core.domain.stats_domain.StateAnswers.
+    # NOTE: The answers stored in submitted_answers_list must be sorted
+    # according to the chronological order of their submission otherwise
+    # TopNUnresolvedAnswersByFrequency calculation in
+    # InteractionAnswerSummariesAggregator will output invalid results.
     submitted_answer_list = ndb.JsonProperty(repeated=True, indexed=False)
     # The version of the submitted_answer_list currently supported by Oppia. If
     # the internal JSON structure of submitted_answer_list changes,
@@ -1337,6 +1341,11 @@ class StateAnswersModel(base_models.BaseModel):
         """See the insert_submitted_answers for general documentation of what
         this method does. It's only safe to call this method from within a
         transaction.
+
+        NOTE: The answers stored in submitted_answers_list must be sorted
+        according to the chronological order of their submission otherwise
+        TopNUnresolvedAnswersByFrequency calculation in
+        InteractionAnswerSummariesAggregator will output invalid results.
 
         Args:
             exploration_id: str. ID of the exploration currently being played.

--- a/extensions/answer_summarizers/models_test.py
+++ b/extensions/answer_summarizers/models_test.py
@@ -379,3 +379,83 @@ class TopAnswersByCategorizationUnitTestCase(CalculationUnitTestBase):
             ],
         }
         self.assertEqual(actual_calc_output.to_raw_type(), expected_calc_output)
+
+
+class TopNUnresolvedAnswersByFrequency(CalculationUnitTestBase):
+    CALCULATION_ID = 'TopNUnresolvedAnswersByFrequency'
+
+    def test_empty_state_answers_dict(self):
+        state_answers_dict = self._create_state_answers_dict([])
+        actual_calc_output = self._perform_calculation(state_answers_dict)
+        expected_calc_output = []
+        self.assertEqual(actual_calc_output.to_raw_type(), expected_calc_output)
+
+    def test_unresolved_answers_list(self):
+        answer_dicts_list = [
+            # EXPLICIT.
+            self._create_answer_dict(
+                'Explicit A',
+                classify_category=exp_domain.EXPLICIT_CLASSIFICATION),
+            self._create_answer_dict(
+                'Explicit B',
+                classify_category=exp_domain.EXPLICIT_CLASSIFICATION),
+            self._create_answer_dict(
+                'Explicit A',
+                classify_category=exp_domain.EXPLICIT_CLASSIFICATION),
+            # TRAINING DATA.
+            self._create_answer_dict(
+                'Trained data A',
+                classify_category=exp_domain.TRAINING_DATA_CLASSIFICATION),
+            self._create_answer_dict(
+                'Trained data B',
+                classify_category=exp_domain.TRAINING_DATA_CLASSIFICATION),
+            self._create_answer_dict(
+                'Trained data B',
+                classify_category=exp_domain.TRAINING_DATA_CLASSIFICATION),
+            # STATS CLASSIFIER.
+            self._create_answer_dict(
+                'Stats B',
+                classify_category=exp_domain.STATISTICAL_CLASSIFICATION),
+            self._create_answer_dict(
+                'Stats C',
+                classify_category=exp_domain.STATISTICAL_CLASSIFICATION),
+            self._create_answer_dict(
+                'Stats C',
+                classify_category=exp_domain.STATISTICAL_CLASSIFICATION),
+            self._create_answer_dict(
+                'Explicit B',
+                classify_category=exp_domain.STATISTICAL_CLASSIFICATION),
+            # EXPLICIT.
+            self._create_answer_dict(
+                'Trained data B',
+                classify_category=exp_domain.EXPLICIT_CLASSIFICATION),
+            # DEFAULT OUTCOMES.
+            self._create_answer_dict(
+                'Default C',
+                classify_category=exp_domain.DEFAULT_OUTCOME_CLASSIFICATION),
+            self._create_answer_dict(
+                'Default C',
+                classify_category=exp_domain.DEFAULT_OUTCOME_CLASSIFICATION),
+            self._create_answer_dict(
+                'Default B',
+                classify_category=exp_domain.DEFAULT_OUTCOME_CLASSIFICATION),
+            # EXPLICIT.
+            self._create_answer_dict(
+                'Default B',
+                classify_category=exp_domain.EXPLICIT_CLASSIFICATION),
+            # STATS CLASSIFIER.
+            self._create_answer_dict(
+                'Default B',
+                classify_category=exp_domain.STATISTICAL_CLASSIFICATION),
+        ]
+        state_answers_dict = self._create_state_answers_dict(answer_dicts_list)
+
+        actual_calc_output = self._perform_calculation(state_answers_dict)
+        expected_calc_output = [
+            {'answer': 'Default B', 'frequency': 3},
+            {'answer': 'Explicit B', 'frequency': 2},
+            {'answer': 'Stats C', 'frequency': 2},
+            {'answer': 'Default C', 'frequency': 2},
+            {'answer': 'Stats B', 'frequency': 1},
+        ]
+        self.assertEqual(actual_calc_output.to_raw_type(), expected_calc_output)

--- a/extensions/interactions/TextInput/TextInput.py
+++ b/extensions/interactions/TextInput/TextInput.py
@@ -71,4 +71,13 @@ class TextInput(base.BaseInteraction):
         },
         'calculation_id': 'Top10AnswerFrequencies',
         'addressed_info_is_supported': True,
+    }, {
+        # Table with answer counts for top N unresolved answers.
+        'id': 'FrequencyTable',
+        'options': {
+            'column_headers': ['Answer', 'Count'],
+            'title': 'Top unresolved answers',
+        },
+        'calculation_id': 'TopNUnresolvedAnswersByFrequency',
+        'addressed_info_is_supported': True,
     }]

--- a/extensions/visualizations/frequency_table_directive.html
+++ b/extensions/visualizations/frequency_table_directive.html
@@ -1,5 +1,5 @@
-<strong><[options.title]></strong>
-<table class="table">
+<strong ng-if="options.title != 'Top unresolved answers'"><[options.title]></strong>
+<table class="table" ng-if="options.title != 'Top unresolved answers'">
   <colgroup>
     <col span="1" style="width: 75%;">
     <col span="1" style="width: 10%;">

--- a/extensions/visualizations/frequency_table_directive.html
+++ b/extensions/visualizations/frequency_table_directive.html
@@ -1,5 +1,5 @@
-<strong ng-if="options.title != 'Top unresolved answers'"><[options.title]></strong>
-<table class="table" ng-if="options.title != 'Top unresolved answers'">
+<strong><[options.title]></strong>
+<table class="table">
   <colgroup>
     <col span="1" style="width: 75%;">
     <col span="1" style="width: 10%;">

--- a/feconf.py
+++ b/feconf.py
@@ -193,6 +193,10 @@ COMMIT_LIST_PAGE_SIZE = 50
 # tab.
 FEEDBACK_TAB_PAGE_SIZE = 20
 
+# The number of top unresolved answers which should be aggragated from all of
+# the submitted answers.
+TOP_UNRESOLVED_ANSWERS_LIMIT = 20
+
 # Default title for a newly-minted exploration.
 DEFAULT_EXPLORATION_TITLE = ''
 # Default category for a newly-minted exploration.

--- a/feconf.py
+++ b/feconf.py
@@ -193,8 +193,8 @@ COMMIT_LIST_PAGE_SIZE = 50
 # tab.
 FEEDBACK_TAB_PAGE_SIZE = 20
 
-# The number of top unresolved answers which should be aggragated from all of
-# the submitted answers.
+# The maximum number of top unresolved answers which should be aggregated
+# from all of the submitted answers.
 TOP_UNRESOLVED_ANSWERS_LIMIT = 20
 
 # Default title for a newly-minted exploration.

--- a/main.py
+++ b/main.py
@@ -401,7 +401,8 @@ URLS = MAPREDUCE_HANDLERS + [
         r'/createhandler/autosave_draft/<exploration_id>',
         editor.EditorAutosaveHandler),
     get_redirect_route(
-        r'/gettopunresolvedanswers', editor.TopUnresolvedAnswersHandler),
+        r'/createhandler/get_top_unresolved_answers/<exploration_id>',
+        editor.TopUnresolvedAnswersHandler),
 
     get_redirect_route(
         r'%s' % feconf.RECENT_COMMITS_DATA_URL,

--- a/main.py
+++ b/main.py
@@ -400,6 +400,8 @@ URLS = MAPREDUCE_HANDLERS + [
     get_redirect_route(
         r'/createhandler/autosave_draft/<exploration_id>',
         editor.EditorAutosaveHandler),
+    get_redirect_route(
+        r'/gettopunresolvedanswers', editor.TopUnresolvedAnswersHandler),
 
     get_redirect_route(
         r'%s' % feconf.RECENT_COMMITS_DATA_URL,


### PR DESCRIPTION
This PR implements following components:
* A new calculation for aggregating top unresolved answers, by frequency.
* Method in stats _service to retrieve the result of the calculation.
* A controller for sending this data to frontend.
* Relevent tests in backend.

Fore more details checkout [design](https://docs.google.com/document/d/19v-zTFS7_8nysUAggDau3xCDN_WS4x20heJJjpZdALs/edit) doc.