### PR TITLE
Split ENABLE_NEW_STRUCTURES flag to 2 flags for editors and players

### DIFF
--- a/assets/constants.js
+++ b/assets/constants.js
@@ -464,7 +464,9 @@ var constants = {
     "\\u001b", "\\u001c", "\\u001d", "\\u001e", "\\u001f"
   ],
 
-  "ENABLE_NEW_STRUCTURES": false,
+  "ENABLE_NEW_STRUCTURE_EDITORS": false,
+
+  "ENABLE_NEW_STRUCTURE_PLAYERS": false,
 
   "NUM_QUESTIONS_PER_PAGE": 10,
 

--- a/core/controllers/concept_card_viewer.py
+++ b/core/controllers/concept_card_viewer.py
@@ -30,7 +30,7 @@ class ConceptCardDataHandler(base.BaseHandler):
     def get(self, skill_id):
         """Handles GET requests."""
 
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_PLAYERS:
             raise self.PageNotFoundException
 
         skill = skill_services.get_skill_by_id(skill_id, strict=False)

--- a/core/controllers/concept_card_viewer_test.py
+++ b/core/controllers/concept_card_viewer_test.py
@@ -47,7 +47,7 @@ class ConceptCardDataHandlerTest(test_utils.GenericTestBase):
             skill_contents=self.skill_contents)
 
     def test_get_concept_card(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', True):
             json_response = self.get_json(
                 '%s/%s' % (feconf.CONCEPT_CARD_DATA_URL_PREFIX, self.skill_id))
             self.assertEqual(
@@ -64,7 +64,7 @@ class ConceptCardDataHandlerTest(test_utils.GenericTestBase):
                 json_response['concept_card_dict']['worked_examples'])
 
     def test_get_concept_card_fails_when_new_structures_not_enabled(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', False):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', False):
             response = self.testapp.get(
                 '%s/%s' % (feconf.CONCEPT_CARD_DATA_URL_PREFIX, self.skill_id),
                 expect_errors=True)

--- a/core/controllers/creator_dashboard.py
+++ b/core/controllers/creator_dashboard.py
@@ -211,7 +211,7 @@ class CreatorDashboardHandler(base.BaseHandler):
             key=lambda x: (x['num_open_threads'], x['last_updated_msec']),
             reverse=True)
 
-        if constants.ENABLE_NEW_STRUCTURES:
+        if constants.ENABLE_NEW_STRUCTURE_PLAYERS:
             topic_summaries = topic_services.get_all_topic_summaries()
             topic_summary_dicts = [
                 summary.to_dict() for summary in topic_summaries]
@@ -324,7 +324,7 @@ class CreatorDashboardHandler(base.BaseHandler):
             'created_suggestions_list': suggestion_dicts_created_by_user,
             'suggestions_to_review_list': suggestion_dicts_which_can_be_reviewed
         })
-        if constants.ENABLE_NEW_STRUCTURES:
+        if constants.ENABLE_NEW_STRUCTURE_PLAYERS:
             self.values.update({
                 'topic_summary_dicts': topic_summary_dicts
             })

--- a/core/controllers/feedback.py
+++ b/core/controllers/feedback.py
@@ -67,7 +67,7 @@ class ThreadListHandlerForTopicsHandler(base.BaseHandler):
 
     @acl_decorators.can_edit_topic
     def get(self, topic_id):
