### PR TITLE
Removing test coverage for incomplete exploration playing from learnerDashboard

### DIFF
--- a/core/tests/protractor/learnerDashboard.js
+++ b/core/tests/protractor/learnerDashboard.js
@@ -99,7 +99,7 @@ describe('Learner dashboard functionality', function() {
     workflow.publishExploration();
   };
 
-  it('displays incomplete and completed explorations', function() {
+  it('displays completed explorations', function() {
     users.createAndLoginUser('originalCreator@learnerDashboard.com',
       'originalCreator');
     // Create exploration 'About Oppia'
@@ -120,31 +120,6 @@ describe('Learner dashboard functionality', function() {
     libraryPage.findExploration('Dummy Exploration');
     libraryPage.playExploration('Dummy Exploration');
     explorationPlayerPage.expectExplorationNameToBe('Dummy Exploration');
-
-    // Play exploration 'About Oppia'.
-    libraryPage.get();
-    libraryPage.findExploration('About Oppia');
-    libraryPage.playExploration('About Oppia');
-    explorationPlayerPage.expectExplorationNameToBe('About Oppia');
-    explorationPlayerPage.submitAnswer('Continue', null);
-    explorationPlayerPage.expectExplorationToNotBeOver();
-
-    // Refresh page to simulate user leaving and accept the alert.
-    general.safeAcceptAlert();
-    // Wait for exploration to re-load again.
-    general.waitForLoadingMessage();
-
-    // Learner Dashboard should display 'About Oppia' as incomplete.
-    learnerDashboardPage.get();
-    learnerDashboardPage.navigateToInCompleteSection();
-    learnerDashboardPage.navigateToIncompleteExplorationsSection();
-    learnerDashboardPage.expectTitleOfExplorationSummaryTileToMatch(
-      'About Oppia');
-    // Learner Dashboard should display 'Dummy Exploration' as complete.
-    learnerDashboardPage.navigateToCompletedSection();
-    learnerDashboardPage.navigateToCompletedExplorationsSection();
-    learnerDashboardPage.expectTitleOfExplorationSummaryTileToMatch(
-      'Dummy Exploration');
 
     // Now play exploration 'About Oppia' completely.
     libraryPage.get();
@@ -192,7 +167,7 @@ describe('Learner dashboard functionality', function() {
     users.logout();
   });
 
-  it('displays incomplete and completed collections', function() {
+  it('displays completed collections', function() {
     users.createAndLoginUser('explorationCreator@learnerDashboard.com',
       'explorationCreator');
     // Create first exploration named 'Head of Collection'
@@ -227,34 +202,6 @@ describe('Learner dashboard functionality', function() {
     users.createAndLoginUser('learner4@learnerDashboard.com',
       'learner4learnerDashboard');
     // Go to 'Test Collection' and play it.
-    libraryPage.get();
-    libraryPage.findExploration('Test Collection');
-    libraryPage.playCollection('Test Collection');
-    var firstExploration = element.all(
-      by.css('.protractor-test-collection-exploration')).first();
-    // Click first exploration in collection.
-    browser.wait(until.elementToBeClickable(firstExploration), 10000,
-      'Could not click first exploration in collection')
-      .then(function(isClickable) {
-        if (isClickable) {
-          firstExploration.click();
-        }
-      });
-    explorationPlayerPage.submitAnswer('Continue', null);
-    explorationPlayerPage.expectExplorationToNotBeOver();
-
-    // Refresh page to simulate user leaving and accept the alert.
-    general.safeAcceptAlert();
-    // Wait for exploration to re-load again.
-    general.waitForLoadingMessage();
-
-    // Learner Dashboard should display 'Test Collection' as incomplete.
-    learnerDashboardPage.get();
-    learnerDashboardPage.navigateToInCompleteSection();
-    learnerDashboardPage.navigateToIncompleteCollectionsSection();
-    learnerDashboardPage.expectTitleOfCollectionSummaryTileToMatch(
-      'Test Collection');
-
     libraryPage.get();
     libraryPage.findExploration('Test Collection');
     libraryPage.playCollection('Test Collection');

--- a/core/tests/protractor_utils/general.js
+++ b/core/tests/protractor_utils/general.js
@@ -208,7 +208,6 @@ var checkConsoleErrorsExist = function(expectedErrors) {
 };
 
 exports.acceptAlert = acceptAlert;
-exports.safeAcceptAlert = safeAcceptAlert;
 exports.waitForSystem = waitForSystem;
 exports.waitForLoadingMessage = waitForLoadingMessage;
 exports.scrollToTop = scrollToTop;

--- a/core/tests/protractor_utils/general.js
+++ b/core/tests/protractor_utils/general.js
@@ -47,26 +47,6 @@ var waitForLoadingMessage = function() {
     'Page takes more than 15 secs to load');
 };
 
-/**
- * Leaving exp/collections mid-play causes an alert window which cannot
- * be handled unless waitForAngular() is disabled. Re-enable waitForAngular()
- * once alert is accepted.
- */
-var safeAcceptAlert = function() {
-  // Disable waiting for Angular to accept alert.
-  browser.waitForAngularEnabled(false);
-  // Refresh page to simulate user leaving.
-  browser.navigate().refresh().then(function() {
-    browser.wait(until.alertIsPresent(), 5000);
-    return browser.switchTo().alert().then(function (alert) {
-      alert.accept().then(function() {
-      // Re-enable waiting for Angular.
-        return browser.waitForAngularEnabled(true);
-      });
-    });
-  });
-};
-
 var scrollToTop = function() {
   browser.executeScript('window.scrollTo(0,0);');
 };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
Context: learnerDashboard is trying to test for displaying incomplete colllection/exp. This is accomplished through quitting exploration mid-playing. (If there is any other way of putting entries into incomplete exploration from user side, please lmk)

Currently, Oppia sends an alert window via ['beforeunload' event](https://github.com/oppia/oppia/blob/e8654c28fc49c7ac4e90e9e4985f11f7a35b6e0a/core/templates/dev/head/pages/exploration_player/ConversationSkinDirective.js#L836) whenever the user tries to leave the exploration after making some progress.

From my time with Protractor, alert window is a fickle thing. I have to use [waitForAngularEnabled(false)]( https://github.com/angular/protractor/blob/a04435916101e8cf367333f3e7a51d41964e83ef/lib/browser.ts#L420) to accept the alert window in learnerDashboard. I do believe this is the source of learnerDashboard's flakiness as stated by the maintainer's comment. On some occasions, Protractor will fluctuate between accepting the alert or outright refusing to work and error-ing out the entire `describe` spec.

This PR will reduce coverage for the scenario of user leaving mid-playing in an attempt to reduce flakiness in our e2e suite. 

I understand that this is very prude approach to fix a problem since it is a regression in coverage. I am open to discussion on how I should handle this. Let's talk!
## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
