### PR TITLE
Fix #5933: Changed Code Editor Prompt in Test Exploration to be More Explicit

### DIFF
--- a/data/explorations/all_interactions/all_interactions.yaml
+++ b/data/explorations/all_interactions/all_interactions.yaml
@@ -14,7 +14,7 @@ states:
     classifier_model_id: null
     content:
       content_id: content
-      html: <p>Code Editor. Write a program which prints hello to me.</p>
+      html: <p>Code Editor. Write a program which prints 'Hello Oppia' to me.</p>
     content_ids_to_audio_translations:
       content: {}
       default_outcome: {}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes the prompt as per #5933 
This is what it looks like now:
![image](https://user-images.githubusercontent.com/39934918/49405591-b21ee100-f707-11e8-9792-ec3262e9ded3.png)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
