### PR TITLE
Refactor the delete-state-callback test.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/ExplorationStatesServiceSpec.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationStatesServiceSpec.js
@@ -76,23 +76,38 @@ describe('ExplorationStatesService', function() {
     });
 
     describe('.registerOnStateDeletedCallback', function() {
+      var STATE_NAME = 'Hola';
+
       beforeEach(inject(function($injector) {
         spyOn(this.cls, 'deleteState');
+
+        var modalArgs = {
+          resolve: {
+            deleteStateName: function() {
+              return STATE_NAME;
+            }
+          }
+        };
+
         // When ExplorationStatesService tries to show the confirm-delete
         // modal, have it immediately confirm.
         spyOn($injector.get('$uibModal'), 'open').and.callFake(
-          function(stateName) {
-            return {result: Promise.resolve(stateName)};
-          });
+          function(modalArgs) {
+            return {
+              result: Promise.resolve(STATE_NAME)
+            };
+          }
+        );
       }));
 
-      it('callsback when a state is deleted', function() {
+      it('callsback when a state is deleted', function(done) {
         var callbackSpy = jasmine.createSpy('callback');
 
         this.ess.registerOnStateDeletedCallback(callbackSpy);
 
-        this.ess.deleteState('Hola').then(function() {
-          expect(callbackSpy).toHaveBeenCalledWith('Hola');
+        this.ess.deleteState(STATE_NAME).then(function() {
+          expect(callbackSpy).toHaveBeenCalledWith(STATE_NAME);
+          done();
         });
       });
     });


### PR DESCRIPTION
For some reason the delete-state-callback test that was removed in #5314 and reinstated in #5347 was failing on develop:

https://api.travis-ci.org/v3/job/406757527/log.txt

This PR attempts to fix that. I dug into the test to understand what was going on and found that stateName was being misused as an arg. I don't know why it passed before.

Reviewers: if you are happy with this PR, please merge as soon as the Travis tests pass, to unbreak develop. Thanks!