### PR TITLE
Fix #5777: add statename in translation tab

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationDirective.js
@@ -268,25 +268,25 @@ oppia.directive('stateTranslation', [
                 ExplorationInitStateNameService.displayed);
             }
 
-            var stateName = StateEditorService.getActiveStateName();
+            $scope.stateName = StateEditorService.getActiveStateName();
 
             $scope.stateContent = ExplorationStatesService
-              .getStateContentMemento(stateName);
+              .getStateContentMemento($scope.stateName);
             $scope.stateSolution = ExplorationStatesService
-              .getSolutionMemento(stateName);
+              .getSolutionMemento($scope.stateName);
             $scope.stateHints = ExplorationStatesService
-              .getHintsMemento(stateName);
+              .getHintsMemento($scope.stateName);
             $scope.stateAnswerGroups = ExplorationStatesService
-              .getInteractionAnswerGroupsMemento(stateName);
+              .getInteractionAnswerGroupsMemento($scope.stateName);
             $scope.stateDefaultOutcome = ExplorationStatesService
-              .getInteractionDefaultOutcomeMemento(stateName);
+              .getInteractionDefaultOutcomeMemento($scope.stateName);
             $scope.stateInteractionId = ExplorationStatesService
-              .getInteractionIdMemento(stateName);
+              .getInteractionIdMemento($scope.stateName);
             $scope.activeHintIndex = null;
             $scope.activeAnswerGroupIndex = null;
 
             var currentCustomizationArgs = ExplorationStatesService
-              .getInteractionCustomizationArgsMemento(stateName);
+              .getInteractionCustomizationArgsMemento($scope.stateName);
             $scope.answerChoices = StateEditorService.getAnswerChoices(
               $scope.stateInteractionId, currentCustomizationArgs);
             $scope.onTabClick($scope.TAB_ID_CONTENT);

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/state_translation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/state_translation_directive.html
@@ -151,17 +151,16 @@
 
 <style>
   .oppia-translation-page-statename {
-    margin-bottom: 80px;
     margin-left: 80px;
-    margin-right: auto;
-    margin-top: 40px;
-    position: absolute;
+    margin-top: 35px;
+    position: relative;
   }
   .oppia-state-translation-page {
     display: flex;
     flex-direction: column;
+    margin-left: 80px;
+    margin-top: 20px;
     min-height: 500px;
-    margin-top: 75px;
     padding: 0px;
     width: 80%;
   }

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/state_translation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/state_translation_directive.html
@@ -1,3 +1,6 @@
+<div class="oppia-translation-page-statename">
+  <strong><[stateName]></strong>
+</div>
 <div class="oppia-page-card oppia-state-translation-page">
   <div class="translation-nav md-tab">
     <ul class="oppia-translation-tabs">
@@ -147,6 +150,13 @@
 </div>
 
 <style>
+  .oppia-translation-page-statename {
+    margin-bottom: 80px;
+    margin-left: 80px;
+    margin-right: auto;
+    margin-top: 10px;
+    position: absolute;
+  }
   .oppia-state-translation-page {
     display: flex;
     flex-direction: column;

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/state_translation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/state_translation_directive.html
@@ -154,13 +154,14 @@
     margin-bottom: 80px;
     margin-left: 80px;
     margin-right: auto;
-    margin-top: 10px;
+    margin-top: 40px;
     position: absolute;
   }
   .oppia-state-translation-page {
     display: flex;
     flex-direction: column;
     min-height: 500px;
+    margin-top: 75px;
     padding: 0px;
     width: 80%;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

  Fixes #5777 This PR  done that the currently user work on the which state that will show the name of the state in translation tab.
## Checklist
- [X] The PR title starts with "Fix #5777 : ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The PR explanation includes the words "Fixes #5777: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [X] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [X] The PR is made from a branch that's add-name called "develop".
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [X] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
