### PR TITLE
Add currency units to the Number with Units interaction

### DIFF
--- a/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactory.js
@@ -316,6 +316,19 @@ oppia.factory('UnitsObjectFactory', [function() {
     // Makes the units compatible with the math.js allowed format.
     units = units.replace(/per/g, '/');
 
+    if (units.includes('Dollars') || units.includes('dollars') ||
+      units.includes('Dollar')) {
+      units = units.replace('dollars', 'dollar');
+      units = units.replace('Dollars', 'dollar');
+      units = units.replace('Dollar', 'dollar');
+    }
+    if (units.includes('Rupees') || units.includes('rupees') ||
+      units.includes('Rupee')) {
+      units = units.replace('rupees', 'rupee');
+      units = units.replace('Rupees', 'rupee');
+      units = units.replace('Rupee', 'rupee');
+    }
+
     // Special symbols need to be replaced as math.js doesn't support custom
     // units starting with special symbols. Also, it doesn't allow units
     // followed by a number as in the case of currency units.
@@ -326,7 +339,7 @@ oppia.factory('UnitsObjectFactory', [function() {
     if (units.includes('Rs') || units.includes('₹')) {
       units = units.replace('Rs', '');
       units = units.replace('₹', '');
-      units = 'rupees ' + units;
+      units = 'rupee ' + units;
     }
     return units.trim();
   };

--- a/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactory.js
@@ -75,14 +75,9 @@ oppia.factory('NumberWithUnitsObjectFactory', [
     };
 
     NumberWithUnits.createCurrencyUnits = function() {
-      // Creates user-defined currency (base + sub) units.
-      math.createUnit('dollar', {aliases: [
-        'dollars', 'Dollar', 'USD', '$', 'Dollars']});
-      math.createUnit('cent', {definition: '0.01 dollar', aliases: [
-        'Cent', 'cents', 'Cents']});
-      math.createUnit('rupees', {aliases: [
-        'Rupees', 'Rs', 'rupee', 'Rupee', '₹']});
-      math.createUnit('paise', {definition: '0.01 rupees', aliases: ['paisa']});
+      try {
+        Units.createCurrencyUnits();
+      } catch (parsingError) {}
     };
 
     NumberWithUnits.fromRawInputString = function(rawInput) {
@@ -290,19 +285,34 @@ oppia.factory('UnitsObjectFactory', [function() {
     return unit.trim();
   };
 
+  Units.createCurrencyUnits = function() {
+    // Creates user-defined currency (base + sub) units.
+    math.createUnit('dollar', {aliases: [
+      'dollars', 'Dollar', 'USD', '$', 'Dollars']});
+    math.createUnit('cent', {definition: '0.01 dollar', aliases: [
+      'Cent', 'cents', 'Cents']});
+    math.createUnit('rupees', {aliases: [
+      'Rupees', 'Rs', 'rupee', 'Rupee', '₹']});
+    math.createUnit('paise', {definition: '0.01 rupees', aliases: ['paisa']});
+  };
+
   Units.fromRawInputString = function(units) {
     units = units.replace(/per/g, '/');
+    try {
+      Units.createCurrencyUnits();
+    } catch (parsingError) {}
+
     // Special symbols need to be replaced as math.js doesn't support custom
     // units starting with special symbols. Also, it doesn't allow units
     // followed by a number as in the case of currency units.
     if (units.includes('$')) {
       units = units.replace('$', '');
-      units += ' dollar';
+      units = 'dollar ' + units;
     }
     if (units.includes('Rs') || units.includes('₹')) {
       units = units.replace('Rs', '');
       units = units.replace('₹', '');
-      units += ' rupees';
+      units = 'rupees ' + units;
     }
 
     if (units !== '') {

--- a/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactory.js
@@ -74,6 +74,17 @@ oppia.factory('NumberWithUnitsObjectFactory', [
       };
     };
 
+    NumberWithUnits.createCurrencyUnits = function() {
+      // Creates user-defined currency (base + sub) units.
+      math.createUnit('dollar', {aliases: [
+        'dollars', 'Dollar', 'USD', '$', 'Dollars']});
+      math.createUnit('cent', {definition: '0.01 dollar', aliases: [
+        'Cent', 'cents', 'Cents']});
+      math.createUnit('rupees', {aliases: [
+        'Rupees', 'Rs', 'rupee', 'Rupee', '₹']});
+      math.createUnit('paise', {definition: '0.01 rupees', aliases: ['paisa']});
+    };
+
     NumberWithUnits.fromRawInputString = function(rawInput) {
       rawInput = rawInput.trim();
       var type = '';
@@ -281,10 +292,20 @@ oppia.factory('UnitsObjectFactory', [function() {
 
   Units.fromRawInputString = function(units) {
     units = units.replace(/per/g, '/');
-    // Right now, validation of currency units is not possible as we need to add
-    // them first.
-    if (units !== '' && !units.includes('$') && !units.includes('Rs') &&
-      !units.includes('₹')) {
+    // Special symbols need to be replaced as math.js doesn't support custom
+    // units starting with special symbols. Also, it doesn't allow units
+    // followed by a number as in the case of currency units.
+    if (units.includes('$')) {
+      units = units.replace('$', '');
+      units += ' dollar';
+    }
+    if (units.includes('Rs') || units.includes('₹')) {
+      units = units.replace('Rs', '');
+      units = units.replace('₹', '');
+      units += ' rupees';
+    }
+
+    if (units !== '') {
       try {
         math.unit(units);
       } catch (err) {

--- a/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactory.js
+++ b/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactory.js
@@ -65,10 +65,10 @@ oppia.factory('NumberWithUnitsObjectFactory', [
       return numberWithUnitsString;
     };
 
-    NumberWithUnits.prototype.toCompatibleString = function() {
+    NumberWithUnits.prototype.toMathjsCompatibleString = function() {
       var numberWithUnitsString = '';
       var unitsString = UnitsObjectFactory.fromList(this.units).toString();
-      unitsString = UnitsObjectFactory.makeUnitsCompatible(unitsString);
+      unitsString = UnitsObjectFactory.toMathjsCompatibleString(unitsString);
 
       if (this.type === 'real') {
         numberWithUnitsString += this.real + ' ';
@@ -312,7 +312,7 @@ oppia.factory('UnitsObjectFactory', [function() {
     math.createUnit('paise', {definition: '0.01 rupees', aliases: ['paisa']});
   };
 
-  Units.makeUnitsCompatible = function(units) {
+  Units.toMathjsCompatibleString = function(units) {
     // Makes the units compatible with the math.js allowed format.
     units = units.replace(/per/g, '/');
 
@@ -336,7 +336,7 @@ oppia.factory('UnitsObjectFactory', [function() {
       Units.createCurrencyUnits();
     } catch (parsingError) {}
 
-    compatibleUnits = Units.makeUnitsCompatible(units);
+    compatibleUnits = Units.toMathjsCompatibleString(units);
     if (compatibleUnits !== '') {
       try {
         math.unit(compatibleUnits);

--- a/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactorySpec.js
@@ -78,17 +78,17 @@ describe('NumberWithUnitsObjectFactory', function() {
       expect(new NumberWithUnits('real', 2.02, new Fraction(false, 0, 0, 1
       ), Units.fromRawInputString('m / s^2')).toString()).toBe('2.02 m^1 s^-2');
       expect(new NumberWithUnits('real', 2.02, new Fraction(false, 0, 0, 1
-      ), Units.fromRawInputString('Rs')).toString()).toBe('Rs 2.02');
+      ), Units.fromRawInputString('Rs')).toString()).toBe('2.02 rupees^1');
       expect(new NumberWithUnits('real', 2, new Fraction(false, 0, 0, 1
       ), Units.fromRawInputString('')).toString()).toBe('2');
       expect(new NumberWithUnits('fraction', 0, new Fraction(true, 0, 4, 3
       ), Units.fromRawInputString('m / s^2')).toString()).toBe('-4/3 m^1 s^-2');
       expect(new NumberWithUnits('fraction', 0, new Fraction(
         false, 0, 4, 3), Units.fromRawInputString('$ per hour')).toString(
-      )).toBe('$ 4/3 hour^-1');
+      )).toBe('4/3 dollar^1 hour^-1');
       expect(new NumberWithUnits('real', 40, new Fraction(
         false, 0, 0, 1), Units.fromRawInputString('Rs per hour')).toString(
-      )).toBe('Rs 40 hour^-1');
+      )).toBe('40 rupees^1 hour^-1');
     });
 
     it('should parse valid units strings', function() {

--- a/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/objects/NumberWithUnitsObjectFactorySpec.js
@@ -51,12 +51,12 @@ describe('NumberWithUnitsObjectFactory', function() {
         [{exponent: -1, unit: 'kg'}, {exponent: 2, unit: 'K'},
           {exponent: 1, unit: 'mol'}, {exponent: -1, unit: 'N'},
           {exponent: -1, unit: 'm'}, {exponent: -1, unit: 's'}]
-      ).toString()).toBe('kg^-1 K^2 mol^1 N^-1 m^-1 s^-1');
+      ).toString()).toBe('kg^-1 K^2 mol N^-1 m^-1 s^-1');
       expect(new Units(
         [{exponent: 1, unit: 'mol'}, {exponent: -1, unit: 'kg'},
           {exponent: 1, unit: 'N'}, {exponent: 1, unit: 'm'},
           {exponent: -2, unit: 's'}]).toString()).toBe(
-        'mol^1 kg^-1 N^1 m^1 s^-2');
+        'mol kg^-1 N m s^-2');
     });
 
     it('should convert units from string to lexical format', function() {
@@ -76,19 +76,19 @@ describe('NumberWithUnitsObjectFactory', function() {
 
     it('should convert number with units object to a string', function() {
       expect(new NumberWithUnits('real', 2.02, new Fraction(false, 0, 0, 1
-      ), Units.fromRawInputString('m / s^2')).toString()).toBe('2.02 m^1 s^-2');
+      ), Units.fromRawInputString('m / s^2')).toString()).toBe('2.02 m s^-2');
       expect(new NumberWithUnits('real', 2.02, new Fraction(false, 0, 0, 1
-      ), Units.fromRawInputString('Rs')).toString()).toBe('2.02 rupees^1');
+      ), Units.fromRawInputString('Rs')).toString()).toBe('Rs 2.02');
       expect(new NumberWithUnits('real', 2, new Fraction(false, 0, 0, 1
       ), Units.fromRawInputString('')).toString()).toBe('2');
       expect(new NumberWithUnits('fraction', 0, new Fraction(true, 0, 4, 3
-      ), Units.fromRawInputString('m / s^2')).toString()).toBe('-4/3 m^1 s^-2');
+      ), Units.fromRawInputString('m / s^2')).toString()).toBe('-4/3 m s^-2');
       expect(new NumberWithUnits('fraction', 0, new Fraction(
         false, 0, 4, 3), Units.fromRawInputString('$ per hour')).toString(
-      )).toBe('4/3 dollar^1 hour^-1');
+      )).toBe('$ 4/3 hour^-1');
       expect(new NumberWithUnits('real', 40, new Fraction(
         false, 0, 0, 1), Units.fromRawInputString('Rs per hour')).toString(
-      )).toBe('40 rupees^1 hour^-1');
+      )).toBe('Rs 40 hour^-1');
     });
 
     it('should parse valid units strings', function() {

--- a/extensions/interactions/NumberWithUnits/directives/NumberWithUnits.js
+++ b/extensions/interactions/NumberWithUnits/directives/NumberWithUnits.js
@@ -47,6 +47,10 @@ oppia.directive('oppiaInteractiveNumberWithUnits', [
             return errorMessage;
           };
 
+          try {
+            NumberWithUnitsObjectFactory.createCurrencyUnits();
+          } catch (parsingError) {}
+
           $scope.$watch('answer', function(newValue) {
             try {
               var numberWithUnits =
@@ -156,6 +160,10 @@ oppia.directive('oppiaShortResponseNumberWithUnits', [
 oppia.factory('numberWithUnitsRulesService', [
   'NumberWithUnitsObjectFactory', 'FractionObjectFactory',
   function(NumberWithUnitsObjectFactory, FractionObjectFactory) {
+    try {
+      NumberWithUnitsObjectFactory.createCurrencyUnits();
+    } catch (parsingError) {}
+
     return {
       IsEqualTo: function(answer, inputs) {
         // Returns true only if input is exactly equal to answer.

--- a/extensions/interactions/NumberWithUnits/directives/NumberWithUnits.js
+++ b/extensions/interactions/NumberWithUnits/directives/NumberWithUnits.js
@@ -167,7 +167,17 @@ oppia.factory('numberWithUnitsRulesService', [
     return {
       IsEqualTo: function(answer, inputs) {
         // Returns true only if input is exactly equal to answer.
-        return angular.equals(answer, inputs.f);
+        answer = NumberWithUnitsObjectFactory.fromDict(answer);
+        inputs = NumberWithUnitsObjectFactory.fromDict(inputs.f);
+
+        answerString = answer.toMathjsCompatibleString();
+        inputsString = inputs.toMathjsCompatibleString();
+
+        answerList = NumberWithUnitsObjectFactory.fromRawInputString(
+          answerString).toDict();
+        inputsList = NumberWithUnitsObjectFactory.fromRawInputString(
+          inputsString).toDict();
+        return angular.equals(answerList, inputsList);
       },
       IsEquivalentTo: function(answer, inputs) {
         answer = NumberWithUnitsObjectFactory.fromDict(answer);

--- a/extensions/interactions/NumberWithUnits/directives/NumberWithUnits.js
+++ b/extensions/interactions/NumberWithUnits/directives/NumberWithUnits.js
@@ -180,8 +180,8 @@ oppia.factory('numberWithUnitsRulesService', [
           inputs.type = 'real';
           inputs.real = inputs.fraction.toFloat();
         }
-        answerString = answer.toCompatibleString();
-        inputsString = inputs.toCompatibleString();
+        answerString = answer.toMathjsCompatibleString();
+        inputsString = inputs.toMathjsCompatibleString();
         return math.unit(answerString).equals(math.unit(inputsString));
       }
     };

--- a/extensions/interactions/NumberWithUnits/directives/NumberWithUnits.js
+++ b/extensions/interactions/NumberWithUnits/directives/NumberWithUnits.js
@@ -180,8 +180,8 @@ oppia.factory('numberWithUnitsRulesService', [
           inputs.type = 'real';
           inputs.real = inputs.fraction.toFloat();
         }
-        answerString = answer.toString();
-        inputsString = inputs.toString();
+        answerString = answer.toCompatibleString();
+        inputsString = inputs.toCompatibleString();
         return math.unit(answerString).equals(math.unit(inputsString));
       }
     };

--- a/extensions/interactions/NumberWithUnits/directives/NumberWithUnitsRulesServiceSpec.js
+++ b/extensions/interactions/NumberWithUnits/directives/NumberWithUnitsRulesServiceSpec.js
@@ -54,6 +54,12 @@ describe('Number with Units rules service', function() {
       false, 0, 2, 3), [{unit: 'kg', exponent: 1}, {unit: 'm', exponent: -2}])
   };
 
+  var CURRENCY_RULE_INPUT = {
+    f: createNumberWithUnitsDict('real', 2, createFractionDict(
+      false, 0, 0, 1), [{unit: 'dollar', exponent: 1}, {unit: 'm',
+      exponent: -2}])
+  };
+
   it('should have a correct \'equal to\' rule', function() {
     expect(nurs.IsEqualTo(createNumberWithUnitsDict(
       'real', 2.5, createFractionDict(false, 0, 0, 1),
@@ -83,6 +89,14 @@ describe('Number with Units rules service', function() {
       'fraction', 0, createFractionDict(false, 0, 2, 3),
       [{unit: 'kg', exponent: 1}, {unit: 'm', exponent: 2}]),
     FRACTION_RULE_INPUT)).toBe(false);
+    expect(nurs.IsEqualTo(createNumberWithUnitsDict(
+      'real', 2, createFractionDict(false, 0, 0, 1),
+      [{unit: 'dollar', exponent: 1}, {unit: 'm', exponent: -2}]),
+    CURRENCY_RULE_INPUT)).toBe(true);
+    expect(nurs.IsEqualTo(createNumberWithUnitsDict(
+      'real', 2, createFractionDict(false, 0, 0, 1),
+      [{unit: 'cent', exponent: 1}, {unit: 'm', exponent: -2}]),
+    CURRENCY_RULE_INPUT)).toBe(false);
   });
 
   it('should have a correct \'equivalent to\' rule', function() {
@@ -122,5 +136,13 @@ describe('Number with Units rules service', function() {
       'fraction', 0, createFractionDict(false, 0, 200, 30),
       [{unit: 'kg', exponent: 1}, {unit: 'm', exponent: -2}]),
     FRACTION_RULE_INPUT)).toBe(false);
+    expect(nurs.IsEquivalentTo(createNumberWithUnitsDict(
+      'real', 2, createFractionDict(false, 0, 0, 1),
+      [{unit: 'Dollars', exponent: 1}, {unit: 'm', exponent: -2}]),
+    CURRENCY_RULE_INPUT)).toBe(true);
+    expect(nurs.IsEquivalentTo(createNumberWithUnitsDict(
+      'real', 200, createFractionDict(false, 0, 0, 1),
+      [{unit: 'cents', exponent: 1}, {unit: 'm', exponent: -2}]),
+    CURRENCY_RULE_INPUT)).toBe(true);
   });
 });

--- a/extensions/interactions/NumberWithUnits/directives/NumberWithUnitsValidationService.js
+++ b/extensions/interactions/NumberWithUnits/directives/NumberWithUnitsValidationService.js
@@ -53,8 +53,8 @@ oppia.factory('NumberWithUnitsValidationService', [
             laterInput.type = 'real';
             laterInput.real = laterInput.fraction.toFloat();
           }
-          earlierInputString = earlierInput.toCompatibleString();
-          laterInputString = laterInput.toCompatibleString();
+          earlierInputString = earlierInput.toMathjsCompatibleString();
+          laterInputString = laterInput.toMathjsCompatibleString();
           return math.unit(laterInputString).equals(math.unit(
             earlierInputString));
         };

--- a/extensions/interactions/NumberWithUnits/directives/NumberWithUnitsValidationService.js
+++ b/extensions/interactions/NumberWithUnits/directives/NumberWithUnitsValidationService.js
@@ -37,7 +37,17 @@ oppia.factory('NumberWithUnitsValidationService', [
         } catch (parsingError) {}
 
         var checkEquality = function(earlierRule, laterRule) {
-          return angular.equals(earlierRule.inputs.f, laterRule.inputs.f);
+          answer = NumberWithUnitsObjectFactory.fromDict(earlierRule.inputs.f);
+          inputs = NumberWithUnitsObjectFactory.fromDict(laterRule.inputs.f);
+
+          answerString = answer.toMathjsCompatibleString();
+          inputsString = inputs.toMathjsCompatibleString();
+
+          answerList = NumberWithUnitsObjectFactory.fromRawInputString(
+            answerString).toDict();
+          inputsList = NumberWithUnitsObjectFactory.fromRawInputString(
+            inputsString).toDict();
+          return angular.equals(answerList, inputsList);
         };
 
         var checkEquivalency = function(earlierRule, laterRule) {

--- a/extensions/interactions/NumberWithUnits/directives/NumberWithUnitsValidationService.js
+++ b/extensions/interactions/NumberWithUnits/directives/NumberWithUnitsValidationService.js
@@ -53,8 +53,8 @@ oppia.factory('NumberWithUnitsValidationService', [
             laterInput.type = 'real';
             laterInput.real = laterInput.fraction.toFloat();
           }
-          earlierInputString = earlierInput.toString();
-          laterInputString = laterInput.toString();
+          earlierInputString = earlierInput.toCompatibleString();
+          laterInputString = laterInput.toCompatibleString();
           return math.unit(laterInputString).equals(math.unit(
             earlierInputString));
         };

--- a/extensions/interactions/NumberWithUnits/directives/NumberWithUnitsValidationService.js
+++ b/extensions/interactions/NumberWithUnits/directives/NumberWithUnitsValidationService.js
@@ -32,6 +32,10 @@ oppia.factory('NumberWithUnitsValidationService', [
         warningsList = warningsList.concat(
           this.getCustomizationArgsWarnings(customizationArgs));
 
+        try {
+          NumberWithUnitsObjectFactory.createCurrencyUnits();
+        } catch (parsingError) {}
+
         var checkEquality = function(earlierRule, laterRule) {
           return angular.equals(earlierRule.inputs.f, laterRule.inputs.f);
         };

--- a/extensions/interactions/NumberWithUnits/directives/number_with_units_help_modal_directive.html
+++ b/extensions/interactions/NumberWithUnits/directives/number_with_units_help_modal_directive.html
@@ -42,6 +42,13 @@
     </tr>
     <tr>
       <td>
+        Separate numerator and denominator of the units using '/' or 'per' symbol.
+      </td>
+      <td>5 kmperhr</td>
+      <td>5 km/hr <br> 5 km per hr</td>
+    </tr>
+    <tr>
+      <td>
         For adding dimensions to the unit, use the caret '^' symbol to add both positive
         and negative powers.
       </td>
@@ -146,6 +153,12 @@
     <tr>
       <td>Binary</td>
       <td>bit (b), byte (B)</td>
+    </tr>
+    <tr>
+      <td>Currency</td>
+      <td>
+        $ (dollar(s), Dollar(s)), ₹ (Rs, Rupee(s), rupee(s)), Cent(s) / cent(s), Paisa / paise
+      </td>
     </tr>
   </table>
 </div>


### PR DESCRIPTION
This PR adds currency units (base + sub units) to the Number with Units interaction.
* `Dollar` as base unit and `cent` as its sub-unit.
* `Rupees` as base unit and `paisa` as its sub-unit.

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
