### PR TITLE
Production fixes for the stats job.

### DIFF
--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -182,23 +182,25 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     in the datastore. Should only be run in events of data corruption.
     """
 
+    ENTITY_CLASSES_TO_MAP_OVER = [
+        stats_models.StateCompleteEventLogEntryModel,
+        stats_models.AnswerSubmittedEventLogEntryModel,
+        stats_models.StateHitEventLogEntryModel,
+        stats_models.SolutionHitEventLogEntryModel,
+        stats_models.StartExplorationEventLogEntryModel,
+        stats_models.ExplorationActualStartEventLogEntryModel,
+        stats_models.CompleteExplorationEventLogEntryModel
+    ]
+
     @classmethod
     def entity_classes_to_map_over(cls):
-        return [stats_models.StateCompleteEventLogEntryModel,
-                stats_models.AnswerSubmittedEventLogEntryModel,
-                stats_models.StateHitEventLogEntryModel,
-                stats_models.SolutionHitEventLogEntryModel,
-                stats_models.StartExplorationEventLogEntryModel,
-                stats_models.ExplorationActualStartEventLogEntryModel,
-                stats_models.CompleteExplorationEventLogEntryModel
-               ]
+        return RecomputeStatisticsOneOffJob.ENTITY_CLASSES_TO_MAP_OVER
 
-    @staticmethod
-    def map(item):
-        if item.event_schema_version != 2:
-            return
+    @classmethod
+    def prepare_map(cls, item):
+        # pylint: disable=too-many-return-statements
         if isinstance(item, stats_models.StateCompleteEventLogEntryModel):
-            yield (
+            return (
                 item.exp_id,
                 {
                     'event_type': feconf.EVENT_TYPE_STATE_COMPLETED,
@@ -207,7 +209,7 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                 })
         elif isinstance(
                 item, stats_models.AnswerSubmittedEventLogEntryModel):
-            yield (
+            return (
                 item.exp_id,
                 {
                     'event_type': feconf.EVENT_TYPE_ANSWER_SUBMITTED,
@@ -216,7 +218,7 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                     'is_feedback_useful': item.is_feedback_useful
                 })
         elif isinstance(item, stats_models.StateHitEventLogEntryModel):
-            yield (
+            return (
                 item.exploration_id,
                 {
                     'event_type': feconf.EVENT_TYPE_STATE_HIT,
@@ -225,7 +227,7 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                     'session_id': item.session_id
                 })
         elif isinstance(item, stats_models.SolutionHitEventLogEntryModel):
-            yield (
+            return (
                 item.exp_id,
                 {
                     'event_type': feconf.EVENT_TYPE_SOLUTION_HIT,
@@ -235,16 +237,18 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                 })
         elif isinstance(
                 item, stats_models.StartExplorationEventLogEntryModel):
-            yield (
+            return (
                 item.exploration_id,
                 {
                     'event_type': feconf.EVENT_TYPE_START_EXPLORATION,
                     'version': item.exploration_version,
-                    'state_name': item.state_name
+                    'state_name': item.state_name,
+                    'id': item.id,
+                    'created_on': str(item.created_on)
                 })
         elif isinstance(
                 item, stats_models.ExplorationActualStartEventLogEntryModel):
-            yield (
+            return (
                 item.exp_id,
                 {
                     'event_type': feconf.EVENT_TYPE_ACTUAL_START_EXPLORATION,
@@ -253,23 +257,56 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                 })
         elif isinstance(
                 item, stats_models.CompleteExplorationEventLogEntryModel):
-            yield (
+            return (
                 item.exploration_id,
                 {
                     'event_type': feconf.EVENT_TYPE_COMPLETE_EXPLORATION,
                     'version': item.exploration_version,
                     'state_name': item.state_name
                 })
+        else:
+            raise Exception('Bad item: %s' % type(item))
+        # pylint: enable=too-many-return-statements
+
+    @staticmethod
+    def map(item):
+        if item.event_schema_version != 2:
+            return
+        yield RecomputeStatisticsOneOffJob.prepare_map(item)
 
     @staticmethod
     def reduce(exp_id, values):
+        exp_stats_dicts, _, error_messages = (
+            RecomputeStatisticsOneOffJob.prepare_reduce(exp_id, values))
+        for error_message in error_messages:
+            yield (error_message,)
+        stats_models.ExplorationStatsModel.save_multi(exp_stats_dicts)
+
+    @classmethod
+    def prepare_reduce(cls, exp_id, values):
         values = map(ast.literal_eval, values)
-        sorted_events_dicts = sorted(values, key=lambda x: x['version'])
+        error_messages = []
+
+        for value in values:
+            if value['version'] is None:
+                error_messages.append(
+                    'None version for %s %s %s %s %s' % (
+                        exp_id,
+                        value['event_type'], value['state_name'], value['id'],
+                        value['created_on']))
+
+        filtered_values = [
+            value for value in values if value['version'] is not None]
+        if not filtered_values:
+            return [], [], error_messages
+
+        sorted_events_dicts = sorted(
+            filtered_values, key=lambda x: x['version'])
 
         # Find the latest version number.
         exploration = exp_services.get_exploration_by_id(exp_id, strict=False)
         if exploration is None:
-            return
+            return [], [], error_messages
         latest_exp_version = exploration.version
         versions = range(1, latest_exp_version + 1)
 
@@ -286,7 +323,16 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
         event_dict_idx = 0
         event_dict = sorted_events_dicts[event_dict_idx]
         for version in versions:
-            datastore_stats_for_version = old_stats[version - 1]
+            datastore_stats_for_version = copy.deepcopy(old_stats[version - 1])
+
+            if datastore_stats_for_version is None:
+                # All datastore stats from this version onwards are missing
+                # anyway. No use processing further.
+                error_messages.append(
+                    'ERROR in retrieving datastore stats. They do not exist '
+                    'for: exp_id: %s, exp_version: %s' % (exp_id, version))
+                break
+
             if version == 1:
                 # Reset the possibly corrupted stats.
                 datastore_stats_for_version.num_starts_v2 = 0
@@ -376,7 +422,8 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                     break
 
             exp_stats_dicts.append(copy.deepcopy(exp_stats_dict))
-        stats_models.ExplorationStatsModel.save_multi(exp_stats_dicts)
+
+        return exp_stats_dicts, old_stats, error_messages
 
     @classmethod
     def _apply_state_name_changes(cls, prev_stats_dict, change_dicts):
@@ -429,262 +476,37 @@ class RecomputeStatisticsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 class RecomputeStatisticsValidationCopyOneOffJob(
         jobs.BaseMapReduceOneOffJobManager):
     """A one-off job for recomputing creator statistics from the events
