### PR TITLE
Added basic Story viewer page (Part 1)

### DIFF
--- a/core/controllers/story_viewer.py
+++ b/core/controllers/story_viewer.py
@@ -1,0 +1,76 @@
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Controllers for the story viewer page."""
+
+from core.controllers import base
+from core.domain import acl_decorators
+from core.domain import story_services
+from core.domain import summary_services
+import feconf
+
+
+class StoryViewerPage(base.BaseHandler):
+    """Renders the story viewer page."""
+
+    @acl_decorators.can_access_story_viewer_page
+    def get(self, story_id):
+        """Handles GET requests."""
+
+        if not feconf.ENABLE_NEW_STRUCTURES:
+            raise self.PageNotFoundException
+
+        story = story_services.get_story_by_id(story_id, strict=False)
+        if story is None:
+            raise self.PageNotFoundException
+
+        self.values.update({
+            'story_id': story.id,
+            'story_title': story.title,
+        })
+
+        self.render_template('pages/story_viewer/story_viewer.html')
+
+
+class StoryPageDataHandler(base.BaseHandler):
+    """Manages the data that needs to be displayed to a learner on the story
+    viewer page."""
+
+    @acl_decorators.can_access_story_viewer_page
+    def get(self, story_id):
+        """Handles GET requests."""
+
+        if not feconf.ENABLE_NEW_STRUCTURES:
+            raise self.PageNotFoundException
+
+        story = story_services.get_story_by_id(story_id, strict=False)
+        story_dict = (
+            summary_services.get_learner_story_dict_by_id(story_id))
+        if story is None:
+            raise self.PageNotFoundException
+
+        self.values.update({
+            'title': story_dict['title'],
+            'id': story_dict['id'],
+            'description': story_dict['description'],
+            'language_code': story_dict['language_code'],
+            'playthrough_dict': story_dict['playthrough_dict'],
+            'story_contents': story_dict['story_contents'],
+            'notes': story_dict['notes'],
+            'is_logged_in': bool(self.user_id),
+            'version': story_dict['version'],
+            'schema_version': story_dict['schema_version'],
+        })
+
+        self.render_json(self.values)

--- a/core/controllers/story_viewer.py
+++ b/core/controllers/story_viewer.py
@@ -45,7 +45,8 @@ class StoryViewerPage(base.BaseHandler):
 
 class StoryPageDataHandler(base.BaseHandler):
     """Manages the data that needs to be displayed to a learner on the story
-    viewer page."""
+    viewer page.
+    """
 
     @acl_decorators.can_access_story_viewer_page
     def get(self, story_id):

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -98,6 +98,7 @@ class BaseStoryViewerControllerTest(test_utils.GenericTestBase):
         story_domain.Story.create_default_story(
             self.unsaved_story_id, 'story_title')
 
