### PR TITLE
Fix #5009: Add wait for suggestions e2e test

### DIFF
--- a/core/tests/protractor_utils/editor.js
+++ b/core/tests/protractor_utils/editor.js
@@ -1162,6 +1162,7 @@ var revertToVersion = function(version) {
 // Wrapper for functions involving the feedback tab
 var _runFromFeedbackTab = function(callbackFunction) {
   element(by.css('.protractor-test-feedback-tab')).click();
+  general.waitForSystem();
   var result = callbackFunction();
   general.waitForSystem();
   element(by.css('.protractor-test-main-tab')).click();

--- a/core/tests/protractor_utils/editor.js
+++ b/core/tests/protractor_utils/editor.js
@@ -1199,6 +1199,7 @@ var acceptSuggestion = function(suggestionDescription) {
       matchingSuggestionRows[0].click();
       general.waitForSystem();
       element(by.css('.protractor-test-view-suggestion-btn')).click();
+      general.waitForSystem();
       element(by.css('.protractor-test-exploration-accept-suggestion-btn')).
         click();
     });


### PR DESCRIPTION
## Explanation
Fix #5009 -- The e2e test that tests suggestions was flaky. The reason is possibly because after clicking the view suggestion button, before the modal appears, the test tries to click the accept button and then it fails to find the button. So I added a wait after the click view suggestion button statement.

PTAL @apb7 @seanlip 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
