### PR TITLE
Minor fix to backend test after flipping USE_NEW_SUGGESTION_FRAMEWORK

### DIFF
--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -16,6 +16,7 @@
 
 """Tests for the feedback controllers."""
 
+from constants import constants
 from core.domain import exp_domain
 from core.domain import exp_services
 from core.domain import feedback_services
@@ -625,8 +626,9 @@ class SuggestionsIntegrationTests(test_utils.GenericTestBase):
 
         # Get a suggestion.
         thread_id = threads[0]['thread_id']
-        response_dict = self.get_json(
-            '%s/%s' % (feconf.FEEDBACK_THREAD_URL_PREFIX, thread_id))
+        with self.swap(constants, 'USE_NEW_SUGGESTION_FRAMEWORK', False):
+            response_dict = self.get_json(
+                '%s/%s' % (feconf.FEEDBACK_THREAD_URL_PREFIX, thread_id))
 
         # Suggestion description should be the same as thread subject.
         self.assertEqual(


### PR DESCRIPTION
## Explanation
One backend test fails after flipping the constant as it tests the old framework. Used self.swap() to actually use the old framework for the test. Without this the tests will fail once the flag is flipped.
## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