+
 class StoryViewerPage(BaseStoryViewerControllerTest):
 
     def test_any_user_can_access_story_viewer_page(self):

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -1,0 +1,129 @@
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the topic viewer page."""
+
+from core.domain import rights_manager
+from core.domain import story_domain
+from core.domain import story_services
+from core.domain import summary_services
+from core.domain import user_services
+from core.tests import test_utils
+import feconf
+
+
+class BaseStoryViewerControllerTest(test_utils.GenericTestBase):
+
+    def setUp(self):
+        """Completes the sign-up process for the various users."""
+        super(BaseStoryViewerControllerTest, self).setUp()
+        self.signup(self.ADMIN_EMAIL, self.ADMIN_USERNAME)
+        self.admin_id = self.get_user_id_from_email(self.ADMIN_EMAIL)
+        self.set_admins([self.ADMIN_USERNAME])
+        self.admin = user_services.UserActionsInfo(self.admin_id)
+
+
+        self.story_id = 'story'
+        self.unsaved_story_id = 'story1'
+
+        self.story = story_domain.Story.create_default_story(
+            self.story_id, 'story_title')
+        self.story.description = 'story_description'
+        self.story.notes = 'notes'
+        self.story.language_code = 'en'
+
+        self.save_new_valid_exploration(
+            'exp', self.admin_id, title='Bridges in England',
+            category='Architecture', language_code='en')
+        rights_manager.publish_exploration(self.admin, 'exp')
+
+        node_1 = {
+            'id': 'node_1',
+            'destination_node_ids': ['node_2'],
+            'acquired_skill_ids': ['skill_2'],
+            'prerequisite_skill_ids': ['skill_1', 'skill_0'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': 'exp'
+        }
+        node_2 = {
+            'id': 'node_2',
+            'destination_node_ids': ['node_3'],
+            'acquired_skill_ids': ['skill_3', 'skill_4'],
+            'prerequisite_skill_ids': ['skill_2'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': 'exp'
+        }
+        node_3 = {
+            'id': 'node_3',
+            'destination_node_ids': ['node_4'],
+            'acquired_skill_ids': [],
+            'prerequisite_skill_ids': ['skill_4'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': 'exp'
+        }
+        node_4 = {
+            'id': 'node_4',
+            'destination_node_ids': [],
+            'acquired_skill_ids': [],
+            'prerequisite_skill_ids': ['skill_2'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': 'exp'
+        }
+        self.story.story_contents.nodes = [
+            story_domain.StoryNode.from_dict(node_1),
+            story_domain.StoryNode.from_dict(node_2),
+            story_domain.StoryNode.from_dict(node_3),
+            story_domain.StoryNode.from_dict(node_4)
+        ]
+
+        self.story.story_contents.initial_node_id = 'node_1'
+        self.story.story_contents.next_node_id = 'node_5'
+        story_services.save_new_story(self.admin_id, self.story)
+
+        story_domain.Story.create_default_story(
+            self.unsaved_story_id, 'story_title')
+
+class StoryViewerPage(BaseStoryViewerControllerTest):
+
+    def test_any_user_can_access_story_viewer_page(self):
+        with self.swap(feconf, 'ENABLE_NEW_STRUCTURES', True):
+            response = self.testapp.get(
+                '%s/%s' % (feconf.STORY_VIEWER_URL_PREFIX, self.story_id))
+
+            self.assertEqual(response.status_int, 200)
+
+    def test_no_user_can_access_unsaved_story_viewer_page(self):
+        with self.swap(feconf, 'ENABLE_NEW_STRUCTURES', True):
+            response = self.testapp.get(
+                '%s/%s' % (
+                    feconf.STORY_VIEWER_URL_PREFIX, self.unsaved_story_id),
+                expect_errors=True)
+
+            self.assertEqual(response.status_int, 404)
+
+
+class StoryPageDataHandler(BaseStoryViewerControllerTest):
+
+    def test_get(self):
+        with self.swap(feconf, 'ENABLE_NEW_STRUCTURES', True):
+            json_response = self.get_json(
+                '%s/%s' % (feconf.STORY_DATA_HANDLER, self.story_id))
+            expected_dict = (
+                summary_services.get_learner_story_dict_by_id(self.story_id))
+
+            self.assertDictContainsSubset(expected_dict, json_response)

--- a/core/domain/acl_decorators.py
+++ b/core/domain/acl_decorators.py
@@ -22,8 +22,8 @@ from core.domain import question_services
 from core.domain import rights_manager
 from core.domain import role_services
 from core.domain import skill_services
-from core.domain import suggestion_services
 from core.domain import story_services
+from core.domain import suggestion_services
 from core.domain import topic_services
 from core.domain import user_services
 from core.platform import models

--- a/core/domain/acl_decorators.py
+++ b/core/domain/acl_decorators.py
@@ -23,6 +23,7 @@ from core.domain import rights_manager
 from core.domain import role_services
 from core.domain import skill_services
 from core.domain import suggestion_services
+from core.domain import story_services
 from core.domain import topic_services
 from core.domain import user_services
 from core.platform import models
@@ -1853,3 +1854,28 @@ def get_decorator_for_accepting_suggestion(decorator):
         return test_can_accept_suggestion
 
     return generate_decorator_for_handler
+
+
+def can_access_story_viewer_page(handler):
+    """Decorator to check whether user can access story viewer page."""
+
+    def test_can_access(self, story_id, **kwargs):
+        """Checks if the user can access story viewer page.
+
+        Args:
+            story_id: str. The id of the story.
+            **kwargs: *. Keyword arguments.
+
+        Returns:
+            bool. Whether the user can access story viewer page.
+        """
+        story = story_services.get_story_by_id(story_id, strict=False)
+
+        if story is None:
+            raise self.PageNotFoundException
+
+        return handler(self, story_id, **kwargs)
+
+    test_can_access.__wrapped__ = True
+
+    return test_can_access

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1666,30 +1666,6 @@ pre.oppia-pre-wrapped-text {
   word-wrap: break-word;
 }
 
-/* Styles for the story viewer view */
-
-
-.oppia-story-player-tiles-container {
-  height: 100%;
-  margin: 0 auto;
-  max-width: 975px;
-  min-height: 500px;
-  padding-bottom: 25px;
-  padding-top: 30px;
-  position: relative;
-}
-
-.oppia-story-player-tiles-container .oppia-page-heading {
-  color: #005048;
-  text-align: center;
-  width: 100%;
-}
-
-.oppia-story-player-title-font {
-  font-family: Capriola, Roboto, Arial, sans-serif;
-  font-size: 45px;
-}
-
 /* Styles for the collections learner view */
 
 .oppia-collection-player-tiles-container {
@@ -1724,6 +1700,29 @@ pre.oppia-pre-wrapped-text {
 }
 
 .oppia-collection-player-title-font {
+  font-family: Capriola, Roboto, Arial, sans-serif;
+  font-size: 45px;
+}
+
+/* Styles for the story viewer view */
+
+.oppia-story-player-tiles-container .oppia-page-heading {
+  color: #005048;
+  text-align: center;
+  width: 100%;
+}
+
+.oppia-story-player-tiles-container {
+  height: 100%;
+  margin: 0 auto;
+  max-width: 975px;
+  min-height: 500px;
+  padding-bottom: 25px;
+  padding-top: 30px;
+  position: relative;
+}
+
+.oppia-story-player-title-font {
   font-family: Capriola, Roboto, Arial, sans-serif;
   font-size: 45px;
 }

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1666,6 +1666,30 @@ pre.oppia-pre-wrapped-text {
   word-wrap: break-word;
 }
 
+/* Styles for the story viewer view */
+
+
+.oppia-story-player-tiles-container {
+  height: 100%;
+  margin: 0 auto;
+  max-width: 975px;
+  min-height: 500px;
+  padding-bottom: 25px;
+  padding-top: 30px;
+  position: relative;
+}
+
+.oppia-story-player-tiles-container .oppia-page-heading {
+  color: #005048;
+  text-align: center;
+  width: 100%;
+}
+
+.oppia-story-player-title-font {
+  font-family: Capriola, Roboto, Arial, sans-serif;
+  font-size: 45px;
+}
+
 /* Styles for the collections learner view */
 
 .oppia-collection-player-tiles-container {

--- a/core/templates/dev/head/domain/story/StoryContentsObjectFactory.js
+++ b/core/templates/dev/head/domain/story/StoryContentsObjectFactory.js
@@ -46,6 +46,14 @@ oppia.factory('StoryContentsObjectFactory', [
       return this._nodes;
     };
 
+    StoryContents.prototype.getNodeCount = function() {
+      return this._nodes.length;
+    };
+
+    StoryContents.prototype.getNodeById = function(nodeId) {
+      return this._nodes[this.getNodeIndex(nodeId)];
+    };
+
     StoryContents.prototype.validate = function() {
       var issues = [];
       var nodes = this._nodes;

--- a/core/templates/dev/head/domain/story/StoryNodeObjectFactory.js
+++ b/core/templates/dev/head/domain/story/StoryNodeObjectFactory.js
@@ -21,7 +21,7 @@ oppia.factory('StoryNodeObjectFactory', ['NODE_ID_PREFIX',
   function(NODE_ID_PREFIX) {
     var StoryNode = function(
         id, destinationNodeIds, prerequisiteSkillIds, acquiredSkillIds, outline,
-        outlineIsFinalized, explorationId) {
+        outlineIsFinalized, explorationId, explorationSummaryObject) {
       this._id = id;
       this._destinationNodeIds = destinationNodeIds;
       this._prerequisiteSkillIds = prerequisiteSkillIds;
@@ -29,6 +29,7 @@ oppia.factory('StoryNodeObjectFactory', ['NODE_ID_PREFIX',
       this._outline = outline;
       this._outlineIsFinalized = outlineIsFinalized;
       this._explorationId = explorationId;
+      this._explorationSummaryObject = angular.copy(explorationSummaryObject);
     };
 
     var _checkValidNodeId = function(nodeId) {
@@ -74,6 +75,10 @@ oppia.factory('StoryNodeObjectFactory', ['NODE_ID_PREFIX',
 
     StoryNode.prototype.markOutlineAsNotFinalized = function() {
       this._outlineIsFinalized = false;
+    };
+
+    StoryNode.prototype.getExplorationSummaryObject = function(){
+      return angular.copy(this._explorationSummaryObject);
     };
 
     StoryNode.prototype.validate = function() {
@@ -207,7 +212,8 @@ oppia.factory('StoryNodeObjectFactory', ['NODE_ID_PREFIX',
         storyNodeBackendObject.acquired_skill_ids,
         storyNodeBackendObject.outline,
         storyNodeBackendObject.outline_is_finalized,
-        storyNodeBackendObject.exploration_id
+        storyNodeBackendObject.exploration_id,
+        storyNodeBackendObject.exploration_summary
       );
     };
 

--- a/core/templates/dev/head/domain/story_viewer/StoryPlaythroughObjectFactory.js
+++ b/core/templates/dev/head/domain/story_viewer/StoryPlaythroughObjectFactory.js
@@ -1,0 +1,78 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Factory for creating and mutating instances of frontend
+ * story playthrough domain objects.
+ */
+
+oppia.factory('StoryPlaythroughObjectFactory', [function() {
+  // Stores information about a current playthrough of a story for a
+  // user.
+  var StoryPlaythrough = function(
+      nextExplorationId, completedExplorationIds) {
+    this._nextExplorationId = nextExplorationId;
+    this._completedExplorationIds = completedExplorationIds;
+  };
+
+  // Returns the upcoming exploration ID. Changes to this are not
+  // reflected in the story.
+  StoryPlaythrough.prototype.getNextExplorationId = function() {
+    return this._nextExplorationId;
+  };
+
+  //   StoryPlaythrough.prototype.getNextRecommendedStoryNodeCount =
+  //     function() {
+  //       // As the story is linear, only a single node would be available,
+  //       // after any node.
+  //       return 1;
+  //     };
+
+  StoryPlaythrough.hasFinishedStory = function() {
+    return this._nextExplorationId === null;
+  };
+
+  // Returns a list of explorations completed that are related to this
+  // story. Changes to this list are not reflected in this story.
+  StoryPlaythrough.prototype.getCompletedExplorationIds = function() {
+    return angular.copy(this._completedExplorationIds);
+  };
+
+  StoryPlaythrough.prototype.getCompletedExplorationNodeCount =
+    function() {
+      return this._completedExplorationIds.length;
+    };
+
+  StoryPlaythrough.prototype.hasStartedStory = function() {
+    return this._completedExplorationIds.length !== 0;
+  };
+
+  // Static class methods. Note that "this" is not available in static
+  // contexts. This function takes a JSON object which represents a backend
+  // story playthrough python dict.
+  StoryPlaythrough.createFromBackendObject = function(
+      storyPlaythroughBackendObject) {
+    return new StoryPlaythrough(
+      storyPlaythroughBackendObject.next_exploration_id,
+      storyPlaythroughBackendObject.completed_exploration_ids);
+  };
+
+  StoryPlaythrough.create = function(
+      nextExplorationId, completedExplorationIds) {
+    return new StoryPlaythrough(
+      nextExplorationId, angular.copy(completedExplorationIds));
+  };
+
+  return StoryPlaythrough;
+}]);

--- a/core/templates/dev/head/domain/story_viewer/StoryViewerBackendApiService.js
+++ b/core/templates/dev/head/domain/story_viewer/StoryViewerBackendApiService.js
@@ -1,0 +1,51 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Service to get story data.
+ */
+oppia.constant(
+  'STORY_DATA_URL_TEMPLATE', '/story_data_handler/<story_id>');
+
+oppia.factory('StoryViewerBackendApiService', [
+  '$http', '$q', 'STORY_DATA_URL_TEMPLATE', 'UrlInterpolationService',
+  function($http, $q, STORY_DATA_URL_TEMPLATE, UrlInterpolationService) {
+    var storyDataDict = null;
+    var _fetchStoryData = function(storyId, successCallback, errorCallback) {
+      var storyDataUrl = UrlInterpolationService.interpolateUrl(
+        STORY_DATA_URL_TEMPLATE, {
+          story_id: storyId
+        });
+
+      $http.get(storyDataUrl).then(function(response) {
+        storyDataDict = angular.copy(response.data);
+        if (successCallback) {
+          successCallback(storyDataDict);
+        }
+      }, function(errorResponse) {
+        if (errorCallback) {
+          errorCallback(errorResponse.data);
+        }
+      });
+    };
+
+    return {
+      fetchStoryData: function(storyId) {
+        return $q(function(resolve, reject) {
+          _fetchStoryData(storyId, resolve, reject);
+        });
+      }
+    };
+  }
+]);

--- a/core/templates/dev/head/pages/story_viewer/StoryViewer.js
+++ b/core/templates/dev/head/pages/story_viewer/StoryViewer.js
@@ -1,0 +1,223 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Controller for the learner's view of a story.
+ */
+
+oppia.animation('.oppia-story-animate-slide', function() {
+  return {
+    enter: function(element) {
+      element.hide().slideDown();
+    },
+    leave: function(element) {
+      element.slideUp();
+    }
+  };
+});
+oppia.constant('NODE_ID_PREFIX', 'node_');
+
+oppia.controller('StoryViewer', [
+  '$scope', '$anchorScroll', '$location', '$http', 'UrlService',
+  'StoryViewerBackendApiService', 'StoryObjectFactory',
+  'StoryPlaythroughObjectFactory', 'AlertsService',
+  'UrlInterpolationService',
+  function(
+      $scope, $anchorScroll, $location, $http, UrlService,
+      StoryViewerBackendApiService, StoryObjectFactory,
+      StoryPlaythroughObjectFactory, AlertsService,
+      UrlInterpolationService) {
+    $scope.story = null;
+    $scope.storyPlaythrough = null;
+    $scope.storyId = UrlService.getStoryIdFromLearnerUrl();
+    $scope.pathIconParameters = [];
+    $scope.explorationCardIsShown = false;
+    $scope.getStaticImageUrl = UrlInterpolationService.getStaticImageUrl;
+    // The pathIconParameters is an array containing the co-ordinates,
+    // background color and icon url for the icons generated on the path.
+    $scope.pathIconParameters = [];
+    $scope.activeHighlightedIconIndex = -1;
+    $scope.MIN_HEIGHT_FOR_PATH_SVG_PX = 220;
+    $scope.ODD_SVG_HEIGHT_OFFSET_PX = 150;
+    $scope.EVEN_SVG_HEIGHT_OFFSET_PX = 280;
+    $scope.ICON_Y_INITIAL_PX = 35;
+    $scope.ICON_Y_INCREMENT_PX = 110;
+    $scope.ICON_X_MIDDLE_PX = 225;
+    $scope.ICON_X_LEFT_PX = 55;
+    $scope.ICON_X_RIGHT_PX = 395;
+    $scope.svgHeight = $scope.MIN_HEIGHT_FOR_PATH_SVG_PX;
+    $scope.nextExplorationId = null;
+
+    $scope.setIconHighlight = function(index) {
+      $scope.activeHighlightedIconIndex = index;
+    };
+
+    $scope.unsetIconHighlight = function() {
+      $scope.activeHighlightedIconIndex = -1;
+    };
+
+    $scope.togglePreviewCard = function() {
+      $scope.explorationCardIsShown = !$scope.explorationCardIsShown;
+    };
+
+    $scope.getNodeForNodeId = function(nodeId) {
+      var storyNode = $scope.story._storyContents.getNodeById(nodeId);
+      if (!storyNode) {
+        AlertsService.addWarning('There was an error loading the story.');
+      }
+      return storyNode;
+    };
+
+    $scope.updateExplorationPreview = function(nodeId) {
+      $scope.explorationCardIsShown = true;
+      $scope.currentNodeId = nodeId;
+      $scope.summaryToPreview = $scope.getNodeForNodeId(
+        nodeId).getExplorationSummaryObject();
+    };
+
+    // Calculates the SVG parameters required to draw the curved path.
+    $scope.generatePathParameters = function() {
+      // The pathSvgParameters represents the final string of SVG parameters
+      // for the bezier curve to be generated. The default parameters represent
+      // the first curve ie. lesson 1 to lesson 3.
+      $scope.pathSvgParameters = 'M250 80  C 470 100, 470 280, 250 300';
+      var storyNodeCount = $scope.story._storyContents.getNodeCount();
+      // The sParameterExtension represents the co-ordinates following the 'S'
+      // (smooth curve to) command in SVG.
+      var sParameterExtension = '';
+      $scope.pathIconParameters = $scope.generatePathIconParameters();
+      if (storyNodeCount === 1) {
+        $scope.pathSvgParameters = '';
+      } else if (storyNodeCount === 2) {
+        $scope.pathSvgParameters = 'M250 80  C 470 100, 470 280, 250 300';
+      } else {
+        // The x and y here represent the co-ordinates of the control points
+        // for the bezier curve (path).
+        var y = 500;
+        for (var i = 1; i < Math.floor(storyNodeCount / 2); i++) {
+          var x = (i % 2) ? 30 : 470;
+          sParameterExtension += x + ' ' + y + ', ';
+          y += 20;
+          sParameterExtension += 250 + ' ' + y + ', ';
+          y += 200;
+        }
+        if (sParameterExtension !== '') {
+          $scope.pathSvgParameters += ' S ' + sParameterExtension;
+        }
+      }
+      if (storyNodeCount % 2 === 0) {
+        if (storyNodeCount === 2) {
+          $scope.svgHeight = $scope.MIN_HEIGHT_FOR_PATH_SVG_PX;
+        } else {
+          $scope.svgHeight = y - $scope.EVEN_SVG_HEIGHT_OFFSET_PX;
+        }
+      } else {
+        if (storyNodeCount === 1) {
+          $scope.svgHeight = $scope.MIN_HEIGHT_FOR_PATH_SVG_PX;
+        } else {
+          $scope.svgHeight = y - $scope.ODD_SVG_HEIGHT_OFFSET_PX;
+        }
+      }
+    };
+
+    $scope.generatePathIconParameters = function() {
+      var storyNodes = $scope.story._storyContents.getNodes();
+      var iconParametersArray = [];
+      iconParametersArray.push({
+        thumbnailIconUrl:
+          storyNodes[0].getExplorationSummaryObject(
+          ).thumbnail_icon_url.replace('subjects', 'inverted_subjects'),
+        left: '225px',
+        top: '35px',
+        thumbnailBgColor:
+          storyNodes[0].getExplorationSummaryObject().thumbnail_bg_color
+      });
+
+      // Here x and y represent the co-ordinates for the icons in the path.
+      var x = $scope.ICON_X_MIDDLE_PX;
+      var y = $scope.ICON_Y_INITIAL_PX;
+      var countMiddleIcon = 1;
+
+      for (var i = 1; i < $scope.story._storyContents.getNodeCount(); i++) {
+        if (countMiddleIcon === 0 && x === $scope.ICON_X_MIDDLE_PX) {
+          x = $scope.ICON_X_LEFT_PX;
+          y += $scope.ICON_Y_INCREMENT_PX;
+          countMiddleIcon = 1;
+        } else if (countMiddleIcon === 1 && x === $scope.ICON_X_MIDDLE_PX) {
+          x = $scope.ICON_X_RIGHT_PX;
+          y += $scope.ICON_Y_INCREMENT_PX;
+          countMiddleIcon = 0;
+        } else {
+          x = $scope.ICON_X_MIDDLE_PX;
+          y += $scope.ICON_Y_INCREMENT_PX;
+        }
+        iconParametersArray.push({
+          thumbnailIconUrl:
+            storyNodes[i].getExplorationSummaryObject(
+            ).thumbnail_icon_url.replace('subjects', 'inverted_subjects'),
+          left: x + 'px',
+          top: y + 'px',
+          thumbnailBgColor:
+            storyNodes[i].getExplorationSummaryObject().thumbnail_bg_color
+        });
+      }
+      return iconParametersArray;
+    };
+
+    $scope.getExplorationUrl = function(explorationId) {
+      return ('/explore/' + explorationId);
+    };
+
+    // Load the story the learner wants to view.
+    StoryViewerBackendApiService.fetchStoryData(
+      $scope.storyId).then(
+      function(storyBackendObject) {
+        $scope.story = StoryObjectFactory.createFromBackendDict(
+          storyBackendObject);
+
+        $scope.storyPlaythrough = (
+          StoryPlaythroughObjectFactory.createFromBackendObject(
+            storyBackendObject.playthrough_dict));
+
+        $scope.nextExplorationId =
+          $scope.storyPlaythrough.getNextExplorationId();
+      },
+      function() {
+        AlertsService.addWarning(
+          'There was an error loading the story.');
+      }
+    );
+
+    $scope.closeOnClickingOutside = function() {
+      $scope.explorationCardIsShown = false;
+    };
+
+    $scope.onClickStopPropagation = function($evt) {
+      $evt.stopPropagation();
+    };
+
+    $scope.$watch('story', function(newValue) {
+      if (newValue !== null) {
+        $scope.generatePathParameters();
+      }
+    }, true);
+
+    // Touching anywhere outside the mobile preview should hide it.
+    document.addEventListener('touchstart', function() {
+      if ($scope.explorationCardIsShown === true) {
+        $scope.explorationCardIsShown = false;
+      }
+    });
+  }
+]);

--- a/core/templates/dev/head/pages/story_viewer/StoryViewerNavbarBreadcrumbDirective.js
+++ b/core/templates/dev/head/pages/story_viewer/StoryViewerNavbarBreadcrumbDirective.js
@@ -1,0 +1,35 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Directive for the navbar breadcrumb of the story viewer.
+ */
+oppia.directive('storyViewerNavbarBreadcrumb', [
+  'UrlInterpolationService', function(UrlInterpolationService) {
+    return {
+      restrict: 'E',
+      scope: {},
+      templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
+        '/pages/story_viewer/story_viewer_navbar_breadcrumb_directive.html'),
+      controller: ['$scope', 'StoryViewerBackendApiService', 'UrlService',
+        function($scope, StoryViewerBackendApiService, UrlService) {
+          StoryViewerBackendApiService.fetchStoryData(
+            UrlService.getStoryIdFromLearnerUrl()).then(
+            function(storyDataDict) {
+              $scope.storyTitle = storyDataDict.story_title;
+            });
+        }
+      ]
+    };
+  }]);

--- a/core/templates/dev/head/pages/story_viewer/story_viewer.html
+++ b/core/templates/dev/head/pages/story_viewer/story_viewer.html
@@ -1,0 +1,342 @@
+{% extends 'pages/base.html' %}
+
+{% block maintitle %}
+  {{ story_title }} - Oppia
+{% endblock maintitle %}
+
+{% block navbar_breadcrumb %}
+  <story-viewer-navbar-breadcrumb>
+  </story-viewer-navbar-breadcrumb>
+{% endblock navbar_breadcrumb %}
+
+{% block content %}
+  <div ng-controller="StoryViewer">
+    <background-banner></background-banner>
+    <div ng-if="story" class="oppia-story-player-tiles-container">
+      <h2 ng-if="!storyPlaythrough.hasFinishedStory()" class="oppia-page-heading" align="center">
+        <span ng-if="!storyPlaythrough.hasStartedStory()" class="oppia-story-player-title-font">Begin <[story.getTitle()]>:</span>
+        <span ng-if="storyPlaythrough.hasStartedStory()" class="oppia-story-player-title-font">Continue <[story.getTitle()]>:</span>
+      </h2>
+      <h2 ng-if="storyPlaythrough.hasFinishedStory()" class="oppia-page-heading">
+        <span>You have finished the story! Feel free to replay any explorations below.</span>
+      </h2>
+      <div ng-if="story" class="oppia-story-path-section hidden-sm hidden-xs">
+        <svg width="500px" ng-attr-height="<[svgHeight + 'px']>" xmlns="http://www.w3.org/2000/svg">
+          <path fill="none"
+                stroke="#296E5F"
+                stroke-dasharray="15,28"
+                stroke-linecap="round"
+                stroke-width="12"
+                d="M80 80 L220 80"/>
+          <path fill="none"
+                stroke="#296E5F"
+                stroke-dasharray="15,28"
+                stroke-linecap="round"
+                stroke-width="12"
+                ng-attr-d="<[pathSvgParameters]>"/>
+          <image ng-if="!storyPlaythrough.hasStartedStory()"
+                x="175"
+                y="100"
+                height="100"
+                width="100"
+                ng-attr-xlink:href="<[getStaticImageUrl('/general/collection_start_here_arrow.svg')]>"
+                xlink:href="">
+          </image>
+          <text ng-if="!storyPlaythrough.hasStartedStory()"
+                x="210"
+                y="170"
+                alignment-baseline="middle"
+                font-family="Capriola, Roboto, Arial, sans-serif"
+                font-size="15"
+                fill="#E14738"
+                text-anchor="middle"
+                translate="I18N_START_HERE">
+          </text>
+        </svg>
+
+        <img ng-src="<[getStaticImageUrl('/general/collection_mascot.svg')]>" class="story-mascot">
+        <a ng-repeat="node in story._storyContents.getNodes()"
+          ng-href="<[getExplorationUrl(node.getExplorationId())]>"
+          ng-style="{position: 'absolute', left: '<[pathIconParameters[$index].left]>', top: '<[pathIconParameters[$index].top]>'}">
+          <svg class="protractor-test-story-exploration"
+              width="100"
+              height="125"
+              xmlns="http://www.w3.org/2000/svg"
+              xmlns:xlink="http://www.w3.org/1999/xlink"
+              version="1.1">
+            <defs>
+              <pattern id="image<[$index]>" patternUnits="userSpaceOnUse" height="150" width="100">
+                <circle cx="50"
+                        cy="70"
+                        r="50"
+                        ng-attr-fill="<[pathIconParameters[$index].thumbnailBgColor]>"/>
+                <image ng-if="isCompletedExploration(node.getExplorationId())"
+                      x="0"
+                      y="20"
+                      height="100"
+                      width="100"
+                      ng-attr-xlink:href="<[getStaticImageUrl('/general/collection_paw.svg')]>"
+                      xlink:href="">
+                </image>
+                <image ng-if="!isCompletedExploration(node.getExplorationId())"
+                      x="10"
+                      y="30"
+                      height="80"
+                      width="80"
+                      ng-attr-xlink:href="<[getStaticImageUrl(pathIconParameters[$index].thumbnailIconUrl)]>"
+                      xlink:href="">
+                </image>
+              </pattern>
+            </defs>
+            <a xlink:href="<[getExplorationUrl(node.getExplorationId())]>"
+              ng-mouseover="updateExplorationPreview(node.getId());
+                            setIconHighlight($index);"
+              ng-mouseleave="togglePreviewCard();
+                              unsetIconHighlight($index);">
+              <circle ng-show="node.getExplorationId() === nextExplorationId &&
+                $index !== activeHighlightedIconIndex"
+                      cx="50"
+                      cy="70"
+                      r="50"
+                      id="<['highlight' + $index]>"
+                      fill="#FF8C00"
+                      fill-opacity="0.5"/>
+              <circle ng-show="($index===activeHighlightedIconIndex)?true:false"
+                      cx="50"
+                      cy="70"
+                      r="50"
+                      id="<['highlight' + $index]>"
+                      fill="#A6DACF"
+                      fill-opacity="0.5"/>
+              <circle cx="50"
+                      cy="70"
+                      r="42"
+                      fill="url(#image<[$index]>)"
+                      stroke="#006553"
+                      stroke-width="2"/>
+            </a>
+          </svg>
+        </a>
+      </div>
+
+      <div ng-if="story" class="oppia-story-table hidden-md hidden-lg hidden-xl">
+        <img ng-src="<[getStaticImageUrl('/general/collection_mascot.svg')]>" class="mobile-lesson-icon">
+        <div class="mobile-path-segment" ng-repeat="node in story._storyContents.getNodes()" id="mobile-path-anchor-<[$index]>">
+          <a href="" style="position: absolute; left: 50%; transform: translate(-50%, 195px); z-index: 1;">
+            <svg class="protractor-mobile-test-story-exploration"
+                 width="100"
+                 height="150"
+                 xmlns="http://www.w3.org/2000/svg"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 version="1.1"
+                 ng-click="scrollToLocation('mobile-path-anchor-' + $index); updateExplorationPreview(node.getId());">
+              <image ng-if="!storyPlaythrough.hasStartedStory() && $index===0"
+                     x="0"
+                     y="83"
+                     height="80"
+                     width="100"
+                     ng-attr-xlink:href="<[getStaticImageUrl('/general/collection_start_here_arrow.svg')]>"
+                     xlink:href="">
+              </image>
+              <text ng-if="!storyPlaythrough.hasStartedStory() && $index===0"
+                    x="50"
+                    y="140"
+                    alignment-baseline="middle"
+                    font-family="Capriola, Roboto, Arial, sans-serif"
+                    font-size="11"
+                    fill="#E14738"
+                    text-anchor="middle"
+                    translate="I18N_START_HERE">
+              </text>
+              <defs>
+                <pattern id="image0<[$index]>" patternUnits="userSpaceOnUse" height="150" width="100">
+                  <circle cx="50"
+                          cy="70"
+                          r="50"
+                          ng-attr-fill="<[pathIconParameters[$index].thumbnailBgColor]>"/>
+                  <image ng-if="isCompletedExploration(node.getExplorationId())"
+                         x="0"
+                         y="20"
+                         height="100"
+                         width="100"
+                         ng-attr-xlink:href="<[getStaticImageUrl('/general/collection_paw.svg')]>"
+                         xlink:href="">
+                  </image>
+                  <image ng-if="!isCompletedExploration(node.getExplorationId())"
+                         x="10"
+                         y="30"
+                         height="80"
+                         width="80"
+                         ng-attr-xlink:href="<[getStaticImageUrl(pathIconParameters[$index].thumbnailIconUrl)]>"
+                         xlink:href="">
+                  </image>
+                </pattern>
+              </defs>
+              <circle ng-show="node.getExplorationId() === nextExplorationId &&
+                $index !== activeHighlightedIconIndex"
+                      cx="50"
+                      cy="70"
+                      r="50"
+                      id="<['highlight' + $index]>"
+                      fill="#FF8C00"
+                      fill-opacity="0.5"/>
+              <circle ng-show="($index===activeHighlightedIconIndex)?true:false"
+                      cx="50"
+                      cy="70"
+                      r="50"
+                      id="<['highlight' + $index]>"
+                      fill="#A6DACF"
+                      fill-opacity="0.5"/>
+              <circle cx="50"
+                      cy="70"
+                      r="42"
+                      fill="url(#image0<[$index]>)"
+                      stroke="#006553"
+                      stroke-width="2"/>
+            </svg>
+          </a>
+          <img ng-src="<[getStaticImageUrl('/general/mobile_path_segment.svg')]>">
+          <div style="position: fixed; z-index: 100; top: 0; left: 0;">
+            <div ng-class="{'oppia-activity-summary-tile-mobile-background-mask': explorationCardIsShown}" ng-click="closeOnClickingOutside()">
+              <exploration-summary-tile ng-if="explorationCardIsShown"
+                                        ng-click="onClickStopPropagation($event)"
+                                        exploration-id="currentExplorationId"
+                                        exploration-title="summaryToPreview.title"
+                                        last-updated-msec="summaryToPreview.last_updated_msec"
+                                        objective="summaryToPreview.objective"
+                                        category="summaryToPreview.category"
+                                        ratings="summaryToPreview.ratings"
+                                        num-views="summaryToPreview.num_views"
+                                        thumbnail-icon-url="summaryToPreview.thumbnail_icon_url"
+                                        thumbnail-bg-color="summaryToPreview.thumbnail_bg_color"
+                                        is-community-owned="summaryToPreview.community_owned"
+                                        is-story-preview-tile="true"
+                                        style="position: absolute; z-index: 10;">
+              </exploration-summary-tile>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div ng-if="story" class="oppia-card-preview-panel hidden-sm hidden-xs">
+      <md-card class="oppia-activity-summary-tile md-default-theme">
+        <div class="title-section" style="background-color: blue; z-index: 1;">
+        </div>
+        <div class="title-section-mask objective oppia-activity-summary-tile-pre-hover-preview">
+          <span>Hover over an icon to preview an exploration.</span>
+        </div>
+      </md-card>
+      <exploration-summary-tile ng-if="explorationCardIsShown"
+                                exploration-id="currentExplorationId"
+                                exploration-title="summaryToPreview.title"
+                                last-updated-msec="summaryToPreview.last_updated_msec"
+                                objective="summaryToPreview.objective"
+                                category="summaryToPreview.category"
+                                ratings="summaryToPreview.ratings"
+                                num-views="summaryToPreview.num_views"
+                                thumbnail-icon-url="summaryToPreview.thumbnail_icon_url"
+                                thumbnail-bg-color="summaryToPreview.thumbnail_bg_color"
+                                is-community-owned="summaryToPreview.community_owned"
+                                style="position: absolute; left: 85px; top: 30px; z-index: 10;">
+      </exploration-summary-tile>
+      </div>
+    </div>
+  </div>
+
+  <style>
+    html, body {
+      background: #eeeeee no-repeat center center fixed;
+      background-size: cover;
+    }
+    .oppia-story-path-section {
+      background: #fff;
+      border-radius: 2px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.14), 0 2px 4px rgba(0, 0, 0, 0.23);
+      float: left;
+      margin-top: 20px;
+      max-width: 675px;
+      padding: 20px 20px 60px 20px;
+      position: absolute;
+      text-align: left;
+      top: 168px;
+    }
+    .oppia-story-table {
+      margin: 0 auto;
+      max-width: 90%;
+      padding: 50px 20px 420px 20px;
+      position: relative;
+      text-align: left;
+      top: 35px;
+      width: 100%;
+    }
+    .oppia-card-preview-panel {
+      background: #fff;
+      border-radius: 2px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.14), 0 2px 4px rgba(0, 0, 0, 0.23);
+      left: 50%;
+      padding: 30px 85px 70px 85px;
+      pointer-events: none;
+      position: fixed;
+      text-align: left;
+      top: 244px;
+      transform: translateX(29%);
+    }
+    .story-mascot {
+      left: 40px;
+      position: absolute;
+      top: 40px;
+      width: 120px;
+    }
+    @media only screen and (max-width : 600px) {
+      .oppia-story-player-title-font {
+        font-size: 32px;
+      }
+    }
+    /* To avoid double shadows caused by overlaying preview card
+    over the blank preview card */
+    .exploration-summary-tile md-card {
+      box-shadow: none;
+    }
+    .mobile-path-segment {
+      margin: 0 auto;
+      width: 250px;
+    }
+    .mobile-lesson-icon {
+      position: absolute;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 100px;
+    }
+
+    @media only screen and (max-width: 998px) {
+      .oppia-activity-summary-tile-mobile-background-mask {
+        align-items: center;
+        background: rgba(0,0,0,0.25);
+        display: flex;
+        height: 100vh;
+        justify-content: space-around;
+        width: 100vw;
+        z-index: -1;
+      }
+    }
+
+  </style>
+{% endblock %}
+
+{% block footer_js %}
+  {{ super() }}
+  <script src="/templates/dev/head/components/summary_tile/ExplorationSummaryTileDirective.js"></script>
+  <script src="/templates/dev/head/components/background/BackgroundBannerDirective.js"></script>
+
+  <script src="/templates/dev/head/components/summary_tile/CircularImageDirective.js"></script>
+
+  <script src="/templates/dev/head/domain/story_viewer/StoryViewerBackendApiService.js"></script>
+  <script src="/templates/dev/head/domain/story/StoryObjectFactory.js"></script>
+  <script src="/templates/dev/head/domain/story/StoryContentsObjectFactory.js"></script>
+  <script src="/templates/dev/head/domain/story_viewer/StoryPlaythroughObjectFactory.js"></script>
+  <script src="/templates/dev/head/domain/story/StoryNodeObjectFactory.js"></script>
+  <script src="/templates/dev/head/components/RatingComputationService.js"></script>
+
+  <script src="/templates/dev/head/pages/story_viewer/StoryViewerNavbarBreadcrumbDirective.js"></script>
+  <script src="/templates/dev/head/pages/story_viewer/StoryViewer.js"></script>
+{% endblock footer_js %}

--- a/core/templates/dev/head/pages/story_viewer/story_viewer.html
+++ b/core/templates/dev/head/pages/story_viewer/story_viewer.html
@@ -35,12 +35,12 @@
                 stroke-width="12"
                 ng-attr-d="<[pathSvgParameters]>"/>
           <image ng-if="!storyPlaythrough.hasStartedStory()"
-                x="175"
-                y="100"
-                height="100"
-                width="100"
-                ng-attr-xlink:href="<[getStaticImageUrl('/general/collection_start_here_arrow.svg')]>"
-                xlink:href="">
+                 x="175"
+                 y="100"
+                 height="100"
+                 width="100"
+                 ng-attr-xlink:href="<[getStaticImageUrl('/general/collection_start_here_arrow.svg')]>"
+                 xlink:href="">
           </image>
           <text ng-if="!storyPlaythrough.hasStartedStory()"
                 x="210"
@@ -56,14 +56,14 @@
 
         <img ng-src="<[getStaticImageUrl('/general/collection_mascot.svg')]>" class="story-mascot">
         <a ng-repeat="node in story._storyContents.getNodes()"
-          ng-href="<[getExplorationUrl(node.getExplorationId())]>"
-          ng-style="{position: 'absolute', left: '<[pathIconParameters[$index].left]>', top: '<[pathIconParameters[$index].top]>'}">
+           ng-href="<[getExplorationUrl(node.getExplorationId())]>"
+           ng-style="{position: 'absolute', left: '<[pathIconParameters[$index].left]>', top: '<[pathIconParameters[$index].top]>'}">
           <svg class="protractor-test-story-exploration"
-              width="100"
-              height="125"
-              xmlns="http://www.w3.org/2000/svg"
-              xmlns:xlink="http://www.w3.org/1999/xlink"
-              version="1.1">
+               width="100"
+               height="125"
+               xmlns="http://www.w3.org/2000/svg"
+               xmlns:xlink="http://www.w3.org/1999/xlink"
+               version="1.1">
             <defs>
               <pattern id="image<[$index]>" patternUnits="userSpaceOnUse" height="150" width="100">
                 <circle cx="50"
@@ -71,28 +71,28 @@
                         r="50"
                         ng-attr-fill="<[pathIconParameters[$index].thumbnailBgColor]>"/>
                 <image ng-if="isCompletedExploration(node.getExplorationId())"
-                      x="0"
-                      y="20"
-                      height="100"
-                      width="100"
-                      ng-attr-xlink:href="<[getStaticImageUrl('/general/collection_paw.svg')]>"
-                      xlink:href="">
+                       x="0"
+                       y="20"
+                       height="100"
+                       width="100"
+                       ng-attr-xlink:href="<[getStaticImageUrl('/general/collection_paw.svg')]>"
+                       xlink:href="">
                 </image>
                 <image ng-if="!isCompletedExploration(node.getExplorationId())"
-                      x="10"
-                      y="30"
-                      height="80"
-                      width="80"
-                      ng-attr-xlink:href="<[getStaticImageUrl(pathIconParameters[$index].thumbnailIconUrl)]>"
-                      xlink:href="">
+                       x="10"
+                       y="30"
+                       height="80"
+                       width="80"
+                       ng-attr-xlink:href="<[getStaticImageUrl(pathIconParameters[$index].thumbnailIconUrl)]>"
+                       xlink:href="">
                 </image>
               </pattern>
             </defs>
             <a xlink:href="<[getExplorationUrl(node.getExplorationId())]>"
-              ng-mouseover="updateExplorationPreview(node.getId());
+               ng-mouseover="updateExplorationPreview(node.getId());
                             setIconHighlight($index);"
-              ng-mouseleave="togglePreviewCard();
-                              unsetIconHighlight($index);">
+               ng-mouseleave="togglePreviewCard();
+                             unsetIconHighlight($index);">
               <circle ng-show="node.getExplorationId() === nextExplorationId &&
                 $index !== activeHighlightedIconIndex"
                       cx="50"
@@ -219,26 +219,26 @@
       </div>
 
       <div ng-if="story" class="oppia-card-preview-panel hidden-sm hidden-xs">
-      <md-card class="oppia-activity-summary-tile md-default-theme">
-        <div class="title-section" style="background-color: blue; z-index: 1;">
-        </div>
-        <div class="title-section-mask objective oppia-activity-summary-tile-pre-hover-preview">
-          <span>Hover over an icon to preview an exploration.</span>
-        </div>
-      </md-card>
-      <exploration-summary-tile ng-if="explorationCardIsShown"
-                                exploration-id="currentExplorationId"
-                                exploration-title="summaryToPreview.title"
-                                last-updated-msec="summaryToPreview.last_updated_msec"
-                                objective="summaryToPreview.objective"
-                                category="summaryToPreview.category"
-                                ratings="summaryToPreview.ratings"
-                                num-views="summaryToPreview.num_views"
-                                thumbnail-icon-url="summaryToPreview.thumbnail_icon_url"
-                                thumbnail-bg-color="summaryToPreview.thumbnail_bg_color"
-                                is-community-owned="summaryToPreview.community_owned"
-                                style="position: absolute; left: 85px; top: 30px; z-index: 10;">
-      </exploration-summary-tile>
+        <md-card class="oppia-activity-summary-tile md-default-theme">
+          <div class="title-section" style="background-color: blue; z-index: 1;">
+          </div>
+          <div class="title-section-mask objective oppia-activity-summary-tile-pre-hover-preview">
+            <span>Hover over an icon to preview an exploration.</span>
+          </div>
+        </md-card>
+        <exploration-summary-tile ng-if="explorationCardIsShown"
+                                  exploration-id="currentExplorationId"
+                                  exploration-title="summaryToPreview.title"
+                                  last-updated-msec="summaryToPreview.last_updated_msec"
+                                  objective="summaryToPreview.objective"
+                                  category="summaryToPreview.category"
+                                  ratings="summaryToPreview.ratings"
+                                  num-views="summaryToPreview.num_views"
+                                  thumbnail-icon-url="summaryToPreview.thumbnail_icon_url"
+                                  thumbnail-bg-color="summaryToPreview.thumbnail_bg_color"
+                                  is-community-owned="summaryToPreview.community_owned"
+                                  style="position: absolute; left: 85px; top: 30px; z-index: 10;">
+        </exploration-summary-tile>
       </div>
     </div>
   </div>

--- a/core/templates/dev/head/pages/story_viewer/story_viewer_navbar_breadcrumb_directive.html
+++ b/core/templates/dev/head/pages/story_viewer/story_viewer_navbar_breadcrumb_directive.html
@@ -1,0 +1,6 @@
+<div class="nav navbar-nav oppia-navbar-breadcrumb ng-cloak">
+  <span class="oppia-navbar-breadcrumb-separator"></span>
+  <span>
+    <[storyTitle]>
+  </span>
+</div>

--- a/core/templates/dev/head/services/contextual/UrlService.js
+++ b/core/templates/dev/head/services/contextual/UrlService.js
@@ -69,6 +69,13 @@ oppia.factory('UrlService', ['$window', function($window) {
       }
       throw Error('Invalid story id url');
     },
+    getStoryIdFromLearnerUrl: function() {
+      var pathname = this.getPathname();
+      if (pathname.match(/\/(story|topic)/g)) {
+        return pathname.split('/')[2];
+      }
+      throw Error('Invalid URL for topic');
+    },
     getStoryIdInPlayer: function() {
       var query = this.getCurrentQueryString();
       if (query.match(/\?story_id=((\w|-){12}\b)/g)) {

--- a/feconf.py
+++ b/feconf.py
@@ -373,7 +373,7 @@ ENABLE_PROMO_BAR = True
 ENABLE_MAINTENANCE_MODE = False
 
 # Disables all the new structures' pages, till they are completed.
-ENABLE_NEW_STRUCTURES = False
+ENABLE_NEW_STRUCTURES = True
 
 # The interactions permissible for a question.
 ALLOWED_QUESTION_INTERACTION_IDS = [
@@ -696,6 +696,8 @@ SKILL_PUBLISH_URL_PREFIX = '/skill_editor_handler/publish_skill'
 SPLASH_URL = '/splash'
 STORY_EDITOR_URL_PREFIX = '/story_editor'
 STORY_EDITOR_DATA_URL_PREFIX = '/story_editor_handler/data'
+STORY_VIEWER_URL_PREFIX = '/story'
+STORY_DATA_HANDLER = '/story_data_handler'
 SUGGESTION_ACTION_URL_PREFIX = '/suggestionactionhandler'
 SUGGESTION_LIST_URL_PREFIX = '/suggestionlisthandler'
 SUGGESTION_URL_PREFIX = '/suggestionhandler'

--- a/main.py
+++ b/main.py
@@ -41,6 +41,7 @@ from core.controllers import recent_commits
 from core.controllers import resources
 from core.controllers import skill_editor
 from core.controllers import story_editor
+from core.controllers import story_viewer
 from core.controllers import subscriptions
 from core.controllers import suggestion
 from core.controllers import topic_editor
@@ -335,6 +336,12 @@ URLS = MAPREDUCE_HANDLERS + [
     get_redirect_route(
         r'%s/<exploration_id>' % feconf.EXPLORATION_INIT_URL_PREFIX,
         reader.ExplorationHandler),
+    get_redirect_route(
+        r'%s/<story_id>' % feconf.STORY_VIEWER_URL_PREFIX,
+        story_viewer.StoryViewerPage),
+    get_redirect_route(
+        r'%s/<story_id>' % feconf.STORY_DATA_HANDLER,
+        story_viewer.StoryPageDataHandler),
     get_redirect_route(
         r'%s/<exploration_id>' % feconf.EXPLORATION_PRETESTS_URL_PREFIX,
         reader.PretestHandler),


### PR DESCRIPTION
In this PR so far:

- I've added backend controllers for story_viewer and defined routes.
- In the frontend, we have a story viewer page for learners that simply displays story nodes in a linear way.

UI mocks:
![screenshot from 2018-08-25 12-06-53](https://user-images.githubusercontent.com/20617436/44615778-03454c00-a860-11e8-8463-3fc42de2793f.png)
![screenshot from 2018-08-25 12-07-04](https://user-images.githubusercontent.com/20617436/44615779-03454c00-a860-11e8-8fbb-8d87eae342bb.png)
![screenshot from 2018-08-25 12-07-09](https://user-images.githubusercontent.com/20617436/44615780-03454c00-a860-11e8-8729-2a3836187ceb.png)
