### PR TITLE
Fix ordering of suggestions on feedback tab.

### DIFF
--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -754,13 +754,13 @@ class SuggestionsIntegrationTests(test_utils.GenericTestBase):
                 feconf.SUGGESTION_LIST_URL_PREFIX, self.EXP_ID, 'all', 'true'))
 
         threads = response_dict['threads']
-        accepted_suggestion_thread_id = threads[0]['thread_id']
-        rejected_suggestion_thread_id = threads[1]['thread_id']
-        unsuccessful_accept_thread_id = threads[2]['thread_id']
+        accepted_suggestion_thread_id = threads[5]['thread_id']
+        rejected_suggestion_thread_id = threads[4]['thread_id']
+        unsuccessful_accept_thread_id = threads[3]['thread_id']
 
-        self.assertEqual(threads[0]['subject'], 'Suggestion for state A.')
-        self.assertEqual(threads[1]['subject'], 'A new value.')
-        self.assertEqual(threads[2]['subject'], 'Empty suggestion')
+        self.assertEqual(threads[5]['subject'], 'Suggestion for state A.')
+        self.assertEqual(threads[4]['subject'], 'A new value.')
+        self.assertEqual(threads[3]['subject'], 'Empty suggestion')
 
         # Accept a suggestion.
         self._accept_suggestion(
@@ -857,8 +857,9 @@ class SuggestionsIntegrationTests(test_utils.GenericTestBase):
             '%s/%s?list_type=%s&has_suggestion=%s' % (
                 feconf.SUGGESTION_LIST_URL_PREFIX, self.EXP_ID, 'all', 'true'))
         threads = response_dict['threads']
-        accepted_suggestion_thread_id = threads[0]['thread_id']
-        self.assertEqual(threads[0]['subject'], 'Suggestion for state A.')
+        thread = threads[len(threads) - 1]
+        accepted_suggestion_thread_id = thread['thread_id']
+        self.assertEqual(thread['subject'], 'Suggestion for state A.')
 
         # Accept a suggestion.
         self._accept_suggestion(
@@ -881,8 +882,9 @@ class SuggestionsIntegrationTests(test_utils.GenericTestBase):
             '%s/%s?list_type=%s&has_suggestion=%s' % (
                 feconf.SUGGESTION_LIST_URL_PREFIX, self.EXP_ID, 'all', 'true'))
         threads = response_dict['threads']