-    in the datastore and then validating it against the existing values.
+    in the datastore and then validating it against the existing values. This
+    does not lead to modifications in the datastore.
     """
 
     @classmethod
     def entity_classes_to_map_over(cls):
-        return [stats_models.StateCompleteEventLogEntryModel,
-                stats_models.AnswerSubmittedEventLogEntryModel,
-                stats_models.StateHitEventLogEntryModel,
-                stats_models.SolutionHitEventLogEntryModel,
-                stats_models.StartExplorationEventLogEntryModel,
-                stats_models.ExplorationActualStartEventLogEntryModel,
-                stats_models.CompleteExplorationEventLogEntryModel
-               ]
+        return RecomputeStatisticsOneOffJob.ENTITY_CLASSES_TO_MAP_OVER
 
     @staticmethod
     def map(item):
         if item.event_schema_version != 2:
             return
-        if isinstance(item, stats_models.StateCompleteEventLogEntryModel):
-            yield (
-                item.exp_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_STATE_COMPLETED,
-                    'version': item.exp_version,
-                    'state_name': item.state_name
-                })
-        elif isinstance(
-                item, stats_models.AnswerSubmittedEventLogEntryModel):
-            yield (
-                item.exp_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_ANSWER_SUBMITTED,
-                    'version': item.exp_version,
-                    'state_name': item.state_name,
-                    'is_feedback_useful': item.is_feedback_useful
-                })
-        elif isinstance(item, stats_models.StateHitEventLogEntryModel):
-            yield (
-                item.exploration_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_STATE_HIT,
-                    'version': item.exploration_version,
-                    'state_name': item.state_name,
-                    'session_id': item.session_id
-                })
-        elif isinstance(item, stats_models.SolutionHitEventLogEntryModel):
-            yield (
-                item.exp_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_SOLUTION_HIT,
-                    'version': item.exp_version,
-                    'state_name': item.state_name,
-                    'session_id': item.session_id
-                })
-        elif isinstance(
-                item, stats_models.StartExplorationEventLogEntryModel):
-            yield (
-                item.exploration_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_START_EXPLORATION,
-                    'version': item.exploration_version,
-                    'state_name': item.state_name
-                })
-        elif isinstance(
-                item, stats_models.ExplorationActualStartEventLogEntryModel):
-            yield (
-                item.exp_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_ACTUAL_START_EXPLORATION,
-                    'version': item.exp_version,
-                    'state_name': item.state_name
-                })
-        elif isinstance(
-                item, stats_models.CompleteExplorationEventLogEntryModel):
-            yield (
-                item.exploration_id,
-                {
-                    'event_type': feconf.EVENT_TYPE_COMPLETE_EXPLORATION,
-                    'version': item.exploration_version,
-                    'state_name': item.state_name
-                })
+        yield RecomputeStatisticsOneOffJob.prepare_map(item)
 
     @staticmethod
     def reduce(exp_id, values):
-        values = map(ast.literal_eval, values)
-        sorted_events_dicts = sorted(values, key=lambda x: x['version'])
+        exp_stats_dicts, old_stats, error_messages = (
+            RecomputeStatisticsOneOffJob.prepare_reduce(exp_id, values))
 
-        # Find the latest version number.
-        exploration = exp_services.get_exploration_by_id(exp_id, strict=False)
-        if exploration is None:
-            return
-        latest_exp_version = exploration.version
-        versions = range(1, latest_exp_version + 1)
+        for error_message in error_messages:
+            yield (error_message,)
 
-        # Get a copy of the corrupted statistics models to copy uncorrupted
-        # v1 fields.
-        old_stats = stats_services.get_multiple_exploration_stats_by_version(
-            exp_id, versions)
-        # Get list of snapshot models for each version of the exploration.
-        snapshots_by_version = (
-            exp_models.ExplorationModel.get_snapshots_metadata(
-                exp_id, versions))
-
-        exp_stats_dicts = []
-        event_dict_idx = 0
-        event_dict = sorted_events_dicts[event_dict_idx]
-        for version in versions:
-            datastore_stats_for_version = copy.deepcopy(old_stats[version - 1])
-            if datastore_stats_for_version is None:
-                # All datastore stats from this version onwards are missing
-                # anyway. No use processing further.
-                return
-
-            if version == 1:
-                # Reset the possibly corrupted stats.
-                datastore_stats_for_version.num_starts_v2 = 0
-                datastore_stats_for_version.num_completions_v2 = 0
-                datastore_stats_for_version.num_actual_starts_v2 = 0
-                for state_stats in (datastore_stats_for_version.
-                                    state_stats_mapping.values()):
-                    state_stats.total_answers_count_v2 = 0
-                    state_stats.useful_feedback_count_v2 = 0
-                    state_stats.total_hit_count_v2 = 0
-                    state_stats.first_hit_count_v2 = 0
-                    state_stats.num_times_solution_viewed_v2 = 0
-                    state_stats.num_completions_v2 = 0
-                exp_stats_dict = datastore_stats_for_version.to_dict()
-            else:
-                change_list = snapshots_by_version[version - 1]['commit_cmds']
-                # Copy recomputed v2 events from previous version.
-                prev_stats_dict = copy.deepcopy(exp_stats_dicts[-1])
-                prev_stats_dict = (
-                    RecomputeStatisticsValidationCopyOneOffJob._upgrade_state_stats_dict( # pylint: disable=line-too-long
-                        prev_stats_dict, change_list))
-                # Copy uncorrupt v1 stats.
-                prev_stats_dict['num_starts_v1'] = (
-                    datastore_stats_for_version.num_starts_v1)
-                prev_stats_dict['num_completions_v1'] = (
-                    datastore_stats_for_version.num_completions_v1)
-                prev_stats_dict['num_actual_starts_v1'] = (
-                    datastore_stats_for_version.num_actual_starts_v1)
-                state_stats_mapping = prev_stats_dict['state_stats_mapping']
-                for state in state_stats_mapping:
-                    state_stats_mapping[state]['total_answers_count_v1'] = (
-                        datastore_stats_for_version.state_stats_mapping[state]
-                        .total_answers_count_v1)
-                    state_stats_mapping[state]['useful_feedback_count_v1'] = (
-                        datastore_stats_for_version.state_stats_mapping[state]
-                        .useful_feedback_count_v1)
-                    state_stats_mapping[state]['total_hit_count_v1'] = (
-                        datastore_stats_for_version.state_stats_mapping[state]
-                        .total_hit_count_v1)
-                    state_stats_mapping[state]['first_hit_count_v1'] = (
-                        datastore_stats_for_version.state_stats_mapping[state]
-                        .first_hit_count_v1)
-                    state_stats_mapping[state]['num_completions_v1'] = (
-                        datastore_stats_for_version.state_stats_mapping[state]
-                        .num_completions_v1)
-                exp_stats_dict = copy.deepcopy(prev_stats_dict)
-
-            # Compute the statistics for events corresponding to this version.
-            state_hit_session_ids, solution_hit_session_ids = set(), set()
-            while event_dict['version'] == version:
-                state_stats = (exp_stats_dict['state_stats_mapping'][
-                    event_dict['state_name']])
-                if event_dict['event_type'] == (
-                        feconf.EVENT_TYPE_START_EXPLORATION):
-                    exp_stats_dict['num_starts_v2'] += 1
-                elif event_dict['event_type'] == (
-                        feconf.EVENT_TYPE_ACTUAL_START_EXPLORATION):
-                    exp_stats_dict['num_actual_starts_v2'] += 1
-                elif event_dict['event_type'] == (
-                        feconf.EVENT_TYPE_COMPLETE_EXPLORATION):
-                    exp_stats_dict['num_completions_v2'] += 1
-                elif event_dict['event_type'] == (
-                        feconf.EVENT_TYPE_ANSWER_SUBMITTED):
-                    state_stats['total_answers_count_v2'] += 1
-                    if event_dict['is_feedback_useful']:
-                        state_stats['useful_feedback_count_v2'] += 1
-                elif event_dict['event_type'] == feconf.EVENT_TYPE_STATE_HIT:
-                    state_stats['total_hit_count_v2'] += 1
-                    state_hit_key = (
-                        event_dict['session_id'] + event_dict['state_name'])
-                    if state_hit_key not in state_hit_session_ids:
-                        state_stats['first_hit_count_v2'] += 1
-                        state_hit_session_ids.add(state_hit_key)
-                elif event_dict['event_type'] == feconf.EVENT_TYPE_SOLUTION_HIT:
-                    solution_hit_key = (
-                        event_dict['session_id'] + event_dict['state_name'])
-                    if solution_hit_key not in solution_hit_session_ids:
-                        state_stats['num_times_solution_viewed_v2'] += 1
-                        solution_hit_session_ids.add(solution_hit_key)
-                elif event_dict['event_type'] == (
-                        feconf.EVENT_TYPE_STATE_COMPLETED):
-                    state_stats['num_completions_v2'] += 1
-                event_dict_idx += 1
-                if event_dict_idx < len(sorted_events_dicts):
-                    event_dict = sorted_events_dicts[event_dict_idx]
-                else:
-                    break
-
-            exp_stats_dicts.append(copy.deepcopy(exp_stats_dict))
-
-            old_stats_dict = old_stats[version - 1].to_dict()
+        for index, exp_stats_dict in enumerate(exp_stats_dicts):
+            old_stats_dict = old_stats[index].to_dict()
             if exp_stats_dict != old_stats_dict:
                 yield (
                     'ERROR in recomputation. exp_id: %s, exp_version: %s, '
                     'new_stats_dict: %s, old_stats_dict: %s' % (
-                        exp_id, version, exp_stats_dict, old_stats_dict))
+                        exp_id, index + 1, exp_stats_dict, old_stats_dict))
 
-    @classmethod
-    def _upgrade_state_stats_dict(cls, prev_stats_dict, change_dicts):
-        """Update the state_stats_mapping to correspond with the changes
-        in change_list.
-
-        Args:
-            prev_stats_dict: dict. A dict representation of an
-                ExplorationStatsModel.
-            change_dicts: list(dict). A list of all of the commit cmds from the
-                old_stats_model up to the next version.
-
-        Returns:
-            dict. A dict representation of an ExplorationStatsModel with updated
-                state_stats_mapping and version.
-        """
-        RELEVANT_COMMIT_CMDS = [
-            exp_domain.CMD_ADD_STATE,
-            exp_domain.CMD_RENAME_STATE,
-            exp_domain.CMD_DELETE_STATE,
-            exp_models.ExplorationModel.CMD_REVERT_COMMIT
-        ]
-
-        change_list = [
-            exp_domain.ExplorationChange(change_dict)
-            for change_dict in change_dicts
-            if change_dict['cmd'] in RELEVANT_COMMIT_CMDS]
-        exp_versions_diff = exp_domain.ExplorationVersionsDiff(change_list)
-
-        # Handling state deletions, renames and additions (in that order). The
-        # order in which the above changes are handled is important.
-
-        for state_name in exp_versions_diff.deleted_state_names:
-            prev_stats_dict['state_stats_mapping'].pop(state_name)
-
-        for old_state_name, new_state_name in (
-                exp_versions_diff.old_to_new_state_names.iteritems()):
-            prev_stats_dict['state_stats_mapping'][new_state_name] = (
-                prev_stats_dict['state_stats_mapping'].pop(old_state_name))
-
-        for state_name in exp_versions_diff.added_state_names:
-            prev_stats_dict['state_stats_mapping'][state_name] = (
-                stats_domain.StateStats.create_default().to_dict())
-
-        prev_stats_dict['exp_version'] += 1
-
-        return prev_stats_dict
+        yield ('Completed', exp_id)
 
 
 class StatisticsAuditV1(jobs.BaseMapReduceOneOffJobManager):

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -116,8 +116,7 @@ class AnswerSubmittedEventLogEntryModel(base_models.BaseModel):
     # Whether the submitted answer received useful feedback.
     is_feedback_useful = ndb.BooleanProperty(indexed=True)
     # The version of the event schema used to describe an event of this type.
-    event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
+    event_schema_version = ndb.IntegerProperty(indexed=True)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -144,7 +143,8 @@ class AnswerSubmittedEventLogEntryModel(base_models.BaseModel):
             state_name=state_name,
             session_id=session_id,
             time_spent_in_state_secs=time_spent_in_state_secs,
-            is_feedback_useful=is_feedback_useful)
+            is_feedback_useful=is_feedback_useful,
+            event_schema_version=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
         answer_submitted_event_entity.put()
         return entity_id
 
@@ -163,8 +163,7 @@ class ExplorationActualStartEventLogEntryModel(base_models.BaseModel):
     # ID of current student's session.
     session_id = ndb.StringProperty(indexed=True)
     # The version of the event schema used to describe an event of this type.
-    event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
+    event_schema_version = ndb.IntegerProperty(indexed=True)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -187,7 +186,8 @@ class ExplorationActualStartEventLogEntryModel(base_models.BaseModel):
             exp_id=exp_id,
             exp_version=exp_version,
             state_name=state_name,
-            session_id=session_id)
+            session_id=session_id,
+            event_schema_version=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
         actual_start_event_entity.put()
         return entity_id
 
@@ -205,8 +205,7 @@ class SolutionHitEventLogEntryModel(base_models.BaseModel):
     # Time since start of this state before this event occurred (in sec).
     time_spent_in_state_secs = ndb.FloatProperty()
     # The version of the event schema used to describe an event of this type.
-    event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
+    event_schema_version = ndb.IntegerProperty(indexed=True)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -232,7 +231,8 @@ class SolutionHitEventLogEntryModel(base_models.BaseModel):
             exp_version=exp_version,
             state_name=state_name,
             session_id=session_id,
-            time_spent_in_state_secs=time_spent_in_state_secs)
+            time_spent_in_state_secs=time_spent_in_state_secs,
+            event_schema_version=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
         solution_hit_event_entity.put()
         return entity_id
 
@@ -275,8 +275,7 @@ class StartExplorationEventLogEntryModel(base_models.BaseModel):
                                    choices=[feconf.PLAY_TYPE_PLAYTEST,
                                             feconf.PLAY_TYPE_NORMAL])
     # The version of the event schema used to describe an event of this type.
-    event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
+    event_schema_version = ndb.IntegerProperty(indexed=True)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -330,7 +329,8 @@ class StartExplorationEventLogEntryModel(base_models.BaseModel):
             session_id=session_id,
             client_time_spent_in_secs=0.0,
             params=params,
-            play_type=play_type)
+            play_type=play_type,
+            event_schema_version=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
         start_event_entity.put()
         return entity_id
 
@@ -389,8 +389,7 @@ class MaybeLeaveExplorationEventLogEntryModel(base_models.BaseModel):
                                    choices=[feconf.PLAY_TYPE_PLAYTEST,
                                             feconf.PLAY_TYPE_NORMAL])
     # The version of the event schema used to describe an event of this type.
-    event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
+    event_schema_version = ndb.IntegerProperty(indexed=True)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -442,7 +441,8 @@ class MaybeLeaveExplorationEventLogEntryModel(base_models.BaseModel):
             session_id=session_id,
             client_time_spent_in_secs=client_time_spent_in_secs,
             params=params,
-            play_type=play_type)
+            play_type=play_type,
+            event_schema_version=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
         leave_event_entity.put()
 
 
@@ -494,8 +494,7 @@ class CompleteExplorationEventLogEntryModel(base_models.BaseModel):
                                    choices=[feconf.PLAY_TYPE_PLAYTEST,
                                             feconf.PLAY_TYPE_NORMAL])
     # The version of the event schema used to describe an event of this type.
-    event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
+    event_schema_version = ndb.IntegerProperty(indexed=True)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -546,7 +545,8 @@ class CompleteExplorationEventLogEntryModel(base_models.BaseModel):
             session_id=session_id,
             client_time_spent_in_secs=client_time_spent_in_secs,
             params=params,
-            play_type=play_type)
+            play_type=play_type,
+            event_schema_version=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
         complete_event_entity.put()
         return entity_id
 
@@ -571,8 +571,7 @@ class RateExplorationEventLogEntryModel(base_models.BaseModel):
     # user rates an exploration for the first time.
     old_rating = ndb.IntegerProperty(indexed=True)
     # The version of the event schema used to describe an event of this type.
-    event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
+    event_schema_version = ndb.IntegerProperty(indexed=True)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, user_id):
@@ -606,11 +605,14 @@ class RateExplorationEventLogEntryModel(base_models.BaseModel):
         """
         entity_id = cls.get_new_event_entity_id(
             exp_id, user_id)
