### PR TITLE
Add more debugging info to help identify cause of undefined states

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/ExplorationStatesService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationStatesService.js
@@ -109,13 +109,6 @@ oppia.factory('ExplorationStatesService', [
     var getStatePropertyMemento = function(stateName, backendName) {
       var accessorList = PROPERTY_REF_DATA[backendName];
       var propertyRef = _states.getState(stateName);
-      if (propertyRef === undefined) {
-        throw Error('Undefined states error debug logs:' +
-          '\nRequested state name: ' + stateName +
-          '\nExploration ID: ' + ContextService.getExplorationId() +
-          '\nChange list: ' + ChangeListService.getChangeList() +
-          '\nAll states names: ' + _states.getStateNames());
-      }
       try {
         accessorList.forEach(function(key) {
           propertyRef = propertyRef[key];

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationStatesService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationStatesService.js
@@ -114,10 +114,11 @@ oppia.factory('ExplorationStatesService', [
           propertyRef = propertyRef[key];
         });
       } catch (e) {
-        var additionalInfo = ('Undefined states error debug logs:' +
+        var additionalInfo = ('\nUndefined states error debug logs:' +
           '\nRequested state name: ' + stateName +
           '\nExploration ID: ' + ContextService.getExplorationId() +
-          '\nChange list: ' + ChangeListService.getChangeList() +
+          '\nChange list: ' + JSON.stringify(
+          ChangeListService.getChangeList()) +
           '\nAll states names: ' + _states.getStateNames());
         e.message += additionalInfo;
         throw e;

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationStatesService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationStatesService.js
@@ -109,6 +109,14 @@ oppia.factory('ExplorationStatesService', [
     var getStatePropertyMemento = function(stateName, backendName) {
       var accessorList = PROPERTY_REF_DATA[backendName];
       var propertyRef = _states.getState(stateName);
+      if (propertyRef === undefined) {
+        throw Error('Undefined states error debug logs:' +
+          '\nRequested state name: ' + stateName +
+          '\nRequested info type: ' + backendName +
+          '\nExploration ID: ' + ContextService.getExplorationId() +
+          '\nChange list: ' + ChangeListService.getChangeList() +
+          '\nAll states names: ' + _states.getStateNames());
+      }
       accessorList.forEach(function(key) {
         propertyRef = propertyRef[key];
       });

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationStatesService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationStatesService.js
@@ -112,14 +112,23 @@ oppia.factory('ExplorationStatesService', [
       if (propertyRef === undefined) {
         throw Error('Undefined states error debug logs:' +
           '\nRequested state name: ' + stateName +
-          '\nRequested info type: ' + backendName +
           '\nExploration ID: ' + ContextService.getExplorationId() +
           '\nChange list: ' + ChangeListService.getChangeList() +
           '\nAll states names: ' + _states.getStateNames());
       }
-      accessorList.forEach(function(key) {
-        propertyRef = propertyRef[key];
-      });
+      try {
+        accessorList.forEach(function(key) {
+          propertyRef = propertyRef[key];
+        });
+      } catch (e) {
+        var additionalInfo = ('Undefined states error debug logs:' +
+          '\nRequested state name: ' + stateName +
+          '\nExploration ID: ' + ContextService.getExplorationId() +
+          '\nChange list: ' + ChangeListService.getChangeList() +
+          '\nAll states names: ' + _states.getStateNames());
+        e.message += additionalInfo;
+        throw e;
+      }
 
       return angular.copy(propertyRef);
     };


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
To help debugging #5794, a new error is thrown whenever get `_states.getState` return undefined.  This new error includes
- Arguments passed into `getStatePropertyMemento`(the state name)
- Exp ID
- Change list
- All states that the current exploration contains.

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
