### PR TITLE
Adding new service for edditing suggestion by reviwer before Accepting

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,7 @@ init-hook='import sys; sys.path.append("../oppia_tools/google_appengine_1.9.67/g
 [MASTER]
 
 # Checks for correct docstring style
-load-plugins=pylint.extensions.docstyle, pylint_quotes, scripts.pylint_extensions
+#load-plugins=pylint.extensions.docstyle, pylint_quotes, scripts.pylint_extensions
 
 string-quote=single
 triple-quote=double

--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,7 @@ init-hook='import sys; sys.path.append("../oppia_tools/google_appengine_1.9.67/g
 [MASTER]
 
 # Checks for correct docstring style
-#load-plugins=pylint.extensions.docstyle, pylint_quotes, scripts.pylint_extensions
+load-plugins=pylint.extensions.docstyle, pylint_quotes, scripts.pylint_extensions
 
 string-quote=single
 triple-quote=double

--- a/core/controllers/suggestion.py
+++ b/core/controllers/suggestion.py
@@ -174,3 +174,15 @@ class SuggestionListHandler(base.BaseHandler):
 
         self.values.update({'suggestions': [s.to_dict() for s in suggestions]})
         self.render_json(self.values)
+
+
+class EditSuggestionHandler(base.BaseHandler):
+    # TODO. Work for permissions regarding
+    def put(self, suggestion_id):
+        """Edits the submitted suggestion.
+        Args:
+            suggestion_id: str. id of suggestion to be edit.
+        """
+        suggestion = suggestion_services.get_suggestion_by_id(suggestion_id)
+        new_suggestion = self.payload.get('change')
+        suggestion_services.edit_suggestion(suggestion, new_suggestion)

--- a/core/controllers/suggestion.py
+++ b/core/controllers/suggestion.py
@@ -177,7 +177,7 @@ class SuggestionListHandler(base.BaseHandler):
 
 
 class EditSuggestionHandler(base.BaseHandler):
-    # TODO. Work for permissions regarding
+    # TODO. Work for permissions regarding.
     def put(self, suggestion_id):
         """Edits the submitted suggestion.
         Args:

--- a/core/controllers/suggestion.py
+++ b/core/controllers/suggestion.py
@@ -178,12 +178,15 @@ class SuggestionListHandler(base.BaseHandler):
 
 class EditSuggestionHandler(base.BaseHandler):
     """Handler for editing the submitted suggestion by reviwer before
-    accepting."""
+    accepting.
+    """
 
     @acl_decorators.can_edit_exploration
     def put(self, exploration_id, target_id, suggestion_id):# pylint: disable=unused-argument
         """Edits the submitted suggestion.
         Args:
+            exploration_id: str. id of exploration.
+            target_id: str. target id.
             suggestion_id: str. id of suggestion to be edit.
         """
         suggestion = suggestion_services.get_suggestion_by_id(suggestion_id)

--- a/core/controllers/suggestion.py
+++ b/core/controllers/suggestion.py
@@ -177,8 +177,11 @@ class SuggestionListHandler(base.BaseHandler):
 
 
 class EditSuggestionHandler(base.BaseHandler):
-    # TODO. Work for permissions regarding.
-    def put(self, suggestion_id):
+    """Handler for editing the submitted suggestion by reviwer before
+    accepting."""
+
+    @acl_decorators.can_edit_exploration
+    def put(self, exploration_id, target_id, suggestion_id):# pylint: disable=unused-argument
         """Edits the submitted suggestion.
         Args:
             suggestion_id: str. id of suggestion to be edit.

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -18,6 +18,7 @@ suggestions.
 
 from core.domain import email_manager
 from core.domain import exp_services
+from core.domain import exp_domain
 from core.domain import feedback_services
 from core.domain import suggestion_registry
 from core.domain import user_domain
@@ -147,7 +148,7 @@ def get_all_stale_suggestions():
 
 
 def _update_suggestion(suggestion):
-    """Updates the given suggestion.
+    """Updates the given suggestion in database.
 
     Args:
         suggestion: Suggestion. The suggestion to be updated.
@@ -163,6 +164,24 @@ def _update_suggestion(suggestion):
     suggestion_model.score_category = suggestion.score_category
 
     suggestion_model.put()
+
+
+def edit_suggestion(suggestion, new_suggestion):
+    """Edits the submitted suggestion.
+
+    Args:
+        suggestion: obj. suggestion to be changed.
+        new_suggestion: dict(str, str). Dictionary contains the new suggestion.
+        The keys and values are as follows:
+
+    Returns:
+        suggestion: obj. Returns the edited suggestion.
+    """
+    old_suggestion_content = suggestion.change.to_dict()
+    old_suggestion_content['new_value'] = new_suggestion['new_value']
+    suggestion.change = old_suggestion_content
+    suggestion.change = exp_domain.ExplorationChange(suggestion.change)
+    _update_suggestion(suggestion)
 
 
 def mark_review_completed(suggestion, status, reviewer_id):

--- a/core/domain/suggestion_services.py
+++ b/core/domain/suggestion_services.py
@@ -17,8 +17,8 @@ suggestions.
 """
 
 from core.domain import email_manager
