### PR TITLE
Fix #5607: fixed error thrown for drag and drop interaction on mobile

### DIFF
--- a/extensions/interactions/DragAndDropSortInput/directives/drag_and_drop_sort_input_interaction_directive.html
+++ b/extensions/interactions/DragAndDropSortInput/directives/drag_and_drop_sort_input_interaction_directive.html
@@ -60,11 +60,15 @@
        will break, as this container will not be scrollable when there are a lot
        of draggable items (see issue #5280). So, it has to be set as
        overflow:scroll with a definite max-height.
+
+       touch-action:manipulation is used for fixing the error (see issue #5607) 
+       while also maintaining vertical touch movements and zoom touch actions.
     */
     margin: auto;
     max-height: 400px;
     overflow: scroll;
     padding: 10px;
+    touch-action:manipulation;
   }
 </style>
 

--- a/extensions/interactions/DragAndDropSortInput/directives/drag_and_drop_sort_input_interaction_directive.html
+++ b/extensions/interactions/DragAndDropSortInput/directives/drag_and_drop_sort_input_interaction_directive.html
@@ -61,8 +61,8 @@
        of draggable items (see issue #5280). So, it has to be set as
        overflow:scroll with a definite max-height.
 
-       'touch-action:manipulation' is used for fixing the error thrown by drag 
-       and drop interactions on mobile (see issue #5607), while also maintaining 
+       'touch-action:manipulation' is used for fixing the error thrown by drag
+       and drop interactions on mobile (see issue #5607), while also maintaining
        vertical touch movements and zoom touch actions.
     */
     margin: auto;

--- a/extensions/interactions/DragAndDropSortInput/directives/drag_and_drop_sort_input_interaction_directive.html
+++ b/extensions/interactions/DragAndDropSortInput/directives/drag_and_drop_sort_input_interaction_directive.html
@@ -61,14 +61,15 @@
        of draggable items (see issue #5280). So, it has to be set as
        overflow:scroll with a definite max-height.
 
-       touch-action:manipulation is used for fixing the error (see issue #5607)
-       while also maintaining vertical touch movements and zoom touch actions.
+       'touch-action:manipulation' is used for fixing the error thrown by drag 
+       and drop interactions on mobile (see issue #5607), while also maintaining 
+       vertical touch movements and zoom touch actions.
     */
     margin: auto;
     max-height: 400px;
     overflow: scroll;
     padding: 10px;
-    touch-action:manipulation;
+    touch-action: manipulation;
   }
 </style>
 

--- a/extensions/interactions/DragAndDropSortInput/directives/drag_and_drop_sort_input_interaction_directive.html
+++ b/extensions/interactions/DragAndDropSortInput/directives/drag_and_drop_sort_input_interaction_directive.html
@@ -59,9 +59,9 @@
        If this class is removed, the auto-scrolling in Drag and drop interaction
        will break, as this container will not be scrollable when there are a lot
        of draggable items (see issue #5280). So, it has to be set as
-       overflow:scroll with a definite max-height.
+       overflow: scroll with a definite max-height.
 
-       'touch-action:manipulation' is used for fixing the error thrown by drag
+       'touch-action: manipulation' is used for fixing the error thrown by drag
        and drop interactions on mobile (see issue #5607), while also maintaining
        vertical touch movements and zoom touch actions.
     */

--- a/extensions/interactions/DragAndDropSortInput/directives/drag_and_drop_sort_input_interaction_directive.html
+++ b/extensions/interactions/DragAndDropSortInput/directives/drag_and_drop_sort_input_interaction_directive.html
@@ -61,7 +61,7 @@
        of draggable items (see issue #5280). So, it has to be set as
        overflow:scroll with a definite max-height.
 
-       touch-action:manipulation is used for fixing the error (see issue #5607) 
+       touch-action:manipulation is used for fixing the error (see issue #5607)
        while also maintaining vertical touch movements and zoom touch actions.
     */
     margin: auto;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
 Fixed #5607 while also keeping touch functionality in the designated drag and drop interaction 
area. Referred to this [documentation](https://developers.google.com/web/updates/2017/01/scrolling-intervention) for solving the issue.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [x] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
