### PR TITLE
Convert all floating point numbers back to float from strings in received classifier data

### DIFF
--- a/core/controllers/classifier.py
+++ b/core/controllers/classifier.py
@@ -107,7 +107,14 @@ class TrainedClassifierHandler(base.BaseHandler):
             raise self.UnauthorizedUserException
 
         job_id = message['job_id']
-        classifier_data = message['classifier_data']
+        # The classifier data received in the payload has all floating point
+        # values stored as strings. This is because floating point numbers
+        # are represented differently on GAE(Oppia) and GCE(Oppia-ml).
+        # Therefore, converting all floating point numbers to string keeps
+        # signature consistent on both Oppia and Oppia-ml.
+        classifier_data = (
+            classifier_services.convert_strings_to_float_numbers_in_classifier_data( #pylint: disable=line-too-long
+                message['classifier_data']))
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
         if classifier_training_job.status == (

--- a/core/controllers/classifier.py
+++ b/core/controllers/classifier.py
@@ -51,11 +51,12 @@ def validate_job_result_message_dict(message):
         bool. Whether the payload dict is valid.
     """
     job_id = message.get('job_id')
-    classifier_data = message.get('classifier_data')
+    classifier_data_with_floats_stringified = message.get(
+        'classifier_data_with_floats_stringified')
 
     if not isinstance(job_id, basestring):
         return False
-    if not isinstance(classifier_data, dict):
+    if not isinstance(classifier_data_with_floats_stringified, dict):
         return False
     return True
 
@@ -115,7 +116,7 @@ class TrainedClassifierHandler(base.BaseHandler):
         # For more info visit: https://stackoverflow.com/q/40173295
         classifier_data = (
             classifier_services.convert_strings_to_float_numbers_in_classifier_data( #pylint: disable=line-too-long
-                message['classifier_data']))
+                message['classifier_data_with_floats_stringified']))
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
         if classifier_training_job.status == (

--- a/core/controllers/classifier.py
+++ b/core/controllers/classifier.py
@@ -112,9 +112,10 @@ class TrainedClassifierHandler(base.BaseHandler):
         # are represented differently on GAE(Oppia) and GCE(Oppia-ml).
         # Therefore, converting all floating point numbers to string keeps
         # signature consistent on both Oppia and Oppia-ml.
+        # For more info visit: https://stackoverflow.com/q/40173295
         classifier_data = (
             classifier_services.convert_strings_to_float_numbers_in_classifier_data( #pylint: disable=line-too-long
-                message['classifier_data']))
+                message['classifier_data'], message['strings_only_key_list']))
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
         if classifier_training_job.status == (

--- a/core/controllers/classifier.py
+++ b/core/controllers/classifier.py
@@ -115,7 +115,7 @@ class TrainedClassifierHandler(base.BaseHandler):
         # For more info visit: https://stackoverflow.com/q/40173295
         classifier_data = (
             classifier_services.convert_strings_to_float_numbers_in_classifier_data( #pylint: disable=line-too-long
-                message['classifier_data'], message['strings_only_key_list']))
+                message['classifier_data']))
         classifier_training_job = (
             classifier_services.get_classifier_training_job_by_id(job_id))
         if classifier_training_job.status == (

--- a/core/controllers/classifier_test.py
+++ b/core/controllers/classifier_test.py
@@ -51,7 +51,7 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
                 assets_list)
         self.exploration = exp_services.get_exploration_by_id(self.exp_id)
 
-        self.classifier_data = {
+        self.classifier_data_with_floats_stringified = {
             '_alpha': '0.1',
             '_beta': '0.001',
             '_prediction_threshold': '0.5',
@@ -60,15 +60,14 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
             '_num_labels': 10,
             '_num_docs': 12,
             '_num_words': 20,
-            '_label_to_id': {'text': 1, 'float_values': []},
-            '_word_to_id': {'hello': 2, 'float_values': []},
+            '_label_to_id': {'text': 1},
+            '_word_to_id': {'hello': 2},
             '_w_dp': [],
             '_b_dl': [],
             '_l_dp': [],
             '_c_dl': [],
             '_c_lw': [],
             '_c_l': [],
-            'float_values': ['_alpha', '_beta', '_prediction_threshold']
         }
         classifier_training_jobs = (
             classifier_services.get_classifier_training_jobs(
@@ -88,7 +87,7 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
 
         self.job_result_dict = {
             'job_id': self.job_id,
-            'classifier_data': self.classifier_data,
+            'classifier_data': self.classifier_data_with_floats_stringified
         }
 
         self.payload = {}
@@ -109,7 +108,7 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
         self.assertEqual(len(classifier_training_jobs), 1)
         decoded_classifier_data = (
             classifier_services.convert_strings_to_float_numbers_in_classifier_data( # pylint: disable=line-too-long
-                self.classifier_data))
+                self.classifier_data_with_floats_stringified))
         self.assertEqual(
             classifier_training_jobs[0].classifier_data,
             decoded_classifier_data)

--- a/core/controllers/classifier_test.py
+++ b/core/controllers/classifier_test.py
@@ -87,7 +87,8 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
 
         self.job_result_dict = {
             'job_id': self.job_id,
-            'classifier_data': self.classifier_data_with_floats_stringified
+            'classifier_data_with_floats_stringified': (
+                self.classifier_data_with_floats_stringified)
         }
 
         self.payload = {}

--- a/core/controllers/classifier_test.py
+++ b/core/controllers/classifier_test.py
@@ -88,6 +88,7 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
         self.job_result_dict = {
             'job_id': self.job_id,
             'classifier_data': self.classifier_data,
+            'strings_only_key_list': []
         }
 
         self.payload = {}

--- a/core/controllers/classifier_test.py
+++ b/core/controllers/classifier_test.py
@@ -52,22 +52,23 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
         self.exploration = exp_services.get_exploration_by_id(self.exp_id)
 
         self.classifier_data = {
-            '_alpha': 0.1,
-            '_beta': 0.001,
-            '_prediction_threshold': 0.5,
+            '_alpha': '0.1',
+            '_beta': '0.001',
+            '_prediction_threshold': '0.5',
             '_training_iterations': 25,
             '_prediction_iterations': 5,
             '_num_labels': 10,
             '_num_docs': 12,
             '_num_words': 20,
-            '_label_to_id': {'text': 1},
-            '_word_to_id': {'hello': 2},
+            '_label_to_id': {'text': 1, 'float_values': []},
+            '_word_to_id': {'hello': 2, 'float_values': []},
             '_w_dp': [],
             '_b_dl': [],
             '_l_dp': [],
             '_c_dl': [],
             '_c_lw': [],
-            '_c_l': []
+            '_c_l': [],
+            'float_values': ['_alpha', '_beta', '_prediction_threshold']
         }
         classifier_training_jobs = (
             classifier_services.get_classifier_training_jobs(
@@ -106,10 +107,12 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
             classifier_services.get_classifier_training_jobs(
                 self.exp_id, self.exploration.version, ['Home']))
         self.assertEqual(len(classifier_training_jobs), 1)
-
+        decoded_classifier_data = (
+            classifier_services.convert_strings_to_float_numbers_in_classifier_data( # pylint: disable=line-too-long
+                self.classifier_data))
         self.assertEqual(
             classifier_training_jobs[0].classifier_data,
-            self.classifier_data)
+            decoded_classifier_data)
         self.assertEqual(
             classifier_training_jobs[0].status,
             feconf.TRAINING_JOB_STATUS_COMPLETE)

--- a/core/controllers/classifier_test.py
+++ b/core/controllers/classifier_test.py
@@ -88,7 +88,6 @@ class TrainedClassifierHandlerTest(test_utils.GenericTestBase):
         self.job_result_dict = {
             'job_id': self.job_id,
             'classifier_data': self.classifier_data,
-            'strings_only_key_list': []
         }
 
         self.payload = {}

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -153,10 +153,6 @@ def handle_non_retrainable_states(exploration, state_names, exp_versions_diff):
         job_exploration_mappings)
 
 
-FLOAT_INDICATOR_KEY = 'float_values'
-# pylint: disable=too-many-branches
-
-
 def convert_strings_to_float_numbers_in_classifier_data(classifier_data):
     """Converts all floating point numbers in classifier data to string.
 
@@ -165,16 +161,17 @@ def convert_strings_to_float_numbers_in_classifier_data(classifier_data):
             values are stored as strings.
 
     Returns:
-        Dict. Original classifier data dict with float values converted back
+        dict. Original classifier data dict with float values converted back
             from string to float.
     """
+    # pylint: disable=too-many-branches
     if isinstance(classifier_data, dict):
-        if not FLOAT_INDICATOR_KEY in classifier_data:
-            # If classifier data does not contain 'float_values' key then
-            # none of its key values need transformation.
-            return classifier_data
+        if not feconf.FLOAT_INDICATOR_KEY in classifier_data:
+            raise Exception(
+                'Classifier data should contain \'%s\' key' %
+                feconf.FLOAT_INDICATOR_KEY)
 
-        float_fields = classifier_data.pop(FLOAT_INDICATOR_KEY)
+        float_fields = classifier_data.pop(feconf.FLOAT_INDICATOR_KEY)
         for k in classifier_data:
             if isinstance(classifier_data[k], dict):
                 classifier_data[k] = (
@@ -201,25 +198,20 @@ def convert_strings_to_float_numbers_in_classifier_data(classifier_data):
         new_list = []
         for item in classifier_data:
             if isinstance(item, basestring):
-                try:
-                    new_list.append(float(item))
-                except ValueError:
-                    new_list.append(item)
+                new_list.append(float(item))
             elif isinstance(item, (dict, list)):
                 new_list.append(
                     convert_strings_to_float_numbers_in_classifier_data(item))
-            elif isinstance(item, int):
-                new_list.append(item)
             else:
                 raise Exception(
                     'Expected list values to be either strings, '
-                    'lists, integers or dicts but received %s.' % (type(item)))
+                    'lists or dicts but received %s.' % (type(item)))
         return new_list
     else:
         raise Exception(
             'Expected all top-level classifier data objects to be lists or '
-            'dicts but received %s.' % (type(classifier_data)))
-# pylint: enable=too-many-branches
+            'dicts but received %s.' % type(classifier_data))
+    # pylint: enable=too-many-branches
 
 
 def get_classifier_training_job_from_model(classifier_training_job_model):

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -154,7 +154,8 @@ def handle_non_retrainable_states(exploration, state_names, exp_versions_diff):
         job_exploration_mappings)
 
 
-def convert_strings_to_float_numbers_in_classifier_data(classifier_data):
+def convert_strings_to_float_numbers_in_classifier_data(
+        classifier_data_with_floats_stringified):
     """Converts all floating point numbers in classifier data to string.
 
     The following function iterates through entire classifier data and converts
@@ -162,39 +163,44 @@ def convert_strings_to_float_numbers_in_classifier_data(classifier_data):
     numbers to corresponding float values.
 
     Args:
-        classifier_data: dict|list|string|int. The original classifier
-            data which needs conversion of floats from strings to floats.
+        classifier_data_with_floats_stringified: dict|list|string|int.
+            The original classifier data which needs conversion of floats from
+            strings to floats.
 
     Raises:
         Exception. If classifier data contains an object whose type is other
             than integer, string, dict or list.
 
     Returns:
-        dict|list|string|int. Original classifier data dict with float values
-            converted back from string to float.
+        dict|list|string|int|float. Original classifier data dict with
+            float values converted back from string to float.
     """
-    if isinstance(classifier_data, dict):
-        for k in classifier_data:
+    if isinstance(classifier_data_with_floats_stringified, dict):
+        classifier_data = {}
+        for k in classifier_data_with_floats_stringified:
             classifier_data[k] = (
                 convert_strings_to_float_numbers_in_classifier_data(
-                    classifier_data[k]))
+                    classifier_data_with_floats_stringified[k]))
         return classifier_data
-    elif isinstance(classifier_data, list):
-        new_list = []
-        for item in classifier_data:
-            new_list.append(
+    elif isinstance(classifier_data_with_floats_stringified, list):
+        classifier_data = []
+        for item in classifier_data_with_floats_stringified:
+            classifier_data.append(
                 convert_strings_to_float_numbers_in_classifier_data(item))
-        return new_list
-    elif isinstance(classifier_data, basestring):
-        if re.match(r'^([-+]?\d+\.\d+)$', classifier_data):
-            return float(classifier_data)
         return classifier_data
-    elif isinstance(classifier_data, int):
-        return classifier_data
+    elif isinstance(classifier_data_with_floats_stringified, basestring):
+        if re.match(
+                feconf.FLOAT_VERIFIER_REGEX,
+                classifier_data_with_floats_stringified):
+            return float(classifier_data_with_floats_stringified)
+        return classifier_data_with_floats_stringified
+    elif isinstance(classifier_data_with_floats_stringified, int):
+        return classifier_data_with_floats_stringified
     else:
         raise Exception(
             'Expected all classifier data objects to be lists, dicts, '
-            'strings, integers but received %s.' % (type(classifier_data)))
+            'strings, integers but received %s.' % type(
+                classifier_data_with_floats_stringified))
 
 
 def get_classifier_training_job_from_model(classifier_training_job_model):

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -153,6 +153,44 @@ def handle_non_retrainable_states(exploration, state_names, exp_versions_diff):
         job_exploration_mappings)
 
 
+def convert_strings_to_float_numbers_in_classifier_data(classifier_data):
+    """Converts all floating point numbers in classifier data to string.
+
+    Args:
+        classifier_data: dict. The trained classifier model in which float
+            values are stored as strings.
+
+    Returns:
+        Dict. Original dict with float values converted back from string to
+            float.
+    """
+    if isinstance(classifier_data, dict):
+        for k in classifier_data.keys():
+            if isinstance(classifier_data[k], (str, unicode)):
+                try:
+                    classifier_data[k] = float(classifier_data[k])
+                except TypeError:
+                    classifier_data[k] = classifier_data[k]
+            else:
+                classifier_data[k] = (
+                    convert_strings_to_float_numbers_in_classifier_data(
+                        classifier_data[k]))
+        return classifier_data
+    elif isinstance(classifier_data, (list, set, tuple)):
+        new_list = []
+        for item in classifier_data:
+            if isinstance(item, (str, unicode)):
+                try:
+                    new_list.append(float(item))
+                except TypeError:
+                    new_list.append(item)
+            else:
+                new_list.append(
+                    convert_strings_to_float_numbers_in_classifier_data(item))
+        return type(classifier_data)(new_list)
+    return classifier_data
+
+
 def get_classifier_training_job_from_model(classifier_training_job_model):
     """Gets a classifier training job domain object from a classifier
     training job model.

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -16,6 +16,7 @@
 
 import datetime
 import logging
+import re
 
 from core.domain import classifier_domain
 from core.platform import models
@@ -198,13 +199,18 @@ def convert_strings_to_float_numbers_in_classifier_data(classifier_data):
         new_list = []
         for item in classifier_data:
             if isinstance(item, basestring):
-                new_list.append(float(item))
+                if re.match(r'^([-+]?\d+\.\d+)$', item):
+                    new_list.append(float(item))
+                else:
+                    new_list.append(item)
             elif isinstance(item, (dict, list)):
                 new_list.append(
                     convert_strings_to_float_numbers_in_classifier_data(item))
+            elif isinstance(item, int):
+                new_list.append(item)
             else:
                 raise Exception(
-                    'Expected list values to be either strings, '
+                    'Expected list values to be either strings, integers, '
                     'lists or dicts but received %s.' % (type(item)))
         return new_list
     else:

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -169,7 +169,7 @@ def convert_strings_to_float_numbers_in_classifier_data(classifier_data):
             if isinstance(classifier_data[k], (str, unicode)):
                 try:
                     classifier_data[k] = float(classifier_data[k])
-                except TypeError:
+                except ValueError:
                     classifier_data[k] = classifier_data[k]
             else:
                 classifier_data[k] = (
@@ -182,7 +182,7 @@ def convert_strings_to_float_numbers_in_classifier_data(classifier_data):
             if isinstance(item, (str, unicode)):
                 try:
                     new_list.append(float(item))
-                except TypeError:
+                except ValueError:
                     new_list.append(item)
             else:
                 new_list.append(

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -157,67 +157,44 @@ def handle_non_retrainable_states(exploration, state_names, exp_versions_diff):
 def convert_strings_to_float_numbers_in_classifier_data(classifier_data):
     """Converts all floating point numbers in classifier data to string.
 
+    The following function iterates through entire classifier data and converts
+    all string values which are successfully matched by regex of floating point
+    numbers to corresponding float values.
+
     Args:
-        classifier_data: dict|list. The trained classifier model in which float
-            values are stored as strings.
+        classifier_data: dict|list|string|int. The original classifier
+            data which needs conversion of floats from strings to floats.
+
+    Raises:
+        Exception. If classifier data contains an object whose type is other
+            than integer, string, dict or list.
 
     Returns:
-        dict. Original classifier data dict with float values converted back
-            from string to float.
+        dict|list|string|int. Original classifier data dict with float values
+            converted back from string to float.
     """
-    # pylint: disable=too-many-branches
     if isinstance(classifier_data, dict):
-        if not feconf.FLOAT_INDICATOR_KEY in classifier_data:
-            raise Exception(
-                'Classifier data should contain \'%s\' key' %
-                feconf.FLOAT_INDICATOR_KEY)
-
-        float_fields = classifier_data.pop(feconf.FLOAT_INDICATOR_KEY)
         for k in classifier_data:
-            if isinstance(classifier_data[k], dict):
-                classifier_data[k] = (
-                    convert_strings_to_float_numbers_in_classifier_data(
-                        classifier_data[k]))
-            elif isinstance(classifier_data[k], list):
-                if k in float_fields:
-                    classifier_data[k] = (
-                        convert_strings_to_float_numbers_in_classifier_data(
-                            classifier_data[k]))
-            elif isinstance(classifier_data[k], basestring):
-                if k in float_fields:
-                    classifier_data[k] = float(classifier_data[k])
-            elif isinstance(classifier_data[k], int):
-                classifier_data[k] = classifier_data[k]
-            else:
-                raise Exception(
-                    'Expected all classifier data dict values to be dicts, '
-                    'lists, integers or strings but received %s.' % (
-                        type(classifier_data[k])))
-
+            classifier_data[k] = (
+                convert_strings_to_float_numbers_in_classifier_data(
+                    classifier_data[k]))
         return classifier_data
     elif isinstance(classifier_data, list):
         new_list = []
         for item in classifier_data:
-            if isinstance(item, basestring):
-                if re.match(r'^([-+]?\d+\.\d+)$', item):
-                    new_list.append(float(item))
-                else:
-                    new_list.append(item)
-            elif isinstance(item, (dict, list)):
-                new_list.append(
-                    convert_strings_to_float_numbers_in_classifier_data(item))
-            elif isinstance(item, int):
-                new_list.append(item)
-            else:
-                raise Exception(
-                    'Expected list values to be either strings, integers, '
-                    'lists or dicts but received %s.' % (type(item)))
+            new_list.append(
+                convert_strings_to_float_numbers_in_classifier_data(item))
         return new_list
+    elif isinstance(classifier_data, basestring):
+        if re.match(r'^([-+]?\d+\.\d+)$', classifier_data):
+            return float(classifier_data)
+        return classifier_data
+    elif isinstance(classifier_data, int):
+        return classifier_data
     else:
         raise Exception(
-            'Expected all top-level classifier data objects to be lists or '
-            'dicts but received %s.' % type(classifier_data))
-    # pylint: enable=too-many-branches
+            'Expected all classifier data objects to be lists, dicts, '
+            'strings, integers but received %s.' % (type(classifier_data)))
 
 
 def get_classifier_training_job_from_model(classifier_training_job_model):

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -465,21 +465,16 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
                         'adca': 'abcd',
                         'adcb': '0.1234',
                         'adcc': ['ade', 'afd'],
-                        'float_values': ['adcb']
                     }],
