### PR TITLE
Create question editor (Part 1): Added frontend domain objects

### DIFF
--- a/core/templates/dev/head/domain/question/EditableQuestionBackendApiService.js
+++ b/core/templates/dev/head/domain/question/EditableQuestionBackendApiService.js
@@ -1,0 +1,100 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Service to send and receive changes to a question in the
+ *  backend.
+ */
+oppia.constant(
+  'EDITABLE_QUESTION_DATA_URL_TEMPLATE',
+  '/question_editor_handler/data/<question_id>');
+
+oppia.factory('EditableQuestionBackendApiService', [
+  '$http', '$q', 'EDITABLE_QUESTION_DATA_URL_TEMPLATE',
+  'UrlInterpolationService',
+  function($http, $q, EDITABLE_QUESTION_DATA_URL_TEMPLATE,
+      UrlInterpolationService) {
+    var _fetchQuestion = function(questionId, successCallback, errorCallback) {
+      var questionDataUrl = UrlInterpolationService.interpolateUrl(
+        EDITABLE_QUESTION_DATA_URL_TEMPLATE, {
+          question_id: questionId
+        });
+
+      $http.get(questionDataUrl).then(function(response) {
+        var questionDict = angular.copy(response.data.question_dict);
+        if (successCallback) {
+          successCallback(questionDict);
+        }
+      }, function(errorResponse) {
+        if (errorCallback) {
+          errorCallback(errorResponse.data);
+        }
+      });
+    };
+
+    var _updateQuestion = function(
+        questionId, questionVersion, commitMessage, changeList,
+        successCallback, errorCallback) {
+      var editableQuestionDataUrl = UrlInterpolationService.interpolateUrl(
+        EDITABLE_QUESTION_DATA_URL_TEMPLATE, {
+          question_id: questionId
+        });
+
+      var putData = {
+        version: questionVersion,
+        commit_message: commitMessage,
+        change_dicts: changeList
+      };
+      $http.put(editableQuestionDataUrl, putData).then(function(response) {
+        // The returned data is an updated question dict.
+        var questionDict = angular.copy(response.data.question_dict);
+
+        if (successCallback) {
+          successCallback(questionDict);
+        }
+      }, function(errorResponse) {
+        if (errorCallback) {
+          errorCallback(errorResponse.data);
+        }
+      });
+    };
+
+    return {
+      fetchQuestion: function(questionId) {
+        return $q(function(resolve, reject) {
+          _fetchQuestion(questionId, resolve, reject);
+        });
+      },
+
+      /**
+       * Updates a question in the backend with the provided question ID.
+       * The changes only apply to the question of the given version and the
+       * request to update the question will fail if the provided question
+       * version is older than the current version stored in the backend. Both
+       * the changes and the message to associate with those changes are used
+       * to commit a change to the question. The new question is passed to
+       * the success callback, if one is provided to the returned promise
+       * object. Errors are passed to the error callback, if one is provided.
+       */
+      updateQuestion: function(
+          questionId, questionVersion, commitMessage, changeList) {
+        return $q(function(resolve, reject) {
+          _updateQuestion(
+            questionId, questionVersion, commitMessage, changeList,
+            resolve, reject);
+        });
+      }
+    };
+  }
+]);

