### PR TITLE
Fixes #5687 : Added feature to re submission of rejected suggestions.

### DIFF
--- a/core/controllers/learner_dashboard.py
+++ b/core/controllers/learner_dashboard.py
@@ -165,9 +165,9 @@ class LearnerDashboardFeedbackThreadHandler(base.BaseHandler):
             exploration = exp_services.get_exploration_by_id(exploration_id)
             current_content_html = (
                 exploration.states[
-                    suggestion.state_name].content.html)
+                    suggestion.change.state_name].content.html)
             suggestion_summary = {
-                'suggestion_html': suggestion.suggestion_html,
+                'suggestion_html': suggestion.change.new_value['html'],
                 'current_content_html': current_content_html,
                 'description': suggestion.description,
                 'author_username': authors_settings[0].username,

--- a/core/controllers/suggestion.py
+++ b/core/controllers/suggestion.py
@@ -88,18 +88,6 @@ class ReSubmitSuggestionHandler(base.BaseHandler):
 
     @acl_decorators.can_resubmit_suggestion
     def put(self, suggestion_id):
-        if len(suggestion_id.split('.')) != 3:
-            raise self.InvalidInputException(
-                'Invalid format for suggestion_id.It must contain'
-                '3 parts separated by \'.\'')
-
-        if (
-                suggestion_id.split('.')[0] !=
-                suggestion_models.TARGET_TYPE_EXPLORATION):
-            raise self.InvalidInputException(
-                'This handler allows actions only on'
-                'suggestions to explorations.')
-
         suggestion = suggestion_services.get_suggestion_by_id(suggestion_id)
         if not suggestion:
             raise self.InvalidInputException(

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -320,6 +320,49 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
             )['suggestions']
         self.assertEqual(len(suggestions), 2)
 
+    def test_resubmit_rejected_suggestion(self):
+
+        self.login(self.EDITOR_EMAIL)
+        response = self.testapp.get('/explore/%s' % self.EXP_ID)
+        csrf_token = self.get_csrf_token_from_response(response)
+
+        suggestion = suggestion_services.query_suggestions(
+            [('author_id', self.author_id), ('target_id', self.EXP_ID)])[0]
+        suggestion_services.reject_suggestion(
+            suggestion, self.reviewer_id, 'reject message')
+        self.logout()
+
+        self.login(self.AUTHOR_EMAIL)
+        response = self.testapp.get('/explore/%s' % self.EXP_ID)
+        csrf_token = self.get_csrf_token_from_response(response)
+
+        self.put_json('%s/resubmit/%s' % (
+            feconf.SUGGESTION_ACTION_URL_PREFIX, suggestion.suggestion_id), {
+                'summary_message': 'summary message',
+                'action': u'resubmit',
+                'change': {
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'property_name': exp_domain.STATE_PROPERTY_CONTENT,
+                    'state_name': 'State 1',
+                    'new_value': self.new_content,
+                    'old_value': self.old_content
+                }
+            }, csrf_token=csrf_token)
+
+        suggestion = suggestion_services.query_suggestions(
+            [('author_id', self.author_id), ('target_id', self.EXP_ID)])[0]
+        self.assertEqual(
+            suggestion.status, suggestion_models.STATUS_IN_REVIEW)
+        self.assertEqual(
+            suggestion.change.new_value['html'], self.new_content['html'])
+        self.assertEqual(
+            suggestion.change.cmd, exp_domain.CMD_EDIT_STATE_PROPERTY)
+        self.assertEqual(
+            suggestion.change.property_name, exp_domain.STATE_PROPERTY_CONTENT)
+        self.assertEqual(
+            suggestion.change.state_name, 'State 1')
+        self.logout()
+
 
 class QuestionSuggestionTests(test_utils.GenericTestBase):
 

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -356,7 +356,8 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             suggestion.status, suggestion_models.STATUS_IN_REVIEW)
         self.assertEqual(
-            suggestion.change.new_value['html'], self.new_content['html'])
+            suggestion.change.new_value['html'],
+            self.resubmit_change_content['html'])
         self.assertEqual(
             suggestion.change.cmd, exp_domain.CMD_EDIT_STATE_PROPERTY)
         self.assertEqual(

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -83,6 +83,8 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
 
         self.new_content = state_domain.SubtitledHtml(
             'content', 'new content html').to_dict()
+        self.resubmit_change_content = state_domain.SubtitledHtml(
+            'content', 'resubmit change content html').to_dict()
 
         self.logout()
 
@@ -344,7 +346,7 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
                     'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
                     'property_name': exp_domain.STATE_PROPERTY_CONTENT,
                     'state_name': 'State 1',
-                    'new_value': self.new_content,
+                    'new_value': self.resubmit_change_content,
                     'old_value': self.old_content
                 }
             }, csrf_token=csrf_token)

