### PR TITLE
Fix test failure

### DIFF
--- a/core/domain/skill_jobs_one_off_test.py
+++ b/core/domain/skill_jobs_one_off_test.py
@@ -126,7 +126,11 @@ class SkillMigrationOneOffJobTest(test_utils.GenericTestBase):
         # version and old(v1) skill contents schema version.
         skill_contents = {
             'worked_examples': [],
-            'explanation': ''
+            'explanation': {
+                'content_id': 'explanation',
+                'html': feconf.DEFAULT_SKILL_EXPLANATION
+            },
+            'content_ids_to_audio_translations': {}
         }
         self.save_new_skill_with_story_and_skill_contents_schema_version(
             self.SKILL_ID, self.albert_id, 'A description', 0,


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
PR https://github.com/oppia/oppia/pull/5677 modified `SkillContents` without actually changing `feconf.CURRENT_SKILL_CONTENTS_SCHEMA_VERSION`. This caused tests in `skill_jobs_one_off_test.py` which hardcode `SkillContents`(in order to test migrations are successful) to break since a new key was added, and existing key `explanation` changed type from `str` to `SubtitledHtml`.

Since Skill(and by extension, SkillContents) aren't released yet, I think it is OK to modify their schema without changing version(as has been done before). So, for now, the test is simply modified to work with the different version of the SkillContents object.

This fixes https://groups.google.com/forum/#!topic/oppia-dev/2UAXmajdZ0w

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.