-                    'float_values': ['adc']
                 },
                 'ae': [['123', '0.123'], ['abc']],
-                'float_values': ['ae']
             },
             'b': {
                 'bd': ['-2.48521656693', '-2.48521656693', '-2.48521656693'],
                 'bg': ['abc', 'def', 'ghi'],
                 'bh': ['abc', '123'],
-                'float_values': ['bd']
             },
             'c': '1.123432',
-            'float_values': ['c']
         }
 
         expected_dict = {

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -459,50 +459,62 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         test_dict = {
             'a': {
                 'ab': 'abcd',
-                'ac': '0.5'
+                'ad': {
+                    'ada': 'abcdef',
+                    'adc': ['fghi', {
+                        'adca': 'abcd',
+                        'adcb': '0.1234',
+                        'adcc': ['ade', 'afd'],
+                        'float_values': ['adcb']
+                    }],
+                    'float_values': ['adc']
+                },
+                'ae': [['123', '0.123'], ['abc']],
+                'af': [['abcde'], ['0.871']],
+                'float_values': ['af']
             },
             'b': {
-                'ba': [1, 2, 3],
-                'bb': [['1.0', '0.0', '1.0'], ['0.0', '1.0', '1.0']],
-                'bc': ['-3.44757604341e-05', '-3.44757604341e-05'],
                 'bd': ['-2.48521656693', '-2.48521656693', '-2.48521656693'],
                 'be': {
                     'bea': 'abcdef',
-                    'beb': '0.0',
-                    'bec': '0.142857142857',
-                    'bed': 3},
-                'bf': ['0.133432545', 1, 2, '3.1233'],
-                'bg': [['abc', 'def'], 'ghi']
+                    'bed': 3,
+                    'float_values': []
+                },
+                'bg': ['abc', 'def', 'ghi'],
+                'bh': ['abc', 123],
+                'float_values': ['bd']
             },
             'c': '1.123432',
-            'd': 21123
+            'float_values': ['c']
         }
