### PR TITLE
Fix #5039: Added continue button in preview mode

### DIFF
--- a/extensions/interactions/Continue/directives/Continue.js
+++ b/extensions/interactions/Continue/directives/Continue.js
@@ -40,8 +40,7 @@ oppia.directive('oppiaInteractiveContinue', [
           var DEFAULT_BUTTON_TEXT = 'Continue';
           var DEFAULT_HUMAN_READABLE_ANSWER = 'Please continue.';
 
-          $scope.isInEditorMode = (
-            ContextService.isInExplorationEditorMode());
+          $scope.isInEditorMode = ContextService.isInExplorationEditorMode();
 
           $scope.submitAnswer = function() {
             // We used to show "(Continue)" to indicate a 'continue' action when

--- a/extensions/interactions/Continue/directives/Continue.js
+++ b/extensions/interactions/Continue/directives/Continue.js
@@ -30,15 +30,18 @@ oppia.directive('oppiaInteractiveContinue', [
         'continue_interaction_directive.html'),
       controller: [
         '$scope', '$attrs', 'WindowDimensionsService',
-        'CurrentInteractionService',
+        'CurrentInteractionService', 'ContextService',
         function(
             $scope, $attrs, WindowDimensionsService,
-            CurrentInteractionService) {
+            CurrentInteractionService, ContextService) {
           $scope.buttonText = HtmlEscaperService.escapedJsonToObj(
             $attrs.buttonTextWithValue);
 
           var DEFAULT_BUTTON_TEXT = 'Continue';
           var DEFAULT_HUMAN_READABLE_ANSWER = 'Please continue.';
+
+          $scope.isInEditorMode = (
+            ContextService.isInExplorationEditorMode());
 
           $scope.submitAnswer = function() {
             // We used to show "(Continue)" to indicate a 'continue' action when

--- a/extensions/interactions/Continue/directives/continue_interaction_directive.html
+++ b/extensions/interactions/Continue/directives/continue_interaction_directive.html
@@ -1,0 +1,4 @@
+<md-button ng-if="isInEditorMode" class="oppia-learner-confirm-button">
+  <[buttonText]>
+  <i class="fa fa-arrow-right" style="font-size: 19px; padding-top: 1.5px;"></i>
+</md-button>


### PR DESCRIPTION
## Explanation
Fixes #5039: Added continue button in preview mode.

Here is a screenshot for the same:
![image](https://user-images.githubusercontent.com/15226041/49684255-55506b80-faf7-11e8-95e4-06efa79dd1eb.png)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
