### PR TITLE
Make instructions clearer in the bug report issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,12 +27,12 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Desktop (please complete the following information):**
+**Desktop (please complete the following information; delete this section if the issue does not arise on desktop):**
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
-**Smartphone (please complete the following information):**
+**Smartphone (please complete the following information; delete this section if the issue does not arise on smartphones):**
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]


### PR DESCRIPTION
I just realized that I misinterpreted @ctao5660's comment in [this issue](https://github.com/oppia/oppia/issues/5861) since I thought it happened on both desktop + mobile. I added a few notes to make the instructions clearer!