### PR TITLE
Fixes to CopyToNewDirectoryJob

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -45,6 +45,7 @@ FILE_COPIED = 'File Copied'
 FILE_ALREADY_EXISTS = 'File already exists in GCS'
 FILE_DELETED = 'File has been deleted'
 FILE_FOUND_IN_GCS = 'File is there in GCS'
+EXP_REFERENCES_UNICODE_FILES = 'Exploration references unicode files'
 INVALID_GCS_URL = 'The url for the entity on GCS is invalid'
 NUMBER_OF_FILES_DELETED = 'Number of files that got deleted'
 WRONG_INSTANCE_ID = 'Error: The instance_id is not correct'
@@ -773,9 +774,25 @@ class CopyToNewDirectoryJob(jobs.BaseMapReduceOneOffJobManager):
             audio_filenames = [
                 GCS_AUDIO_ID_REGEX.match(url).group(3) for url in audio_urls]
 
+            references_unicode_files = False
             for image_filename in image_filenames:
                 try:
-                    raw_image = fs_old.get('image/%s' % image_filename)
+                    fs_old.get('image/%s' % image_filename)
+                except Exception as e:
+                    references_unicode_files = True
+                    break
+
+            if references_unicode_files:
+                image_filenames_str = '%s' % image_filenames
+                yield (
+                    EXP_REFERENCES_UNICODE_FILES,
+                    'Exp: %s, image filenames: %s' % (
+                        exp_id, image_filenames_str.encode('utf-8')))
+
+            for image_filename in image_filenames:
+                try:
+                    raw_image = fs_old.get(
+                        'image/%s' % image_filename.encode('utf-8'))
                     height, width = gae_image_services.get_image_dimensions(
                         raw_image)
                     filename_with_dimensions = (
@@ -783,8 +800,14 @@ class CopyToNewDirectoryJob(jobs.BaseMapReduceOneOffJobManager):
                             image_filename, height, width))
                     exp_services.save_original_and_compressed_versions_of_image( # pylint: disable=line-too-long
                         'ADMIN', filename_with_dimensions, exp_id, raw_image)
-                except Exception:
-                    yield (ERROR_IN_FILENAME, image_filename.encode('utf-8'))
+                except Exception as e:
+                    error = traceback.format_exc()
+                    logging.error(
+                        'File %s in %s failed migration: %s' %
+                        (image_filename.encode('utf-8'), exp_id, error))
+                    yield (
+                        ERROR_IN_FILENAME, 'Error when copying %s in %s: %s' % (
+                            image_filename.encode('utf-8'), exp_id, error))
 
             for audio_filename in audio_filenames:
                 filetype = audio_filename[audio_filename.rfind('.') + 1:]

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -778,7 +778,7 @@ class CopyToNewDirectoryJob(jobs.BaseMapReduceOneOffJobManager):
             for image_filename in image_filenames:
                 try:
                     fs_old.get('image/%s' % image_filename)
-                except Exception as e:
+                except Exception:
                     references_unicode_files = True
                     break
 
@@ -800,7 +800,7 @@ class CopyToNewDirectoryJob(jobs.BaseMapReduceOneOffJobManager):
                             image_filename, height, width))
                     exp_services.save_original_and_compressed_versions_of_image( # pylint: disable=line-too-long
                         'ADMIN', filename_with_dimensions, exp_id, raw_image)
