### PR TITLE
Fix #6118 : Improved spacing between reload buttons on admin page

### DIFF
--- a/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
@@ -71,3 +71,13 @@
     </div>
   </div>
 </md-card>
+
+<style>
+    .protractor-test-reload-collection-row {
+      margin-bottom: 5px;
+    }
+    
+    .protractor-test-reload-exploration-row {
+      margin-bottom: 5px;
+    }
+</style>

--- a/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
@@ -2,7 +2,7 @@
   <div class="container" style="margin-left: 0;">
     <h3>Reload a single exploration</h3>
     <div ng-repeat="exploration in DEMO_EXPLORATIONS"
-         class="row protractor-test-reload-exploration-row">
+         class="row oppia-reload-exploration-row protractor-test-reload-exploration-row">
       <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-exploration-title">
         <[exploration[1]]>
       </span>
@@ -57,7 +57,7 @@
   <div class="container" style="margin-left: 0;">
     <h3>Reload a single collection</h3>
     <div ng-repeat="collection in DEMO_COLLECTIONS"
-         class="row protractor-test-reload-collection-row">
+         class="row oppia-reload-collection-row protractor-test-reload-collection-row">
       <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-collection-title">
         <[collection[1]]>
       </span>
@@ -73,11 +73,11 @@
 </md-card>
 
 <style>
-    .protractor-test-reload-collection-row {
+    .oppia-reload-collection-row {
       margin-bottom: 5px;
     }
 
-    .protractor-test-reload-exploration-row {
+    .oppia-reload-exploration-row {
       margin-bottom: 5px;
     }
 </style>

--- a/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
@@ -2,7 +2,7 @@
   <div class="container" style="margin-left: 0;">
     <h3>Reload a single exploration</h3>
     <div ng-repeat="exploration in DEMO_EXPLORATIONS"
-         class="row oppia-reload-exploration-row protractor-test-reload-exploration-row">
+         class="row oppia-reload-btn protractor-test-reload-exploration-row">
       <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-exploration-title">
         <[exploration[1]]>
       </span>
@@ -57,7 +57,7 @@
   <div class="container" style="margin-left: 0;">
     <h3>Reload a single collection</h3>
     <div ng-repeat="collection in DEMO_COLLECTIONS"
-         class="row oppia-reload-collection-row protractor-test-reload-collection-row">
+         class="row oppia-reload-btn protractor-test-reload-collection-row">
       <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-collection-title">
         <[collection[1]]>
       </span>
@@ -73,11 +73,7 @@
 </md-card>
 
 <style>
-    .oppia-reload-collection-row {
-      margin-bottom: 5px;
-    }
-
-    .oppia-reload-exploration-row {
+    .oppia-reload-btn {
       margin-bottom: 5px;
     }
 </style>

--- a/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
@@ -76,7 +76,7 @@
     .protractor-test-reload-collection-row {
       margin-bottom: 5px;
     }
-    
+
     .protractor-test-reload-exploration-row {
       margin-bottom: 5px;
     }

--- a/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
+++ b/core/templates/dev/head/pages/admin/activities_tab/admin_dev_mode_activities_tab_directive.html
@@ -2,7 +2,7 @@
   <div class="container" style="margin-left: 0;">
     <h3>Reload a single exploration</h3>
     <div ng-repeat="exploration in DEMO_EXPLORATIONS"
-         class="row oppia-reload-btn protractor-test-reload-exploration-row">
+         class="row oppia-reload-exploration-row protractor-test-reload-exploration-row">
       <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-exploration-title">
         <[exploration[1]]>
       </span>
@@ -57,7 +57,7 @@
   <div class="container" style="margin-left: 0;">
     <h3>Reload a single collection</h3>
     <div ng-repeat="collection in DEMO_COLLECTIONS"
-         class="row oppia-reload-btn protractor-test-reload-collection-row">
+         class="row oppia-reload-collection-row protractor-test-reload-collection-row">
       <span class="col-lg-4 col-md-4 col-sm-4 protractor-test-reload-collection-title">
         <[collection[1]]>
       </span>
@@ -73,7 +73,7 @@
 </md-card>
 
 <style>
-    .oppia-reload-btn {
+    .oppia-reload-collection-row, .oppia-reload-exploration-row {
       margin-bottom: 5px;
     }
 </style>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #6118 
Inserted proper spacing between the reload buttons on Admin Page

**Screenshots**
Before
<img width="1440" alt="screenshot 2019-01-15 at 11 08 44 pm" src="https://user-images.githubusercontent.com/35570715/51252383-b0606280-19c1-11e9-81f6-22b39f97afc1.png">

After
<img width="1440" alt="screenshot 2019-01-16 at 7 06 34 pm" src="https://user-images.githubusercontent.com/35570715/51252481-f0bfe080-19c1-11e9-91cb-b7eb4eca811b.png">



## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