--- a/core/domain/acl_decorators.py
+++ b/core/domain/acl_decorators.py
@@ -876,6 +876,35 @@ def can_suggest_changes(handler):
     return test_can_suggest
 
 
+def can_edit_suggestion(handler):
+    """Decorator to check whether a use can edit a suggestion."""
+
+    def test_can_edit_suggestion(self, suggestion_id, **kwargs):
+        """Checks if the use can edit the given suggestion.
+
+
+        Args:
+            suggestion_id: str. The suggestion id.
+            **kwargs: *. keyword arguments.
+
+        Returns:
+            *. The return value of the decorated function.
+
+        Raises:
+            UnauthorizedUserException: The user does not have
+                credentials to edit this suggestion.
+        """
+        if suggestion_services.check_can_edit_suggestion(
+                suggestion_id, self.user_id):
+            return handler(self, suggestion_id, **kwargs)
+        else:
+            raise base.UserFacingExceptions.UnauthorizedUserException(
+                'You do not have credentials to edit this suggestion.')
+    test_can_edit_suggestion.__wrapped__ = True
+
+    return test_can_edit_suggestion
+
+
 def can_publish_exploration(handler):
     """Decorator to check whether user can publish exploration."""
 

--- a/core/domain/acl_decorators.py
+++ b/core/domain/acl_decorators.py
@@ -876,10 +876,10 @@ def can_suggest_changes(handler):
     return test_can_suggest
 
 
-def can_edit_suggestion(handler):
+def can_resubmit_suggestion(handler):
     """Decorator to check whether a use can edit a suggestion."""
 
-    def test_can_edit_suggestion(self, suggestion_id, **kwargs):
+    def test_can_resubmit_suggestion(self, suggestion_id, **kwargs):
         """Checks if the use can edit the given suggestion.
 
 
@@ -894,15 +894,15 @@ def can_edit_suggestion(handler):
             UnauthorizedUserException: The user does not have
                 credentials to edit this suggestion.
         """
