### PR TITLE
Fix #5134: Write backend tests for core.storage.exploration.gae_models

### DIFF
--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -328,26 +328,6 @@ class ExplorationCommitLogEntryModel(base_models.BaseCommitLogEntryModel):
         return cls._fetch_page_sorted_by_last_updated(
             query, page_size, urlsafe_start_cursor)
 
-    @classmethod
-    def get_all_exploration_commits(cls, exp_id, latest_version):
-        """Fetches all the commits made on a particular exploration up to latest
-        version of exploration.
-
-        Args:
-            exp_id: str. The exploration id.
-            latest_version: int. Latest version of the exploration.
-
-        Returns:
-            list(ExplorationCommitLogEntryModel). Commit log entry model
-            for each version of the given exploration.
-        """
-        model_ids = []
-        for version in range(1, latest_version + 1):
-            model_ids.append(cls._get_instance_id(exp_id, version))
-
-        models = cls.get_multi(model_ids)
-        return models
-
 
 class ExpSummaryModel(base_models.BaseModel):
     """Summary model for an Oppia exploration.

--- a/core/storage/exploration/gae_models_test.py
+++ b/core/storage/exploration/gae_models_test.py
@@ -1,0 +1,323 @@
+# coding: utf-8
+#
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Exploration models."""
+from constants import constants
+from core.domain import exp_domain
+from core.domain import exp_services
+from core.domain import rights_manager
+from core.platform import models
+from core.tests import test_utils
+
+(exploration_models,) = models.Registry.import_models(
+    [models.NAMES.exploration])
+
+
+class ExplorationModelUnitTest(test_utils.GenericTestBase):
+    """Test the ExplorationModel class."""
+
+    def test_get_exploration_count(self):
+        exploration = exp_domain.Exploration.create_default_exploration(
+            'id', title='A title',
+            category='A Category', objective='An Objective')
+        exp_services.save_new_exploration('id', exploration)
+
+        self.assertEquals(
+            exploration_models.ExplorationModel.get_exploration_count(), 1)
+
+
+class ExplorationRightsModelUnitTest(test_utils.GenericTestBase):
+    """Test the ExplorationRightsModel class."""
+
+    def test_save(self):
+        exploration_models.ExplorationRightsModel(
+            id='id_0',
+            owner_ids=['owner_ids'],
+            editor_ids=['editor_ids'],
+            translator_ids=['translator_ids'],
+            viewer_ids=['viewer_ids'],
+            community_owned=False,
+            status=constants.ACTIVITY_STATUS_PUBLIC,
+            viewable_if_private=False,
+            first_published_msec=0.0
+        ).save(
+            'cid', 'Created new collection',
+            [{'cmd': rights_manager.CMD_CREATE_NEW}])
+        saved_model = exploration_models.ExplorationRightsModel.get('id_0')
+        self.assertEqual(saved_model.id, 'id_0')
+
+
+class ExplorationCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
+    """Test the ExplorationCommitLogEntryModel class."""
+
+    def test_get_all_non_private_commits(self):
+        private_commit = (
+            exploration_models.ExplorationCommitLogEntryModel.create(
+                'a', 1, 'commiter_id', 'username', 'msg',
+                'create', [{}],
+                constants.ACTIVITY_STATUS_PRIVATE, False))
+        public_commit = (
+            exploration_models.ExplorationCommitLogEntryModel.create(
+                'b', 1, 'commiter_id', 'username', 'msg',
+                'create', [{}],
+                constants.ACTIVITY_STATUS_PUBLIC, False))
+        private_commit.exploration_id = 'a'
+        public_commit.exploration_id = 'b'
+        private_commit.put()
+        public_commit.put()
+        results, _, more = (
+            exploration_models.ExplorationCommitLogEntryModel
+            .get_all_non_private_commits(2, None, None))
+        self.assertFalse(more)
+        self.assertEquals(len(results), 1)
+
+    def test_get_all_exploration_commits(self):
+        commit_v1 = (
+            exploration_models.ExplorationCommitLogEntryModel.create(
+                'a', 1, 'commiter_id', 'username', 'msg',
+                'create', [{}],
+                constants.ACTIVITY_STATUS_PRIVATE, False))
+        commit_v2 = (
+            exploration_models.ExplorationCommitLogEntryModel.create(
+                'a', 2, 'commiter_id', 'username', 'msg',
+                'edit', [{}],
+                constants.ACTIVITY_STATUS_PRIVATE, False))
+        commit_v1.exploration_id = 'a'
+        commit_v2.exploration_id = 'a'
+        commit_v1.put()
+        commit_v2.put()
+
+        results = (
+            exploration_models.ExplorationCommitLogEntryModel
+            .get_all_exploration_commits('a', 1))
+        self.assertEquals(results, [commit_v1])
+        results = (
+            exploration_models.ExplorationCommitLogEntryModel
+            .get_all_exploration_commits('a', 2))
+        self.assertEquals(results, [commit_v1, commit_v2])
+
+
+class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
+    """Tests for the ExpSummaryModel."""
+
+    def test_get_non_private(self):
+        public_exploration_summary_model = (
+            exploration_models.ExpSummaryModel(
+                id='id0',
+                title='title',
+                category='category',
+                objective='objective',
+                language_code='language_code',
+                tags=['tags'],
+                status=constants.ACTIVITY_STATUS_PUBLIC,
+                community_owned=False,
+                owner_ids=['owner_ids'],
+                editor_ids=['editor_ids'],
+                viewer_ids=['viewer_ids'],
+                contributor_ids=[''],
+                contributors_summary={},
+                version=0,
+                exploration_model_last_updated=None,
+                exploration_model_created_on=None,
+            ))
+        public_exploration_summary_model.put()
+
+        private_exploration_summary_model = (
+            exploration_models.ExpSummaryModel(
+                id='id1',
+                title='title',
+                category='category',
+                objective='objective',
+                language_code='language_code',
+                tags=['tags'],
+                status=constants.ACTIVITY_STATUS_PRIVATE,
+                community_owned=False,
+                owner_ids=['owner_ids'],
+                editor_ids=['editor_ids'],
+                viewer_ids=['viewer_ids'],
+                contributor_ids=[''],
+                contributors_summary={},
+                version=0,
+                exploration_model_last_updated=None,
+                exploration_model_created_on=None,
+            ))
+        private_exploration_summary_model.put()
+        exploration_summary_models = (
+            exploration_models.ExpSummaryModel.get_non_private())
+        self.assertEqual(
+            exploration_summary_models,
+            [public_exploration_summary_model])
+
+    def test_get_top_rated(self):
+        good_rating_exploration_summary_model = (
+            exploration_models.ExpSummaryModel(
+                id='id0',
+                title='title',
+                category='category',
+                objective='objective',
+                language_code='language_code',
+                tags=['tags'],
+                status=constants.ACTIVITY_STATUS_PUBLIC,
+                community_owned=False,
+                owner_ids=['owner_ids'],
+                editor_ids=['editor_ids'],
+                viewer_ids=['viewer_ids'],
+                contributor_ids=[''],
+                contributors_summary={},
+                version=0,
+                exploration_model_last_updated=None,
+                exploration_model_created_on=None,
+            ))
+        good_rating_exploration_summary_model.scaled_average_rating = 100
+        good_rating_exploration_summary_model.put()
+
+        bad_rating_exploration_summary_model = (
+            exploration_models.ExpSummaryModel(
+                id='id1',
+                title='title',
+                category='category',
+                objective='objective',
+                language_code='language_code',
+                tags=['tags'],
+                status=constants.ACTIVITY_STATUS_PUBLIC,
+                community_owned=False,
+                owner_ids=['owner_ids'],
+                editor_ids=['editor_ids'],
+                viewer_ids=['viewer_ids'],
+                contributor_ids=[''],
+                contributors_summary={},
+                version=0,
+                exploration_model_last_updated=None,
+                exploration_model_created_on=None,
+            ))
+        bad_rating_exploration_summary_model.scaled_average_rating = 0
+        bad_rating_exploration_summary_model.put()
+
+        self.assertEqual(
+            exploration_models.ExpSummaryModel.get_top_rated(1),
+            [good_rating_exploration_summary_model])
+        self.assertEqual(
+            exploration_models.ExpSummaryModel.get_top_rated(2),
+            [good_rating_exploration_summary_model,
+             bad_rating_exploration_summary_model])
+
+        # Test that private summaries should be ignored.
+        good_rating_exploration_summary_model.status = (
+            constants.ACTIVITY_STATUS_PRIVATE)
+        good_rating_exploration_summary_model.put()
+        self.assertEqual(
+            exploration_models.ExpSummaryModel.get_top_rated(2),
+            [bad_rating_exploration_summary_model])
+
+    def test_get_private_at_least_viewable(self):
+        viewable_exploration_summary_model = (
+            exploration_models.ExpSummaryModel(
+                id='id0',
+                title='title',
+                category='category',
+                objective='objective',
+                language_code='language_code',
+                tags=['tags'],
+                status=constants.ACTIVITY_STATUS_PRIVATE,
+                community_owned=False,
+                owner_ids=['owner_ids'],
+                editor_ids=['editor_ids'],
+                viewer_ids=['a'],
+                contributor_ids=[''],
+                contributors_summary={},
+                version=0,
+                exploration_model_last_updated=None,
+                exploration_model_created_on=None,
+            ))
+        viewable_exploration_summary_model.put()
+
+        unviewable_exploration_summary_model = (
+            exploration_models.ExpSummaryModel(
+                id='id1',
+                title='title',
+                category='category',
+                objective='objective',
+                language_code='language_code',
+                tags=['tags'],
+                status=constants.ACTIVITY_STATUS_PRIVATE,
+                community_owned=False,
+                owner_ids=['owner_ids'],
+                editor_ids=['editor_ids'],
+                viewer_ids=['viewer_ids'],
+                contributor_ids=[''],
+                contributors_summary={},
+                version=0,
+                exploration_model_last_updated=None,
+                exploration_model_created_on=None,
+            ))
+        unviewable_exploration_summary_model.put()
+        exploration_summary_models = (
+            exploration_models.ExpSummaryModel
+            .get_private_at_least_viewable('a'))
+        self.assertEqual(1, len(exploration_summary_models))
+        self.assertEqual('id0', exploration_summary_models[0].id)
+
+    def test_get_at_least_editable(self):
+        editable_collection_summary_model = (
+            exploration_models.ExpSummaryModel(
+                id='id0',
+                title='title',
+                category='category',
+                objective='objective',
+                language_code='language_code',
+                tags=['tags'],
+                status=constants.ACTIVITY_STATUS_PRIVATE,
+                community_owned=False,
+                owner_ids=['a'],
+                editor_ids=['editor_ids'],
+                viewer_ids=['viewer_ids'],
+                contributor_ids=[''],
+                contributors_summary={},
+                version=0,
+                exploration_model_last_updated=None,
+                exploration_model_created_on=None,
+            ))
+        editable_collection_summary_model.put()
+
+        uneditable_collection_summary_model = (
+            exploration_models.ExpSummaryModel(
+                id='id1',
+                title='title',
+                category='category',
+                objective='objective',
+                language_code='language_code',
+                tags=['tags'],
+                status=constants.ACTIVITY_STATUS_PRIVATE,
+                community_owned=False,
+                owner_ids=['owner_ids'],
+                editor_ids=['editor_ids'],
+                viewer_ids=['viewer_ids'],
+                contributor_ids=[''],
+                contributors_summary={},
+                version=0,
+                exploration_model_last_updated=None,
+                exploration_model_created_on=None,
+            ))
+        uneditable_collection_summary_model.put()
+        exploration_summary_models = (
+            exploration_models.ExpSummaryModel
+            .get_at_least_editable('a'))
+        self.assertEqual(1, len(exploration_summary_models))
+        self.assertEqual('id0', exploration_summary_models[0].id)
+        exploration_summary_models = (
+            exploration_models.ExpSummaryModel
+            .get_at_least_editable('viewer_ids'))
+        self.assertEqual(0, len(exploration_summary_models))