-
-        strings_only_key_list = ['a.ab', 'b.be.bea', 'b.bg']
 
         expected_dict = {
             'a': {
                 'ab': 'abcd',
-                'ac': 0.5
+                'ad': {
+                    'ada': 'abcdef',
+                    'adc': ['fghi', {
+                        'adca': 'abcd',
+                        'adcb': 0.1234,
+                        'adcc': ['ade', 'afd']
+                    }]
+                },
+                'ae': [['123', '0.123'], ['abc']],
+                'af': [['abcde'], [0.871]]
             },
             'b': {
-                'ba': [1, 2, 3],
-                'bb': [[1.0, 0.0, 1.0], [0.0, 1.0, 1.0]],
-                'bc': [-3.44757604341e-05, -3.44757604341e-05],
                 'bd': [-2.48521656693, -2.48521656693, -2.48521656693],
                 'be': {
                     'bea': 'abcdef',
-                    'beb': 0.0,
-                    'bec': 0.142857142857,
-                    'bed': 3},
-                'bf': [0.133432545, 1, 2, 3.1233],
-                'bg': [['abc', 'def'], 'ghi']
+                    'bed': 3
+                },
+                'bg': ['abc', 'def', 'ghi'],
+                'bh': ['abc', 123],
             },
             'c': 1.123432,
