### PR TITLE
Fix #5494: Fix second item selection issue in CKEditor for Drag and drop interaction.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_tab/customize_interaction_modal_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_tab/customize_interaction_modal_directive.html
@@ -30,6 +30,9 @@
   <form ng-if="StateInteractionIdService.displayed && hasCustomizationArgs" name="form.schemaForm" class="interaction-editor-form protractor-test-interaction-editor">
     <div ng-repeat="customizationArgSpec in customizationArgSpecs track by $index">
       <div ng-if="customizationArgSpec.schema.type !== 'bool'" class="oppia-interaction-customization-label"><[customizationArgSpec.description]></div>
+      <h5 ng-if="StateInteractionIdService.displayed == 'DragAndDropSortInput'">
+        <b>Note:</b> Please enter at least two choices.
+      </h5>
       <schema-based-editor ng-class="{'boolean-checkbox': customizationArgSpec.schema.type === 'bool'}" local-value="StateCustomizationArgsService.displayed[customizationArgSpec.name].value" schema="customizationArgSpec.schema">
       </schema-based-editor>
       <div ng-if="customizationArgSpec.schema.type === 'bool'" class="oppia-interaction-customization-label"><[customizationArgSpec.description]></div>

--- a/extensions/interactions/DragAndDropSortInput/DragAndDropSortInput.py
+++ b/extensions/interactions/DragAndDropSortInput/DragAndDropSortInput.py
@@ -38,12 +38,14 @@ class DragAndDropSortInput(base.BaseInteraction):
             'type': 'list',
             'validators': [{
                 'id': 'has_length_at_least',
-                # NOTE: There is slight stricter validation of the number of
+                # NOTE: There is slightly stricter validation of the number of
                 # minimum choices in frontend. It should be at least 2 from the
                 # frontend perspective but we can't impose it here as min_value
                 # in the customization schema determines the number of RTEs that
                 # appear in the customization modal initially that needs to be
-                # one.
+                # 1. Here min_value: 2 and default_value: [''] aren't allowed as
+                # default_value needs to be at least of same length as min_value
+                # else schema tests for customization args will fail.
                 'min_value': 1
             }],
             'items': {

--- a/extensions/interactions/DragAndDropSortInput/DragAndDropSortInput.py
+++ b/extensions/interactions/DragAndDropSortInput/DragAndDropSortInput.py
@@ -38,7 +38,7 @@ class DragAndDropSortInput(base.BaseInteraction):
             'type': 'list',
             'validators': [{
                 'id': 'has_length_at_least',
-                'min_value': 2
+                'min_value': 1
             }],
             'items': {
                 'type': 'html',
@@ -52,7 +52,7 @@ class DragAndDropSortInput(base.BaseInteraction):
                 'add_element_text': 'Add a new item',
             }
         },
-        'default_value': ['', ''],
+        'default_value': [''],
     }]
 
     _answer_visualization_specs = []

--- a/extensions/interactions/DragAndDropSortInput/DragAndDropSortInput.py
+++ b/extensions/interactions/DragAndDropSortInput/DragAndDropSortInput.py
@@ -38,6 +38,12 @@ class DragAndDropSortInput(base.BaseInteraction):
             'type': 'list',
             'validators': [{
                 'id': 'has_length_at_least',
+                # NOTE: There is slight stricter validation of the number of
+                # minimum choices in frontend. It should be at least 2 from the
+                # frontend perspective but we can't impose it here as min_value
+                # in the customization schema determines the number of RTEs that
+                # appear in the customization modal initially that needs to be
+                # one.
                 'min_value': 1
             }],
             'items': {

--- a/extensions/interactions/DragAndDropSortInput/directives/DragAndDropSortInputValidationService.js
+++ b/extensions/interactions/DragAndDropSortInput/directives/DragAndDropSortInputValidationService.js
@@ -31,6 +31,13 @@ oppia.factory('DragAndDropSortInputValidationService', [
         var seenChoices = [];
         var numChoices = customizationArgs.choices.value.length;
 
+        if (numChoices < 2) {
+          warningsList.push({
+            type: WARNING_TYPES.CRITICAL,
+            message: 'Please enter at least two choices.'
+          });
+        }
+
         for (var i = 0; i < numChoices; i++) {
           var choice = customizationArgs.choices.value[i];
           if (choice.trim().length === 0) {

--- a/extensions/interactions/DragAndDropSortInput/directives/DragAndDropSortInputValidationServiceSpec.js
+++ b/extensions/interactions/DragAndDropSortInput/directives/DragAndDropSortInputValidationServiceSpec.js
@@ -125,6 +125,17 @@ describe('DragAndDropSortInputValidationService', function() {
     }]);
   });
 
+  it('should expect at least two choices', function() {
+    customizationArgs.choices.value = ['1'];
+
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups, goodDefaultOutcome);
+    expect(warnings).toEqual([{
+      type: WARNING_TYPES.CRITICAL,
+      message: 'Please enter at least two choices.'
+    }]);
+  });
+
   it('should expect all choices to be nonempty', function() {
     // Set the first choice to empty.
     customizationArgs.choices.value[0] = '';


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
This fix is made by having just one field as default, but preventing saving unless we have two or more choices.
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
