### PR TITLE
Start selenium server using a specific chromedriver

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -61,6 +61,10 @@ function maybeInstallDependencies {
     bash scripts/install_frontend_tests_dependencies.sh
 
     $NODE_MODULE_DIR/.bin/webdriver-manager update --versions.chrome 2.41
+    # Start a selenium server using chromedriver 2.41.
+    # The 'detach' option continues the flow once the server is up and runnning.
+    # The 'quiet' option prints only the necessary information about the server start-up
+    # process.
     $NODE_MODULE_DIR/.bin/webdriver-manager start --versions.chrome 2.41 --detach --quiet
   fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -61,6 +61,7 @@ function maybeInstallDependencies {
     bash scripts/install_frontend_tests_dependencies.sh
 
     $NODE_MODULE_DIR/.bin/webdriver-manager update --versions.chrome 2.41
+    $NODE_MODULE_DIR/.bin/webdriver-manager start --versions.chrome 2.41 --detach --quiet
   fi
 
   if [ "$RUN_MINIFIED_TESTS" = "true" ]; then


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
Sometime back, we had fixed the Chrome version we use to run end-to-end tests but we were still susceptible to updates to the chromedriver. Chromedriver gets frequently updated and each new version drops support for some earlier version of Chrome, implying that we eventually had to update the Chrome version as well!
This PR fixes this issue by starting a selenium server using a specific chromedriver manually.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
