### PR TITLE
Only append to the general error log for non-404 errors.

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -453,7 +453,6 @@ class BaseHandler(webapp2.RequestHandler):
             return
 
         logging.info(''.join(traceback.format_exception(*sys.exc_info())))
-        logging.error('Exception raised: %s', exception)
 
         if isinstance(exception, self.PageNotFoundException):
             logging.warning('Invalid URL requested: %s', self.request.uri)
@@ -462,6 +461,8 @@ class BaseHandler(webapp2.RequestHandler):
                 404, {
                     'error': 'Could not find the page %s.' % self.request.uri})
             return
+
+        logging.error('Exception raised: %s', exception)
 
         if isinstance(exception, self.UnauthorizedUserException):
             self.error(401)


### PR DESCRIPTION
This follows on from #5233. I missed moving an additional error call there (oops), so it's still noisy, albeit only half as noisy as last time :)