### PR TITLE
Re-enable backend coverage in travis checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,7 @@ env:
   matrix:
     - RUN_LINT=true
     - RUN_FRONTEND_TESTS=true
-    - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=false EXCLUDE_LOAD_TESTS=true
-    # TODO(sll): Reinstate this when we can get it to run in reasonable time.
-    # - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=true
+    - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=true EXCLUDE_LOAD_TESTS=true
     # TODO(sll): Reinstate this when the load tests are more reliable.
     # - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=true EXCLUDE_LOAD_TESTS=false
     - RUN_E2E_TESTS_ACCESSIBILITY=true

--- a/scripts/backend_tests.py
+++ b/scripts/backend_tests.py
@@ -34,7 +34,7 @@ import time
 
 
 COVERAGE_PATH = os.path.join(
-    os.getcwd(), '..', 'oppia_tools', 'coverage-4.0', 'coverage')
+    os.getcwd(), '..', 'oppia_tools', 'coverage-4.5.1', 'coverage')
 TEST_RUNNER_PATH = os.path.join(os.getcwd(), 'core', 'tests', 'gae_suite.py')
 LOG_LOCK = threading.Lock()
 ALL_ERRORS = []

--- a/scripts/run_backend_tests.sh
+++ b/scripts/run_backend_tests.sh
@@ -80,9 +80,7 @@ for arg in "$@"; do
     echo Checking whether coverage is installed in $TOOLS_DIR
     if [ ! -d "$TOOLS_DIR/coverage-4.5.1" ]; then
       echo Installing coverage
-      curl -o coverage.tar.gz https://files.pythonhosted.org/packages/35/fe/e7df7289d717426093c68d156e0fd9117c8f4872b6588e8a8928a0f68424/coverage-4.5.1.tar.gz
-      tar xvzf coverage.tar.gz -C $TOOLS_DIR
-      rm coverage.tar.gz
+      pip install coverage==4.5.1 --target="$TOOLS_DIR/coverage-4.5.1"
     fi
   fi
 done

--- a/scripts/run_backend_tests.sh
+++ b/scripts/run_backend_tests.sh
@@ -78,10 +78,9 @@ bash scripts/install_third_party.sh
 for arg in "$@"; do
   if [ "$arg" == "--generate_coverage_report" ]; then
     echo Checking whether coverage is installed in $TOOLS_DIR
-    if [ ! -d "$TOOLS_DIR/coverage-4.0" ]; then
+    if [ ! -d "$TOOLS_DIR/coverage-4.5.1" ]; then
       echo Installing coverage
-      rm -rf $TOOLS_DIR/coverage
-      curl -o coverage.tar.gz https://pypi.python.org/packages/source/c/coverage/coverage-4.0.tar.gz#md5=13e119b1f111c22b613c3d5cd19a95ac
+      curl -o coverage.tar.gz https://files.pythonhosted.org/packages/35/fe/e7df7289d717426093c68d156e0fd9117c8f4872b6588e8a8928a0f68424/coverage-4.5.1.tar.gz
       tar xvzf coverage.tar.gz -C $TOOLS_DIR
       rm coverage.tar.gz
     fi

--- a/scripts/setup_gae.sh
+++ b/scripts/setup_gae.sh
@@ -23,7 +23,7 @@ if [ "$SETUP_GAE_DONE" ]; then
 fi
 
 export GOOGLE_APP_ENGINE_HOME=$TOOLS_DIR/google_appengine_1.9.67/google_appengine
-export COVERAGE_HOME=$TOOLS_DIR/coverage-4.0
+export COVERAGE_HOME=$TOOLS_DIR/coverage-4.5.1
 
 # Note that if the following line is changed so that it uses webob_1_1_1, PUT requests from the frontend fail.
 export PYTHONPATH=.:$COVERAGE_HOME:$GOOGLE_APP_ENGINE_HOME:$GOOGLE_APP_ENGINE_HOME/lib/webob_0_9:$TOOLS_DIR/webtest-1.4.2:$PYTHONPATH


### PR DESCRIPTION
In #1210 we disabled backend coverage checks because they were taking too long to run on Travis. This PR attempts to reinstate them and see if this is still the case, since our coverage numbers at the moment are currently misleading. (This will also help developers to check that their PRs have adequate test coverage.)

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.