### PR TITLE
Fix #5472: Add ui-tree dependency to make items in Drag and Drop interaction draggable

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -22,9 +22,9 @@
 var oppia = angular.module(
   'oppia', [
     'ngMaterial', 'ngAnimate', 'ngAudio', 'angularAudioRecorder', 'ngSanitize',
-    'ngTouch', 'ngResource', 'ui.bootstrap', 'ui.sortable', 'infinite-scroll',
-    'ngJoyRide', 'ngImgCrop', 'ui.validate', 'pascalprecht.translate',
-    'ngCookies', 'toastr', 'headroom', 'dndLists'
+    'ngTouch', 'ngResource', 'ui.bootstrap', 'ui.tree', 'ui.sortable',
+    'infinite-scroll', 'ngJoyRide', 'ngImgCrop', 'ui.validate',
+    'pascalprecht.translate', 'ngCookies', 'toastr', 'headroom', 'dndLists'
   ].concat(
     window.GLOBALS ? (window.GLOBALS.ADDITIONAL_ANGULAR_MODULES || []) : []));
 


### PR DESCRIPTION
This issue was introduced in PR [#5279](https://github.com/oppia/oppia/pull/5279). I added `ui-tree` dependency to `app.js` and items are draggable now. 