### PR TITLE
Added test for unique model names and renamed SuggestionModel to GeneralSuggestionModel

### DIFF
--- a/core/storage/storage_models_test.py
+++ b/core/storage/storage_models_test.py
@@ -24,6 +24,9 @@ class StorageModelsTest(test_utils.GenericTestBase):
 
     def test_all_model_names_unique(self):
         all_model_names = []
+
+        # As models.NAMES is an enum, it cannot be iterated. So we use the
+        # __dict__ property which can be iterated.
         for name in models.NAMES.__dict__:
             if '__' not in name:
                 all_model_names.append(name)

--- a/core/storage/storage_models_test.py
+++ b/core/storage/storage_models_test.py
@@ -28,7 +28,7 @@ class StorageModelsTest(test_utils.GenericTestBase):
             if '__' not in name:
                 all_model_names.append(name)
 
-        all_models = []
+        names_of_ndb_model_subclasses = []
         for name in all_model_names:
             (module, ) = models.Registry.import_models([name])
             for member_name, member_obj in inspect.getmembers(module):
@@ -40,15 +40,8 @@ class StorageModelsTest(test_utils.GenericTestBase):
                             'ndb.Model' in ancestor_names or
                             'BaseModel' in ancestor_names or
                             'VersionedModel' in ancestor_names):
-                        all_models.append(clazz.__name__)
+                        names_of_ndb_model_subclasses.append(clazz.__name__)
 
-        frequency_of_models = {}
-        for model in all_models:
-            if model in frequency_of_models:
-                frequency_of_models[model] += 1
-            else:
-                frequency_of_models[model] = 1
-
-        for model in frequency_of_models:
-            print model, frequency_of_models[model]
-            self.assertEqual(frequency_of_models[model], 1)
+        self.assertEqual(
+            len(set(names_of_ndb_model_subclasses)),
+            len(names_of_ndb_model_subclasses))

--- a/core/storage/storage_models_test.py
+++ b/core/storage/storage_models_test.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 """Tests for Oppia storage models."""
-import os
-import pkgutil
 import inspect
 
 from core.platform import models
 from core.tests import test_utils
+
 
 class StorageModelsTest(test_utils.GenericTestBase):
     """Tests for Oppia storage models."""
@@ -38,9 +37,9 @@ class StorageModelsTest(test_utils.GenericTestBase):
                     ancestor_names = [
                         base_class.__name__ for base_class in clazz.__bases__]
                     if (
-                        'ndb.Model' in ancestor_names or
-                        'BaseModel' in ancestor_names or
-                        'VersionedModel' in ancestor_names):
+                            'ndb.Model' in ancestor_names or
+                            'BaseModel' in ancestor_names or
+                            'VersionedModel' in ancestor_names):
                         all_models.append(clazz.__name__)
 
         frequency_of_models = {}

--- a/core/storage/storage_models_test.py
+++ b/core/storage/storage_models_test.py
@@ -1,0 +1,57 @@
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Oppia storage models."""
+import os
+import pkgutil
+
+from core.platform import models
+from core.tests import test_utils
+
+class StorageModelsTest(test_utils.GenericTestBase):
+    """Tests for Oppia storage models"""
+
+    def test_all_model_names_unique(self):
+        all_model_file_paths = [
+            os.path.join('core', 'storage', name)
+            for name in vars(models.NAMES)]
+        all_models = []
+        for path in all_model_file_paths:
+            for loader, name, _ in pkgutil.iter_modules(path=[path]):
+                module = loader.find_module(name).load_module(name)
+                if '_test' in module.__file__: continue
+                #print module.__file__, dir(module)
+                for var in dir(module):
+                    if 'Model' in var:
+                        clazz = getattr(module, var)
+                        ancestor_names = [
+                            base_class.__name__ for base_class in clazz.__bases__]
+                        if (
+                            'ndb.Model' in ancestor_names or
+                            'BaseModel' in ancestor_names or
+                            'VersionedModel' in ancestor_names):
+                            #print module.__file__, clazz.__name__
+                            all_models.append(clazz.__name__)
+        print dir(module)
+        frequency_of_model_names = {}
+        for model in all_models:
+            if model in frequency_of_model_names:
+                frequency_of_model_names[model] += 1
+            else:
+                frequency_of_model_names[model] = 1
+        print frequency_of_model_names
+        for model in frequency_of_model_names:
+            print model, frequency_of_model_names[model]
+            self.assertEqual(frequency_of_model_names[model], 1)
+

--- a/core/storage/suggestion/gae_models.py
+++ b/core/storage/suggestion/gae_models.py
@@ -73,7 +73,7 @@ SCORE_TYPE_CHOICES = [
 SCORE_CATEGORY_DELIMITER = '.'
 
 
-class SuggestionModel(base_models.BaseModel):
+class GeneralSuggestionModel(base_models.BaseModel):
     """Model to store suggestions made by Oppia users.
 
     The ID of the suggestions are created is the same as the ID of the thread

