### PR TITLE
Fix part of #3950 : Replace Jinja templates in error/error.html with Angular

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -414,6 +414,7 @@ class BaseHandler(webapp2.RequestHandler):
         """
         assert error_code in [400, 401, 404, 500]
         values['status_code'] = error_code
+        values['error_page_title'] = 'I18N_ERROR_PAGE_TITLE_' + str(error_code)
 
         # This checks if the response should be JSON or HTML.
         # For GET requests, there is no payload, so we check against

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -1853,6 +1853,7 @@ class EditorAutosaveTest(BaseEditorControllerTest):
         self.assertEqual(exp_user_data.draft_change_list_id, 2)
         self.assertEqual(
             response, {'status_code': 400,
+                       'error_page_title': 'I18N_ERROR_PAGE_TITLE_400',
                        'error': 'Expected title to be a string, received 1'})
 
     def test_draft_updated_version_valid(self):

--- a/core/controllers/translator_test.py
+++ b/core/controllers/translator_test.py
@@ -104,6 +104,7 @@ class TranslatorTest(BaseTranslatorControllerTest):
         # Checking the response to have error.
         self.assertEqual(
             response, {'status_code': 400,
+                       'error_page_title': 'I18N_ERROR_PAGE_TITLE_400',
                        'error': (
                            'Translator does not have permission to make'
                            ' some changes in the change list.')
@@ -193,6 +194,7 @@ class TranslatorAutosaveTest(BaseTranslatorControllerTest):
         self.assertEqual(exp_user_data.draft_change_list_id, 1)
         self.assertEqual(
             response, {'status_code': 400,
+                       'error_page_title': 'I18N_ERROR_PAGE_TITLE_400',
                        'error': (
                            'Translator does not have permission to make'
                            ' some changes in the change list.')

--- a/core/templates/dev/head/pages/error/error.html
+++ b/core/templates/dev/head/pages/error/error.html
@@ -4,15 +4,7 @@
 {% endblock navbar_breadcrumb %}
 
 {% block maintitle %}
-  {% if status_code == 400 %}
-    I18N_ERROR_PAGE_TITLE_400
-  {% elif status_code == 401 %}
-    I18N_ERROR_PAGE_TITLE_401
-  {% elif status_code == 404 %}
-    I18N_ERROR_PAGE_TITLE_404
-  {% elif status_code == 500 %}
-    I18N_ERROR_PAGE_TITLE_500
-  {% endif %}
+  {{ error_page_title }}
 {% endblock maintitle %}
 
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
Replaces Jinja templates in error/error.html with Angular.
Fixes part of #3950.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.