### PR TITLE
Add @nithusha21 as codeowner for /scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 /core/storage/ @BenHenning @seanlip
 /core/tests/ @apb7 @seanlip
 manifest.json @vojtechjelinek @hoangviet1993 @seanlip
-/scripts/ @apb7 @seanlip @BenHenning
+/scripts/ @apb7 @seanlip @BenHenning @nithusha21


### PR DESCRIPTION
## Explanation
As the other codeowners for /scripts are out, and @apb7 wanted to work on files in scripts over the next week. Temporarily, he suggested, I add myself to the list of codeowners, so that we can continue development. 