### PR TITLE
Fix #5336: Added brackets to valid url characters

### DIFF
--- a/core/templates/dev/head/domain/utilities/UrlInterpolationService.js
+++ b/core/templates/dev/head/domain/utilities/UrlInterpolationService.js
@@ -130,8 +130,8 @@ oppia.factory('UrlInterpolationService', [
           if (!value.match(VALID_URL_PARAMETER_VALUE_REGEX)) {
             AlertsService.fatalWarning(
               'Parameter values passed into interpolateUrl must only contain ' +
-              'alphanumerical characters, hyphens, underscores, brackets or ' +
-              'spaces: \'' + value + '\'');
+              'alphanumerical characters, hyphens, underscores, parentheses ' +
+              'or spaces: \'' + value + '\'');
             return null;
           }
 

--- a/core/templates/dev/head/domain/utilities/UrlInterpolationService.js
+++ b/core/templates/dev/head/domain/utilities/UrlInterpolationService.js
@@ -108,7 +108,7 @@ oppia.factory('UrlInterpolationService', [
 
         // Parameter values can only contain alphanumerical characters, spaces,
         // hyphens, underscores, periods or the equal to symbol.
-        var VALID_URL_PARAMETER_VALUE_REGEX = /^(\w| |_|-|[.]|=)+$/;
+        var VALID_URL_PARAMETER_VALUE_REGEX = /^(\w| |_|-|[.]|=|\(|\))+$/;
 
         if (urlTemplate.match(INVALID_VARIABLE_REGEX) ||
             urlTemplate.match(EMPTY_VARIABLE_REGEX)) {
@@ -130,8 +130,8 @@ oppia.factory('UrlInterpolationService', [
           if (!value.match(VALID_URL_PARAMETER_VALUE_REGEX)) {
             AlertsService.fatalWarning(
               'Parameter values passed into interpolateUrl must only contain ' +
-              'alphanumerical characters, hyphens, underscores or spaces: \'' +
-              value + '\'');
+              'alphanumerical characters, hyphens, underscores, brackets or ' +
+              'spaces: \'' + value + '\'');
             return null;
           }
 

--- a/core/templates/dev/head/domain/utilities/UrlInterpolationServiceSpec.js
+++ b/core/templates/dev/head/domain/utilities/UrlInterpolationServiceSpec.js
@@ -96,7 +96,7 @@ describe('URL Interpolation Service', function() {
     })).toBe('/test_url/');
   });
 
-  it('should interpolate URLs when parameters have brackets', function() {
+  it('should interpolate URLs when parameters have parentheses', function() {
     expect(uis.interpolateUrl('/test_url/<param>', {
       param: 'value (1'
     })).toBe('/test_url/value%20(1');
@@ -190,22 +190,22 @@ describe('URL Interpolation Service', function() {
       name: '<value>'
     })).toThrow(new Error(
       'Parameter values passed into interpolateUrl must only contain ' +
-      'alphanumerical characters, hyphens, underscores, brackets or spaces: ' +
-      "'<value>'"));
+      'alphanumerical characters, hyphens, underscores, parentheses or ' +
+      'spaces: \'<value>\''));
 
     expect(uis.interpolateUrl.bind(null, '/test_url/<name>', {
       name: '<<value>>'
     })).toThrow(new Error(
       'Parameter values passed into interpolateUrl must only contain ' +
-      'alphanumerical characters, hyphens, underscores, brackets or spaces: ' +
-      "'<<value>>'"));
+      'alphanumerical characters, hyphens, underscores, parentheses or ' +
+      'spaces: \'<<value>>\''));
 
     expect(uis.interpolateUrl.bind(null, '/test_url/<name>', {
       name: '<>'
     })).toThrow(new Error(
       'Parameter values passed into interpolateUrl must only contain ' +
-      'alphanumerical characters, hyphens, underscores, brackets or spaces: ' +
-      '\'<>\''));
+      'alphanumerical characters, hyphens, underscores, parentheses or ' +
+      'spaces: \'<>\''));
 
     // Values cannot contain non-alphanumerical characters or spaces, including
     // newlines or website symbols.
