### PR TITLE
Fix prod bug that breaks creator dashboard

### DIFF
--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -317,8 +317,13 @@ class SuggestionEditStateContent(BaseSuggestion):
     def populate_old_value_of_change(self):
         """Populates old value of the change."""
         exploration = exp_services.get_exploration_by_id(self.target_id)
-        old_content = (
-            exploration.states[self.change.state_name].content.to_dict())
+        if self.change.state_name not in exploration.states:
+            # As the state doesn't exist now, we cannot find the content of the
+            # state to populate the old_value field. So we set it as None.
+            old_content = None
+        else:
+            old_content = (
+                exploration.states[self.change.state_name].content.to_dict())
 
         self.change.old_value = old_content
 


### PR DESCRIPTION
## Explanation
Returns None when the old content of a suggestion to a state, that no longer exists, is populated. This fixes a bug caught in prod where the library and creator dashboard were broken.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
