### PR TITLE
Fix #5749 - get-involved link

### DIFF
--- a/core/templates/dev/head/pages/footer.html
+++ b/core/templates/dev/head/pages/footer.html
@@ -22,7 +22,7 @@
       <div class="col-sm-3">
         <h4 translate="I18N_FOOTER_CONTRIBUTE_ALL_CAPS"></h4>
         <ul>
-          <li><a href="http://oppiafoundation.org/get-involved/" translate="I18N_FOOTER_GET_INVOLVED"></a></li>
+          <li><a href="http://oppiafoundation.org/volunteer" translate="I18N_FOOTER_GET_INVOLVED"></a></li>
           <li><a href="/teach#teach" translate="I18N_FOOTER_TEACH"></a></li>
           <li><a href="/donate" class="protractor-test-donate-link"  translate="I18N_FOOTER_DONATE"></a></li>
           <li><a href="/about#credits" translate="I18N_FOOTER_CREDITS"></a></li>

--- a/core/templates/dev/head/pages/footer.html
+++ b/core/templates/dev/head/pages/footer.html
@@ -22,7 +22,7 @@
       <div class="col-sm-3">
         <h4 translate="I18N_FOOTER_CONTRIBUTE_ALL_CAPS"></h4>
         <ul>
-          <li><a href="http://oppiafoundation.org/volunteer" translate="I18N_FOOTER_GET_INVOLVED"></a></li>
+          <li><a href="https://oppiafoundation.org/volunteer" translate="I18N_FOOTER_GET_INVOLVED"></a></li>
           <li><a href="/teach#teach" translate="I18N_FOOTER_TEACH"></a></li>
           <li><a href="/donate" class="protractor-test-donate-link"  translate="I18N_FOOTER_DONATE"></a></li>
           <li><a href="/about#credits" translate="I18N_FOOTER_CREDITS"></a></li>


### PR DESCRIPTION
## Explanation
Fixes the link `https://oppiafoundation.org/get-involved/` -> `https://oppiafoundation.org/volunteer` in the footer.