### PR TITLE
Change FrequencyTableDirective to depend on StateTopAnswersStatsService

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/statistics_tab/StatisticsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/statistics_tab/StatisticsTab.js
@@ -217,6 +217,7 @@ oppia.controller('StatisticsTab', [
                   var el = $(
                     '<oppia-visualization-' +
                     $filter('camelCaseToHyphens')(vizInfo.id) + '/>');
+                  el.attr('state-name', stateName);
                   el.attr('escaped-data', escapedData);
                   el.attr('escaped-options', escapedOptions);
                   el.attr(

--- a/data/explorations/hola.yaml
+++ b/data/explorations/hola.yaml
@@ -358,7 +358,7 @@ states:
           param_changes: []
         rule_specs:
         - inputs:
-            x: '0'
+            x: 0
           rule_type: Equals
       - correct: false
         outcome:
@@ -369,7 +369,7 @@ states:
           param_changes: []
         rule_specs:
         - inputs:
-            x: '1'
+            x: 1
           rule_type: Equals
       - correct: false
         outcome:
@@ -379,7 +379,7 @@ states:
           param_changes: []
         rule_specs:
         - inputs:
-            x: '2'
+            x: 2
           rule_type: Equals
       confirmed_unclassified_answers: []
       customization_args:

--- a/extensions/visualizations/frequency_table_directive.html
+++ b/extensions/visualizations/frequency_table_directive.html
@@ -1,10 +1,10 @@
 <strong><[options.title]></strong>
 <table class="table">
   <colgroup>
-    <col ng-repeat="columnController in columnControllers" style="width: <[columnController.widthCss]>;">
+    <col ng-repeat="columnController in columnControllers" style="width: <[columnController.getWidthCss()]>;">
   </colgroup>
   <tr>
-    <th ng-repeat="columnController in columnControllers" ng-bind-html="columnController.headerHtml"></th>
+    <th ng-repeat="columnController in columnControllers" ng-bind-html="columnController.getHeaderHtml()"></th>
   </tr>
   <tr ng-repeat="row in rows track by $index">
     <td ng-repeat="columnController in columnControllers" ng-bind-html="columnController.makeCellHtmlForRow(row)"></td>

--- a/extensions/visualizations/frequency_table_directive.html
+++ b/extensions/visualizations/frequency_table_directive.html
@@ -1,22 +1,13 @@
 <strong><[options.title]></strong>
 <table class="table">
   <colgroup>
-    <col span="1" style="width: 75%;">
-    <col span="1" style="width: 10%;">
-    <col span="1" style="width: 15%;">
+    <col ng-repeat="columnController in columnControllers" style="width: <[columnController.widthCss]>;">
   </colgroup>
   <tr>
-    <th><[options.column_headers[0]]></th>
-    <th><[options.column_headers[1]]></th>
-    <th ng-if="addressedInfoIsSupported">Addressed specifically?</th>
+    <th ng-repeat="columnController in columnControllers" ng-bind-html="columnController.headerHtml"></th>
   </tr>
-  <tr ng-repeat="row in data track by $index">
-    <td><[row.answer]></td>
-    <td><[row.frequency]></td>
-    <td ng-if="addressedInfoIsSupported">
-      <span ng-if="row.is_addressed">Yes</span>
-      <span ng-if="!row.is_addressed">No</span>
-    </td>
+  <tr ng-repeat="row in rows track by $index">
+    <td ng-repeat="columnController in columnControllers" ng-bind-html="columnController.makeCellHtmlForRow(row)"></td>
   </tr>
 </table>
 

--- a/extensions/visualizations/frequency_table_directive.html
+++ b/extensions/visualizations/frequency_table_directive.html
@@ -6,7 +6,7 @@
   <tr>
     <th ng-repeat="columnController in columnControllers" ng-bind-html="columnController.getHeaderHtml()"></th>
   </tr>
-  <tr ng-repeat="row in rows track by $index">
+  <tr ng-repeat="row in rows">
     <td ng-repeat="columnController in columnControllers" ng-bind-html="columnController.makeCellHtmlForRow(row)"></td>
   </tr>
 </table>

--- a/extensions/visualizations/visualizations.js
+++ b/extensions/visualizations/visualizations.js
@@ -62,6 +62,31 @@ oppia.directive('oppiaVisualizationBarChart', [function() {
   };
 }]);
 
+// TODO(brianrodri): These controllers may benefit from being reused
+// by future visualizations. If we end up using them a lot, consider
+// moving them into a service.
+var answerColumnController = {
+  headerHtml: 'Answer',
+  widthCss: '75%',
+  makeCellHtmlForRow: function(row) {
+    return row.answer;
+  },
+};
+var frequencyColumnController = {
+  headerHtml: 'Count',
+  widthCss: '10%',
+  makeCellHtmlForRow: function(row) {
+    return row.frequency;
+  },
+};
+var addressedInfoColumnController = {
+  headerHtml: 'Addressed specifically?',
+  widthCss: '15%',
+  makeCellHtmlForRow: function(row) {
+    return row.is_addressed ? 'Yes' : 'No';
+  },
+};
+
 oppia.directive('oppiaVisualizationFrequencyTable', [
   'UrlInterpolationService', function(UrlInterpolationService) {
     return {
@@ -73,31 +98,6 @@ oppia.directive('oppiaVisualizationFrequencyTable', [
         '$scope', '$attrs', 'HtmlEscaperService', 'StateTopAnswersStatsService',
         function(
             $scope, $attrs, HtmlEscaperService, StateTopAnswersStatsService) {
-          // TODO(brianrodri): These controllers may benefit from being reused
-          // by future visualizations. If we end up using them a lot, consider
-          // moving them into a service.
-          var answerColumnController = {
-            headerHtml: 'Answer',
-            widthCss: '75%',
-            makeCellHtmlForRow: function(row) {
-              return row.answer;
-            },
-          };
-          var frequencyColumnController = {
-            headerHtml: 'Count',
-            widthCss: '10%',
-            makeCellHtmlForRow: function(row) {
-              return row.frequency;
-            },
-          };
-          var addressedInfoColumnController = {
-            headerHtml: 'Addressed specifically?',
-            widthCss: '15%',
-            makeCellHtmlForRow: function(row) {
-              return row.is_addressed ? 'Yes' : 'No';
-            },
-          };
-
           var stateName = $attrs.stateName;
           $scope.rows = StateTopAnswersStatsService.hasStateStats(stateName) ?
             StateTopAnswersStatsService.getStateStats(stateName) : [];

--- a/extensions/visualizations/visualizations.js
+++ b/extensions/visualizations/visualizations.js
@@ -112,9 +112,9 @@ oppia.directive('oppiaVisualizationFrequencyTable', [
         '$scope', '$attrs', 'HtmlEscaperService', 'StateTopAnswersStatsService',
         function(
             $scope, $attrs, HtmlEscaperService, StateTopAnswersStatsService) {
-          var stateName = $attrs.stateName;
-          $scope.rows = StateTopAnswersStatsService.hasStateStats(stateName) ?
-            StateTopAnswersStatsService.getStateStats(stateName) : [];
+          $scope.rows =
+            StateTopAnswersStatsService.hasStateStats($attrs.stateName) ?
+            StateTopAnswersStatsService.getStateStats($attrs.stateName) : [];
           $scope.options =
             HtmlEscaperService.escapedJsonToObj($attrs.escapedOptions);
           $scope.columnControllers = [

--- a/extensions/visualizations/visualizations.js
+++ b/extensions/visualizations/visualizations.js
@@ -66,22 +66,36 @@ oppia.directive('oppiaVisualizationBarChart', [function() {
 // by future visualizations. If we end up using them a lot, consider
 // moving them into a service.
 var answersColumnController = {
-  headerHtml: 'Answer',
-  widthCss: '75%',
+  getHeaderHtml: function() {
+    return 'Answer';
+  },
+  getWidthCss: function() {
+    return '75%';
+  },
   makeCellHtmlForRow: function(row) {
     return row.answer;
   },
 };
+
 var frequenciesColumnController = {
-  headerHtml: 'Count',
-  widthCss: '10%',
+  getHeaderHtml: function() {
+    return 'Count';
+  },
+  getWidthCss: function() {
+    return '10%';
+  },
   makeCellHtmlForRow: function(row) {
     return row.frequency;
   },
 };
+
 var addressedInfoColumnController = {
-  headerHtml: 'Addressed specifically?',
-  widthCss: '15%',
+  getHeaderHtml: function() {
+    return 'Addressed specifically?';
+  },
+  getWidthCss: function() {
+    return '15%';
+  },
   makeCellHtmlForRow: function(row) {
     return row.is_addressed ? 'Yes' : 'No';
   },

--- a/extensions/visualizations/visualizations.js
+++ b/extensions/visualizations/visualizations.js
@@ -70,12 +70,46 @@ oppia.directive('oppiaVisualizationFrequencyTable', [
       templateUrl: UrlInterpolationService.getExtensionResourceUrl(
         '/visualizations/frequency_table_directive.html'),
       controller: [
-        '$scope', '$attrs', 'HtmlEscaperService',
-        function($scope, $attrs, HtmlEscaperService) {
-          $scope.data = HtmlEscaperService.escapedJsonToObj($attrs.escapedData);
+        '$scope', '$attrs', 'HtmlEscaperService', 'StateTopAnswersStatsService',
+        function(
+            $scope, $attrs, HtmlEscaperService, StateTopAnswersStatsService) {
+          // TODO(brianrodri): These controllers may benefit from being reused
+          // by future visualizations. If we end up using them a lot, consider
+          // moving them into a service.
+          var answerColumnController = {
+            headerHtml: 'Answer',
+            widthCss: '75%',
+            makeCellHtmlForRow: function(row) {
+              return row.answer;
+            },
+          };
+          var frequencyColumnController = {
+            headerHtml: 'Count',
+            widthCss: '10%',
+            makeCellHtmlForRow: function(row) {
+              return row.frequency;
+            },
+          };
+          var addressedInfoColumnController = {
+            headerHtml: 'Addressed specifically?',
+            widthCss: '15%',
+            makeCellHtmlForRow: function(row) {
+              return row.is_addressed ? 'Yes' : 'No';
+            },
+          };
+
+          var stateName = $attrs.stateName;
+          $scope.rows = StateTopAnswersStatsService.hasStateStats(stateName) ?
+            StateTopAnswersStatsService.getStateStats(stateName) : [];
           $scope.options =
             HtmlEscaperService.escapedJsonToObj($attrs.escapedOptions);
-          $scope.addressedInfoIsSupported = $attrs.addressedInfoIsSupported;
+          $scope.columnControllers = [
+            answerColumnController,
+            frequencyColumnController,
+          ];
+          if ($attrs.addressedInfoIsSupported) {
+            $scope.columnControllers.push(addressedInfoColumnController);
+          }
         }
       ]
     };

--- a/extensions/visualizations/visualizations.js
+++ b/extensions/visualizations/visualizations.js
@@ -65,14 +65,14 @@ oppia.directive('oppiaVisualizationBarChart', [function() {
 // TODO(brianrodri): These controllers may benefit from being reused
 // by future visualizations. If we end up using them a lot, consider
 // moving them into a service.
-var answerColumnController = {
+var answersColumnController = {
   headerHtml: 'Answer',
   widthCss: '75%',
   makeCellHtmlForRow: function(row) {
     return row.answer;
   },
 };
-var frequencyColumnController = {
+var frequenciesColumnController = {
   headerHtml: 'Count',
   widthCss: '10%',
   makeCellHtmlForRow: function(row) {
@@ -104,8 +104,8 @@ oppia.directive('oppiaVisualizationFrequencyTable', [
           $scope.options =
             HtmlEscaperService.escapedJsonToObj($attrs.escapedOptions);
           $scope.columnControllers = [
-            answerColumnController,
-            frequencyColumnController,
+            answersColumnController,
+            frequenciesColumnController,
           ];
           if ($attrs.addressedInfoIsSupported) {
             $scope.columnControllers.push(addressedInfoColumnController);


### PR DESCRIPTION
`StateRulesStats` is being deprecated in favor of the more efficient `StateTopAnswerStatsService`. This PR migrates one of our visualizations, frequency tables, to use the new service.