### PR TITLE
Fix part of #4374: Added docstrings to scripts.cut_release_branch and scripts.pylint_ext…

### DIFF
--- a/scripts/cut_release_branch.py
+++ b/scripts/cut_release_branch.py
@@ -35,12 +35,12 @@ import common  # pylint: disable=relative-import
 
 
 def new_version_type(arg, pattern=re.compile(r'\d\.\d\.\d')):
-    r"""Checks that the new version name matches the expected pattern.
+    """Checks that the new version name matches the expected pattern.
 
     Args:
         arg: str. The new version name.
         pattern: RegularExpression. The pattern that release version should
-            match. Default is r'\d\.\d\.\d'.
+            match.
 
     Raises:
         argparse.ArgumentTypeError: The new version name does not match
@@ -76,7 +76,11 @@ def _verify_target_branch_does_not_already_exist(remote_alias):
     remotely.
 
     Args:
-        remote_alias: str. The alias that points to the remote oppia repository.
+        remote_alias: str. The alias that points to the remote oppia
+            repository. Example: When calling git remote -v, you get:
+            upstream    https://github.com/oppia/oppia.git (fetch),
+            where 'upstream' is the alias that points to the remote oppia
+            repository.
 
     Raises:
         Exception: The target branch name already exists locally.
@@ -104,13 +108,14 @@ def _verify_target_version_is_consistent_with_latest_released_version():
     Raises:
         Exception: Failed to fetch latest release info from GitHub.
         Exception: Could not parse version number of latest GitHub release.
-        AssertionError: The previous and the current version are not the same.
-        AssertionError: The current patch is not equal to previous patch plus
-            one.
-        AssertionError: The current patch is greater or equal to 10.
-        AssertionError: The current minor is not equal to previous minor plus
-            one.
-        AssertionError: The current patch is different than 0.
+        AssertionError: The previous and the current major version are not the
+            same.
+        AssertionError: The current patch version is not equal to previous patch
+            version plus one.
+        AssertionError: The current patch version is greater or equal to 10.
+        AssertionError: The current minor version is not equal to previous
+            minor version plus one.
+        AssertionError: The current patch version is different than 0.
     """
     response = urllib.urlopen(
         'https://api.github.com/repos/oppia/oppia/releases/latest')

--- a/scripts/cut_release_branch.py
+++ b/scripts/cut_release_branch.py
@@ -35,6 +35,20 @@ import common  # pylint: disable=relative-import
 
 
 def new_version_type(arg, pattern=re.compile(r'\d\.\d\.\d')):
+    r"""Checks that the new version name matches the expected pattern.
+
+    Args:
+        arg: str. The new version name.
+        pattern: RegularExpression. The pattern that release version should
+        match. Default is re.compile(re'\d\.\d\.\d').
+
+    Raises:
+        argparse.ArgumentTypeError: The new version name does not match
+        the pattern.
+
+    Returns:
+        str. The new version name with correct pattern.
+    """
     if not pattern.match(arg):
         raise argparse.ArgumentTypeError(
             'The format of "new_version" should be: x.x.x')
@@ -60,6 +74,14 @@ assert '.' not in NEW_APP_YAML_VERSION
 def _verify_target_branch_does_not_already_exist(remote_alias):
     """Checks that the new release branch doesn't already exist locally or
     remotely.
+
+    Args:
+        remote_alias: The alias that points to the remote oppia repository.
+
+    Raises:
+        Exception: The target branch name already exists locally.
+        Exception: The target branch name already exists on the remote
+        oppia repository.
     """
 
     git_branch_output = subprocess.check_output(['git', 'branch'])
@@ -78,6 +100,17 @@ def _verify_target_branch_does_not_already_exist(remote_alias):
 def _verify_target_version_is_consistent_with_latest_released_version():
     """Checks that the target version is consistent with the latest released
     version on GitHub.
