### PR TITLE
Fixes #6016: Removes hover color change from multiple choice text button bar + radio button

### DIFF
--- a/extensions/interactions/MultipleChoiceInput/static/multiple_choice_input.css
+++ b/extensions/interactions/MultipleChoiceInput/static/multiple_choice_input.css
@@ -20,11 +20,6 @@
   vertical-align: top;
 }
 
-.multiple-choice-option:hover {
-  color: #115FD4;
-}
-
-.multiple-choice-option:hover .multiple-choice-inner-radio-button,
 .multiple-choice-option:focus .multiple-choice-inner-radio-button {
   background-color: #115FD4;
   border-radius: 50%;
@@ -34,7 +29,6 @@
   width: 8px;
 }
 
-.multiple-choice-option:hover .multiple-choice-outer-radio-button,
 .multiple-choice-option:focus .multiple-choice-outer-radio-button {
   border-color: #115FD4;
 }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #6016: Removes the color change and radial button selection from hovering over a multiple choice text button div so that the issue of hovering anywhere within the div highlighting the answer and temporarily selecting the radio button is resolved. The answer must now be clicked on or tabbed to appear selected, as expected.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
