### PR TITLE
Improving the dev workflow: Add check for double quotes for values of attributes of html tags

### DIFF
--- a/core/templates/dev/head/components/forms/image_uploader_directive.html
+++ b/core/templates/dev/head/components/forms/image_uploader_directive.html
@@ -10,7 +10,7 @@
     Please do not upload watermarked images.
   </span>
   <label for="image-file-input" translate="I18N_DIRECTIVES_UPLOAD_A_FILE" class="image-uploader-upload-label-button"></label>
-  <input type="file" id='image-file-input' class="image-uploader-file-input" ng-class="fileInputClassName">
+  <input type="file" id="image-file-input" class="image-uploader-file-input" ng-class="fileInputClassName">
 </div>
 
 <style>

--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/test_interaction_modal_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/test_interaction_modal_directive.html
@@ -30,7 +30,7 @@
     </div>
   </div>
   <br>
-  <div class='submit-answer-btn'>
+  <div class="submit-answer-btn">
     <md-button class="oppia-learner-confirm-button protractor-test-submit-answer-button"
                ng-disabled="!interactionAnswerIsValid"
                ng-click="onSubmitAnswerFromButton()"

--- a/core/templates/dev/head/pages/exploration_editor/history_tab/history_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/history_tab/history_tab.html
@@ -3,7 +3,7 @@
     <h3>List of Changes</h3>
     <div ng-repeat="versionNumber in versionNumbersToDisplay" class="row">
       <div class="col-sm-4 col-md-4 col-lg-4">
-        <input type="checkbox" name="compareVer" ng-model="versionCheckboxArray[versionNumber].selected" ng-init="init()" ng-click="changeSelectedVersions($event, versionNumber)" ng-disabled="isCheckboxDisabled(versionNumber)" ng-hide="comparisonsAreDisabled" class='protractor-test-history-checkbox-selector'>
+        <input type="checkbox" name="compareVer" ng-model="versionCheckboxArray[versionNumber].selected" ng-init="init()" ng-click="changeSelectedVersions($event, versionNumber)" ng-disabled="isCheckboxDisabled(versionNumber)" ng-hide="comparisonsAreDisabled" class="protractor-test-history-checkbox-selector">
         [<[versionNumber]>]
         <strong><profile-link-text username="explorationVersionMetadata[versionNumber].committerId"></profile-link-text></strong>
       </div>
@@ -14,7 +14,7 @@
         <span>
           <em><[explorationVersionMetadata[versionNumber].createdOnStr]></em>
           <span ng-if="versionNumber !== currentVersion && EditabilityService.isEditable()">
-            | <a href="#" class='protractor-test-revert-version' ng-click="showRevertExplorationModal(versionNumber)">Revert</a>
+            | <a href="#" class="protractor-test-revert-version" ng-click="showRevertExplorationModal(versionNumber)">Revert</a>
           </span>
           <span>
             | <a href="#" ng-click="downloadExplorationWithVersion(versionNumber)" title="Download exploration as a zip file.">Download</a>

--- a/core/templates/dev/head/pages/signup/licence_explanation_modal_directive.html
+++ b/core/templates/dev/head/pages/signup/licence_explanation_modal_directive.html
@@ -6,7 +6,7 @@
   <p style="line-height: 1.5;" translate="I18N_SIGNUP_SITE_OBJECTIVE" translate-values="{sitename: siteName}">
   </p>
 
-  <p style="line-height: 1.5;" translate="I18N_SIGNUP_LICENSE_OBJECTIVE" translate-licenselink="<a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/&quot; target=&quot;_blank&quot;>CC-BY-SA v4.0</a>">
+  <p style="line-height: 1.5;" translate="I18N_SIGNUP_LICENSE_OBJECTIVE" translate-licenselink="<a href='https://creativecommons.org/licenses/by-sa/4.0/' target='_blank'>CC-BY-SA v4.0</a>">
   </p>
 
   <p style="line-height: 1.5;" translate="I18N_SIGNUP_WAIVER_OBJECTIVE"></p>