-            'd': 21123
         }
 
         output_dict = (
             classifier_services.convert_strings_to_float_numbers_in_classifier_data( #pylint: disable=line-too-long
-                test_dict, strings_only_key_list))
+                test_dict))
         self.assertDictEqual(expected_dict, output_dict)

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -453,3 +453,52 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
             classifier_services.get_classifier_training_jobs(
                 exp_id, 1, [false_state_name]))
         self.assertEqual(classifier_training_jobs, [None])
+
+    def test_convert_strings_to_float_numbers_in_classifier_data(self):
+        """Make sure that all values are converted correctly."""
+        test_dict = {
+            'a': {
+                'ab': 'abcd',
+                'ac': '0.5'
+            },
+            'b': {
+                'ba': [1, 2, 3],
+                'bb': [['1.0', '0.0', '1.0'], ['0.0', '1.0', '1.0']],
+                'bc': ['-3.44757604341e-05', '-3.44757604341e-05'],
+                'bd': ['-2.48521656693', '-2.48521656693', '-2.48521656693'],
+                'be': {
+                    'bea': 'abcdef',
+                    'beb': '0.0',
+                    'bec': '0.142857142857',
+                    'bed': 3},
+                'bf': ['0.133432545', 1, 2, '3.1233']
+            },
+            'c': '1.123432',
+            'd': 21123
+        }
+
+        expected_dict = {
+            'a': {
+                'ab': 'abcd',
+                'ac': 0.5
+            },
+            'b': {
+                'ba': [1, 2, 3],
+                'bb': [[1.0, 0.0, 1.0], [0.0, 1.0, 1.0]],
+                'bc': [-3.44757604341e-05, -3.44757604341e-05],
+                'bd': [-2.48521656693, -2.48521656693, -2.48521656693],
+                'be': {
+                    'bea': 'abcdef',
+                    'beb': 0.0,
+                    'bec': 0.142857142857,
+                    'bed': 3},
+                'bf': [0.133432545, 1, 2, 3.1233]
+            },
+            'c': 1.123432,
+            'd': 21123
+        }
+
+        output_dict = (
+            classifier_services.convert_strings_to_float_numbers_in_classifier_data( #pylint: disable=line-too-long
+                test_dict))
+        self.assertDictEqual(expected_dict, output_dict)

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -461,17 +461,22 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
                 'ab': 'abcd',
                 'ad': {
                     'ada': 'abcdef',
-                    'adc': ['fghi', {
+                    'adc': [{
                         'adca': 'abcd',
                         'adcb': '0.1234',
                         'adcc': ['ade', 'afd'],
+                        'float_values': ['adcb']
+                    }, {
+                        'adca': 'abce',
+                        'adcb': '0.34',
+                        'adcc': [],
                         'float_values': ['adcb']
                     }],
                     'float_values': ['adc']
                 },
                 'ae': [['123', '0.123'], ['abc']],
                 'af': [['abcde'], ['0.871']],
-                'float_values': ['af']
+                'float_values': []
             },
             'b': {
                 'bd': ['-2.48521656693', '-2.48521656693', '-2.48521656693'],
@@ -481,7 +486,7 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
                     'float_values': []
                 },
                 'bg': ['abc', 'def', 'ghi'],
-                'bh': ['abc', 123],
+                'bh': ['abc', '123'],
                 'float_values': ['bd']
             },
             'c': '1.123432',
