### PR TITLE
Fix #4978 : change JSON response on user not logged in

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -440,7 +440,6 @@ class BaseHandler(webapp2.RequestHandler):
                 in debug mode.
         """
         if isinstance(exception, self.NotLoggedInException):
-
             # This checks if the response should be JSON or HTML.
             # For GET requests, there is no payload, so we check against
             # GET_HANDLER_ERROR_RETURN_TYPE.

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -440,8 +440,19 @@ class BaseHandler(webapp2.RequestHandler):
                 in debug mode.
         """
         if isinstance(exception, self.NotLoggedInException):
-            self.redirect(
-                current_user_services.create_login_url(self.request.uri))
+
+            # This checks if the response should be JSON or HTML.
+            # For GET requests, there is no payload, so we check against
+            # GET_HANDLER_ERROR_RETURN_TYPE.
+            # Otherwise, we check whether self.payload exists.
+            if (self.payload is not None or
+                    self.GET_HANDLER_ERROR_RETURN_TYPE ==
+                    feconf.HANDLER_TYPE_JSON):
+                self.error(401)
+                self._render_exception(401, {'error': unicode(exception)})
+            else:
+                self.redirect(
+                    current_user_services.create_login_url(self.request.uri))
             return
 
         logging.info(''.join(traceback.format_exception(*sys.exc_info())))

--- a/core/domain/acl_decorators_test.py
+++ b/core/domain/acl_decorators_test.py
@@ -218,11 +218,19 @@ class EditCollectionDecoratorTest(test_utils.GenericTestBase):
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
         rights_manager.publish_collection(self.owner, self.published_col_id)
 
-    def test_guest_is_redirected_to_login_page(self):
+    def test_guest_cannot_edit_collection_on_JSON_return_type(self):
         with self.swap(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.published_col_id, expect_errors=True,
                 expected_status_int=401)
+
+    def test_guest_is_redirected_on_HTML_return_type(self):
+        with self.swap(
+            self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
+            feconf.HANDLER_TYPE_HTML):
+            response = self.mock_testapp.get(
+                '/mock/%s' % self.published_col_id, expect_errors=True)
+        self.assertEqual(response.status_int, 302)
 
     def test_normal_user_cannot_edit_collection(self):
         self.login(self.user_email)
@@ -299,10 +307,17 @@ class CreateExplorationDecoratorTest(test_utils.GenericTestBase):
         self.assertEqual(response['success'], True)
         self.logout()
 
-    def test_guest_user_is_redirected_to_login_page(self):
+    def test_guest_cannot_create_exploration_on_JSON_return_type(self):
         with self.swap(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/create', expect_errors=True,
                           expected_status_int=401)
+
+    def test_guest_is_redirected_on_HTML_return_type(self):
+        with self.swap(
+            self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
+            feconf.HANDLER_TYPE_HTML):
+            response = self.mock_testapp.get('/mock/create', expect_errors=True)
+        self.assertEqual(response.status_int, 302)
 
 
 class CreateCollectionDecoratorTest(test_utils.GenericTestBase):
@@ -330,10 +345,17 @@ class CreateCollectionDecoratorTest(test_utils.GenericTestBase):
             debug=feconf.DEBUG,
         ))
 
