### PR TITLE
Handle exploration reverts for ExplorationStatsModel

### DIFF
--- a/core/domain/event_services.py
+++ b/core/domain/event_services.py
@@ -75,16 +75,16 @@ class StatsEventsHandler(BaseEventHandler):
     EVENT_TYPE = feconf.EVENT_TYPE_ALL_STATS
 
     @classmethod
-    def is_latest_version(cls, exp_id, exp_version):
+    def _is_latest_version(cls, exp_id, exp_version):
         """Verifies whether the exploration version for the stats to be stored
-        correspond to the latest version of the exploration.
+        corresponds to the latest version of the exploration.
         """
         exploration = exp_services.get_exploration_by_id(exp_id)
         return exploration.version == exp_version
 
     @classmethod
     def _handle_event(cls, exploration_id, exp_version, aggregated_stats):
-        if cls.is_latest_version(exploration_id, exp_version):
+        if cls._is_latest_version(exploration_id, exp_version):
             taskqueue_services.defer(
                 stats_services.update_stats,
                 taskqueue_services.QUEUE_NAME_STATS, exploration_id,

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -874,12 +874,14 @@ def _save_exploration(committer_id, exploration, commit_message, change_list):
 
     exploration.version += 1
 
+    exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
+
     # Trigger statistics model update.
     stats_services.handle_stats_creation_for_new_exp_version(
-        exploration.id, exploration.version, exploration.states, change_list)
+        exploration.id, exploration.version, exploration.states,
+        exp_versions_diff)
 
     if feconf.ENABLE_ML_CLASSIFIERS:
