### PR TITLE
Fix #5115: fix backend load test for feedback threads

### DIFF
--- a/core/tests/load_tests/feedback_thread_summaries_test.py
+++ b/core/tests/load_tests/feedback_thread_summaries_test.py
@@ -71,8 +71,7 @@ class FeedbackThreadSummariesLoadTest(test_utils.GenericTestBase):
             # Create 5 messages in each thread.
             for _ in range(5):
                 feedback_services.create_message(
-                    self.EXP_ID_1, thread.get_thread_id(), self.user_id, None,
-                    None, 'editor message')
+                    thread.id, self.user_id, None, None, 'editor message')
 
         start = time.time()
         # Fetch the summaries of all the threads.


### PR DESCRIPTION
## Explanation
Fix #5115 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