@@ -493,14 +498,18 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
                 'ab': 'abcd',
                 'ad': {
                     'ada': 'abcdef',
-                    'adc': ['fghi', {
+                    'adc': [{
                         'adca': 'abcd',
                         'adcb': 0.1234,
                         'adcc': ['ade', 'afd']
+                    }, {
+                        'adca': 'abce',
+                        'adcb': 0.34,
+                        'adcc': []
                     }]
                 },
                 'ae': [['123', '0.123'], ['abc']],
-                'af': [['abcde'], [0.871]]
+                'af': [['abcde'], ['0.871']]
             },
             'b': {
                 'bd': [-2.48521656693, -2.48521656693, -2.48521656693],
@@ -509,7 +518,7 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
                     'bed': 3
                 },
                 'bg': ['abc', 'def', 'ghi'],
-                'bh': ['abc', 123],
+                'bh': ['abc', '123'],
             },
             'c': 1.123432,
         }

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -466,25 +466,14 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
                         'adcb': '0.1234',
                         'adcc': ['ade', 'afd'],
                         'float_values': ['adcb']
-                    }, {
-                        'adca': 'abce',
-                        'adcb': '0.34',
-                        'adcc': [],
-                        'float_values': ['adcb']
                     }],
                     'float_values': ['adc']
                 },
                 'ae': [['123', '0.123'], ['abc']],
