### PR TITLE
Fix clutter in default PR descriptions by encouraging removal of checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,3 +20,4 @@
 - [ ] The PR is assigned to an appropriate reviewer.
   - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
   - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
+- [ ] The PR content has removed this checklist after all other items are done.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,4 @@
 - [ ] The PR is assigned to an appropriate reviewer.
   - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
   - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
-- [ ] The PR content has removed this checklist after all other items are done.
+- [ ] The PR description has removed this checklist after all other items are done.


### PR DESCRIPTION
I find that keeping the checklist around adds clutter to PR descriptions. I'd like to start suggesting to contributors they remove it after all other items have been completed, so that reviewers can focus on the explanation.

@nithusha21, @BenHenning, @apb7, what do you all think?