### PR TITLE
Fix #3677: Make category select2 to reload when a user moves to the settings tab.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
@@ -64,9 +64,9 @@ oppia.controller('SettingsTab', [
     var CREATOR_DASHBOARD_PAGE_URL = '/creator_dashboard';
     var EXPLORE_PAGE_PREFIX = '/explore/';
 
-    // This is needed to make select2 re-load the category data
-    // if user have changed the category while publishing exploration.
-    $scope.showSelectCategoryDropdown = function() {
+    // This is needed to make select2 re-load the dom if user have
+    // changed/added new value while publishing exploration.
+    $scope.showSelect2Dropdown = function() {
       return RouterService.getActiveTabName() === 'settings';
     };
 

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
@@ -26,7 +26,7 @@ oppia.controller('SettingsTab', [
   'ExplorationParamChangesService', 'ExplorationParamSpecsService',
   'ExplorationRightsService', 'ExplorationStatesService',
   'ExplorationTagsService', 'ExplorationTitleService',
-  'ExplorationWarningsService', 'UrlInterpolationService',
+  'ExplorationWarningsService', 'RouterService', 'UrlInterpolationService',
   'UserEmailPreferencesService', 'ALL_CATEGORIES',
   'EXPLORATION_TITLE_INPUT_FOCUS_LABEL',
   function(
@@ -39,7 +39,7 @@ oppia.controller('SettingsTab', [
       ExplorationParamChangesService, ExplorationParamSpecsService,
       ExplorationRightsService, ExplorationStatesService,
       ExplorationTagsService, ExplorationTitleService,
-      ExplorationWarningsService, UrlInterpolationService,
+      ExplorationWarningsService, RouterService, UrlInterpolationService,
       UserEmailPreferencesService, ALL_CATEGORIES,
       EXPLORATION_TITLE_INPUT_FOCUS_LABEL) {
     $scope.EXPLORATION_TITLE_INPUT_FOCUS_LABEL = (
@@ -63,6 +63,12 @@ oppia.controller('SettingsTab', [
 
     var CREATOR_DASHBOARD_PAGE_URL = '/creator_dashboard';
     var EXPLORE_PAGE_PREFIX = '/explore/';
+
+    // This is needed to make select2 re-load the category data
+    // if user have changed the category while publishing exploration.
+    $scope.showSelectCategoryDropdown = function() {
+      return RouterService.getActiveTabName() === 'settings';
+    };
 
     $scope.getExplorePageUrl = function() {
       return (

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -18,7 +18,7 @@
             <div class="form-group" ng-class="{'has-error': !explorationCategoryService.displayed}">
               <label for="explorationCategory" class="col-lg-2 col-md-2 col-sm-2">Category</label>
               <div class="col-lg-10 col-md-10 col-sm-10">
-                <div ng-if="hasPageLoaded">
+                <div ng-if="hasPageLoaded && showSelectCategoryDropdown()">
                   <select2-dropdown id="explorationCategory"
                                     class="protractor-test-exploration-category-input"
                                     item="explorationCategoryService.displayed"

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -18,7 +18,7 @@
             <div class="form-group" ng-class="{'has-error': !explorationCategoryService.displayed}">
               <label for="explorationCategory" class="col-lg-2 col-md-2 col-sm-2">Category</label>
               <div class="col-lg-10 col-md-10 col-sm-10">
-                <div ng-if="hasPageLoaded && showSelectCategoryDropdown()">
+                <div ng-if="hasPageLoaded && showSelect2Dropdown()">
                   <select2-dropdown id="explorationCategory"
                                     class="protractor-test-exploration-category-input"
                                     item="explorationCategoryService.displayed"
@@ -58,7 +58,7 @@
             <div class="form-group">
               <label for="explorationTags" class="col-lg-2 col-md-2 col-sm-2">Tags</label>
               <div class="col-lg-10 col-md-10 col-sm-10">
-                <div ng-if="hasPageLoaded">
+                <div ng-if="hasPageLoaded && showSelect2Dropdown()">
                   <select2-dropdown item="$parent.explorationTagsService.displayed"
                                     choices="$parent.explorationTagsService.displayed"
                                     allow-multiple-choices="true"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->
Fixes #3677: Make category select2 to reload when a user moves to the settings tab.
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
