### PR TITLE
Fix #4883: Improvement to tabbing order 

### DIFF
--- a/core/templates/dev/head/components/side_navigation_bar/SideNavigationBarDirective.js
+++ b/core/templates/dev/head/components/side_navigation_bar/SideNavigationBarDirective.js
@@ -24,10 +24,18 @@ oppia.directive('sideNavigationBar', [
       templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
         '/components/side_navigation_bar/' +
         'side_navigation_bar_directive.html'),
-      controller: ['$scope', '$timeout', function(
-          $scope, $timeout) {
+      controller: ['$scope', '$timeout', 'WindowDimensionsService', function(
+          $scope, $timeout, WindowDimensionsService) {
         $scope.NAV_MODE = GLOBALS.NAV_MODE;
         $scope.getStaticImageUrl = UrlInterpolationService.getStaticImageUrl;
+        $scope.windowIsNarrow = WindowDimensionsService.isWindowNarrow();
+
+
+        WindowDimensionsService.registerOnResizeHook(function() {
+            $scope.windowIsNarrow = WindowDimensionsService.isWindowNarrow();
+            $scope.$apply();  
+        });
+
       }]
     };
   }]);

--- a/core/templates/dev/head/components/side_navigation_bar/SideNavigationBarDirective.js
+++ b/core/templates/dev/head/components/side_navigation_bar/SideNavigationBarDirective.js
@@ -30,12 +30,10 @@ oppia.directive('sideNavigationBar', [
         $scope.getStaticImageUrl = UrlInterpolationService.getStaticImageUrl;
         $scope.windowIsNarrow = WindowDimensionsService.isWindowNarrow();
 
-
         WindowDimensionsService.registerOnResizeHook(function() {
-            $scope.windowIsNarrow = WindowDimensionsService.isWindowNarrow();
-            $scope.$apply();  
+          $scope.windowIsNarrow = WindowDimensionsService.isWindowNarrow();
+          $scope.$apply();
         });
-
       }]
     };
   }]);

--- a/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/side_navigation_bar/side_navigation_bar_directive.html
@@ -81,7 +81,7 @@
   }
 
 </style>
-<nav class="oppia-sidebar-menu oppia-sidebar-menu-transition">
+<nav class="oppia-sidebar-menu oppia-sidebar-menu-transition" ng-if="windowIsNarrow">
   <div class="oppia-sidebar-header">
     <div class="oppia-sidebar-logo-container">
     </div>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fix #4883: Improvement to tabbing order
As a first step, to removed hidden menu items from the tabbing order,  I used ng-if to remove side_navigation_bar directive, depending on the value of WindowDimensionsService.isWindowNarrow().  I also worked on the tabbing order itself.


## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.