-                'af': [['abcde'], ['0.871']],
-                'float_values': []
+                'float_values': ['ae']
             },
             'b': {
                 'bd': ['-2.48521656693', '-2.48521656693', '-2.48521656693'],
-                'be': {
-                    'bea': 'abcdef',
-                    'bed': 3,
-                    'float_values': []
-                },
                 'bg': ['abc', 'def', 'ghi'],
                 'bh': ['abc', '123'],
                 'float_values': ['bd']
@@ -502,21 +491,12 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
                         'adca': 'abcd',
                         'adcb': 0.1234,
                         'adcc': ['ade', 'afd']
-                    }, {
-                        'adca': 'abce',
-                        'adcb': 0.34,
-                        'adcc': []
                     }]
                 },
-                'ae': [['123', '0.123'], ['abc']],
-                'af': [['abcde'], ['0.871']]
+                'ae': [['123', 0.123], ['abc']],
             },
             'b': {
                 'bd': [-2.48521656693, -2.48521656693, -2.48521656693],
-                'be': {
-                    'bea': 'abcdef',
-                    'bed': 3
-                },
                 'bg': ['abc', 'def', 'ghi'],
                 'bh': ['abc', '123'],
             },

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -471,11 +471,14 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
                     'beb': '0.0',
                     'bec': '0.142857142857',
                     'bed': 3},
