### PR TITLE
Add codeownership control for html_cleaner.py

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 # Per-directory ownership and automatic assignment for pull requests.
+/core/domain/html_cleaner.py @seanlip
 /core/storage/ @BenHenning @seanlip
 manifest.json @vojtechjelinek @hoangviet1993


### PR DESCRIPTION
(I think we should have some checks in place to make sure that the definition of HTML content does not overly expand.)