### PR TITLE
Fix part of #3950: Removes Jinja templates in the Exploration Editor

### DIFF
--- a/core/templates/dev/head/pages/base.html
+++ b/core/templates/dev/head/pages/base.html
@@ -67,7 +67,7 @@
     string it would be displayed as is. This is the only way to translate
     the page title because the head of the file is outside the scope of
     any other controller. -->
-    <title itemprop="name" translate="{% block maintitle %}Oppia{% endblock maintitle %}"></title>
+    <title itemprop="name" ng-bind="$root.title" translate="{% block maintitle %}Oppia{% endblock maintitle %}"></title>
     {% block base_url %}
     {% endblock base_url %}
 

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
@@ -118,6 +118,14 @@ oppia.controller('ExplorationEditor', [
         ExplorationStatesService.init(data.states);
 
         ExplorationTitleService.init(data.title);
+
+        if ((data.title !== undefined) && (data.title !== '')) {
+          $rootScope.title = data.title + '- Oppia Editor';
+        } else {
+          $rootScope.title = 'Untitled Exploration - Oppia Editor';
+        }
+
+
         ExplorationCategoryService.init(data.category);
         ExplorationObjectiveService.init(data.objective);
         ExplorationLanguageCodeService.init(data.language_code);

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -1,13 +1,5 @@
 {% extends 'pages/base.html' %}
 
-{% block maintitle %}
-  {% if title %}
-    {{ title }} - Oppia Editor
-  {% else %}
-    Untitled Exploration - Oppia Editor
-  {% endif %}
-{% endblock maintitle %}
-
 {% block header_js %}
   {{ super() }}
   <script type="text/javascript">


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
    Fixes #3950 
      This PR removes the Jinja template in exploration_editor.html.
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.

@shubha1593  please review this PR.