### PR TITLE
Generalised review system: Remove assigned reviewer field

### DIFF
--- a/core/controllers/suggestion.py
+++ b/core/controllers/suggestion.py
@@ -39,7 +39,6 @@ class SuggestionHandler(base.BaseHandler):
             self.payload.get('target_version_at_submission'),
             self.user_id, self.payload.get('change_cmd'),
             self.payload.get('description'),
-            self.payload.get('assigned_reviewer_id'),
             self.payload.get('final_reviewer_id'))
         self.render_json(self.values)
 
@@ -92,7 +91,6 @@ class SuggestionToExplorationActionHandler(base.BaseHandler):
 class SuggestionListHandler(base.BaseHandler):
     """Handles list operations on suggestions."""
 
-    LIST_TYPE_ASSIGNED_REVIEWER = 'assignedReviewer'
     LIST_TYPE_AUTHOR = 'author'
     LIST_TYPE_ID = 'id'
     LIST_TYPE_REVIEWER = 'reviewer'
@@ -101,8 +99,6 @@ class SuggestionListHandler(base.BaseHandler):
     LIST_TYPE_TARGET_ID = 'target'
 
     LIST_TYPES_TO_SERVICES_MAPPING = {
-        LIST_TYPE_ASSIGNED_REVIEWER: (
-            suggestion_services.get_suggestions_assigned_to_reviewer),
         LIST_TYPE_AUTHOR: suggestion_services.get_suggestions_by_author,
         LIST_TYPE_ID: suggestion_services.get_suggestion_by_id,
         LIST_TYPE_REVIEWER: suggestion_services.get_suggestions_reviewed_by,
@@ -112,7 +108,6 @@ class SuggestionListHandler(base.BaseHandler):
     }
 
     PARAMS_FOR_LIST_TYPES = {
-        LIST_TYPE_ASSIGNED_REVIEWER: ['assigned_reviewer_id'],
         LIST_TYPE_AUTHOR: ['author_id'],
         LIST_TYPE_ID: ['suggestion_id'],
         LIST_TYPE_REVIEWER: ['reviewer_id'],

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -36,7 +36,6 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
 
     AUTHOR_EMAIL = 'author@example.com'
     AUTHOR_EMAIL_2 = 'author2@example.com'
-    ASSIGNED_REVIEWER_EMAIL = 'assigned_reviewer@example.com'
 
     def setUp(self):
         super(SuggestionUnitTests, self).setUp()
@@ -44,14 +43,11 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
         self.signup(self.AUTHOR_EMAIL, 'author')
         self.signup(self.AUTHOR_EMAIL_2, 'author2')
-        self.signup(self.ASSIGNED_REVIEWER_EMAIL, 'assignedReviewer')
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
         self.author_id = self.get_user_id_from_email(self.AUTHOR_EMAIL)
         self.author_id_2 = self.get_user_id_from_email(self.AUTHOR_EMAIL_2)
         self.reviewer_id = self.editor_id
-        self.assigned_reviewer_id = self.get_user_id_from_email(
-            self.ASSIGNED_REVIEWER_EMAIL)
 
         self.editor = user_services.UserActionsInfo(self.editor_id)
 
@@ -101,7 +97,6 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
                     },
                     'description': 'change to state 1',
                     'final_reviewer_id': self.reviewer_id,
-                    'assigned_reviewer_id': self.assigned_reviewer_id
                 }, csrf_token)
             self.logout()
 
@@ -125,7 +120,6 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
                     },
                     'description': 'change to state 2',
                     'final_reviewer_id': self.reviewer_id,
-                    'assigned_reviewer_id': self.assigned_reviewer_id
                 }, csrf_token)
 
             self.post_json(
@@ -144,7 +138,6 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
                     },
                     'description': 'change to state 3',
                     'final_reviewer_id': self.reviewer_id,
-                    'assigned_reviewer_id': self.assigned_reviewer_id
                 }, csrf_token)
             self.logout()
 

--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -120,7 +120,7 @@ class SuggestionMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
             suggestion_models.TARGET_TYPE_EXPLORATION + '.' + suggestion.id)
         thread = feedback_models.FeedbackThreadModel.get_by_id(suggestion.id)
         if thread.status == feedback_models.STATUS_CHOICES_OPEN:
-            status = suggestion_models.STATUS_RECEIVED
+            status = suggestion_models.STATUS_IN_REVIEW
         elif thread.status == feedback_models.STATUS_CHOICES_FIXED:
             status = suggestion_models.STATUS_ACCEPTED
         elif thread.status == feedback_models.STATUS_CHOICES_IGNORED:
@@ -153,9 +153,9 @@ class SuggestionMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
             target_id=suggestion.exploration_id,
             target_version_at_submission=suggestion.exploration_version,
             status=status, author_id=suggestion.author_id,
