### PR TITLE
Fix #5651: Keep a count of warnings in total_errors

### DIFF
--- a/scripts/backend_tests.py
+++ b/scripts/backend_tests.py
@@ -316,9 +316,10 @@ def main():
                 # There was an internal error, and the tests did not run (The
                 # error message did not match `tests_failed_regex_match`).
                 test_count = 0
+                total_errors += 1
                 print ''
                 print '------------------------------------------------------'
-                print '    WARNING: FAILED TO RUN TESTS.'
+                print '    WARNING: FAILED TO RUN %s' % spec.test_target
                 print ''
                 print '    This is most likely due to an import error.'
                 print '------------------------------------------------------'


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
Fixes #5651
Tested by un-doing the changes made by @vojtechjelinek to fix the tests.
## Checklist
- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [X] The PR explanation includes the words "Fixes #bugnum: ...".
- [X] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [X] The PR is made from a branch that's **not** called "develop".
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [X] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
