### PR TITLE
Fix #5105: GraphInput Viewbox console errors

### DIFF
--- a/extensions/interactions/GraphInput/directives/GraphInput.js
+++ b/extensions/interactions/GraphInput/directives/GraphInput.js
@@ -408,6 +408,17 @@ oppia.directive('graphViz', [
             }
           };
 
+          var initViewboxSize = function() {
+            var svgContainer = $($element).find('.oppia-graph-viz-svg')[0];
+            var boundingBox = svgContainer.getBBox();
+            var viewBoxHeight = Math.max(
+              boundingBox.height + boundingBox.y,
+              svgContainer.getAttribute('height'));
+            $scope.svgViewBox = (
+              0 + ' ' + 0 + ' ' + (boundingBox.width + boundingBox.x) +
+                ' ' + (viewBoxHeight));
+          };
+
           $scope.graphOptions = [{
             text: 'Labeled',
             option: 'isLabeled'
@@ -781,22 +792,10 @@ oppia.directive('graphViz', [
           };
 
           // Initial value of SVG view box.
-          $scope.svgViewBox = '';
+          $scope.svgViewBox = initViewboxSize();
 
           if ($scope.isInteractionActive()) {
             $scope.init();
-
-            // Set the SVG viewBox to appropriate size.
-            $timeout(function() {
-              var svgContainer = $($element).find('.oppia-graph-viz-svg')[0];
-              var boundingBox = svgContainer.getBBox();
-              var viewBoxHeight = Math.max(
-                boundingBox.height + boundingBox.y,
-                svgContainer.getAttribute('height'));
-              $scope.svgViewBox = (
-                0 + ' ' + 0 + ' ' + (boundingBox.width + boundingBox.x) +
-                ' ' + (viewBoxHeight));
-            }, 1000);
           }
         }
       ]

--- a/extensions/interactions/GraphInput/directives/graph_viz_directive.html
+++ b/extensions/interactions/GraphInput/directives/graph_viz_directive.html
@@ -19,7 +19,7 @@
   }
 </style>
 <div class="oppia-graph-input-viz-container">
-  <svg class="oppia-graph-viz-svg" width="100%" height="250" ng-mousemove="mousemoveGraphSVG($event)" ng-click="onClickGraphSVG($event)"  ng-attr-view_box="{{svgViewBox}}">
+  <svg class="oppia-graph-viz-svg" width="100%" height="250" ng-mousemove="mousemoveGraphSVG($event)" ng-click="onClickGraphSVG($event)"  ng-attr-view_box="<[svgViewBox]>">
     <svg viewBox="0 0 90 250" width="100%" height="250" preserveAspectRatio="xMaxYMin meet">
       <g ng-if="canEditOptions" ng-repeat="button in graphOptions">
         <rect width="70"

--- a/extensions/interactions/GraphInput/directives/graph_viz_directive.html
+++ b/extensions/interactions/GraphInput/directives/graph_viz_directive.html
@@ -19,7 +19,7 @@
   }
 </style>
 <div class="oppia-graph-input-viz-container">
-  <svg class="oppia-graph-viz-svg" width="100%" height="250" ng-mousemove="mousemoveGraphSVG($event)" ng-click="onClickGraphSVG($event)" viewBox="<[svgViewBox]>">
+  <svg class="oppia-graph-viz-svg" width="100%" height="250" ng-mousemove="mousemoveGraphSVG($event)" ng-click="onClickGraphSVG($event)"  ng-attr-view_box="{{svgViewBox}}">
     <svg viewBox="0 0 90 250" width="100%" height="250" preserveAspectRatio="xMaxYMin meet">
       <g ng-if="canEditOptions" ng-repeat="button in graphOptions">
         <rect width="70"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
PR for issue #5105 
There are 2 different console errors to tackle here:
1) The data-binding for svg's viewbox size was incorrect.
Here is some resources from my findinds : [SO](https://stackoverflow.com/questions/45570401/how-to-size-an-svg-viewbox-with-angularjs) and from that post's AngularJS docs for [SVG](https://docs.angularjs.org/guide/interpolation#-ngattr-for-binding-to-arbitrary-attributes)
2) The scope variable svgViewbox was not initialized on load. I put the necessary statements into a function and assign it directly to the declaration of svgViewbox.
Also \u003C is '<' and \u003E '>' 👍 
## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
