### PR TITLE
Feedback migration fix: carry forward last updated and created on fields to the new models

### DIFF
--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -233,7 +233,9 @@ class FeedbackThreadIdMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                  old_id_parts[1], old_id_parts[2]])
             feedback_models.GeneralFeedbackThreadUserModel(
                 id=new_id,
-                message_ids_read_by_user=item.message_ids_read_by_user
+                message_ids_read_by_user=item.message_ids_read_by_user,
+                last_updated=item.last_updated, created_on=item.created_on,
+                deleted=item.deleted
             ).put()
             yield ('GeneralFeedbackThreadUserModel', 1)
         elif isinstance(item, email_models.FeedbackEmailReplyToIdModel):
@@ -242,7 +244,9 @@ class FeedbackThreadIdMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                 [old_id_parts[0], feconf.ENTITY_TYPE_EXPLORATION,
                  old_id_parts[1], old_id_parts[2]])
             email_models.GeneralFeedbackEmailReplyToIdModel(
-                id=new_id, reply_to_id=item.reply_to_id).put()
+                id=new_id, reply_to_id=item.reply_to_id,
+                last_updated=item.last_updated, created_on=item.created_on,
+                deleted=item.deleted).put()
             yield ('GeneralFeedbackEmailReplyToIdModel', 1)
         elif isinstance(item, user_models.UserSubscriptionsModel):
             new_thread_ids = (

--- a/core/domain/feedback_jobs_one_off_test.py
+++ b/core/domain/feedback_jobs_one_off_test.py
@@ -466,12 +466,24 @@ class FeedbackThreadIdMigrationOneOffJobTest(test_utils.GenericTestBase):
         new_thread_user_model = (
             feedback_models.GeneralFeedbackThreadUserModel.get_by_id(
                 'author.exploration.exp1.thread1'))
+        old_thread_user_model = (
+            feedback_models.FeedbackThreadUserModel.get_by_id(
+                'author.exp1.thread1'))
         self.assertEqual(new_thread_user_model.message_ids_read_by_user, [1])
+        self.assertEqual(
+            new_thread_user_model.last_updated,
+            old_thread_user_model.last_updated)
 
         new_reply_to_id_model = (
             email_models.GeneralFeedbackEmailReplyToIdModel.get_by_id(
                 'author.exploration.exp1.thread1'))
+        old_reply_to_id_model = (
+            email_models.FeedbackEmailReplyToIdModel.get_by_id(
+                'author.exp1.thread1'))
         self.assertEqual(new_reply_to_id_model.reply_to_id, '1234')
+        self.assertEqual(
+            new_reply_to_id_model.last_updated,
+            old_reply_to_id_model.last_updated)
 
         new_user_subscription_model = (
             user_models.UserSubscriptionsModel.get_by_id('author'))

--- a/core/storage/email/gae_models.py
+++ b/core/storage/email/gae_models.py
@@ -450,6 +450,9 @@ class GeneralFeedbackEmailReplyToIdModel(base_models.BaseModel):
     """
     # The reply-to ID that is used in the reply-to email address.
     reply_to_id = ndb.StringProperty(indexed=True, required=True)
+    # TODO (nithesh): Overriding last_updated of base model for migrating
+    # instances from old model to the new one. To be removed after migration.
+    last_updated = ndb.DateTimeProperty()
 
     @classmethod
     def _generate_id(cls, user_id, thread_id):

--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -736,6 +736,9 @@ class GeneralFeedbackThreadUserModel(base_models.BaseModel):
     Instances of this class have keys of the form [user_id].[thread_id]
     """
     message_ids_read_by_user = ndb.IntegerProperty(repeated=True, indexed=True)
+    # TODO (nithesh): Overriding last_updated of base model for migrating
+    # instances from old model to the new one. To be removed after migration.
+    last_updated = ndb.DateTimeProperty()
 
     @classmethod
     def generate_full_id(cls, user_id, thread_id):


### PR DESCRIPTION
## Explanation
Carries forward the last_updated and created_on fields for the newly created models. 

PTAL @seanlip

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
