### PR TITLE
Fix part of  #6051: Smooth Color change to navbar tabs.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2139,6 +2139,14 @@ div#ng-curtain {
   display: inline-block;
   vertical-align: top;
 }
+.oppia-navbar-tabs li a{
+
+  -webkit-transition: all .5s ease;
+  -moz-transition: all .5s ease;
+  -o-transition: all .5s ease;
+  transition: all .5s ease;
+
+}
 .oppia-clickable-navbar-element:hover {
   display: inline-block;
 }

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -574,17 +574,13 @@ textarea {
 .oppia-navbar-dropdown > li > a {
   color: #009688;
 }
-
-/* smooth color chang to the navbar-tabs */
+/*Smooth color change to the navbar-tabs*/
 .oppia-navbar-tabs li a {
-
-  -webkit-transition: all .5s ease;
   -moz-transition: all .5s ease;
   -o-transition: all .5s ease;
   transition: all .5s ease;
-
+  -webkit-transition: all .5s ease;
 }
-
 .oppia-dashboard-container a:hover,
 .oppia-dashboard-container a:active,
 .oppia-dashboard-container a:visited {
@@ -2150,8 +2146,6 @@ div#ng-curtain {
   display: inline-block;
   vertical-align: top;
 }
-
-
 .oppia-clickable-navbar-element:hover {
   display: inline-block;
 }
@@ -2159,7 +2153,6 @@ div#ng-curtain {
   /* Prevent whitespace from inline-block elements from adding space. */
   font-size: 0;
 }
-
 .nav > li > a.oppia-navbar-tab,
 .nav > li > div.oppia-navbar-tab {
   font-family: "Capriola", "Roboto", Arial, sans-serif;


### PR DESCRIPTION


## Explanation :
This PR adds a smooth color change animation to navbar tabs as a part of #6051.
The smooth dropdown animation for the dropdown menu, ie. about and signin tabs in navbar are yet to be made.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
