### PR TITLE
Adding Pip cache directory to replace special cache directive. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 # In order to install Chrome stable we need trusty distribution.
 dist: trusty
 language: python
-cache: pip
 python:
 - 2.7
 
@@ -108,6 +107,8 @@ cache:
     - ../node_modules/
     - ../oppia_tools/
     - third_party/
+    - $HOME/.cache/pip
+
 
 before_cache:
   # Delete python bytecode to prevent cache rebuild.


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
It has been a few days after my #5244 was merged and yet, Travis was still installing codecov and pyyaml on start. Pics from build [11932.1](https://travis-ci.org/oppia/oppia/jobs/403214282) on develop:
![screen shot 2018-07-13 at 11 21 04 am](https://user-images.githubusercontent.com/11153258/42699507-f92dca8c-868e-11e8-818a-25e934eaa23b.png)
This means that codecov and pyyaml was not cached at all.

In the spirit of careful investigation for every line of code written, I dig up the related #1640 and its parent issue #1636. Toward the end of #1636 thread, pip cache was dropped due to instability and ruled ineffective due to variable time. 

We have since grown from running 3 jobs to 13 jobs. Every seconds saved is tangible imo. I started to look into why pip modules are not getting cached. Here is my [finding](https://github.com/travis-ci/travis-ci/issues/3239). I then made the changes and tested on [my own Oppia's Travis](https://travis-ci.org/oppia/oppia/builds/403214281). Here is pic from my Travis's job 138.1 of branch viet_branch_5222:
![screen shot 2018-07-13 at 11 28 49 am](https://user-images.githubusercontent.com/11153258/42699854-01355be0-8690-11e8-8d89-1c9c034dba75.png)
As you can see, cached pyyaml shaved 8 secs off that one job. 8 x 13 = 104 secs, less than 2 minutes for each PR. In the grand scheme of things, 2 minutes are not a lot but is still worthy of a PR for me!


## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
