### PR TITLE
Fixes part of #4057: Adding tests to increase coverage of OutcomeObjectFactory.js

### DIFF
--- a/core/templates/dev/head/domain/exploration/OutcomeObjectFactorySpec.js
+++ b/core/templates/dev/head/domain/exploration/OutcomeObjectFactorySpec.js
@@ -51,4 +51,12 @@ describe('Outcome object factory', function() {
       expect(testOutcome3.hasNonemptyFeedback()).toBe(false);
     }
   );
+
+  it('should correctly set the destination of an outcome',
+    function() {
+      var testOutcome = oof.createNew('A', 'feedback_1', 'feedback', []);
+      testOutcome.setDestination('B');
+      expect(testOutcome.dest).toEqual('B');
+    }
+  );
 });


### PR DESCRIPTION
Fixes part of #4057: Adding tests to increase coverage of domain/exploration/OutcomeObjectFactory.js to 100%. Karma coverage report is as follows: 
![opp](https://user-images.githubusercontent.com/15020747/51088693-e070f100-1788-11e9-928c-58f81a41a865.PNG)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