-                except Exception as e:
+                except Exception:
                     error = traceback.format_exc()
                     logging.error(
                         'File %s in %s failed migration: %s' %

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -1687,19 +1687,19 @@ def save_original_and_compressed_versions_of_image(
     # already there. Also, even if the compressed, micro versions for some
     # image exists, then this would prevent from creating another copy of
     # the same.
-    if not fs.isfile(filepath):
+    if not fs.isfile(filepath.encode('utf-8')):
         fs.commit(
-            user_id, filepath, original_image_content,
+            user_id, filepath.encode('utf-8'), original_image_content,
             mimetype='image/%s' % filetype)
 
-    if not fs.isfile(compressed_image_filepath):
+    if not fs.isfile(compressed_image_filepath.encode('utf-8')):
         fs.commit(
-            user_id, compressed_image_filepath,
+            user_id, compressed_image_filepath.encode('utf-8'),
             compressed_image_content, mimetype='image/%s' % filetype)
 
-    if not fs.isfile(micro_image_filepath):
+    if not fs.isfile(micro_image_filepath.encode('utf-8')):
         fs.commit(
-            user_id, micro_image_filepath,
+            user_id, micro_image_filepath.encode('utf-8'),
             micro_image_content, mimetype='image/%s' % filetype)
 
 

--- a/core/platform/image/gae_image_services.py
+++ b/core/platform/image/gae_image_services.py
@@ -26,6 +26,10 @@ from google.appengine.api import images
 app_identity_services = models.Registry.import_app_identity_services()
 
 
+# The maximum width or length an image can be resized to, inclusive.
+MAX_RESIZE_DIMENSION_PX = 4000.0
+
+
 def get_image_dimensions(file_content):
     """Gets the dimensions of the image with the given file_content.
 
@@ -43,18 +47,34 @@ def get_image_dimensions(file_content):
 def compress_image(image_content, scaling_factor):
     """Compresses the image by resizing the image with the scaling factor.
 
+    Note that if the image's dimensions, after the scaling factor is applied,
+    exceed 4000 then the scaling factor will be recomputed and applied such that
+    the larger dimension of the image does not exceed 4000 after resizing. This
+    is due to an implementation limitation. See https://goo.gl/TJCbmE for
+    context.
+
     Args:
         image_content: str. Content of the file to be compressed.
         scaling_factor: float. The number by which the dimensions of the image
-            will be scaled.
+            will be scaled. This is expected to be greater than zero.
 
     Returns:
         str. Returns the content of the compressed image.
     """
     if not feconf.DEV_MODE:
         height, width = get_image_dimensions(image_content)
+        new_width = int(width * scaling_factor)
+        new_height = int(height * scaling_factor)
+        if (new_width > MAX_RESIZE_DIMENSION_PX
+            or new_height > MAX_RESIZE_DIMENSION_PX):
+            # Recompute the scaling factor such that the larger dimension does
+            # not exceed 4000 when scaled.
+            new_scaling_factor = MAX_RESIZE_DIMENSION_PX / max(width, height)
+            new_width = int(width * new_scaling_factor)
+            new_height = int(height * new_scaling_factor)
         return images.resize(
-            image_data=image_content, width=int(width * scaling_factor),
-            height=int(height * scaling_factor))
+            image_data=image_content,
+            width=min(new_width, MAX_RESIZE_DIMENSION_PX),
+            height=min(new_height, MAX_RESIZE_DIMENSION_PX))
     else:
         return image_content

--- a/core/platform/image/gae_image_services.py
+++ b/core/platform/image/gae_image_services.py
@@ -66,7 +66,7 @@ def compress_image(image_content, scaling_factor):
         new_width = int(width * scaling_factor)
         new_height = int(height * scaling_factor)
         if (new_width > MAX_RESIZE_DIMENSION_PX
-            or new_height > MAX_RESIZE_DIMENSION_PX):
+                or new_height > MAX_RESIZE_DIMENSION_PX):
             # Recompute the scaling factor such that the larger dimension does
             # not exceed 4000 when scaled.
             new_scaling_factor = MAX_RESIZE_DIMENSION_PX / max(width, height)


### PR DESCRIPTION
Fix CopyToNewDirectoryJob such that:
- Ensure image file names are properly encoded in UTF-8 since some filenames include Unicode characters
- Ensure that images are not resized above 4000x4000, as this is a PIL limitation

Also, improved logging and diagnostic support for the job to help with debugability.