### PR TITLE
Fix #4973: Add minify_only option to build.py

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1030,10 +1030,11 @@ def _verify_build(input_dirnames, output_dirnames, file_hashes):
             THIRD_PARTY_GENERATED_OUT_DIR, third_party_css_final_filename)])
 
 
-def generate_build_directory():
+def generate_build_directory(minify_only):
     """Generates hashes for files. Minifies files and interpolates paths
     in HTMLs to include hashes. Renames the files to include hashes and copies
     them into build directory.
+    If minify_only set to True, return after minify.
     """
     print 'Building Oppia in production mode...'
 
@@ -1045,6 +1046,8 @@ def generate_build_directory():
     copy_tasks = collections.deque()
     # Minify third party resources.
     minify_third_party_libs(THIRD_PARTY_GENERATED_DEV_DIR)
+    if minify_only:
+        return
 
     # Create hashes for all directories and files.
     HASH_DIRS = [
@@ -1102,12 +1105,15 @@ def build():
     parser = optparse.OptionParser()
     parser.add_option(
         '--prod_env', action='store_true', default=False, dest='prod_mode')
+    parser.add_option(
+        '--prod_minify_only', action='store_true', default=False,
+        dest='minify_only')
     options = parser.parse_args()[0]
     # Regenerate /third_party/generated from scratch.
     safe_delete_directory_tree(THIRD_PARTY_GENERATED_DEV_DIR)
     build_third_party_libs(THIRD_PARTY_GENERATED_DEV_DIR)
     if options.prod_mode:
-        generate_build_directory()
+        generate_build_directory(options.minify_only)
 
 
 if __name__ == '__main__':

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1103,19 +1103,23 @@ def build():
     parser.add_option(
         '--prod_env', action='store_true', default=False, dest='prod_mode')
     parser.add_option(
-        '--prod_minify_only', action='store_true', default=False,
+        '--minify_third_party_libs_only', action='store_true', default=False,
         dest='minify_third_party_libs_only')
     options = parser.parse_args()[0]
     # Regenerate /third_party/generated from scratch.
     safe_delete_directory_tree(THIRD_PARTY_GENERATED_DEV_DIR)
     build_third_party_libs(THIRD_PARTY_GENERATED_DEV_DIR)
+
+    # If minify_third_party_libs_only is set to True, skips the rest of the
+    # build process once third party libs are minified.
+    if options.minify_third_party_libs_only:
+        if not options.prod_mode:
+            raise Exception(
+                'minify_third_party_libs_only is set to true in non-prod mode.')
+        minify_third_party_libs(THIRD_PARTY_GENERATED_DEV_DIR)
+        return
     if options.prod_mode:
-        # If minify_third_party_libs_only is set to True, skips the rest of the
-        # build process once third party libs are minified.
-        if options.minify_third_party_libs_only:
-            minify_third_party_libs(THIRD_PARTY_GENERATED_DEV_DIR)
-        else:
-            generate_build_directory()
+        generate_build_directory()
 
 
 if __name__ == '__main__':

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1030,11 +1030,10 @@ def _verify_build(input_dirnames, output_dirnames, file_hashes):
             THIRD_PARTY_GENERATED_OUT_DIR, third_party_css_final_filename)])
 
 
-def generate_build_directory(minify_only):
+def generate_build_directory():
     """Generates hashes for files. Minifies files and interpolates paths
     in HTMLs to include hashes. Renames the files to include hashes and copies
     them into build directory.
-    If minify_only set to True, return after minify.
     """
     print 'Building Oppia in production mode...'
 
@@ -1046,8 +1045,6 @@ def generate_build_directory(minify_only):
     copy_tasks = collections.deque()
     # Minify third party resources.
     minify_third_party_libs(THIRD_PARTY_GENERATED_DEV_DIR)
-    if minify_only:
-        return
 
     # Create hashes for all directories and files.
     HASH_DIRS = [
@@ -1107,13 +1104,18 @@ def build():
         '--prod_env', action='store_true', default=False, dest='prod_mode')
     parser.add_option(
         '--prod_minify_only', action='store_true', default=False,
-        dest='minify_only')
+        dest='minify_third_party_libs_only')
     options = parser.parse_args()[0]
     # Regenerate /third_party/generated from scratch.
     safe_delete_directory_tree(THIRD_PARTY_GENERATED_DEV_DIR)
     build_third_party_libs(THIRD_PARTY_GENERATED_DEV_DIR)
     if options.prod_mode:
-        generate_build_directory(options.minify_only)
+        # If minify_third_party_libs_only is set to True, skips the rest of the
+        # build process once third party libs are minified.
+        if options.minify_third_party_libs_only:
+            minify_third_party_libs(THIRD_PARTY_GENERATED_DEV_DIR)
+        else:
+            generate_build_directory()
 
 
 if __name__ == '__main__':

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1043,8 +1043,6 @@ def generate_build_directory():
     hashes = dict()
     build_tasks = collections.deque()
     copy_tasks = collections.deque()
-    # Minify third party resources.
-    minify_third_party_libs(THIRD_PARTY_GENERATED_DEV_DIR)
 
     # Create hashes for all directories and files.
     HASH_DIRS = [
@@ -1112,14 +1110,13 @@ def build():
 
     # If minify_third_party_libs_only is set to True, skips the rest of the
     # build process once third party libs are minified.
-    if options.minify_third_party_libs_only:
-        if not options.prod_mode:
-            raise Exception(
-                'minify_third_party_libs_only is set to true in non-prod mode.')
-        minify_third_party_libs(THIRD_PARTY_GENERATED_DEV_DIR)
-        return
+    if options.minify_third_party_libs_only and not options.prod_mode:
+        raise Exception(
+            'minify_third_party_libs_only should not be set in non-prod mode.')
     if options.prod_mode:
-        generate_build_directory()
+        minify_third_party_libs(THIRD_PARTY_GENERATED_DEV_DIR)
+        if not options.minify_third_party_libs_only:
+            generate_build_directory()
 
 
 if __name__ == '__main__':

--- a/scripts/run_frontend_tests.sh
+++ b/scripts/run_frontend_tests.sh
@@ -69,7 +69,7 @@ if [ "$RUN_MINIFIED_TESTS" = "true" ]; then
   echo ""
   echo "  Running test in production environment"
   echo ""
-  $PYTHON_CMD scripts/build.py --prod_env
+  $PYTHON_CMD scripts/build.py --prod_env --prod_minify_only
   $XVFB_PREFIX $NODE_MODULE_DIR/karma/bin/karma start core/tests/karma.conf.js --prod_env=True
 fi
 

--- a/scripts/run_frontend_tests.sh
+++ b/scripts/run_frontend_tests.sh
@@ -69,7 +69,7 @@ if [ "$RUN_MINIFIED_TESTS" = "true" ]; then
   echo ""
   echo "  Running test in production environment"
   echo ""
-  $PYTHON_CMD scripts/build.py --prod_env --prod_minify_only
+  $PYTHON_CMD scripts/build.py --prod_env --minify_third_party_libs_only
   $XVFB_PREFIX $NODE_MODULE_DIR/karma/bin/karma start core/tests/karma.conf.js --prod_env=True
 fi
 


### PR DESCRIPTION
When minify_only is set to true, prod run tests will only minify third_party.js and skip hashing.
Fix #4973 