### PR TITLE
Add additional instructions for prefixing PR title for partial fixes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,8 @@
   -->
 
 ## Checklist
-- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
-- [ ] The PR explanation includes the words "Fixes #bugnum: ...". If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".
+- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
+- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
 - [ ] The linter/Karma presubmit checks have passed.
   - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
 - [ ] The PR is made from a branch that's **not** called "develop".

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,14 +5,14 @@
 
 ## Explanation
 <!--
-  - Explain what your PR does. If this PR fixes an existing bug, please include 
-  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue 
+  - Explain what your PR does. If this PR fixes an existing bug, please include
+  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
   - when this PR is merged.
   -->
 
 ## Checklist
 - [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
-- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
+- [ ] The PR explanation includes the words "Fixes #bugnum: ...". If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".
 - [ ] The linter/Karma presubmit checks have passed.
   - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
 - [ ] The PR is made from a branch that's **not** called "develop".


### PR DESCRIPTION
## Explanation
Add instructions on how to prefix PR title if the PR only partially fixes an issue. 

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes.
- [ ] The PR explanation includes the words "Fixes #bugnum: ...".
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
