### PR TITLE
Refactor one-off jobs to maintain parity.

### DIFF
--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -182,16 +182,19 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     in the datastore. Should only be run in events of data corruption.
     """
 
+    ENTITY_CLASSES_TO_MAP_OVER = [
+        stats_models.StateCompleteEventLogEntryModel,
+        stats_models.AnswerSubmittedEventLogEntryModel,
+        stats_models.StateHitEventLogEntryModel,
+        stats_models.SolutionHitEventLogEntryModel,
+        stats_models.StartExplorationEventLogEntryModel,
+        stats_models.ExplorationActualStartEventLogEntryModel,
+        stats_models.CompleteExplorationEventLogEntryModel
+    ]
+
     @classmethod
     def entity_classes_to_map_over(cls):
-        return [stats_models.StateCompleteEventLogEntryModel,
-                stats_models.AnswerSubmittedEventLogEntryModel,
-                stats_models.StateHitEventLogEntryModel,
-                stats_models.SolutionHitEventLogEntryModel,
-                stats_models.StartExplorationEventLogEntryModel,
-                stats_models.ExplorationActualStartEventLogEntryModel,
-                stats_models.CompleteExplorationEventLogEntryModel
-               ]
+        return RecomputeStatisticsOneOffJob.ENTITY_CLASSES_TO_MAP_OVER
 
     @staticmethod
     def map(item):
@@ -263,8 +266,18 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
     @staticmethod
     def reduce(exp_id, values):
+        exp_stats_dicts, _, error_messages = (
+            RecomputeStatisticsOneOffJob.prepare_reduce(exp_id, values))
+        for error_message in error_messages:
+            yield (error_message,)
+        stats_models.ExplorationStatsModel.save_multi(exp_stats_dicts)
+
+    @classmethod
+    def prepare_reduce(cls, exp_id, values):
         values = map(ast.literal_eval, values)
         sorted_events_dicts = sorted(values, key=lambda x: x['version'])
+
+        error_messages = []
 
         # Find the latest version number.
         exploration = exp_services.get_exploration_by_id(exp_id, strict=False)
@@ -286,7 +299,16 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
         event_dict_idx = 0
         event_dict = sorted_events_dicts[event_dict_idx]
         for version in versions:
-            datastore_stats_for_version = old_stats[version - 1]
+            datastore_stats_for_version = copy.deepcopy(old_stats[version - 1])
+
+            if datastore_stats_for_version is None:
+                # All datastore stats from this version onwards are missing
+                # anyway. No use processing further.
+                error_messages.append(
+                    'ERROR in retrieving datastore stats. They do not exist '
+                    'for: exp_id: %s, exp_version: %s' % (exp_id, version))
+                break
+
             if version == 1:
                 # Reset the possibly corrupted stats.
                 datastore_stats_for_version.num_starts_v2 = 0
@@ -376,7 +398,8 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                     break
 
             exp_stats_dicts.append(copy.deepcopy(exp_stats_dict))
-        stats_models.ExplorationStatsModel.save_multi(exp_stats_dicts)
+
+        return exp_stats_dicts, old_stats, error_messages
 
     @classmethod
     def _apply_state_name_changes(cls, prev_stats_dict, change_dicts):
@@ -429,262 +452,33 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 class RecomputeStatisticsValidationCopyOneOffJob(
         jobs.BaseMapReduceOneOffJobManager):
     """A one-off job for recomputing creator statistics from the events