--- a/core/templates/dev/head/domain/question/EditableQuestionBackendApiServiceSpec.js
+++ b/core/templates/dev/head/domain/question/EditableQuestionBackendApiServiceSpec.js
@@ -1,0 +1,173 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for EditableQuestionBackendApiService.
+ */
+
+describe('Editable question backend API service', function() {
+  var EditableQuestionBackendApiService = null;
+  var sampleDataResults = null;
+  var $rootScope = null;
+  var $scope = null;
+  var $httpBackend = null;
+
+  beforeEach(module('oppia'));
+  beforeEach(module('oppia', GLOBALS.TRANSLATOR_PROVIDER_FOR_TESTS));
+
+  beforeEach(inject(function($injector) {
+    EditableQuestionBackendApiService = $injector.get(
+      'EditableQuestionBackendApiService');
+    $rootScope = $injector.get('$rootScope');
+    $scope = $rootScope.$new();
+    $httpBackend = $injector.get('$httpBackend');
+
+    // Sample question object returnable from the backend
+    sampleDataResults = {
+      question_dict: {
+        id: '0',
+        question_state_data: {
+          content: {
+            html: 'Question 1'
+          },
+          content_ids_to_audio_translations: {},
+          interaction: {
+            answer_groups: [],
+            confirmed_unclassified_answers: [],
+            customization_args: {},
+            default_outcome: {
+              dest: null,
+              feedback: {
+                html: 'Correct Answer'
+              },
+              param_changes: [],
+              labelled_as_correct: true
+            },
+            hints: [
+              {
+                hint_content: {
+                  html: 'Hint 1'
+                }
+              }
+            ],
+            solution: {
+              correct_answer: 'This is the correct answer',
+              answer_is_exclusive: false,
+              explanation: {
+                html: 'Solution explanation'
+              }
+            },
+            id: 'TextInput'
+          },
+          param_changes: []
+        },
+        language_code: 'en',
+        version: 1
+      }
+    };
+  }));
+
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  it('should successfully fetch an existing question from the backend',
+    function() {
+      var successHandler = jasmine.createSpy('success');
+      var failHandler = jasmine.createSpy('fail');
+
+      $httpBackend.expect('GET', '/question_editor_handler/data/0').respond(
+        sampleDataResults);
+      EditableQuestionBackendApiService.fetchQuestion('0').then(
+        successHandler, failHandler);
+      $httpBackend.flush();
+
+      expect(successHandler).toHaveBeenCalledWith(
+        sampleDataResults.question_dict);
+      expect(failHandler).not.toHaveBeenCalled();
+    }
+  );
+
+  it('should use the rejection handler if the backend request failed',
+    function() {
+      var successHandler = jasmine.createSpy('success');
+      var failHandler = jasmine.createSpy('fail');
+
+      $httpBackend.expect('GET', '/question_editor_handler/data/1').respond(
+        500, 'Error loading question 1.');
+      EditableQuestionBackendApiService.fetchQuestion('1').then(
+        successHandler, failHandler);
+      $httpBackend.flush();
+
+      expect(successHandler).not.toHaveBeenCalled();
+      expect(failHandler).toHaveBeenCalledWith('Error loading question 1.');
+    }
+  );
+
+  it('should update a question after fetching it from the backend',
+    function() {
+      var successHandler = jasmine.createSpy('success');
+      var failHandler = jasmine.createSpy('fail');
+
+      // Loading a question the first time should fetch it from the backend.
+      $httpBackend.expect('GET', '/question_editor_handler/data/0').respond(
+        sampleDataResults);
+
+      EditableQuestionBackendApiService.fetchQuestion('0').then(
+        function(questionDict) {
+          question = questionDict;
+        });
+      $httpBackend.flush();
+
+      question.question_state_data.content.html = 'New Question Content';
+      question.version = '2';
+      var questionWrapper = {
+        question_dict: question
+      };
+
+      $httpBackend.expect('PUT', '/question_editor_handler/data/0').respond(
+        questionWrapper);
+
+      // Send a request to update question
+      EditableQuestionBackendApiService.updateQuestion(
+        question.id, question.version, 'Question Data is updated', []
+      ).then(successHandler, failHandler);
+      $httpBackend.flush();
+
+      expect(successHandler).toHaveBeenCalledWith(question);
+      expect(failHandler).not.toHaveBeenCalled();
+    }
+  );
+
+  it('should use the rejection handler if the question to update doesn\'t exist',
+    function() {
+      var successHandler = jasmine.createSpy('success');
+      var failHandler = jasmine.createSpy('fail');
+
+      // Loading a question the first time should fetch it from the backend.
+      $httpBackend.expect('PUT', '/question_editor_handler/data/1').respond(
+        404, 'Question with given id doesn\'t exist.');
+
+      EditableQuestionBackendApiService.updateQuestion(
+        '1', '1', 'Update an invalid question.', []
+      ).then(successHandler, failHandler);
+      $httpBackend.flush();
+
+      expect(successHandler).not.toHaveBeenCalled();
+      expect(failHandler).toHaveBeenCalledWith(
+        'Question with given id doesn\'t exist.');
+    }
+  );
+});

--- a/core/templates/dev/head/domain/question/EditableQuestionBackendApiServiceSpec.js
+++ b/core/templates/dev/head/domain/question/EditableQuestionBackendApiServiceSpec.js
@@ -151,23 +151,22 @@ describe('Editable question backend API service', function() {
     }
   );
 
-  it('should use the rejection handler if the question to update doesn\'t exist',
-    function() {
-      var successHandler = jasmine.createSpy('success');
-      var failHandler = jasmine.createSpy('fail');
+  it('should use the rejection handler if the question to update ' +
+     'doesn\'t exist', function() {
+    var successHandler = jasmine.createSpy('success');
+    var failHandler = jasmine.createSpy('fail');
 
-      // Loading a question the first time should fetch it from the backend.
-      $httpBackend.expect('PUT', '/question_editor_handler/data/1').respond(
-        404, 'Question with given id doesn\'t exist.');
+    // Loading a question the first time should fetch it from the backend.
+    $httpBackend.expect('PUT', '/question_editor_handler/data/1').respond(
+      404, 'Question with given id doesn\'t exist.');
 
-      EditableQuestionBackendApiService.updateQuestion(
-        '1', '1', 'Update an invalid question.', []
-      ).then(successHandler, failHandler);
-      $httpBackend.flush();
+    EditableQuestionBackendApiService.updateQuestion(
+      '1', '1', 'Update an invalid question.', []
+    ).then(successHandler, failHandler);
+    $httpBackend.flush();
 
-      expect(successHandler).not.toHaveBeenCalled();
-      expect(failHandler).toHaveBeenCalledWith(
-        'Question with given id doesn\'t exist.');
-    }
-  );
+    expect(successHandler).not.toHaveBeenCalled();
+    expect(failHandler).toHaveBeenCalledWith(
+      'Question with given id doesn\'t exist.');
+  });
 });