-        cls(id=entity_id,
+        cls(
+            id=entity_id,
             event_type=feconf.EVENT_TYPE_RATE_EXPLORATION,
             exploration_id=exp_id,
             rating=rating,
-            old_rating=old_rating).put()
+            old_rating=old_rating,
+            event_schema_version=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION
+        ).put()
 
 
 class StateHitEventLogEntryModel(base_models.BaseModel):
@@ -650,8 +652,7 @@ class StateHitEventLogEntryModel(base_models.BaseModel):
                                    choices=[feconf.PLAY_TYPE_PLAYTEST,
                                             feconf.PLAY_TYPE_NORMAL])
     # The version of the event schema used to describe an event of this type.
-    event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
+    event_schema_version = ndb.IntegerProperty(indexed=True)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -702,7 +703,8 @@ class StateHitEventLogEntryModel(base_models.BaseModel):
             state_name=state_name,
             session_id=session_id,
             params=params,
-            play_type=play_type)
+            play_type=play_type,
+            event_schema_version=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
         state_event_entity.put()
         return entity_id
 
@@ -720,8 +722,7 @@ class StateCompleteEventLogEntryModel(base_models.BaseModel):
     # Time since start of this state before this event occurred (in sec).
     time_spent_in_state_secs = ndb.FloatProperty()
     # The version of the event schema used to describe an event of this type.