--- a/core/storage/exploration/gae_models_test.py
+++ b/core/storage/exploration/gae_models_test.py
@@ -93,35 +93,6 @@ class ExplorationCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
         self.assertFalse(more)
         self.assertEquals(len(results), 1)
 
-    def test_get_all_exploration_commits(self):
-        commit_v1 = (
-            exploration_models.ExplorationCommitLogEntryModel.create(
-                'a', 1, 'commiter_id', 'username', 'msg',
-                'create', [{}],
-                constants.ACTIVITY_STATUS_PRIVATE, False))
-        commit_v2 = (
-            exploration_models.ExplorationCommitLogEntryModel.create(
-                'a', 2, 'commiter_id', 'username', 'msg',
-                'edit', [{}],
-                constants.ACTIVITY_STATUS_PRIVATE, False))
-        commit_v1.exploration_id = 'a'
-        commit_v2.exploration_id = 'a'
-        commit_v1.put()
-        commit_v2.put()
-
-        results = (
-            exploration_models.ExplorationCommitLogEntryModel
-            .get_all_exploration_commits('a', 1))
-        self.assertEquals(results, [commit_v1])
-        results = (
-            exploration_models.ExplorationCommitLogEntryModel
-            .get_all_exploration_commits('a', 2))
-        self.assertEquals(results, [commit_v1, commit_v2])
-        results = (
-            exploration_models.ExplorationCommitLogEntryModel
-            .get_all_exploration_commits('a', 3))
-        self.assertEquals(results, [commit_v1, commit_v2, None])
-
 
 class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
     """Tests for the ExpSummaryModel."""

