### PR TITLE
Fix part of #5134 Backend test for audit models

### DIFF
--- a/core/storage/audit/gae_models.py
+++ b/core/storage/audit/gae_models.py
@@ -31,8 +31,6 @@ class RoleQueryAuditModel(base_models.BaseModel):
     Instances of this class are keyed by a custom Id.
     [user_id].[timestamp_in_sec].[intent].[random_number]
     """
-    # The id used to key this model.
-    id = ndb.StringProperty(required=True)
     # The user_id of the user making query.
     user_id = ndb.StringProperty(required=True, indexed=True)
     # The intent of making query (viewing (by role or username)

--- a/core/storage/audit/gae_models_test.py
+++ b/core/storage/audit/gae_models_test.py
@@ -14,13 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test for audit models"""
+"""Test for audit models."""
 
 from core.platform import models
 from core.tests import test_utils
 import feconf
-import logging
-logging.basicConfig(filename='debug_logs', level=logging.DEBUG)
 
 (audit_models,) = models.Registry.import_models([models.NAMES.audit])
 

--- a/core/storage/audit/gae_models_test.py
+++ b/core/storage/audit/gae_models_test.py
@@ -24,21 +24,16 @@ import feconf
 
 
 class RoleQueryAuditModelUnitTests(test_utils.GenericTestBase):
-    """Records the data for query made to the role structure using admin
-    interface.
-
-    Instances of this class are keyed by a custom Id.
-    [user_id].[timestamp_in_sec].[intent].[random_number]
-    """
+    """Unit tests for the RoleQueryAuditModel class."""
 
     def test_create_and_get_model(self):
         audit_models.RoleQueryAuditModel(
             id='a', user_id='b', intent=feconf.ROLE_ACTION_UPDATE,
             role='c', username='d').put()
-        a = audit_models.RoleQueryAuditModel.get('a')
+        audit_model = audit_models.RoleQueryAuditModel.get('a')
 
-        self.assertEqual(a.id, 'a')
-        self.assertEqual(a.intent, feconf.ROLE_ACTION_UPDATE)
-        self.assertEqual(a.user_id, 'b')
-        self.assertEqual(a.role, 'c')
-        self.assertEqual(a.username, 'd')
+        self.assertEqual(audit_model.id, 'a')
+        self.assertEqual(audit_model.intent, feconf.ROLE_ACTION_UPDATE)
+        self.assertEqual(audit_model.user_id, 'b')
+        self.assertEqual(audit_model.role, 'c')
+        self.assertEqual(audit_model.username, 'd')

--- a/core/storage/audit/gae_models_test.py
+++ b/core/storage/audit/gae_models_test.py
@@ -37,14 +37,10 @@ class RoleQueryAuditModelUnitTests(test_utils.GenericTestBase):
         audit_models.RoleQueryAuditModel(
             id='a', user_id='b', intent=feconf.ROLE_ACTION_UPDATE,
             role='c', username='d').put()
-        am = audit_models.RoleQueryAuditModel.get_all()
-        i = 0
-        a = None
-        for a in am:
-            logging.debug(a.id)
-            i += 1
+        a = audit_models.RoleQueryAuditModel.get('a')
 
-        logging.debug(i)
         self.assertEqual(a.id, 'a')
-        b = audit_models.RoleQueryAuditModel.get(a.id)
-        self.assertEqual(b.id, 'a')
+        self.assertEqual(a.intent, feconf.ROLE_ACTION_UPDATE)
+        self.assertEqual(a.user_id, 'b')
+        self.assertEqual(a.role, 'c')
+        self.assertEqual(a.username, 'd')

--- a/core/storage/audit/gae_models_test.py
+++ b/core/storage/audit/gae_models_test.py
@@ -33,19 +33,17 @@ class RoleQueryAuditModelUnitTests(test_utils.GenericTestBase):
     [user_id].[timestamp_in_sec].[intent].[random_number]
     """
 
-    def setUp(self):
-        super(RoleQueryAuditModelUnitTests, self).setUp()
-
     def test_create_and_get_model(self):
         audit_models.RoleQueryAuditModel(
             id='a', user_id='b', intent=feconf.ROLE_ACTION_UPDATE,
             role='c', username='d').put()
         am = audit_models.RoleQueryAuditModel.get_all()
         i = 0
+        a = None
         for a in am:
             logging.debug(a.id)
             i += 1
-            pass
+
         logging.debug(i)
         self.assertEqual(a.id, 'a')
         b = audit_models.RoleQueryAuditModel.get(a.id)

--- a/core/storage/audit/gae_models_test.py
+++ b/core/storage/audit/gae_models_test.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+#
+# Copyright 2017 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test for audit models"""
+
+from core.platform import models
+from core.tests import test_utils
+import feconf
+import logging
+logging.basicConfig(filename='debug_logs', level=logging.DEBUG)
+
+(audit_models,) = models.Registry.import_models([models.NAMES.audit])
+
+
+class RoleQueryAuditModelUnitTests(test_utils.GenericTestBase):
+    """Records the data for query made to the role structure using admin
+    interface.
+
+    Instances of this class are keyed by a custom Id.
+    [user_id].[timestamp_in_sec].[intent].[random_number]
+    """
+
+    def setUp(self):
+        super(RoleQueryAuditModelUnitTests, self).setUp()
+
+    def test_create_and_get_model(self):
+        audit_models.RoleQueryAuditModel(
+            id='a', user_id='b', intent=feconf.ROLE_ACTION_UPDATE,
+            role='c', username='d').put()
+        am = audit_models.RoleQueryAuditModel.get_all()
+        i = 0
+        for a in am:
+            logging.debug(a.id)
+            i += 1
+            pass
+        logging.debug(i)
+        self.assertEqual(a.id, 'a')
+        b = audit_models.RoleQueryAuditModel.get(a.id)
+        self.assertEqual(b.id, 'a')

--- a/debug_logs
+++ b/debug_logs
@@ -1,2 +1,0 @@
-DEBUG:root:a
-DEBUG:root:1

--- a/debug_logs
+++ b/debug_logs
@@ -1,0 +1,2 @@
+DEBUG:root:a
+DEBUG:root:1


### PR DESCRIPTION
Having some trouble with getting the test to pass. Seems like it should be simple since there is almost nothing in this file but the get method does not seem to find the object, despite finding it with get_all. debug_logs shows the model is the one found by get_all. Any intuition to share?
