### PR TITLE
Fix #6016: Limited the selection area of multiple choice option

### DIFF
--- a/extensions/interactions/MultipleChoiceInput/static/multiple_choice_input.css
+++ b/extensions/interactions/MultipleChoiceInput/static/multiple_choice_input.css
@@ -8,7 +8,8 @@
   color: #0D48A1;
   text-align: left;
   /* This is needed so that images stay bounded by the container in Firefox. */
-  width: 100%;
+  /* Also, width is not fixed. This prevents the accidental selection of option by limiting the selection area to the text and radio button. */
+  width: auto;
 }
 
 .multiple-choice-radio-button-container {

--- a/extensions/interactions/MultipleChoiceInput/static/multiple_choice_input.css
+++ b/extensions/interactions/MultipleChoiceInput/static/multiple_choice_input.css
@@ -8,7 +8,7 @@
   color: #0D48A1;
   text-align: left;
   /* This is needed so that images stay bounded by the container in Firefox. */
-  /* Also, width is not fixed. This prevents the accidental selection of option by limiting the selection area to the text and radio button. */
+  /* This also limits the selection area of the option to the text and radio button. */
   width: auto;
 }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #6016: Changed the width property in css of multiple choice option from 100% to auto.
By doing this, the selection area is limited to the radio button and text. This prevents accidental selection of an option by clicking somewhere on the div where no text is present. 
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