-from core.domain import exp_services
 from core.domain import exp_domain
+from core.domain import exp_services
 from core.domain import feedback_services
 from core.domain import suggestion_registry
 from core.domain import user_domain

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
@@ -179,6 +179,8 @@ oppia.controller('FeedbackTab', [
             $scope.canReject = $scope.canEdit && $scope.isNotHandled;
             $scope.canAccept = $scope.canEdit && $scope.isNotHandled &&
               suggestionIsValid && !unsavedChangesExist;
+            $scope.suggestionEditorIsShown = false;
+            $scope.saveButton = false;
 
             if (!$scope.canEdit) {
               $scope.errorMessage = '';
@@ -218,6 +220,42 @@ oppia.controller('FeedbackTab', [
               $uibModalInstance.close({
                 action: ACTION_REJECT_SUGGESTION,
                 reviewMessage: $scope.reviewMessage
+              });
+            };
+
+            $scope.editSuggestion = function() {
+              $scope.suggestionEditorIsShown = true;
+              $scope.isNotHandled = true;
+              $scope.saveButton = true;
+            };
+
+            $scope.saveSuggestion = function() {
+              $scope.suggestionEditorIsShown = false;
+              $scope.saveButton = false;
+
+              url = UrlInterpolationService.interpolateUrl(
+                '/suggestionactionhandler/edit/<suggestion_id>', {
+                  suggestion_id: ThreadDataService.data.suggestionThreads[0].
+                    suggestion.suggestionId
+                });
+
+              data = {
+                action: 'edit',
+                summary_message: $scope.summaryMessage,
+                change: {
+                  cmd: 'edit_state_property',
+                  property_name: 'content',
+                  state_name: ThreadDataService.data.suggestionThreads[0].
+                    suggestion.stateName,
+                  old_value: $scope.currentContent,
+                  new_value: {
+                    html: $scope.newContent
+                  }
+                }
+              };
+
+              $http.put(url, data).then(function() {
+
               });
             };
 

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/FeedbackTab.js
@@ -234,9 +234,13 @@ oppia.controller('FeedbackTab', [
               $scope.saveButton = false;
 
               url = UrlInterpolationService.interpolateUrl(
-                '/suggestionactionhandler/edit/<suggestion_id>', {
+                '/suggestionactionhandler/edit/<exploration_id>/<target_id>/' +
+                  '<suggestion_id>', {
+                  exploration_id: ExplorationDataService.explorationId,
                   suggestion_id: ThreadDataService.data.suggestionThreads[0].
-                    suggestion.suggestionId
+                    suggestion.suggestionId,
+                  target_id: ThreadDataService.data.suggestionThreads[0].
+                    threadId
                 });
 
               data = {

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/editor_view_suggestion_modal_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/editor_view_suggestion_modal_directive.html
@@ -14,17 +14,21 @@
     </div>
     <div class="oppia-suggestion-review-panel-container" style="float: right;">
       <strong>Suggested:</strong>
-      <div class="oppia-suggestion-review-panel">
+      <div class="oppia-suggestion-review-panel" ng-show="!suggestionEditorIsShown">
         <angular-html-bind html-data="newContent">
         </angular-html-bind>
       </div>
+      <div ng-show="suggestionEditorIsShown">
+        <ck-editor-rte ng-model="newContent"></ck-editor-rte>
+        <input type="text" class="form-control oppia-review-message" ng-model="summaryMessage" placeholder="Summarize your new changes">
+      </div>
     </div>
   </section>
-  <div ng-show="canAccept" style="margin-top: 20px; margin-left: 10px;">
+  <div ng-show="canAccept && !saveButton" style="margin-top: 20px; margin-left: 10px;">
     Review message (required if rejecting):
     <input type="text" ng-model="reviewMessage" style="width: 100%">
   </div>
-  <div style="margin-top: 20px; margin-left: 10px;" ng-show="canAccept">
+  <div style="margin-top: 20px; margin-left: 10px;" ng-show="canAccept && !saveButton">
     Brief Description of Changes (required if accepting):
     <input class="protractor-test-suggestion-commit-message"type="text" ng-model="commitMessage" style="width: 100%">
   </div>
@@ -35,6 +39,8 @@
     <[ errorMessage ]>
   </div>
   <button class="btn btn-default" ng-click="cancelReview()">Cancel</button>
-  <button class="btn btn-danger" ng-show="canEdit && isNotHandled" ng-click="rejectSuggestion()" ng-disabled="!canReject">Reject</button>
-  <button class="btn btn-success protractor-test-exploration-accept-suggestion-btn" ng-show="canEdit && isNotHandled" ng-click="acceptSuggestion()" ng-disabled="!canAccept || commitMessage.length == 0">Accept</button>
+  <button class="btn btn-info" ng-click="editSuggestion()" ng-if="!saveButton && isNotHandled">Edit</button>
+  <button class="btn btn-info" ng-click="saveSuggestion()" ng-if="suggestionEditorIsShown && saveButton">Save</button>
+  <button class="btn btn-danger" ng-show="canEdit && isNotHandled && !suggestionEditorIsShown" ng-click="rejectSuggestion()" ng-disabled="!canReject">Reject</button>
+  <button class="btn btn-success protractor-test-exploration-accept-suggestion-btn" ng-show="canEdit && isNotHandled && !suggestionEditorIsShown" ng-click="acceptSuggestion()" ng-disabled="!canAccept || commitMessage.length == 0">Accept</button>
 </div>

--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/editor_view_suggestion_modal_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/editor_view_suggestion_modal_directive.html
@@ -39,8 +39,8 @@
     <[ errorMessage ]>
   </div>
   <button class="btn btn-default" ng-click="cancelReview()">Cancel</button>
-  <button class="btn btn-info" ng-click="editSuggestion()" ng-if="!saveButton && isNotHandled">Edit</button>
-  <button class="btn btn-info" ng-click="saveSuggestion()" ng-if="suggestionEditorIsShown && saveButton">Save</button>
+  <button class="btn btn-info" ng-click="editSuggestion()" ng-if="!saveButton && isNotHandled && canEdit">Edit</button>
+  <button class="btn btn-info" ng-click="saveSuggestion()" ng-if="suggestionEditorIsShown && saveButton && canEdit">Save</button>
   <button class="btn btn-danger" ng-show="canEdit && isNotHandled && !suggestionEditorIsShown" ng-click="rejectSuggestion()" ng-disabled="!canReject">Reject</button>
   <button class="btn btn-success protractor-test-exploration-accept-suggestion-btn" ng-show="canEdit && isNotHandled && !suggestionEditorIsShown" ng-click="acceptSuggestion()" ng-disabled="!canAccept || commitMessage.length == 0">Accept</button>
 </div>

--- a/main.py
+++ b/main.py
@@ -510,6 +510,10 @@ URLS = MAPREDUCE_HANDLERS + [
         r'%s/resubmit/<suggestion_id>' % feconf.SUGGESTION_ACTION_URL_PREFIX,
         suggestion.ResubmitSuggestionHandler),
     get_redirect_route(
+        r'%s/edit/<exploration_id>/<target_id>/<suggestion_id>' %
+        feconf.SUGGESTION_ACTION_URL_PREFIX,
+        suggestion.EditSuggestionHandler),
+    get_redirect_route(
         r'%s/topic/<target_id>/<suggestion_id>' %
         feconf.SUGGESTION_ACTION_URL_PREFIX,
         suggestion.SuggestionToTopicActionHandler),


### PR DESCRIPTION
This PR is related to issue Allow editing a suggestion which is under review #5726. 
I added a new feature for editing the submitted suggestion before acceptig.
Created Two Buttons in frontend 'Edit' and 'Save' for editng.
Here's the screenshot.

The Edit button
![screenshot from 2019-01-08 01-17-22](https://user-images.githubusercontent.com/34139754/50789966-a1075800-12e3-11e9-82b3-06914cecb02c.png)

The Save button
![screenshot from 2019-01-08 01-17-28](https://user-images.githubusercontent.com/34139754/50790060-e0ce3f80-12e3-11e9-9ca8-87b1c73e9867.png)

This PR only allows the reviewer to edit the suggestion. Feature for editing the suggestion by the author is not created. Should be done in next commit.