-        exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         trainable_states_dict = exploration.get_trainable_states_dict(
             old_states, exp_versions_diff)
         state_names_with_changed_answer_groups = trainable_states_dict[
@@ -896,7 +898,6 @@ def _save_exploration(committer_id, exploration, commit_message, change_list):
 
     # Trigger exploration issues model updation.
     if feconf.ENABLE_PLAYTHROUGHS:
-        exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.update_exp_issues_for_new_exp_version(
             exploration, exp_versions_diff=exp_versions_diff,
             revert_to_version=None)

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -879,7 +879,7 @@ def _save_exploration(committer_id, exploration, commit_message, change_list):
     # Trigger statistics model update.
     stats_services.handle_stats_creation_for_new_exp_version(
         exploration.id, exploration.version, exploration.states,
-        exp_versions_diff)
+        exp_versions_diff=exp_versions_diff, revert_to_version=None)
 
     if feconf.ENABLE_ML_CLASSIFIERS:
         trainable_states_dict = exploration.get_trainable_states_dict(
@@ -1423,6 +1423,10 @@ def revert_exploration(
     # Update the exploration summary, but since this is just a revert do
     # not add the committer of the revert to the list of contributors.
     update_exploration_summary(exploration_id, None)
+
+    stats_services.handle_stats_creation_for_new_exp_version(
+        exploration.id, exploration.version, exploration.states,
+        exp_versions_diff=None, revert_to_version=revert_to_version)
 
     if feconf.ENABLE_PLAYTHROUGHS:
         current_exploration = get_exploration_by_id(

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -76,6 +76,9 @@ class ExplorationIssuesModelCreatorOneOffJob(
 class RegenerateMissingStatsModelsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     """A one-off job to regenerate missing stats models for explorations with
     correct v1 stats from previous versions.
+
+    This job is meant to be run only before the RecomputeStatisticsOneOffJob,
+    the v2 stats will be inconsistent otherwise.
     """
 
     @classmethod

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -146,9 +146,6 @@ class RegenerateMissingStatsModelsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                                 state_name].useful_feedback_count_v1 = (
                                     pssm.useful_feedback_count_v1)
                             exp_stats_default.state_stats_mapping[
-                                state_name].num_times_solution_viewed_v1 = (
-                                    pssm.num_times_solution_viewed_v1)
-                            exp_stats_default.state_stats_mapping[
                                 state_name].total_answers_count_v1 = (
                                     pssm.total_answers_count_v1)
                             exp_stats_default.state_stats_mapping[

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -884,22 +884,23 @@ class StatisticsAuditV2(jobs.BaseMapReduceOneOffJobManager):
                 value dict.
             value: dict. Its structure is as follows:
                 {
-                    'num_starts_v1': int. # of times exploration was
+                    'num_starts_v2': int. # of times exploration was
                         started.
-                    'num_completions_v1': int. # of times exploration was
+                    'num_completions_v2': int. # of times exploration was
                         completed.
-                    'num_actual_starts_v1': int. # of times exploration was
+                    'num_actual_starts_v2': int. # of times exploration was
                         actually started.
                     'state_stats_mapping': A dict containing the values of
                         stats for the states of the exploration. It is
                         formatted as follows:
                         {
                             state_name: {
-                                'total_answers_count_v1',
-                                'useful_feedback_count_v1',
-                                'total_hit_count_v1',
-                                'first_hit_count_v1',
-                                'num_completions_v1'
+                                'total_answers_count_v2',
+                                'useful_feedback_count_v2',
+                                'total_hit_count_v2',
+                                'first_hit_count_v2',
+                                'num_times_solution_viewed_v2',
+                                'num_completions_v2'
                             }
                         }
                 }

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -77,8 +77,8 @@ class RegenerateMissingStatsModelsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     """A one-off job to regenerate missing stats models for explorations with
     correct v1 stats from previous versions.
 
-    This job is meant to be run only before the RecomputeStatisticsOneOffJob,
-    the v2 stats will be inconsistent otherwise.
+    Note that job RecomputeStatisticsOneOffJob must be run immediately after
+    this one, otherwise the v2 stats will be inconsistent.
     """
 
     @classmethod

--- a/core/domain/stats_jobs_one_off_test.py
+++ b/core/domain/stats_jobs_one_off_test.py
@@ -19,6 +19,7 @@
 from core.domain import exp_domain
 from core.domain import exp_services
 from core.domain import stats_jobs_one_off
+from core.domain import stats_services
 from core.platform import models
 from core.platform.taskqueue import gae_taskqueue_services as taskqueue_services
 from core.tests import test_utils
@@ -114,6 +115,74 @@ class ExplorationIssuesModelCreatorOneOffJobTest(test_utils.GenericTestBase):
         self.assertEqual(exp_issues2.exp_id, self.exp_id2)
         self.assertEqual(exp_issues2.exp_version, self.exp2.version)
         self.assertEqual(exp_issues2.unresolved_issues, [])
+
+
+class RegenerateMissingStatsModelsOneOffJobTest(test_utils.GenericTestBase):
+    exp_id = 'exp_id1'
+
+    def setUp(self):
+        super(RegenerateMissingStatsModelsOneOffJobTest, self).setUp()
+
+        self.exp1 = self.save_new_valid_exploration(self.exp_id, 'owner')
+
+        state_stats_dict = {
+            'total_answers_count_v1': 3,
+            'total_answers_count_v2': 0,
+            'useful_feedback_count_v1': 3,
+            'useful_feedback_count_v2': 0,
+            'total_hit_count_v1': 3,
+            'total_hit_count_v2': 0,
+            'first_hit_count_v1': 3,
+            'first_hit_count_v2': 0,
+            'num_times_solution_viewed_v2': 0,
+            'num_completions_v1': 3,
+            'num_completions_v2': 0
+        }
+
+        stats_models.ExplorationStatsModel.create(
+            self.exp_id, 1, 7, 0, 5, 0, 2, 0,
+            {
+                self.exp1.init_state_name: state_stats_dict
+            })
+
+        self.exp1.add_states(['New state'])
+        change_list = [exp_domain.ExplorationChange({
+            'cmd': 'add_state',
+            'state_name': 'New state'
+        })]
+        # v2 version does not have ExplorationStatsModel.
+        exp_services.update_exploration(
+            feconf.SYSTEM_COMMITTER_ID, self.exp1.id, change_list, '')
+        self.exp1 = exp_services.get_exploration_by_id(self.exp1.id)
+
+    def test_stats_models_regeneration_works(self):
+        """Test that stats models are regenerated with correct v1 stats values.
+        """
+        job_id = (
+            stats_jobs_one_off.RegenerateMissingStatsModelsOneOffJob.create_new()) # pylint: disable=line-too-long
+        stats_jobs_one_off.RegenerateMissingStatsModelsOneOffJob.enqueue(
+            job_id)
+
+        self.assertEqual(
+            self.count_jobs_in_taskqueue(
+                taskqueue_services.QUEUE_NAME_ONE_OFF_JOBS), 1)
+        self.process_and_flush_pending_tasks()
+
+        # Verify exploration version 2 has a stats model and values are correct.
+        exp_stats = stats_services.get_exploration_stats_by_id(
+            self.exp_id, 2)
+
+        self.assertEqual(exp_stats.num_starts_v1, 7)
+        self.assertEqual(exp_stats.num_actual_starts_v1, 5)
+        self.assertEqual(exp_stats.num_completions_v1, 2)
+
+        state_stats = exp_stats.state_stats_mapping[self.exp1.init_state_name]
+
+        self.assertEqual(state_stats.total_answers_count_v1, 3)
+        self.assertEqual(state_stats.useful_feedback_count_v1, 3)
+        self.assertEqual(state_stats.total_hit_count_v1, 3)
+        self.assertEqual(state_stats.first_hit_count_v1, 3)
+        self.assertEqual(state_stats.num_completions_v1, 3)
 
 
 class RecomputeStateCompleteStatisticsTest(test_utils.GenericTestBase):

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -20,7 +20,6 @@ import collections
 import copy
 import itertools
 
-from core.domain import exp_domain
 from core.domain import interaction_registry
 from core.domain import stats_domain
 from core.platform import models
@@ -174,7 +173,7 @@ def handle_stats_creation_for_new_exploration(exp_id, exp_version, state_names):
 
 
 def handle_stats_creation_for_new_exp_version(
-        exp_id, exp_version, state_names, exp_versions_diff):
+        exp_id, exp_version, state_names, exp_versions_diff, revert_to_version):
     """Retrieves the ExplorationStatsModel for the old exp_version and makes
     any required changes to the structure of the model. Then, a new
     ExplorationStatsModel is created for the new exp_version.
@@ -185,6 +184,8 @@ def handle_stats_creation_for_new_exp_version(
         state_names: list(str). State names of the exploration.
         exp_versions_diff: ExplorationVersionsDiff|None. The domain object for
             the exploration versions difference, None if it is a revert.
+        revert_to_version: int|None. If the change is a revert, the version.
+            Otherwise, None.
     """
     old_exp_version = exp_version - 1
     new_exp_version = exp_version
@@ -193,6 +194,24 @@ def handle_stats_creation_for_new_exp_version(
     if exploration_stats is None:
         handle_stats_creation_for_new_exploration(
             exp_id, new_exp_version, state_names)
+        return
+
+    # Handling reverts.
+    if revert_to_version:
+        old_exp_stats = get_exploration_stats_by_id(exp_id, revert_to_version)
+        # If the old exploration issues model doesn't exist, the current model
+        # is carried over (this is a fallback case for some tests, and can
+        # never happen in production.)
+        if old_exp_stats:
+            exploration_stats.num_starts_v2 = old_exp_stats.num_starts_v2
+            exploration_stats.num_actual_starts_v2 = (
+                old_exp_stats.num_actual_starts_v2)
+            exploration_stats.num_completions_v2 = (
+                old_exp_stats.num_completions_v2)
+            exploration_stats.state_stats_mapping = (
+                old_exp_stats.state_stats_mapping)
+        exploration_stats.exp_version = new_exp_version
+        create_stats_model(exploration_stats)
         return
 
     # Handling state deletions.

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -174,7 +174,7 @@ def handle_stats_creation_for_new_exploration(exp_id, exp_version, state_names):
 
 
 def handle_stats_creation_for_new_exp_version(
-        exp_id, exp_version, state_names, change_list):
+        exp_id, exp_version, state_names, exp_versions_diff):
     """Retrieves the ExplorationStatsModel for the old exp_version and makes
     any required changes to the structure of the model. Then, a new
     ExplorationStatsModel is created for the new exp_version.
@@ -183,8 +183,8 @@ def handle_stats_creation_for_new_exp_version(
         exp_id: str. ID of the exploration.
         exp_version: int. Version of the exploration.
         state_names: list(str). State names of the exploration.
-        change_list: list(ExplorationChange). A list of changes introduced in
-            this commit.
+        exp_versions_diff: ExplorationVersionsDiff|None. The domain object for
+            the exploration versions difference, None if it is a revert.
     """
     old_exp_version = exp_version - 1
     new_exp_version = exp_version
@@ -195,18 +195,20 @@ def handle_stats_creation_for_new_exp_version(
             exp_id, new_exp_version, state_names)
         return
 
-    # Handling state additions, deletions and renames.
-    for change in change_list:
-        if change.cmd == exp_domain.CMD_ADD_STATE:
-            exploration_stats.state_stats_mapping[
-                change.state_name
-            ] = stats_domain.StateStats.create_default()
-        elif change.cmd == exp_domain.CMD_DELETE_STATE:
-            exploration_stats.state_stats_mapping.pop(change.state_name)
-        elif change.cmd == exp_domain.CMD_RENAME_STATE:
-            exploration_stats.state_stats_mapping[
-                change.new_state_name
-            ] = exploration_stats.state_stats_mapping.pop(change.old_state_name)
+    # Handling state deletions.
+    for state_name in exp_versions_diff.deleted_state_names:
+        exploration_stats.state_stats_mapping.pop(state_name)
+
+    # Handling state additions.
+    for state_name in exp_versions_diff.added_state_names:
+        exploration_stats.state_stats_mapping[state_name] = (
+            stats_domain.StateStats.create_default())
+
+    # Handling state renames.
+    for new_state_name in exp_versions_diff.new_to_old_state_names:
+        exploration_stats.state_stats_mapping[new_state_name] = (
+            exploration_stats.state_stats_mapping.pop(
+                exp_versions_diff.new_to_old_state_names[new_state_name]))
 
     exploration_stats.exp_version = new_exp_version
 

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -319,7 +319,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            exp_versions_diff)
+            exp_versions_diff=exp_versions_diff, revert_to_version=None)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)
@@ -348,7 +348,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            exp_versions_diff)
+            exp_versions_diff=exp_versions_diff, revert_to_version=None)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)
@@ -367,7 +367,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            exp_versions_diff)
+            exp_versions_diff=exp_versions_diff, revert_to_version=None)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)
@@ -395,7 +395,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            exp_versions_diff)
+            exp_versions_diff=exp_versions_diff, revert_to_version=None)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)
@@ -424,7 +424,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            exp_versions_diff)
+            exp_versions_diff=exp_versions_diff, revert_to_version=None)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)
@@ -468,7 +468,7 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            exp_versions_diff)
+            exp_versions_diff=exp_versions_diff, revert_to_version=None)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)
@@ -494,6 +494,21 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
         self.assertEqual(
             exploration_stats.state_stats_mapping[
                 'New state 4'].total_answers_count_v2, 0)