--- a/core/templates/dev/head/pages/signup/licence_explanation_modal_directive.html
+++ b/core/templates/dev/head/pages/signup/licence_explanation_modal_directive.html
@@ -6,7 +6,7 @@
   <p style="line-height: 1.5;" translate="I18N_SIGNUP_SITE_OBJECTIVE" translate-values="{sitename: siteName}">
   </p>
 
-  <p style="line-height: 1.5;" translate="I18N_SIGNUP_LICENSE_OBJECTIVE" translate-licenselink="<a href='https://creativecommons.org/licenses/by-sa/4.0/' target='_blank'>CC-BY-SA v4.0</a>">
+  <p style="line-height: 1.5;" translate="I18N_SIGNUP_LICENSE_OBJECTIVE" translate-licenselink="<a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/&quot; target=&quot;_blank&quot;</a>">
   </p>
 
   <p style="line-height: 1.5;" translate="I18N_SIGNUP_WAIVER_OBJECTIVE"></p>

--- a/core/templates/dev/head/pages/signup/licence_explanation_modal_directive.html
+++ b/core/templates/dev/head/pages/signup/licence_explanation_modal_directive.html
@@ -6,7 +6,7 @@
   <p style="line-height: 1.5;" translate="I18N_SIGNUP_SITE_OBJECTIVE" translate-values="{sitename: siteName}">
   </p>
 
-  <p style="line-height: 1.5;" translate="I18N_SIGNUP_LICENSE_OBJECTIVE" translate-licenselink="<a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/&quot; target=&quot;_blank&quot;</a>">
+  <p style="line-height: 1.5;" translate="I18N_SIGNUP_LICENSE_OBJECTIVE" translate-licenselink="<a href=&quot;https://creativecommons.org/licenses/by-sa/4.0/&quot; target=&quot;_blank&quot;>CC-BY-SA v4.0</a>">
   </p>
 
   <p style="line-height: 1.5;" translate="I18N_SIGNUP_WAIVER_OBJECTIVE"></p>

--- a/extensions/interactions/CodeRepl/directives/code_repl_response_directive.html
+++ b/extensions/interactions/CodeRepl/directives/code_repl_response_directive.html
@@ -8,7 +8,7 @@
   </span>
 
   <span ng-if="answer.error" focus-on="<[errorFocusLabel]>">
-    <font color=red>Error: <[answer.error]></font><br>
+    <font color="red">Error: <[answer.error]></font><br>
   </span>
 
   <span ng-if="answer.evaluation">

--- a/extensions/interactions/CodeRepl/directives/code_repl_short_response_directive.html
+++ b/extensions/interactions/CodeRepl/directives/code_repl_short_response_directive.html
@@ -6,5 +6,5 @@
 </span>
 
 <span ng-if="answer.error" focus-on="<[errorFocusLabel]>">
-  <font color=red>Error: <[answer.error]></font><br>
+  <font color="red">Error: <[answer.error]></font><br>
 </span>

--- a/extensions/interactions/GraphInput/directives/graph_viz_directive.html
+++ b/extensions/interactions/GraphInput/directives/graph_viz_directive.html
@@ -110,7 +110,7 @@
             class="unselectable-text">
         <[vertex.label]>
       </text>
-      <circle class="protractor-test-graph-vertex-<[$index]>""
+      <circle class="protractor-test-graph-vertex-<[$index]>"
               ng-mouseenter="state.hoveredVertex = $index"
               ng-mouseleave="onMouseleaveVertex($index)"
               ng-click="onClickVertex($index)"

--- a/extensions/interactions/LogicProof/static/js/tools/demonstration.html
+++ b/extensions/interactions/LogicProof/static/js/tools/demonstration.html
@@ -32,7 +32,7 @@
 
 
 