-        if suggestion_services.check_can_edit_suggestion(
+        if suggestion_services.check_can_resubmit_suggestion(
                 suggestion_id, self.user_id):
             return handler(self, suggestion_id, **kwargs)
         else:
             raise base.UserFacingExceptions.UnauthorizedUserException(
                 'You do not have credentials to edit this suggestion.')
-    test_can_edit_suggestion.__wrapped__ = True
+    test_can_resubmit_suggestion.__wrapped__ = True
 
-    return test_can_edit_suggestion
+    return test_can_resubmit_suggestion
 
 
 def can_publish_exploration(handler):

--- a/core/domain/acl_decorators.py
+++ b/core/domain/acl_decorators.py
@@ -877,7 +877,7 @@ def can_suggest_changes(handler):
 
 
 def can_resubmit_suggestion(handler):
-    """Decorator to check whether a use can edit a suggestion."""
+    """Decorator to check whether a user can resubmit a suggestion."""
 
     def test_can_resubmit_suggestion(self, suggestion_id, **kwargs):
         """Checks if the use can edit the given suggestion.
@@ -899,7 +899,7 @@ def can_resubmit_suggestion(handler):
             return handler(self, suggestion_id, **kwargs)
         else:
             raise base.UserFacingExceptions.UnauthorizedUserException(
-                'You do not have credentials to edit this suggestion.')
+                'You do not have credentials to resubmit this suggestion.')
     test_can_resubmit_suggestion.__wrapped__ = True
 
     return test_can_resubmit_suggestion

--- a/core/domain/acl_decorators.py
+++ b/core/domain/acl_decorators.py
@@ -882,9 +882,8 @@ def can_resubmit_suggestion(handler):
     def test_can_resubmit_suggestion(self, suggestion_id, **kwargs):
         """Checks if the use can edit the given suggestion.
 
-
         Args:
-            suggestion_id: str. The suggestion id.
+            suggestion_id: str. The ID of the suggestion.
             **kwargs: *. keyword arguments.
 
         Returns:

--- a/core/domain/acl_decorators_test.py
+++ b/core/domain/acl_decorators_test.py
@@ -1289,14 +1289,13 @@ class ResubmitSuggestionDecoratorsTest(test_utils.GenericTestBase):
         self.assertEqual(response['suggestion_id'], self.suggestion_id)
         self.logout()
 
-    def test_normal_user_cannot_resubmit_suggestion(self):
+    def test_non_author_cannot_resubmit_suggestion(self):
         self.login(self.user_email)
         with self.swap(self, 'testapp', self.mock_testapp):
             self.get_json(
                 '/mock/%s' % self.suggestion_id, expect_errors=True,
                 expected_status_int=401)
         self.logout()
-
 
 
 class PublishExplorationTest(test_utils.GenericTestBase):

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -365,7 +365,7 @@ class SuggestionEditStateContent(BaseSuggestion):
                 self.change.state_name)
         elif self.change.new_value['html'] == change.new_value['html']:
             raise utils.ValidationError(
-                'The new html must be not equals to old html')
+                'The new html must not match the old html')
 
 
 class SuggestionAddQuestion(BaseSuggestion):

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -344,23 +344,28 @@ class SuggestionEditStateContent(BaseSuggestion):
     def pre_update_validate(self, change):
         """Performs the pre update validation. This functions need to be called
         before updating the suggestion.
+
+        Args:
+            change: ExplorationChange. The new change.
+
+        Raises:
+            ValidationError: Invalid new change.
         """
         if self.change.cmd != change.cmd:
             raise utils.ValidationError(
-                'The new change cmd must be equals to %s' %
+                'The new change cmd must be equal to %s' %
                 self.change.cmd)
         elif self.change.property_name != change.property_name:
             raise utils.ValidationError(
-                'The new change property_name must be equals to %s' %
+                'The new change property_name must be equal to %s' %
                 self.change.property_name)
         elif self.change.state_name != change.state_name:
             raise utils.ValidationError(
-                'The new change state_name must be equals to %s' %
+                'The new change state_name must be equal to %s' %
                 self.change.state_name)
         elif self.change.new_value['html'] == change.new_value['html']:
             raise utils.ValidationError(
                 'The new html must be not equals to old html')
-
 
 
 class SuggestionAddQuestion(BaseSuggestion):