-    event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
+    event_schema_version = ndb.IntegerProperty(indexed=True)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -747,7 +748,8 @@ class StateCompleteEventLogEntryModel(base_models.BaseModel):
             exp_version=exp_version,
             state_name=state_name,
             session_id=session_id,
-            time_spent_in_state_secs=time_spent_in_state_secs)
+            time_spent_in_state_secs=time_spent_in_state_secs,
+            event_schema_version=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
         state_finish_event_entity.put()
         return entity_id
 
@@ -767,8 +769,7 @@ class LeaveForRefresherExplorationEventLogEntryModel(base_models.BaseModel):
     # Time since start of this state before this event occurred (in sec).
     time_spent_in_state_secs = ndb.FloatProperty()
     # The version of the event schema used to describe an event of this type.
-    event_schema_version = ndb.IntegerProperty(
-        indexed=True, default=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
+    event_schema_version = ndb.IntegerProperty(indexed=True)
 
     @classmethod
     def get_new_event_entity_id(cls, exp_id, session_id):
@@ -795,7 +796,8 @@ class LeaveForRefresherExplorationEventLogEntryModel(base_models.BaseModel):
             exp_version=exp_version,
             state_name=state_name,
             session_id=session_id,
-            time_spent_in_state_secs=time_spent_in_state_secs)
+            time_spent_in_state_secs=time_spent_in_state_secs,
+            event_schema_version=feconf.CURRENT_EVENT_MODELS_SCHEMA_VERSION)
         leave_for_refresher_exp_entity.put()
         return entity_id
 

