### PR TITLE
No object assign

### DIFF
--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -429,7 +429,7 @@ class QuestionSuggestionTests(test_utils.GenericTestBase):
                     suggestion_models.STATUS_ACCEPTED)
                 questions, _ = (
                     question_services.get_question_summaries_linked_to_skills(
-                        [self.SKILL_ID], ''))
+                        1, [self.SKILL_ID], ''))
                 self.assertEqual(len(questions), 1)
                 self.assertEqual(questions[0].creator_id, self.author_id)
                 self.assertEqual(

--- a/core/templates/dev/head/services/StateRulesStatsService.js
+++ b/core/templates/dev/head/services/StateRulesStatsService.js
@@ -58,8 +58,9 @@ oppia.factory('StateRulesStatsService', [
             exploration_id: explorationId,
             visualizations_info: response.data.visualizations_info.map(
               function(vizInfo) {
-                if (vizInfo.addressed_info_is_supported) {
-                  vizInfo.data.forEach(function(vizInfoDatum) {
+                var newVizInfo = angular.copy(vizInfo);
+                if (newVizInfo.addressed_info_is_supported) {
+                  newVizInfo.data.forEach(function(vizInfoDatum) {
                     vizInfoDatum.is_addressed =
                       AnswerClassificationService
                         .isClassifiedExplicitlyOrGoesToNewState(
@@ -67,7 +68,7 @@ oppia.factory('StateRulesStatsService', [
                           interactionRulesService);
                   });
                 }
-                return vizInfo;
+                return newVizInfo;
               })
           };
         });

--- a/core/templates/dev/head/services/StateRulesStatsService.js
+++ b/core/templates/dev/head/services/StateRulesStatsService.js
@@ -58,22 +58,17 @@ oppia.factory('StateRulesStatsService', [
             exploration_id: explorationId,
             visualizations_info: response.data.visualizations_info.map(
               function(vizInfo) {
-                var vizInfoDataWithAddressedInfo = {};
                 if (vizInfo.addressed_info_is_supported) {
-                  vizInfoDataWithAddressedInfo = {
-                    data: vizInfo.data.map(function(vizInfoDatum) {
-                      return Object.assign({
-                        is_addressed: (
-                          AnswerClassificationService
-                            .isClassifiedExplicitlyOrGoesToNewState(
-                              state.name, state,
-                              vizInfoDatum.answer, interactionRulesService))
-                      }, vizInfoDatum);
-                    })
-                  };
+                  vizInfo = {data: vizInfo};
+                  angular.forEach(vizInfo, function(vizInfoDatum) {
+                    vizInfoDatum.is_addressed =
+                      AnswerClassificationService
+                        .isClassifiedExplicitlyOrGoesToNewState(
+                          state.name, state, vizInfoDatum.answer,
+                          interactionRulesService)
+                  });
                 }
-
-                return Object.assign({}, vizInfo, vizInfoDataWithAddressedInfo);
+                return vizInfo;
               })
           };
         });

--- a/core/templates/dev/head/services/StateRulesStatsService.js
+++ b/core/templates/dev/head/services/StateRulesStatsService.js
@@ -65,7 +65,7 @@ oppia.factory('StateRulesStatsService', [
                       AnswerClassificationService
                         .isClassifiedExplicitlyOrGoesToNewState(
                           state.name, state, vizInfoDatum.answer,
-                          interactionRulesService)
+                          interactionRulesService);
                   });
                 }
                 return vizInfo;

--- a/core/templates/dev/head/services/StateRulesStatsService.js
+++ b/core/templates/dev/head/services/StateRulesStatsService.js
@@ -59,8 +59,7 @@ oppia.factory('StateRulesStatsService', [
             visualizations_info: response.data.visualizations_info.map(
               function(vizInfo) {
                 if (vizInfo.addressed_info_is_supported) {
-                  vizInfo = {data: vizInfo};
-                  angular.forEach(vizInfo, function(vizInfoDatum) {
+                  vizInfo.data.forEach(function(vizInfoDatum) {
                     vizInfoDatum.is_addressed =
                       AnswerClassificationService
                         .isClassifiedExplicitlyOrGoesToNewState(


### PR DESCRIPTION
Fix part of #5434

Removes usage of `Object.assign` in `services/StateRulesStatsService.js`.