-    def test_guest_user_is_redirected_to_login_page(self):
+    def test_guest_cannot_create_collection_on_JSON_return_type(self):
         with self.swap(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/create', expect_errors=True, expected_status_int=401)
+
+    def test_guest_is_redirected_on_HTML_return_type(self):
+        with self.swap(
+            self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
+            feconf.HANDLER_TYPE_HTML):
+            response = self.mock_testapp.get('/mock/create', expect_errors=True)
+        self.assertEqual(response.status_int, 302)
 
     def test_normal_user_cannot_create_collection(self):
         self.login(self.EDITOR_EMAIL)
@@ -427,7 +449,7 @@ class CommentOnFeedbackThreadTest(test_utils.GenericTestBase):
 
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
 
-    def test_guest_cannot_comment_on_feedback_threads(self):
+    def test_guest_cannot_comment_on_feedback_threads_on_JSON_return_type(self):
         with self.swap(constants, 'ENABLE_GENERALIZED_FEEDBACK_THREADS', True):
             with self.swap(self, 'testapp', self.mock_testapp):
                 self.get_json(
@@ -436,6 +458,20 @@ class CommentOnFeedbackThreadTest(test_utils.GenericTestBase):
                 self.get_json(
                     '/mock/exploration.%s.thread1' % self.published_exp_id,
                     expect_errors=True, expected_status_int=401)
+
+    def test_guest_is_redirected_on_HTML_return_type(self):
+        with self.swap(constants, 'ENABLE_GENERALIZED_FEEDBACK_THREADS', True):
+            with self.swap(
+                self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
+                feconf.HANDLER_TYPE_HTML):
+                response = self.mock_testapp.get(
+                    '/mock/exploration.%s.thread1' % self.private_exp_id,
+                    expect_errors=True)
+                self.assertEqual(response.status_int, 302)
+                response = self.mock_testapp.get(
+                    '/mock/exploration.%s.thread1' % self.published_exp_id,
+                    expect_errors=True)
+                self.assertEqual(response.status_int, 302)
 
     def test_owner_can_comment_on_feedback_for_private_exploration(self):
         self.login(self.OWNER_EMAIL)

--- a/core/domain/acl_decorators_test.py
+++ b/core/domain/acl_decorators_test.py
@@ -219,9 +219,10 @@ class EditCollectionDecoratorTest(test_utils.GenericTestBase):
         rights_manager.publish_collection(self.owner, self.published_col_id)
 
     def test_guest_is_redirected_to_login_page(self):
-        response = self.mock_testapp.get(
-            '/mock/%s' % self.published_col_id, expect_errors=True)
-        self.assertEqual(response.status_int, 302)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/%s' % self.published_col_id, expect_errors=True,
+                expected_status_int=401)
 
     def test_normal_user_cannot_edit_collection(self):
         self.login(self.user_email)
@@ -299,8 +300,9 @@ class CreateExplorationDecoratorTest(test_utils.GenericTestBase):
         self.logout()
 
     def test_guest_user_is_redirected_to_login_page(self):
-        response = self.mock_testapp.get('/mock/create', expect_errors=True)
-        self.assertEqual(response.status_int, 302)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json('/mock/create', expect_errors=True,
+                          expected_status_int=401)
 
 
 class CreateCollectionDecoratorTest(test_utils.GenericTestBase):
@@ -329,8 +331,9 @@ class CreateCollectionDecoratorTest(test_utils.GenericTestBase):
         ))
 
     def test_guest_user_is_redirected_to_login_page(self):
-        response = self.mock_testapp.get('/mock/create', expect_errors=True)
-        self.assertEqual(response.status_int, 302)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/create', expect_errors=True, expected_status_int=401)
 
     def test_normal_user_cannot_create_collection(self):
         self.login(self.EDITOR_EMAIL)
@@ -426,14 +429,13 @@ class CommentOnFeedbackThreadTest(test_utils.GenericTestBase):
 
     def test_guest_cannot_comment_on_feedback_threads(self):
         with self.swap(constants, 'ENABLE_GENERALIZED_FEEDBACK_THREADS', True):
-            response = self.mock_testapp.get(
-                '/mock/exploration.%s.thread1' % self.private_exp_id,
-                expect_errors=True)
-            self.assertEqual(response.status_int, 302)
-            response = self.mock_testapp.get(
-                '/mock/exploration.%s.thread1' % self.published_exp_id,
-                expect_errors=True)
-            self.assertEqual(response.status_int, 302)
+            with self.swap(self, 'testapp', self.mock_testapp):
+                self.get_json(
+                    '/mock/exploration.%s.thread1' % self.private_exp_id,
+                    expect_errors=True, expected_status_int=401)
+                self.get_json(
+                    '/mock/exploration.%s.thread1' % self.published_exp_id,
+                    expect_errors=True, expected_status_int=401)
 
     def test_owner_can_comment_on_feedback_for_private_exploration(self):
         self.login(self.OWNER_EMAIL)
