### PR TITLE
Change 'compliment' feedback to use a green background colour.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadStatusDisplayService.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadStatusDisplayService.js
@@ -40,6 +40,8 @@ oppia.factory('ThreadStatusDisplayService', [function() {
     getLabelClass: function(status) {
       if (status === 'open') {
         return 'label label-info';
+      } else if (status === 'compliment') {
+        return 'label label-success';
       } else {
         return 'label label-default';
       }

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadStatusDisplayServiceSpec.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/ThreadStatusDisplayServiceSpec.js
@@ -60,6 +60,6 @@ describe('Thread Status Display Service', function() {
 
     mockStatusID = 'compliment';
     expect(ThreadStatusDisplayService.getLabelClass(mockStatusID)).toBe(
-      'label label-default');
+      'label label-success');
   });
 });

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/feedback_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/feedback_tab.html
@@ -1,4 +1,4 @@
-<md-card class="oppia-editor-card" ng-controller="FeedbackTab">
+<md-card class="oppia-editor-card oppia-feedback-card" ng-controller="FeedbackTab">
   <div ng-if="!activeThread">
     <div ng-if="threadData.suggestionThreads.length > 0">
       <h2>Suggestions from Learners</h2>
@@ -140,3 +140,13 @@
     <em ng-if="!userIsLoggedIn">To respond to a feedback thread, please log in.</em>
   </div>
 </md-card>
+
+
+<style>
+  /* Overwrite the default "success" color to a darker shade of green in order
+  to prevent this overshadowing the active action buttons (like "Create New
+  Thread"). */
+  .oppia-feedback-card span.label.label-success {
+    background-color: #038603;
+  }
+</style>


### PR DESCRIPTION
This separates the 'compliment'-type feedback from the others more visually.