### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Per-directory ownership and automatic assignment for pull requests.
+/core/storage/user/ @BenHenning


### PR DESCRIPTION
Creates initial CODEOWNERS file with ownership specified for user model changes.

This does not restrict approval to contributors listed in this file as that requires a top-level branch setting for develop. The outcome of this change is just automate reviewer assignment.