+
+        # Test reverts.
+        exploration.version += 1
+        stats_services.handle_stats_creation_for_new_exp_version(
+            exploration.id, exploration.version, exploration.states,
+            exp_versions_diff=None, revert_to_version=5)
+        exploration_stats = stats_services.get_exploration_stats_by_id(
+            exploration.id, exploration.version)
+        self.assertEqual(exploration_stats.exp_version, 8)
+        self.assertEqual(
+            set(exploration_stats.state_stats_mapping.keys()),
+            set(['Home', 'Renamed state', 'End']))
+
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 0)
+        self.assertEqual(exploration_stats.num_completions_v2, 0)
 
     def test_create_exp_issues_for_new_exploration(self):
         """Test the create_exp_issues_for_new_exploration method."""

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -316,9 +316,10 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'cmd': 'add_state',
             'state_name': 'New state 2'
         })]
+        exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            change_list)
+            exp_versions_diff)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)
@@ -344,9 +345,10 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'old_state_name': 'New state 2',
             'new_state_name': 'Renamed state'
         })]
+        exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            change_list)
+            exp_versions_diff)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)
@@ -362,9 +364,10 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'cmd': 'delete_state',
             'state_name': 'New state'
         })]
+        exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            change_list)
+            exp_versions_diff)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)
@@ -389,9 +392,10 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'cmd': 'delete_state',
             'state_name': 'Renamed state 2'
         })]
