### PR TITLE
Fix hola

### DIFF
--- a/data/explorations/hola.yaml
+++ b/data/explorations/hola.yaml
@@ -358,7 +358,7 @@ states:
           param_changes: []
         rule_specs:
         - inputs:
-            x: '0'
+            x: 0
           rule_type: Equals
       - correct: false
         outcome:
@@ -369,7 +369,7 @@ states:
           param_changes: []
         rule_specs:
         - inputs:
-            x: '1'
+            x: 1
           rule_type: Equals
       - correct: false
         outcome:
@@ -379,7 +379,7 @@ states:
           param_changes: []
         rule_specs:
         - inputs:
-            x: '2'
+            x: 2
           rule_type: Equals
       confirmed_unclassified_answers: []
       customization_args:

--- a/data/explorations/hola.yaml
+++ b/data/explorations/hola.yaml
@@ -65,7 +65,7 @@ states:
           param_changes: []
         rule_specs:
         - inputs:
-            x: '0'
+            x: 0
           rule_type: Equals
       - correct: false
         outcome:
@@ -75,7 +75,7 @@ states:
           param_changes: []
         rule_specs:
         - inputs:
-            x: '1'
+            x: 1
           rule_type: Equals
       - correct: false
         outcome:
@@ -85,7 +85,7 @@ states:
           param_changes: []
         rule_specs:
         - inputs:
-            x: '2'
+            x: 2
           rule_type: Equals
       - correct: false
         outcome:
@@ -95,7 +95,7 @@ states:
           param_changes: []
         rule_specs:
         - inputs:
-            x: '3'
+            x: 3
           rule_type: Equals
       confirmed_unclassified_answers: []
       customization_args:


### PR DESCRIPTION
MultipleChoiceInput requires int values, but this .yaml file is using strings. This fix allows it to work as intended.