### PR TITLE
Fix #5885 Only run front end test when front end file changed

### DIFF
--- a/core/templates/dev/head/pages/about/about.html
+++ b/core/templates/dev/head/pages/about/about.html
@@ -182,6 +182,7 @@
                   <li>Charisse De Torres</li>
                   <li>Chase Albert</li>
                   <li>Chen Shenyue</li>
+                  <li>Test for front end files change</li>
                   <li>Chin Zhan Xiong</li>
                   <li>Christopher Tao</li>
                   <li>Cihan Bebek</li>

--- a/core/templates/dev/head/pages/about/about.html
+++ b/core/templates/dev/head/pages/about/about.html
@@ -182,7 +182,6 @@
                   <li>Charisse De Torres</li>
                   <li>Chase Albert</li>
                   <li>Chen Shenyue</li>
-                  <li>Test for front end files change</li>
                   <li>Chin Zhan Xiong</li>
                   <li>Christopher Tao</li>
                   <li>Cihan Bebek</li>

--- a/scripts/run_presubmit_checks.sh
+++ b/scripts/run_presubmit_checks.sh
@@ -85,11 +85,11 @@ else
   BRANCH=develop
 fi
 
-FRONT_END_DIR='core/templates/dev/head'
+FRONTEND_DIR='core/templates/dev/head'
 
 echo "Comparing the current branch with $BRANCH"
 
-if git diff --cached --name-only --diff-filter=ACM ${BRANCH} | grep ${FRONT_END_DIR} --quiet
+if [ -n "$(git diff --cached --name-only --diff-filter=ACM ${BRANCH} | grep ${FRONTEND_DIR})" ]
 then 
   # Run frontend unit tests.
   echo 'Running frontend unit tests'
@@ -97,7 +97,7 @@ then
   echo 'Frontend tests passed.'
   echo ''
 else 
-  # If files in FRONT_END_DIR were not changed, skip the tests.
+  # If files in FRONTEND_DIR were not changed, skip the tests.
   echo 'No frontend files were changed.'
   echo 'Skipped frontend tests'
 fi

--- a/scripts/run_presubmit_checks.sh
+++ b/scripts/run_presubmit_checks.sh
@@ -21,15 +21,27 @@
 # Run this script from the oppia root folder prior to opening a PR:
 #   bash scripts/run_presubmit_checks.sh
 #
-# It runs all the tests, in this order:
+# It runs the following tests in all cases.
 # - Javascript and Python Linting
-# - Frontend Karma unit tests
 # - Backend Python tests
+# 
+# Only when frontend files are changed will it run Frontend Karma unit tests.
 #
 # If any of these tests result in errors, this script will terminate.
 #
 # Note: The test scripts are arranged in increasing order of time taken. This
 # enables a broken build to be detected as quickly as possible.
+# 
+# =====================
+# CUSTOMIZATION OPTIONS
+# =====================
+#
+# Set the origin branch to compare against by adding
+#
+#   --branch=your_branch or -b=your_branch
+#
+# By default the origin branch is set to origin/develop.
+
 if [ -z "$BASH_VERSION" ]
 then
   echo ""
@@ -47,6 +59,7 @@ python $(dirname $0)/pre_commit_linter.py || exit 1
 echo 'Linting passed.'
 echo ''
 
+# Read arguments from the command line.
 for i in "$@"
 do
 case $i in
@@ -57,7 +70,7 @@ case $i in
 esac
 done
 
-# default origin branch set to origin/develop
+# Set the origin branch to origin/develop if it's not specified.
 if [ -z $ORIGIN_BRANCH ];
 then
   BRANCH=origin/develop
@@ -74,9 +87,9 @@ then
   echo 'Frontend tests passed.'
   echo ''
 else 
-  # If files in FRONT_END_DIR not changed, skip the tests
-  echo 'Front end files not changed'
-  echo 'Skip front end tests'
+  # If files in FRONT_END_DIR were not changed, skip the tests.
+  echo 'No frontend files were changed.'
+  echo 'Skipped frontend tests'
 fi
 
 

--- a/scripts/run_presubmit_checks.sh
+++ b/scripts/run_presubmit_checks.sh
@@ -40,7 +40,7 @@
 #
 #   --branch=your_branch or -b=your_branch
 #
-# By default the origin branch is set to origin/develop.
+# By default the origin branch is set to develop.
 
 if [ -z "$BASH_VERSION" ]
 then
@@ -70,12 +70,12 @@ case $i in
 esac
 done
 
-# Set the origin branch to origin/develop if it's not specified.
+# Set the origin branch to develop if it's not specified.
 if [ -z $ORIGIN_BRANCH ];
 then
-  BRANCH=origin/develop
+  BRANCH=develop
 else
-  BRANCH=origin/$ORIGIN_BRANCH
+  BRANCH=$ORIGIN_BRANCH
 fi
 FRONT_END_DIR='core/templates/dev/head'
 

--- a/scripts/run_presubmit_checks.sh
+++ b/scripts/run_presubmit_checks.sh
@@ -40,7 +40,9 @@
 #
 #   --branch=your_branch or -b=your_branch
 #
-# By default the origin branch is set to develop.
+# By default, if the current branch tip exists on remote origin,
+# the current branch is compared against its tip on GitHub.
+# Otherwise it's compared against 'develop'.
 
 if [ -z "$BASH_VERSION" ]
 then
@@ -70,14 +72,22 @@ case $i in
 esac
 done
 
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+# If the current branch exists on remote origin, MATCHED_BRANCH_NUM=1
+# else MATCHED_BRANCH_NUM=0
+MATCHED_BRANCH_NUM=$(git ls-remote --heads origin $CURRENT_BRANCH | wc -l)
 # Set the origin branch to develop if it's not specified.
-if [ -z $ORIGIN_BRANCH ];
-then
-  BRANCH=develop
-else
+if [ -n "$ORIGIN_BRANCH" ]; then
   BRANCH=$ORIGIN_BRANCH
+elif [ $MATCHED_BRANCH_NUM == 1 ]; then
+  BRANCH=origin/$CURRENT_BRANCH
+else
+  BRANCH=develop
 fi
+
 FRONT_END_DIR='core/templates/dev/head'
+
+echo "Comparing the current branch with $BRANCH"
 
 if git diff --cached --name-only --diff-filter=ACM ${BRANCH} | grep ${FRONT_END_DIR} --quiet
 then 


### PR DESCRIPTION
## Explanation
Fix #5885:
This PR changes the `pre_submit_test.sh` workflow. If the front end files, i.e. all the files under `core/templates/dev/head`, not changed, then it skips the front end check.

By default, it compares the local **committed** changes against the `origin/develop` branch, but you can also pass your working branch name by the following
```shell
bash scripts/run_presubmit_checks.sh --branch=your_branch
```

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