-            assigned_reviewer_id=None, final_reviewer_id=None,
-            change_cmd=change_cmd, score_category=score_category,
-            created_on=suggestion.created_on, deleted=suggestion.deleted).put()
+            final_reviewer_id=None, change_cmd=change_cmd,
+            score_category=score_category, created_on=suggestion.created_on,
+            deleted=suggestion.deleted).put()
 
     @staticmethod
     def reduce(key, value):

--- a/core/domain/feedback_jobs_one_off_test.py
+++ b/core/domain/feedback_jobs_one_off_test.py
@@ -367,10 +367,9 @@ class SuggestionMigrationOneOffJobTest(test_utils.GenericTestBase):
         self.assertEqual(suggestion.target_id, self.EXP_ID)
         self.assertEqual(
             suggestion.target_version_at_submission, exploration.version)
-        self.assertEqual(suggestion.status, suggestion_models.STATUS_RECEIVED)
+        self.assertEqual(suggestion.status, suggestion_models.STATUS_IN_REVIEW)
         self.assertEqual(suggestion.author_id, self.author_id)
         self.assertEqual(suggestion.final_reviewer_id, None)
-        self.assertEqual(suggestion.assigned_reviewer_id, None)
         self.assertDictEqual(
             suggestion.change_cmd, expected_change_cmd)
         self.assertEqual(

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -38,8 +38,6 @@ class BaseSuggestion(object):
             entity at the time of creation of the suggestion.
         status: str. The status of the suggestion.
         author_id: str. The ID of the user who submitted the suggestion.
-        assigned_reviewer_id: str. The ID of the user assigned to
-            review the suggestion.
         final_reviewer_id: str. The ID of the reviewer who has accepted/rejected
             the suggestion.
         change_cmd: Change. The details of the suggestion. This should be an
@@ -69,7 +67,6 @@ class BaseSuggestion(object):
             'status': self.status,
             'author_name': self.get_author_name(),
             'final_reviewer_id': self.final_reviewer_id,
-            'assigned_reviewer_id': self.assigned_reviewer_id,
             'change_cmd': self.change_cmd.to_dict(),
             'score_category': self.score_category,
             'last_updated': utils.get_time_in_millisecs(self.last_updated)
@@ -154,12 +151,6 @@ class BaseSuggestion(object):
                 'Expected author_id to be a string, received %s' % type(
                     self.author_id))
 
-        if not isinstance(self.assigned_reviewer_id, basestring):
-            if self.assigned_reviewer_id:
-                raise utils.ValidationError(
-                    'Expected assigned_reviewer_id to be a string,'
-                    ' received %s' % type(self.assigned_reviewer_id))
-
         if not isinstance(self.final_reviewer_id, basestring):
             if self.final_reviewer_id:
                 raise utils.ValidationError(
@@ -223,8 +214,7 @@ class BaseSuggestion(object):
         Returns:
             bool. Whether the suggestion has been handled or not.
         """
-        return (self.status not in [suggestion_models.STATUS_IN_REVIEW,
-                                    suggestion_models.STATUS_RECEIVED])
+        return self.status != suggestion_models.STATUS_IN_REVIEW
 
 
 class SuggestionEditStateContent(BaseSuggestion):
@@ -234,7 +224,7 @@ class SuggestionEditStateContent(BaseSuggestion):
 
     def __init__( # pylint: disable=super-init-not-called
             self, suggestion_id, target_id, target_version_at_submission,
-            status, author_id, assigned_reviewer_id, final_reviewer_id,
+            status, author_id, final_reviewer_id,
             change_cmd, score_category, last_updated):
         """Initializes an object of type SuggestionEditStateContent
         corresponding to the SUGGESTION_TYPE_EDIT_STATE_CONTENT choice.
@@ -247,7 +237,6 @@ class SuggestionEditStateContent(BaseSuggestion):
         self.target_version_at_submission = target_version_at_submission
         self.status = status
         self.author_id = author_id
-        self.assigned_reviewer_id = assigned_reviewer_id
         self.final_reviewer_id = final_reviewer_id
         self.change_cmd = exp_domain.ExplorationChange(change_cmd)
         self.score_category = score_category
@@ -347,7 +336,6 @@ class SuggestionEditStateContent(BaseSuggestion):
             suggestion_dict['target_id'],
             suggestion_dict['target_version_at_submission'],
             suggestion_dict['status'], suggestion_dict['author_id'],
-            suggestion_dict['assigned_reviewer_id'],
             suggestion_dict['final_reviewer_id'], suggestion_dict['change_cmd'],
             suggestion_dict['score_category'], suggestion_dict['last_updated'])
 

