### PR TITLE
Downgrade 404 logs to warnings.

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -456,7 +456,7 @@ class BaseHandler(webapp2.RequestHandler):
         logging.error('Exception raised: %s', exception)
 
         if isinstance(exception, self.PageNotFoundException):
-            logging.error('Invalid URL requested: %s', self.request.uri)
+            logging.warning('Invalid URL requested: %s', self.request.uri)
             self.error(404)
             self._render_exception(
                 404, {


### PR DESCRIPTION
The error logs for 404 are making the logs quite noisy, hence this PR.