### PR TITLE
Fix #4830: Create and use delete_json in tests

### DIFF
--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -277,6 +277,7 @@ class ExplorationHandler(EditorHandler):
         log_info_string = '(%s) %s deleted exploration %s' % (
             self.role, self.user_id, exploration_id)
         logging.info(log_info_string)
+        self.render_json(self.values)
 
 
 class ExplorationRightsHandler(EditorHandler):

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -679,27 +679,27 @@ class ExplorationDeletionRightsTest(BaseEditorControllerTest):
             rights_manager.ROLE_TRANSLATOR)
 
         self.login(self.EDITOR_EMAIL)
-        response = self.testapp.delete(
-            '/createhandler/data/%s' % unpublished_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        self.delete_json(
+            '/createhandler/data/%s' % unpublished_exp_id, expect_errors=True,
+            expected_status_int=401)
         self.logout()
 
         self.login(self.VIEWER_EMAIL)
-        response = self.testapp.delete(
-            '/createhandler/data/%s' % unpublished_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        self.delete_json(
+            '/createhandler/data/%s' % unpublished_exp_id, expect_errors=True,
+            expected_status_int=401)
         self.logout()
 
         self.login(self.TRANSLATOR_EMAIL)
-        response = self.testapp.delete(
-            '/createhandler/data/%s' % unpublished_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        self.delete_json(
+            '/createhandler/data/%s' % unpublished_exp_id, expect_errors=True,
+            expected_status_int=401)
         self.logout()
 
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.delete(
-            '/createhandler/data/%s' % unpublished_exp_id)
-        self.assertEqual(response.status_int, 200)
+        self.delete_json(
+            '/createhandler/data/%s' % unpublished_exp_id,
+            expected_status_int=200)
         self.logout()
 
     def test_deletion_rights_for_published_exploration(self):
@@ -718,33 +718,33 @@ class ExplorationDeletionRightsTest(BaseEditorControllerTest):
         rights_manager.publish_exploration(self.owner, published_exp_id)
 
         self.login(self.EDITOR_EMAIL)
-        response = self.testapp.delete(
-            '/createhandler/data/%s' % published_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        self.delete_json(
+            '/createhandler/data/%s' % published_exp_id, expect_errors=True,
+            expected_status_int=401)
         self.logout()
 
         self.login(self.VIEWER_EMAIL)
-        response = self.testapp.delete(
-            '/createhandler/data/%s' % published_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        self.delete_json(
+            '/createhandler/data/%s' % published_exp_id, expect_errors=True,
+            expected_status_int=401)
         self.logout()
 
         self.login(self.TRANSLATOR_EMAIL)
-        response = self.testapp.delete(
-            '/createhandler/data/%s' % published_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        self.delete_json(
+            '/createhandler/data/%s' % published_exp_id, expect_errors=True,
+            expected_status_int=401)
         self.logout()
 
         self.login(self.OWNER_EMAIL)
-        response = self.testapp.delete(
-            '/createhandler/data/%s' % published_exp_id, expect_errors=True)
-        self.assertEqual(response.status_int, 401)
+        self.delete_json(
+            '/createhandler/data/%s' % published_exp_id, expect_errors=True,
+            expected_status_int=401)
         self.logout()
 
         self.login(self.ADMIN_EMAIL)
-        response = self.testapp.delete(
-            '/createhandler/data/%s' % published_exp_id)
-        self.assertEqual(response.status_int, 200)
+        self.delete_json(
+            '/createhandler/data/%s' % published_exp_id,
+            expected_status_int=200)
         self.logout()
 
     def test_logging_info_after_deletion(self):
@@ -769,7 +769,7 @@ class ExplorationDeletionRightsTest(BaseEditorControllerTest):
             exp_services.save_new_exploration(self.owner_id, exploration)
 
             self.login(self.OWNER_EMAIL)
-            self.testapp.delete(
+            self.delete_json(
                 '/createhandler/data/%s' % exp_id, expect_errors=True)
 
             # Observed_log_messages[1] is 'Attempting to delete documents
@@ -796,7 +796,7 @@ class ExplorationDeletionRightsTest(BaseEditorControllerTest):
             exp_services.save_new_exploration(self.admin_id, exploration)
 
             self.login(self.ADMIN_EMAIL)
-            self.testapp.delete(
+            self.delete_json(
                 '/createhandler/data/%s' % exp_id, expect_errors=True)
             self.assertEqual(len(observed_log_messages), 3)
             self.assertEqual(
@@ -817,7 +817,7 @@ class ExplorationDeletionRightsTest(BaseEditorControllerTest):
             exp_services.save_new_exploration(self.moderator_id, exploration)
 
             self.login(self.MODERATOR_EMAIL)
-            self.testapp.delete(
+            self.delete_json(
                 '/createhandler/data/%s' % exp_id, expect_errors=True)
             self.assertEqual(len(observed_log_messages), 3)
             self.assertEqual(

--- a/core/controllers/learner_playlist_test.py
+++ b/core/controllers/learner_playlist_test.py
@@ -277,7 +277,7 @@ class LearnerPlaylistHandlerTests(test_utils.GenericTestBase):
                 self.viewer_id), [self.EXP_ID_1, self.EXP_ID_2])
 
         # Remove an exploration.
-        self.testapp.delete(str(
+        self.delete_json(str(
             '%s/%s/%s' % (
                 feconf.LEARNER_PLAYLIST_DATA_URL,
                 constants.ACTIVITY_TYPE_EXPLORATION,
@@ -287,7 +287,7 @@ class LearnerPlaylistHandlerTests(test_utils.GenericTestBase):
                 self.viewer_id), [self.EXP_ID_2])
 
         # Removing the same exploration again has no effect.
-        self.testapp.delete(str('%s/%s/%s' % (
+        self.delete_json(str('%s/%s/%s' % (
             feconf.LEARNER_PLAYLIST_DATA_URL,
             constants.ACTIVITY_TYPE_EXPLORATION,
             self.EXP_ID_1)))
@@ -296,7 +296,7 @@ class LearnerPlaylistHandlerTests(test_utils.GenericTestBase):
                 self.viewer_id), [self.EXP_ID_2])
 
         # Remove the second exploration.
-        self.testapp.delete(str('%s/%s/%s' % (
+        self.delete_json(str('%s/%s/%s' % (
             feconf.LEARNER_PLAYLIST_DATA_URL,
             constants.ACTIVITY_TYPE_EXPLORATION,
             self.EXP_ID_2)))
@@ -319,7 +319,7 @@ class LearnerPlaylistHandlerTests(test_utils.GenericTestBase):
                 self.viewer_id), [self.COL_ID_1, self.COL_ID_2])
 
         # Remove a collection.
-        self.testapp.delete(str('%s/%s/%s' % (
+        self.delete_json(str('%s/%s/%s' % (
             feconf.LEARNER_PLAYLIST_DATA_URL,
             constants.ACTIVITY_TYPE_COLLECTION, self.COL_ID_1)))
         self.assertEqual(
@@ -327,7 +327,7 @@ class LearnerPlaylistHandlerTests(test_utils.GenericTestBase):
                 self.viewer_id), [self.COL_ID_2])
 
         # Removing the same collection again has no effect.
-        self.testapp.delete(str('%s/%s/%s' % (
+        self.delete_json(str('%s/%s/%s' % (
             feconf.LEARNER_PLAYLIST_DATA_URL,
             constants.ACTIVITY_TYPE_COLLECTION, self.COL_ID_1)))
         self.assertEqual(
@@ -335,7 +335,7 @@ class LearnerPlaylistHandlerTests(test_utils.GenericTestBase):
                 self.viewer_id), [self.COL_ID_2])
 
         # Remove the second collection.
-        self.testapp.delete(str('%s/%s/%s' % (
+        self.delete_json(str('%s/%s/%s' % (
             feconf.LEARNER_PLAYLIST_DATA_URL,
             constants.ACTIVITY_TYPE_COLLECTION, self.COL_ID_2)))
         self.assertEqual(

--- a/core/controllers/question_editor.py
+++ b/core/controllers/question_editor.py
@@ -167,3 +167,4 @@ class EditableQuestionDataHandler(base.BaseHandler):
             raise self.PageNotFoundException(
                 'The question with the given id doesn\'t exist.')
         question_services.delete_question(self.user_id, question_id)
+        self.render_json(self.values)

--- a/core/controllers/question_editor_test.py
+++ b/core/controllers/question_editor_test.py
@@ -190,7 +190,7 @@ class QuestionSkillLinkHandlerTest(BaseQuestionEditorControllerTest):
             self.logout()
 
             self.login(self.ADMIN_EMAIL)
-            self.testapp.delete(
+            self.delete_json(
                 '%s/%s/%s' % (
                     feconf.QUESTION_SKILL_LINK_URL_PREFIX, self.question_id,
                     self.skill_id
@@ -203,7 +203,7 @@ class QuestionSkillLinkHandlerTest(BaseQuestionEditorControllerTest):
             self.logout()
 
             self.login(self.TOPIC_MANAGER_EMAIL)
-            self.testapp.delete(
+            self.delete_json(
                 '%s/%s/%s' % (
                     feconf.QUESTION_SKILL_LINK_URL_PREFIX, self.question_id_2,
                     self.skill_id
@@ -271,10 +271,10 @@ class EditableQuestionDataHandlerTest(BaseQuestionEditorControllerTest):
     def test_delete(self):
         self.login(self.ADMIN_EMAIL)
         with self.swap(feconf, 'ENABLE_NEW_STRUCTURES', True):
-            response = self.testapp.delete(
+            self.delete_json(
                 '%s/%s' % (
-                    feconf.QUESTION_EDITOR_DATA_URL_PREFIX, self.question_id))
-            self.assertEqual(response.status_int, 200)
+                    feconf.QUESTION_EDITOR_DATA_URL_PREFIX, self.question_id),
+                expected_status_int=200)
             self.logout()
 
     def test_put(self):

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -1218,7 +1218,7 @@ class LearnerProgressTest(test_utils.GenericTestBase):
                 self.user_id), [self.EXP_ID_0, self.EXP_ID_1])
 
         # Remove one exploration.
-        self.testapp.delete(str(
+        self.delete_json(str(
             '%s/%s/%s' %
             (
                 feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,
@@ -1229,7 +1229,7 @@ class LearnerProgressTest(test_utils.GenericTestBase):
                 self.user_id), [self.EXP_ID_1])
 
         # Remove another exploration.
-        self.testapp.delete(str(
+        self.delete_json(str(
             '%s/%s/%s' %
             (
                 feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,
@@ -1254,7 +1254,7 @@ class LearnerProgressTest(test_utils.GenericTestBase):
                 self.user_id), [self.COL_ID_0, self.COL_ID_1])
 
         # Remove one collection.
-        self.testapp.delete(str(
+        self.delete_json(str(
             '%s/%s/%s' %
             (
                 feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,
@@ -1265,7 +1265,7 @@ class LearnerProgressTest(test_utils.GenericTestBase):
                 self.user_id), [self.COL_ID_1])
 
         # Remove another collection.
-        self.testapp.delete(str(
+        self.delete_json(str(
             '%s/%s/%s' %
             (
                 feconf.LEARNER_INCOMPLETE_ACTIVITY_DATA_URL,

--- a/core/controllers/skill_editor.py
+++ b/core/controllers/skill_editor.py
@@ -185,6 +185,8 @@ class EditableSkillDataHandler(base.BaseHandler):
             raise self.PageNotFoundException
         skill_services.delete_skill(self.user_id, skill_id)
 
+        self.render_json(self.values)
+
 
 class SkillPublishHandler(base.BaseHandler):
     """A handler for publishing skills."""

--- a/core/controllers/skill_editor_test.py
+++ b/core/controllers/skill_editor_test.py
@@ -126,10 +126,10 @@ class SkillEditorTest(BaseSkillEditorControllerTest):
         with self.swap(feconf, 'ENABLE_NEW_STRUCTURES', True):
             # Check that admins can delete a skill.
             self.login(self.ADMIN_EMAIL)
-            response = self.testapp.delete(
+            self.delete_json(
                 '%s/%s' % (
-                    feconf.SKILL_EDITOR_DATA_URL_PREFIX, self.skill_id))
-            self.assertEqual(response.status_int, 200)
+                    feconf.SKILL_EDITOR_DATA_URL_PREFIX, self.skill_id),
+                expected_status_int=200)
             self.logout()
 
             # Check that non-admins cannot delete a skill.

--- a/core/controllers/story_editor.py
+++ b/core/controllers/story_editor.py
@@ -157,3 +157,5 @@ class EditableStoryDataHandler(base.BaseHandler):
                 Exception('The topic with the given id doesn\'t exist.'))
 
         story_services.delete_story(self.user_id, story_id)
+
+        self.render_json(self.values)

--- a/core/controllers/story_editor_test.py
+++ b/core/controllers/story_editor_test.py
@@ -133,11 +133,10 @@ class StoryEditorTest(BaseStoryEditorControllerTest):
         with self.swap(feconf, 'ENABLE_NEW_STRUCTURES', True):
             # Check that admins can delete a story.
             self.login(self.ADMIN_EMAIL)
-            response = self.testapp.delete(
+            self.delete_json(
                 '%s/%s/%s' % (
                     feconf.STORY_EDITOR_DATA_URL_PREFIX, self.topic_id,
-                    self.story_id))
-            self.assertEqual(response.status_int, 200)
+                    self.story_id), expected_status_int=200)
             self.logout()
 
             # Check that non-admins cannot delete a story.

--- a/core/controllers/topic_editor.py
+++ b/core/controllers/topic_editor.py
@@ -322,6 +322,8 @@ class EditableTopicDataHandler(base.BaseHandler):
                 'The topic with the given id doesn\'t exist.')
         topic_services.delete_topic(self.user_id, topic_id)
 
+        self.render_json(self.values)
+
 
 class TopicRightsHandler(base.BaseHandler):
     """A handler for returning topic rights."""

--- a/core/controllers/topic_editor_test.py
+++ b/core/controllers/topic_editor_test.py
@@ -384,10 +384,10 @@ class TopicEditorTest(BaseTopicEditorControllerTest):
         with self.swap(feconf, 'ENABLE_NEW_STRUCTURES', True):
             # Check that admins can delete a topic.
             self.login(self.ADMIN_EMAIL)
-            response = self.testapp.delete(
+            self.delete_json(
                 '%s/%s' % (
-                    feconf.TOPIC_EDITOR_DATA_URL_PREFIX, self.topic_id))
-            self.assertEqual(response.status_int, 200)
+                    feconf.TOPIC_EDITOR_DATA_URL_PREFIX, self.topic_id),
+                expected_status_int=200)
             self.logout()
 
             # Check that non-admins cannot delete a topic.

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -466,6 +466,24 @@ tags: []
         return self._parse_json_response(
             json_response, expect_errors=expect_errors)
 
+    def delete_json(self, url, params='', expect_errors=False,
+                    expected_status_int=200):
+        """Delete object on the server using a JSON call."""
+        json_response = self.testapp.delete(
+            url, params, expect_errors=expect_errors,
+            status=expected_status_int)
+
+        # Testapp takes in a status parameter which is the expected status of
+        # the response. However this expected status is verified only when
+        # expect_errors=False. For other situations we need to explicitly check
+        # the status.
+        # Reference URL:
+        # https://github.com/Pylons/webtest/blob/
+        # bf77326420b628c9ea5431432c7e171f88c5d874/webtest/app.py#L1119 .
+        self.assertEqual(json_response.status_int, expected_status_int)
+        return self._parse_json_response(
+            json_response, expect_errors=expect_errors)
+
     def _send_post_request(
             self, app, url, data, expect_errors=False, expected_status_int=200,
             upload_files=None, headers=None):


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
Fix #4830 
- Creates delete_json method in test_utils.
- Replaces uses of `self.testapp.delete` and fixes bugs where the app would return 'text/html' and not 'application/json' content.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.