@@ -503,35 +508,40 @@ class SuggestionAddQuestion(BaseSuggestion):
     def pre_update_validate(self, change):
         """Performs the pre update validation. This functions need to be called
         before updating the suggestion.
+
+        Args:
+            change: QuestionChange. The new change.
+
+        Raises:
+            ValidationError: Invalid new change.
         """
         if self.change.cmd != change.cmd:
             raise utils.ValidationError(
-                'The new change cmd must be equals to %s' %
+                'The new change cmd must be equal to %s' %
                 self.change.cmd)
         if self.change.cmd == question_domain.CMD_UPDATE_QUESTION_PROPERTY:
             if self.change.property_name != change.property_name:
                 raise utils.ValidationError(
-                    'The new change property_name must be equals to %s' %
+                    'The new change property_name must be equal to %s' %
                     change.property_name)
             elif self.change.old_value != change.old_value:
                 raise utils.ValidationError(
-                    'The new change old_value must be equals to %s' %
+                    'The new change old_value must be equal to %s' %
                     self.change.old_value)
             elif self.change.new_value == change.new_value:
                 raise utils.ValidationError(
-                    'The new change new_value must not be equals to old value')
+                    'The new change new_value must not be equal to old value')
 
         elif (self.change.cmd ==
               question_domain.CMD_CREATE_NEW_FULLY_SPECIFIED_QUESTION):
             if self.change.skill_id != change.skill_id:
                 raise utils.ValidationError(
-                    'The new change skill_id must be equals to %s' %
+                    'The new change skill_id must be equal to %s' %
                     self.change.skill_id)
             if self.change.question_domain != change.question_dict:
                 raise utils.ValidationError(
                     'The new change question_dict must',
-                    ' not be equals to old question_dict')
-
+                    ' not be equal to old question_dict')
 
 
 SUGGESTION_TYPES_TO_DOMAIN_CLASSES = {

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -530,7 +530,7 @@ class SuggestionAddQuestion(BaseSuggestion):
                     self.change.old_value)
             elif self.change.new_value == change.new_value:
                 raise utils.ValidationError(
-                    'The new change new_value must not be equal to old value')
+                    'The updated value must differ from the existing value')
 
         elif (self.change.cmd ==
               question_domain.CMD_CREATE_NEW_FULLY_SPECIFIED_QUESTION):

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -519,29 +519,15 @@ class SuggestionAddQuestion(BaseSuggestion):
             raise utils.ValidationError(
                 'The new change cmd must be equal to %s' %
                 self.change.cmd)
-        if self.change.cmd == question_domain.CMD_UPDATE_QUESTION_PROPERTY:
-            if self.change.property_name != change.property_name:
-                raise utils.ValidationError(
-                    'The new change property_name must be equal to %s' %
-                    change.property_name)
-            elif self.change.old_value != change.old_value:
-                raise utils.ValidationError(
-                    'The new change old_value must be equal to %s' %
-                    self.change.old_value)
-            elif self.change.new_value == change.new_value:
-                raise utils.ValidationError(
-                    'The updated value must differ from the existing value')
+        if self.change.skill_id != change.skill_id:
+            raise utils.ValidationError(
+                'The new change skill_id must be equal to %s' %
+                self.change.skill_id)
+        if self.change.question_domain == change.question_dict:
+            raise utils.ValidationError(
+                'The new change question_dict must',
+                ' not be equal to old question_dict')
 
-        elif (self.change.cmd ==
-              question_domain.CMD_CREATE_NEW_FULLY_SPECIFIED_QUESTION):
-            if self.change.skill_id != change.skill_id:
-                raise utils.ValidationError(
-                    'The new change skill_id must be equal to %s' %
-                    self.change.skill_id)
-            if self.change.question_domain != change.question_dict:
-                raise utils.ValidationError(
-                    'The new change question_dict must',
-                    ' not be equal to old question_dict')
 
 
 SUGGESTION_TYPES_TO_DOMAIN_CLASSES = {

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -286,7 +286,6 @@ def resubmit_rejected_suggestion(suggestion, summary_message, author_id):
             summarize new suggestion.
         author_id: str. The ID of the author creating the suggestion.
 
-
     Raises:
         Exception: Only rejected suggestions can be resubmitted.
     """
@@ -295,8 +294,9 @@ def resubmit_rejected_suggestion(suggestion, summary_message, author_id):
     if not suggestion.is_handled:
         raise Exception('The suggestion is not yet handled.')
     if suggestion.status == suggestion_models.STATUS_ACCEPTED:
-        raise Exception('The suggestion was accepted.' +
-                        'only rejected suggestions can be resubmitted.')
+        raise Exception(
+            'The suggestion was accepted.'
+            'only rejected suggestions can be resubmitted.')
 
     suggestion.status = suggestion_models.STATUS_IN_REVIEW
     _update_suggestion(suggestion)
@@ -527,7 +527,16 @@ def update_position_in_rotation(score_category, user_id):
 
 
 def check_can_resubmit_suggestion(suggestion_id, user_id):
-    """Checks whether the given user can resubmit the suggestion."""
+    """Checks whether the given user can resubmit the suggestion.
+
+    Args:
+        suggestion_id: str. The ID of the suggestion.
+        user_id: str. The ID of the user
+
+    Returns:
+        bool: A boolean indication whether
+            the user can resubmit the suggestion or not.
+    """
 
     suggestion = get_suggestion_by_id(suggestion_id)
 

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -159,7 +159,7 @@ def _update_suggestion(suggestion):
 
     suggestion_model.status = suggestion.status
     suggestion_model.final_reviewer_id = suggestion.final_reviewer_id
-    suggestion_model.change = suggestion.change.to_dict()
+    suggestion_model.change_cmd = suggestion.change.to_dict()
     suggestion_model.score_category = suggestion.score_category
 
     suggestion_model.put()

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -184,7 +184,6 @@ def mark_review_completed(suggestion, status, reviewer_id):
     _update_suggestion(suggestion)
 
 
-
 def get_commit_message_for_suggestion(author_username, commit_message):
     """Returns a modified commit message for an accepted suggestion.
 
@@ -278,8 +277,8 @@ def reject_suggestion(suggestion, reviewer_id, review_message):
         None, review_message)
 
 