--- a/core/domain/suggestion_registry_test.py
+++ b/core/domain/suggestion_registry_test.py
@@ -55,9 +55,6 @@ class SuggestionEditStateContentUnitTests(test_utils.GenericTestBase):
         self.author_id = self.get_user_id_from_email(self.AUTHOR_EMAIL)
         self.signup(self.REVIEWER_EMAIL, 'reviewer')
         self.reviewer_id = self.get_user_id_from_email(self.REVIEWER_EMAIL)
-        self.signup(self.ASSIGNED_REVIEWER_EMAIL, 'assignedReviewer')
-        self.assigned_reviewer_id = self.get_user_id_from_email(
-            self.ASSIGNED_REVIEWER_EMAIL)
         self.suggestion_dict = {
             'suggestion_id': 'exploration.exp1.thread1',
             'suggestion_type': (
@@ -68,7 +65,6 @@ class SuggestionEditStateContentUnitTests(test_utils.GenericTestBase):
             'status': suggestion_models.STATUS_ACCEPTED,
             'author_name': 'author',
             'final_reviewer_id': self.reviewer_id,
-            'assigned_reviewer_id': self.assigned_reviewer_id,
             'change_cmd': {
                 'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
                 'property_name': exp_domain.STATE_PROPERTY_CONTENT,
@@ -88,8 +84,7 @@ class SuggestionEditStateContentUnitTests(test_utils.GenericTestBase):
             expected_suggestion_dict['target_id'],
             expected_suggestion_dict['target_version_at_submission'],
             expected_suggestion_dict['status'], self.author_id,
-            self.assigned_reviewer_id, self.reviewer_id,
-            expected_suggestion_dict['change_cmd'],
+            self.reviewer_id, expected_suggestion_dict['change_cmd'],
             expected_suggestion_dict['score_category'], self.fake_date)
 
         self.assertDictEqual(
@@ -106,7 +101,6 @@ class SuggestionEditStateContentUnitTests(test_utils.GenericTestBase):
             'status': suggestion_models.STATUS_ACCEPTED,
             'author_id': self.author_id,
             'final_reviewer_id': self.reviewer_id,
-            'assigned_reviewer_id': self.assigned_reviewer_id,
             'change_cmd': {
                 'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
                 'property_name': exp_domain.STATE_PROPERTY_CONTENT,
@@ -133,8 +127,7 @@ class SuggestionEditStateContentUnitTests(test_utils.GenericTestBase):
             expected_suggestion_dict['target_id'],
             expected_suggestion_dict['target_version_at_submission'],
             expected_suggestion_dict['status'], self.author_id,
-            self.assigned_reviewer_id, self.reviewer_id,
-            expected_suggestion_dict['change_cmd'],
+            self.reviewer_id, expected_suggestion_dict['change_cmd'],
             expected_suggestion_dict['score_category'], self.fake_date)
 
         suggestion.validate()
@@ -147,8 +140,7 @@ class SuggestionEditStateContentUnitTests(test_utils.GenericTestBase):
             expected_suggestion_dict['target_id'],
             expected_suggestion_dict['target_version_at_submission'],
             expected_suggestion_dict['status'], self.author_id,
-            self.assigned_reviewer_id, self.reviewer_id,
-            expected_suggestion_dict['change_cmd'],
+            self.reviewer_id, expected_suggestion_dict['change_cmd'],
             expected_suggestion_dict['score_category'], self.fake_date)
 
         self.assertEqual(suggestion.get_score_type(), 'content')

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -34,8 +34,7 @@ DEFAULT_SUGGESTION_THREAD_INITIAL_MESSAGE = ''
 
 def create_suggestion(
         suggestion_type, target_type, target_id, target_version_at_submission,
-        author_id, change_cmd, description,
-        assigned_reviewer_id, final_reviewer_id):
+        author_id, change_cmd, description, final_reviewer_id):
     """Creates a new SuggestionModel and the corresponding FeedbackThread.
 
     Args:
@@ -51,8 +50,6 @@ def create_suggestion(
         author_id: str. The ID of the user who submitted the suggestion.
         change_cmd: dict. The details of the suggestion.
         description: str. The description of the changes provided by the author.
-        assigned_reviewer_id: str|None. The ID of the user assigned to
-            review the suggestion.
         final_reviewer_id: str|None. The ID of the reviewer who has
             accepted/rejected the suggestion.
     """
@@ -72,9 +69,7 @@ def create_suggestion(
     else:
         raise Exception('Feedback threads can only be linked to explorations')
 
-    status = (
-        suggestion_models.STATUS_IN_REVIEW if assigned_reviewer_id else
-        suggestion_models.STATUS_RECEIVED)
+    status = suggestion_models.STATUS_IN_REVIEW
 
     if target_type == suggestion_models.TARGET_TYPE_EXPLORATION:
         exploration = exp_services.get_exploration_by_id(target_id)
@@ -85,7 +80,7 @@ def create_suggestion(
 
     suggestion_models.GeneralSuggestionModel.create(
         suggestion_type, target_type, target_id,
-        target_version_at_submission, status, author_id, assigned_reviewer_id,
+        target_version_at_submission, status, author_id,
         final_reviewer_id, change_cmd, score_category, thread_id)
 
 
@@ -105,7 +100,6 @@ def get_suggestion_from_model(suggestion_model):
         suggestion_model.id, suggestion_model.target_id,
         suggestion_model.target_version_at_submission,
         suggestion_model.status, suggestion_model.author_id,
-        suggestion_model.assigned_reviewer_id,
         suggestion_model.final_reviewer_id, suggestion_model.change_cmd,
         suggestion_model.score_category, suggestion_model.last_updated)
 
@@ -154,22 +148,6 @@ def get_suggestions_reviewed_by(reviewer_id):
         get_suggestion_from_model(s)
         for s in suggestion_models.GeneralSuggestionModel
         .get_suggestions_reviewed_by(reviewer_id)]
-
-
-def get_suggestions_assigned_to_reviewer(assigned_reviewer_id):
-    """Gets a list of suggestions assigned to the given user for review.
-
-    Args:
-        assigned_reviewer_id: str. The ID of the reviewer assigned to review the
-                suggestion.
-
-    Returns:
-        list(Suggestion). A list of suggestions assigned to the given user
-            for review.
-    """
-    return [get_suggestion_from_model(s)
-            for s in suggestion_models.GeneralSuggestionModel
-            .get_suggestions_assigned_to_reviewer(assigned_reviewer_id)]
 
 
 def get_suggestions_by_status(status):
@@ -227,7 +205,6 @@ def _update_suggestion(suggestion):
         suggestion.suggestion_id)
 
     suggestion_model.status = suggestion.status