--- a/core/storage/suggestion/gae_models_test.py
+++ b/core/storage/suggestion/gae_models_test.py
@@ -35,35 +35,35 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
 
     def setUp(self):
         super(SuggestionModelUnitTests, self).setUp()
-        suggestion_models.SuggestionModel.create(
+        suggestion_models.GeneralSuggestionModel.create(
             suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_IN_REVIEW, 'author_1',
             'reviewer_1', 'reviewer_1', self.change_cmd, self.score_category,
             'exploration.exp1.thread_1')
-        suggestion_models.SuggestionModel.create(
+        suggestion_models.GeneralSuggestionModel.create(
             suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_ACCEPTED, 'author_2',
             'reviewer_2', 'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp1.thread_2')
-        suggestion_models.SuggestionModel.create(
+        suggestion_models.GeneralSuggestionModel.create(
             suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_ACCEPTED, 'author_2',
             'reviewer_3', 'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp1.thread_3')
-        suggestion_models.SuggestionModel.create(
+        suggestion_models.GeneralSuggestionModel.create(
             suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_REJECTED, 'author_2',
             'reviewer_2', 'reviewer_3', self.change_cmd, self.score_category,
             'exploration.exp1.thread_4')
-        suggestion_models.SuggestionModel.create(
+        suggestion_models.GeneralSuggestionModel.create(
             suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
@@ -77,7 +77,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
                 suggestion_models.SCORE_CATEGORY_DELIMITER not in score_type)
 
     def test_create_new_object_succesfully(self):
-        suggestion_models.SuggestionModel.create(
+        suggestion_models.GeneralSuggestionModel.create(
             suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
@@ -87,7 +87,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
 
         suggestion_id = 'exploration.exp1.thread_6'
 
-        observed_suggestion_model = suggestion_models.SuggestionModel.get_by_id(
+        observed_suggestion_model = suggestion_models.GeneralSuggestionModel.get_by_id(
             suggestion_id)
 
 
@@ -118,7 +118,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(
             Exception, 'There is already a suggestion with the given id: '
                        'exploration.exp1.thread_1'):
-            suggestion_models.SuggestionModel.create(
+            suggestion_models.GeneralSuggestionModel.create(
                 suggestion_models.SUGGESTION_EDIT_STATE_CONTENT,
                 suggestion_models.TARGET_TYPE_EXPLORATION,
                 self.target_id, self.target_version_at_submission,
@@ -128,76 +128,98 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
 
     def test_get_suggestions_by_type(self):
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_by_type(
+            len(suggestion_models.GeneralSuggestionModel.get_suggestions_by_type(
                 suggestion_models.SUGGESTION_EDIT_STATE_CONTENT)), 5)
         with self.assertRaisesRegexp(
             Exception, 'Value \'invalid_suggestion_type\' for property'
                        ' suggestion_type is not an allowed choice'):
-            suggestion_models.SuggestionModel.get_suggestions_by_type(
+            suggestion_models.GeneralSuggestionModel.get_suggestions_by_type(
                 'invalid_suggestion_type')
 
     def test_get_suggestion_by_author(self):
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_by_author(
-                'author_1')), 1)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_by_author('author_1')), 1)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_by_author(
-                'author_2')), 3)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_by_author('author_2')), 3)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_by_author(
-                'author_3')), 1)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_by_author('author_3')), 1)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_by_author(
-                'author_invalid')), 0)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_by_author('author_invalid')), 0)
 
     def test_get_suggestion_assigned_to_reviewer(self):
         self.assertEqual(
             len(
-                suggestion_models.SuggestionModel
+                suggestion_models.GeneralSuggestionModel
                 .get_suggestions_assigned_to_reviewer('reviewer_1')), 1)
         self.assertEqual(
             len(
-                suggestion_models.SuggestionModel
+                suggestion_models.GeneralSuggestionModel
                 .get_suggestions_assigned_to_reviewer('reviewer_2')), 2)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel
+            len(suggestion_models.GeneralSuggestionModel
                 .get_suggestions_assigned_to_reviewer('reviewer_3')), 2)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel
+            len(suggestion_models.GeneralSuggestionModel
                 .get_suggestions_assigned_to_reviewer('reviewer_invalid')), 0)
 
     def test_get_suggestion_by_reviewer(self):
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_reviewed_by(
-                'reviewer_1')), 1)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_reviewed_by('reviewer_1')), 1)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_reviewed_by(
-                'reviewer_2')), 3)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_reviewed_by('reviewer_2')), 3)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_reviewed_by(
-                'reviewer_3')), 1)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_reviewed_by('reviewer_3')), 1)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_reviewed_by(
-                'reviewer_invalid')), 0)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_reviewed_by('reviewer_invalid')), 0)
 
     def test_get_suggestions_by_status(self):
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_by_status(
-                suggestion_models.STATUS_IN_REVIEW)), 1)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_by_status(
+                    suggestion_models.STATUS_IN_REVIEW)), 1)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_by_status(
-                suggestion_models.STATUS_REJECTED)), 2)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_by_status(
+                    suggestion_models.STATUS_REJECTED)), 2)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_by_status(
-                suggestion_models.STATUS_ACCEPTED)), 2)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_by_status(
+                    suggestion_models.STATUS_ACCEPTED)), 2)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_by_status(
-                suggestion_models.STATUS_INVALID)), 0)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_by_status(
+                    suggestion_models.STATUS_INVALID)), 0)
 
     def test_get_suggestions_by_target_id(self):
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_by_target_id(
-                suggestion_models.TARGET_TYPE_EXPLORATION, self.target_id)), 5)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_by_target_id(
+                    suggestion_models.TARGET_TYPE_EXPLORATION, self.target_id)),
+            5)
         self.assertEqual(
-            len(suggestion_models.SuggestionModel.get_suggestions_by_target_id(
-                suggestion_models.TARGET_TYPE_EXPLORATION, 'exp_invalid')), 0)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_by_target_id(
+                    suggestion_models.TARGET_TYPE_EXPLORATION, 'exp_invalid')),
+            0)

--- a/core/storage/suggestion/gae_models_test.py
+++ b/core/storage/suggestion/gae_models_test.py
@@ -87,8 +87,8 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
 
         suggestion_id = 'exploration.exp1.thread_6'
 
-        observed_suggestion_model = suggestion_models.GeneralSuggestionModel.get_by_id(
-            suggestion_id)
+        observed_suggestion_model = (
+            suggestion_models.GeneralSuggestionModel.get_by_id(suggestion_id))
 
 
         self.assertEqual(
@@ -128,8 +128,10 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
 
     def test_get_suggestions_by_type(self):
         self.assertEqual(
-            len(suggestion_models.GeneralSuggestionModel.get_suggestions_by_type(
-                suggestion_models.SUGGESTION_EDIT_STATE_CONTENT)), 5)
+            len(
+                suggestion_models.GeneralSuggestionModel
+                .get_suggestions_by_type(
+                    suggestion_models.SUGGESTION_EDIT_STATE_CONTENT)), 5)
         with self.assertRaisesRegexp(
             Exception, 'Value \'invalid_suggestion_type\' for property'
                        ' suggestion_type is not an allowed choice'):


### PR DESCRIPTION
## Explanation
To check against multiple models having the same name, we are adding a backend test. However, while writing the test, I ran into some issues. Here are the problems and what I tried.

- In a lot of the files, models from outside the file are also being identified. In line 44, the print statement prints out a lot of these invalid file, class pairs. Because of this, there is a lot of duplicate counting
- The path=[path] in line 31 caused some issues. Though it takes a list of paths, for some reason,  it was listing only stuff from the first path. So I looped through and fed it one path at a time.
- It looked like the modules were added cumulatively while loading (probably why there are repeats). so I thought I'll let the loop run and then try to use vars() or dir() on module but that didn't work either.
- Another key point is that because of not being able to specifically detect what's in that particular file, it wasn't possible to make out whether the value is actually repeated or just a fake double.

Not sure what I am missing out and what else I should do. PTAL @seanlip. 
## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
