### PR TITLE
Fix #5688: Added users to user condition if only 1 user has reviewed an exploration

### DIFF
--- a/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
+++ b/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
@@ -38,7 +38,12 @@
           <h1 class="stat-value-with-rating" ng-show="dashboardStats.num_ratings || relativeChangeInTotalPlays"><[dashboardStats.average_ratings || 'N/A']></h1>
           <h1 class="stat-value-without-rating" ng-hide="dashboardStats.num_ratings || relativeChangeInTotalPlays"><[dashboardStats.average_ratings || 'N/A']></h1>
           <p ng-hide="!dashboardStats.num_ratings">
-            (by <[dashboardStats.num_ratings]> users)
+            <p ng-hide="dashboardStats.num_ratings == 1">
+                (by <[dashboardStats.num_ratings]> users)
+              </p>
+              <p ng-hide="dashboardStats.num_ratings > 1">
+                (by <[dashboardStats.num_ratings]> user)
+              </p>
           </p>
         </div>
         <div class="total-plays stats-card">

--- a/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
+++ b/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
@@ -38,11 +38,11 @@
           <h1 class="stat-value-with-rating" ng-show="dashboardStats.num_ratings || relativeChangeInTotalPlays"><[dashboardStats.average_ratings || 'N/A']></h1>
           <h1 class="stat-value-without-rating" ng-hide="dashboardStats.num_ratings || relativeChangeInTotalPlays"><[dashboardStats.average_ratings || 'N/A']></h1>
           <p ng-hide="!dashboardStats.num_ratings">
-            <p ng-hide="dashboardStats.num_ratings == 1">
-              (by <[dashboardStats.num_ratings]> users)
-            </p>
-            <p ng-hide="dashboardStats.num_ratings > 1">
+            <p ng-if="dashboardStats.num_ratings === 1">
               (by <[dashboardStats.num_ratings]> user)
+            </p>
+            <p ng-if="dashboardStats.num_ratings > 1">
+              (by <[dashboardStats.num_ratings]> users)
             </p>
           </p>
         </div>

--- a/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
+++ b/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
@@ -39,11 +39,11 @@
           <h1 class="stat-value-without-rating" ng-hide="dashboardStats.num_ratings || relativeChangeInTotalPlays"><[dashboardStats.average_ratings || 'N/A']></h1>
           <p ng-hide="!dashboardStats.num_ratings">
             <p ng-hide="dashboardStats.num_ratings == 1">
-                (by <[dashboardStats.num_ratings]> users)
-              </p>
-              <p ng-hide="dashboardStats.num_ratings > 1">
-                (by <[dashboardStats.num_ratings]> user)
-              </p>
+              (by <[dashboardStats.num_ratings]> users)
+            </p>
+            <p ng-hide="dashboardStats.num_ratings > 1">
+              (by <[dashboardStats.num_ratings]> user)
+            </p>
           </p>
         </div>
         <div class="total-plays stats-card">


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include 
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
  - when this PR is merged.
  -->
*Fixes #5688 
Edited `creator_dashboard.html` so that if there is only a single user that has reviewed an exploration the text displayed is `(by 1 user)` instead of `(by 1 users)`.   