--- a/core/storage/exploration/gae_models_test.py
+++ b/core/storage/exploration/gae_models_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 """Tests for Exploration models."""
+
 from constants import constants
 from core.domain import exp_domain
 from core.domain import exp_services
@@ -31,12 +32,17 @@ class ExplorationModelUnitTest(test_utils.GenericTestBase):
 
     def test_get_exploration_count(self):
         exploration = exp_domain.Exploration.create_default_exploration(
-            'id', title='A title',
+            'id', title='A Title',
             category='A Category', objective='An Objective')
         exp_services.save_new_exploration('id', exploration)
 
         self.assertEquals(
             exploration_models.ExplorationModel.get_exploration_count(), 1)
+        saved_exploration = (
+            exploration_models.ExplorationModel.get_all().fetch(1)[0])
+        self.assertEquals(saved_exploration.title, 'A Title')
+        self.assertEquals(saved_exploration.category, 'A Category')
+        self.assertEquals(saved_exploration.objective, 'An Objective')
 
 
 class ExplorationRightsModelUnitTest(test_utils.GenericTestBase):
@@ -45,19 +51,22 @@ class ExplorationRightsModelUnitTest(test_utils.GenericTestBase):
     def test_save(self):
         exploration_models.ExplorationRightsModel(
             id='id_0',
-            owner_ids=['owner_ids'],
-            editor_ids=['editor_ids'],
-            translator_ids=['translator_ids'],
-            viewer_ids=['viewer_ids'],
+            owner_ids=['owner_id'],
+            editor_ids=['editor_id'],
+            translator_ids=['translator_id'],
+            viewer_ids=['viewer_id'],
             community_owned=False,
             status=constants.ACTIVITY_STATUS_PUBLIC,
             viewable_if_private=False,
             first_published_msec=0.0
         ).save(
-            'cid', 'Created new collection',
+            'cid', 'Created new exploration right',
             [{'cmd': rights_manager.CMD_CREATE_NEW}])
         saved_model = exploration_models.ExplorationRightsModel.get('id_0')
         self.assertEqual(saved_model.id, 'id_0')
