### PR TITLE
Stop submit button for MultipleChoiceInput from firing ng-click twice

### DIFF
--- a/extensions/interactions/MultipleChoiceInput/directives/MultipleChoiceInput.js
+++ b/extensions/interactions/MultipleChoiceInput/directives/MultipleChoiceInput.js
@@ -39,6 +39,9 @@ oppia.directive('oppiaInteractiveMultipleChoiceInput', [
         $scope.answer = null;
 
         $scope.submitAnswer = function(answer) {
+          if (answer === null) {
+            return;
+          }
           answer = parseInt(answer, 10);
           $scope.onSubmit({
             answer: answer,

--- a/extensions/interactions/MultipleChoiceInput/directives/multiple_choice_input_interaction_directive.html
+++ b/extensions/interactions/MultipleChoiceInput/directives/multiple_choice_input_interaction_directive.html
@@ -1,6 +1,6 @@
 <form ng-submit="submitAnswer(answer)">
   <div class="multiple-choice-option-container" ng-repeat="choice in choices track by $index">
-    <button class="multiple-choice-option" ng-click="submitAnswer($index)">
+    <button class="multiple-choice-option" ng-click="submitAnswer($index);$event.preventDefault()">
       <div class="multiple-choice-radio-button-container">
         <span class="multiple-choice-outer-radio-button">
           <span class="multiple-choice-inner-radio-button"></span>

--- a/extensions/interactions/MultipleChoiceInput/directives/multiple_choice_input_interaction_directive.html
+++ b/extensions/interactions/MultipleChoiceInput/directives/multiple_choice_input_interaction_directive.html
@@ -1,6 +1,6 @@
 <form ng-submit="submitAnswer(answer)">
   <div class="multiple-choice-option-container" ng-repeat="choice in choices track by $index">
-    <button class="multiple-choice-option" ng-click="submitAnswer($index);$event.preventDefault()">
+    <button class="multiple-choice-option" ng-click="submitAnswer($index)">
       <div class="multiple-choice-radio-button-container">
         <span class="multiple-choice-outer-radio-button">
           <span class="multiple-choice-inner-radio-button"></span>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
This PR fixes #5251. The button is firing ng-click twice due to being inside  a div with ng-repeat, related [SO](https://stackoverflow.com/questions/45772971/angularjs-one-ng-click-call-the-function-twice-why?rq=1) post, which will trigger FatigueDetectionService twice down the line.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