+        exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            change_list)
+            exp_versions_diff)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)
@@ -417,9 +421,10 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'old_state_name': 'New state 3',
             'new_state_name': 'New state 4'
         })]
+        exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            change_list)
+            exp_versions_diff)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)
@@ -460,9 +465,10 @@ class StatisticsServicesTest(test_utils.GenericTestBase):
             'old_state_name': 'New state',
             'new_state_name': 'New state 4'
         })]
+        exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
         stats_services.handle_stats_creation_for_new_exp_version(
             exploration.id, exploration.version, exploration.states,
-            change_list)
+            exp_versions_diff)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exploration.id, exploration.version)

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -57,6 +57,7 @@ ONE_OFF_JOB_MANAGERS = [
     stats_jobs_one_off.ExplorationIssuesModelCreatorOneOffJob,
     stats_jobs_one_off.RecomputeStatisticsOneOffJob,
     stats_jobs_one_off.RecomputeStatisticsValidationCopyOneOffJob,
+    stats_jobs_one_off.RegenerateMissingStatsModelsOneOffJob,
     stats_jobs_one_off.StatisticsAuditV1,
     stats_jobs_one_off.StatisticsAudit,
     user_jobs_one_off.DashboardSubscriptionsOneOffJob,

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -56,6 +56,7 @@ ONE_OFF_JOB_MANAGERS = [
     recommendations_jobs_one_off.ExplorationRecommendationsOneOffJob,
     stats_jobs_one_off.ExplorationIssuesModelCreatorOneOffJob,
     stats_jobs_one_off.RecomputeStatisticsOneOffJob,
+    stats_jobs_one_off.RecomputeStatisticsValidationCopyOneOffJob,
     stats_jobs_one_off.StatisticsAuditV1,
     stats_jobs_one_off.StatisticsAudit,
     user_jobs_one_off.DashboardSubscriptionsOneOffJob,

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -59,6 +59,7 @@ ONE_OFF_JOB_MANAGERS = [
     stats_jobs_one_off.RecomputeStatisticsValidationCopyOneOffJob,
     stats_jobs_one_off.RegenerateMissingStatsModelsOneOffJob,
     stats_jobs_one_off.StatisticsAuditV1,
+    stats_jobs_one_off.StatisticsAuditV2,
     stats_jobs_one_off.StatisticsAudit,
     user_jobs_one_off.DashboardSubscriptionsOneOffJob,
     user_jobs_one_off.LongUserBiosOneOffJob,


### PR DESCRIPTION
This handles reverts in exploration statistics model.

This PR fixes the flow for all future reverts and does not handle already affected models. This PR also changes the stats incremental update function to use the ExplorationVersionsDiff domain object instead of explicitly using change lists.

@seanlip PTAL! Thanks