+        self.assertEqual(saved_model.owner_ids, ['owner_id'])
+        self.assertEqual(saved_model.translator_ids, ['translator_id'])
+        self.assertEqual(saved_model.viewer_ids, ['viewer_id'])
 
 
 class ExplorationCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
@@ -108,6 +117,10 @@ class ExplorationCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
             exploration_models.ExplorationCommitLogEntryModel
             .get_all_exploration_commits('a', 2))
         self.assertEquals(results, [commit_v1, commit_v2])
+        results = (
+            exploration_models.ExplorationCommitLogEntryModel
+            .get_all_exploration_commits('a', 3))
+        self.assertEquals(results, [commit_v1, commit_v2, None])
 
 
 class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
@@ -121,12 +134,12 @@ class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
                 category='category',
                 objective='objective',
                 language_code='language_code',
-                tags=['tags'],
+                tags=['tag'],
                 status=constants.ACTIVITY_STATUS_PUBLIC,
                 community_owned=False,
-                owner_ids=['owner_ids'],
-                editor_ids=['editor_ids'],
-                viewer_ids=['viewer_ids'],
+                owner_ids=['owner_id'],
+                editor_ids=['editor_id'],
+                viewer_ids=['viewer_id'],
                 contributor_ids=[''],
                 contributors_summary={},
                 version=0,
@@ -142,12 +155,12 @@ class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
                 category='category',
                 objective='objective',
                 language_code='language_code',
-                tags=['tags'],
+                tags=['tag'],
                 status=constants.ACTIVITY_STATUS_PRIVATE,
                 community_owned=False,
-                owner_ids=['owner_ids'],
-                editor_ids=['editor_ids'],
-                viewer_ids=['viewer_ids'],
+                owner_ids=['owner_id'],
+                editor_ids=['editor_id'],
+                viewer_ids=['viewer_id'],
                 contributor_ids=[''],
                 contributors_summary={},
                 version=0,
@@ -169,12 +182,12 @@ class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
                 category='category',
                 objective='objective',
                 language_code='language_code',
-                tags=['tags'],
+                tags=['tag'],
                 status=constants.ACTIVITY_STATUS_PUBLIC,
                 community_owned=False,
