### PR TITLE
Fix #5606: Logic Proof Truncation and Display

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
@@ -71,7 +71,7 @@
 </style>
 
 <script type="text/ng-template" id="popover/answer">
-  <div style="max-height:300px;overflow-y:scroll;">
+  <div style="max-height: 300px; overflow-y: scroll;">
     <angular-html-bind html-data="getAnswerHtml()">
     </angular-html-bind>
   </div>

--- a/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
@@ -71,7 +71,7 @@
 </style>
 
 <script type="text/ng-template" id="popover/answer">
-  <div>
+  <div style="max-height:300px;overflow-y:scroll;">
     <angular-html-bind html-data="getAnswerHtml()">
     </angular-html-bind>
   </div>

--- a/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
@@ -72,7 +72,7 @@
 
 <script type="text/ng-template" id="popover/answer">
   <div>
-    <angular-html-bind html-data="answer()">
+    <angular-html-bind html-data="getAnswerHtml()">
     </angular-html-bind>
   </div>
 </script>

--- a/extensions/interactions/LogicProof/directives/LogicProof.js
+++ b/extensions/interactions/LogicProof/directives/LogicProof.js
@@ -86,8 +86,8 @@ oppia.directive('oppiaInteractiveLogicProof', [
             $scope.questionData.language.operators);
           $scope.questionString = (
             $scope.assumptionsString === '' ?
-            'I18N_INTERACTIONS_LOGIC_PROOF_QUESTION_STR_NO_ASSUMPTION' :
-            'I18N_INTERACTIONS_LOGIC_PROOF_QUESTION_STR_ASSUMPTIONS');
+              'I18N_INTERACTIONS_LOGIC_PROOF_QUESTION_STR_NO_ASSUMPTION':
+              'I18N_INTERACTIONS_LOGIC_PROOF_QUESTION_STR_ASSUMPTIONS');
           $scope.questionStringData = {
             target: $scope.targetString,
             assumptions: $scope.assumptionsString
@@ -225,7 +225,7 @@ oppia.directive('oppiaInteractiveLogicProof', [
               target_string: $scope.targetString,
               proof_string: $scope.proofString,
               proof_num_lines: $scope.proofString.split('\n').length,
-              displayed_question: $scope.questionString
+              displayed_question: $scope.questionString,
             };
             try {
               var proof = logicProofStudent.buildProof(

--- a/extensions/interactions/LogicProof/directives/LogicProof.js
+++ b/extensions/interactions/LogicProof/directives/LogicProof.js
@@ -225,7 +225,7 @@ oppia.directive('oppiaInteractiveLogicProof', [
               target_string: $scope.targetString,
               proof_string: $scope.proofString,
               proof_num_lines: $scope.proofString.split('\n').length,
-              displayed_question: $scope.questionString,
+              displayed_question: $scope.questionString
             };
             try {
               var proof = logicProofStudent.buildProof(

--- a/extensions/interactions/LogicProof/directives/logic_proof_response_directive.html
+++ b/extensions/interactions/LogicProof/directives/logic_proof_response_directive.html
@@ -1,5 +1,5 @@
 <div>
-  <p>Assuming <[answer.assumptions_string]>; prove <[answer.target_string]>.</p>
+  <span translate="<[answer.displayed_question]>" translate-values="{target: answer.target_string, assumptions: answer.assumptions_string}"></span>
   <div ng-if="answer.correct">
     <pre><[answer.displayed_proof[0]]></pre>
   </div>

--- a/extensions/interactions/LogicProof/directives/logic_proof_response_directive.html
+++ b/extensions/interactions/LogicProof/directives/logic_proof_response_directive.html
@@ -1,5 +1,5 @@
 <div>
-  <[answer.displayed_question]>
+  <p>Assuming <[answer.assumptions_string]>; prove <[answer.target_string]>.</p>
   <div ng-if="answer.correct">
     <pre><[answer.displayed_proof[0]]></pre>
   </div>

--- a/extensions/interactions/LogicProof/directives/logic_proof_short_response_directive.html
+++ b/extensions/interactions/LogicProof/directives/logic_proof_short_response_directive.html
@@ -4,5 +4,5 @@
 </span>
 <span ng-if="!answer.correct">
   <span translate="I18N_INTERACTIONS_LOGIC_PROOF_INCORRECT_ANSWERS"></span>:
-  <pre><[answer.displayed_proof[1] | truncateAtFirstLine]></pre>
+  <pre><[answer.displayed_proof.join('\n') | truncateAtFirstLine]></pre>
 </span>


### PR DESCRIPTION
# Explanation
Fixes #5606:

This PR sets the short answer output of the logic proof interaction to be truncated if it contains multiple lines. This was done by editing the output of the `file logic_proof_short_response_directive.html` to truncate the entire joined output from the answer instead of only using the erroneous line.

Also, set the popup displayed when a short response is clicked to show the entire response and not the empty popup.