### PR TITLE
Fix part of #5134: Add tests for config_services domain

### DIFF
--- a/core/domain/config_services.py
+++ b/core/domain/config_services.py
@@ -35,7 +35,7 @@ def set_property(committer_id, name, value):
 
     config_property = config_domain.Registry.get_config_property(name)
     if config_property is None:
-        raise ValueError('No config property with name %s found.' % name)
+        raise Exception('No config property with name %s found.' % name)
 
     config_property.set_value(committer_id, value)
 
@@ -51,6 +51,6 @@ def revert_property(committer_id, name):
 
     config_property = config_domain.Registry.get_config_property(name)
     if config_property is None:
-        raise ValueError('No config property with name %s found.' % name)
+        raise Exception('No config property with name %s found.' % name)
 
     set_property(committer_id, name, config_property.default_value)

--- a/core/domain/config_services.py
+++ b/core/domain/config_services.py
@@ -35,7 +35,7 @@ def set_property(committer_id, name, value):
 
     config_property = config_domain.Registry.get_config_property(name)
     if config_property is None:
-        raise Exception('No config property with name %s found.' % name)
+        raise ValueError('No config property with name %s found.' % name)
 
     config_property.set_value(committer_id, value)
 
@@ -51,6 +51,6 @@ def revert_property(committer_id, name):
 
     config_property = config_domain.Registry.get_config_property(name)
     if config_property is None:
-        raise Exception('No config property with name %s found.' % name)
+        raise ValueError('No config property with name %s found.' % name)
 
     set_property(committer_id, name, config_property.default_value)

--- a/core/domain/config_services_test.py
+++ b/core/domain/config_services_test.py
@@ -14,8 +14,6 @@
 
 """Testing Services for configuration properties."""
 
-import collections
-
 from core.domain import config_domain
 from core.domain import config_services
 from core.tests import test_utils
@@ -25,19 +23,16 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
 
     def setUp(self):
         super(ConfigServicesDomainUnitTests, self).setUp()
-        ConfigObj = collections.namedtuple(
-            'ConfigObj', 'name new_config_value')
         self.committer_id = u'configServicesCommitterID'
-        self.config_obj = ConfigObj(
-            name='propertyName', new_config_value='propertyValue')
         self.invalid_property_name = u'_no_such_property_name'
         self.property_dummy_value = u'TEST_VALUE'
         self.schema_unicode = 'unicode'
-        self.cfg_schemas = config_domain.Registry.get_config_property_schemas()
+        self.config_schemas = (
+            config_domain.Registry.get_config_property_schemas())
         # Get first property name, with unicode as schema type.
         self.property_name = next(
-            x for x in self.cfg_schemas if
-            self.cfg_schemas[x]['schema']['type'] == self.schema_unicode)
+            x for x in self.config_schemas if
+            self.config_schemas[x]['schema']['type'] == self.schema_unicode)
 
     def test_set_property(self):
         with self.assertRaisesRegexp(Exception, (
@@ -48,14 +43,18 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
         config_services.set_property(
             self.committer_id, self.property_name,
             self.property_dummy_value)
+        self.assertNotEqual(
+            self.config_schemas[self.property_name],
+            config_domain.Registry.get_config_property_schemas()[(
+                self.property_name)])
 
     def test_revert_property(self):
         with self.assertRaisesRegexp(Exception, (
-            'No config property with name.+')):
+            'No config property with name')):
             config_services.revert_property(
                 self.committer_id, self.invalid_property_name)
         config_services.revert_property(self.committer_id, self.property_name)
         updated_schemas = config_domain.Registry.get_config_property_schemas()
         updated_property_config = updated_schemas[self.property_name]
         self.assertEqual(
-            updated_property_config, self.cfg_schemas[self.property_name])
+            updated_property_config, self.config_schemas[self.property_name])

--- a/core/domain/config_services_test.py
+++ b/core/domain/config_services_test.py
@@ -36,7 +36,7 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
 
     def test_set_property(self):
         with self.assertRaisesRegexp(Exception, (
-            'No config property with name.+')):
+            'No config property with name')):
             config_services.set_property(
                 self.committer_id, self.invalid_property_name,
                 self.property_dummy_value)

--- a/core/domain/config_services_test.py
+++ b/core/domain/config_services_test.py
@@ -42,6 +42,7 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
     def test_set_property(self):
         with self.assertRaisesRegexp(
                 Exception, 'No config property with name.+'):
+
             config_services.set_property(
                 self.committer_id, self.invalid_property_name,
                 self.property_dummy_value)
