### PR TITLE
Fix #5041 and #5033: Hide unresolved student answers when the exploration is private, since there is no data to show.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/UnresolvedAnswersOverviewDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/UnresolvedAnswersOverviewDirective.js
@@ -26,15 +26,16 @@ oppia.directive('unresolvedAnswersOverview', [
         'unresolved_answers_overview_directive.html'),
       controller: [
         '$scope', 'EditorStateService', 'ExplorationStatesService',
-        'StateRulesStatsService',
+        'StateRulesStatsService', 'ExplorationRightsService',
         function(
             $scope, EditorStateService, ExplorationStatesService,
-            StateRulesStatsService) {
+            StateRulesStatsService, ExplorationRightsService) {
           var MAXIMUM_UNRESOLVED_ANSWERS = 5;
           var MINIMUM_UNRESOLVED_ANSWER_FREQUENCY = 2;
 
           $scope.unresolvedAnswersData = null;
           $scope.latestRefreshDate = new Date();
+          $scope.unresolvedAnswersOverviewIsShown = false;
 
           $scope.computeUnresolvedAnswers = function() {
             var state = ExplorationStatesService.getState(
@@ -83,7 +84,13 @@ oppia.directive('unresolvedAnswersOverview', [
             }
           };
 
-          $scope.$on('refreshStateEditor', $scope.computeUnresolvedAnswers);
+          $scope.$on('refreshStateEditor', function() {
+            $scope.unresolvedAnswersOverviewIsShown = (
+              ExplorationRightsService.isPublic());
+            if ($scope.unresolvedAnswersOverviewIsShown) {
+              $scope.computeUnresolvedAnswers();
+            }
+          });
         }
       ]
     };

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/editor_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/editor_tab.html
@@ -5,7 +5,7 @@
   <div class="col-lg-4 col-md-4 col-sm-4">
     <div class="oppia-editor-sidebar hidden-xs hidden-sm">
       {% include 'pages/exploration_editor/editor_tab/exploration_graph.html' %}
-      {% include 'pages/exploration_editor/editor_tab/issues_overview.html' %}
+      <unresolved-answers-overview></unresolved-answers-overview>
     </div>
   </div>
   <attribution-guide></attribution-guide>

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/issues_overview.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/issues_overview.html
@@ -1,9 +1,0 @@
-<div>
-  <span style="font-size: 16px;">
-    <strong>Issues Overview</strong>
-  </span>
-
-  <md-card style="background-color: white; margin: 20px 0px; padding: 8px;">
-    <unresolved-answers-overview/>
-  </md-card>
-</div>

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/unresolved_answers_overview_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/unresolved_answers_overview_directive.html
@@ -11,17 +11,24 @@
   }
 </style>
 
-<div ng-show="unresolvedAnswersData !== null">
-  <strong>Unresolved Student Answers</strong>
-  <ul>
-    <li ng-repeat="data in unresolvedAnswersData" class="answer-container">
-      <strong>(<[data.frequency]> times)</strong>: <span ng-bind-html="data.answer"></span>
-    </li>
-    <li ng-if="unresolvedAnswersData.length === 0">
-      <em>No outstanding answers requiring attention.</em>
-    </li>
-  </ul>
-  <div class="refresh-container">
-    <a ng-click="computeUnresolvedAnswers()">Refresh</a>; last updated: <[latestRefreshDate.toLocaleString()]>.
-  </div>
+<div ng-if="unresolvedAnswersOverviewIsShown">
+  <span style="font-size: 16px;">
+    <strong>Issues Overview</strong>
+  </span>
+  <md-card style="background-color: white; margin: 20px 0; padding: 8px;">
+    <div ng-show="unresolvedAnswersData !== null">
+      <strong>Unresolved Student Answers</strong>
+      <ul>
+        <li ng-repeat="data in unresolvedAnswersData" class="answer-container">
+          <strong>(<[data.frequency]> times)</strong>: <span ng-bind-html="data.answer"></span>
+        </li>
+        <li ng-if="unresolvedAnswersData.length === 0">
+          <em>No outstanding answers require attention.</em>
+        </li>
+      </ul>
+      <div class="refresh-container">
+        <a ng-click="computeUnresolvedAnswers()">Refresh</a>; last updated: <[latestRefreshDate.toLocaleString()]>.
+      </div>
+    </div>
+  </md-card>
 </div>


### PR DESCRIPTION
This fixes #5041, which is a blocking bug for the upcoming release. /cc @tjiang11 @kevinlee12 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.