### PR TITLE
Fix #5691: Calculate answer choices

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationDirective.js
@@ -293,22 +293,25 @@ oppia.directive('stateTranslation', [
             if (interactionId) {
               var interactionPreviewHtml = ExplorationHtmlFormatterService
                 .getInteractionHtml(
-                  interactionId, currentCustomizationArgs, false)
+                  interactionId, currentCustomizationArgs, false);
 
               // Special cases for multiple choice input and image click input.
               if (interactionId === 'MultipleChoiceInput') {
                 $scope.answerChoices =
-                  currentCustomizationArgs.choices.value.map(function(val, ind) {
-                    return {
-                      val: ind,
-                      label: val
-                    };
-                  });
+                  currentCustomizationArgs.choices.value.map(
+                    function(val, ind) {
+                      return {
+                        val: ind,
+                        label: val
+                      };
+                    }
+                  );
               } else if (interactionId === 'ImageClickInput') {
                 var _answerChoices = [];
                 var imageWithRegions =
                   currentCustomizationArgs.imageAndRegions.value;
-                for (var j = 0; j < imageWithRegions.labeledRegions.length; j++) {
+                for (
+                  var j = 0; j < imageWithRegions.labeledRegions.length; j++) {
                   _answerChoices.push({
                     val: imageWithRegions.labeledRegions[j].label,
                     label: imageWithRegions.labeledRegions[j].label

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationDirective.js
@@ -33,7 +33,7 @@ oppia.directive('stateTranslation', [
         'TranslationStatusService', 'COMPONENT_NAME_CONTENT',
         'COMPONENT_NAME_FEEDBACK', 'COMPONENT_NAME_HINT',
         'COMPONENT_NAME_SOLUTION', 'INTERACTION_SPECS',
-        'RULE_SUMMARY_WRAP_CHARACTER_COUNT',
+        'RULE_SUMMARY_WRAP_CHARACTER_COUNT', 'ResponsesService',
         function(
             $scope, $filter, $rootScope, StateEditorService,
             ExplorationStatesService, ExplorationInitStateNameService,
@@ -41,7 +41,7 @@ oppia.directive('stateTranslation', [
             TranslationStatusService, COMPONENT_NAME_CONTENT,
             COMPONENT_NAME_FEEDBACK, COMPONENT_NAME_HINT,
             COMPONENT_NAME_SOLUTION, INTERACTION_SPECS,
-            RULE_SUMMARY_WRAP_CHARACTER_COUNT) {
+            RULE_SUMMARY_WRAP_CHARACTER_COUNT, ResponsesService) {
           // Define tab constants.
           $scope.TAB_ID_CONTENT = COMPONENT_NAME_CONTENT;
           $scope.TAB_ID_FEEDBACK = COMPONENT_NAME_FEEDBACK;
@@ -72,6 +72,10 @@ oppia.directive('stateTranslation', [
 
           $scope.navigateToState = function(stateName) {
             RouterService.navigateToMainTab(stateName);
+          };
+
+          $scope.getAnswerChoices = function() {
+            return ResponsesService.getAnswerChoices();
           };
 
           $scope.onTabClick = function(tabId) {

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationDirective.js
@@ -34,7 +34,6 @@ oppia.directive('stateTranslation', [
         'COMPONENT_NAME_FEEDBACK', 'COMPONENT_NAME_HINT',
         'COMPONENT_NAME_SOLUTION', 'INTERACTION_SPECS',
         'RULE_SUMMARY_WRAP_CHARACTER_COUNT',
-        'ExplorationHtmlFormatterService',
         function(
             $scope, $filter, $rootScope, StateEditorService,
             ExplorationStatesService, ExplorationInitStateNameService,
@@ -42,8 +41,7 @@ oppia.directive('stateTranslation', [
             TranslationStatusService, COMPONENT_NAME_CONTENT,
             COMPONENT_NAME_FEEDBACK, COMPONENT_NAME_HINT,
             COMPONENT_NAME_SOLUTION, INTERACTION_SPECS,
-            RULE_SUMMARY_WRAP_CHARACTER_COUNT,
-            ExplorationHtmlFormatterService) {
+            RULE_SUMMARY_WRAP_CHARACTER_COUNT) {
           // Define tab constants.
           $scope.TAB_ID_CONTENT = COMPONENT_NAME_CONTENT;
           $scope.TAB_ID_FEEDBACK = COMPONENT_NAME_FEEDBACK;
@@ -291,10 +289,6 @@ oppia.directive('stateTranslation', [
               .getInteractionCustomizationArgsMemento(stateName);
             var interactionId = $scope.stateInteractionId;
             if (interactionId) {
-              var interactionPreviewHtml = ExplorationHtmlFormatterService
-                .getInteractionHtml(
-                  interactionId, currentCustomizationArgs, false);
-
               // Special cases for multiple choice input and image click input.
               if (interactionId === 'MultipleChoiceInput') {
                 $scope.answerChoices =

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/state_translation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/state_translation_directive.html
@@ -51,8 +51,8 @@
                ng-class="{'oppia-rule-tab-active': activeAnswerGroupIndex === $index}"
                ng-style="contentIdStatusColorStyle(answerGroup.outcome.feedback.getContentId())">
               <response-header index="$index"
-                               summary="summarizeAnswerGroup(answerGroup, stateInteractionId, getAnswerChoices(), false)"
-                               short-summary="summarizeAnswerGroup(answerGroup, stateInteractionId, getAnswerChoices(), true)"
+                               summary="summarizeAnswerGroup(answerGroup, stateInteractionId, answerChoices, false)"
+                               short-summary="summarizeAnswerGroup(answerGroup, stateInteractionId, answerChoices, true)"
                                is-active="$index === activeAnswerGroupIndex"
                                outcome="answerGroup.outcome"
                                num-rules="answerGroup.rules.length"


### PR DESCRIPTION
Fixes #5691. The `getAnswerChoices()` function in `state_translation_editor_directive.html` was not present in the corresponding JS file, so added that.