-                'bf': ['0.133432545', 1, 2, '3.1233']
+                'bf': ['0.133432545', 1, 2, '3.1233'],
+                'bg': [['abc', 'def'], 'ghi']
             },
             'c': '1.123432',
             'd': 21123
         }
+
+        strings_only_key_list = ['a.ab', 'b.be.bea', 'b.bg']
 
         expected_dict = {
             'a': {
@@ -492,7 +495,8 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
                     'beb': 0.0,
                     'bec': 0.142857142857,
                     'bed': 3},
-                'bf': [0.133432545, 1, 2, 3.1233]
+                'bf': [0.133432545, 1, 2, 3.1233],
+                'bg': [['abc', 'def'], 'ghi']
             },
             'c': 1.123432,
             'd': 21123
@@ -500,5 +504,5 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
 
         output_dict = (
             classifier_services.convert_strings_to_float_numbers_in_classifier_data( #pylint: disable=line-too-long
-                test_dict))
+                test_dict, strings_only_key_list))
         self.assertDictEqual(expected_dict, output_dict)

--- a/feconf.py
+++ b/feconf.py
@@ -741,11 +741,14 @@ SHOW_COLLECTION_NAVIGATION_TAB_STATS = False
 # is created or updated.
 ENABLE_STATE_ID_MAPPING = False
 
