### PR TITLE
Fix for error in migration validation testing

### DIFF
--- a/core/domain/html_cleaner.py
+++ b/core/domain/html_cleaner.py
@@ -279,7 +279,7 @@ def convert_to_text_angular(html_data):
             try:
                 tag.unwrap()
             except Exception:
-                return "exception: " + html_data
+                raise Exception('Invalid unwrapping for string.')
 
     # Removal of tags can break the soup into parts which are continuous
     # and not wrapped in any tag. This part recombines the continuous
@@ -396,11 +396,19 @@ def validate_textangular_format(html_list, run_migration=False):
         ['ALLOWED_TAG_LIST'])
 
     for html_data in html_list:
-        if run_migration:
-            migrated_data = convert_to_text_angular(html_data)
-            soup = bs4.BeautifulSoup(migrated_data, 'html.parser')
-        else:
-            soup = bs4.BeautifulSoup(html_data, 'html.parser')
+        try:
+            if run_migration:
+                migrated_data = convert_to_text_angular(html_data)
+                soup = bs4.BeautifulSoup(migrated_data, 'html.parser')
+            else:
+                soup = bs4.BeautifulSoup(html_data, 'html.parser')
+        except Exception as e:
+            if e in err_dict:
+                err_dict[e] += [html_data]
+            else:
+                err_dict[e] = [html_data]
+            continue
+
         # Text with no parent tag is also invalid.
         for content in soup.contents:
             if not content.name:

--- a/core/domain/html_cleaner.py
+++ b/core/domain/html_cleaner.py
@@ -232,44 +232,35 @@ def convert_to_text_angular(html_data):
         # the same appearance.
         elif tag.name == 'hr':
             tag.name = 'br'
-        # a tag is to be replaced with oppia-noninteractive-link.
-        # For this the attributes and text within a tag is used to
-        # create new link tag which is wrapped as parent of a and then
-        # a tag is removed.
-        # There are cases where there is no href attribute of a tag.
-        # In such cases a tag is simply removed.
         elif tag.name == 'a':
-            try:
-                if tag.has_attr('href'):
-                    link = soup.new_tag('oppia-noninteractive-link')
-                    url = tag['href']
-                    text = tag.get_text()
-                    link['url-with-value'] = url
-                    link['text-with-value'] = text
-                    tag.wrap(link)
-                    # If any part of text in a tag is wrapped in b or i tag
-                    # link tag is also wrapped in those tags to maintain
-                    # almost similar appearance.
-                    children = tag.findChildren()
-                    count_of_b_parent = 0
-                    count_of_i_parent = 0
-                    for child in children:
-                        if child.name == 'b' and not count_of_b_parent:
-                            link.wrap(soup.new_tag('b'))
-                            count_of_b_parent = 1
-                        if child.name == 'i' and not count_of_i_parent:
-                            link.wrap(soup.new_tag('i'))
-                            count_of_i_parent = 1
-                        # This part is to ensure that oppia-noninteractive-link
-                        # within a tag is preserved to obtain test case. This
-                        # has to be removed after finding invalid case.
-                        if child.name == 'oppia-noninteractive-link':
-                            link.append(child)
-                    tag.extract()
-                else:
-                    tag.unwrap()
-            except Exception:
-                pass
+            if tag.has_attr('href'):
+                link = soup.new_tag('oppia-noninteractive-link')
+                url = tag['href']
+                text = tag.get_text()
+                link['url-with-value'] = url
+                link['text-with-value'] = text
+                tag.wrap(link)
+                # If any part of text in a tag is wrapped in b or i tag
+                # link tag is also wrapped in those tags to maintain
+                # almost similar appearance.
+                children = tag.findChildren()
+                count_of_b_parent = 0
+                count_of_i_parent = 0
+                for child in children:
+                    if child.name == 'b' and not count_of_b_parent:
+                        link.wrap(soup.new_tag('b'))
+                        count_of_b_parent = 1
+                    if child.name == 'i' and not count_of_i_parent:
+                        link.wrap(soup.new_tag('i'))
+                        count_of_i_parent = 1
+                    # This part is to ensure that oppia-noninteractive-link
+                    # within a tag is preserved to obtain test case. This
+                    # has to be removed after finding invalid case.
+                    if child.name == 'oppia-noninteractive-link':
+                        link.append(child)
+                tag.extract()
+            else:
+                tag.unwrap()
         # To maintain the appearance of table, tab is added after
         # each element in row. In one of the cases the elements were
         # p tags with some text and line breaks. In such case td.string
@@ -278,10 +269,7 @@ def convert_to_text_angular(html_data):
         elif tag.name == 'td' and tag.next_sibling:
             if tag.string:
                 tag.string = tag.string + "\t"
-            try:
-                tag.unwrap()
-            except Exception:
-                pass
+            tag.unwrap()
         # div and table rows both are replaced with p tag
         # to maintain almost same apperance.
         elif tag.name == 'div' or tag.name == 'tr':
