### PR TITLE
Fix #5386: start.sh produces an error when using VirtualBox "no method available for opening 'http://localhost8181/'"

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -94,12 +94,21 @@ fi
 
 # Launch a browser window.
 if [ ${OS} == "Linux" ]; then
-  echo ""
-  echo "  INFORMATION"
-  echo "  Setting up a local development server at localhost:8181. Opening a"
-  echo "  default browser window pointing to this server."
-  echo ""
-  (sleep 5; xdg-open http://localhost:8181/ )&
+  detect_virt="$(ls -1 /dev/disk/by-id/)"
+  if [[ $detect_virt = *"VBOX"* ]]; then
+    echo ""
+    echo "  INFORMATION"
+    echo "  Setting up a local development server. You can access this server"
+    echo "  by navigating to localhost:8181 in a browser window."
+    echo ""
+  else
+    echo ""
+    echo "  INFORMATION"
+    echo "  Setting up a local development server at localhost:8181. Opening a"
+    echo "  default browser window pointing to this server."
+    echo ""
+    (sleep 5; xdg-open http://localhost:8181/ )&
+  fi
 elif [ ${OS} == "Darwin" ]; then
   echo ""
   echo "  INFORMATION"

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -94,8 +94,8 @@ fi
 
 # Launch a browser window.
 if [ ${OS} == "Linux" ]; then
-  detect_virt="$(ls -1 /dev/disk/by-id/)"
-  if [[ $detect_virt = *"VBOX"* ]]; then
+  detect_virtualbox="$(ls -1 /dev/disk/by-id/)"
+  if [[ $detect_virtualbox = *"VBOX"* ]]; then
     echo ""
     echo "  INFORMATION"
     echo "  Setting up a local development server. You can access this server"


### PR DESCRIPTION
## Explanation
Fixes #5386: start.sh produces an error when using VirtualBox "no method available for opening 'http://localhost8181/'"

I added a virtualization check to start.sh so that it will NOT attempt to launch a browser window in the case of virtualization (Windows/VirtualBox users.)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
