### PR TITLE
Fixes #6004: Added presubmit checks to ensure imports are sorted.

### DIFF
--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -1350,6 +1350,54 @@ def _check_directive_scope(all_files):
     return summary_messages
 
 
+def _check_sorted_imports(all_files):
+    """This function checks that the imports are sorted
+    according to di-order rule of  angular plugin of eslint.
+    """
+    print 'Starting sorted imports check'
+    print '----------------------------------------'
+    files_to_check = [
+        filename for filename in all_files if not
+        any(fnmatch.fnmatch(filename, pattern) for pattern in EXCLUDED_PATHS)
+        and filename.endswith('.js')]
+    properties_to_check = ['controller', 'directive', 'factory']
+    failed = False
+    summary_messages = []
+    for filename in files_to_check:
+        with open(filename) as f:
+            content = f.read()
+        parsed_dict = _validate_and_parse_js_file(filename, content)
+        parsed_nodes = parsed_dict['body']
+        for parsed_node in parsed_nodes:
+            if parsed_node['type'] != 'ExpressionStatement':
+                continue
+            expression = parsed_node['expression']
+            if expression['type'] != 'CallExpression':
+                continue
+            if expression['callee']['type'] != 'MemberExpression':
+                continue
+            property_name = expression['callee']['property']['name']
+            if property_name not in properties_to_check:
+                continue
+            arguments = expression['arguments']
+            arguments = arguments[1:]
+            for argument in arguments:
+                if argument['type'] != 'ArrayExpression':
+                    continue
+                literal_args = []
+                function_args = []
+                elements = argument['elements']
+                for element in elements:
+                    if element['type'] == 'Literal':
+                 	    literal_args.append(str(element['value']))
+                    elif element['type'] == 'FunctionExpression':
+                   	    func_args = element['params']
+                  	    for func_arg in func_args:
+                            function_args.append(str(func_arg['name']))
+            
+            
+            
+    
 def _match_line_breaks_in_controller_dependencies(all_files):
     """This function checks whether the line breaks between the dependencies
     listed in the controller of a directive or service exactly match those

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -1413,9 +1413,9 @@ def _check_sorted_imports(all_files):
                 if sorted_imports != function_args:
                     failed = True
                     print (
-       	                'Please ensure that %s in %s, the injected dependecies should be in the following manner.'
-       	                'Firstly dollar imports in sorted form, then regular imports in sorted form'
-       	                'and then constant imports in sorted form.' % (property_value, filename))
+                        'Please ensure that %s in %s, the injected dependecies should be in the following manner.'
+                        'Firstly dollar imports in sorted form, then regular imports in sorted form'
+                        'and then constant imports in sorted form.' % (property_value, filename))
        	        if sorted_imports != literal_args:
        	            failed = True
        	            print (

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -1402,26 +1402,29 @@ def _check_sorted_imports(all_files):
                 for arg in function_args:
                     if arg.startswith('$'):
                         dollar_imports.append(arg)
-                    elif (re.match(r'[a-z]', arg)):
+                    elif re.match(r'[A-Z]', arg):
                         constant_imports.append(arg)
                     else:
                         regular_imports.append(arg)
                 dollar_imports.sort()
                 regular_imports.sort()
                 constant_imports.sort()
-                sorted_imports = dollar_imports + regular_imports + constant_imports
+                sorted_imports = dollar_imports + regular_imports + constant_imports #pylint: disable=line-too-long
                 if sorted_imports != function_args:
                     failed = True
                     print (
-                        'Please ensure that %s in %s, the injected dependecies should be in the following manner.'
-                        'Firstly dollar imports in sorted form, then regular imports in sorted form'
-                        'and then constant imports in sorted form.' % (property_value, filename))
-       	        if sorted_imports != literal_args:
-       	            failed = True
-       	            print (
-       	                'Please ensure that %s in %s, the dependecies literally mentioned should be '
-       	                'in the following manner. Firstly dollar imports in sorted form, then regular'
-       	                'imports in sorted form and then constant imports in sorted form.'
+                        'Please ensure that %s in %s, the injected dependecies'
+                        'should be in the following manner. Firstly dollar '
+                        'imports in sorted form, then regular imports in sorted'
+                        'form and then constant imports in sorted form.'
+                        % (property_value, filename))
+                if sorted_imports != literal_args:
+                    failed = True
+                    print (
+       	                'Please ensure that %s in %s, the dependecies literally'
+       	                'mentioned should be in the following manner. Firstly '
+       	                'dollar imports in sorted form, then regular imports in'
+       	                'sorted form and then constant imports in sorted form.'
        	                % (property_value, filename))
 
     if failed:
@@ -1751,6 +1754,7 @@ def main():
     """
     all_files = _get_all_files()
     directive_scope_messages = _check_directive_scope(all_files)
+    sorted_imports_messages = _check_sorted_imports(all_files)
     controller_dependency_messages = (
         _match_line_breaks_in_controller_dependencies(all_files))
     html_directive_name_messages = _check_html_directive_name(all_files)
@@ -1768,6 +1772,7 @@ def main():
     all_messages = (
         directive_scope_messages + controller_dependency_messages +
         html_directive_name_messages + import_order_messages +
+        sorted_imports_messages +
         newline_messages + docstring_messages + comment_messages +
         html_tag_and_attribute_messages + html_linter_messages +
         linter_messages + pattern_messages + copyright_notice_messages)


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #6004 : Added the logic to ensure sorted imports in js files for properties ```directives, controller, factory```.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