@@ -53,6 +54,7 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
     def test_revert_property(self):
         with self.assertRaisesRegexp(
                 Exception, 'No config property with name.+'):
+
             config_services.revert_property(
                 self.committer_id, self.invalid_property_name)
 

--- a/core/domain/config_services_test.py
+++ b/core/domain/config_services_test.py
@@ -40,23 +40,21 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
             self.cfg_schemas[x]['schema']['type'] == self.schema_unicode)
 
     def test_set_property(self):
-        try:
+        with self.assertRaisesRegexp(Exception,
+                                     'No config property with name.+'):
             config_services.set_property(
                 self.committer_id, self.invalid_property_name,
                 self.property_dummy_value)
-        except Exception:
-            pass
 
         config_services.set_property(
             self.committer_id, self.property_name,
             self.property_dummy_value)
 
     def test_revert_property(self):
-        try:
+        with self.assertRaisesRegexp(Exception,
+                                     'No config property with name.+'):
             config_services.revert_property(
                 self.committer_id, self.invalid_property_name)
-        except Exception:
-            pass
 
         config_services.revert_property(self.committer_id, self.property_name)
         updated_schemas = config_domain.Registry.get_config_property_schemas()

--- a/core/domain/config_services_test.py
+++ b/core/domain/config_services_test.py
@@ -28,7 +28,6 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
         ConfigObj = collections.namedtuple(
             'ConfigObj', 'name new_config_value')
         self.committer_id = u'configServicesCommitterID'
-        self.except_str = 'No config property with name.+'
         self.config_obj = ConfigObj(
             name='propertyName', new_config_value='propertyValue')
         self.invalid_property_name = u'_no_such_property_name'
@@ -41,7 +40,8 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
             self.cfg_schemas[x]['schema']['type'] == self.schema_unicode)
 
     def test_set_property(self):
-        with self.assertRaisesRegexp(Exception, self.except_str):
+        with self.assertRaisesRegexp(Exception, (
+            'No config property with name.+')):
             config_services.set_property(
                 self.committer_id, self.invalid_property_name,
                 self.property_dummy_value)
@@ -50,7 +50,8 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
             self.property_dummy_value)
 
     def test_revert_property(self):
-        with self.assertRaisesRegexp(Exception, self.except_str):
+        with self.assertRaisesRegexp(Exception, (
+            'No config property with name.+')):
             config_services.revert_property(
                 self.committer_id, self.invalid_property_name)
         config_services.revert_property(self.committer_id, self.property_name)

--- a/core/domain/config_services_test.py
+++ b/core/domain/config_services_test.py
@@ -16,7 +16,7 @@
 
 import collections
 
-from core.domain import config_domain as cd
+from core.domain import config_domain
 from core.domain import config_services
 from core.tests import test_utils
 
@@ -33,7 +33,7 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
         self.invalid_property_name = u'_no_such_property_name'
         self.property_dummy_value = u'TEST_VALUE'
         self.schema_unicode = 'unicode'
-        self.cfg_schemas = cd.Registry.get_config_property_schemas()
+        self.cfg_schemas = config_domain.Registry.get_config_property_schemas()
         # Get first property name, with unicode as schema type.
         self.property_name = next(
             x for x in self.cfg_schemas if
@@ -44,7 +44,7 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
             config_services.set_property(
                 self.committer_id, self.invalid_property_name,
                 self.property_dummy_value)
-        except ValueError:
+        except Exception:
             pass
 
         config_services.set_property(
@@ -55,9 +55,11 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
         try:
             config_services.revert_property(
                 self.committer_id, self.invalid_property_name)
-        except ValueError:
+        except Exception:
             pass
+
         config_services.revert_property(self.committer_id, self.property_name)
+        updated_schemas = config_domain.Registry.get_config_property_schemas()
+        updated_property_config = updated_schemas[self.property_name]
         self.assertEqual(
-            cd.Registry.get_config_property_schemas()[self.property_name],
-            self.cfg_schemas[self.property_name])
+            updated_property_config, self.cfg_schemas[self.property_name])

--- a/core/domain/config_services_test.py
+++ b/core/domain/config_services_test.py
@@ -28,6 +28,7 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
         ConfigObj = collections.namedtuple(
             'ConfigObj', 'name new_config_value')
         self.committer_id = u'configServicesCommitterID'
+        self.except_str = 'No config property with name.+'
         self.config_obj = ConfigObj(
             name='propertyName', new_config_value='propertyValue')
         self.invalid_property_name = u'_no_such_property_name'
@@ -40,24 +41,18 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
             self.cfg_schemas[x]['schema']['type'] == self.schema_unicode)
 
     def test_set_property(self):
