### PR TITLE
Fixes #5861 Updated Test for Email Truncation

### DIFF
--- a/core/controllers/tasks_test.py
+++ b/core/controllers/tasks_test.py
@@ -48,6 +48,8 @@ class TasksTests(test_utils.GenericTestBase):
         self.user_id_b = self.get_user_id_from_email(self.USER_B_EMAIL)
         self.signup(self.EDITOR_EMAIL, self.EDITOR_USERNAME)
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
+        self.set_user_role(
+            self.EDITOR_USERNAME, feconf.ROLE_ID_EXPLORATION_EDITOR)
         self.exploration = self.save_new_default_exploration(
             'A', self.editor_id, title='Title')
         self.can_send_emails_ctx = self.swap(
@@ -74,25 +76,20 @@ class TasksTests(test_utils.GenericTestBase):
             messages = feedback_services.get_messages(thread_id)
             self.assertEqual(len(messages), 2)
 
-            # Telling tasks.py to send email to User 'A'.
-            payload = {
-                'user_id': self.user_id_a}
-            taskqueue_services.enqueue_email_task(
-                feconf.TASK_URL_FEEDBACK_MESSAGE_EMAILS, payload, 0)
-
-            # Check that there are no feedback emails sent to User 'A'.
-            messages = self.mail_stub.get_sent_messages(to=self.USER_A_EMAIL)
+            # Check that there are no feedback emails sent to Editor.
+            messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)
             self.assertEqual(len(messages), 0)
 
-            # Send task and subsequent email to User 'A'.
+            # Send task and subsequent email to Editor.
             self.process_and_flush_pending_tasks()
-            messages = self.mail_stub.get_sent_messages(to=self.USER_A_EMAIL)
+            messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)
             expected_message = (
-                'Hi userA,\n\nNew update to thread "a subject"'
-                ' on Title:\n- userB: user b message\n(You received'
-                ' this message because you are a participant in this thread.)'
-                '\n\nBest wishes,\nThe Oppia team\n\nYou can change your email'
-                ' preferences via the Preferences page.')
+                'Hi editor,\n\nYou\'ve received 2 new messages on your'
+                ' Oppia explorations:\n- Title:\n- some text\n- user b message'
+                '\nYou can view and reply to your messages from your dashboard.'
+                '\n\nThanks, and happy teaching!\n\nBest wishes,\nThe Oppia'
+                ' Team\n\nYou can change your email preferences via the '
+                'Preferences page.')
 
             # Assert that the message is correct.
             self.assertEqual(len(messages), 1)
@@ -107,30 +104,23 @@ class TasksTests(test_utils.GenericTestBase):
             messages = feedback_services.get_messages(thread_id)
             self.assertEqual(len(messages), 3)
 
-            # Telling tasks.py to send email to User 'A'.
-            payload = {
-                'user_id': self.user_id_a}
-            taskqueue_services.enqueue_email_task(
-                feconf.TASK_URL_FEEDBACK_MESSAGE_EMAILS, payload, 0)
-
-            # Check that there is one feedback email sent to User 'A'.
-            messages = self.mail_stub.get_sent_messages(to=self.USER_A_EMAIL)
-            self.assertEqual(len(messages), 1)
-
-            # Send task and subsequent email to User 'A'.
+            # Send task and subsequent email to Editor.
             self.process_and_flush_pending_tasks()
-            messages = self.mail_stub.get_sent_messages(to=self.USER_A_EMAIL)
+            messages = self.mail_stub.get_sent_messages(to=self.EDITOR_EMAIL)
 
             # What is expected in the email body.
             expected_message = (
-                'Hi userA,\n\nNew update to thread "a subject"'
-                ' on Title:\n- userB:' + 'B' * 200 + '...' + ' e\n(You received'
-                ' this message because you are a participant in this thread.)'
-                '\n\nBest wishes,\nThe Oppia team\n\nYou can change your email'
-                ' preferences via the Preferences page.')
+                'Hi editor,\n\nYou\'ve received a new message on your Oppia'
+                ' explorations:\n- Title:\n- ' + 'B' * 200 + '...' + '\nYou can'
+                ' view and reply to your messages from your dashboard.\n\nThank'
+                's, and happy teaching!\n\nBest wishes,\nThe Oppia Team\n\nYou'
+                ' can change your email preferences via the Preferences page.')
 
-            # Check that greater than 200 word message is sent.
+            # Check that greater than 200 word message is sent
+            # and has correct message.
+
             self.assertEqual(len(messages), 2)
+            self.assertEqual(messages[1].body.decode(), expected_message)
 
     def test_email_is_sent_when_suggestion_created(self):
         """Tests SuggestionEmailHandler functionality."""


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #5861 , updated test to reflect more accurately what the handler does. In the first version, I had included testing emails sent to user A and B, the participants of the test thread, but the unsent feedback message handler only sends emails to moderators and editors. Also checks the truncation functionality

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
