### PR TITLE
Fixes #5260: Unable to type anything in the Math expression input box in mobile

### DIFF
--- a/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
+++ b/extensions/interactions/MathExpressionInput/directives/MathExpressionInput.js
@@ -103,7 +103,7 @@ oppia.directive('oppiaInteractiveMathExpressionInput', [
             var setGuppyContentFromInput = function() {
               // Clear the Guppy instance by setting its content to the
               // output of get_content when empty.
-              guppyInstance.set_content('<m><e></e></m>');
+              guppyInstance.import_xml('<m><e></e></m>');
               guppyInstance.render(true);
 
               // Get content of the text input field as an array of characters.


### PR DESCRIPTION
Fixes #5260 

**Explanation**
The set_content function applies to the Guppy engine. Here guppyInstance is a prototype of the engine. As defined in guppy.js (line 742). the function import_xml will be used to set the content of the document.