### PR TITLE
Allow machine learning classification in editor preview mode of exploration

### DIFF
--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -1965,6 +1965,25 @@ def get_user_exploration_data(
     exploration_email_preferences = (
         user_services.get_email_preferences_for_exploration(
             user_id, exploration_id))
+
+    # Retrieve all classifiers for the exploration.
+    state_classifier_mapping = {}
+    classifier_training_jobs = (
+        classifier_services.get_classifier_training_jobs(
+            exploration_id, exploration.version, exploration.states))
+    for index, state_name in enumerate(exploration.states):
+        if classifier_training_jobs[index] is not None:
+            classifier_data = classifier_training_jobs[
+                index].classifier_data
+            algorithm_id = classifier_training_jobs[index].algorithm_id
+            data_schema_version = (
+                classifier_training_jobs[index].data_schema_version)
+            state_classifier_mapping[state_name] = {
+                'algorithm_id': algorithm_id,
+                'classifier_data': classifier_data,
+                'data_schema_version': data_schema_version
+            }
+
     editor_dict = {
         'auto_tts_enabled': exploration.auto_tts_enabled,
         'category': exploration.category,
@@ -1986,7 +2005,8 @@ def get_user_exploration_data(
         'version': exploration.version,
         'is_version_of_draft_valid': is_valid_draft_version,
         'draft_changes': draft_changes,
-        'email_preferences': exploration_email_preferences.to_dict()
+        'email_preferences': exploration_email_preferences.to_dict(),
+        'state_classifier_mapping': state_classifier_mapping
     }
 
     return editor_dict

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -1067,7 +1067,7 @@ class SubmittedAnswer(object):
                 'Expected answer_group_index to be an integer, received %s' %
                 str(self.answer_group_index))
 
-        if not isinstance(self.rule_spec_index, int):
+        if self.rule_spec_index and not isinstance(self.rule_spec_index, int):
             raise utils.ValidationError(
                 'Expected rule_spec_index to be an integer, received %s' %
                 str(self.rule_spec_index))
@@ -1077,7 +1077,7 @@ class SubmittedAnswer(object):
                 'Expected answer_group_index to be non-negative, received %d' %
                 self.answer_group_index)
 
-        if self.rule_spec_index < 0:
+        if self.rule_spec_index and self.rule_spec_index < 0:
             raise utils.ValidationError(
                 'Expected rule_spec_index to be non-negative, received %d' %
                 self.rule_spec_index)

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -1067,7 +1067,8 @@ class SubmittedAnswer(object):
                 'Expected answer_group_index to be an integer, received %s' %
                 str(self.answer_group_index))
 
-        if self.rule_spec_index and not isinstance(self.rule_spec_index, int):
+        if self.rule_spec_index is not None and not (
+                isinstance(self.rule_spec_index, int)):
             raise utils.ValidationError(
                 'Expected rule_spec_index to be an integer, received %s' %
                 str(self.rule_spec_index))
@@ -1077,7 +1078,7 @@ class SubmittedAnswer(object):
                 'Expected answer_group_index to be non-negative, received %d' %
                 self.answer_group_index)
 
-        if self.rule_spec_index and self.rule_spec_index < 0:
+        if self.rule_spec_index is not None and self.rule_spec_index < 0:
             raise utils.ValidationError(
                 'Expected rule_spec_index to be non-negative, received %d' %
                 self.rule_spec_index)

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -1093,6 +1093,11 @@ class SubmittedAnswerValidationTests(test_utils.GenericTestBase):
         self.submitted_answer.rule_spec_index = '0'
         self._assert_validation_error(
             self.submitted_answer, 'Expected rule_spec_index to be an integer')
+        self.submitted_answer.rule_spec_index = ''
+        self._assert_validation_error(
+            self.submitted_answer, 'Expected rule_spec_index to be an integer')
+        self.submitted_answer.rule_spec_index = 0
+        self.submitted_answer.validate()
 
     def test_rule_spec_index_must_be_positive(self):
         self.submitted_answer.rule_spec_index = -1

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -1085,6 +1085,10 @@ class SubmittedAnswerValidationTests(test_utils.GenericTestBase):
             self.submitted_answer,
             'Expected answer_group_index to be non-negative')
 
+    def test_rule_spec_index_can_be_none(self):
+        self.submitted_answer.rule_spec_index = None
+        self.submitted_answer.validate()
+
     def test_rule_spec_index_must_be_integer(self):
         self.submitted_answer.rule_spec_index = '0'
         self._assert_validation_error(

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
@@ -53,7 +53,7 @@ oppia.controller('ExplorationEditor', [
   'ParamSpecsObjectFactory', 'ExplorationAutomaticTextToSpeechService',
   'UrlInterpolationService', 'ExplorationCorrectnessFeedbackService',
   'StateTopAnswersStatsService', 'StateTopAnswersStatsBackendApiService',
-  'ThreadDataService',
+  'ThreadDataService', 'StateClassifierMappingService',
   function(
       $scope, $http, $window, $rootScope, $log, $timeout,
       ExplorationDataService, EditorStateService, ExplorationTitleService,
@@ -70,7 +70,7 @@ oppia.controller('ExplorationEditor', [
       ParamSpecsObjectFactory, ExplorationAutomaticTextToSpeechService,
       UrlInterpolationService, ExplorationCorrectnessFeedbackService,
       StateTopAnswersStatsService, StateTopAnswersStatsBackendApiService,
-      ThreadDataService) {
+      ThreadDataService, StateClassifierMappingService) {
     $scope.EditabilityService = EditabilityService;
     $scope.EditorStateService = EditorStateService;
 
@@ -130,6 +130,7 @@ oppia.controller('ExplorationEditor', [
         ExplorationAutomaticTextToSpeechService.init(data.auto_tts_enabled);
         ExplorationCorrectnessFeedbackService.init(
           data.correctness_feedback_enabled);
+        StateClassifierMappingService.init(data.state_classifier_mapping);
 
         $scope.explorationTitleService = ExplorationTitleService;
         $scope.explorationCategoryService = ExplorationCategoryService;


### PR DESCRIPTION
This PR adds the code to send trained classifier models to frontend even when exploration is in editor mode. Thus it makes it possible to test classifiers in editor preview mode.