-    line <input type="text" ng-model="line"> mistake <input type="text" ng-model=mistakeName>
+    line <input type="text" ng-model="line"> mistake <input type="text" ng-model="mistakeName">
     <button ng-click="doLocalCheck()">Check</button> {{localCheck}}
 
     <hr>

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -1323,6 +1323,23 @@ class CustomHTMLParser(HTMLParser.HTMLParser):
             column_number + len(tag) + 2)
         starttag_text = self.get_starttag_text()
 
+        # Check whether the values of all attributes are placed
+        # in double quotes.
+        for attr, value in attrs:
+            # Not all attributes will have a value.
+            # Therefore the check should run only for those
+            # attributes which have a value.
+            if value:
+                expected_value = '"' + value + '"'
+                if not expected_value in starttag_text:
+                    self.failed = True
+                    print (
+                        '%s --> The value %s of attribute '
+                        '%s for the tag %s on line %s should '
+                        'be enclosed within double quotes.' % (
+                            self.filename, value, attr,
+                            tag, line_number))
+
         for line_num, line in enumerate(
                 str.splitlines(starttag_text)):
             if line_num == 0:
@@ -1392,10 +1409,10 @@ class CustomHTMLParser(HTMLParser.HTMLParser):
                 self.indentation_level -= 1
 
 
-def _check_html_indent(all_files, debug=False):
+def _check_html_tags_and_attributes(all_files, debug=False):
     """This function checks the indentation of lines in HTML files."""
 
-    print 'Starting HTML indentation check'
+    print 'Starting HTML tag and attribute check'
     print '----------------------------------------'
 
     html_files_to_lint = [
@@ -1418,12 +1435,12 @@ def _check_html_indent(all_files, debug=False):
                 failed = True
 
     if failed:
-        summary_message = '%s   HTML indentation check failed' % (
+        summary_message = '%s   HTML tag and attribute check failed' % (
             _MESSAGE_TYPE_FAILED)
         print summary_message
         summary_messages.append(summary_message)
     else:
-        summary_message = '%s  HTML indentation check passed' % (
+        summary_message = '%s  HTML tag and attribute check passed' % (
             _MESSAGE_TYPE_SUCCESS)
         print summary_message
         summary_messages.append(summary_message)
@@ -1503,9 +1520,9 @@ def main():
     newline_messages = _check_newline_character(all_files)
     docstring_messages = _check_docstrings(all_files)
     comment_messages = _check_comments(all_files)
-    # The html indent check has an additional debug mode which
-    # when enabled prints the tag_stack for each file.
-    html_indent_messages = _check_html_indent(all_files)
+    # The html tags and attributes check check has an additional
+    # debug mode which when enabled prints the tag_stack for each file.
+    html_tag_and_attribute_messages = _check_html_tags_and_attributes(all_files)
     html_linter_messages = _lint_html_files(all_files)
     linter_messages = _pre_commit_linter(all_files)
     pattern_messages = _check_bad_patterns(all_files)
@@ -1514,7 +1531,7 @@ def main():
         directive_scope_messages + controller_dependency_messages +
         html_directive_name_messages + import_order_messages +
         newline_messages + docstring_messages + comment_messages +
-        html_indent_messages + html_linter_messages +
+        html_tag_and_attribute_messages + html_linter_messages +
         linter_messages + pattern_messages +
         copyright_notice_messages)
     if any([message.startswith(_MESSAGE_TYPE_FAILED) for message in

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -1331,7 +1331,14 @@ class CustomHTMLParser(HTMLParser.HTMLParser):
             # attributes which have a value.
             if value:
                 expected_value = '"' + value + '"'
-                if not expected_value in starttag_text:
+
+                # &quot; is rendered as a double quote by the parser.
+                if '&quot;' in starttag_text:
+                    rendered_text = starttag_text.replace('&quot;', '"')
+                else:
+                    rendered_text = starttag_text
+
+                if not expected_value in rendered_text:
                     self.failed = True
                     print (
                         '%s --> The value %s of attribute '


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
Fixes #5108 

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [X] The PR explanation includes the words "Fixes #bugnum: ...".
- [X] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [X] The PR is made from a branch that's **not** called "develop".
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [X] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