-    suggestion_model.assigned_reviewer_id = suggestion.assigned_reviewer_id
     suggestion_model.final_reviewer_id = suggestion.final_reviewer_id
     suggestion_model.change_cmd = suggestion.change_cmd.to_dict()
     suggestion_model.score_category = suggestion.score_category
@@ -250,20 +227,6 @@ def mark_review_completed(suggestion, status, reviewer_id):
 
     suggestion.status = status
     suggestion.final_reviewer_id = reviewer_id
-    suggestion.assigned_reviewer_id = None
-
-    _update_suggestion(suggestion)
-
-
-def assign_reviewer_to_suggestion(suggestion, assigned_reviewer_id):
-    """Assigns a user to review the suggestion.
-
-    Args:
-        suggestion: Suggestion. The suggestion to be updated.
-        assigned_reviewer_id: str. The ID of the user who is assigned to review.
-    """
-    suggestion.status = suggestion_models.STATUS_IN_REVIEW
-    suggestion.assigned_reviewer_id = assigned_reviewer_id
 
     _update_suggestion(suggestion)
 

--- a/core/domain/suggestion_services_test.py
+++ b/core/domain/suggestion_services_test.py
@@ -47,7 +47,6 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
 
     AUTHOR_EMAIL = 'author@example.com'
     REVIEWER_EMAIL = 'reviewer@example.com'
-    ASSIGNED_REVIEWER_EMAIL = 'assigned_reviewer@example.com'
 
     THREAD_ID = 'exp1.thread_1'
 
@@ -64,9 +63,6 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
         self.author_id = self.get_user_id_from_email(self.AUTHOR_EMAIL)
         self.signup(self.REVIEWER_EMAIL, 'reviewer')
         self.reviewer_id = self.get_user_id_from_email(self.REVIEWER_EMAIL)
-        self.signup(self.ASSIGNED_REVIEWER_EMAIL, 'assignedReviewer')
-        self.assigned_reviewer_id = self.get_user_id_from_email(
-            self.ASSIGNED_REVIEWER_EMAIL)
 
     def generate_thread_id(self, unused_exp_id):
         return self.THREAD_ID
@@ -103,7 +99,6 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
             'status': suggestion_models.STATUS_IN_REVIEW,
             'author_name': 'author',
             'final_reviewer_id': self.reviewer_id,
-            'assigned_reviewer_id': self.assigned_reviewer_id,
             'change_cmd': {
                 'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
                 'property_name': exp_domain.STATE_PROPERTY_CONTENT,
@@ -124,7 +119,7 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
                     suggestion_models.TARGET_TYPE_EXPLORATION,
                     self.target_id, self.target_version_at_submission,
                     self.author_id, self.change_cmd, 'test description',
-                    self.assigned_reviewer_id, self.reviewer_id)
+                    self.reviewer_id)
 
             observed_suggestion = suggestion_services.get_suggestion_by_id(
                 self.suggestion_id)
