### PR TITLE
Fix #6117: The Role tab tooltip on the admin page is now placed correctly

### DIFF
--- a/core/templates/dev/head/pages/admin/admin_navbar_directive.html
+++ b/core/templates/dev/head/pages/admin/admin_navbar_directive.html
@@ -128,7 +128,7 @@
                ng-href="<[::ADMIN_TAB_URLS.ROLES]>"
                ng-class="{active: isRolesTabOpen()}"
                uib-tooltip="Roles"
-               tooltip-placemnt="bottom">
+               tooltip-placement="bottom">
               Roles
             </a>
           </li>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #6117 
The Role tab tooltip on the admin page is now placed correctly.

Screenshot
<img width="1440" alt="screenshot 2019-01-15 at 11 08 44 pm" src="https://user-images.githubusercontent.com/35570715/51198551-8e5fd500-191a-11e9-8c24-0d7031f88a4b.png">


## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