--- a/scripts/install_frontend_tests_dependencies.sh
+++ b/scripts/install_frontend_tests_dependencies.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+source $(dirname $0)/setup.sh || exit 1
+
+install_node_module jasmine-core 2.5.2
+install_node_module karma 1.5.0
+install_node_module karma-jasmine 1.1.0
+install_node_module karma-jasmine-jquery 0.1.1
+install_node_module karma-json-fixtures-preprocessor 0.0.6
+install_node_module karma-coverage 1.1.1
+install_node_module karma-ng-html2js-preprocessor 1.0.0
+install_node_module karma-chrome-launcher 2.0.0
+install_node_module protractor 5.3.1
+install_node_module protractor-screenshot-reporter 0.0.5
+install_node_module jasmine-spec-reporter 3.2.0

--- a/scripts/install_third_party.sh
+++ b/scripts/install_third_party.sh
@@ -42,18 +42,6 @@ install_node_module through2 2.0.0
 install_node_module uglify-js 3.3.11
 install_node_module yargs 3.29.0
 
-install_node_module jasmine-core 2.5.2
-install_node_module karma 1.5.0
-install_node_module karma-jasmine 1.1.0
-install_node_module karma-jasmine-jquery 0.1.1
-install_node_module karma-json-fixtures-preprocessor 0.0.6
-install_node_module karma-coverage 1.1.1
-install_node_module karma-ng-html2js-preprocessor 1.0.0
-install_node_module karma-chrome-launcher 2.0.0
-install_node_module protractor 5.3.1
-install_node_module protractor-screenshot-reporter 0.0.5
-install_node_module jasmine-spec-reporter 3.2.0
-
 # Download and install Skulpt. Skulpt is built using a Python script included
 # within the Skulpt repository (skulpt.py). This script normally requires
 # GitPython, however the patches to it below (with the sed operations) lead to