@@ -151,7 +146,7 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
                     suggestion_models.TARGET_TYPE_EXPLORATION,
                     self.target_id, self.target_version_at_submission,
                     self.author_id, self.change_cmd, 'test description',
-                    self.assigned_reviewer_id, self.reviewer_id)
+                    self.reviewer_id)
 
         suggestion = suggestion_services.get_suggestion_by_id(
             self.suggestion_id)
@@ -177,7 +172,6 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
                 suggestion.status, suggestion_models.STATUS_ACCEPTED)
             self.assertEqual(
                 suggestion.final_reviewer_id, self.reviewer_id)
-            self.assertEqual(suggestion.assigned_reviewer_id, None)
             thread_messages = feedback_services.get_messages(self.THREAD_ID)
             last_message = thread_messages[len(thread_messages) - 1]
             self.assertEqual(
@@ -195,7 +189,7 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
                     suggestion_models.TARGET_TYPE_EXPLORATION,
                     self.target_id, self.target_version_at_submission,
                     self.author_id, self.change_cmd, 'test description',
-                    self.assigned_reviewer_id, self.reviewer_id)
+                    self.reviewer_id)
 
         suggestion = suggestion_services.get_suggestion_by_id(
             self.suggestion_id)
@@ -237,7 +231,7 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
                     suggestion_models.TARGET_TYPE_EXPLORATION,
                     self.target_id, self.target_version_at_submission,
                     self.author_id, self.change_cmd, 'test description',
-                    self.assigned_reviewer_id, self.reviewer_id)
+                    self.reviewer_id)
         suggestion = suggestion_services.get_suggestion_by_id(
             self.suggestion_id)
 
@@ -266,7 +260,7 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
                     suggestion_models.TARGET_TYPE_EXPLORATION,
                     self.target_id, self.target_version_at_submission,
                     self.author_id, self.change_cmd, 'test description',
-                    self.assigned_reviewer_id, self.reviewer_id)
+                    self.reviewer_id)
         suggestion = suggestion_services.get_suggestion_by_id(
             self.suggestion_id)
 
@@ -287,7 +281,7 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
                     suggestion_models.TARGET_TYPE_EXPLORATION,
                     self.target_id, self.target_version_at_submission,
                     self.author_id, self.change_cmd, 'test description',
-                    self.assigned_reviewer_id, self.reviewer_id)
+                    self.reviewer_id)
         suggestion = suggestion_services.get_suggestion_by_id(
             self.suggestion_id)
 
@@ -315,7 +309,7 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
                     suggestion_models.TARGET_TYPE_EXPLORATION,
                     self.target_id, self.target_version_at_submission,
                     self.author_id, self.change_cmd, 'test description',
-                    self.assigned_reviewer_id, self.reviewer_id)
+                    self.reviewer_id)
         suggestion = suggestion_services.get_suggestion_by_id(
             self.suggestion_id)
 
@@ -364,11 +358,9 @@ class SuggestionGetServicesUnitTests(test_utils.GenericTestBase):
 
     AUTHOR_EMAIL_1 = 'author1@example.com'
     REVIEWER_EMAIL_1 = 'reviewer1@example.com'
-    ASSIGNED_REVIEWER_EMAIL_1 = 'assigned_reviewer1@example.com'
 
     AUTHOR_EMAIL_2 = 'author2@example.com'
     REVIEWER_EMAIL_2 = 'reviewer2@example.com'
-    ASSIGNED_REVIEWER_EMAIL_2 = 'assigned_reviewer2@example.com'
 
     def generate_thread_id(self, unused_exp_id):
         return self.THREAD_ID
@@ -399,18 +391,11 @@ class SuggestionGetServicesUnitTests(test_utils.GenericTestBase):
         self.author_id_1 = self.get_user_id_from_email(self.AUTHOR_EMAIL_1)
         self.signup(self.REVIEWER_EMAIL_1, 'reviewer1')
         self.reviewer_id_1 = self.get_user_id_from_email(self.REVIEWER_EMAIL_1)
-        self.signup(self.ASSIGNED_REVIEWER_EMAIL_1, 'assignedReviewer1')
-        self.assigned_reviewer_id_1 = self.get_user_id_from_email(
-            self.ASSIGNED_REVIEWER_EMAIL_1)
-
 
         self.signup(self.AUTHOR_EMAIL_2, 'author2')
         self.author_id_2 = self.get_user_id_from_email(self.AUTHOR_EMAIL_2)
         self.signup(self.REVIEWER_EMAIL_2, 'reviewer2')
         self.reviewer_id_2 = self.get_user_id_from_email(self.REVIEWER_EMAIL_2)
