### PR TITLE
Fix #4231: override modal-open to fix not scrolling bug in editor tab

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -48,6 +48,9 @@
     html, body {
       background-color: #eee;
     }
+    .modal-open {
+      overflow: auto;
+    }
   </style>
 
 {% endblock header_js %}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
Fixes #4231: This PR fixes the bug where people can't scroll down in the editor tab during the `Add Response` phase after changing the `If the learner's answer` option.

This fix was done via overriding the .modal-open css in exploration_editor.

@vibhor98 and @prasanna08 , during my testing, this has fixed the problem of not being able to scroll down but it introduces another problem of being able to scroll the body in the very bottom where the the modal ends. 
e.g. 
![image](https://user-images.githubusercontent.com/10623811/43873952-d1e7ebce-9b3d-11e8-9af2-b2b1658d4d99.png)

If you scroll up from there, the rest of the body scrolls.

Do you guys have any tip on how to go about this?

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
