### PR TITLE
Fix #5453: Too many options in the status choices

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadStatusDisplayService.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadStatusDisplayService.js
@@ -33,24 +33,12 @@ oppia.factory('ThreadStatusDisplayService', [function() {
   }, {
     id: 'not_actionable',
     text: 'Not Actionable'
-  }, {
-    id: 'received',
-    text: 'open'
-  }, {
-    id: 'review',
-    text: 'open'
-  }, {
-    id: 'accepted',
-    text: 'Fixed'
-  }, {
-    id: 'rejected',
-    text: 'Ignored'
   }];
 
   return {
     STATUS_CHOICES: angular.copy(_STATUS_CHOICES),
     getLabelClass: function(status) {
-      if (status === 'open' || status === 'received' || status === 'review') {
+      if (status === 'open') {
         return 'label label-info';
       } else {
         return 'label label-default';


### PR DESCRIPTION
Fix #5453

## Explanation
These status choices were added earlier (as status for suggestions were different) but after adding domain objects, these weren't required as the thread status is only being used. So these other statuses have been removed.

PTAL @seanlip.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
