### PR TITLE
Allow admins to assign topic managers to topics

### DIFF
--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -32,6 +32,8 @@ from core.domain import recommendations_services
 from core.domain import rights_manager
 from core.domain import role_services
 from core.domain import stats_services
+from core.domain import topic_domain
+from core.domain import topic_services
 from core.domain import user_services
 from core.platform import models
 import feconf
@@ -51,6 +53,9 @@ class AdminPage(base.BaseHandler):
 
         recent_job_data = jobs.get_data_for_recent_jobs()
         unfinished_job_data = jobs.get_data_for_unfinished_jobs()
+        topic_summaries = topic_services.get_all_topic_summaries()
+        topic_summary_dicts = [
+            summary.to_dict() for summary in topic_summaries]
         for job in unfinished_job_data:
             job['can_be_canceled'] = job['is_cancelable'] and any([
                 klass.__name__ == job['job_type']
@@ -101,6 +106,7 @@ class AdminPage(base.BaseHandler):
                 role: role_services.HUMAN_READABLE_ROLES[role]
                 for role in role_services.VIEWABLE_ROLES
             },
+            'topic_summaries': topic_summary_dicts,
             'role_graph_data': role_services.get_role_graph_data()
         })
 
@@ -266,6 +272,7 @@ class AdminRoleHandler(base.BaseHandler):
     @acl_decorators.can_access_admin_page
     def get(self):
         view_method = self.request.get('method')
+        topic_summaries = topic_services.get_all_topic_summaries()
 
         if view_method == feconf.VIEW_METHOD_ROLE:
             role = self.request.get(feconf.VIEW_METHOD_ROLE)
@@ -297,6 +304,8 @@ class AdminRoleHandler(base.BaseHandler):
     def post(self):
         username = self.payload.get('username')
         role = self.payload.get('role')
+        topic_id = self.payload.get('topic_id')
+        print "Topic Id: ", topic_id
         user_id = user_services.get_user_id_from_username(username)
         if user_id is None:
             raise self.InvalidInputException(
@@ -305,6 +314,14 @@ class AdminRoleHandler(base.BaseHandler):
         role_services.log_role_query(
             self.user_id, feconf.ROLE_ACTION_UPDATE, role=role,
             username=username)
+
+        if topic_id:
+            print "assigning role"
+            user = user_services.UserActionsInfo(user_id)
+            topic_services.assign_role(
+                user_services.get_system_user(), user,
+                topic_domain.ROLE_MANAGER, topic_id)
+        
         self.render_json({})
 
 

--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -272,7 +272,6 @@ class AdminRoleHandler(base.BaseHandler):
     @acl_decorators.can_access_admin_page
     def get(self):
         view_method = self.request.get('method')
-        topic_summaries = topic_services.get_all_topic_summaries()
 
         if view_method == feconf.VIEW_METHOD_ROLE:
             role = self.request.get(feconf.VIEW_METHOD_ROLE)

--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -305,7 +305,6 @@ class AdminRoleHandler(base.BaseHandler):
         username = self.payload.get('username')
         role = self.payload.get('role')
         topic_id = self.payload.get('topic_id')
-        print "Topic Id: ", topic_id
         user_id = user_services.get_user_id_from_username(username)
         if user_id is None:
             raise self.InvalidInputException(
@@ -316,12 +315,11 @@ class AdminRoleHandler(base.BaseHandler):
             username=username)
 
         if topic_id:
-            print "assigning role"
             user = user_services.UserActionsInfo(user_id)
             topic_services.assign_role(
                 user_services.get_system_user(), user,
                 topic_domain.ROLE_MANAGER, topic_id)
-        
+
         self.render_json({})
 
 

--- a/core/templates/dev/head/pages/admin/admin.html
+++ b/core/templates/dev/head/pages/admin/admin.html
@@ -22,6 +22,7 @@
         RECENT_JOB_DATA: JSON.parse('{{recent_job_data|js_string}}'),
         UPDATABLE_ROLES: JSON.parse('{{updatable_roles|js_string}}'),
         VIEWABLE_ROLES: JSON.parse('{{viewable_roles|js_string}}'),
+        TOPIC_SUMMARIES: JSON.parse('{{topic_summaries|js_string}}'),
         ROLE_GRAPH_DATA: JSON.parse('{{role_graph_data|js_string}}'),
         userIsLoggedIn: JSON.parse('{{user_is_logged_in|js_string}}'),
       }

