### PR TITLE
Fixes #5845 Uploading same image twice in a row succeeds now

### DIFF
--- a/core/templates/dev/head/components/forms/image_uploader_directive.html
+++ b/core/templates/dev/head/components/forms/image_uploader_directive.html
@@ -10,7 +10,7 @@
     Please do not upload watermarked images.
   </span>
   <label for="image-file-input" translate="I18N_DIRECTIVES_UPLOAD_A_FILE" class="image-uploader-upload-label-button"></label>
-  <input type="file" id="image-file-input" class="image-uploader-file-input" ng-class="fileInputClassName">
+  <input type="file" id="image-file-input" onclick="this.value = null" class="image-uploader-file-input" ng-class="fileInputClassName">
 </div>
 
 <style>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #5845 , in researching this I found it was a common bug among AngularJS file input uploaders. All the other browsers except for Chrome have a regular way of sensing a change, but Chrome does this a special way that I forget the exact specifics. The fix is to set the value of it to NULL so that any image uploaded will be detected as a change.

 You can probably tell from my vague explanation that I don't know much about the frontend, but I'm working on it!
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