-        self.signup(self.ASSIGNED_REVIEWER_EMAIL_2, 'assignedReviewer2')
-        self.assigned_reviewer_id_2 = self.get_user_id_from_email(
-            self.ASSIGNED_REVIEWER_EMAIL_2)
 
         with self.swap(
             exp_services, 'get_exploration_by_id',
@@ -421,35 +406,33 @@ class SuggestionGetServicesUnitTests(test_utils.GenericTestBase):
                 suggestion_models.TARGET_TYPE_EXPLORATION,
                 self.target_id_1, self.target_version_at_submission,
                 self.author_id_1, self.change_cmd, 'test description',
-                self.assigned_reviewer_id_1, self.reviewer_id_1)
+                self.reviewer_id_1)
 
             suggestion_services.create_suggestion(
                 suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
                 suggestion_models.TARGET_TYPE_EXPLORATION,
                 self.target_id_1, self.target_version_at_submission,
-                self.author_id_1, self.change_cmd, 'test description',
-                self.assigned_reviewer_id_1, None)
+                self.author_id_1, self.change_cmd, 'test description', None)
 
             suggestion_services.create_suggestion(
                 suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
                 suggestion_models.TARGET_TYPE_EXPLORATION,
                 self.target_id_1, self.target_version_at_submission,
-                self.author_id_1, self.change_cmd, 'test description', None,
-                None)
+                self.author_id_1, self.change_cmd, 'test description', None)
 
             suggestion_services.create_suggestion(
                 suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
                 suggestion_models.TARGET_TYPE_EXPLORATION,
                 self.target_id_1, self.target_version_at_submission,
                 self.author_id_2, self.change_cmd, 'test description',
-                self.assigned_reviewer_id_1, self.reviewer_id_2)
+                self.reviewer_id_2)
 
             suggestion_services.create_suggestion(
                 suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
                 suggestion_models.TARGET_TYPE_EXPLORATION,
                 self.target_id_2, self.target_version_at_submission,
                 self.author_id_2, self.change_cmd, 'test description',
-                self.assigned_reviewer_id_2, self.reviewer_id_2)
+                self.reviewer_id_2)
 
     def test_get_by_author(self):
         self.assertEqual(len(suggestion_services.get_suggestions_by_author(
@@ -463,14 +446,6 @@ class SuggestionGetServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(len(suggestion_services.get_suggestions_reviewed_by(
             self.reviewer_id_2)), 2)
 
-    def test_get_by_assigned_reviewer(self):
-        self.assertEqual(
-            len(suggestion_services.get_suggestions_assigned_to_reviewer(
-                self.assigned_reviewer_id_1)), 3)
-        self.assertEqual(
-            len(suggestion_services.get_suggestions_assigned_to_reviewer(
-                self.assigned_reviewer_id_2)), 1)
-
     def test_get_by_target_id(self):
         self.assertEqual(len(suggestion_services.get_suggestions_by_target_id(
             suggestion_models.TARGET_TYPE_EXPLORATION, self.target_id_1)), 4)
@@ -479,9 +454,7 @@ class SuggestionGetServicesUnitTests(test_utils.GenericTestBase):
 
     def test_get_by_status(self):
         self.assertEqual(len(suggestion_services.get_suggestions_by_status(
-            suggestion_models.STATUS_IN_REVIEW)), 4)
-        self.assertEqual(len(suggestion_services.get_suggestions_by_status(
-            suggestion_models.STATUS_RECEIVED)), 1)
+            suggestion_models.STATUS_IN_REVIEW)), 5)
 
     def test_get_by_type(self):
         self.assertEqual(len(suggestion_services.get_suggestion_by_type(
@@ -494,7 +467,6 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
     TRANSLATION_LANGUAGE_CODE = 'en'
 
     AUTHOR_EMAIL = 'author@example.com'
-    ASSIGNED_REVIEWER_EMAIL = 'assigned_reviewer@example.com'
 
     score_category = (
         suggestion_models.SCORE_TYPE_CONTENT +
@@ -512,13 +484,10 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
         self.signup(self.AUTHOR_EMAIL, 'author')
-        self.signup(self.ASSIGNED_REVIEWER_EMAIL, 'assignedReviewer')
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
         self.author_id = self.get_user_id_from_email(self.AUTHOR_EMAIL)
         self.reviewer_id = self.editor_id
-        self.assigned_reviewer_id = self.get_user_id_from_email(
-            self.ASSIGNED_REVIEWER_EMAIL)
 
         self.editor = user_services.UserActionsInfo(self.editor_id)
 
@@ -571,8 +540,7 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
                 suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
                 suggestion_models.TARGET_TYPE_EXPLORATION,
                 self.EXP_ID, self.target_version_at_submission,
-                self.author_id, self.change_cmd, 'test description',
-                self.assigned_reviewer_id, None)
+                self.author_id, self.change_cmd, 'test description', None)
 
         suggestion_id = 'exploration.' + self.THREAD_ID
         suggestion = suggestion_services.get_suggestion_by_id(suggestion_id)
@@ -596,8 +564,7 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
                 suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
                 suggestion_models.TARGET_TYPE_EXPLORATION,
                 self.EXP_ID, self.target_version_at_submission,
-                self.author_id, self.change_cmd, 'test description',
-                self.assigned_reviewer_id, None)
+                self.author_id, self.change_cmd, 'test description', None)
 
         suggestion_id = 'exploration.' + self.THREAD_ID
         suggestion = suggestion_services.get_suggestion_by_id(suggestion_id)
