### PR TITLE
Forbidding browser.sleep by adding lint rule and fixing an e2e flake in editorFeatures

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -80,7 +80,7 @@ oppia.constant('COMPONENT_NAME_DEFAULT_OUTCOME', 'default_outcome');
 oppia.constant('CURRENT_ACTION_SCHEMA_VERSION', 1);
 oppia.constant('CURRENT_ISSUE_SCHEMA_VERSION', 1);
 oppia.constant('EARLY_QUIT_THRESHOLD_IN_SECS', 45);
-oppia.constant('NUM_INCORRECT_ANSWERS_THRESHOLD', 5);
+oppia.constant('NUM_INCORRECT_ANSWERS_THRESHOLD', 3);
 oppia.constant('NUM_REPEATED_CYCLES_THRESHOLD', 3);
 oppia.constant('MAX_PLAYTHROUGHS_FOR_ISSUE', 5);
 

--- a/core/templates/dev/head/pages/exploration_editor/statistics_tab/IssuesService.js
+++ b/core/templates/dev/head/pages/exploration_editor/statistics_tab/IssuesService.js
@@ -19,11 +19,11 @@
 oppia.factory('IssuesService', [
   '$sce', 'IssuesBackendApiService', 'ISSUE_TYPE_EARLY_QUIT',
   'ISSUE_TYPE_MULTIPLE_INCORRECT_SUBMISSIONS',
-  'ISSUE_TYPE_CYCLIC_STATE_TRANSITIONS',
+  'ISSUE_TYPE_CYCLIC_STATE_TRANSITIONS', 'NUM_INCORRECT_ANSWERS_THRESHOLD',
   function(
       $sce, IssuesBackendApiService, ISSUE_TYPE_EARLY_QUIT,
       ISSUE_TYPE_MULTIPLE_INCORRECT_SUBMISSIONS,
-      ISSUE_TYPE_CYCLIC_STATE_TRANSITIONS) {
+      ISSUE_TYPE_CYCLIC_STATE_TRANSITIONS, NUM_INCORRECT_ANSWERS_THRESHOLD) {
     var issues = null;
     var explorationId = null;
     var explorationVersion = null;
@@ -36,7 +36,8 @@ oppia.factory('IssuesService', [
     var renderMultipleIncorrectIssueStatement = function(stateName) {
       var statement =
         'Several learners submitted answers to card "' + stateName +
-        '" several times, then gave up and quit.';
+        '" ' + NUM_INCORRECT_ANSWERS_THRESHOLD + ' times, ' +
+        'then gave up and quit.';
       return statement;
     };
 

--- a/core/templates/dev/head/pages/exploration_editor/statistics_tab/IssuesService.js
+++ b/core/templates/dev/head/pages/exploration_editor/statistics_tab/IssuesService.js
@@ -19,11 +19,11 @@
 oppia.factory('IssuesService', [
   '$sce', 'IssuesBackendApiService', 'ISSUE_TYPE_EARLY_QUIT',
   'ISSUE_TYPE_MULTIPLE_INCORRECT_SUBMISSIONS',
-  'ISSUE_TYPE_CYCLIC_STATE_TRANSITIONS', 'NUM_INCORRECT_ANSWERS_THRESHOLD',
+  'ISSUE_TYPE_CYCLIC_STATE_TRANSITIONS',
   function(
       $sce, IssuesBackendApiService, ISSUE_TYPE_EARLY_QUIT,
       ISSUE_TYPE_MULTIPLE_INCORRECT_SUBMISSIONS,
-      ISSUE_TYPE_CYCLIC_STATE_TRANSITIONS, NUM_INCORRECT_ANSWERS_THRESHOLD) {
+      ISSUE_TYPE_CYCLIC_STATE_TRANSITIONS) {
     var issues = null;
     var explorationId = null;
     var explorationVersion = null;
@@ -36,8 +36,7 @@ oppia.factory('IssuesService', [
     var renderMultipleIncorrectIssueStatement = function(stateName) {
       var statement =
         'Several learners submitted answers to card "' + stateName +
-        '" ' + NUM_INCORRECT_ANSWERS_THRESHOLD + ' times, ' +
-        'then gave up and quit.';
+        '" several times, then gave up and quit.';
       return statement;
     };
 

--- a/core/tests/protractor/learnerFlow.js
+++ b/core/tests/protractor/learnerFlow.js
@@ -210,8 +210,6 @@ describe('Learner dashboard functionality', function() {
     // User clicks on Oppia logo to leave exploration.
     oppiaLogo.click();
     general.acceptAlert();
-    // Wait for /learner_dashboard to load.
-    waitFor.pageToFullyLoad();
 
     // Go to 'Test Exploration'.
     libraryPage.get();
@@ -350,8 +348,6 @@ describe('Learner dashboard functionality', function() {
     // User clicks on Oppia logo to leave collection.
     oppiaLogo.click();
     general.acceptAlert();
-    // Wait for /learner_dashboard to load.
-    waitFor.pageToFullyLoad();
 
     // Learner Dashboard should display
     // 'Test Collection' as incomplete.

--- a/core/tests/protractor_desktop/editorFeatures.js
+++ b/core/tests/protractor_desktop/editorFeatures.js
@@ -759,7 +759,7 @@ describe('Issues visualization', function() {
     explorationEditorPage.navigateToStatsTab();
     explorationEditorStatsTab.clickIssue(0, 'Issue 1');
     explorationEditorStatsTab.expectIssueTitleToBe(
-      'Several learners submitted answers to card "One" 3 times, ' +
+      'Several learners submitted answers to card "One" several times, ' +
       'then gave up and quit.');
     explorationEditorStatsTab.markResolved();
     users.logout();

--- a/core/tests/protractor_desktop/editorFeatures.js
+++ b/core/tests/protractor_desktop/editorFeatures.js
@@ -621,6 +621,7 @@ describe('Issues visualization', function() {
   var oppiaLogo = element(by.css('.protractor-test-oppia-main-logo'));
 
   beforeAll(function() {
+    creatorDashboardPage = new CreatorDashboardPage.CreatorDashboardPage();
     explorationEditorPage = new ExplorationEditorPage.ExplorationEditorPage();
     explorationEditorStatsTab = explorationEditorPage.getStatsTab();
     explorationEditorMainTab = explorationEditorPage.getMainTab();
@@ -737,18 +738,15 @@ describe('Issues visualization', function() {
     libraryPage.findExploration(EXPLORATION_TITLE);
     libraryPage.playExploration(EXPLORATION_TITLE);
 
-    explorationPlayerPage.submitAnswer('TextInput', 'One');
-    explorationPlayerPage.clickThroughToNextCard();
     explorationPlayerPage.submitAnswer('TextInput', 'WrongAnswer1');
-    browser.sleep(3000);
+    explorationPlayerPage.expectLatestFeedbackToMatch(
+      forms.toRichText('Try again'));
     explorationPlayerPage.submitAnswer('TextInput', 'WrongAnswer2');
-    browser.sleep(3000);
+    explorationPlayerPage.expectLatestFeedbackToMatch(
+      forms.toRichText('Try again'));
     explorationPlayerPage.submitAnswer('TextInput', 'WrongAnswer3');
-    browser.sleep(3000);
-    explorationPlayerPage.submitAnswer('TextInput', 'WrongAnswer4');
-    browser.sleep(3000);
-    explorationPlayerPage.submitAnswer('TextInput', 'WrongAnswer5');
-    browser.sleep(3000);
+    explorationPlayerPage.expectLatestFeedbackToMatch(
+      forms.toRichText('Try again'));
     explorationPlayerPage.expectExplorationToNotBeOver();
 
     oppiaLogo.click();
@@ -756,15 +754,12 @@ describe('Issues visualization', function() {
     users.logout();
 
     users.login('user1@ExplorationIssues.com');
-    libraryPage.get();
-    libraryPage.findExploration(EXPLORATION_TITLE);
-    libraryPage.playExploration(EXPLORATION_TITLE);
-    general.moveToEditor();
+    creatorDashboardPage.get();
+    creatorDashboardPage.editExploration(EXPLORATION_TITLE);
     explorationEditorPage.navigateToStatsTab();
-
     explorationEditorStatsTab.clickIssue(0, 'Issue 1');
     explorationEditorStatsTab.expectIssueTitleToBe(
-      'Several learners submitted answers to card "Two" several times, ' +
+      'Several learners submitted answers to card "One" 3 times, ' +
       'then gave up and quit.');
     explorationEditorStatsTab.markResolved();
     users.logout();

--- a/core/tests/protractor_utils/general.js
+++ b/core/tests/protractor_utils/general.js
@@ -145,6 +145,7 @@ var ensurePageHasNoTranslationIds = function() {
 var acceptAlert = function() {
   waitFor.alertToBePresent();
   browser.switchTo().alert().accept();
+  waitFor.pageToFullyLoad();
 };
 
 var _getUniqueLogMessages = function(logs) {

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -113,6 +113,12 @@ BAD_PATTERNS_JS_REGEXP = [
         'excluded_dirs': ()
     },
     {
+        'regexp': r'\b(browser.sleep)\(',
+        'message': "In tests, please do not use browser.sleep().",
+        'excluded_files': (),
+        'excluded_dirs': ()
+    },
+    {
         'regexp': r'\b(browser.waitForAngular)\(',
         'message': "In tests, please do not use browser.waitForAngular().",
         'excluded_files': (),


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
Summary: Due to the fact that `FatigueDetectionService` does not permit 4 answer submissions in under 10s, various `browser.sleep()` statements were employed in `editorFeatures.js` to reach the desired exploration player's issue type.
Changes in these PR is one solution that I can think of to get around `FatigueDetectionService` while not invoking `browser.sleep()` in e2e tests. 
Other solution includes:
1) increase the time limit/ answer count required to trigger the `fatigue` modal .
2) make an exception here and add a linter pragma to exclude `browser.sleep` lines in editorFeatures while adding comments on why `browser.sleep` should not be used liberally.

@pranavsid98 I have made some changes to `IssueService.js`, please lmk if I should not be doing it in the first place.

This PR also sets out to resolve an occasional flake that I have been observing the last day or two:
Link to PR build: https://travis-ci.org/oppia/oppia/jobs/416542458
![screen shot 2018-08-15 at 6 21 22 pm](https://user-images.githubusercontent.com/11153258/44186152-c0f47000-a0e5-11e8-84ee-c88f8eaca8c1.png)
(In case PR build got reset) 
@apb7 I have also made some changes to `pre_commit_linter.py` to outlaw `browser.sleep` completely, PTAL!

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
