### PR TITLE
Fix error in which a null interaction ID was being referenced by StateTopAnswersStatsService.

### DIFF
--- a/core/templates/dev/head/services/StateTopAnswersStatsService.js
+++ b/core/templates/dev/head/services/StateTopAnswersStatsService.js
@@ -20,11 +20,11 @@
 oppia.factory('StateTopAnswersStatsService', [
   '$injector', 'AngularNameService', 'AnswerClassificationService',
   'AnswerStatsObjectFactory', 'ContextService',
-  'ExplorationStatesService',
+  'ExplorationStatesService', 'ExplorationRightsService',
   function(
       $injector, AngularNameService, AnswerClassificationService,
       AnswerStatsObjectFactory, ContextService,
-      ExplorationStatesService) {
+      ExplorationStatesService, ExplorationRightsService) {
     /**
      * @typedef AnswerStatsCache
      * @property {AnswerStats[]} allAnswers
@@ -88,7 +88,9 @@ oppia.factory('StateTopAnswersStatsService', [
     };
 
     var onStateAnswerGroupsSaved = function(stateName) {
-      refreshAddressedInfo(stateName);
+      if (ExplorationRightsService.isPublic()) {
+        refreshAddressedInfo(stateName);
+      }
     };
 
     return {

--- a/core/templates/dev/head/services/StateTopAnswersStatsServiceSpec.js
+++ b/core/templates/dev/head/services/StateTopAnswersStatsServiceSpec.js
@@ -54,6 +54,9 @@ describe('StateTopAnswersStatsService', function() {
 
     spyOn($injector.get('ContextService'), 'getExplorationId')
       .and.returnValue('7');
+
+    spyOn($injector.get('ExplorationRightsService'), 'isPublic')
+      .and.returnValue(true);
   }));
 
   describe('.isInitialized', function() {


### PR DESCRIPTION
This PR aims to fix a "Cannot read property 'charAt' of null" error in production thrown by getNameOfInteractionRulesService() due to StateTopAnswersStatsService.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.