### PR TITLE
Fixes #4407 KaTeX text no longer goes outside text container in MathExpressionInput

### DIFF
--- a/extensions/interactions/MathExpressionInput/directives/math_expression_input_interaction_directive.html
+++ b/extensions/interactions/MathExpressionInput/directives/math_expression_input_interaction_directive.html
@@ -1,5 +1,5 @@
 <div class="guppy-div"
-     style="width: 100%; height: 100px; padding: 5px;">
+     style="width: 100%; height: 100px; padding: 5px; overflow:auto">
 </div>
 <button ng-if="mobileOverlayIsShown" id="startMathInputButton" class="oppia-mathexpression-input-mobile-overlay"
         ng-click="startMobileMathInput()">

--- a/extensions/interactions/MathExpressionInput/directives/math_expression_input_interaction_directive.html
+++ b/extensions/interactions/MathExpressionInput/directives/math_expression_input_interaction_directive.html
@@ -1,5 +1,5 @@
 <div class="guppy-div"
-     style="width: 100%; height: 100px; padding: 5px; overflow:auto; word-break: normal; line-break; word-wrap: normal">
+     style="width: 100%; height: 100px; padding: 5px; overflow: auto; word-break: normal; word-wrap: normal;">
 </div>
 <button ng-if="mobileOverlayIsShown" id="startMathInputButton" class="oppia-mathexpression-input-mobile-overlay"
         ng-click="startMobileMathInput()">

--- a/extensions/interactions/MathExpressionInput/directives/math_expression_input_interaction_directive.html
+++ b/extensions/interactions/MathExpressionInput/directives/math_expression_input_interaction_directive.html
@@ -1,5 +1,5 @@
 <div class="guppy-div"
-     style="width: 100%; height: 100px; padding: 5px; overflow:auto">
+     style="width: 100%; height: 100px; padding: 5px; overflow:auto; word-break: normal; line-break; word-wrap: normal">
 </div>
 <button ng-if="mobileOverlayIsShown" id="startMathInputButton" class="oppia-mathexpression-input-mobile-overlay"
         ng-click="startMobileMathInput()">


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #4407, Katex text now overflows correctly.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
