### PR TITLE
Fix #5304: Remove protractor-add-test-answer css class from modify training data button

### DIFF
--- a/core/templates/dev/head/components/answer_group_editor_directive.html
+++ b/core/templates/dev/head/components/answer_group_editor_directive.html
@@ -24,7 +24,10 @@
 
   answer-group-editor .oppia-add-rule-button:active,
   answer-group-editor .oppia-add-rule-button:focus,
-  answer-group-editor .oppia-add-rule-button:hover {
+  answer-group-editor .oppia-add-rule-button:hover,
+  answer-group-editor .oppia-modify-training-data-button:active,
+  answer-group-editor .oppia-modify-training-data-button:focus,
+  answer-group-editor .oppia-modify-training-data-button:hover {
     background-color: rgba(165,165,165,1);
     color: white;
     opacity: 1;
@@ -42,6 +45,13 @@
   }
 
   answer-group-editor .oppia-modify-training-data-button {
+    background-color: rgba(165,165,165,0.9);
+    border: 0;
+    border-radius: 0;
+    color: white;
+    opacity: 0.9;
+    padding: 7px;
+    width: 100%;
     margin-top: 4%;
   }
 </style>
@@ -87,8 +97,8 @@
       + Add Another Possible Answer
     </button>
 
-    <div ng-if="isCurrentInteractionTrainable()">
-      <button type="button" class="btn btn-default btn-lg oppia-add-rule-button protractor-test-add-answer oppia-modify-training-data-button" ng-click="openTrainingDataEditor()">
+    <div ng-if="isEditable && isCurrentInteractionTrainable()">
+      <button type="button" class="btn btn-default btn-lg oppia-modify-training-data-button" ng-click="openTrainingDataEditor()">
         <i class="material-icons md-24">playlist_add</i> Modify Training Data
       </button>
     </div>


### PR DESCRIPTION
Fixes #5204 and removes `protractor-test-add-answer` class from modify training data button. Also, added condition that button should not appear if exploration is not editable for some user.