-    in the datastore and then validating it against the existing values.
+    in the datastore and then validating it against the existing values. This
+    does not lead to modifications in the datastore.
     """
 
     @classmethod
     def entity_classes_to_map_over(cls):
-        return [stats_models.StateCompleteEventLogEntryModel,
-                stats_models.AnswerSubmittedEventLogEntryModel,
-                stats_models.StateHitEventLogEntryModel,
-                stats_models.SolutionHitEventLogEntryModel,
-                stats_models.StartExplorationEventLogEntryModel,
-                stats_models.ExplorationActualStartEventLogEntryModel,
-                stats_models.CompleteExplorationEventLogEntryModel
-               ]
+        return RecomputeStatisticsOneOffJob.ENTITY_CLASSES_TO_MAP_OVER
 
     @staticmethod
     def map(item):
-        if item.event_schema_version != 2:
-            return
-        if isinstance(item, stats_models.StateCompleteEventLogEntryModel):
-            yield (
-                item.exp_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_STATE_COMPLETED,
-                    'version': item.exp_version,
-                    'state_name': item.state_name
-                })
-        elif isinstance(
-                item, stats_models.AnswerSubmittedEventLogEntryModel):
-            yield (
-                item.exp_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_ANSWER_SUBMITTED,
-                    'version': item.exp_version,
-                    'state_name': item.state_name,
-                    'is_feedback_useful': item.is_feedback_useful
-                })
-        elif isinstance(item, stats_models.StateHitEventLogEntryModel):
-            yield (
-                item.exploration_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_STATE_HIT,
-                    'version': item.exploration_version,
-                    'state_name': item.state_name,
-                    'session_id': item.session_id
-                })
-        elif isinstance(item, stats_models.SolutionHitEventLogEntryModel):
-            yield (
-                item.exp_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_SOLUTION_HIT,
-                    'version': item.exp_version,
-                    'state_name': item.state_name,
-                    'session_id': item.session_id
-                })
-        elif isinstance(
-                item, stats_models.StartExplorationEventLogEntryModel):
-            yield (
-                item.exploration_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_START_EXPLORATION,
-                    'version': item.exploration_version,
-                    'state_name': item.state_name
-                })
-        elif isinstance(
-                item, stats_models.ExplorationActualStartEventLogEntryModel):
-            yield (
-                item.exp_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_ACTUAL_START_EXPLORATION,
-                    'version': item.exp_version,
-                    'state_name': item.state_name
-                })
-        elif isinstance(
-                item, stats_models.CompleteExplorationEventLogEntryModel):
-            yield (
-                item.exploration_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_COMPLETE_EXPLORATION,
-                    'version': item.exploration_version,
-                    'state_name': item.state_name
-                })
+        RecomputeStatisticsOneOffJob.map(item)
 
     @staticmethod
     def reduce(exp_id, values):
-        values = map(ast.literal_eval, values)
-        sorted_events_dicts = sorted(values, key=lambda x: x['version'])
+        exp_stats_dicts, old_stats, error_messages = (
+            RecomputeStatisticsOneOffJob.prepare_reduce(exp_id, values))
 
-        # Find the latest version number.
-        exploration = exp_services.get_exploration_by_id(exp_id, strict=False)
-        if exploration is None:
-            return
-        latest_exp_version = exploration.version
-        versions = range(1, latest_exp_version + 1)
+        for error_message in error_messages:
+            yield (error_message,)
 
-        # Get a copy of the corrupted statistics models to copy uncorrupted
-        # v1 fields.
-        old_stats = stats_services.get_multiple_exploration_stats_by_version(
-            exp_id, versions)
-        # Get list of snapshot models for each version of the exploration.
-        snapshots_by_version = (
-            exp_models.ExplorationModel.get_snapshots_metadata(
-                exp_id, versions))
-
-        exp_stats_dicts = []
-        event_dict_idx = 0
-        event_dict = sorted_events_dicts[event_dict_idx]
-        for version in versions:
-            datastore_stats_for_version = copy.deepcopy(old_stats[version - 1])
-            if datastore_stats_for_version is None:
-                # All datastore stats from this version onwards are missing
-                # anyway. No use processing further.
-                return
-
-            if version == 1:
-                # Reset the possibly corrupted stats.
-                datastore_stats_for_version.num_starts_v2 = 0
-                datastore_stats_for_version.num_completions_v2 = 0
-                datastore_stats_for_version.num_actual_starts_v2 = 0
-                for state_stats in (datastore_stats_for_version.
-                                    state_stats_mapping.values()):
-                    state_stats.total_answers_count_v2 = 0
-                    state_stats.useful_feedback_count_v2 = 0
-                    state_stats.total_hit_count_v2 = 0
-                    state_stats.first_hit_count_v2 = 0
-                    state_stats.num_times_solution_viewed_v2 = 0
-                    state_stats.num_completions_v2 = 0
-                exp_stats_dict = datastore_stats_for_version.to_dict()
-            else:
-                change_list = snapshots_by_version[version - 1]['commit_cmds']
-                # Copy recomputed v2 events from previous version.
-                prev_stats_dict = copy.deepcopy(exp_stats_dicts[-1])
-                prev_stats_dict = (
-                    RecomputeStatisticsValidationCopyOneOffJob._upgrade_state_stats_dict( # pylint: disable=line-too-long
-                        prev_stats_dict, change_list))
-                # Copy uncorrupt v1 stats.
-                prev_stats_dict['num_starts_v1'] = (
-                    datastore_stats_for_version.num_starts_v1)
-                prev_stats_dict['num_completions_v1'] = (
-                    datastore_stats_for_version.num_completions_v1)
-                prev_stats_dict['num_actual_starts_v1'] = (
-                    datastore_stats_for_version.num_actual_starts_v1)
-                state_stats_mapping = prev_stats_dict['state_stats_mapping']
-                for state in state_stats_mapping:
-                    state_stats_mapping[state]['total_answers_count_v1'] = (
-                        datastore_stats_for_version.state_stats_mapping[state]
-                        .total_answers_count_v1)
-                    state_stats_mapping[state]['useful_feedback_count_v1'] = (
-                        datastore_stats_for_version.state_stats_mapping[state]
-                        .useful_feedback_count_v1)
-                    state_stats_mapping[state]['total_hit_count_v1'] = (
-                        datastore_stats_for_version.state_stats_mapping[state]
-                        .total_hit_count_v1)
-                    state_stats_mapping[state]['first_hit_count_v1'] = (
-                        datastore_stats_for_version.state_stats_mapping[state]
-                        .first_hit_count_v1)
-                    state_stats_mapping[state]['num_completions_v1'] = (
-                        datastore_stats_for_version.state_stats_mapping[state]
-                        .num_completions_v1)
-                exp_stats_dict = copy.deepcopy(prev_stats_dict)
-
-            # Compute the statistics for events corresponding to this version.
-            state_hit_session_ids, solution_hit_session_ids = set(), set()
-            while event_dict['version'] == version:
-                state_stats = (exp_stats_dict['state_stats_mapping'][
-                    event_dict['state_name']])
-                if event_dict['event_type'] == (
-                        feconf.EVENT_TYPE_START_EXPLORATION):
-                    exp_stats_dict['num_starts_v2'] += 1
-                elif event_dict['event_type'] == (
-                        feconf.EVENT_TYPE_ACTUAL_START_EXPLORATION):
-                    exp_stats_dict['num_actual_starts_v2'] += 1
-                elif event_dict['event_type'] == (
-                        feconf.EVENT_TYPE_COMPLETE_EXPLORATION):
-                    exp_stats_dict['num_completions_v2'] += 1
-                elif event_dict['event_type'] == (
-                        feconf.EVENT_TYPE_ANSWER_SUBMITTED):
-                    state_stats['total_answers_count_v2'] += 1
-                    if event_dict['is_feedback_useful']:
-                        state_stats['useful_feedback_count_v2'] += 1
-                elif event_dict['event_type'] == feconf.EVENT_TYPE_STATE_HIT:
-                    state_stats['total_hit_count_v2'] += 1
-                    state_hit_key = (
-                        event_dict['session_id'] + event_dict['state_name'])
-                    if state_hit_key not in state_hit_session_ids:
-                        state_stats['first_hit_count_v2'] += 1
-                        state_hit_session_ids.add(state_hit_key)
-                elif event_dict['event_type'] == feconf.EVENT_TYPE_SOLUTION_HIT:
-                    solution_hit_key = (
-                        event_dict['session_id'] + event_dict['state_name'])
-                    if solution_hit_key not in solution_hit_session_ids:
-                        state_stats['num_times_solution_viewed_v2'] += 1
-                        solution_hit_session_ids.add(solution_hit_key)
-                elif event_dict['event_type'] == (
-                        feconf.EVENT_TYPE_STATE_COMPLETED):
-                    state_stats['num_completions_v2'] += 1
-                event_dict_idx += 1
-                if event_dict_idx < len(sorted_events_dicts):
-                    event_dict = sorted_events_dicts[event_dict_idx]
-                else:
-                    break
-
-            exp_stats_dicts.append(copy.deepcopy(exp_stats_dict))
-
-            old_stats_dict = old_stats[version - 1].to_dict()
+        for index, exp_stats_dict in enumerate(exp_stats_dicts):
+            old_stats_dict = old_stats[index].to_dict()
             if exp_stats_dict != old_stats_dict:
                 yield (
                     'ERROR in recomputation. exp_id: %s, exp_version: %s, '
                     'new_stats_dict: %s, old_stats_dict: %s' % (
-                        exp_id, version, exp_stats_dict, old_stats_dict))
-
-    @classmethod
-    def _upgrade_state_stats_dict(cls, prev_stats_dict, change_dicts):
-        """Update the state_stats_mapping to correspond with the changes
-        in change_list.
-
-        Args:
-            prev_stats_dict: dict. A dict representation of an
-                ExplorationStatsModel.
-            change_dicts: list(dict). A list of all of the commit cmds from the
-                old_stats_model up to the next version.
-
-        Returns:
-            dict. A dict representation of an ExplorationStatsModel with updated
-                state_stats_mapping and version.
-        """
-        RELEVANT_COMMIT_CMDS = [
-            exp_domain.CMD_ADD_STATE,
-            exp_domain.CMD_RENAME_STATE,
-            exp_domain.CMD_DELETE_STATE,
-            exp_models.ExplorationModel.CMD_REVERT_COMMIT
-        ]
-
-        change_list = [
-            exp_domain.ExplorationChange(change_dict)
-            for change_dict in change_dicts
-            if change_dict['cmd'] in RELEVANT_COMMIT_CMDS]
-        exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
-
-        # Handling state deletions, renames and additions (in that order). The
-        # order in which the above changes are handled is important.
-
-        for state_name in exp_versions_diff.deleted_state_names:
-            prev_stats_dict['state_stats_mapping'].pop(state_name)
-
-        for old_state_name, new_state_name in (
-                exp_versions_diff.old_to_new_state_names.iteritems()):
-            prev_stats_dict['state_stats_mapping'][new_state_name] = (
-                prev_stats_dict['state_stats_mapping'].pop(old_state_name))
-
-        for state_name in exp_versions_diff.added_state_names:
-            prev_stats_dict['state_stats_mapping'][state_name] = (
-                stats_domain.StateStats.create_default().to_dict())
-
-        prev_stats_dict['exp_version'] += 1
-
-        return prev_stats_dict
+                        exp_id, index + 1, exp_stats_dict, old_stats_dict))
 
 
 class StatisticsAuditV1(jobs.BaseMapReduceOneOffJobManager):


### PR DESCRIPTION
This makes sure that, once we run the verification job successfully, the other job will also run correctly/successfully.