### PR TITLE
Fix erroneous image path in production.

### DIFF
--- a/core/templates/dev/head/services/AssetsBackendApiService.js
+++ b/core/templates/dev/head/services/AssetsBackendApiService.js
@@ -36,7 +36,7 @@ oppia.factory('AssetsBackendApiService', [
     var ASSET_TYPE_IMAGE = 'image';
 
     var GCS_PREFIX = ('https://storage.googleapis.com/' +
-      GLOBALS.GCS_RESOURCE_BUCKET_NAME + '/exploration/');
+      GLOBALS.GCS_RESOURCE_BUCKET_NAME + '/exploration');
     var AUDIO_DOWNLOAD_URL_TEMPLATE = (
       (DEV_MODE ? '/assetsdevhandler' : GCS_PREFIX) +
       '/<exploration_id>/assets/audio/<filename>');

--- a/core/templates/dev/head/services/AssetsBackendApiServiceSpec.js
+++ b/core/templates/dev/head/services/AssetsBackendApiServiceSpec.js
@@ -42,6 +42,14 @@ describe('Assets Backend API Service', function() {
     $httpBackend.verifyNoOutstandingRequest();
   });
 
+  it('Should correctly formulate the download URL', function() {
+    // TODO(sll): Find a way to substitute out constants.DEV_MODE so that we
+    // can test the production URL, too.
+    expect(
+      AssetsBackendApiService.getAudioDownloadUrl('expid12345', 'a.mp3')
+    ).toEqual('/assetsdevhandler/expid12345/assets/audio/a.mp3');
+  });
+
   it('Should successfully fetch and cache audio', function() {
     var successHandler = jasmine.createSpy('success');
     var failHandler = jasmine.createSpy('fail');

--- a/core/tests/karma-globals.js
+++ b/core/tests/karma-globals.js
@@ -78,7 +78,7 @@ var GLOBALS = {
     id: 'en',
     text: 'English'
   }],
-  GCS_RESOURCE_BUCKET_NAME: 'abc',
+  GCS_RESOURCE_BUCKET_NAME: null,
   userIsLoggedIn: true
 };
 

--- a/core/tests/karma-globals.js
+++ b/core/tests/karma-globals.js
@@ -78,8 +78,7 @@ var GLOBALS = {
     id: 'en',
     text: 'English'
   }],
-  DEV_MODE: true,
-  GCS_RESOURCE_BUCKET_NAME: null,
+  GCS_RESOURCE_BUCKET_NAME: 'abc',
   userIsLoggedIn: true
 };
 


### PR DESCRIPTION
The image path in production had an extra slash, which is causing images to not load.

(Also, there doesn't seem to be a way to effectively substitute values in constants.js in tests, hence the TODO. I am going to follow up with the tech leads on finding a good pattern for this.)