@@ -216,8 +216,8 @@ describe('URL Interpolation Service', function() {
       });
     }).toThrow(new Error(
       'Parameter values passed into interpolateUrl must only contain ' +
-      'alphanumerical characters, hyphens, underscores, brackets or spaces: ' +
-      '\'https://www.oppia.org/\''));
+      'alphanumerical characters, hyphens, underscores, parentheses or ' +
+      'spaces: \'https://www.oppia.org/\''));
 
     expect(function() {
       uis.interpolateUrl('/test_url/<name>', {
@@ -225,8 +225,8 @@ describe('URL Interpolation Service', function() {
       });
     }).toThrow(new Error(
       'Parameter values passed into interpolateUrl must only contain ' +
-      'alphanumerical characters, hyphens, underscores, brackets or spaces: ' +
-      '\'value\nmultiple lines\''));
+      'alphanumerical characters, hyphens, underscores, parentheses or ' +
+      'spaces: \'value\nmultiple lines\''));
   });
 
   it('should throw an error for missing parameters', function() {

--- a/core/templates/dev/head/domain/utilities/UrlInterpolationServiceSpec.js
+++ b/core/templates/dev/head/domain/utilities/UrlInterpolationServiceSpec.js
@@ -96,6 +96,18 @@ describe('URL Interpolation Service', function() {
     })).toBe('/test_url/');
   });
 
+  it('should interpolate URLs when parameters have brackets', function() {
+    expect(uis.interpolateUrl('/test_url/<param>', {
+      param: 'value (1'
+    })).toBe('/test_url/value%20(1');
+    expect(uis.interpolateUrl('/test_url/<param>', {
+      param: 'value 1)'
+    })).toBe('/test_url/value%201)');
+    expect(uis.interpolateUrl('/test_url/<param>', {
+      param: 'value (1)'
+    })).toBe('/test_url/value%20(1)');
+  });
+
   it('should interpolate URLs requiring one or more parameters', function() {
     expect(uis.interpolateUrl('/test_url/<fparam>', {
       fparam: 'value'

--- a/core/templates/dev/head/domain/utilities/UrlInterpolationServiceSpec.js
+++ b/core/templates/dev/head/domain/utilities/UrlInterpolationServiceSpec.js
@@ -190,21 +190,21 @@ describe('URL Interpolation Service', function() {
       name: '<value>'
     })).toThrow(new Error(
       'Parameter values passed into interpolateUrl must only contain ' +
-      'alphanumerical characters, hyphens, underscores or spaces: ' +
+      'alphanumerical characters, hyphens, underscores, brackets or spaces: ' +
       "'<value>'"));
 
     expect(uis.interpolateUrl.bind(null, '/test_url/<name>', {
       name: '<<value>>'
     })).toThrow(new Error(
       'Parameter values passed into interpolateUrl must only contain ' +
-      'alphanumerical characters, hyphens, underscores or spaces: ' +
+      'alphanumerical characters, hyphens, underscores, brackets or spaces: ' +
       "'<<value>>'"));
 
     expect(uis.interpolateUrl.bind(null, '/test_url/<name>', {
       name: '<>'
     })).toThrow(new Error(
       'Parameter values passed into interpolateUrl must only contain ' +
-      'alphanumerical characters, hyphens, underscores or spaces: ' +
+      'alphanumerical characters, hyphens, underscores, brackets or spaces: ' +
       '\'<>\''));
 
     // Values cannot contain non-alphanumerical characters or spaces, including
@@ -216,7 +216,7 @@ describe('URL Interpolation Service', function() {
       });
     }).toThrow(new Error(
       'Parameter values passed into interpolateUrl must only contain ' +
-      'alphanumerical characters, hyphens, underscores or spaces: ' +
+      'alphanumerical characters, hyphens, underscores, brackets or spaces: ' +
       '\'https://www.oppia.org/\''));
 
     expect(function() {
@@ -225,7 +225,7 @@ describe('URL Interpolation Service', function() {
       });
     }).toThrow(new Error(
       'Parameter values passed into interpolateUrl must only contain ' +
-      'alphanumerical characters, hyphens, underscores or spaces: ' +
+      'alphanumerical characters, hyphens, underscores, brackets or spaces: ' +
       '\'value\nmultiple lines\''));
   });
 


### PR DESCRIPTION
This PR fixes #5336 .
Since brackets are valid URL characters. As a quick fix for the issue, brackets have been added to the allowed characters regex in UrlInterpolationService and tests have been added.