-        if not constants.ENABLE_NEW_STRUCTURE_PLAYERS:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         self.values.update({

--- a/core/controllers/feedback.py
+++ b/core/controllers/feedback.py
@@ -67,7 +67,7 @@ class ThreadListHandlerForTopicsHandler(base.BaseHandler):
 
     @acl_decorators.can_edit_topic
     def get(self, topic_id):
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_PLAYERS:
             raise self.PageNotFoundException
 
         self.values.update({

--- a/core/controllers/question_editor.py
+++ b/core/controllers/question_editor.py
@@ -32,7 +32,7 @@ class QuestionCreationHandler(base.BaseHandler):
     @acl_decorators.can_manage_question_skill_status
     def post(self, skill_id):
         """Handles POST requests."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         skill_domain.Skill.require_valid_skill_id(skill_id)
@@ -69,7 +69,7 @@ class QuestionSkillLinkHandler(base.BaseHandler):
     @acl_decorators.can_manage_question_skill_status
     def post(self, question_id, skill_id):
         """Links a question to a skill."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         skill_domain.Skill.require_valid_skill_id(skill_id)
@@ -85,7 +85,7 @@ class QuestionSkillLinkHandler(base.BaseHandler):
     @acl_decorators.can_manage_question_skill_status
     def delete(self, question_id, skill_id):
         """Unlinks a question from a skill."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         question_services.delete_question_skill_link(
@@ -102,7 +102,7 @@ class EditableQuestionDataHandler(base.BaseHandler):
     def get(self, question_id):
         """Gets the data for the question overview page."""
 
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         question = question_services.get_question_by_id(
@@ -129,7 +129,7 @@ class EditableQuestionDataHandler(base.BaseHandler):
     @acl_decorators.can_edit_question
     def put(self, question_id):
         """Updates properties of the given question."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         question = question_services.get_question_by_id(
@@ -170,7 +170,7 @@ class EditableQuestionDataHandler(base.BaseHandler):
     @acl_decorators.can_delete_question
     def delete(self, question_id):
         """Handles Delete requests."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         question = question_services.get_question_by_id(

--- a/core/controllers/question_editor_test.py
+++ b/core/controllers/question_editor_test.py
@@ -68,7 +68,7 @@ class QuestionCreationHandlerTest(BaseQuestionEditorControllerTests):
         self.save_new_skill(self.skill_id, self.admin_id, 'Skill Description')
 
     def test_post(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             self.login(self.NEW_USER_EMAIL)
             response = self.testapp.post(
                 '%s/%s' % (feconf.NEW_QUESTION_URL, self.skill_id),
@@ -127,7 +127,7 @@ class QuestionSkillLinkHandlerTest(BaseQuestionEditorControllerTests):
             self._create_valid_question_data('ABC'))
 
     def test_post(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             self.login(self.NEW_USER_EMAIL)
             response = self.testapp.get(feconf.CREATOR_DASHBOARD_URL)
             csrf_token = self.get_csrf_token_from_response(response)
@@ -178,7 +178,7 @@ class QuestionSkillLinkHandlerTest(BaseQuestionEditorControllerTests):
             self.question_id, self.skill_id)
         question_services.create_new_question_skill_link(
             self.question_id_2, self.skill_id)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             self.login(self.NEW_USER_EMAIL)
             response = self.testapp.delete(
                 '%s/%s/%s' % (
@@ -226,7 +226,7 @@ class EditableQuestionDataHandlerTest(BaseQuestionEditorControllerTests):
             self.question_id, self.skill_id)
 
     def test_get(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             # Check that non-admin and topic_manager cannot access the editor
             # data.
             self.login(self.NEW_USER_EMAIL)
@@ -291,7 +291,7 @@ class EditableQuestionDataHandlerTest(BaseQuestionEditorControllerTests):
 
     def test_delete(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             self.delete_json(
                 '%s/%s' % (
                     feconf.QUESTION_EDITOR_DATA_URL_PREFIX, self.question_id),
@@ -299,7 +299,7 @@ class EditableQuestionDataHandlerTest(BaseQuestionEditorControllerTests):
             self.logout()
 
     def test_put(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             payload = {}
             new_question_data = self._create_valid_question_data('DEF')
             change_list = [{

--- a/core/controllers/skill_editor.py
+++ b/core/controllers/skill_editor.py
@@ -56,7 +56,7 @@ class SkillEditorPage(base.BaseHandler):
     def get(self, skill_id):
         """Handles GET requests."""
 
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         skill_domain.Skill.require_valid_skill_id(skill_id)
@@ -125,7 +125,7 @@ class EditableSkillDataHandler(base.BaseHandler):
     @acl_decorators.can_edit_skill
     def get(self, skill_id):
         """Populates the data on the individual skill page."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         skill_domain.Skill.require_valid_skill_id(skill_id)
@@ -143,7 +143,7 @@ class EditableSkillDataHandler(base.BaseHandler):
     @acl_decorators.can_edit_skill
     def put(self, skill_id):
         """Updates properties of the given skill."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         skill_domain.Skill.require_valid_skill_id(skill_id)
@@ -178,7 +178,7 @@ class EditableSkillDataHandler(base.BaseHandler):
     @acl_decorators.can_delete_skill
     def delete(self, skill_id):
         """Handles Delete requests."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         skill_domain.Skill.require_valid_skill_id(skill_id)

--- a/core/controllers/skill_editor_test.py
+++ b/core/controllers/skill_editor_test.py
@@ -238,7 +238,8 @@ class EditableSkillDataHandlerTest(BaseSkillEditorControllerTests):
                                  expected_status_int=404)
         # Check DELETE returns 500 when the skill still has associated
         # questions.
-        constants_swap = self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True)
+        constants_swap = self.swap(
+            constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True)
         skill_has_questions_swap = self.swap(
             skill_services, 'skill_has_associated_questions', lambda x: True)
         with constants_swap, skill_has_questions_swap:

--- a/core/controllers/skill_editor_test.py
+++ b/core/controllers/skill_editor_test.py
@@ -52,7 +52,7 @@ class BaseSkillEditorControllerTests(test_utils.GenericTestBase):
     def _get_csrf_token_for_put(self):
         csrf_token = None
         url_prefix = feconf.SKILL_EDITOR_URL_PREFIX
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             response = self.testapp.get('%s/%s' % (url_prefix, self.skill_id))
             csrf_token = self.get_csrf_token_from_response(response)
         return csrf_token
@@ -86,7 +86,7 @@ class SkillEditorTest(BaseSkillEditorControllerTests):
     def test_access_skill_editor_page(self):
         """Test access to editor pages for the sample skill."""
 
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             # Check that non-admins cannot access the editor page.
             self.login(self.NEW_USER_EMAIL)
             response = self.testapp.get(
@@ -103,13 +103,13 @@ class SkillEditorTest(BaseSkillEditorControllerTests):
     def test_skill_editor_page_fails(self):
         self.login(self.ADMIN_EMAIL)
         # Check GET returns 404 when new strutures' pages are not enabled.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', False):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', False):
             response = self.testapp.get(self.url, expect_errors=True)
             self.assertEqual(response.status_int, 404)
 
         # Check GET returns 404 when cannot get skill by id.
         self._delete_skill_model_and_memcache(self.admin_id, self.skill_id)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             response = self.testapp.get(self.url, expect_errors=True)
             self.assertEqual(response.status_int, 404)
         self.logout()
@@ -168,7 +168,7 @@ class EditableSkillDataHandlerTest(BaseSkillEditorControllerTests):
 
     def test_editable_skill_handler_get_succeeds(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             # Check that admins can access the editable skill data.
             json_response = self.get_json(self.url)
             self.assertEqual(self.skill_id, json_response['skill']['id'])
@@ -177,19 +177,19 @@ class EditableSkillDataHandlerTest(BaseSkillEditorControllerTests):
     def test_editable_skill_handler_get_fails(self):
         self.login(self.ADMIN_EMAIL)
         # Check GET returns 404 when new strutures' pages are not enabled.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', False):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', False):
             response = self.testapp.get(self.url, expect_errors=True)
             self.assertEqual(response.status_int, 404)
         # Check GET returns 404 when cannot get skill by id.
         self._delete_skill_model_and_memcache(self.admin_id, self.skill_id)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             response = self.testapp.get(self.url, expect_errors=True)
             self.assertEqual(response.status_int, 404)
         self.logout()
 
     def test_editable_skill_handler_put_succeeds(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             csrf_token = self._get_csrf_token_for_put()
             # Check that admins can edit a skill.
             json_response = self.put_json(
@@ -201,10 +201,10 @@ class EditableSkillDataHandlerTest(BaseSkillEditorControllerTests):
 
     def test_editable_skill_handler_put_fails(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             csrf_token = self._get_csrf_token_for_put()
             # Check PUT returns 404 when new strutures' pages are not enabled.
-            with self.swap(constants, 'ENABLE_NEW_STRUCTURES', False):
+            with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', False):
                 self.put_json(self.url, self.put_payload, csrf_token=csrf_token,
                               expect_errors=True, expected_status_int=404)
             # Check PUT returns 400 when an exception is raised updating the
@@ -223,22 +223,22 @@ class EditableSkillDataHandlerTest(BaseSkillEditorControllerTests):
 
     def test_editable_skill_handler_delete_succeeds(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             # Check that admins can delete a skill.
             self.delete_json(self.url)
         self.logout()
 
     def test_editable_skill_handler_delete_fails(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             # Check DELETE returns 404 when new strutures' pages are not
             # enabled.
-            with self.swap(constants, 'ENABLE_NEW_STRUCTURES', False):
+            with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', False):
                 self.delete_json(self.url, expect_errors=True,
                                  expected_status_int=404)
         # Check DELETE returns 500 when the skill still has associated
         # questions.
-        constants_swap = self.swap(constants, 'ENABLE_NEW_STRUCTURES', True)
+        constants_swap = self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True)
         skill_has_questions_swap = self.swap(
             skill_services, 'skill_has_associated_questions', lambda x: True)
         with constants_swap, skill_has_questions_swap:
@@ -256,7 +256,7 @@ class SkillPublishHandlerTest(BaseSkillEditorControllerTests):
 
     def test_skill_publish_handler_succeeds(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             # Check that an admin can publish a skill.
             csrf_token = self._get_csrf_token_for_put()
             self.put_json(self.url, {'version': 1}, csrf_token=csrf_token)
@@ -265,7 +265,7 @@ class SkillPublishHandlerTest(BaseSkillEditorControllerTests):
     def test_skill_publish_handler_fails(self):
 
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             csrf_token = self._get_csrf_token_for_put()
             # Check that a skill cannot be published when the payload has no
             # version.

--- a/core/controllers/story_editor.py
+++ b/core/controllers/story_editor.py
@@ -32,7 +32,7 @@ class StoryEditorPage(base.BaseHandler):
     def get(self, topic_id, story_id):
         """Handles GET requests."""
 
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         story_domain.Story.require_valid_story_id(story_id)
@@ -78,7 +78,7 @@ class EditableStoryDataHandler(base.BaseHandler):
     @acl_decorators.can_edit_story
     def get(self, topic_id, story_id):
         """Populates the data on the individual story page."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         story_domain.Story.require_valid_story_id(story_id)
@@ -102,7 +102,7 @@ class EditableStoryDataHandler(base.BaseHandler):
     @acl_decorators.can_edit_story
     def put(self, topic_id, story_id):
         """Updates properties of the given story."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         story_domain.Story.require_valid_story_id(story_id)
@@ -141,7 +141,7 @@ class EditableStoryDataHandler(base.BaseHandler):
     @acl_decorators.can_delete_story
     def delete(self, topic_id, story_id):
         """Handles Delete requests."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         story_domain.Story.require_valid_story_id(story_id)

--- a/core/controllers/story_editor_test.py
+++ b/core/controllers/story_editor_test.py
@@ -50,7 +50,7 @@ class StoryEditorTests(BaseStoryEditorControllerTests):
     def test_access_story_editor_page(self):
         """Test access to editor pages for the sample story."""
 
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             # Check that non-admins cannot access the editor page.
             self.login(self.NEW_USER_EMAIL)
             response = self.testapp.get(
@@ -72,7 +72,7 @@ class StoryEditorTests(BaseStoryEditorControllerTests):
 
     def test_editable_story_handler_get(self):
         # Check that non-admins cannot access the editable story data.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             self.login(self.NEW_USER_EMAIL)
             response = self.testapp.get(
                 '%s/%s/%s' % (
@@ -105,7 +105,7 @@ class StoryEditorTests(BaseStoryEditorControllerTests):
             }]
         }
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             response = self.testapp.get(
                 '%s/%s/%s' % (
                     feconf.STORY_EDITOR_URL_PREFIX, self.topic_id,
@@ -132,7 +132,7 @@ class StoryEditorTests(BaseStoryEditorControllerTests):
             self.assertEqual(json_response['status_code'], 401)
 
     def test_editable_story_handler_delete(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             # Check that admins can delete a story.
             self.login(self.ADMIN_EMAIL)
             self.delete_json(

--- a/core/controllers/suggestion.py
+++ b/core/controllers/suggestion.py
@@ -110,7 +110,7 @@ class SuggestionToTopicActionHandler(base.BaseHandler):
     @acl_decorators.get_decorator_for_accepting_suggestion(
         acl_decorators.can_edit_topic)
     def put(self, target_id, suggestion_id):
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_PLAYERS:
             raise self.PageNotFoundException
 
         if len(suggestion_id.split('.')) != 3:

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -444,7 +444,7 @@ class QuestionSuggestionTests(test_utils.GenericTestBase):
         self.login(self.ADMIN_EMAIL)
         response = self.testapp.get(feconf.CREATOR_DASHBOARD_URL)
         csrf_token = self.get_csrf_token_from_response(response)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', True):
             self.put_json('%s/topic/%s/%s' % (
                 feconf.SUGGESTION_ACTION_URL_PREFIX,
                 suggestion_to_accept['target_id'],

--- a/core/controllers/topic_editor.py
+++ b/core/controllers/topic_editor.py
@@ -48,7 +48,7 @@ class TopicEditorStoryHandler(base.BaseHandler):
     def get(self, topic_id):
         """Handles GET requests."""
 
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
         topic = topic_services.get_topic_by_id(topic_id)
         canonical_story_summaries = story_services.get_story_summaries_by_ids(
@@ -73,7 +73,7 @@ class TopicEditorStoryHandler(base.BaseHandler):
         Currently, this only adds the story to the canonical story id list of
         the topic.
         """
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
         topic_domain.Topic.require_valid_topic_id(topic_id)
         title = self.payload.get('title')
@@ -103,7 +103,7 @@ class TopicEditorQuestionHandler(base.BaseHandler):
     @acl_decorators.can_view_any_topic_editor
     def get(self, topic_id):
         """Handles GET requests."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
         topic_domain.Topic.require_valid_topic_id(topic_id)
 
@@ -134,7 +134,7 @@ class TopicEditorPage(base.BaseHandler):
     def get(self, topic_id):
         """Handles GET requests."""
 
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         topic_domain.Topic.require_valid_topic_id(topic_id)
@@ -200,7 +200,7 @@ class EditableSubtopicPageDataHandler(base.BaseHandler):
     def get(self, topic_id, subtopic_id):
         """Handles GET requests."""
 
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         topic_domain.Topic.require_valid_topic_id(topic_id)
@@ -241,7 +241,7 @@ class EditableTopicDataHandler(base.BaseHandler):
     @acl_decorators.can_view_any_topic_editor
     def get(self, topic_id):
         """Populates the data on the individual topic page."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         topic_domain.Topic.require_valid_topic_id(topic_id)
@@ -273,7 +273,7 @@ class EditableTopicDataHandler(base.BaseHandler):
         subtopics), while False would mean it is for a Subtopic Page (this
         includes editing its html data as of now).
         """
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         topic_domain.Topic.require_valid_topic_id(topic_id)
@@ -319,7 +319,7 @@ class EditableTopicDataHandler(base.BaseHandler):
     @acl_decorators.can_delete_topic
     def delete(self, topic_id):
         """Handles Delete requests."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         topic_domain.Topic.require_valid_topic_id(topic_id)

--- a/core/controllers/topic_editor_test.py
+++ b/core/controllers/topic_editor_test.py
@@ -66,7 +66,7 @@ class TopicEditorStoryHandlerTests(BaseTopicEditorControllerTests):
 
     def test_story_creation(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             response = self.testapp.get(
                 '%s/%s' % (feconf.TOPIC_EDITOR_URL_PREFIX, self.topic_id))
             csrf_token = self.get_csrf_token_from_response(response)
@@ -93,7 +93,7 @@ class TopicEditorQuestionHandlerTests(BaseTopicEditorControllerTests):
             question_services.create_new_question_skill_link(
                 question_id, self.skill_id)
 
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             self.login(self.ADMIN_EMAIL)
             with self.swap(constants, 'NUM_QUESTIONS_PER_PAGE', 1):
                 json_response = self.get_json(
@@ -150,7 +150,7 @@ class SubtopicPageEditorTests(BaseTopicEditorControllerTests):
     def test_editable_subtopic_page_get(self):
         # Check that non-admins and non-topic managers cannot access the
         # editable subtopic data.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             self.login(self.NEW_USER_EMAIL)
             response = self.testapp.get(
                 '%s/%s/%s' % (
@@ -198,7 +198,7 @@ class TopicEditorTests(BaseTopicEditorControllerTests):
     def test_access_topic_editor_page(self):
         """Test access to editor pages for the sample topic."""
 
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             # Check that non-admin and topic_manager cannot access the editor
             # page.
             self.login(self.NEW_USER_EMAIL)
@@ -226,7 +226,7 @@ class TopicEditorTests(BaseTopicEditorControllerTests):
 
     def test_editable_topic_handler_get(self):
         # Check that non-admins cannot access the editable topic data.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             self.login(self.NEW_USER_EMAIL)
             response = self.testapp.get(
                 '%s/%s' % (
@@ -280,7 +280,7 @@ class TopicEditorTests(BaseTopicEditorControllerTests):
             }]
         }
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             response = self.testapp.get(
                 '%s/%s' % (feconf.TOPIC_EDITOR_URL_PREFIX, self.topic_id))
             csrf_token = self.get_csrf_token_from_response(response)
@@ -366,7 +366,7 @@ class TopicEditorTests(BaseTopicEditorControllerTests):
             self.topic_id)
 
         self.login(self.TOPIC_MANAGER_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             response = self.testapp.get(
                 '%s/%s' % (feconf.TOPIC_EDITOR_URL_PREFIX, self.topic_id))
             csrf_token = self.get_csrf_token_from_response(response)
@@ -381,7 +381,7 @@ class TopicEditorTests(BaseTopicEditorControllerTests):
             self.logout()
 
     def test_editable_topic_handler_delete(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             # Check that admins can delete a topic.
             self.login(self.ADMIN_EMAIL)
             self.delete_json(
@@ -405,7 +405,7 @@ class TopicManagerRightsHandlerTests(BaseTopicEditorControllerTests):
     def test_assign_topic_manager_role(self):
         """Test the assign topic manager role for a topic functionality."""
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             response = self.testapp.get(
                 '%s/%s' % (feconf.TOPIC_EDITOR_URL_PREFIX, self.topic_id))
             csrf_token = self.get_csrf_token_from_response(response)
@@ -445,7 +445,7 @@ class TopicRightsHandlerTests(BaseTopicEditorControllerTests):
     def test_get_topic_rights(self):
         """Test the get topic rights functionality."""
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             # Test whether admin can access topic rights.
             json_response = self.get_json(
                 '%s/%s' % (
@@ -469,7 +469,7 @@ class TopicPublishHandlerTests(BaseTopicEditorControllerTests):
     def test_publish_and_unpublish_topic(self):
         """Test the publish and unpublish functionality."""
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             response = self.testapp.get(
                 '%s/%s' % (feconf.TOPIC_EDITOR_URL_PREFIX, self.topic_id))
             csrf_token = self.get_csrf_token_from_response(response)

--- a/core/controllers/topic_viewer.py
+++ b/core/controllers/topic_viewer.py
@@ -29,7 +29,7 @@ class TopicViewerPage(base.BaseHandler):
     def get(self, topic_name):
         """Handles GET requests."""
 
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_PLAYERS:
             raise self.PageNotFoundException
 
         topic = topic_services.get_topic_by_name(topic_name)
@@ -50,7 +50,7 @@ class TopicPageDataHandler(base.BaseHandler):
     def get(self, topic_name):
         """Handles GET requests."""
 
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_PLAYERS:
             raise self.PageNotFoundException
 
         topic = topic_services.get_topic_by_name(topic_name)

--- a/core/controllers/topic_viewer_test.py
+++ b/core/controllers/topic_viewer_test.py
@@ -58,14 +58,14 @@ class BaseTopicViewerControllerTests(test_utils.GenericTestBase):
 class TopicViewerPageTests(BaseTopicViewerControllerTests):
 
     def test_any_user_can_access_topic_viewer_page(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', True):
             response = self.testapp.get(
                 '%s/%s' % (feconf.TOPIC_VIEWER_URL_PREFIX, 'public_topic_name'))
 
             self.assertEqual(response.status_int, 200)
 
     def test_no_user_can_access_unpublished_topic_viewer_page(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', True):
             response = self.testapp.get(
                 '%s/%s' % (
                     feconf.TOPIC_VIEWER_URL_PREFIX, 'private_topic_name'),
@@ -74,7 +74,7 @@ class TopicViewerPageTests(BaseTopicViewerControllerTests):
             self.assertEqual(response.status_int, 404)
 
     def test_get_fails_when_new_structures_not_enabled(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', False):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', False):
             response = self.testapp.get(
                 '%s/%s' % (feconf.TOPIC_VIEWER_URL_PREFIX, 'public_topic_name'),
                 expect_errors=True)
@@ -84,7 +84,7 @@ class TopicViewerPageTests(BaseTopicViewerControllerTests):
 class TopicPageDataHandlerTests(BaseTopicViewerControllerTests):
 
     def test_get(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', True):
             json_response = self.get_json(
                 '%s/%s' % (feconf.TOPIC_DATA_HANDLER, 'public_topic_name'))
             expected_dict = {
@@ -99,7 +99,7 @@ class TopicPageDataHandlerTests(BaseTopicViewerControllerTests):
             self.assertDictContainsSubset(expected_dict, json_response)
 
     def test_get_fails_when_new_structures_not_enabled(self):
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', False):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', False):
             response = self.testapp.get(
                 '%s/%s' % (feconf.TOPIC_DATA_HANDLER, 'public_topic_name'),
                 expect_errors=True)

--- a/core/controllers/topics_and_skills_dashboard.py
+++ b/core/controllers/topics_and_skills_dashboard.py
@@ -33,7 +33,7 @@ class TopicsAndSkillsDashboardPage(base.BaseHandler):
 
     @acl_decorators.can_access_topics_and_skills_dashboard
     def get(self):
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         self.values.update({
@@ -135,7 +135,7 @@ class NewTopicHandler(base.BaseHandler):
     @acl_decorators.can_create_topic
     def post(self):
         """Handles POST requests."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
         name = self.payload.get('name')
 
@@ -154,7 +154,7 @@ class NewSkillHandler(base.BaseHandler):
 
     @acl_decorators.can_create_skill
     def post(self):
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
 
         description = self.payload.get('description')
@@ -187,7 +187,7 @@ class MergeSkillHandler(base.BaseHandler):
     @acl_decorators.can_access_topics_and_skills_dashboard
     def post(self):
         """Handles the POST request."""
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             raise self.PageNotFoundException
         old_skill_id = self.payload.get('old_skill_id')
         new_skill_id = self.payload.get('new_skill_id')

--- a/core/controllers/topics_and_skills_dashboard_test.py
+++ b/core/controllers/topics_and_skills_dashboard_test.py
@@ -50,7 +50,7 @@ class BaseTopicsAndSkillsDashboardTests(test_utils.GenericTestBase):
     def _get_csrf_token_for_put(self):
         csrf_token = None
         url_prefix = feconf.TOPICS_AND_SKILLS_DASHBOARD_URL
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             response = self.testapp.get(url_prefix)
             csrf_token = self.get_csrf_token_from_response(response)
         return csrf_token
@@ -60,7 +60,7 @@ class TopicsAndSkillsDashboardPageTests(BaseTopicsAndSkillsDashboardTests):
 
     def test_get_fails_when_new_structures_not_enabled(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', False):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', False):
             url = feconf.TOPICS_AND_SKILLS_DASHBOARD_URL
             response = self.testapp.get(url, expect_errors=True)
             self.assertEqual(response.status_int, 404)
@@ -78,7 +78,7 @@ class TopicsAndSkillsDashboardPageDataHandlerTests(
         self.save_new_skill(skill_id, self.admin_id, 'Description')
         skill_services.publish_skill(skill_id, self.admin_id)
         self.save_new_skill(skill_id_2, self.admin_id, 'Description 2')
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             self.login(self.NEW_USER_EMAIL)
             response = self.testapp.get(
                 feconf.TOPICS_AND_SKILLS_DASHBOARD_DATA_URL, expect_errors=True)
@@ -165,7 +165,7 @@ class NewTopicHandlerTests(BaseTopicsAndSkillsDashboardTests):
 
     def test_topic_creation(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             csrf_token = self._get_csrf_token_for_put()
 
             json_response = self.post_json(
@@ -178,7 +178,7 @@ class NewTopicHandlerTests(BaseTopicsAndSkillsDashboardTests):
 
     def test_topic_creation_fails_when_new_structures_not_enabled(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', False):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', False):
             csrf_token = self._get_csrf_token_for_put()
 
             self.post_json(
@@ -195,7 +195,7 @@ class NewSkillHandlerTests(BaseTopicsAndSkillsDashboardTests):
 
     def test_skill_creation(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             csrf_token = self._get_csrf_token_for_put()
 
             json_response = self.post_json(
@@ -209,7 +209,7 @@ class NewSkillHandlerTests(BaseTopicsAndSkillsDashboardTests):
 
     def test_skill_creation_fails_when_new_structures_not_enabled(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', False):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', False):
             csrf_token = self._get_csrf_token_for_put()
             self.post_json(
                 self.url, {}, csrf_token=csrf_token, expect_errors=True,
@@ -218,7 +218,7 @@ class NewSkillHandlerTests(BaseTopicsAndSkillsDashboardTests):
 
     def test_skill_creation_in_invalid_topic(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             csrf_token = self._get_csrf_token_for_put()
             payload = {
                 'description': 'Skill Description',
@@ -232,7 +232,7 @@ class NewSkillHandlerTests(BaseTopicsAndSkillsDashboardTests):
 
     def test_skill_creation_in_valid_topic(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             csrf_token = self._get_csrf_token_for_put()
             payload = {
                 'description': 'Skill Description',
@@ -278,7 +278,7 @@ class MergeSkillHandlerTests(BaseTopicsAndSkillsDashboardTests):
         self.assertEqual(old_links[0].skill_id, old_skill_id)
         self.assertEqual(len(new_links), 0)
 
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             csrf_token = self._get_csrf_token_for_put()
             payload = {
                 'old_skill_id': old_skill_id,
@@ -301,7 +301,7 @@ class MergeSkillHandlerTests(BaseTopicsAndSkillsDashboardTests):
 
     def test_merge_skill_fails_when_new_structures_not_enabled(self):
         self.login(self.ADMIN_EMAIL)
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', False):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', False):
             csrf_token = self._get_csrf_token_for_put()
             self.post_json(
                 self.url, {}, csrf_token=csrf_token, expect_errors=True,

--- a/core/domain/question_jobs_one_off.py
+++ b/core/domain/question_jobs_one_off.py
@@ -48,7 +48,7 @@ class QuestionMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
     @staticmethod
     def map(item):
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             return
 
         if item.deleted:

--- a/core/domain/question_jobs_one_off_test.py
+++ b/core/domain/question_jobs_one_off_test.py
@@ -60,7 +60,7 @@ class QuestionMigrationOneOffJobTests(test_utils.GenericTestBase):
             feconf.CURRENT_STATES_SCHEMA_VERSION)
 
         # Start migration job.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 question_jobs_one_off.QuestionMigrationOneOffJob.create_new())
             question_jobs_one_off.QuestionMigrationOneOffJob.enqueue(job_id)
@@ -93,7 +93,7 @@ class QuestionMigrationOneOffJobTests(test_utils.GenericTestBase):
             question_services.get_question_by_id(self.QUESTION_ID)
 
         # Start migration job on sample question.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 question_jobs_one_off.QuestionMigrationOneOffJob.create_new())
             question_jobs_one_off.QuestionMigrationOneOffJob.enqueue(job_id)
@@ -124,7 +124,7 @@ class QuestionMigrationOneOffJobTests(test_utils.GenericTestBase):
         self.assertEqual(question.question_state_schema_version, 25)
 
         # Start migration job.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 question_jobs_one_off.QuestionMigrationOneOffJob.create_new())
             question_jobs_one_off.QuestionMigrationOneOffJob.enqueue(job_id)

--- a/core/domain/skill_jobs_one_off.py
+++ b/core/domain/skill_jobs_one_off.py
@@ -48,7 +48,7 @@ class SkillMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
     @staticmethod
     def map(item):
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             return
 
         if item.deleted:

--- a/core/domain/skill_jobs_one_off_test.py
+++ b/core/domain/skill_jobs_one_off_test.py
@@ -60,7 +60,7 @@ class SkillMigrationOneOffJobTests(test_utils.GenericTestBase):
             feconf.CURRENT_MISCONCEPTIONS_SCHEMA_VERSION)
 
         # Start migration job.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 skill_jobs_one_off.SkillMigrationOneOffJob.create_new())
             skill_jobs_one_off.SkillMigrationOneOffJob.enqueue(job_id)
@@ -98,7 +98,7 @@ class SkillMigrationOneOffJobTests(test_utils.GenericTestBase):
             skill_services.get_skill_by_id(self.SKILL_ID)
 
         # Start migration job on sample skill.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 skill_jobs_one_off.SkillMigrationOneOffJob.create_new())
             skill_jobs_one_off.SkillMigrationOneOffJob.enqueue(job_id)
@@ -141,7 +141,7 @@ class SkillMigrationOneOffJobTests(test_utils.GenericTestBase):
         self.assertEqual(skill.skill_contents_schema_version, 1)
 
         # Start migration job.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 skill_jobs_one_off.SkillMigrationOneOffJob.create_new())
             skill_jobs_one_off.SkillMigrationOneOffJob.enqueue(job_id)

--- a/core/domain/story_jobs_one_off.py
+++ b/core/domain/story_jobs_one_off.py
@@ -48,7 +48,7 @@ class StoryMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
     @staticmethod
     def map(item):
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             return
 
         if item.deleted:

--- a/core/domain/story_jobs_one_off_test.py
+++ b/core/domain/story_jobs_one_off_test.py
@@ -57,7 +57,7 @@ class StoryMigrationOneOffJobTests(test_utils.GenericTestBase):
             feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION)
 
         # Start migration job.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 story_jobs_one_off.StoryMigrationOneOffJob.create_new())
             story_jobs_one_off.StoryMigrationOneOffJob.enqueue(job_id)
@@ -92,7 +92,7 @@ class StoryMigrationOneOffJobTests(test_utils.GenericTestBase):
             story_services.get_story_by_id(self.STORY_ID)
 
         # Start migration job on sample story.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 story_jobs_one_off.StoryMigrationOneOffJob.create_new())
             story_jobs_one_off.StoryMigrationOneOffJob.enqueue(job_id)
@@ -124,7 +124,7 @@ class StoryMigrationOneOffJobTests(test_utils.GenericTestBase):
         self.assertEqual(story.schema_version, 1)
 
         # Start migration job.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 story_jobs_one_off.StoryMigrationOneOffJob.create_new())
             story_jobs_one_off.StoryMigrationOneOffJob.enqueue(job_id)

--- a/core/domain/topic_jobs_one_off.py
+++ b/core/domain/topic_jobs_one_off.py
@@ -48,7 +48,7 @@ class TopicMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
     @staticmethod
     def map(item):
-        if not constants.ENABLE_NEW_STRUCTURES:
+        if not constants.ENABLE_NEW_STRUCTURE_EDITORS:
             return
 
         if item.deleted:

--- a/core/domain/topic_jobs_one_off_test.py
+++ b/core/domain/topic_jobs_one_off_test.py
@@ -38,7 +38,7 @@ class TopicMigrationOneOffJobTests(test_utils.GenericTestBase):
     def setUp(self):
         super(TopicMigrationOneOffJobTests, self).setUp()
 
-        self.swap(constants, 'ENABLE_NEW_STRUCTURES', True)
+        self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True)
 
         # Setup user who will own the test topics.
         self.albert_id = self.get_user_id_from_email(self.ALBERT_EMAIL)
@@ -60,7 +60,7 @@ class TopicMigrationOneOffJobTests(test_utils.GenericTestBase):
             feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION)
 
         # Start migration job.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 topic_jobs_one_off.TopicMigrationOneOffJob.create_new())
             topic_jobs_one_off.TopicMigrationOneOffJob.enqueue(job_id)
@@ -97,7 +97,7 @@ class TopicMigrationOneOffJobTests(test_utils.GenericTestBase):
             topic_services.get_topic_by_id(self.TOPIC_ID)
 
         # Start migration job on sample topic.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 topic_jobs_one_off.TopicMigrationOneOffJob.create_new())
             topic_jobs_one_off.TopicMigrationOneOffJob.enqueue(job_id)
@@ -129,7 +129,7 @@ class TopicMigrationOneOffJobTests(test_utils.GenericTestBase):
         self.assertEqual(topic.subtopic_schema_version, 1)
 
         # Start migration job.
-        with self.swap(constants, 'ENABLE_NEW_STRUCTURES', True):
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
             job_id = (
                 topic_jobs_one_off.TopicMigrationOneOffJob.create_new())
             topic_jobs_one_off.TopicMigrationOneOffJob.enqueue(job_id)

--- a/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeDestinationEditorDirective.js
@@ -36,7 +36,8 @@ oppia.directive('outcomeDestinationEditor', [
             StateEditorService, StateGraphLayoutService, UserService,
             EXPLORATION_AND_SKILL_ID_PATTERN, PLACEHOLDER_OUTCOME_DEST) {
           var currentStateName = null;
-          $scope.canAddPrerequisiteSkill = constants.ENABLE_NEW_STRUCTURES;
+          $scope.canAddPrerequisiteSkill =
+            constants.ENABLE_NEW_STRUCTURE_EDITORS;
 
           $scope.$on('saveOutcomeDestDetails', function() {
             // Create new state if specified.

--- a/core/templates/dev/head/components/OutcomeEditorDirective.js
+++ b/core/templates/dev/head/components/OutcomeEditorDirective.js
@@ -43,7 +43,8 @@ oppia.directive('outcomeEditor', [
             StateInteractionIdService, INTERACTION_SPECS) {
           $scope.editOutcomeForm = {};
           $scope.isInQuestionMode = StateEditorService.isInQuestionMode;
-          $scope.canAddPrerequisiteSkill = constants.ENABLE_NEW_STRUCTURES;
+          $scope.canAddPrerequisiteSkill =
+            constants.ENABLE_NEW_STRUCTURE_EDITORS;
           $scope.feedbackEditorIsOpen = false;
           $scope.destinationEditorIsOpen = false;
           $scope.correctnessLabelEditorIsOpen = false;

--- a/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
+++ b/core/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js
@@ -82,7 +82,7 @@ oppia.directive('topNavigationBar', [
             'topic_editor', 'story_editor'];
           $scope.NAV_MODE = GLOBALS.NAV_MODE;
           $scope.LABEL_FOR_CLEARING_FOCUS = LABEL_FOR_CLEARING_FOCUS;
-          $scope.newStructuresEnabled = constants.ENABLE_NEW_STRUCTURES;
+          $scope.newStructuresEnabled = constants.ENABLE_NEW_STRUCTURE_EDITORS;
           $scope.getStaticImageUrl = UrlInterpolationService.getStaticImageUrl;
           $scope.activeMenuName = '';
           $scope.logoutUrl = GLOBALS.logoutUrl;

--- a/core/templates/dev/head/pages/creator_dashboard/CreatorDashboard.js
+++ b/core/templates/dev/head/pages/creator_dashboard/CreatorDashboard.js
@@ -187,7 +187,7 @@ oppia.controller('CreatorDashboard', [
       ExplorationCreationService.createNewExploration);
     $scope.getLocaleAbbreviatedDatetimeString = (
       DateTimeFormatService.getLocaleAbbreviatedDatetimeString);
-    $scope.enableQuestionSuggestions = constants.ENABLE_NEW_STRUCTURES;
+    $scope.enableQuestionSuggestions = constants.ENABLE_NEW_STRUCTURE_PLAYERS;
     $scope.getHumanReadableStatus = (
       ThreadStatusDisplayService.getHumanReadableStatus);
 


### PR DESCRIPTION
In this PR, the ENABLE_NEW_STRUCTURES flag is split into 2 flags - ENABLE_NEW_STRUCTURE_EDITORS and ENABLE_NEW_STRUCTURE_PLAYERS and the usage in the various files have been changed accordingly.