### PR TITLE
Fix #5088: Removed refresh option from the create view

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/unresolved_answers_overview_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/unresolved_answers_overview_directive.html
@@ -27,7 +27,7 @@
         </li>
       </ul>
       <div class="refresh-container">
-        <a ng-click="computeUnresolvedAnswers()">Refresh</a>; last updated: <[latestRefreshDate.toLocaleString()]>.
+        last updated: <[latestRefreshDate.toLocaleString()]>.
       </div>
     </div>
   </md-card>

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/unresolved_answers_overview_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/unresolved_answers_overview_directive.html
@@ -27,7 +27,7 @@
         </li>
       </ul>
       <div class="refresh-container">
-        last updated: <[latestRefreshDate.toLocaleString()]>.
+        Last updated: <[latestRefreshDate.toLocaleString()]>.
       </div>
     </div>
   </md-card>


### PR DESCRIPTION
## Explanation
Fixes #5088 PTAL @seanlip @brianrodri 
I have just removed the clickable refresh link itself
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
