### PR TITLE
Fix #2584-When adding a Link to a lesson, example URL is now a placeholder

### DIFF
--- a/assets/rich_text_components_definitions.js
+++ b/assets/rich_text_components_definitions.js
@@ -94,10 +94,13 @@ var richTextComponents = {
       "name": "url",
       "description": "The link URL. If no protocol is specified, HTTPS will be used.",
       "schema": {
-        "type": "custom",
-        "obj_type": "SanitizedUrl"
-      },
-      "default_value": "https://www.example.com"
+        "type": "unicdoe",
+        "obj_type": "SanitizedUrl",
+        "ui_config": {
+          "placeholder": "https://www.example.com/"
+        }
+},
+      "default_value": ""
     }, {
       "name": "text",
       "description": "The link text. If left blank, the link URL will be used.",


### PR DESCRIPTION
Fix #2584-When adding a Link to a lesson, example URL is now a placeholder instead of a default text

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - #2584 The default text which appears while inserting a link from RTE should be a placeholder. I modified the code and the default text is now a placeholder.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
