### PR TITLE
Fix #5600: correctly align the translation progress label in Firefox

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/translator_overview_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/translator_overview_directive.html
@@ -47,4 +47,29 @@
     padding: 2px;
     border-radius: 8px;
   }
+  /* Firefox rules */
+  @-moz-document url-prefix(){
+    .oppia-translation-progress {
+      display: inline-flex;
+      margin-top: 8px;
+    }
+    .oppia-translator-overview{
+      width:650px;
+      height: 45px;
+      padding-top: 5px;
+      text-align: center;
+      margin: 0 auto;
+    }
+    .oppia-progress-info {
+      display: inline-block;
+      width: 300px;
+      font-size: 16px;
+    }
+    .oppia-translation-progess-bar {
+      display: inline-block;
+      margin-top: 5px;
+      width: 350px;
+      height: 10px;
+    }
+  }
 </style>

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/translator_overview_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/translator_overview_directive.html
@@ -19,17 +19,17 @@
 
 <style>
   .oppia-translator-overview {
-    width: 600px;
     height: 45px;
+    margin: 0 auto;
     padding-top: 5px;
     text-align: center;
-    margin: 0 auto;
+    width: 600px;
   }
   .oppia-progress-info {
     display: -webkit-flex;
     display: flex;
-    width: 250px;
     font-size: 16px;
+    width: 250px;
   }
   .oppia-translation-progress {
     display: -webkit-flex;
@@ -39,37 +39,37 @@
   .oppia-translation-progess-bar {
     display: -webkit-flex;
     display: flex;
+    height: 10px;
     margin-top: 5px;
     width: 350px;
-    height: 10px;
   }
   .oppia-translation-language-selector {
-    padding: 2px;
     border-radius: 8px;
+    padding: 2px;
   }
   /* Firefox rules */
-  @-moz-document url-prefix(){
+  @-moz-document url-prefix() {
     .oppia-translation-progress {
       display: inline-flex;
       margin-top: 8px;
     }
-    .oppia-translator-overview{
-      width:650px;
+    .oppia-translator-overview {
       height: 45px;
+      margin: 0 auto;
       padding-top: 5px;
       text-align: center;
-      margin: 0 auto;
+      width: 650px;
     }
     .oppia-progress-info {
       display: inline-block;
-      width: 300px;
       font-size: 16px;
+      width: 300px;
     }
     .oppia-translation-progess-bar {
       display: inline-block;
+      height: 10px;
       margin-top: 5px;
       width: 350px;
-      height: 10px;
     }
   }
 </style>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes#5600 Firefox translation progress font-weight label.
 
## Checklist
- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [X] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [X] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