@@ -624,8 +591,7 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
                 suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
                 suggestion_models.TARGET_TYPE_EXPLORATION,
                 self.EXP_ID, self.target_version_at_submission,
-                self.author_id, self.change_cmd, 'test description',
-                self.assigned_reviewer_id, None)
+                self.author_id, self.change_cmd, 'test description', None)
 
         suggestion_id = 'exploration.' + self.THREAD_ID
         suggestion = suggestion_services.get_suggestion_by_id(suggestion_id)

--- a/core/storage/suggestion/gae_models.py
+++ b/core/storage/suggestion/gae_models.py
@@ -37,13 +37,11 @@ TARGET_TYPE_CHOICES = [
 # Constants defining the different possible statuses of a suggestion.
 STATUS_ACCEPTED = 'accepted'
 STATUS_IN_REVIEW = 'review'
-STATUS_RECEIVED = 'received'
 STATUS_REJECTED = 'rejected'
 
 STATUS_CHOICES = [
     STATUS_ACCEPTED,
     STATUS_IN_REVIEW,
-    STATUS_RECEIVED,
     STATUS_REJECTED
 ]
 
@@ -97,8 +95,6 @@ class GeneralSuggestionModel(base_models.BaseModel):
         required=True, indexed=True, choices=STATUS_CHOICES)
     # The ID of the author of the suggestion.
     author_id = ndb.StringProperty(required=True, indexed=True)
-    # The ID of the reviewer assigned to review the suggestion.
-    assigned_reviewer_id = ndb.StringProperty(indexed=True)
     # The ID of the reviewer who accepted/rejected the suggestion.
     final_reviewer_id = ndb.StringProperty(indexed=True)
     # The change command linked to the suggestion. Contains the details of the
@@ -113,7 +109,7 @@ class GeneralSuggestionModel(base_models.BaseModel):
     def create(
             cls, suggestion_type, target_type, target_id,
             target_version_at_submission, status, author_id,
-            assigned_reviewer_id, final_reviewer_id, change_cmd, score_category,
+            final_reviewer_id, change_cmd, score_category,
             thread_id):
         """Creates a new SuggestionModel entry.
 
@@ -125,8 +121,6 @@ class GeneralSuggestionModel(base_models.BaseModel):
                 entity at the time of creation of the suggestion.
             status: str. The status of the suggestion.
             author_id: str. The ID of the user who submitted the suggestion.
-            assigned_reviewer_id: str. The ID of the user assigned to
-                review the suggestion.
             final_reviewer_id: str. The ID of the reviewer who has
                 accepted/rejected the suggestion.
             change_cmd: dict. The actual content of the suggestion.
@@ -147,7 +141,6 @@ class GeneralSuggestionModel(base_models.BaseModel):
             target_type=target_type, target_id=target_id,
             target_version_at_submission=target_version_at_submission,
             status=status, author_id=author_id,
-            assigned_reviewer_id=assigned_reviewer_id,
             final_reviewer_id=final_reviewer_id, change_cmd=change_cmd,
             score_category=score_category).put()
 
@@ -180,23 +173,6 @@ class GeneralSuggestionModel(base_models.BaseModel):
         """
         return cls.get_all().filter(
             cls.author_id == author_id).fetch(feconf.DEFAULT_QUERY_LIMIT)
-
-    @classmethod
-    def get_suggestions_assigned_to_reviewer(cls, assigned_reviewer_id):
-        """Gets all suggestions assigned to the given user for review.
-
-        Args:
-            assigned_reviewer_id: str. The ID of the reviewer assigned to
-                review the suggestion.
-
-        Returns:
-            list(SuggestionModel). A list of suggestions assigned to the given
-                user for review, up to a maximum of feconf.DEFAULT_QUERY_LIMIT
-                suggestions.
-        """
-        return cls.get_all().filter(
-            cls.assigned_reviewer_id == assigned_reviewer_id).fetch(
-                feconf.DEFAULT_QUERY_LIMIT)
 
     @classmethod
     def get_suggestions_reviewed_by(cls, final_reviewer_id):

