### PR TITLE
Fix #5286: Remove the text that comes when cursor is moved over editor

### DIFF
--- a/core/templates/dev/head/components/CkEditorRteDirective.js
+++ b/core/templates/dev/head/components/CkEditorRteDirective.js
@@ -109,6 +109,7 @@ oppia.directive('ckEditorRte', [
           'indentblock,pre,blockquote,widget,lineutils,sharedspace,' +
           pluginNames,
           startupFocus: true,
+          title: false,
           floatSpaceDockedOffsetY: 15,
           extraAllowedContent: extraAllowedContentRules,
           sharedSpaces: {


### PR DESCRIPTION
Fixes #5286.