--- a/core/templates/dev/head/domain/question/QuestionObjectFactory.js
+++ b/core/templates/dev/head/domain/question/QuestionObjectFactory.js
@@ -1,0 +1,62 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Factory for creating and mutating instances of frontend
+ * question domain objects.
+ */
+
+oppia.factory('QuestionObjectFactory', ['StateObjectFactory',
+  function(StateObjectFactory) {
+    var Question = function(id, stateData, languageCode, version) {
+      this._id = id;
+      this._stateData = stateData;
+      this._languageCode = languageCode;
+      this._version = version;
+    };
+
+    // Instance methods
+
+    Question.prototype.getId = function() {
+      return this._id;
+    };
+
+    Question.prototype.getStateData = function() {
+      return this._stateData;
+    };
+
+    Question.prototype.getLanguageCode = function() {
+      return this._languageCode;
+    };
+
+    Question.prototype.setLanguageCode = function(languageCode) {
+      this._languageCode = languageCode;
+    };
+
+    Question.prototype.getVersion = function() {
+      return this._version;
+    };
+
+    Question.createFromBackendDict = function(questionBackendDict) {
+      return new Question(
+        questionBackendDict.id,
+        StateObjectFactory.createFromBackendDict(
+          'question', questionBackendDict.question_state_data),
+        questionBackendDict.language_code, questionBackendDict.version
+      );
+    };
+
+    return Question;
+  }
+]);

--- a/core/templates/dev/head/domain/question/QuestionObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/question/QuestionObjectFactorySpec.js
@@ -1,0 +1,89 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Tests for QuestionContentsObjectFactory.
+ */
+
+describe('Question object factory', function() {
+  var QuestionObjectFactory = null;
+  var _sampleQuestion = null;
+
+  beforeEach(module('oppia'));
+
+  beforeEach(inject(function($injector) {
+    QuestionObjectFactory = $injector.get('QuestionObjectFactory');
+
+    var sampleQuestionBackendDict = {
+      id: 'question_id',
+      question_state_data: {
+        content: {
+          html: 'Question 1'
+        },
+        content_ids_to_audio_translations: {},
+        interaction: {
+          answer_groups: [],
+          confirmed_unclassified_answers: [],
+          customization_args: {},
+          default_outcome: {
+            dest: null,
+            feedback: {
+              html: 'Correct Answer'
+            },
+            param_changes: [],
+            labelled_as_correct: true
+          },
+          hints: [
+            {
+              hint_content: {
+                html: 'Hint 1'
+              }
+            }
+          ],
+          solution: {
+            correct_answer: 'This is the correct answer',
+            answer_is_exclusive: false,
+            explanation: {
+              html: 'Solution explanation'
+            }
+          },
+          id: 'TextInput'
+        },
+        param_changes: []
+      },
+      language_code: 'en',
+      version: 1
+    };
+    _sampleQuestion = QuestionObjectFactory.createFromBackendDict(
+      sampleQuestionBackendDict);
+  }));
+
+  it('should correctly get various fields of the question', function() {
+    expect(_sampleQuestion.getId()).toEqual('question_id');
+    expect(_sampleQuestion.getLanguageCode()).toEqual('en');
+    var stateData = _sampleQuestion.getStateData();
+    expect(stateData.name).toEqual('question');
+    expect(stateData.content.getHtml()).toEqual('Question 1');
+    var interaction = stateData.interaction;
+    expect(interaction.id).toEqual('TextInput');
+    expect(interaction.hints[0].hintContent.getHtml()).toEqual('Hint 1');
+    expect(interaction.solution.explanation.getHtml()).toEqual(
+      'Solution explanation');
+    expect(interaction.solution.correctAnswer).toEqual(
+      'This is the correct answer');
+    var defaultOutcome = interaction.defaultOutcome;
+    expect(defaultOutcome.labelledAsCorrect).toEqual(true);
+    expect(defaultOutcome.feedback.getHtml()).toEqual('Correct Answer');
+  });
+});


### PR DESCRIPTION
In this PR, the backend API service and domain object factory for questions have been added to prepare the frontend for adding the question editor directive.