### PR TITLE
Fixes part of #4374 - Updated docstrings in core.domain.activity_services_test

### DIFF
--- a/core/domain/activity_services_test.py
+++ b/core/domain/activity_services_test.py
@@ -34,14 +34,39 @@ class ActivityServicesTests(test_utils.GenericTestBase):
     COL_ID_2 = 'COL_ID_2'
 
     def _create_exploration_reference(self, exploration_id):
+        """Creates the activity reference object for the exploration.
+		
+		Args:
+			exploration_id: str. The id of the published exploration. 
+		
+		Returns:
+			activity_domain.ActivityReference: obj. Domain object for the activity reference.
+		"""
         return activity_domain.ActivityReference(
             constants.ACTIVITY_TYPE_EXPLORATION, exploration_id)
 
     def _create_collection_reference(self, collection_id):
+        """Creates the activity reference object for the collection.
+		
+		Args:
+			collection_id: str. The id of the collection. 
+		
+		Returns: 
+			activity_domain.ActivityReference: Obj. Domain object for the activity reference.
+		"""
         return activity_domain.ActivityReference(
             constants.ACTIVITY_TYPE_COLLECTION, collection_id)
 
     def _compare_lists(self, reference_list_1, reference_list_2):
+        """Compares the hash values of items in two dictionaries.
+		
+		Args:
+			reference_list_1:  dict(str, str). 
+			reference_list_2:  dict(str, str).
+			
+		Raises:
+			AssertionError: Hash for first item does not equal hash for second item.
+        """
         hashes_1 = [reference.get_hash() for reference in reference_list_1]
         hashes_2 = [reference.get_hash() for reference in reference_list_2]
         self.assertEqual(hashes_1, hashes_2)


### PR DESCRIPTION
_create_exploration_reference, _create_collection_reference, _compare_lists

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes part of #4374 - added docstrings for _create_exploration_reference, and _create_collection_reference, _compare_lists methods in activity_services_test.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
