### PR TITLE
Fixed backend tests

### DIFF
--- a/core/domain/stats_jobs_one_off_test.py
+++ b/core/domain/stats_jobs_one_off_test.py
@@ -36,10 +36,10 @@ class ExplorationIssuesModelCreatorOneOffJobTest(test_utils.GenericTestBase):
         super(ExplorationIssuesModelCreatorOneOffJobTest, self).setUp()
         self.exp1 = self.save_new_valid_exploration(self.exp_id1, 'owner')
         self.exp1.add_states(['New state'])
-        change_list = [{
+        change_list = [exp_domain.ExplorationChange({
             'cmd': 'add_state',
             'state_name': 'New state'
-        }]
+        })]
         exp_services.update_exploration(
             feconf.SYSTEM_COMMITTER_ID, self.exp1.id, change_list, '')
         self.exp1 = exp_services.get_exploration_by_id(self.exp1.id)

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -491,11 +491,11 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         # Test renaming of states.
         exploration.rename_state('Home', 'Renamed state')
         exploration.version += 1
-        change_list = [{
+        change_list = [exp_domain.ExplorationChange({
             'cmd': 'rename_state',
             'old_state_name': 'Home',
             'new_state_name': 'Renamed state'
-        }]
+        })]
         exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.update_exp_issues_for_new_exp_version(
             exploration, exp_versions_diff, False)
@@ -535,10 +535,10 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         # Test deletion of states.
         exploration.delete_state('End')
         exploration.version += 1
-        change_list = [{
+        change_list = [exp_domain.ExplorationChange({
             'cmd': 'delete_state',
             'state_name': 'End'
-        }]
+        })]
         exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.update_exp_issues_for_new_exp_version(
             exploration, exp_versions_diff, False)


### PR DESCRIPTION
After my recent PR which converted all change_dicts to objects, a PR went in that used change_dicts, which caused travis to throw backend errors for all other PRs. This PR fixes that error.

Also, as a note to all developers: When updating an exploration in any tests, make sure the change_list is a list of ExplorationChange objects and not dicts.