--- a/core/storage/suggestion/gae_models_test.py
+++ b/core/storage/suggestion/gae_models_test.py
@@ -40,35 +40,35 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_IN_REVIEW, 'author_1',
-            'reviewer_1', 'reviewer_1', self.change_cmd, self.score_category,
+            'reviewer_1', self.change_cmd, self.score_category,
             'exploration.exp1.thread_1')
         suggestion_models.GeneralSuggestionModel.create(
             suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_ACCEPTED, 'author_2',
-            'reviewer_2', 'reviewer_2', self.change_cmd, self.score_category,
+            'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp1.thread_2')
         suggestion_models.GeneralSuggestionModel.create(
             suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_ACCEPTED, 'author_2',
-            'reviewer_3', 'reviewer_2', self.change_cmd, self.score_category,
+            'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp1.thread_3')
         suggestion_models.GeneralSuggestionModel.create(
             suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_REJECTED, 'author_2',
-            'reviewer_2', 'reviewer_3', self.change_cmd, self.score_category,
+            'reviewer_3', self.change_cmd, self.score_category,
             'exploration.exp1.thread_4')
         suggestion_models.GeneralSuggestionModel.create(
             suggestion_models.SUGGESTION_TYPE_EDIT_STATE_CONTENT,
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_REJECTED, 'author_3',
-            'reviewer_3', 'reviewer_2', self.change_cmd, self.score_category,
+            'reviewer_2', self.change_cmd, self.score_category,
             'exploration.exp1.thread_5')
 
     def test_score_type_contains_delimiter(self):
@@ -82,7 +82,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             suggestion_models.TARGET_TYPE_EXPLORATION,
             self.target_id, self.target_version_at_submission,
             suggestion_models.STATUS_IN_REVIEW, 'author_3',
-            'reviewer_3', 'reviewer_3', self.change_cmd, self.score_category,
+            'reviewer_3', self.change_cmd, self.score_category,
             'exploration.exp1.thread_6')
 
         suggestion_id = 'exploration.exp1.thread_6'
@@ -107,8 +107,6 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             suggestion_models.STATUS_IN_REVIEW)
         self.assertEqual(observed_suggestion_model.author_id, 'author_3')
         self.assertEqual(
-            observed_suggestion_model.assigned_reviewer_id, 'reviewer_3')
-        self.assertEqual(
             observed_suggestion_model.final_reviewer_id, 'reviewer_3')
         self.assertEqual(
             observed_suggestion_model.score_category, self.score_category)
@@ -123,7 +121,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
                 suggestion_models.TARGET_TYPE_EXPLORATION,
                 self.target_id, self.target_version_at_submission,
                 suggestion_models.STATUS_IN_REVIEW, 'author_3',
-                'reviewer_3', 'reviewer_3', self.change_cmd,
+                'reviewer_3', self.change_cmd,
                 self.score_category, 'exploration.exp1.thread_1')
 
     def test_get_suggestions_by_type(self):
@@ -155,22 +153,6 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             len(
                 suggestion_models.GeneralSuggestionModel
                 .get_suggestions_by_author('author_invalid')), 0)
-
-    def test_get_suggestion_assigned_to_reviewer(self):
-        self.assertEqual(
-            len(
-                suggestion_models.GeneralSuggestionModel
-                .get_suggestions_assigned_to_reviewer('reviewer_1')), 1)
-        self.assertEqual(
-            len(
-                suggestion_models.GeneralSuggestionModel
-                .get_suggestions_assigned_to_reviewer('reviewer_2')), 2)
-        self.assertEqual(
-            len(suggestion_models.GeneralSuggestionModel
-                .get_suggestions_assigned_to_reviewer('reviewer_3')), 2)
-        self.assertEqual(
-            len(suggestion_models.GeneralSuggestionModel
-                .get_suggestions_assigned_to_reviewer('reviewer_invalid')), 0)
 
     def test_get_suggestion_by_reviewer(self):
         self.assertEqual(
@@ -206,11 +188,6 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
                 suggestion_models.GeneralSuggestionModel
                 .get_suggestions_by_status(
                     suggestion_models.STATUS_ACCEPTED)), 2)
-        self.assertEqual(
-            len(
-                suggestion_models.GeneralSuggestionModel
-                .get_suggestions_by_status(
-                    suggestion_models.STATUS_RECEIVED)), 0)
 
     def test_get_suggestions_by_target_id(self):
         self.assertEqual(


### PR DESCRIPTION
## Explanation
As per discussion, we decided to remove the assigned_reviewer field. 

PTAL @seanlip @anmolshkl. Thanks

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
