### PR TITLE
Added one off job and validation job to populate last_updated field.

### DIFF
--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -61,8 +61,8 @@ class ValidateLastUpdatedFieldOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     @staticmethod
     def map(item):
         if item.last_updated is None:
-            yield (type(item).__name__, 1)
+            yield (type(item).__name__, item.id)
 
     @staticmethod
-    def reduce(key, value):
-        yield (key, len(value))
+    def reduce(key, instance_ids):
+        yield (key, instance_ids)

--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -61,7 +61,7 @@ class ValidateLastUpdatedFieldOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     @staticmethod
     def map(item):
         if item.last_updated is None:
-            yield ('count', 1)
+            yield (type(item).__name__, 1)
 
     @staticmethod
     def reduce(key, value):

--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -1,0 +1,68 @@
+# Copyright 2018 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One off jobs relating to the feedback framework."""
+
+from core import jobs
+from core.platform import models
+
+(feedback_models, email_models, user_models) = models.Registry.import_models(
+    [models.NAMES.feedback, models.NAMES.email, models.NAMES.user])
+
+
+class PopulateLastUpdatedFieldOneOffJob(jobs.BaseMapReduceOneOffJobManager):
+    """One-off job for populating last updated field for migrated models."""
+
+    @classmethod
+    def entity_classes_to_map_over(cls):
+        """Return a list of datastore class references to map over."""
+        return [feedback_models.GeneralFeedbackThreadModel,
+                feedback_models.GeneralFeedbackMessageModel,
+                feedback_models.GeneralFeedbackThreadUserModel,
+                email_models.GeneralFeedbackEmailReplyToIdModel,
+                user_models.UserSubscriptionsModel]
+
+    @staticmethod
+    def map(item):
+        if item.last_updated is None:
+            # Sets the last updated time as the time of the job run.
+            item.put()
+
+    @staticmethod
+    def reduce(key, value):
+        pass
+
+
+class ValidateLastUpdatedFieldOneOffJob(jobs.BaseMapReduceOneOffJobManager):
+    """One-off job for validating that the last updated field is not None for
+    migrated models.
+    """
+
+    @classmethod
+    def entity_classes_to_map_over(cls):
+        """Return a list of datastore class references to map over."""
+        return [feedback_models.GeneralFeedbackThreadModel,
+                feedback_models.GeneralFeedbackMessageModel,
+                feedback_models.GeneralFeedbackThreadUserModel,
+                email_models.GeneralFeedbackEmailReplyToIdModel,
+                user_models.UserSubscriptionsModel]
+
+    @staticmethod
+    def map(item):
+        if item.last_updated is None:
+            yield ('count', 1)
+
+    @staticmethod
+    def reduce(key, value):
+        yield (key, len(value))

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -21,6 +21,7 @@ from core.domain import collection_jobs_one_off
 from core.domain import email_jobs_one_off
 from core.domain import exp_jobs_one_off
 from core.domain import feedback_jobs_continuous
+from core.domain import feedback_jobs_one_off
 from core.domain import recommendations_jobs_one_off
 from core.domain import stats_jobs_continuous
 from core.domain import stats_jobs_one_off
@@ -54,6 +55,8 @@ ONE_OFF_JOB_MANAGERS = [
     exp_jobs_one_off.InteractionCustomizationArgsValidationJob,
     exp_jobs_one_off.CopyToNewDirectoryJob,
     exp_jobs_one_off.VerifyAllUrlsMatchGcsIdRegexJob,
+    feedback_jobs_one_off.PopulateLastUpdatedFieldOneOffJob,
+    feedback_jobs_one_off.ValidateLastUpdatedFieldOneOffJob,
     recommendations_jobs_one_off.ExplorationRecommendationsOneOffJob,
     stats_jobs_one_off.ExplorationIssuesModelCreatorOneOffJob,
     stats_jobs_one_off.RecomputeStatisticsOneOffJob,


### PR DESCRIPTION
## Explanation
Following up from https://github.com/oppia/oppia/pull/5631#issuecomment-421218353.
The best we can do is to just make the last_updated field to the current value by doing a put operation. To set the last_updated field to something specific, we would need to override the field again, and then set it, and then remove the override (which is exactly what we tried to do here!). So I think we would just end up in this cycle if we try to set something specific.

Please take a look @seanlip.

Also /cc @tjiang11 as this PR needs to go into the release :)

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
