### PR TITLE
e2e's extensions.js: Removing unconsumed console error entries

### DIFF
--- a/core/tests/protractor/extensions.js
+++ b/core/tests/protractor/extensions.js
@@ -93,17 +93,9 @@ describe('rich-text components', function() {
 
   afterEach(function() {
     general.checkForConsoleErrors([
-      // TODO (Jacob) Remove when
-      // https://code.google.com/p/google-cast-sdk/issues/detail?id=309 is fixed
-      'cast_sender.js - Failed to load resource: net::ERR_FAILED',
-      'Uncaught ReferenceError: ytcfg is not defined',
       // TODO (@pranavsid98) This error is caused by the upgrade from Chrome 60
       // to Chrome 61. Chrome version at time of recording this is 61.0.3163.
       'chrome-extension://invalid/ - Failed to load resource: net::ERR_FAILED',
-      'Error parsing header X-XSS-Protection: 1; mode=block; ' +
-      'report=https:\/\/www.google.com\/appserve\/security-bugs\/log\/youtube:',
-      'https://www.youtube.com/youtubei/v1/log_interaction?.* Failed to load ' +
-      'resource: the server responded with a status of 401 ()',
     ]);
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
This PR removes #5047's console error entry produced by embedded YouTube player in video RTE. 

To prevent constant maintenance in the future, I propose this particular video component should be tested from unit test level(VideoDirective.js) instead of e2e. It is prone to errors from third party provider i.e YouTube. This is shown by the fact that all of the errors entries are from embedding a YouTube link.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