-# Each dict/subdict in classifier data should contain following key which
-# stores a list of keys whose values should undergo transformation on Oppia.
-# The value of following constant must be same with corresponding constant
-# on Oppia-ml stored at vmconf.py file.
-FLOAT_INDICATOR_KEY = 'float_values'
+# The regular expression used to identify whether a string contains float value.
+# The regex must match with regex that is stored in vmconf.py file of Oppia-ml.
+# If this regex needs to be modified then first of all shutdown Oppia-ml VM.
+# Then update the regex constant in here and Oppia both.
+# Run any migration job that is required to migrate existing trained models
+# before starting Oppia-ml again.
+FLOAT_VERIFIER_REGEX = (
+    '^([-+]?\\d*\\.\\d+)$|^([-+]?(\\d*\\.?\\d+|\\d+\\.?\\d*)e[-+]?\\d*)$')
 
 # Current event models schema version. All event models with an
 # event_schema_version of 1 are the events collected before the rework of the

--- a/feconf.py
+++ b/feconf.py
@@ -741,6 +741,12 @@ SHOW_COLLECTION_NAVIGATION_TAB_STATS = False
 # is created or updated.
 ENABLE_STATE_ID_MAPPING = False
 
+# Each dict/subdict in classifier data should contain following key which
+# stores a list of keys whose values should undergo transformation on Oppia.
+# The value of following constant must be same with corresponding constant
+# on Oppia-ml stored at vmconf.py file.
+FLOAT_INDICATOR_KEY = 'float_values'
+
 # Current event models schema version. All event models with an
 # event_schema_version of 1 are the events collected before the rework of the
 # statistics framework which brought about the recording of new event models;


### PR DESCRIPTION
This PR adds code to convert all floating point values in classifier data back to float from string after generating signature and storing it in Oppia. This is required because Oppia and Oppia-ml both use slightly [different representation for floating point numbers](https://stackoverflow.com/questions/40173295/float-formatting-json-dump-with-python-and-google-app-engine-issue). This allows us to keep signature consistent on both Oppia and Oppia-ml.