### PR TITLE
2584-Changed Example URL to placeholder for Links icon

### DIFF
--- a/assets/rich_text_components_definitions.js
+++ b/assets/rich_text_components_definitions.js
@@ -91,10 +91,13 @@ var richTextComponents = {
       "name": "url",
       "description": "The link URL. If no protocol is specified, HTTPS will be used.",
       "schema": {
-        "type": "custom",
-        "obj_type": "SanitizedUrl"
-      },
-      "default_value": "https://www.example.com"
+        "type": "unicode",
+        "obj_type": "SanitizedUrl",
+        "ui_config": {
+          "placeholder": "https://www.example.com/"
+              }
+            },
+      "default_value": ""
     }, {
       "name": "text",
       "description": "The link text. If left blank, the link URL will be used.",


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - #2584 The default text which appears when adding a link should be a placeholder. The example URL has now been converted to a placeholder.
  -->

##Original Pull Request #5481 