### PR TITLE
Fix #5553: Enable audio translation for Safari

### DIFF
--- a/core/templates/dev/head/domain/utilities/BrowserCheckerService.js
+++ b/core/templates/dev/head/domain/utilities/BrowserCheckerService.js
@@ -56,7 +56,8 @@ oppia.factory('BrowserCheckerService', [
         return _supportsSpeechSynthesis();
       },
       supportsAudioPlayback: function() {
-        return !isSafari;
+        var _supportSafari = true;
+        return !isSafari || _supportSafari;
       },
       isMobileDevice: function() {
         return _isMobileDevice();

--- a/core/templates/dev/head/domain/utilities/BrowserCheckerService.js
+++ b/core/templates/dev/head/domain/utilities/BrowserCheckerService.js
@@ -55,10 +55,6 @@ oppia.factory('BrowserCheckerService', [
       supportsSpeechSynthesis: function() {
         return _supportsSpeechSynthesis();
       },
-      supportsAudioPlayback: function() {
-        var _supportSafari = true;
-        return !isSafari || _supportSafari;
-      },
       isMobileDevice: function() {
         return _isMobileDevice();
       }

--- a/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
@@ -69,7 +69,6 @@ oppia.directive('audioBar', [
 
           $scope.isAudioBarAvailable = function() {
             return (
-              BrowserCheckerService.supportsAudioPlayback() &&
               $scope.languagesInExploration.length > 0);
           };
 

--- a/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/AudioBarDirective.js
@@ -68,8 +68,7 @@ oppia.directive('audioBar', [
           });
 
           $scope.isAudioBarAvailable = function() {
-            return (
-              $scope.languagesInExploration.length > 0);
+            return $scope.languagesInExploration.length > 0;
           };
 
           $scope.onNewLanguageSelected = function() {

--- a/core/templates/dev/head/services/AssetsBackendApiService.js
+++ b/core/templates/dev/head/services/AssetsBackendApiService.js
@@ -67,7 +67,11 @@ oppia.factory('AssetsBackendApiService', [
         timeout: canceler.promise
       }).success(function(data) {
         try {
-          var assetBlob = new Blob([data]);
+          if (assetType === ASSET_TYPE_AUDIO) {
+            var assetBlob = new Blob([data], {type: 'audio/mpeg'});
+          } else {
+            var assetBlob = new Blob([data]);
+          }
         } catch (exception) {
           window.BlobBuilder = window.BlobBuilder ||
                          window.WebKitBlobBuilder ||

--- a/core/templates/dev/head/services/AssetsBackendApiService.js
+++ b/core/templates/dev/head/services/AssetsBackendApiService.js
@@ -68,6 +68,8 @@ oppia.factory('AssetsBackendApiService', [
       }).success(function(data) {
         try {
           if (assetType === ASSET_TYPE_AUDIO) {
+            // Add type for audio assets. Without this, translations can
+            // not be played on Safari.
             var assetBlob = new Blob([data], {type: 'audio/mpeg'});
           } else {
             var assetBlob = new Blob([data]);


### PR DESCRIPTION
Added type: 'audio/mpeg' to audio assets to enable audio for Safari.