### PR TITLE
Add arg name to arg with default values.

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -528,7 +528,7 @@ class ExplorationMigrationValidationJobForTextAngular(
         html_list = exploration.get_all_html_content_strings()
 
         err_dict = html_cleaner.validate_rte_format(
-            html_list, feconf.RTE_FORMAT_TEXTANGULAR, True)
+            html_list, feconf.RTE_FORMAT_TEXTANGULAR, run_migration=True)
 
         for key in err_dict:
             if err_dict[key]:
@@ -596,7 +596,7 @@ class ExplorationMigrationValidationJobForCKEditor(
         html_list = exploration.get_all_html_content_strings()
 
         err_dict = html_cleaner.validate_rte_format(
-            html_list, feconf.RTE_FORMAT_CKEDITOR, True)
+            html_list, feconf.RTE_FORMAT_CKEDITOR, run_migration=True)
 
         for key in err_dict:
             if err_dict[key]:

--- a/core/domain/html_cleaner_test.py
+++ b/core/domain/html_cleaner_test.py
@@ -331,7 +331,7 @@ class ContentMigrationTests(test_utils.GenericTestBase):
         actual_output_with_migration_for_textangular = (
             html_cleaner.validate_rte_format(
                 test_cases_for_textangular,
-                feconf.RTE_FORMAT_TEXTANGULAR, True))
+                feconf.RTE_FORMAT_TEXTANGULAR, run_migration=True))
         actual_output_without_migration_for_textangular = (
             html_cleaner.validate_rte_format(
                 test_cases_for_textangular, feconf.RTE_FORMAT_TEXTANGULAR))
@@ -382,7 +382,8 @@ class ContentMigrationTests(test_utils.GenericTestBase):
 
         actual_output_with_migration_for_ckeditor = (
             html_cleaner.validate_rte_format(
-                test_cases_for_ckeditor, feconf.RTE_FORMAT_CKEDITOR, True))
+                test_cases_for_ckeditor, feconf.RTE_FORMAT_CKEDITOR,
+                run_migration=True))
         actual_output_without_migration_for_ckeditor = (
             html_cleaner.validate_rte_format(
                 test_cases_for_ckeditor, feconf.RTE_FORMAT_CKEDITOR))


### PR DESCRIPTION
Fixes a lint issue: we should specify the arg name in the caller when the arg has a default value in the function being called.

/cc @apb7 @kevinlee12 could we please institute a lint check for this? This is important for comprehensibility and ensuring that it's clear when default values are being overridden.