### PR TITLE
Fix #5782: Added custom check to remove backslash continuation

### DIFF
--- a/scripts/pylint_extensions.py
+++ b/scripts/pylint_extensions.py
@@ -749,14 +749,12 @@ class BackslashContinuationChecker(checkers.BaseChecker):
         Args:
             node: astroid.scoped_nodes.Function. Node to access module content.
         """
-        file_content = node.stream().readlines()
-        file_length = len(file_content)
-
-        for line_num in xrange(file_length):
-            line = file_content[line_num]
-            if line.rstrip('\r\n').endswith('\\'):
-                self.add_message(
-                    'backslash-continuation', line=line_num + 1)
+        with node.stream() as stream:
+            file_content = stream.readlines()
+            for (line_num, line) in enumerate(file_content):
+                if line.rstrip('\r\n').endswith('\\'):
+                    self.add_message(
+                        'backslash-continuation', line=line_num + 1)
 
 
 def register(linter):

--- a/scripts/pylint_extensions.py
+++ b/scripts/pylint_extensions.py
@@ -725,6 +725,40 @@ class ImportOnlyModulesChecker(checkers.BaseChecker):
                 pass
 
 
+class BackslashContinuationChecker(checkers.BaseChecker):
+    """Custom pylint checker which checks that backslash is not used
+    for continuation.
+    """
+    __implements__ = interfaces.IRawChecker
+
+    name = 'backslash-continuation'
+    priority = -1
+    msgs = {
+        'C0004': (
+            (
+                'Backslash should not be used to break continuation lines. '
+                'Use braces to break long lines.'),
+            'backslash-continuation',
+            'Use braces to break long lines instead of backslash.'
+        ),
+    }
+
+    def process_module(self, node):
+        """Process a module.
+
+        Args:
+            node: astroid.scoped_nodes.Function. Node to access module content.
+        """
+        file_content = node.stream().readlines()
+        file_length = len(file_content)
+
+        for line_num in xrange(file_length):
+            line = file_content[line_num]
+            if line.rstrip('\r\n').endswith('\\'):
+                self.add_message(
+                    'backslash-continuation', line=line_num + 1)
+
+
 def register(linter):
     """Registers the checker with pylint.
 
@@ -735,3 +769,4 @@ def register(linter):
     linter.register_checker(HangingIndentChecker(linter))
     linter.register_checker(DocstringParameterChecker(linter))
     linter.register_checker(ImportOnlyModulesChecker(linter))
+    linter.register_checker(BackslashContinuationChecker(linter))

--- a/scripts/pylint_extensions_test.py
+++ b/scripts/pylint_extensions_test.py
@@ -189,3 +189,44 @@ class ImportOnlyModulesCheckerTests(unittest.TestCase):
         ):
             checker_test_object.checker.visit_importfrom(
                 importfrom_node2)
+
+
+class BackslashContinuationCheckerTests(unittest.TestCase):
+
+    def test_finds_backslash_continuation(self):
+        checker_test_object = testutils.CheckerTestCase()
+        checker_test_object.CHECKER_CLASS = (
+            pylint_extensions.BackslashContinuationChecker)
+        checker_test_object.setup_method()
+        node = astroid.scoped_nodes.Module(name='test', doc='Custom test')
+        temp_file = tempfile.NamedTemporaryFile()
+        filename = temp_file.name
+        # pylint: disable=backslash-continuation
+        with open(filename, 'w') as tmp:
+            tmp.write(
+                """message1 = 'abc'\\
+                'cde'\\
+                'xyz'
+                message2 = 'abc\\\\'
+                message3 = (
+                    'abc\\\\'
+                    'xyz\\\\'
+                )
+                """)
+        # pylint: enable=backslash-continuation
+        node.file = filename
+        node.path = filename
+
+        checker_test_object.checker.process_module(node)
+
+        with checker_test_object.assertAddsMessages(
+            testutils.Message(
+                msg_id='backslash-continuation',
+                line=1
+            ),
+            testutils.Message(
+                msg_id='backslash-continuation',
+                line=2
+            ),
+        ):
+            temp_file.close()

--- a/scripts/pylint_extensions_test.py
+++ b/scripts/pylint_extensions_test.py
@@ -201,19 +201,19 @@ class BackslashContinuationCheckerTests(unittest.TestCase):
         node = astroid.scoped_nodes.Module(name='test', doc='Custom test')
         temp_file = tempfile.NamedTemporaryFile()
         filename = temp_file.name
-        # pylint: disable=backslash-continuation
+
         with open(filename, 'w') as tmp:
             tmp.write(
-                """message1 = 'abc'\\
-                'cde'\\
-                'xyz'
+                """message1 = 'abc'\\\n""" # pylint: disable=backslash-continuation
+                """'cde'\\\n""" # pylint: disable=backslash-continuation
+                """'xyz'
                 message2 = 'abc\\\\'
                 message3 = (
                     'abc\\\\'
                     'xyz\\\\'
                 )
                 """)
-        # pylint: enable=backslash-continuation
+
         node.file = filename
         node.path = filename
 


### PR DESCRIPTION
## Explanation
Fixes #5782: Added custom pylint checker to ensure that backslash is not used for breaking long lines.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
