### PR TITLE
Updated the Migration function for CKEditor 

### DIFF
--- a/core/domain/html_cleaner.py
+++ b/core/domain/html_cleaner.py
@@ -509,6 +509,18 @@ def convert_to_ckeditor(html_data):
         while li.parent.name in ['li', 'p']:
             li.parent.unwrap()
 
+    # Ensure li is wrapped in ol/ul.
+    for li in soup.findAll('li'):
+        if li.parent.name not in ['ol', 'ul']:
+            new_parent = soup.new_tag('ul')
+            next_sib = list(li.next_siblings)
+            li.wrap(new_parent)
+            for sib in next_sib:
+                if sib.name == 'li':
+                    sib.wrap(new_parent)
+                else:
+                    break
+
     LIST_TAGS = ['ol', 'ul']
 
     # Ensure that the children of ol/ul are li/pre.

--- a/core/domain/html_cleaner.py
+++ b/core/domain/html_cleaner.py
@@ -509,9 +509,11 @@ def convert_to_ckeditor(html_data):
         while li.parent.name in ['li', 'p']:
             li.parent.unwrap()
 
+    LIST_TAGS = ['ol', 'ul']
+
     # Ensure li is wrapped in ol/ul.
     for li in soup.findAll('li'):
-        if li.parent.name not in ['ol', 'ul']:
+        if li.parent.name not in LIST_TAGS:
             new_parent = soup.new_tag('ul')
             next_sib = list(li.next_siblings)
             li.wrap(new_parent)
@@ -520,8 +522,6 @@ def convert_to_ckeditor(html_data):
                     sib.wrap(new_parent)
                 else:
                     break
-
-    LIST_TAGS = ['ol', 'ul']
 
     # Ensure that the children of ol/ul are li/pre.
     for tag_name in LIST_TAGS:
@@ -542,7 +542,7 @@ def convert_to_ckeditor(html_data):
     for p in soup.findAll('p'):
         if p.parent.name == 'pre':
             p.unwrap()
-        elif p.parent.name in ['ol', 'ul']:
+        elif p.parent.name in LIST_TAGS:
             p.wrap(soup.new_tag('li'))
 
     # Replaces <p><br></p> with <p>&nbsp;</p> and <pre>...<br>...</pre>

--- a/core/domain/html_cleaner_test.py
+++ b/core/domain/html_cleaner_test.py
@@ -731,6 +731,15 @@ class ContentMigrationTests(test_utils.GenericTestBase):
             'expected_output': (
                 '<pre>Hello this is test case for br in pre tag\n</pre>'
             )
+        }, {
+            'html_content': (
+                '<p><li> Hello this is test case for li in p which results '
+                'in </li><li> in document </li><li> after unwrapping </li></p>'
+            ),
+            'expected_output': (
+                '<ul><li> Hello this is test case for li in p which results '
+                'in </li><li> in document </li><li> after unwrapping </li></ul>'
+            )
         }]
 
         for test_case in test_cases:


### PR DESCRIPTION
This PR updates the Migration for CKEditor on the basis of invalid strings obtained from the production server. 
Both cases include a string of the form 
```
<p><li>Blah1</li><li>Blah2</li></p>
```
I updated this function to change strings of above form to 
```
<ul><li>Blah1</li><li>Blah2</li></ul>
```
I have added the tests for the same.