@@ -291,7 +279,7 @@ def convert_to_text_angular(html_data):
             try:
                 tag.unwrap()
             except Exception:
-                pass
+                return "exception: " + html_data
 
     # Removal of tags can break the soup into parts which are continuous
     # and not wrapped in any tag. This part recombines the continuous

--- a/core/domain/html_cleaner.py
+++ b/core/domain/html_cleaner.py
@@ -232,6 +232,12 @@ def convert_to_text_angular(html_data):
         # the same appearance.
         elif tag.name == 'hr':
             tag.name = 'br'
+        # a tag is to be replaced with oppia-noninteractive-link.
+        # For this the attributes and text within a tag is used to
+        # create new link tag which is wrapped as parent of a and then
+        # a tag is removed.
+        # There are cases where there is no href attribute of a tag.
+        # In such cases a tag is simply removed.
         elif tag.name == 'a':
             if tag.has_attr('href'):
                 link = soup.new_tag('oppia-noninteractive-link')

--- a/core/domain/html_cleaner.py
+++ b/core/domain/html_cleaner.py
@@ -239,34 +239,37 @@ def convert_to_text_angular(html_data):
         # There are cases where there is no href attribute of a tag.
         # In such cases a tag is simply removed.
         elif tag.name == 'a':
-            if tag.has_attr('href'):
-                link = soup.new_tag('oppia-noninteractive-link')
-                url = tag['href']
-                text = tag.get_text()
-                link['url-with-value'] = url
-                link['text-with-value'] = text
-                tag.wrap(link)
-                # If any part of text in a tag is wrapped in b or i tag
-                # link tag is also wrapped in those tags to maintain
-                # almost similar appearance.
-                children = tag.findChildren()
-                count_of_b_parent = 0
-                count_of_i_parent = 0
-                for child in children:
-                    if child.name == 'b' and not count_of_b_parent:
-                        link.wrap(soup.new_tag('b'))
-                        count_of_b_parent = 1
-                    if child.name == 'i' and not count_of_i_parent:
-                        link.wrap(soup.new_tag('i'))
-                        count_of_i_parent = 1
-                    # This part is to ensure that oppia-noninteractive-link
-                    # within a tag is preserved to obtain test case. This
-                    # has to be removed after finding invalid case.
-                    if child.name == 'oppia-noninteractive-link':
-                        link.append(child)
-                tag.extract()
-            else:
-                tag.unwrap()
+            try:
+                if tag.has_attr('href'):
+                    link = soup.new_tag('oppia-noninteractive-link')
+                    url = tag['href']
+                    text = tag.get_text()
+                    link['url-with-value'] = url
+                    link['text-with-value'] = text
+                    tag.wrap(link)
+                    # If any part of text in a tag is wrapped in b or i tag
+                    # link tag is also wrapped in those tags to maintain
+                    # almost similar appearance.
+                    children = tag.findChildren()
+                    count_of_b_parent = 0
+                    count_of_i_parent = 0
+                    for child in children:
+                        if child.name == 'b' and not count_of_b_parent:
+                            link.wrap(soup.new_tag('b'))
+                            count_of_b_parent = 1
+                        if child.name == 'i' and not count_of_i_parent:
+                            link.wrap(soup.new_tag('i'))
+                            count_of_i_parent = 1
+                        # This part is to ensure that oppia-noninteractive-link
+                        # within a tag is preserved to obtain test case. This
+                        # has to be removed after finding invalid case.
+                        if child.name == 'oppia-noninteractive-link':
+                            link.append(child)
+                    tag.extract()
+                else:
+                    tag.unwrap()
+            except Exception:
+                pass
         # To maintain the appearance of table, tab is added after
         # each element in row. In one of the cases the elements were
         # p tags with some text and line breaks. In such case td.string
@@ -275,14 +278,20 @@ def convert_to_text_angular(html_data):
         elif tag.name == 'td' and tag.next_sibling:
             if tag.string:
                 tag.string = tag.string + "\t"
-            tag.unwrap()
+            try:
+                tag.unwrap()
+            except Exception:
+                pass
         # div and table rows both are replaced with p tag
         # to maintain almost same apperance.
         elif tag.name == 'div' or tag.name == 'tr':
             tag.name = 'p'
         # All other invalid tags are simply removed.
         elif tag.name not in allowed_tag_list:
-            tag.unwrap()
+            try:
+                tag.unwrap()
+            except Exception:
+                pass
 
     # Removal of tags can break the soup into parts which are continuous
     # and not wrapped in any tag. This part recombines the continuous


### PR DESCRIPTION
This PR fixes the issue raised when the migration validation job is run on backup server due to unwrapping a tag not present in html soup.

It also adds test for `wrap_with_siblings` function.