### PR TITLE
Fixing PieChartDirective console error

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/statistics_tab/PieChartDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/statistics_tab/PieChartDirective.js
@@ -34,13 +34,15 @@ oppia.directive('pieChart', [function() {
       var options = $scope.options();
       var chart = null;
 
+      // Need to wait for load statement in editor template to finish.
+      // https://stackoverflow.com/questions/42714876/
+      google.charts.setOnLoadCallback(function () {
+        if (!chart) {
+          chart = new google.visualization.PieChart($element[0]);
+        }
+      });
       var redrawChart = function() {
-        // Need to wait for load statement in editor template to finish.
-        // https://stackoverflow.com/questions/42714876/google-visualization-piechart-is-not-a-constructor
-        google.charts.setOnLoadCallback(function () {
-          if (!chart) {
-            chart = new google.visualization.PieChart($element[0]);
-          }
+        if (chart !== null) {
           chart.draw(google.visualization.arrayToDataTable($scope.data()), {
             title: options.title,
             pieHole: options.pieHole,
@@ -60,7 +62,7 @@ oppia.directive('pieChart', [function() {
             },
             width: options.width
           });
-        });
+        }
       };
 
       $scope.$watch('data()', redrawChart);

--- a/core/templates/dev/head/pages/exploration_editor/statistics_tab/PieChartDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/statistics_tab/PieChartDirective.js
@@ -38,24 +38,28 @@ oppia.directive('pieChart', [function() {
         if (!chart) {
           chart = new google.visualization.PieChart($element[0]);
         }
-        chart.draw(google.visualization.arrayToDataTable($scope.data()), {
-          title: options.title,
-          pieHole: options.pieHole,
-          pieSliceTextStyle: {
-            color: options.pieSliceTextStyleColor,
-          },
-          pieSliceBorderColor: options.pieSliceBorderColor,
-          pieSliceText: 'none',
-          chartArea: {
-            left: options.left,
-            width: options.chartAreaWidth
-          },
-          colors: options.colors,
-          height: options.height,
-          legend: {
-            position: options.legendPosition || 'none'
-          },
-          width: options.width
+        // Need to wait for load statement in editor template to finish.
+        // https://stackoverflow.com/questions/42714876/google-visualization-piechart-is-not-a-constructor
+        google.charts.setOnLoadCallback(function () {
+          chart.draw(google.visualization.arrayToDataTable($scope.data()), {
+            title: options.title,
+            pieHole: options.pieHole,
+            pieSliceTextStyle: {
+              color: options.pieSliceTextStyleColor,
+            },
+            pieSliceBorderColor: options.pieSliceBorderColor,
+            pieSliceText: 'none',
+            chartArea: {
+              left: options.left,
+              width: options.chartAreaWidth
+            },
+            colors: options.colors,
+            height: options.height,
+            legend: {
+              position: options.legendPosition || 'none'
+            },
+            width: options.width
+          });
         });
       };
 

--- a/core/templates/dev/head/pages/exploration_editor/statistics_tab/PieChartDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/statistics_tab/PieChartDirective.js
@@ -35,12 +35,12 @@ oppia.directive('pieChart', [function() {
       var chart = null;
 
       var redrawChart = function() {
-        if (!chart) {
-          chart = new google.visualization.PieChart($element[0]);
-        }
         // Need to wait for load statement in editor template to finish.
         // https://stackoverflow.com/questions/42714876/google-visualization-piechart-is-not-a-constructor
         google.charts.setOnLoadCallback(function () {
+          if (!chart) {
+            chart = new google.visualization.PieChart($element[0]);
+          }
           chart.draw(google.visualization.arrayToDataTable($scope.data()), {
             title: options.title,
             pieHole: options.pieHole,

--- a/core/tests/protractor/stateEditor.js
+++ b/core/tests/protractor/stateEditor.js
@@ -523,10 +523,6 @@ describe('State editor', function() {
   });
 
   afterEach(function() {
-    // TODO(pranavsid98): Remove this checked error once we figure out and fix
-    // the cause.
-    general.checkForConsoleErrors([
-      'TypeError: google.visualization.PieChart is not a constructor'
-    ]);
+    general.checkForConsoleErrors([]);
   });
 });


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
I was doing some QA on the test server and saw the Pie Chart console error
![screen shot 2018-07-13 at 1 37 32 pm](https://user-images.githubusercontent.com/11153258/42705635-f2792afc-86a1-11e8-99d5-01a0fad8b8bb.png)
First place I looked is this [SO](https://stackoverflow.com/questions/42714876/google-visualization-piechart-is-not-a-constructor) post. I then looked at the [docs](https://developers.google.com/chart/interactive/docs/drawing_charts) provided by Google which seems to support that SO post. 
I have removed the console error entry from the stats tab e2e test and it ran successfully on my local.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
