### PR TITLE
Added unit test for exploration reverts effect on exploration issues model

### DIFF
--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -896,13 +896,8 @@ def _save_exploration(committer_id, exploration, commit_message, change_list):
     # Trigger exploration issues model updation.
     if feconf.ENABLE_PLAYTHROUGHS:
         exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
-        revert_to_version = None
-        if change_list:
-            if change_list[0].cmd == (
-                    exp_models.ExplorationModel.CMD_REVERT_COMMIT):
-                revert_to_version = change_list[0].version_number
         stats_services.update_exp_issues_for_new_exp_version(
-            exploration, exp_versions_diff, revert_to_version)
+            exploration, exp_versions_diff, None)
 
     # Save state id mapping model for exploration.
     create_and_save_state_id_mapping_model(exploration, change_list)
@@ -1425,6 +1420,12 @@ def revert_exploration(
     # Update the exploration summary, but since this is just a revert do
     # not add the committer of the revert to the list of contributors.
     update_exploration_summary(exploration_id, None)
+
+    if feconf.ENABLE_PLAYTHROUGHS:
+        current_exploration = get_exploration_by_id(
+            exploration_id, version=current_version)
+        stats_services.update_exp_issues_for_new_exp_version(
+            current_exploration, None, revert_to_version)
 
     # Save state id mapping model for the new exploration version.
     create_and_save_state_id_mapping_model_for_reverted_exploration(

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -897,7 +897,8 @@ def _save_exploration(committer_id, exploration, commit_message, change_list):
     if feconf.ENABLE_PLAYTHROUGHS:
         exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.update_exp_issues_for_new_exp_version(
-            exploration, exp_versions_diff, None)
+            exploration, exp_versions_diff=exp_versions_diff,
+            revert_to_version=None)
 
     # Save state id mapping model for exploration.
     create_and_save_state_id_mapping_model(exploration, change_list)
@@ -1425,7 +1426,8 @@ def revert_exploration(
         current_exploration = get_exploration_by_id(
             exploration_id, version=current_version)
         stats_services.update_exp_issues_for_new_exp_version(
-            current_exploration, None, revert_to_version)
+            current_exploration, exp_versions_diff=None,
+            revert_to_version=revert_to_version)
 
     # Save state id mapping model for the new exploration version.
     create_and_save_state_id_mapping_model_for_reverted_exploration(

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -305,7 +305,11 @@ def update_exp_issues_for_new_exp_version(
     # Handling reverts.
     if revert_to_version:
         old_exp_issues = get_exp_issues(exploration.id, revert_to_version)
-        exp_issues.unresolved_issues = old_exp_issues.unresolved_issues
+        # If the old exploration issues model doesn't exist, the current model
+        # is carried over (this is a fallback case for some tests, and can
+        # never happen in production.)
+        if old_exp_issues:
+            exp_issues.unresolved_issues = old_exp_issues.unresolved_issues
         exp_issues.exp_version = exploration.version + 1
         create_exp_issues_model(exp_issues)
         return

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -291,8 +291,8 @@ def update_exp_issues_for_new_exp_version(
 
     Args:
         exploration: Exploration. Domain object for the exploration.
-        exp_versions_diff: ExplorationVersionsDiff. The domain object for the
-            exploration versions difference.
+        exp_versions_diff: ExplorationVersionsDiff|None. The domain object for
+            the exploration versions difference, None if it is a revert.
         revert_to_version: int|None. If the change is a revert, the version.
             Otherwise, None.
     """
@@ -306,7 +306,7 @@ def update_exp_issues_for_new_exp_version(
     if revert_to_version:
         old_exp_issues = get_exp_issues(exploration.id, revert_to_version)
         exp_issues.unresolved_issues = old_exp_issues.unresolved_issues
-        exp_issues.exp_version += 1
+        exp_issues.exp_version = exploration.version + 1
         create_exp_issues_model(exp_issues)
         return
 

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -166,7 +166,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             assets_list)
         exploration = exp_services.get_exploration_by_id(exp_id)
         exp_issues = stats_services.get_exp_issues(exp_id, exploration.version)
-        self.assertEqual(exp_issues.exp_version, 1)
+        self.assertEqual(exp_issues.exp_version, exploration.version)
         self.assertEqual(exp_issues.unresolved_issues, [])
 
         # Update exploration to next version, exploration issues model also
@@ -179,7 +179,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'committer_id_v3', exploration.id, change_list, 'Added new state')
         exploration = exp_services.get_exploration_by_id(exp_id)
         exp_issues = stats_services.get_exp_issues(exp_id, exploration.version)
-        self.assertEqual(exp_issues.exp_version, 2)
+        self.assertEqual(exp_issues.exp_version, exploration.version)
         self.assertEqual(exp_issues.unresolved_issues, [])
 
         # Create a playthrough and assign it to an issue in exploration issues
@@ -227,7 +227,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'committer_id_v3', exploration.id, change_list, 'Deleted a state')
         exploration = exp_services.get_exploration_by_id(exp_id)
         exp_issues = stats_services.get_exp_issues(exp_id, exploration.version)
-        self.assertEqual(exp_issues.exp_version, 3)
+        self.assertEqual(exp_issues.exp_version, exploration.version)
         self.assertEqual(exp_issues.unresolved_issues[0].to_dict(), {
             'issue_type': 'EarlyQuit',
             'issue_customization_args': {
@@ -248,7 +248,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'committer_id_v4', exp_id, current_version=3, revert_to_version=2)
         exploration = exp_services.get_exploration_by_id(exp_id)
         exp_issues = stats_services.get_exp_issues(exp_id, exploration.version)
-        self.assertEqual(exp_issues.exp_version, 4)
+        self.assertEqual(exp_issues.exp_version, exploration.version)
         self.assertEqual(exp_issues.unresolved_issues[0].to_dict(), {
             'issue_type': 'EarlyQuit',
             'issue_customization_args': {

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -151,6 +151,118 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         self.assertEqual(stats_for_new_exploration_log.times_called, 1)
         self.assertEqual(stats_for_new_exp_version_log.times_called, 1)
 
+    def test_exploration_changes_effect_on_exp_issues_model(self):
+        """Test the effect of exploration changes on exploration issues model.
+        """
+        exp_id = 'exp_id'
+        test_exp_filepath = os.path.join(
+            feconf.TESTS_DATA_DIR, 'string_classifier_test.yaml')
+        yaml_content = utils.get_file_contents(test_exp_filepath)
+        assets_list = []
+
+        # Exploration is created, exploration issues model must also be created.
+        exp_services.save_new_exploration_from_yaml_and_assets(
+            feconf.SYSTEM_COMMITTER_ID, yaml_content, exp_id,
+            assets_list)
+        exploration = exp_services.get_exploration_by_id(exp_id)
+        exp_issues = stats_services.get_exp_issues(exp_id, exploration.version)
+        self.assertEqual(exp_issues.exp_version, 1)
+        self.assertEqual(exp_issues.unresolved_issues, [])
+
+        # Update exploration to next version, exploration issues model also
+        # created.
+        change_list = [exp_domain.ExplorationChange({
+            'cmd': exp_domain.CMD_ADD_STATE,
+            'state_name': 'New state'
+        })]
+        exp_services.update_exploration(
+            'committer_id_v3', exploration.id, change_list, 'Added new state')
+        exploration = exp_services.get_exploration_by_id(exp_id)
+        exp_issues = stats_services.get_exp_issues(exp_id, exploration.version)
+        self.assertEqual(exp_issues.exp_version, 2)
+        self.assertEqual(exp_issues.unresolved_issues, [])
+
+        # Create a playthrough and assign it to an issue in exploration issues
+        # model.
+        playthrough_id1 = stats_models.PlaythroughModel.create(
+            exploration.id, exploration.version, 'EarlyQuit', {
+                'state_name': {
+                    'value': 'New state'
+                },
+                'time_spent_in_exp_in_msecs': {
+                    'value': 200
+                }
+            }, [{
+                'action_type': 'ExplorationStart',
+                'action_customization_args': {
+                    'state_name': {
+                        'value': 'New state'
+                    }
+                },
+                'schema_version': 1
+            }])
+        exp_issue1 = stats_domain.ExplorationIssue.from_dict({
+            'issue_type': 'EarlyQuit',
+            'issue_customization_args': {
+                'state_name': {
+                    'value': 'New state'
+                },
+                'time_spent_in_exp_in_msecs': {
+                    'value': 200
+                }
+            },
+            'playthrough_ids': [playthrough_id1],
+            'schema_version': 1,
+            'is_valid': True
+        })
+        exp_issues.unresolved_issues = [exp_issue1]
+        stats_services.save_exp_issues_model_transactional(exp_issues)
+
+        # Delete a state.
+        change_list = [exp_domain.ExplorationChange({
+            'cmd': exp_domain.CMD_DELETE_STATE,
+            'state_name': 'New state'
+        })]
+        exp_services.update_exploration(
+            'committer_id_v3', exploration.id, change_list, 'Deleted a state')
+        exploration = exp_services.get_exploration_by_id(exp_id)
+        exp_issues = stats_services.get_exp_issues(exp_id, exploration.version)
+        self.assertEqual(exp_issues.exp_version, 3)
+        self.assertEqual(exp_issues.unresolved_issues[0].to_dict(), {
+            'issue_type': 'EarlyQuit',
+            'issue_customization_args': {
+                'state_name': {
+                    'value': 'New state'
+                },
+                'time_spent_in_exp_in_msecs': {
+                    'value': 200
+                }
+            },
+            'playthrough_ids': [playthrough_id1],
+            'schema_version': 1,
+            'is_valid': False
+        })
+
+        # Revert to an older version, exploration issues model also changes.
+        exp_services.revert_exploration('committer_id_v4', exp_id, 3, 2)
+        exploration = exp_services.get_exploration_by_id(exp_id)
+        exp_issues = stats_services.get_exp_issues(exp_id, exploration.version)
+        self.assertEqual(exp_issues.exp_version, 4)
+        self.assertEqual(exp_issues.unresolved_issues[0].to_dict(), {
+            'issue_type': 'EarlyQuit',
+            'issue_customization_args': {
+                'state_name': {
+                    'value': 'New state'
+                },
+                'time_spent_in_exp_in_msecs': {
+                    'value': 200
+                }
+            },
+            'playthrough_ids': [playthrough_id1],
+            'schema_version': 1,
+            'is_valid': True
+        })
+
     def test_handle_stats_creation_for_new_exploration(self):
         """Test the handle_stats_creation_for_new_exploration method."""
         # Create exploration object in datastore.

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -215,7 +215,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'schema_version': 1,
             'is_valid': True
         })
-        exp_issues.unresolved_issues = [exp_issue1]
+        exp_issues.unresolved_issues.append(exp_issue1)
         stats_services.save_exp_issues_model_transactional(exp_issues)
 
         # Delete a state.
@@ -244,7 +244,8 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         })
 
         # Revert to an older version, exploration issues model also changes.
-        exp_services.revert_exploration('committer_id_v4', exp_id, 3, 2)
+        exp_services.revert_exploration(
+            'committer_id_v4', exp_id, current_version=3, revert_to_version=2)
         exploration = exp_services.get_exploration_by_id(exp_id)
         exp_issues = stats_services.get_exp_issues(exp_id, exploration.version)
         self.assertEqual(exp_issues.exp_version, 4)


### PR DESCRIPTION
Hi @tjiang11 @seanlip 

This PR fixes the reverting procedure and additionally adds tests to it. Flag flipping should be good to go now.

Thanks