-        accepted_suggestion_thread_id = threads[0]['thread_id']
-        self.assertEqual(threads[0]['subject'], 'Suggestion for state A.')
+        thread = threads[len(threads) - 1]
+        accepted_suggestion_thread_id = thread['thread_id']
+        self.assertEqual(thread['subject'], 'Suggestion for state A.')
 
         # Accept a suggestion.
         self._accept_suggestion(

--- a/core/domain/feedback_jobs_one_off_test.py
+++ b/core/domain/feedback_jobs_one_off_test.py
@@ -245,20 +245,20 @@ class FeedbackSubjectOneOffJobTest(test_utils.GenericTestBase):
             threads = feedback_services.get_threads(
                 'exploration', self.EXP_ID_1)
 
-        self.assertEqual(threads[0].subject, u'a small summary')
-        self.assertEqual(threads[1].subject, u'Some subject')
+        self.assertEqual(threads[6].subject, u'a small summary')
+        self.assertEqual(threads[5].subject, u'Some subject')
         self.assertEqual(
-            threads[2].subject,
+            threads[4].subject,
             u'It has to convert to a substring as it exceeds...')
         self.assertEqual(
             threads[3].subject,
             u'ItisjustaverylongsinglewordfortestinggetAbbreviate...')
-        self.assertEqual(threads[4].subject, u'(Feedback from a learner)')
+        self.assertEqual(threads[2].subject, u'(Feedback from a learner)')
         self.assertEqual(
-            threads[5].subject,
+            threads[1].subject,
             u'Itisjustaverylongsinglewordfortesting')
         self.assertEqual(
-            threads[6].subject,
+            threads[0].subject,
             u'â, ??î or ôu🕧� n☁i✑💴++$-💯 ♓!🇪🚑🌚‼⁉4⃣od;...')
 
         self.assertEqual(threads[0].last_updated, threads_old[0].last_updated)

--- a/core/domain/feedback_services_test.py
+++ b/core/domain/feedback_services_test.py
@@ -184,8 +184,8 @@ class SuggestionQueriesUnitTests(test_utils.GenericTestBase):
         threads = feedback_services.get_closed_threads(
             'exploration', self.EXP_ID1, True)
         self.assertEqual(len(threads), 2)
-        self.assertEqual(threads[0].id, self.THREAD_ID2)
-        self.assertEqual(threads[1].id, self.THREAD_ID3)
+        thread_ids = [thread.id for thread in threads]
+        self.assertItemsEqual(thread_ids, [self.THREAD_ID2, self.THREAD_ID3])
 
     def test_get_closed_threads_without_suggestions(self):
         threads = feedback_services.get_closed_threads(
@@ -197,16 +197,16 @@ class SuggestionQueriesUnitTests(test_utils.GenericTestBase):
         threads = feedback_services.get_all_threads(
             'exploration', self.EXP_ID1, True)
         self.assertEqual(len(threads), 3)
-        self.assertEqual(threads[0].id, self.THREAD_ID1)
-        self.assertEqual(threads[1].id, self.THREAD_ID2)
-        self.assertEqual(threads[2].id, self.THREAD_ID3)
+        thread_ids = [thread.id for thread in threads]
+        self.assertItemsEqual(
+            thread_ids, [self.THREAD_ID1, self.THREAD_ID2, self.THREAD_ID3])
 
     def test_get_all_threads_without_suggestion(self):
         threads = feedback_services.get_all_threads(
             'exploration', self.EXP_ID1, False)
         self.assertEqual(len(threads), 2)
-        self.assertEqual(threads[0].id, self.THREAD_ID4)
-        self.assertEqual(threads[1].id, self.THREAD_ID5)
+        thread_ids = [thread.id for thread in threads]
+        self.assertItemsEqual(thread_ids, [self.THREAD_ID4, self.THREAD_ID5])
 
 
 class FeedbackThreadUnitTests(test_utils.GenericTestBase):

--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -158,7 +158,7 @@ class FeedbackThreadModel(base_models.BaseModel):
         """
 
         return cls.get_all().filter(cls.exploration_id == exploration_id).order(
-            cls.last_updated).fetch(limit)
+            -cls.last_updated).fetch(limit)
 
 
 class FeedbackMessageModel(base_models.BaseModel):

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadDataService.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadDataService.js
@@ -82,11 +82,14 @@ oppia.factory('ThreadDataService', [
           }
           for (var i = 0; i < suggestionThreads.length; i++) {
             for (var j = 0; j < res[1].data.suggestions.length; j++) {
+              var suggestion = (
+                SuggestionObjectFactory.createFromBackendDict(
+                  res[1].data.suggestions[j]));
               if (suggestionThreads[i].thread_id ===
-                  res[1].data.suggestions[j].threadId()) {
+                  suggestion.threadId()) {
                 var suggestionThread = (
                   SuggestionThreadObjectFactory.createFromBackendDicts(
-                    suggestionThreads[i], res[1].data.suggestions[i]));
+                    suggestionThreads[i], res[1].data.suggestions[j]));
                 _data.suggestionThreads.push(suggestionThread);
                 break;
               }

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadDataService.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadDataService.js
@@ -80,15 +80,13 @@ oppia.factory('ThreadDataService', [
             $log.error('Number of suggestion threads doesn\'t match number of' +
                        'suggestion objects');
           }
-          for (var i = 0; i < res[1].data.suggestions.length; i++) {
-            var suggestion = SuggestionObjectFactory.createFromBackendDict(
-              res[1].data.suggestions[i]);
-            for (var j = 0; j < suggestionThreads.length; j++) {
-              if (suggestion.threadId() ===
-                  suggestionThreads[j].thread_id) {
+          for (var i = 0; i < suggestionThreads.length; i++) {
+            for (var j = 0; j < res[1].data.suggestions.length; j++) {
+              if (suggestionThreads[i].thread_id ===
+                  res[1].data.suggestions[j].threadId()) {
                 var suggestionThread = (
                   SuggestionThreadObjectFactory.createFromBackendDicts(
-                    suggestionThreads[j], res[1].data.suggestions[i]));
+                    suggestionThreads[i], res[1].data.suggestions[i]));
                 _data.suggestionThreads.push(suggestionThread);
                 break;
               }

--- a/index.yaml
+++ b/index.yaml
@@ -111,13 +111,13 @@ indexes:
   - name: deleted
   - name: exploration_id
   - name: last_updated
-    direction: desc
 
 - kind: FeedbackThreadModel
   properties:
   - name: deleted
   - name: exploration_id
   - name: last_updated
+    direction: desc
 
 - kind: GeneralSuggestionModel
   properties:

--- a/index.yaml
+++ b/index.yaml
@@ -111,6 +111,13 @@ indexes:
   - name: deleted
   - name: exploration_id
   - name: last_updated
+    direction: desc
+
+- kind: FeedbackThreadModel
+  properties:
+  - name: deleted
+  - name: exploration_id
+  - name: last_updated
 
 - kind: GeneralSuggestionModel
   properties:


### PR DESCRIPTION
## Explanation
Fixes ordering of suggestions in the feedback tab.

The issue was that the suggestions weren't ordered and we were augmenting the list of suggestionThreads in the order of suggestions we obtained (which was random). So I have re coded that logic to now be according to the order of the threads obtained, which is ordered by last_updated. 

I manually tested it and before these changes there was no definite ordering, and after these changes, the latest one appears on top.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
