### PR TITLE
Manually Construct URL

### DIFF
--- a/core/templates/dev/head/services/StateRulesStatsService.js
+++ b/core/templates/dev/head/services/StateRulesStatsService.js
@@ -52,10 +52,9 @@ oppia.factory('StateRulesStatsService', [
         var explorationId = ContextService.getExplorationId();
 
         return $http.get(
-          UrlInterpolationService.interpolateUrl(STATE_RULES_STATS_URL, {
-            exploration_id: explorationId,
-            escaped_state_name: encodeURIComponent(state.name),
-          })
+          '/createhandler/state_rules_stats/' +
+          encodeURIComponent(explorationId) + '/' +
+          encodeURIComponent(state.name)
         ).then(function(response) {
           return {
             state_name: state.name,

--- a/core/templates/dev/head/services/StateRulesStatsService.js
+++ b/core/templates/dev/head/services/StateRulesStatsService.js
@@ -16,10 +16,6 @@
  * @fileoverview Factory for calculating the statistics of a particular state.
  */
 
-oppia.constant(
-  'STATE_RULES_STATS_URL',
-  '/createhandler/state_rules_stats/<exploration_id>/<escaped_state_name>');
-
 oppia.factory('StateRulesStatsService', [
   '$http', '$injector', 'AngularNameService', 'AnswerClassificationService',
   'ContextService', 'UrlInterpolationService', 'STATE_RULES_STATS_URL',

--- a/core/templates/dev/head/services/StateRulesStatsService.js
+++ b/core/templates/dev/head/services/StateRulesStatsService.js
@@ -18,7 +18,7 @@
 
 oppia.constant(
   'STATE_RULES_STATS_URL',
-  '/createhandler/state_rules_stats/<exploration_id>/<escaped_state_name>')
+  '/createhandler/state_rules_stats/<exploration_id>/<escaped_state_name>');
 
 oppia.factory('StateRulesStatsService', [
   '$http', '$injector', 'AngularNameService', 'AnswerClassificationService',

--- a/core/templates/dev/head/services/StateRulesStatsService.js
+++ b/core/templates/dev/head/services/StateRulesStatsService.js
@@ -48,9 +48,10 @@ oppia.factory('StateRulesStatsService', [
         var explorationId = ContextService.getExplorationId();
 
         return $http.get(
-          '/createhandler/state_rules_stats/' +
-          encodeURIComponent(explorationId) + '/' +
-          encodeURIComponent(state.name)
+          '/createhandler/state_rules_stats/' + [
+            encodeURIComponent(explorationId),
+            encodeURIComponent(state.name)
+          ].join('/')
         ).then(function(response) {
           return {
             state_name: state.name,

--- a/core/templates/dev/head/services/StateRulesStatsService.js
+++ b/core/templates/dev/head/services/StateRulesStatsService.js
@@ -18,10 +18,10 @@
 
 oppia.factory('StateRulesStatsService', [
   '$http', '$injector', 'AngularNameService', 'AnswerClassificationService',
-  'ContextService', 'UrlInterpolationService', 'STATE_RULES_STATS_URL',
+  'ContextService', 'UrlInterpolationService',
   function(
       $http, $injector, AngularNameService, AnswerClassificationService,
-      ContextService, UrlInterpolationService, STATE_RULES_STATS_URL) {
+      ContextService, UrlInterpolationService) {
     return {
       /**
        * TODO(brianrodri): Consider moving this into a visualization domain

--- a/core/templates/dev/head/services/StateRulesStatsService.js
+++ b/core/templates/dev/head/services/StateRulesStatsService.js
@@ -49,8 +49,10 @@ oppia.factory('StateRulesStatsService', [
 
         return $http.get(
           UrlInterpolationService.interpolateUrl(
-            '/createhandler/state_rules_stats/<exploration_id>/<state_name>',
-            {exploration_id: explorationId, state_name: state.name})
+            '/createhandler/state_rules_stats/<exploration_id>/<state_name>', {
+              exploration_id: explorationId,
+              state_name: encodeURIComponent(state.name),
+            })
         ).then(function(response) {
           return {
             state_name: state.name,

--- a/core/templates/dev/head/services/StateRulesStatsService.js
+++ b/core/templates/dev/head/services/StateRulesStatsService.js
@@ -16,12 +16,16 @@
  * @fileoverview Factory for calculating the statistics of a particular state.
  */
 
+oppia.constant(
+  'STATE_RULES_STATS_URL',
+  '/createhandler/state_rules_stats/<exploration_id>/<escaped_state_name>')
+
 oppia.factory('StateRulesStatsService', [
   '$http', '$injector', 'AngularNameService', 'AnswerClassificationService',
-  'ContextService', 'UrlInterpolationService',
+  'ContextService', 'UrlInterpolationService', 'STATE_RULES_STATS_URL',
   function(
       $http, $injector, AngularNameService, AnswerClassificationService,
-      ContextService, UrlInterpolationService) {
+      ContextService, UrlInterpolationService, STATE_RULES_STATS_URL) {
     return {
       /**
        * TODO(brianrodri): Consider moving this into a visualization domain
@@ -48,11 +52,10 @@ oppia.factory('StateRulesStatsService', [
         var explorationId = ContextService.getExplorationId();
 
         return $http.get(
-          UrlInterpolationService.interpolateUrl(
-            '/createhandler/state_rules_stats/<exploration_id>/<state_name>', {
-              exploration_id: explorationId,
-              state_name: encodeURIComponent(state.name),
-            })
+          UrlInterpolationService.interpolateUrl(STATE_RULES_STATS_URL, {
+            exploration_id: explorationId,
+            escaped_state_name: encodeURIComponent(state.name),
+          })
         ).then(function(response) {
           return {
             state_name: state.name,


### PR DESCRIPTION
Fix #5325

`UrlInterpolationService.interpolateUrl ` is too restrictive to encode a unicode string. It seems other places in the codebase which relies on encoding state names gets around that restriction by building it manually through string concatenation. This PR does the same to hotfix the issue.