-def reopen_rejected_suggestion(suggestion, summary_message, author_id):
-    """Resubmit the rejected suggestion.
+def resubmit_rejected_suggestion(suggestion, summary_message, author_id):
+    """Resubmit a rejected suggestion.
 
      Args:
         suggestion: Suggestion. The rejected suggestion.
@@ -289,18 +288,17 @@ def reopen_rejected_suggestion(suggestion, summary_message, author_id):
 
 
     Raises:
-        Exception: rejected suggestions can resubmit.
+        Exception: Only rejected suggestions can be resubmitted.
     """
+    if not summary_message:
+        raise Exception('Summary message cannot be empty.')
     if not suggestion.is_handled:
         raise Exception('The suggestion is not yet handled.')
-    if not suggestion.status != suggestion_models.STATUS_ACCEPTED:
+    if suggestion.status == suggestion_models.STATUS_ACCEPTED:
         raise Exception('The suggestion was accepted.' +
-                        'only rejected suggestions can resubmit')
-    if not summary_message:
-        raise Exception('Review message cannot be empty.')
+                        'only rejected suggestions can be resubmitted.')
 
     suggestion.status = suggestion_models.STATUS_IN_REVIEW
-
     _update_suggestion(suggestion)
 
     thread_id = suggestion.suggestion_id
@@ -528,8 +526,8 @@ def update_position_in_rotation(score_category, user_id):
         score_category, user_id)
 
 
-def check_can_edit_suggestion(suggestion_id, user_id):
-    """Checks whether the given user can edit the suggestion."""
+def check_can_resubmit_suggestion(suggestion_id, user_id):
+    """Checks whether the given user can resubmit the suggestion."""
 
     suggestion = get_suggestion_by_id(suggestion_id)
 

--- a/core/domain/suggestion_services_test.py
+++ b/core/domain/suggestion_services_test.py
@@ -418,7 +418,7 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
                     self.suggestion_id)
                 with self.assertRaisesRegexp(
                     Exception,
-                    'The suggestion was accepted.only rejected suggestions'
+                    'The suggestion was accepted.only rejected suggestions '
                     'can be resubmitted.'):
                     suggestion_services.resubmit_rejected_suggestion(
                         suggestion, 'resubmit summary message', self.author_id)

--- a/core/templates/dev/head/pages/creator_dashboard/CreatorDashboard.js
+++ b/core/templates/dev/head/pages/creator_dashboard/CreatorDashboard.js
@@ -245,15 +245,19 @@ oppia.controller('CreatorDashboard', [
           },
           stateName: function(){
             return $scope.activeThread.suggestion.stateName;
+          },
+          suggestionType: function(){
+            return $scope.activeThread.suggestion.suggestionType;
           }
         },
         controller: [
           '$scope', '$log', '$uibModalInstance', 'suggestionIsHandled',
           'suggestionStatus', 'description', 'oldContent',
-          'newContent', 'canReviewActiveThread', 'stateName', function(
+          'newContent', 'canReviewActiveThread', 'stateName', 'suggestionType',
+          function(
               $scope, $log, $uibModalInstance, suggestionIsHandled,
               suggestionStatus, description, oldContent,
-              newContent, canReviewActiveThread, stateName) {
+              newContent, canReviewActiveThread, stateName, suggestionType) {
             var SUGGESTION_ACCEPTED_MSG = 'This suggestion has already been ' +
               'accepted.';
             var SUGGESTION_REJECTED_MSG = 'This suggestion has already been ' +
@@ -281,6 +285,7 @@ oppia.controller('CreatorDashboard', [
             $scope.oldContent = oldContent;
             $scope.newContent = newContent;
             $scope.stateName = stateName;
+            $scope.suggestionType = suggestionType;
             $scope.commitMessage = description;
             $scope.reviewMessage = null;
             $scope.summaryMessage = null;
@@ -333,6 +338,7 @@ oppia.controller('CreatorDashboard', [
                 newSuggestionHtml: $scope.suggestionData.newSuggestionHtml,
                 summaryMessage: $scope.summaryMessage,
                 stateName: $scope.stateName,
+                suggestionType: $scope.suggestionType,
                 oldContent: $scope.oldContent
               });
             };
@@ -340,7 +346,8 @@ oppia.controller('CreatorDashboard', [
         ]
       }).result.then(function(result) {
         var url, data;
-        if (result.action === 'resubmit'){
+        if (result.action === 'resubmit' && result.suggestionType ===
+          'edit_exploration_state_content'){
           url = '/suggestionactionhandler/resubmit/' +
             $scope.activeThread.suggestion.suggestionId;
           data = {

--- a/core/templates/dev/head/pages/creator_dashboard/view_suggestion_edit_exploration_state_content_modal.html
+++ b/core/templates/dev/head/pages/creator_dashboard/view_suggestion_edit_exploration_state_content_modal.html
@@ -44,20 +44,20 @@
 </div>
 <style type="text/css">
 
-.oppia-edit-mode .oppia-suggestion-review-panel-container:nth-child(1){
+.oppia-edit-mode .oppia-suggestion-review-panel-container:nth-child(1) {
   width: 100%;
   height: 35%;
 }
-.oppia-edit-mode .oppia-suggestion-review-panel-container:nth-child(2){
+.oppia-edit-mode .oppia-suggestion-review-panel-container:nth-child(2) {
   width: 100%;
   height: 55%;
   margin-top: 30px;
 }
-.oppia-edit-mode .oppia-rte{
+.oppia-edit-mode .oppia-rte {
   max-height: 100px;
   overflow-y: scroll;
 }
-.oppia-edit-mode .oppia-review-message{
+.oppia-edit-mode .oppia-review-message {
   margin-top: 10px;
 }
 </style>

--- a/core/templates/dev/head/pages/creator_dashboard/view_suggestion_edit_exploration_state_content_modal.html
+++ b/core/templates/dev/head/pages/creator_dashboard/view_suggestion_edit_exploration_state_content_modal.html
@@ -3,7 +3,7 @@
 </div>
 
 <div class="modal-body">
-  <section class="oppia-suggestion-review-container">
+  <section ng-class="['oppia-suggestion-review-container',{'oppia-edit-mode':showEditor}]">
     <div class="oppia-suggestion-review-panel-container" style="float: left;">
       <strong>Current:</strong>
       <div class="oppia-suggestion-review-panel">
@@ -14,15 +14,19 @@
     </div>
     <div class="oppia-suggestion-review-panel-container" style="float: right;">
       <strong>Suggested:</strong>
-      <div class="oppia-suggestion-review-panel">
+      <div class="oppia-suggestion-review-panel" ng-show="!showEditor">
         <angular-html-bind html-data="newContent.html">
         </angular-html-bind>
+      </div>
+      <div ng-show="showEditor">
+        <ck-editor-rte ng-model="suggestionData.newSuggestionHtml"></ck-editor-rte>
+        <input type="text" class="form-control oppia-review-message" ng-model="summaryMessage" placeholder="Summarize your new changes">
       </div>
     </div>
   </section>
   <div style="margin-top: 20px; margin-left: 10px;" ng-show="canReviewActiveThread">
     Review message (required if rejecting):
-    <input type="text" ng-model="reviewMessage" style="width: 100%">
+    <input type="text" ng-model="reviewMessage" style="width: 100%" >
     Brief Description of Changes (required if accepting):
     <input class="protractor-test-suggestion-commit-message"type="text" ng-model="commitMessage" style="width: 100%">
   </div>
@@ -33,6 +37,27 @@
     <[ errorMessage ]>
   </div>
   <button class="btn btn-default" ng-click="cancelReview()">Cancel</button>
+  <button class="btn btn-info" ng-if="showEditButton()" ng-click="editSuggestion()">Edit</button>
+  <button class="btn btn-primary" ng-disabled="disableResubmitButton()" ng-if="showResubmitButton()" ng-click="submitChanges()">Submit Changes</button>
   <button class="btn btn-danger" ng-show="canReviewActiveThread && isNotHandled" ng-click="rejectSuggestion()">Reject</button>
   <button class="btn btn-success protractor-test-exploration-accept-suggestion-btn" ng-show="canReviewActiveThread && isNotHandled" ng-click="acceptSuggestion()" ng-disabled="commitMessage.length == 0">Accept</button>
 </div>
+<style type="text/css">
+
+.oppia-edit-mode .oppia-suggestion-review-panel-container:nth-child(1){
+  width: 100%;
+  height: 35%;
+}
+.oppia-edit-mode .oppia-suggestion-review-panel-container:nth-child(2){
+  width: 100%;
+  height: 55%;
+  margin-top: 30px;
+}
+.oppia-edit-mode .oppia-rte{
+  max-height: 100px;
+  overflow-y: scroll;
+}
+.oppia-edit-mode .oppia-review-message{
+  margin-top: 10px;
+}
+</style>

--- a/core/templates/dev/head/pages/creator_dashboard/view_suggestion_edit_exploration_state_content_modal.html
+++ b/core/templates/dev/head/pages/creator_dashboard/view_suggestion_edit_exploration_state_content_modal.html
@@ -3,7 +3,7 @@
 </div>
 
 <div class="modal-body">
-  <section ng-class="['oppia-suggestion-review-container',{'oppia-edit-mode':showEditor}]">
+  <section ng-class="['oppia-suggestion-review-container',{'oppia-edit-mode':showSuggestionEditor}]">
     <div class="oppia-suggestion-review-panel-container" style="float: left;">
       <strong>Current:</strong>
       <div class="oppia-suggestion-review-panel">
@@ -14,11 +14,11 @@
     </div>
     <div class="oppia-suggestion-review-panel-container" style="float: right;">
       <strong>Suggested:</strong>
-      <div class="oppia-suggestion-review-panel" ng-show="!showEditor">
+      <div class="oppia-suggestion-review-panel" ng-show="!showSuggestionEditor">
         <angular-html-bind html-data="newContent.html">
         </angular-html-bind>
       </div>
-      <div ng-show="showEditor">
+      <div ng-show="showSuggestionEditor">
         <ck-editor-rte ng-model="suggestionData.newSuggestionHtml"></ck-editor-rte>
         <input type="text" class="form-control oppia-review-message" ng-model="summaryMessage" placeholder="Summarize your new changes">
       </div>
@@ -38,7 +38,7 @@
   </div>
   <button class="btn btn-default" ng-click="cancelReview()">Cancel</button>
   <button class="btn btn-info" ng-if="showEditButton()" ng-click="editSuggestion()">Edit</button>
-  <button class="btn btn-primary" ng-disabled="disableResubmitButton()" ng-if="showResubmitButton()" ng-click="submitChanges()">Submit Changes</button>
+  <button class="btn btn-primary" ng-disabled="disableResubmitButton()" ng-if="showResubmitButton()" ng-click="resubmitChanges()">Submit Changes</button>
   <button class="btn btn-danger" ng-show="canReviewActiveThread && isNotHandled" ng-click="rejectSuggestion()">Reject</button>
   <button class="btn btn-success protractor-test-exploration-accept-suggestion-btn" ng-show="canReviewActiveThread && isNotHandled" ng-click="acceptSuggestion()" ng-disabled="commitMessage.length == 0">Accept</button>
 </div>

--- a/core/templates/dev/head/pages/creator_dashboard/view_suggestion_edit_exploration_state_content_modal.html
+++ b/core/templates/dev/head/pages/creator_dashboard/view_suggestion_edit_exploration_state_content_modal.html
@@ -26,14 +26,14 @@
   </section>
   <div style="margin-top: 20px; margin-left: 10px;" ng-show="canReviewActiveThread">
     Review message (required if rejecting):
-    <input type="text" ng-model="reviewMessage" style="width: 100%" >
+    <input type="text" ng-model="reviewMessage" style="width: 100%">
     Brief Description of Changes (required if accepting):
     <input class="protractor-test-suggestion-commit-message"type="text" ng-model="commitMessage" style="width: 100%">
   </div>
 </div>
 
 <div class="modal-footer">
-  <div ng-show="errorMessage" class="oppia-suggestion-review-error">
+  <div ng-show="errorMessage && !showResubmitButton()" class="oppia-suggestion-review-error">
     <[ errorMessage ]>
   </div>
   <button class="btn btn-default" ng-click="cancelReview()">Cancel</button>

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
@@ -21,13 +21,13 @@ oppia.controller('FeedbackTab', [
   'DateTimeFormatService', 'ThreadStatusDisplayService',
   'ThreadDataService', 'ExplorationStatesService', 'ExplorationDataService',
   'ChangeListService', 'StateObjectFactory', 'UrlInterpolationService',
-  'ACTION_ACCEPT_SUGGESTION', 'ACTION_REJECT_SUGGESTION',
+  'ACTION_ACCEPT_SUGGESTION', 'ACTION_REJECT_SUGGESTION', '$log',
   function(
       $scope, $http, $uibModal, $timeout, $rootScope, AlertsService,
       DateTimeFormatService, ThreadStatusDisplayService,
       ThreadDataService, ExplorationStatesService, ExplorationDataService,
       ChangeListService, StateObjectFactory, UrlInterpolationService,
-      ACTION_ACCEPT_SUGGESTION, ACTION_REJECT_SUGGESTION) {
+      ACTION_ACCEPT_SUGGESTION, ACTION_REJECT_SUGGESTION, $log) {
     $scope.STATUS_CHOICES = ThreadStatusDisplayService.STATUS_CHOICES;
     $scope.threadData = ThreadDataService.data;
     $scope.getLabelClass = ThreadStatusDisplayService.getLabelClass;

--- a/main.py
+++ b/main.py
@@ -478,8 +478,8 @@ URLS = MAPREDUCE_HANDLERS + [
         feconf.SUGGESTION_ACTION_URL_PREFIX,
         suggestion.SuggestionToExplorationActionHandler),
     get_redirect_route(
-        r'%s/reopen/<suggestion_id>' % feconf.SUGGESTION_ACTION_URL_PREFIX,
-        suggestion.ReOpenSuggestionHandler),
+        r'%s/resubmit/<suggestion_id>' % feconf.SUGGESTION_ACTION_URL_PREFIX,
+        suggestion.ReSubmitSuggestionHandler),
     get_redirect_route(
         r'%s/topic/<target_id>/<suggestion_id>' %
         feconf.SUGGESTION_ACTION_URL_PREFIX,

--- a/main.py
+++ b/main.py
@@ -478,6 +478,9 @@ URLS = MAPREDUCE_HANDLERS + [
         feconf.SUGGESTION_ACTION_URL_PREFIX,
         suggestion.SuggestionToExplorationActionHandler),
     get_redirect_route(
+        r'%s/reopen/<suggestion_id>' % feconf.SUGGESTION_ACTION_URL_PREFIX,
+        suggestion.ReOpenSuggestionHandler),
+    get_redirect_route(
         r'%s/topic/<target_id>/<suggestion_id>' %
         feconf.SUGGESTION_ACTION_URL_PREFIX,
         suggestion.SuggestionToTopicActionHandler),


### PR DESCRIPTION
Added a feature to resubmit rejected suggestions

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