@@ -1443,8 +1445,9 @@ class AccessLearnerDashboardDecoratorTest(test_utils.GenericTestBase):
 
     def test_banned_user_is_redirected(self):
         self.login(self.banned_user_email)
-        response = self.mock_testapp.get('/mock/', expect_errors=True)
-        self.assertEqual(response.status_int, 302)
+        with self.swap(self, 'testapp', self.mock_testapp):
+            self.get_json(
+                '/mock/', expect_errors=True, expected_status_int=401)
         self.logout()
 
     def test_exploration_editor_can_access_learner_dashboard(self):

--- a/core/domain/acl_decorators_test.py
+++ b/core/domain/acl_decorators_test.py
@@ -218,13 +218,13 @@ class EditCollectionDecoratorTest(test_utils.GenericTestBase):
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
         rights_manager.publish_collection(self.owner, self.published_col_id)
 
-    def test_guest_cannot_edit_collection_on_JSON_return_type(self):
+    def test_guest_cannot_edit_collection_via_json_handler(self):
         with self.swap(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.published_col_id, expect_errors=True,
                 expected_status_int=401)
 
-    def test_guest_is_redirected_on_HTML_return_type(self):
+    def test_guest_is_redirected_when_using_html_handler(self):
         with self.swap(
             self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
             feconf.HANDLER_TYPE_HTML):
@@ -307,12 +307,12 @@ class CreateExplorationDecoratorTest(test_utils.GenericTestBase):
         self.assertEqual(response['success'], True)
         self.logout()
 
-    def test_guest_cannot_create_exploration_on_JSON_return_type(self):
+    def test_guest_cannot_create_exploration_via_json_handler(self):
         with self.swap(self, 'testapp', self.mock_testapp):
             self.get_json('/mock/create', expect_errors=True,
                           expected_status_int=401)
 
-    def test_guest_is_redirected_on_HTML_return_type(self):
+    def test_guest_is_redirected_when_using_html_handler(self):
         with self.swap(
             self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
             feconf.HANDLER_TYPE_HTML):
@@ -345,12 +345,12 @@ class CreateCollectionDecoratorTest(test_utils.GenericTestBase):
             debug=feconf.DEBUG,
         ))
 
