### PR TITLE
Fix #5063: Hint button should not appear for terminal or linear interactions

### DIFF
--- a/core/templates/dev/head/components/HintAndSolutionButtonsDirective.js
+++ b/core/templates/dev/head/components/HintAndSolutionButtonsDirective.js
@@ -59,7 +59,9 @@ oppia.directive('hintAndSolutionButtons', [
           $scope.isHintButtonVisible = function(index) {
             return HintsAndSolutionManagerService.isHintViewable(index) &&
               !INTERACTION_SPECS[ExplorationPlayerService.getInteraction(
-                PlayerPositionService.getCurrentStateName()).id].is_terminal;
+                PlayerPositionService.getCurrentStateName()).id].is_terminal &&
+                !INTERACTION_SPECS[ExplorationPlayerService.getInteraction(
+                  PlayerPositionService.getCurrentStateName()).id].is_linear;
           };
 
           $scope.isSolutionButtonVisible = function() {

--- a/core/templates/dev/head/components/HintAndSolutionButtonsDirective.js
+++ b/core/templates/dev/head/components/HintAndSolutionButtonsDirective.js
@@ -28,13 +28,13 @@ oppia.directive('hintAndSolutionButtons', [
         'ExplorationPlayerService', 'PlayerTranscriptService',
         'HintAndSolutionModalService', 'DeviceInfoService',
         'PlayerPositionService', 'EVENT_ACTIVE_CARD_CHANGED',
-        'EVENT_NEW_CARD_OPENED',
+        'EVENT_NEW_CARD_OPENED', 'INTERACTION_SPECS',
         function(
             $scope, $rootScope, HintsAndSolutionManagerService,
             ExplorationPlayerService, PlayerTranscriptService,
             HintAndSolutionModalService, DeviceInfoService,
             PlayerPositionService, EVENT_ACTIVE_CARD_CHANGED,
-            EVENT_NEW_CARD_OPENED) {
+            EVENT_NEW_CARD_OPENED, INTERACTION_SPECS) {
           // The state name of the latest card that's open. This is the state
           // name that the current hints and solution correspond to.
           var latestStateName = null;
@@ -57,7 +57,9 @@ oppia.directive('hintAndSolutionButtons', [
           };
 
           $scope.isHintButtonVisible = function(index) {
-            return HintsAndSolutionManagerService.isHintViewable(index);
+            return HintsAndSolutionManagerService.isHintViewable(index) &&
+              !INTERACTION_SPECS[ExplorationPlayerService.getInteraction(
+                PlayerPositionService.getCurrentStateName()).id].is_terminal;
           };
 
           $scope.isSolutionButtonVisible = function() {


### PR DESCRIPTION


## Explanation
Fixes #5063: Added check for terminal or interaction so that hint button doesn't appear.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.

