### PR TITLE
Fix error while displaying suggestion threads on learner dashboard page

### DIFF
--- a/core/controllers/learner_dashboard.py
+++ b/core/controllers/learner_dashboard.py
@@ -163,6 +163,7 @@ class LearnerDashboardFeedbackThreadHandler(base.BaseHandler):
         message_summary_list = []
         suggestion = suggestion_services.get_suggestion_by_id(thread_id)
         suggestion_thread = feedback_services.get_thread(thread_id)
+
         exploration_id = feedback_services.get_exp_id_from_thread_id(thread_id)
         if suggestion:
             exploration = exp_services.get_exploration_by_id(exploration_id)

--- a/core/controllers/learner_dashboard.py
+++ b/core/controllers/learner_dashboard.py
@@ -162,7 +162,7 @@ class LearnerDashboardFeedbackThreadHandler(base.BaseHandler):
 
         message_summary_list = []
         suggestion = suggestion_services.get_suggestion_by_id(thread_id)
-
+        suggestion_thread = feedback_services.get_thread(thread_id)
         exploration_id = feedback_services.get_exp_id_from_thread_id(thread_id)
         if suggestion:
             exploration = exp_services.get_exploration_by_id(exploration_id)
@@ -172,7 +172,7 @@ class LearnerDashboardFeedbackThreadHandler(base.BaseHandler):
             suggestion_summary = {
                 'suggestion_html': suggestion.change.new_value['html'],
                 'current_content_html': current_content_html,
-                'description': suggestion.description,
+                'description': suggestion_thread.subject,
                 'author_username': authors_settings[0].username,
                 'author_picture_data_url': (
                     authors_settings[0].profile_picture_data_url)


### PR DESCRIPTION
## Explanation
While navigating on the test server I came across this error on the learner dashboard.
![image](https://user-images.githubusercontent.com/11898234/49696721-3f64a880-fbd4-11e8-881d-3d5e898655b7.png)

This PR aims to fix that. Also, it does affect one of the important functionalities, and it needs to be included in this release.

PTAL @aks681 @bansalnitish 

To test: 
- create an exploration, and submit a suggestion. 
- Navigate to the learner dashboard on the suggestion author's account, and go to the feedback updates tab. 
- Select the thread you created, and the above error message shouldn't appear

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
