### PR TITLE
Generalised review system: Validation job for the suggestion migration

### DIFF
--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -160,3 +160,26 @@ class SuggestionMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     @staticmethod
     def reduce(key, value):
         pass
+
+
+class SuggestionMigrationValdiationOneOffJob(
+        jobs.BaseMapReduceOneOffJobManager):
+    """One-off job for validating all suggestions from the old model are
+    converted to the new model.
+    """
+    @classmethod
+    def entity_classes_to_map_over(cls):
+        return [feedback_models.SuggestionModel,
+                suggestion_models.GeneralSuggestionModel]
+
+    @staticmethod
+    def map(item):
+        if isinstance(item, feedback_models.SuggestionModel):
+            yield ('old', item.id)
+        else:
+            yield ('new', item.id)
+
+    @staticmethod
+    def reduce(key, value):
+        yield (key, len(value))
+

--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -182,4 +182,3 @@ class SuggestionMigrationValdiationOneOffJob(
     @staticmethod
     def reduce(key, value):
         yield (key, len(value))
-

--- a/core/domain/feedback_jobs_one_off_test.py
+++ b/core/domain/feedback_jobs_one_off_test.py
@@ -279,6 +279,24 @@ class SuggestionMigrationOneOffJobTest(test_utils.GenericTestBase):
                 taskqueue_services.QUEUE_NAME_ONE_OFF_JOBS), 1)
         self.process_and_flush_pending_tasks()
 
+    def _run_validation_job(self):
+        job_id = (
+            feedback_jobs_one_off.SuggestionMigrationValdiationOneOffJob
+            .create_new())
+        feedback_jobs_one_off.SuggestionMigrationValdiationOneOffJob.enqueue(
+            job_id)
+        self.assertEqual(
+            self.count_jobs_in_taskqueue(
+                taskqueue_services.QUEUE_NAME_ONE_OFF_JOBS), 1)
+        self.process_and_flush_pending_tasks()
+        stringified_output = (
+            feedback_jobs_one_off.SuggestionMigrationValdiationOneOffJob
+            .get_output(job_id))
+
+        eval_output = [ast.literal_eval(stringified_item)
+                       for stringified_item in stringified_output]
+        return eval_output
+
     def setUp(self):
         super(SuggestionMigrationOneOffJobTest, self).setUp()
 
@@ -357,3 +375,14 @@ class SuggestionMigrationOneOffJobTest(test_utils.GenericTestBase):
             suggestion.change_cmd, expected_change_cmd)
         self.assertEqual(
             suggestion.score_category, 'content.' + exploration.category)
+
+    def test_suggestion_miigration_validation_one_off_job(self):
+        exploration = exp_services.get_exploration_by_id(self.EXP_ID)
+        for i in range(10):
+            feedback_services.create_suggestion(
+                self.EXP_ID, self.author_id, exploration.version, 'State 1',
+                'description', 'new_value')
+        self._run_one_off_job()
+
+        output = self._run_validation_job()
+        self.assertEqual(output[0][1], output[1][1])

--- a/core/domain/feedback_jobs_one_off_test.py
+++ b/core/domain/feedback_jobs_one_off_test.py
@@ -378,7 +378,7 @@ class SuggestionMigrationOneOffJobTest(test_utils.GenericTestBase):
 
     def test_suggestion_miigration_validation_one_off_job(self):
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)
-        for i in range(10):
+        for _ in range(10):
             feedback_services.create_suggestion(
                 self.EXP_ID, self.author_id, exploration.version, 'State 1',
                 'description', 'new_value')
@@ -386,3 +386,4 @@ class SuggestionMigrationOneOffJobTest(test_utils.GenericTestBase):
 
         output = self._run_validation_job()
         self.assertEqual(output[0][1], output[1][1])
+        self.assertEqual(output[0][1], 10)

--- a/core/domain/feedback_jobs_one_off_test.py
+++ b/core/domain/feedback_jobs_one_off_test.py
@@ -376,7 +376,7 @@ class SuggestionMigrationOneOffJobTest(test_utils.GenericTestBase):
         self.assertEqual(
             suggestion.score_category, 'content.' + exploration.category)
 
-    def test_suggestion_miigration_validation_one_off_job(self):
+    def test_suggestion_migration_validation_one_off_job(self):
         exploration = exp_services.get_exploration_by_id(self.EXP_ID)
         for _ in range(10):
             feedback_services.create_suggestion(

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -51,6 +51,7 @@ ONE_OFF_JOB_MANAGERS = [
     feedback_jobs_one_off.FeedbackThreadMessagesCountOneOffJob,
     feedback_jobs_one_off.FeedbackSubjectOneOffJob,
     feedback_jobs_one_off.SuggestionMigrationOneOffJob,
+    feedback_jobs_one_off.SuggestionMigrationValdiationOneOffJob,
     recommendations_jobs_one_off.ExplorationRecommendationsOneOffJob,
     stats_jobs_one_off.ExplorationIssuesModelCreatorOneOffJob,
     stats_jobs_one_off.RecomputeStatisticsOneOffJob,


### PR DESCRIPTION
## Explanation
This PR adds a job that will help validate the suggestion migration job. It yields the count of elements in the old and new framework so that we can easily verify that the counts match.

PTAL @anmolshkl. Also please note to prioritize this for this release. Thanks!
## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