-    def test_guest_cannot_create_collection_on_JSON_return_type(self):
+    def test_guest_cannot_create_collection_via_json_handler(self):
         with self.swap(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/create', expect_errors=True, expected_status_int=401)
 
-    def test_guest_is_redirected_on_HTML_return_type(self):
+    def test_guest_is_redirected_when_using_html_handler(self):
         with self.swap(
             self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
             feconf.HANDLER_TYPE_HTML):
@@ -449,7 +449,7 @@ class CommentOnFeedbackThreadTest(test_utils.GenericTestBase):
 
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
 
-    def test_guest_cannot_comment_on_feedback_threads_on_JSON_return_type(self):
+    def test_guest_cannot_comment_on_feedback_threads_via_json_handler(self):
         with self.swap(constants, 'ENABLE_GENERALIZED_FEEDBACK_THREADS', True):
             with self.swap(self, 'testapp', self.mock_testapp):
                 self.get_json(
@@ -459,7 +459,7 @@ class CommentOnFeedbackThreadTest(test_utils.GenericTestBase):
                     '/mock/exploration.%s.thread1' % self.published_exp_id,
                     expect_errors=True, expected_status_int=401)
 
-    def test_guest_is_redirected_on_HTML_return_type(self):
+    def test_guest_is_redirected_when_using_html_handler(self):
         with self.swap(constants, 'ENABLE_GENERALIZED_FEEDBACK_THREADS', True):
             with self.swap(
                 self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',

--- a/core/domain/old_acl_decorators_test.py
+++ b/core/domain/old_acl_decorators_test.py
@@ -123,7 +123,7 @@ class CommentOnFeedbackThreadTest(test_utils.GenericTestBase):
 
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
 
-    def test_guest_cannot_comment_on_feedback_threads(self):
+    def test_guest_cannot_comment_on_feedback_threads_on_JSON_return_type(self):
         with self.swap(constants, 'ENABLE_GENERALIZED_FEEDBACK_THREADS', False):
             with self.swap(self, 'testapp', self.mock_testapp):
                 self.get_json(
@@ -132,6 +132,20 @@ class CommentOnFeedbackThreadTest(test_utils.GenericTestBase):
                 self.get_json(
                     '/mock/%s.thread1' % self.published_exp_id,
                     expect_errors=True, expected_status_int=401)
+
+    def test_guest_is_redirected_on_HTML_return_type(self):
+        with self.swap(constants, 'ENABLE_GENERALIZED_FEEDBACK_THREADS', True):
+            with self.swap(
+                self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',
+                feconf.HANDLER_TYPE_HTML):
+                response = self.mock_testapp.get(
+                    '/mock/exploration.%s.thread1' % self.private_exp_id,
+                    expect_errors=True)
+                self.assertEqual(response.status_int, 302)
+                response = self.mock_testapp.get(
+                    '/mock/exploration.%s.thread1' % self.published_exp_id,
+                    expect_errors=True)
+                self.assertEqual(response.status_int, 302)
 
     def test_owner_can_comment_on_feedback_for_private_exploration(self):
         self.login(self.OWNER_EMAIL)

--- a/core/domain/old_acl_decorators_test.py
+++ b/core/domain/old_acl_decorators_test.py
@@ -125,14 +125,13 @@ class CommentOnFeedbackThreadTest(test_utils.GenericTestBase):
 
     def test_guest_cannot_comment_on_feedback_threads(self):
         with self.swap(constants, 'ENABLE_GENERALIZED_FEEDBACK_THREADS', False):
-            response = self.mock_testapp.get(
-                '/mock/%s.thread1' % self.private_exp_id,
-                expect_errors=True)
-            self.assertEqual(response.status_int, 302)
-            response = self.mock_testapp.get(
-                '/mock/%s.thread1' % self.published_exp_id,
-                expect_errors=True)
-            self.assertEqual(response.status_int, 302)
+            with self.swap(self, 'testapp', self.mock_testapp):
+                self.get_json(
+                    '/mock/%s.thread1' % self.private_exp_id,
+                    expect_errors=True, expected_status_int=401)
+                self.get_json(
+                    '/mock/%s.thread1' % self.published_exp_id,
+                    expect_errors=True, expected_status_int=401)
 
     def test_owner_can_comment_on_feedback_for_private_exploration(self):
         self.login(self.OWNER_EMAIL)

--- a/core/domain/old_acl_decorators_test.py
+++ b/core/domain/old_acl_decorators_test.py
@@ -123,7 +123,7 @@ class CommentOnFeedbackThreadTest(test_utils.GenericTestBase):
 
         rights_manager.publish_exploration(self.owner, self.published_exp_id)
 
-    def test_guest_cannot_comment_on_feedback_threads_on_JSON_return_type(self):
+    def test_guest_cannot_comment_on_feedback_threads_via_json_handler(self):
         with self.swap(constants, 'ENABLE_GENERALIZED_FEEDBACK_THREADS', False):
             with self.swap(self, 'testapp', self.mock_testapp):
                 self.get_json(
@@ -133,7 +133,7 @@ class CommentOnFeedbackThreadTest(test_utils.GenericTestBase):
                     '/mock/%s.thread1' % self.published_exp_id,
                     expect_errors=True, expected_status_int=401)
 
-    def test_guest_is_redirected_on_HTML_return_type(self):
+    def test_guest_is_redirected_when_using_html_handler(self):
         with self.swap(constants, 'ENABLE_GENERALIZED_FEEDBACK_THREADS', True):
             with self.swap(
                 self.MockHandler, 'GET_HANDLER_ERROR_RETURN_TYPE',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->

Now, for JSON requests when user is not logged in, 401 is returned instead of 302(redirect).
Tests are also updated to use `get_json` accordingly.

Instead of 404(as mentioned [here](https://github.com/oppia/oppia/pull/4959#discussion_r190497434)), 401 is returned since it is more appropriate for the case in my understanding.

Fixes #4978
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.