### PR TITLE
Fix #6078: Updating publish button after modal is dismissed.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
@@ -399,15 +399,7 @@ oppia.factory('ExplorationSaveService', [
                 };
 
                 $scope.cancel = function() {
-                  whenModalsClosed.resolve();
-                  ExplorationTitleService.restoreFromMemento();
-                  ExplorationObjectiveService.restoreFromMemento();
-                  ExplorationCategoryService.restoreFromMemento();
-                  ExplorationLanguageCodeService.restoreFromMemento();
-                  ExplorationTagsService.restoreFromMemento();
-
                   $uibModalInstance.dismiss('cancel');
-                  AlertsService.clearWarnings();
                 };
               }
             ]
@@ -446,6 +438,14 @@ oppia.factory('ExplorationSaveService', [
                   whenModalsClosed.resolve();
                 });
             }
+          }, function() {
+            whenModalsClosed.resolve();
+            ExplorationTitleService.restoreFromMemento();
+            ExplorationObjectiveService.restoreFromMemento();
+            ExplorationCategoryService.restoreFromMemento();
+            ExplorationLanguageCodeService.restoreFromMemento();
+            ExplorationTagsService.restoreFromMemento();
+            AlertsService.clearWarnings();
           });
         } else {
           // No further metadata is needed. Open the publish modal immediately.

--- a/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationSaveService.js
@@ -129,8 +129,6 @@ oppia.factory('ExplorationSaveService', [
 
             $scope.cancel = function() {
               $uibModalInstance.dismiss('cancel');
-              AlertsService.clearWarnings();
-              whenModalClosed.resolve();
             };
           }
         ]
@@ -152,6 +150,9 @@ oppia.factory('ExplorationSaveService', [
               ExplorationDataService.explorationId);
             whenModalClosed.resolve();
           });
+      }, function() {
+        AlertsService.clearWarnings();
+        whenModalClosed.resolve();
       });
 
       return whenModalClosed.promise;


### PR DESCRIPTION
## Explanation
Fixes #6078: text on Publish button remains at 'Publishing' after modal is dismissed.
This solution now works for both cancel button and escape key.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
