### PR TITLE
Fix #5973: Fixed the changed space when the text is added just below the image

### DIFF
--- a/core/templates/dev/head/components/CkEditorRteDirective.js
+++ b/core/templates/dev/head/components/CkEditorRteDirective.js
@@ -158,7 +158,7 @@ oppia.directive('ckEditorRte', [
             } else {
               return '<div type="oppia-noninteractive-' + p3 + '"' +
                      'class="oppia-rte-component-container">' + match +
-                     '<div class="oppia-rte-component-overlay"></div></div>';
+                     '</div>';
             }
           });
         };

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1505,8 +1505,6 @@ pre.oppia-pre-wrapped-text {
 }
 .oppia-rte-content > div > p {
   line-height: 1.846;
-  margin-bottom: 18px;
-  margin-top: 18px;
 }
 
 /* Add inter-paragraph spacing to the ng-joyride tutorial contents. */

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1494,8 +1494,6 @@ pre.oppia-pre-wrapped-text {
 
 .oppia-rte-editor > p {
   line-height: 1.846;
-  margin-bottom: 18px;
-  margin-top: 18px;
 }
 .oppia-info-card-content p {
   display: block;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1494,6 +1494,8 @@ pre.oppia-pre-wrapped-text {
 
 .oppia-rte-editor > p {
   line-height: 1.846;
+  margin-bottom: 18px;
+  margin-top: 18px;
 }
 .oppia-info-card-content p {
   display: block;

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -247,8 +247,6 @@ otherwise they will interfere with the iframed conversation skin directive.
   */
   .rte-viewer > p {
     line-height: 1.846;
-    margin-bottom: 18px;
-    margin-top: 18px;
   }
   .rte-viewer > p:first-child {
     margin-top: 0px;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #5973: The CkeditorRteDirective is changed to expected behavior.
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