--- a/scripts/install_third_party.sh
+++ b/scripts/install_third_party.sh
@@ -42,6 +42,18 @@ install_node_module through2 2.0.0
 install_node_module uglify-js 3.3.11
 install_node_module yargs 3.29.0
 
+install_node_module jasmine-core 2.5.2
+install_node_module karma 1.5.0
+install_node_module karma-jasmine 1.1.0
+install_node_module karma-jasmine-jquery 0.1.1
+install_node_module karma-json-fixtures-preprocessor 0.0.6
+install_node_module karma-coverage 1.1.1
+install_node_module karma-ng-html2js-preprocessor 1.0.0
+install_node_module karma-chrome-launcher 2.0.0
+install_node_module protractor 5.3.1
+install_node_module protractor-screenshot-reporter 0.0.5
+install_node_module jasmine-spec-reporter 3.2.0
+
 # Download and install Skulpt. Skulpt is built using a Python script included
 # within the Skulpt repository (skulpt.py). This script normally requires
 # GitPython, however the patches to it below (with the sed operations) lead to

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -58,6 +58,7 @@ function maybeInstallDependencies {
     echo ""
 
     $NODE_PATH/bin/node $NODE_MODULE_DIR/gulp/bin/gulp.js build
+    bash scripts/install_frontend_tests_dependencies.sh
 
     $NODE_MODULE_DIR/.bin/webdriver-manager update --versions.chrome 2.40
   fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -59,18 +59,6 @@ function maybeInstallDependencies {
 
     $NODE_PATH/bin/node $NODE_MODULE_DIR/gulp/bin/gulp.js build
 
-    install_node_module jasmine-core 2.5.2
-    install_node_module karma 1.5.0
-    install_node_module karma-jasmine 1.1.0
-    install_node_module karma-jasmine-jquery 0.1.1
-    install_node_module karma-json-fixtures-preprocessor 0.0.6
-    install_node_module karma-coverage 1.1.1
-    install_node_module karma-ng-html2js-preprocessor 1.0.0
-    install_node_module karma-chrome-launcher 2.0.0
-    install_node_module protractor 5.3.1
-    install_node_module protractor-screenshot-reporter 0.0.5
-    install_node_module jasmine-spec-reporter 3.2.0
-
     $NODE_MODULE_DIR/.bin/webdriver-manager update --versions.chrome 2.40
   fi
 


### PR DESCRIPTION
Supersedes #5368. Fixes two issues:

- We are supposed to run RecomputeStatisticsValidationCopyOneOffJob in production (to verify invariants) and then, if the result is successful, run RecomputeStatisticsOneOffJob. However, both jobs are currently implemented as two entirely separate jobs with a lot of code duplication. This PR combines these in order to avoid code skew and ensure that if the validation job passes, then the main job will also pass.
- In debugging this, I found a subtle error in how we handle event models. Some old event schema models had a schema version of None (this was before we introduced versioned event schemas) but the ndb.Model class specifies a default of "current schema version". This means that, when the model is retrieved, it erroneously gets tagged with the current schema version, which causes problems when the job tries to filter the event models by schema version (the job ends up mistakenly attempting to process some old event models that should not be processed). This PR fixes that.