### PR TITLE
Add e2e functions patterns to BAD_PATTERNS_JS_REGEXP

### DIFF
--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -101,6 +101,18 @@ BAD_PATTERNS = {
 
 BAD_PATTERNS_JS_REGEXP = [
     {
+        'regexp': r'\b(browser.explore)\(',
+        'message': "Please remove browser.explore() calls from e2e tests.",
+        'excluded_files': (),
+        'excluded_dirs': ()
+    },
+    {
+        'regexp': r'\b(browser.pause)\(',
+        'message': "Please remove browser.pause() calls from e2e tests.",
+        'excluded_files': (),
+        'excluded_dirs': ()
+    },
+    {
         'regexp': r'\b(ddescribe|fdescribe)\(',
         'message': "In tests, please use 'describe' instead of 'ddescribe'"
                    "or 'fdescribe'",

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -102,13 +102,13 @@ BAD_PATTERNS = {
 BAD_PATTERNS_JS_REGEXP = [
     {
         'regexp': r'\b(browser.explore)\(',
-        'message': "Please remove browser.explore() calls from e2e tests.",
+        'message': "In tests, please do not use browser.explore().",
         'excluded_files': (),
         'excluded_dirs': ()
     },
     {
         'regexp': r'\b(browser.pause)\(',
-        'message': "Please remove browser.pause() calls from e2e tests.",
+        'message': "In tests, please do not use browser.pause().",
         'excluded_files': (),
         'excluded_dirs': ()
     },


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
This PR adds two more patterns : browser.explore() and browser.pause() to pre_commit_linter.py

I have done some preliminary testing. Lmk if I should adjust my regex pattern any further :+1:  

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
