### PR TITLE
Fix #5755: Added padding to cards to fix alignment issue on mobile view

### DIFF
--- a/core/templates/dev/head/pages/library/library.html
+++ b/core/templates/dev/head/pages/library/library.html
@@ -95,7 +95,7 @@
           </div>
 
           <div class="oppia-library-group" ng-repeat="group in libraryGroups track by $index" ng-mouseenter="setActiveGroup($index)" ng-mouseleave="clearActiveGroup()">
-            <div class="row oppia-library-group-header-container">
+            <div class="oppia-library-group-header-container">
               <h2 ng-class="{'active': activeGroupIndex === $index}" class="oppia-library-group-header">
                 <a ng-if="group.has_full_results_page" class="protractor-test-library-<[group.protractor_id]>" ng-click="showFullResultsPage(group.categories, group.full_results_url)" tabindex="0">
                   <span translate="<[group.header_i18n_id]>"></span>
@@ -274,6 +274,11 @@
         width: -moz-calc(80% - 120px);
         width: -o-calc(80% - 120px);
         width: calc(80% - 120px);
+      }
+    }
+    @media(max-width: 390px) {
+      .oppia-library-group-header {
+        margin-left: 11.25%;
       }
     }
     .oppia-library-group-header a, .oppia-library-group-header span {

--- a/core/templates/dev/head/pages/library/library.html
+++ b/core/templates/dev/head/pages/library/library.html
@@ -235,12 +235,12 @@
       height: 350px;
       margin-bottom: 72px;
       margin-top: 36px;
-      max-width: 975px;
-      padding-left: 5%;
+      max-width: 928px;
       width: 100vw;
     }
     .oppia-library-group-header-container {
-      max-width: 975px;
+      max-width: 928px;
+      margin: 0 -15px 0 0;
       min-width: 315px;
       width: calc(100% - 120px);
       width: -moz-calc(100% - 120px);

--- a/core/templates/dev/head/pages/library/library.html
+++ b/core/templates/dev/head/pages/library/library.html
@@ -235,11 +235,12 @@
       height: 350px;
       margin-bottom: 72px;
       margin-top: 36px;
-      max-width: 928px;
+      max-width: 975px;
+      padding-left: 5%;
       width: 100vw;
     }
     .oppia-library-group-header-container {
-      max-width: 928px;
+      max-width: 975px;
       min-width: 315px;
       width: calc(100% - 120px);
       width: -moz-calc(100% - 120px);


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #5755 
Earlier the cards were not aligned with the headers in mobile view.

**Screenshots**
<img width="884" alt="screenshot 2018-12-09 at 2 09 59 pm" src="https://user-images.githubusercontent.com/35570715/49724949-9af46c00-fc90-11e8-95ba-1ea1086d82f1.png">

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