+
+    Raises:
+        Exception: Failed to fetch latest release info from GitHub.
+        Exception: Could not parse version number of latest GitHub release.
+        AssertionError: The previous and the current version are not the same.
+        AssertionError: The current patch and the previous one plus one are not
+        the same.
+        AssertionError: The current patch is greater or equal to 10.
+        AssertionError: The current minor and the previous one plus one are not
+        the same.
+        AssertionError: The current patch is different than 0.
     """
     response = urllib.urlopen(
         'https://api.github.com/repos/oppia/oppia/releases/latest')
@@ -108,6 +141,11 @@ def _verify_target_version_is_consistent_with_latest_released_version():
 
 
 def _execute_branch_cut():
+    """Prepares, cuts, creates and pushes to GitHub the new release branch.
+
+    Raises:
+         AssertionError: 'version: default' was not found in app.yaml
+    """
     # Do prerequisite checks.
     common.require_cwd_to_be_oppia()
     common.verify_local_repo_is_clean()

--- a/scripts/cut_release_branch.py
+++ b/scripts/cut_release_branch.py
@@ -40,7 +40,7 @@ def new_version_type(arg, pattern=re.compile(r'\d\.\d\.\d')):
     Args:
         arg: str. The new version name.
         pattern: RegularExpression. The pattern that release version should
-            match. Default is re.compile(r'\d\.\d\.\d').
+            match. Default is r'\d\.\d\.\d'.
 
     Raises:
         argparse.ArgumentTypeError: The new version name does not match
@@ -105,11 +105,11 @@ def _verify_target_version_is_consistent_with_latest_released_version():
         Exception: Failed to fetch latest release info from GitHub.
         Exception: Could not parse version number of latest GitHub release.
         AssertionError: The previous and the current version are not the same.
-        AssertionError: The current patch and the previous one plus one are not
-            the same.
+        AssertionError: The current patch is not equal to previous patch plus
+            one.
         AssertionError: The current patch is greater or equal to 10.
-        AssertionError: The current minor and the previous one plus one are not
-            the same.
+        AssertionError: The current minor is not equal to previous minor plus
+            one.
         AssertionError: The current patch is different than 0.
     """
     response = urllib.urlopen(
@@ -141,7 +141,7 @@ def _verify_target_version_is_consistent_with_latest_released_version():
 
 
 def _execute_branch_cut():
-    """Prepares, cuts, creates and pushes to GitHub the new release branch.
+    """Pushes the new release branch to Github.
 
     Raises:
          AssertionError: 'version: default' was not found in app.yaml

--- a/scripts/cut_release_branch.py
+++ b/scripts/cut_release_branch.py
@@ -40,11 +40,11 @@ def new_version_type(arg, pattern=re.compile(r'\d\.\d\.\d')):
     Args:
         arg: str. The new version name.
         pattern: RegularExpression. The pattern that release version should
-        match. Default is re.compile(re'\d\.\d\.\d').
+            match. Default is re.compile(r'\d\.\d\.\d').
 
     Raises:
         argparse.ArgumentTypeError: The new version name does not match
-        the pattern.
+            the pattern.
 
     Returns:
         str. The new version name with correct pattern.
@@ -76,12 +76,12 @@ def _verify_target_branch_does_not_already_exist(remote_alias):
     remotely.
 
     Args:
-        remote_alias: The alias that points to the remote oppia repository.
+        remote_alias: str. The alias that points to the remote oppia repository.
 
     Raises:
         Exception: The target branch name already exists locally.
         Exception: The target branch name already exists on the remote
-        oppia repository.
+            oppia repository.
     """
 
     git_branch_output = subprocess.check_output(['git', 'branch'])
@@ -106,10 +106,10 @@ def _verify_target_version_is_consistent_with_latest_released_version():
         Exception: Could not parse version number of latest GitHub release.
         AssertionError: The previous and the current version are not the same.
         AssertionError: The current patch and the previous one plus one are not
-        the same.
+            the same.
         AssertionError: The current patch is greater or equal to 10.
         AssertionError: The current minor and the previous one plus one are not
-        the same.
+            the same.
         AssertionError: The current patch is different than 0.
     """
     response = urllib.urlopen(

--- a/scripts/pylint_extensions.py
+++ b/scripts/pylint_extensions.py
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Implements custom pylint checkers for explicit keyword args, hanging
+indent, docstring parameters and import only modules.
+"""
+
 import astroid
 import docstrings_checker  # pylint: disable=relative-import
 

--- a/scripts/pylint_extensions.py
+++ b/scripts/pylint_extensions.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Implements custom pylint checkers for explicit keyword args, hanging
-indent, docstring parameters and import only modules.
+"""Implements additional custom Pylint checkers to be used as part of
+presubmit checks.
 """
 
 import astroid


### PR DESCRIPTION
…ensions

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
This PR adds docstrings to scripts.cut_release_branch and scripts.pylint_extensions.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
