### PR TITLE
Fix part of #3905: Add check to match line breaks between stringfied dependencies and controller function parameters

### DIFF
--- a/core/templates/dev/head/components/VersionDiffVisualizationDirective.js
+++ b/core/templates/dev/head/components/VersionDiffVisualizationDirective.js
@@ -253,9 +253,10 @@ oppia.directive('versionDiffVisualization', [
               'headers', 'ExplorationContextService',
               'UrlInterpolationService',
               function(
-                  $scope, $http, $uibModalInstance, $timeout, newStateName,
-                  oldStateName, newState, oldState, headers,
-                  ExplorationContextService, UrlInterpolationService) {
+                  $scope, $http, $uibModalInstance, $timeout,
+                  newStateName, oldStateName, newState, oldState,
+                  headers, ExplorationContextService,
+                  UrlInterpolationService) {
                 var STATE_YAML_URL = UrlInterpolationService.interpolateUrl(
                   '/createhandler/state_yaml/<exploration_id>', {
                     exploration_id: (

--- a/core/templates/dev/head/components/create_button/CreateActivityButtonDirective.js
+++ b/core/templates/dev/head/components/create_button/CreateActivityButtonDirective.js
@@ -27,8 +27,9 @@ oppia.directive('createActivityButton', [
         'ExplorationCreationService', 'CollectionCreationService',
         'siteAnalyticsService', 'UrlService',
         function(
-            $scope, $timeout, $window, $uibModal, ExplorationCreationService,
-            CollectionCreationService, siteAnalyticsService, UrlService) {
+            $scope, $timeout, $window, $uibModal,
+            ExplorationCreationService, CollectionCreationService,
+            siteAnalyticsService, UrlService) {
           $scope.creationInProgress = false;
 
           $scope.userIsLoggedIn = GLOBALS.userIsLoggedIn;

--- a/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
+++ b/core/templates/dev/head/components/forms/AudioTranslationsEditorDirective.js
@@ -37,9 +37,9 @@ oppia.directive('audioTranslationsEditor', [
         'ExplorationContextService', 'AssetsBackendApiService',
         function(
             $scope, $rootScope, $uibModal, $sce, stateContentService,
-            stateContentIdsToAudioTranslationsService, EditabilityService,
-            LanguageUtilService, AlertsService, ExplorationContextService,
-            AssetsBackendApiService) {
+            stateContentIdsToAudioTranslationsService,
+            EditabilityService, LanguageUtilService, AlertsService,
+            ExplorationContextService, AssetsBackendApiService) {
           $scope.isTranslatable = EditabilityService.isTranslatable;
 
           $scope.stateContentIdsToAudioTranslationsService =

--- a/core/templates/dev/head/components/share/SharingLinksDirective.js
+++ b/core/templates/dev/head/components/share/SharingLinksDirective.js
@@ -35,8 +35,8 @@ oppia.directive('sharingLinks', [
         '$scope', '$window', 'HtmlEscaperService',
         'ExplorationEmbedButtonService', 'siteAnalyticsService',
         function(
-            $scope, $window, HtmlEscaperService, ExplorationEmbedButtonService,
-            siteAnalyticsService) {
+            $scope, $window, HtmlEscaperService,
+            ExplorationEmbedButtonService, siteAnalyticsService) {
           $scope.registerShareEvent = null;
 
           if ($scope.shareType === 'exploration') {

--- a/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
+++ b/core/templates/dev/head/pages/collection_editor/CollectionEditorNavbarDirective.js
@@ -31,8 +31,9 @@ oppia.directive('collectionEditorNavbar', [
         'EVENT_COLLECTION_INITIALIZED', 'EVENT_COLLECTION_REINITIALIZED',
         'EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED',
         function(
-            $scope, $uibModal, AlertsService, RouterService, UndoRedoService,
-            CollectionEditorStateService, CollectionValidationService,
+            $scope, $uibModal, AlertsService, RouterService,
+            UndoRedoService, CollectionEditorStateService,
+            CollectionValidationService,
             CollectionRightsBackendApiService,
             EditableCollectionBackendApiService,
             EVENT_COLLECTION_INITIALIZED, EVENT_COLLECTION_REINITIALIZED,
@@ -151,7 +152,7 @@ oppia.directive('collectionEditorNavbar', [
                   '$scope', '$uibModalInstance', 'CollectionEditorStateService',
                   'CollectionUpdateService', 'ALL_CATEGORIES',
                   function(
-                      $scope, $uibModalInstance, CollectionEditorStatesService,
+                      $scope, $uibModalInstance, CollectionEditorStateService,
                       CollectionUpdateService, ALL_CATEGORIES) {
                     var collection = (
                       CollectionEditorStateService.getCollection());

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/StateResponses.js
@@ -247,11 +247,12 @@ oppia.controller('StateResponses', [
           '$scope', '$uibModalInstance', 'ResponsesService',
           'EditorStateService', 'EditorFirstTimeEventsService',
           'RuleObjectFactory', 'OutcomeObjectFactory',
-          'COMPONENT_NAME_FEEDBACK', 'GenerateContentIdService', function(
+          'COMPONENT_NAME_FEEDBACK', 'GenerateContentIdService',
+          function(
               $scope, $uibModalInstance, ResponsesService,
               EditorStateService, EditorFirstTimeEventsService,
-              RuleObjectFactory, OutcomeObjectFactory, COMPONENT_NAME_FEEDBACK,
-              GenerateContentIdService) {
+              RuleObjectFactory, OutcomeObjectFactory,
+              COMPONENT_NAME_FEEDBACK, GenerateContentIdService) {
             $scope.feedbackEditorIsOpen = false;
 
             $scope.openFeedbackEditor = function() {

--- a/core/templates/dev/head/pages/library/SearchBarDirective.js
+++ b/core/templates/dev/head/pages/library/SearchBarDirective.js
@@ -28,9 +28,9 @@ oppia.directive('searchBar', [
         '$translate', 'SearchService', 'DebouncerService', 'HtmlEscaperService',
         'UrlService', 'ConstructTranslationIdsService',
         function(
-            $scope, $rootScope, $timeout, $window, $location, $translate,
-            SearchService, DebouncerService, HtmlEscaperService, UrlService,
-            ConstructTranslationIdsService) {
+            $scope, $rootScope, $timeout, $window, $location,
+            $translate, SearchService, DebouncerService, HtmlEscaperService,
+            UrlService, ConstructTranslationIdsService) {
           $scope.isSearchInProgress = SearchService.isSearchInProgress;
           $scope.SEARCH_DROPDOWN_CATEGORIES = (
             GLOBALS.SEARCH_DROPDOWN_CATEGORIES.map(

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -1221,7 +1221,7 @@ def _match_line_breaks_in_controller_dependencies(all_files):
     listed in the controller of a directive or service exactly match those
     between the arguments of the controller function.
     """
-    print 'Starting controller dependency check'
+    print 'Starting controller dependency line break check'
     print '----------------------------------------'
     files_to_check = [
         filename for filename in all_files if not
@@ -1248,19 +1248,21 @@ def _match_line_breaks_in_controller_dependencies(all_files):
                 failed = True
                 print (
                     '%s --> Please ensure that line breaks between '
-                    'the stringfied dependencies,"%s" and the function '
-                    'parameters, "%s" for the corresponding controller '
+                    'the stringfied dependencies: "%s" and the function '
+                    'parameters: "%s" for the corresponding controller '
                     'in this file exactly match.' % (
                         filename, stringfied_dependencies, function_parameters))
 
     if failed:
-        summary_message = '%s   Controller dependency check failed' % (
-            _MESSAGE_TYPE_FAILED)
+        summary_message = (
+            '%s   Controller dependency line break check failed' % (
+                _MESSAGE_TYPE_FAILED))
         print summary_message
         summary_messages.append(summary_message)
     else:
-        summary_message = '%s  Controller dependency check passed' % (
-            _MESSAGE_TYPE_SUCCESS)
+        summary_message = (
+            '%s  Controller dependency line break check passed' % (
+                _MESSAGE_TYPE_SUCCESS))
         print summary_message
         summary_messages.append(summary_message)
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [X] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [X] The PR is made from a branch that's **not** called "develop".
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [X] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