-        with self.assertRaisesRegexp(
-            Exception, 'No config property with name.+'):
-
+        with self.assertRaisesRegexp(Exception, self.except_str):
             config_services.set_property(
                 self.committer_id, self.invalid_property_name,
                 self.property_dummy_value)
-
         config_services.set_property(
             self.committer_id, self.property_name,
             self.property_dummy_value)
 
     def test_revert_property(self):
-        with self.assertRaisesRegexp(
-            Exception, 'No config property with name.+'):
-
+        with self.assertRaisesRegexp(Exception, self.except_str):
             config_services.revert_property(
                 self.committer_id, self.invalid_property_name)
-
         config_services.revert_property(self.committer_id, self.property_name)
         updated_schemas = config_domain.Registry.get_config_property_schemas()
         updated_property_config = updated_schemas[self.property_name]

--- a/core/domain/config_services_test.py
+++ b/core/domain/config_services_test.py
@@ -1,0 +1,63 @@
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Testing Services for configuration properties."""
+
+import collections
+
+from core.domain import config_domain as cd
+from core.domain import config_services
+from core.tests import test_utils
+
+
+class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
+
+    def setUp(self):
+        super(ConfigServicesDomainUnitTests, self).setUp()
+        ConfigObj = collections.namedtuple(
+            'ConfigObj', 'name new_config_value')
+        self.committer_id = u'configServicesCommitterID'
+        self.config_obj = ConfigObj(
+            name='propertyName', new_config_value='propertyValue')
+        self.invalid_property_name = u'_no_such_property_name'
+        self.property_dummy_value = u'TEST_VALUE'
+        self.schema_unicode = 'unicode'
+        self.cfg_schemas = cd.Registry.get_config_property_schemas()
+        # Get first property name, with unicode as schema type.
+        self.property_name = next(
+            x for x in self.cfg_schemas if
+            self.cfg_schemas[x]['schema']['type'] == self.schema_unicode)
+
+    def test_set_property(self):
+        try:
+            config_services.set_property(
+                self.committer_id, self.invalid_property_name,
+                self.property_dummy_value)
+        except ValueError:
+            pass
+
+        config_services.set_property(
+            self.committer_id, self.property_name,
+            self.property_dummy_value)
+
+    def test_revert_property(self):
+        try:
+            config_services.revert_property(
+                self.committer_id, self.invalid_property_name)
+        except ValueError:
+            pass
+        config_services.revert_property(self.committer_id, self.property_name)
+        self.assertEqual(
+            cd.Registry.get_config_property_schemas()[self.property_name],
+            self.cfg_schemas[self.property_name])

--- a/core/domain/config_services_test.py
+++ b/core/domain/config_services_test.py
@@ -40,8 +40,8 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
             self.cfg_schemas[x]['schema']['type'] == self.schema_unicode)
 
     def test_set_property(self):
-        with self.assertRaisesRegexp(Exception,
-                                     'No config property with name.+'):
+        with self.assertRaisesRegexp(
+                Exception, 'No config property with name.+'):
             config_services.set_property(
                 self.committer_id, self.invalid_property_name,
                 self.property_dummy_value)
@@ -51,8 +51,8 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
             self.property_dummy_value)
 
     def test_revert_property(self):
-        with self.assertRaisesRegexp(Exception,
-                                     'No config property with name.+'):
+        with self.assertRaisesRegexp(
+                Exception, 'No config property with name.+'):
             config_services.revert_property(
                 self.committer_id, self.invalid_property_name)
 

--- a/core/domain/config_services_test.py
+++ b/core/domain/config_services_test.py
@@ -41,7 +41,7 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
 
     def test_set_property(self):
         with self.assertRaisesRegexp(
-                Exception, 'No config property with name.+'):
+            Exception, 'No config property with name.+'):
 
             config_services.set_property(
                 self.committer_id, self.invalid_property_name,
@@ -53,7 +53,7 @@ class ConfigServicesDomainUnitTests(test_utils.GenericTestBase):
 
     def test_revert_property(self):
         with self.assertRaisesRegexp(
-                Exception, 'No config property with name.+'):
+            Exception, 'No config property with name.+'):
 
             config_services.revert_property(
                 self.committer_id, self.invalid_property_name)


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
This PR fixes part of #5134 and adds tests for config_services.py domain.
Test coverage is 100%.

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
