### PR TITLE
Fix #6089: Moved common css to oppia.css and removed extra comments for sync

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1481,19 +1481,13 @@ pre.oppia-pre-wrapped-text {
   margin: 1.5em 0;
 }
 
-/* These rules must be kept in sync with corresponding rules in
-   pages/exploration_player/conversation_skin_directive.html
-   (those with '.rte-viewer > p' selectors specifying the same
-   line-height, margin-top and margin-bottom attributes)
-*/
-
 /* Line-height is set to 1.846 to ensure that the line-spacing inside
    a paragraph is consistent both in the editor mode while editing and
    after saving. The value 1.846 came from
    /third_party/generated/css/third_party.css.
 */
 
-.oppia-rte-editor > p {
+.oppia-rte-editor > p, .rte-viewer > p {
   line-height: 1.846;
 }
 .oppia-info-card-content p {
@@ -1519,11 +1513,27 @@ pre.oppia-pre-wrapped-text {
 .oppia-rte-editor > p:last-child {
   margin-bottom: 0;
 }
-.form-control.oppia-rte-content > div > p:first-child {
+
+/* The four rules below should be in sync. */
+.rte-viewer > p:first-child {
   margin-top: 0;
 }
-.form-control.oppia-rte-content > div > p:last-child {
+.rte-viewer > p:last-child {
   margin-bottom: 0;
+}
+.form-control.oppia-rte-content > div > p:first-child {
+  margin-top: 0px;
+}
+.form-control.oppia-rte-content > div > p:last-child {
+  margin-bottom: 0px;
+}
+
+.rte-viewer {
+  border-radius: 2px;
+  display: inline-block;
+  max-width: 100%;
+  position: relative;
+  text-align: left;
 }
 
 .oppia-prevent-selection {

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1487,7 +1487,7 @@ pre.oppia-pre-wrapped-text {
    /third_party/generated/css/third_party.css.
 */
 
-.oppia-rte-editor > p, .rte-viewer > p {
+.oppia-rte-editor > p, .oppia-rte-viewer > p {
   line-height: 1.846;
 }
 .oppia-info-card-content p {
@@ -1515,10 +1515,10 @@ pre.oppia-pre-wrapped-text {
   margin-bottom: 0;
 }
 
-.rte-viewer > p:first-child {
+.oppia-rte-viewer > p:first-child {
   margin-top: 0;
 }
-.rte-viewer > p:last-child {
+.oppia-rte-viewer > p:last-child {
   margin-bottom: 0;
 }
 .form-control.oppia-rte-content > div > p:first-child {
@@ -1528,7 +1528,7 @@ pre.oppia-pre-wrapped-text {
   margin-bottom: 0;
 }
 
-.rte-viewer {
+.oppia-rte-viewer {
   border-radius: 2px;
   display: inline-block;
   max-width: 100%;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1507,6 +1507,7 @@ pre.oppia-pre-wrapped-text {
   margin-top: 10px;
 }
 
+/* The six rules below should be in sync. */
 .oppia-rte-editor > p:first-child {
   margin-top: 0;
 }
@@ -1514,7 +1515,6 @@ pre.oppia-pre-wrapped-text {
   margin-bottom: 0;
 }
 
-/* The four rules below should be in sync. */
 .rte-viewer > p:first-child {
   margin-top: 0;
 }

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1522,10 +1522,10 @@ pre.oppia-pre-wrapped-text {
   margin-bottom: 0;
 }
 .form-control.oppia-rte-content > div > p:first-child {
-  margin-top: 0px;
+  margin-top: 0;
 }
 .form-control.oppia-rte-content > div > p:last-child {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 .rte-viewer {

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -5,7 +5,7 @@
 <div class="conversation-skin-future-tutor-card" aria-hidden="true">
   <div class="oppia-learner-view-card-content">
     <div class="oppia-learner-view-card-top-section">
-      <angular-html-bind class="rte-viewer oppia-learner-view-card-top-content"
+      <angular-html-bind class="oppia-rte-viewer oppia-learner-view-card-top-content"
                          html-data="nextCard.getContentHtml()">
       </angular-html-bind>
     </div>

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -240,29 +240,6 @@ otherwise they will interfere with the iframed conversation skin directive.
     z-index: 2;
   }
 
-  /* These rules must be kept in sync with corresponding rules in oppia.css
-     (those with '.oppia-rte-editor > p,
-       .form-control.oppia-rte-content > div > p' selectors specifying
-      the same line-height, margin-top and margin-bottom attributes)
-  */
-  .rte-viewer > p {
-    line-height: 1.846;
-  }
-  .rte-viewer > p:first-child {
-    margin-top: 0px;
-  }
-  .rte-viewer > p:last-child {
-    margin-bottom: 0px;
-  }
-
-  .rte-viewer {
-    border-radius: 2px;
-    display: inline-block;
-    max-width: 100%;
-    position: relative;
-    text-align: left;
-  }
-
   .conversation-skin-oppia-feedback-content,
   .conversation-skin-learner-answer-content {
     margin-bottom: 12px;

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -385,34 +385,6 @@ directive. -->
     padding: 0 20px;
   }
 
-  /* These rules must be kept in sync with corresponding rules in oppia.css
-     (those with '.oppia-rte-editor > p,
-       .form-control.oppia-rte-content > div > p' selectors specifying
-      the same line-height, margin-top and margin-bottom attributes)
-  */
-
-  .rte-viewer > p {
-    line-height: 28px;
-    margin-bottom: 18px;
-    margin-top: 18px;
-  }
-
-  .rte-viewer > p:first-child {
-    margin-top: 0;
-  }
-
-  .rte-viewer > p:last-child {
-    margin-bottom: 0;
-  }
-
-  .rte-viewer {
-    border-radius: 2px;
-    display: inline-block;
-    max-width: 100%;
-    position: relative;
-    text-align: left;
-  }
-
   .conversation-skin-oppia-feedback-content,
   .conversation-skin-learner-answer-content {
     margin-bottom: 12px;

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -5,7 +5,7 @@
 <div class="conversation-skin-future-tutor-card" aria-hidden="true">
   <div class="oppia-learner-view-card-content">
     <div class="oppia-learner-view-card-top-section">
-      <angular-html-bind class="rte-viewer oppia-learner-view-card-top-content"
+      <angular-html-bind class="oppia-rte-viewer oppia-learner-view-card-top-content"
                          html-data="nextCard.getContentHtml()">
       </angular-html-bind>
     </div>

--- a/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/input_response_pair_directive.html
@@ -4,16 +4,16 @@
     <div ng-if="getShortAnswerHtml()"
          popover-placement="bottom" uib-popover-template="'popover/answer'"
          popover-trigger="click" style="cursor: pointer;">
-      <angular-html-bind class="rte-viewer conversation-skin-learner-answer-content" html-data="getShortAnswerHtml()">
+      <angular-html-bind class="oppia-rte-viewer conversation-skin-learner-answer-content" html-data="getShortAnswerHtml()">
       </angular-html-bind>
     </div>
     <div ng-if="!getShortAnswerHtml()">
-      <angular-html-bind class="rte-viewer conversation-skin-learner-answer-content" html-data="getAnswerHtml()">
+      <angular-html-bind class="oppia-rte-viewer conversation-skin-learner-answer-content" html-data="getAnswerHtml()">
       </angular-html-bind>
     </div>
   </div>
   <div ng-if="data.isHint">
-    <div class="rte-viewer conversation-skin-learner-answer-content">
+    <div class="oppia-rte-viewer conversation-skin-learner-answer-content">
       <[data.learnerInput | translate]>
     </div>
   </div>
@@ -30,7 +30,7 @@
   <div>
     <angular-html-bind ng-if="data.oppiaResponse !== null"
                        html-data="data.oppiaResponse"
-                       class="rte-viewer conversation-skin-oppia-feedback-content protractor-test-conversation-feedback"
+                       class="oppia-rte-viewer conversation-skin-oppia-feedback-content protractor-test-conversation-feedback"
                        ng-class="getFeedbackAudioHighlightClass()">
     </angular-html-bind>
   </div>

--- a/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/supplemental_card_directive.html
@@ -8,7 +8,7 @@
       <i class="material-icons md-18">&#xE5CD;</i>
     </button>
     <div>
-      <angular-html-bind class="rte-viewer conversation-skin-help-card-content protractor-test-conversation-feedback" html-data="helpCardHtml" ng-class="getFeedbackAudioHighlightClass()">
+      <angular-html-bind class="oppia-rte-viewer conversation-skin-help-card-content protractor-test-conversation-feedback" html-data="helpCardHtml" ng-class="getFeedbackAudioHighlightClass()">
       </angular-html-bind>
     </div>
     <br>

--- a/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/tutor_card_directive.html
@@ -6,7 +6,7 @@
     <div class="oppia-learner-view-card-top-section">
       <img class="conversation-skin-oppia-avatar"
            ng-src="<[OPPIA_AVATAR_IMAGE_URL]>" alt="">
-      <div class="rte-viewer oppia-learner-view-card-top-content"
+      <div class="oppia-rte-viewer oppia-learner-view-card-top-content"
            ng-class="getContentAudioHighlightClass()"
            focus-on="<[getContentFocusLabel($index)]>">
         <div>


### PR DESCRIPTION
## Explanation
Fixes #6089: Moved common css to `oppia.css` and removed extra comments which were required for sync.