-                owner_ids=['owner_ids'],
-                editor_ids=['editor_ids'],
-                viewer_ids=['viewer_ids'],
+                owner_ids=['owner_id'],
+                editor_ids=['editor_id'],
+                viewer_ids=['viewer_id'],
                 contributor_ids=[''],
                 contributors_summary={},
                 version=0,
@@ -191,12 +204,12 @@ class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
                 category='category',
                 objective='objective',
                 language_code='language_code',
-                tags=['tags'],
+                tags=['tag'],
                 status=constants.ACTIVITY_STATUS_PUBLIC,
                 community_owned=False,
-                owner_ids=['owner_ids'],
-                editor_ids=['editor_ids'],
-                viewer_ids=['viewer_ids'],
+                owner_ids=['owner_id'],
+                editor_ids=['editor_id'],
+                viewer_ids=['viewer_id'],
                 contributor_ids=[''],
                 contributors_summary={},
                 version=0,
@@ -211,6 +224,10 @@ class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
             [good_rating_exploration_summary_model])
         self.assertEqual(
             exploration_models.ExpSummaryModel.get_top_rated(2),
+            [good_rating_exploration_summary_model,
+             bad_rating_exploration_summary_model])
+        self.assertEqual(
+            exploration_models.ExpSummaryModel.get_top_rated(3),
             [good_rating_exploration_summary_model,
              bad_rating_exploration_summary_model])
 
@@ -230,11 +247,11 @@ class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
                 category='category',
                 objective='objective',
                 language_code='language_code',
-                tags=['tags'],
+                tags=['tag'],
                 status=constants.ACTIVITY_STATUS_PRIVATE,
                 community_owned=False,
-                owner_ids=['owner_ids'],
-                editor_ids=['editor_ids'],
+                owner_ids=['owner_id'],
+                editor_ids=['editor_id'],
                 viewer_ids=['a'],
                 contributor_ids=[''],
                 contributors_summary={},
@@ -251,12 +268,12 @@ class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
                 category='category',
                 objective='objective',
                 language_code='language_code',
-                tags=['tags'],
+                tags=['tag'],
                 status=constants.ACTIVITY_STATUS_PRIVATE,
                 community_owned=False,
-                owner_ids=['owner_ids'],
-                editor_ids=['editor_ids'],
-                viewer_ids=['viewer_ids'],
+                owner_ids=['owner_id'],
+                editor_ids=['editor_id'],
+                viewer_ids=['viewer_id'],
                 contributor_ids=[''],
                 contributors_summary={},
                 version=0,
@@ -278,12 +295,12 @@ class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
                 category='category',
                 objective='objective',
                 language_code='language_code',
-                tags=['tags'],
+                tags=['tag'],
                 status=constants.ACTIVITY_STATUS_PRIVATE,
                 community_owned=False,
                 owner_ids=['a'],
-                editor_ids=['editor_ids'],
-                viewer_ids=['viewer_ids'],
+                editor_ids=['editor_id'],
+                viewer_ids=['viewer_id'],
                 contributor_ids=[''],
                 contributors_summary={},
                 version=0,
@@ -299,12 +316,12 @@ class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
                 category='category',
                 objective='objective',
                 language_code='language_code',
-                tags=['tags'],
+                tags=['tag'],
                 status=constants.ACTIVITY_STATUS_PRIVATE,
                 community_owned=False,
-                owner_ids=['owner_ids'],
-                editor_ids=['editor_ids'],
-                viewer_ids=['viewer_ids'],
+                owner_ids=['owner_id'],
+                editor_ids=['editor_id'],
+                viewer_ids=['viewer_id'],
                 contributor_ids=[''],
                 contributors_summary={},
                 version=0,
@@ -312,12 +329,19 @@ class ExpSummaryModelUnitTest(test_utils.GenericTestBase):
                 exploration_model_created_on=None,
             ))
         uneditable_collection_summary_model.put()
+
         exploration_summary_models = (
             exploration_models.ExpSummaryModel
             .get_at_least_editable('a'))
         self.assertEqual(1, len(exploration_summary_models))
         self.assertEqual('id0', exploration_summary_models[0].id)
+
         exploration_summary_models = (
             exploration_models.ExpSummaryModel
-            .get_at_least_editable('viewer_ids'))
+            .get_at_least_editable('viewer_id'))
+        self.assertEqual(0, len(exploration_summary_models))
+
+        exploration_summary_models = (
+            exploration_models.ExpSummaryModel
+            .get_at_least_editable('nonexistent_id'))
         self.assertEqual(0, len(exploration_summary_models))


### PR DESCRIPTION
This PR adds a unit test core.storage.exploration.gae_models_test to test the exploration model.