### PR TITLE
Fix issue #5751: remove G+ from the sharing icons.

### DIFF
--- a/core/templates/dev/head/components/share/sharing_links_directive.html
+++ b/core/templates/dev/head/components/share/sharing_links_directive.html
@@ -59,6 +59,7 @@
   ul.oppia-sharing-links {
     list-style: none;
     padding-top: 15px;
+    padding-left: 0px;
   }
 
   ul.oppia-sharing-links i.oppia-share-icons {

--- a/core/templates/dev/head/components/share/sharing_links_directive.html
+++ b/core/templates/dev/head/components/share/sharing_links_directive.html
@@ -1,12 +1,5 @@
 <ul class="oppia-sharing-links" layout="<[layoutType]>" layout-align="<[layoutAlignType]>">
   <li>
-    <a ng-href="https://plus.google.com/share?url=<[serverName]>/<[activityType]>/<[activityId]>" onclick="return !window.open(this.href, '', 'height=600, width=600, menubar=no, toolbar=no, resizable=yes, scrollbars=yes')" ng-click="registerShareEvent('gplus')" target="_window">
-      <i class="oppia-share-icons fa fa-google-plus-square"></i>
-      <span class="oppia-icon-accessibility-label">Google+</span>
-    </a>
-  </li>
-
-  <li>
     <a ng-href="https://www.facebook.com/sharer/sharer.php?sdk=joey&u=<[serverName]>/<[activityType]>/<[activityId]>&display=popup&ref=plugin&src=share_button" onclick="return !window.open(this.href, '', 'height=336, width=640')" ng-click="registerShareEvent('facebook')" target="_window">
       <i class="oppia-share-icons fa fa-facebook-square"></i>
       <span class="oppia-icon-accessibility-label">Facebook</span>
@@ -71,10 +64,6 @@
   ul.oppia-sharing-links i.oppia-share-icons {
     font-size:  40px;
     padding: 0 5px;
-  }
-
-  i.oppia-share-icons.fa.fa-google-plus-square {
-    color: #dd4b39;
   }
 
   i.oppia-share-icons.fa.fa-facebook-square {


### PR DESCRIPTION
## Explanation
Fixes issue #5751: remove G+ from the sharing icons.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