--- a/core/templates/dev/head/pages/admin/roles_tab/RolesTabDirective.js
+++ b/core/templates/dev/head/pages/admin/roles_tab/RolesTabDirective.js
@@ -40,7 +40,7 @@ oppia.directive('adminRolesTab', [
         $scope.viewFormValues = {};
         $scope.updateFormValues = {};
         $scope.viewFormValues.method = 'role';
-        
+
         $scope.graphDataLoaded = false;
         // Calculating initStateId and finalStateIds for graphData
         // Since role graph is acyclic, node with no incoming edge

--- a/core/templates/dev/head/pages/admin/roles_tab/RolesTabDirective.js
+++ b/core/templates/dev/head/pages/admin/roles_tab/RolesTabDirective.js
@@ -32,6 +32,7 @@ oppia.directive('adminRolesTab', [
       controller: ['$scope', function($scope) {
         $scope.UPDATABLE_ROLES = GLOBALS.UPDATABLE_ROLES;
         $scope.VIEWABLE_ROLES = GLOBALS.VIEWABLE_ROLES;
+        $scope.topicSummaries = GLOBALS.TOPIC_SUMMARIES;
         $scope.graphData = GLOBALS.ROLE_GRAPH_DATA;
         $scope.resultRolesVisible = false;
         $scope.result = {};
@@ -39,6 +40,8 @@ oppia.directive('adminRolesTab', [
         $scope.viewFormValues = {};
         $scope.updateFormValues = {};
         $scope.viewFormValues.method = 'role';
+
+        console.log("Test SUmmaries: " + $scope.topicSummaries);
 
         $scope.graphDataLoaded = false;
         // Calculating initStateId and finalStateIds for graphData
@@ -101,18 +104,19 @@ oppia.directive('adminRolesTab', [
           if (AdminTaskManagerService.isTaskRunning()) {
             return;
           }
-
           $scope.setStatusMessage('Updating User Role');
           AdminTaskManagerService.startTask();
           $http.post(ADMIN_ROLE_HANDLER_URL, {
             role: values.newRole,
-            username: values.username
+            username: values.username,
+            topic_id: values.topicId
           }).then(function() {
             $scope.setStatusMessage(
               'Role of ' + values.username +
               ' successfully updated to ' + values.newRole);
             $scope.updateFormValues.username = '';
             $scope.updateFormValues.newRole = '';
+            $scope.updateFormValues.topicId = '';
           }, function(errorResponse) {
             $scope.setStatusMessage(
               'Server error: ' + errorResponse.data.error);

--- a/core/templates/dev/head/pages/admin/roles_tab/RolesTabDirective.js
+++ b/core/templates/dev/head/pages/admin/roles_tab/RolesTabDirective.js
@@ -40,7 +40,7 @@ oppia.directive('adminRolesTab', [
         $scope.viewFormValues = {};
         $scope.updateFormValues = {};
         $scope.viewFormValues.method = 'role';
-
+        
         $scope.graphDataLoaded = false;
         // Calculating initStateId and finalStateIds for graphData
         // Since role graph is acyclic, node with no incoming edge

--- a/core/templates/dev/head/pages/admin/roles_tab/RolesTabDirective.js
+++ b/core/templates/dev/head/pages/admin/roles_tab/RolesTabDirective.js
@@ -41,8 +41,6 @@ oppia.directive('adminRolesTab', [
         $scope.updateFormValues = {};
         $scope.viewFormValues.method = 'role';
 
-        console.log("Test SUmmaries: " + $scope.topicSummaries);
-
         $scope.graphDataLoaded = false;
         // Calculating initStateId and finalStateIds for graphData
         // Since role graph is acyclic, node with no incoming edge

--- a/core/templates/dev/head/pages/admin/roles_tab/roles_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/roles_tab/roles_tab_directive.html
@@ -82,13 +82,13 @@
             </div>
           </div>
 
-           <div class="form-group" ng-if="updateFormValues.newRole==='TOPIC_MANAGER'">
-              <label class="col-md-4 col-lg-4 col-sm-4 control-label pull-left">Enter Topic for Topic Manager</label>
-              <div class="col-md-8 col-lg-8 col-sm-8">
-                <select ng-options="topic.id as topic.name for topic in topicSummaries" ng-model="updateFormValues.topicId" class="form-control protractor-update-form-role-select">
-                </select>
-              </div>
+          <div class="form-group" ng-if="updateFormValues.newRole==='TOPIC_MANAGER'">
+            <label class="col-md-4 col-lg-4 col-sm-4 control-label pull-left">Enter Topic for Topic Manager</label>
+            <div class="col-md-8 col-lg-8 col-sm-8">
+              <select ng-options="topic.id as topic.name for topic in topicSummaries" ng-model="updateFormValues.topicId" class="form-control protractor-update-form-role-select">
+              </select>
             </div>
+          </div>
           <button type="submit" class="btn btn-success protractor-update-form-submit" ng-disabled="!updateFormValues.newRole || !updateFormValues.username || (updateFormValues.newRole==='TOPIC_MANAGER' && !updateFormValues.topicId)" value="update role">Update Role</button>
         </form>
       </md-card>

--- a/core/templates/dev/head/pages/admin/roles_tab/roles_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/roles_tab/roles_tab_directive.html
@@ -24,7 +24,6 @@
               </select>
             </div>
           </div>
-
           <div class="form-group" ng-if="viewFormValues.method==='role'">
             <label class="col-md-4 col-lg-4 col-sm-4 control-label pull-left">Select Role</label>
             <div class="col-md-8 col-lg-8 col-sm-8">
@@ -83,7 +82,14 @@
             </div>
           </div>
 
-          <button type="submit" class="btn btn-success protractor-update-form-submit" ng-disabled="!updateFormValues.newRole || !updateFormValues.username" value="update role">Update Role</button>
+           <div class="form-group" ng-if="updateFormValues.newRole==='TOPIC_MANAGER'">
+              <label class="col-md-4 col-lg-4 col-sm-4 control-label pull-left">Enter Topic for Topic Manager</label>
+              <div class="col-md-8 col-lg-8 col-sm-8">
+                <select ng-options="topic.id as topic.name for topic in topicSummaries" ng-model="updateFormValues.topicId" class="form-control protractor-update-form-role-select">
+                </select>
+              </div>
+            </div>
+          <button type="submit" class="btn btn-success protractor-update-form-submit" ng-disabled="!updateFormValues.newRole || !updateFormValues.username || (updateFormValues.newRole==='TOPIC_MANAGER' && !updateFormValues.topicId)" value="update role">Update Role</button>
         </form>
       </md-card>
     </div>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Added functionality in the update roles section of the admin page, where if the role is 'topic manager', the admin will get a drop down with list of topics and can assign the topic manager to the topic
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
