### PR TITLE
Fix #5853: Remove weird image in rte

### DIFF
--- a/core/templates/dev/head/app.js
+++ b/core/templates/dev/head/app.js
@@ -139,6 +139,7 @@ oppia.run([
             button: componentDefn.tooltip,
             inline: isInline,
             template: componentTemplate,
+            draggable: false,
             edit: function(event) {
               editor.fire('lockSnapshot', {
                 dontUpdate: true


### PR DESCRIPTION
## Explanation
Fixes #5853: Removing the drag handlers for widgets fixes the issue of extra image being added in RTE.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
