### PR TITLE
Fix part of #5201: Remove jquery-ui-themes.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -315,13 +315,6 @@
           "js": []
         }
       },
-      "jqueryThemes": {
-        "version": "1.10.3",
-        "downloadFormat": "zip",
-        "url": "http://jqueryui.com/resources/download/jquery-ui-themes-1.10.3.zip",
-        "rootDirPrefix": "jquery-ui-themes-",
-        "targetDirPrefix": "jquery-ui-themes-"
-      },
       "jqueryUITouchPunch": {
         "version": "0.3.1",
         "downloadFormat": "zip",


### PR DESCRIPTION
## Explanation
Fixes part of #5201: Removes jquery-ui-themes since we don't use them anymore.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
