### PR TITLE
Removed exception from templateUrl linter

### DIFF
--- a/extensions/objects/templates/ImageWithRegionsEditor.js
+++ b/extensions/objects/templates/ImageWithRegionsEditor.js
@@ -490,7 +490,9 @@ oppia.directive('imageWithRegionsEditor', [
           };
           $scope.resetEditor = function() {
             $uibModal.open({
-              templateUrl: 'modals/imageRegionsResetConfirmation',
+              templateUrl: UrlInterpolationService.getExtensionResourceUrl(
+                '/objects/templates/' +
+                'image_with_regions_reset_confirmation_directive.html'),
               backdrop: 'static',
               keyboard: false,
               controller: [

--- a/extensions/objects/templates/image_with_regions_editor_directive.html
+++ b/extensions/objects/templates/image_with_regions_editor_directive.html
@@ -65,18 +65,6 @@
   <div style="color: red; margin-bottom: 4px"><[errorText]></div>
   <button type="button" class="btn btn-danger" ng-click="resetEditor()">Clear Image and Regions</button>
 </div>
-<script type="text/ng-template" id="modals/imageRegionsResetConfirmation">
-  <div class="modal-header">
-    <h4 class="modal-title">Clear Image and Regions</h4>
-  </div>
-  <div class="modal-body">
-    <span>This will remove the image and all regions. Are you sure?</span>
-  </div>
-  <div class="modal-footer">
-    <button type="button" ng-click="cancel()" class="btn btn-default">Cancel</button>
-    <button type="button" ng-click="confirmClear()" class="btn btn-danger">Clear Image and Regions</button>
-  </div>
-</script>
 <style>
   input.oppia-image-with-regions-region-label-editor {
     background-color: rgba(0, 0, 0, 0.5);

--- a/extensions/objects/templates/image_with_regions_reset_confirmation_directive.html
+++ b/extensions/objects/templates/image_with_regions_reset_confirmation_directive.html
@@ -1,0 +1,10 @@
+<div class="modal-header">
+  <h4 class="modal-title">Clear Image and Regions</h4>
+</div>
+<div class="modal-body">
+  <span>This will remove the image and all regions. Are you sure?</span>
+</div>
+<div class="modal-footer">
+  <button type="button" ng-click="cancel()" class="btn btn-default">Cancel</button>
+  <button type="button" ng-click="confirmClear()" class="btn btn-danger">Clear Image and Regions</button>
+</div>

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -124,7 +124,6 @@ BAD_PATTERNS_JS_REGEXP = [
             'extensions/answer_summarizers/',
             'extensions/classifiers/',
             'extensions/dependencies/',
-            'extensions/objects/',
             'extensions/value_generators/',
             'extensions/visualizations/')
     },


### PR DESCRIPTION
## Explanation
Removed exception from templateUrl linter for /extensions/objects and directly referenced one forgotten 
directive.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
