### PR TITLE
Fix part of #5134: Increased coverage to 100% for mailgun_email_services.py

### DIFF
--- a/core/platform/email/mailgun_email_services_test.py
+++ b/core/platform/email/mailgun_email_services_test.py
@@ -67,11 +67,11 @@ class EmailTests(test_utils.GenericTestBase):
         mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
         allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
 
-        # this data should have been sent in the requests.post()
+        # This data should have been sent in the requests.post().
         expected = {'from':feconf.SYSTEM_EMAIL_ADDRESS, 'to': feconf.ADMIN_EMAIL_ADDRESS, \
                     'subject':'subject', 'text':'body', 'html':'html'}
 
-        # lambda function, will replace requests.post() in send_mail
+        # Lambda function, will replace requests.post() in send_mail.
         requests_post_lambda = lambda domain_name, auth=None, data=None: \
                                 self.assertDictContainsSubset(expected, data)
         modified_post_request = self.swap(requests, 'post', requests_post_lambda)
@@ -94,7 +94,7 @@ class EmailTests(test_utils.GenericTestBase):
         mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
         allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
 
-        # lambda function, will replace requests.post() in send_mail
+        # Lambda function, will replace requests.post() in send_mail.
         requests_post_lambda = lambda domain_name, auth=None, data=None: \
                         self.assertEqual(data['bcc'], feconf.ADMIN_EMAIL_ADDRESS)
         modified_post_request = self.swap(requests, 'post', requests_post_lambda)
@@ -114,7 +114,7 @@ class EmailTests(test_utils.GenericTestBase):
         allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
         reply_id = 123
 
-        # lambda function, will replace requests.post() in send_mail
+        # Lambda function, will replace requests.post() in send_mail.
         requests_post_lambda = lambda domain_name, auth=None, data=None: \
                         self.assertEqual(data['h:Reply-To'], \
                             "reply+" + str(reply_id) + "@" + feconf.INCOMING_EMAILS_DOMAIN_NAME)
@@ -169,11 +169,11 @@ class EmailTests(test_utils.GenericTestBase):
         allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
         recipients = [feconf.ADMIN_EMAIL_ADDRESS]
 
-        # this data should have been sent in the requests.post()
+        # This data should have been sent in the requests.post().
         expected = {'from':feconf.SYSTEM_EMAIL_ADDRESS, 'to': [feconf.ADMIN_EMAIL_ADDRESS], \
                     'subject':'subject', 'text':'body', 'html':'html', 'recipient-variables': '{}'}
 
-        # lambda function, will replace requests.post() in send_mail
+        # Lambda function, will replace requests.post() in send_mail.
         requests_post_lambda = lambda domain_name, auth=None, data=None: \
                         self.assertDictContainsSubset(expected, data)
 

--- a/core/platform/email/mailgun_email_services_test.py
+++ b/core/platform/email/mailgun_email_services_test.py
@@ -96,7 +96,7 @@ class EmailTests(test_utils.GenericTestBase):
 
         # lambda function, will replace requests.post() in send_mail
         requests_post_lambda = lambda domain_name, auth=None, data=None: \
-                        self.assertEquals(data['bcc'], feconf.ADMIN_EMAIL_ADDRESS)
+                        self.assertEqual(data['bcc'], feconf.ADMIN_EMAIL_ADDRESS)
         modified_post_request = self.swap(requests, 'post', requests_post_lambda)
 
         with mailgun_api, mailgun_domain, modified_post_request, allow_email_sending:
@@ -116,7 +116,7 @@ class EmailTests(test_utils.GenericTestBase):
 
         # lambda function, will replace requests.post() in send_mail
         requests_post_lambda = lambda domain_name, auth=None, data=None: \
-                        self.assertEquals(data['h:Reply-To'], \
+                        self.assertEqual(data['h:Reply-To'], \
                             "reply+" + str(reply_id) + "@" + feconf.INCOMING_EMAILS_DOMAIN_NAME)
         modified_post_request = self.swap(requests, 'post', requests_post_lambda)
 

--- a/core/platform/email/mailgun_email_services_test.py
+++ b/core/platform/email/mailgun_email_services_test.py
@@ -19,14 +19,18 @@
 from core.platform.email import mailgun_email_services
 from core.tests import test_utils
 import feconf
+import requests
 
 
 class EmailTests(test_utils.GenericTestBase):
     """Tests for sending emails."""
 
-    def test_sending_email(self):
-        # Emails are not sent if the CAN_SEND_EMAILS setting is not turned on.
-        # mailgun api key and domain name are required to use API.
+    def test_sending_email_exceptions(self):
+        """
+        Will test the possible exceptions in the send_mail function.
+        1) Emails are not sent if the CAN_SEND_EMAILS setting is not turned on.
+        2) Mailgun API key and/or domain name are not supplied (required for API).
+        """
         mailgun_api_exception = (
             self.assertRaisesRegexp(
                 Exception, 'Mailgun API key is not available.'))
@@ -53,3 +57,129 @@ class EmailTests(test_utils.GenericTestBase):
             mailgun_email_services.send_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
                 'subject', 'body', 'html', bcc_admin=False)
+
+
+    def test_sending_email_data(self):
+        """
+        Verifies that the data sent in send_mail is correct.
+        """
+        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
+        allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+
+        # this data should have been sent in the requests.post()
+        expected = {'from':feconf.SYSTEM_EMAIL_ADDRESS, 'to': feconf.ADMIN_EMAIL_ADDRESS, \
+                    'subject':'subject', 'text':'body', 'html':'html'}
+
+        # lambda function, will replace requests.post() in send_mail
+        requests_post_lambda = lambda domain_name, auth=None, data=None: \
+                                self.assertDictContainsSubset(expected, data)
+        modified_post_request = self.swap(requests, 'post', requests_post_lambda)
+
+        with mailgun_api, mailgun_domain, modified_post_request, allow_email_sending:
+            mailgun_email_services.send_mail(
+                feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
+                'subject', 'body', 'html', bcc_admin=False)
+
+
+    def test_bcc_admin_flag(self):
+        """
+        Verifies that the bcc admin flag is working properly in send_mail.
+
+        Note that we replace the requests.post() function in send_mail with 
+        an alternate lambda that asserts the correct values were placed in 
+        the data dictionary that is then passed to the mailgun api.
+        """
+        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
+        allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+
+        # lambda function, will replace requests.post() in send_mail
+        requests_post_lambda = lambda domain_name, auth=None, data=None: \
+                        self.assertEquals(data['bcc'], feconf.ADMIN_EMAIL_ADDRESS)
+        modified_post_request = self.swap(requests, 'post', requests_post_lambda)
+
+        with mailgun_api, mailgun_domain, modified_post_request, allow_email_sending:
+            mailgun_email_services.send_mail(
+                feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
+                'subject', 'body', 'html', bcc_admin=True)
+
+
+    def test_reply_to_id_flag(self):
+        """
+        Verifies that the reply_to_id flag is working properly.
+        """
+        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
+        allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        reply_id = 123
+
+        # lambda function, will replace requests.post() in send_mail
+        requests_post_lambda = lambda domain_name, auth=None, data=None: \
+                        self.assertEquals(data['h:Reply-To'], \
+                            "reply+" + str(reply_id) + "@" + feconf.INCOMING_EMAILS_DOMAIN_NAME)
+        modified_post_request = self.swap(requests, 'post', requests_post_lambda)
+
+        with mailgun_api, mailgun_domain, modified_post_request, allow_email_sending:
+            mailgun_email_services.send_mail(
+                feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
+                'subject', 'body', 'html', bcc_admin=False, reply_to_id=reply_id)
+
+
+    def test_sending_bulk_email_exceptions(self):
+        """
+        Will test the same exceptions as those in test_sending_email_exceptions,
+        but for the send bulk mail function.
+        """
+        mailgun_api_exception = (
+            self.assertRaisesRegexp(
+                Exception, 'Mailgun API key is not available.'))
+        with mailgun_api_exception:
+            mailgun_email_services.send_bulk_mail(
+                feconf.SYSTEM_EMAIL_ADDRESS, [feconf.ADMIN_EMAIL_ADDRESS],
+                'subject', 'body', 'html')
+
+        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_domain_name_exception = (
+            self.assertRaisesRegexp(
+                Exception, 'Mailgun domain name is not set.'))
+        with mailgun_api, mailgun_domain_name_exception:
+            mailgun_email_services.send_bulk_mail(
+                feconf.SYSTEM_EMAIL_ADDRESS, [feconf.ADMIN_EMAIL_ADDRESS],
+                'subject', 'body', 'html')
+
+        send_email_exception = (
+            self.assertRaisesRegexp(
+                Exception, 'This app cannot send emails to users.'))
+        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
+        with mailgun_api, mailgun_domain, send_email_exception:
+            mailgun_email_services.send_bulk_mail(
+                feconf.SYSTEM_EMAIL_ADDRESS, [feconf.ADMIN_EMAIL_ADDRESS],
+                'subject', 'body', 'html')
+
+
+    def test_sending_bulk_email_data(self):
+        """
+        Verifies that the data sent in send_bulk_mail is correct
+        for each user in the recipient list.
+        """
+        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
+        allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        recipients = [feconf.ADMIN_EMAIL_ADDRESS]
+
+        # this data should have been sent in the requests.post()
+        expected = {'from':feconf.SYSTEM_EMAIL_ADDRESS, 'to': [feconf.ADMIN_EMAIL_ADDRESS], \
+                    'subject':'subject', 'text':'body', 'html':'html', 'recipient-variables': '{}'}
+
+        # lambda function, will replace requests.post() in send_mail
+        requests_post_lambda = lambda domain_name, auth=None, data=None: \
+                        self.assertDictContainsSubset(expected, data)
+
+        modified_post_request = self.swap(requests, 'post', requests_post_lambda)
+
+        with mailgun_api, mailgun_domain, modified_post_request, allow_email_sending:
+            mailgun_email_services.send_bulk_mail(
+                feconf.SYSTEM_EMAIL_ADDRESS, [feconf.ADMIN_EMAIL_ADDRESS],
+                'subject', 'body', 'html')

--- a/core/platform/email/mailgun_email_services_test.py
+++ b/core/platform/email/mailgun_email_services_test.py
@@ -141,7 +141,8 @@ class EmailTests(test_utils.GenericTestBase):
 
     def test_send_bulk_mail_raises_exception_for_missing_api_key(self):
         """Test that send_bulk_mail raises exception for missing
-            mailgun api key."""
+            mailgun api key.
+        """
         mailgun_api_exception = (
             self.assertRaisesRegexp(
                 Exception, 'Mailgun API key is not available.'))
@@ -153,7 +154,8 @@ class EmailTests(test_utils.GenericTestBase):
 
     def test_send_bulk_mail_raises_exception_for_missing_domain_name(self):
         """Tests the missing Mailgun domain name exception for
-            send_bulk_mail."""
+            send_bulk_mail.
+        """
         mailgun_api_context = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
         mailgun_domain_name_exception = (
             self.assertRaisesRegexp(
@@ -166,7 +168,8 @@ class EmailTests(test_utils.GenericTestBase):
 
     def test_send_bulk_mail_exception_for_invalid_permissions(self):
         """Tests the send_bulk_mail exception raised for invalid user
-           permissions."""
+           permissions.
+        """
         send_email_exception = (
             self.assertRaisesRegexp(
                 Exception, 'This app cannot send emails to users.'))
@@ -181,7 +184,8 @@ class EmailTests(test_utils.GenericTestBase):
 
     def test_send_bulk_mail_data_properly_sent(self):
         """Verifies that the data sent in send_bulk_mail is correct
-           for each user in the recipient list."""
+           for each user in the recipient list.
+        """
         mailgun_api_context = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
         mailgun_domain_context = (self.swap(feconf, 'MAILGUN_DOMAIN_NAME',
                                             'domain'))

--- a/core/platform/email/mailgun_email_services_test.py
+++ b/core/platform/email/mailgun_email_services_test.py
@@ -25,13 +25,8 @@ import requests
 class EmailTests(test_utils.GenericTestBase):
     """Tests for sending emails."""
 
-    def test_sending_email_exceptions(self):
-        """Will test the possible exceptions in the send_mail function.
-
-        1) Emails are not sent if the CAN_SEND_EMAILS setting is not turned on.
-        2) Mailgun API key and/or domain name are not supplied
-        (required for API).
-        """
+    def test_send_mail_raises_exception_for_missing_api_key(self):
+        """Tests the missing Mailgun API key exception."""
         mailgun_api_exception = (
             self.assertRaisesRegexp(
                 Exception, 'Mailgun API key is not available.'))
@@ -40,43 +35,54 @@ class EmailTests(test_utils.GenericTestBase):
                 feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
                 'subject', 'body', 'html', bcc_admin=False)
 
-        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+
+    def test_send_mail_raises_exception_for_missing_domain_name(self):
+        """Tests the missing Mailgun domain name exception."""
+        mailgun_api_context = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
         mailgun_domain_name_exception = (
             self.assertRaisesRegexp(
                 Exception, 'Mailgun domain name is not set.'))
-        with mailgun_api, mailgun_domain_name_exception:
+        with mailgun_api_context, mailgun_domain_name_exception:
             mailgun_email_services.send_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
                 'subject', 'body', 'html', bcc_admin=False)
 
+
+    def test_send_mail_raises_exception_for_invalid_permissions(self):
+        """Tests the send_mail exception raised for invalid user permissions."""
         send_email_exception = (
             self.assertRaisesRegexp(
                 Exception, 'This app cannot send emails to users.'))
-        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_api_context = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
         mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
-        with mailgun_api, mailgun_domain, send_email_exception:
+        with mailgun_api_context, mailgun_domain, send_email_exception:
             mailgun_email_services.send_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
                 'subject', 'body', 'html', bcc_admin=False)
 
 
-    def test_sending_email_data(self):
+    def test_send_mail_data_properly_sent(self):
         """Verifies that the data sent in send_mail is correct."""
-        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
-        mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
-        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        mailgun_api_context = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_domain_context = (self.swap(feconf, 'MAILGUN_DOMAIN_NAME',
+                                            'domain'))
+        allow_emailing_context = self.swap(feconf, 'CAN_SEND_EMAILS', True)
 
-        # This data should have been sent in the requests.post().
-        expected = {'from': feconf.SYSTEM_EMAIL_ADDRESS, 'to':
-                    feconf.ADMIN_EMAIL_ADDRESS, 'subject': 'subject',
-                    'text': 'body', 'html': 'html'}
+        # Data we expect to have been sent in the requests.post().
+        expected = {'from': feconf.SYSTEM_EMAIL_ADDRESS,
+                    'to': feconf.ADMIN_EMAIL_ADDRESS,
+                    'subject': 'subject',
+                    'text': 'body',
+                    'html': 'html'}
 
         # Lambda function, will replace requests.post() in send_mail.
         req_post_lambda = (lambda domain_name, auth=None, data=None:
                            self.assertDictContainsSubset(expected, data))
-        modified_post_request = (self.swap(requests, 'post', req_post_lambda))
+        post_request_context = self.swap(requests, 'post', req_post_lambda)
 
-        with mailgun_api, mailgun_domain, modified_post_request, allow_emailing:
+        with (
+            mailgun_api_context, mailgun_domain_context, post_request_context,
+            allow_emailing_context):
             mailgun_email_services.send_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
                 'subject', 'body', 'html', bcc_admin=False)
@@ -89,17 +95,20 @@ class EmailTests(test_utils.GenericTestBase):
         an alternate lambda that asserts the correct values were placed in
         the data dictionary that is then passed to the mailgun api.
         """
-        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
-        mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
-        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        mailgun_api_context = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_domain_context = (self.swap(feconf, 'MAILGUN_DOMAIN_NAME',
+                                            'domain'))
+        allow_emailing_context = self.swap(feconf, 'CAN_SEND_EMAILS', True)
 
         # Lambda function, will replace requests.post() in send_mail.
         req_post_lambda = (lambda domain_name, auth=None, data=None:
                            self.assertEqual(
                                data['bcc'], feconf.ADMIN_EMAIL_ADDRESS))
-        modified_post_request = self.swap(requests, 'post', req_post_lambda)
+        post_request_context = self.swap(requests, 'post', req_post_lambda)
 
-        with mailgun_api, mailgun_domain, modified_post_request, allow_emailing:
+        with (
+            mailgun_api_context, mailgun_domain_context, post_request_context,
+            allow_emailing_context):
             mailgun_email_services.send_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
                 'subject', 'body', 'html', bcc_admin=True)
@@ -107,9 +116,10 @@ class EmailTests(test_utils.GenericTestBase):
 
     def test_reply_to_id_flag(self):
         """Verifies that the reply_to_id flag is working properly."""
-        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
-        mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
-        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        mailgun_api_context = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_domain_context = (self.swap(feconf, 'MAILGUN_DOMAIN_NAME',
+                                            'domain'))
+        allow_emailing_context = self.swap(feconf, 'CAN_SEND_EMAILS', True)
         reply_id = 123
 
         # Lambda function, will replace requests.post() in send_mail.
@@ -117,20 +127,21 @@ class EmailTests(test_utils.GenericTestBase):
                            self.assertEqual(data['h:Reply-To'],
                                             'reply+' + str(reply_id) + '@' +
                                             feconf.INCOMING_EMAILS_DOMAIN_NAME))
-        modified_post_request = (self.swap(requests, 'post',
-                                           req_post_lambda))
+        post_request_context = (self.swap(requests, 'post',
+                                          req_post_lambda))
 
-        with mailgun_api, mailgun_domain, modified_post_request, allow_emailing:
+        with (
+            mailgun_api_context, mailgun_domain_context, post_request_context,
+            allow_emailing_context):
             mailgun_email_services.send_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
                 'subject', 'body', 'html',
                 bcc_admin=False, reply_to_id=reply_id)
 
 
-    def test_sending_bulk_email_exceptions(self):
-        """Will test the same exceptions as those in
-        test_sending_email_exceptions, but for the send bulk mail function.
-        """
+    def test_send_bulk_mail_raises_exception_for_missing_api_key(self):
+        """Test that send_bulk_mail raises exception for missing
+            mailgun api key."""
         mailgun_api_exception = (
             self.assertRaisesRegexp(
                 Exception, 'Mailgun API key is not available.'))
@@ -139,36 +150,45 @@ class EmailTests(test_utils.GenericTestBase):
                 feconf.SYSTEM_EMAIL_ADDRESS, [feconf.ADMIN_EMAIL_ADDRESS],
                 'subject', 'body', 'html')
 
-        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+
+    def test_send_bulk_mail_raises_exception_for_missing_domain_name(self):
+        """Tests the missing Mailgun domain name exception for
+            send_bulk_mail."""
+        mailgun_api_context = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
         mailgun_domain_name_exception = (
             self.assertRaisesRegexp(
                 Exception, 'Mailgun domain name is not set.'))
-        with mailgun_api, mailgun_domain_name_exception:
+        with mailgun_api_context, mailgun_domain_name_exception:
             mailgun_email_services.send_bulk_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, [feconf.ADMIN_EMAIL_ADDRESS],
                 'subject', 'body', 'html')
 
+
+    def test_send_bulk_mail_exception_for_invalid_permissions(self):
+        """Tests the send_bulk_mail exception raised for invalid user
+           permissions."""
         send_email_exception = (
             self.assertRaisesRegexp(
                 Exception, 'This app cannot send emails to users.'))
-        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
-        mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
-        with mailgun_api, mailgun_domain, send_email_exception:
+        mailgun_api_context = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_domain_context = (self.swap(feconf, 'MAILGUN_DOMAIN_NAME',
+                                            'domain'))
+        with mailgun_api_context, mailgun_domain_context, send_email_exception:
             mailgun_email_services.send_bulk_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, [feconf.ADMIN_EMAIL_ADDRESS],
                 'subject', 'body', 'html')
 
 
-    def test_sending_bulk_email_data(self):
+    def test_send_bulk_mail_data_properly_sent(self):
         """Verifies that the data sent in send_bulk_mail is correct
-        for each user in the recipient list.
-        """
-        mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
-        mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
-        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+           for each user in the recipient list."""
+        mailgun_api_context = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
+        mailgun_domain_context = (self.swap(feconf, 'MAILGUN_DOMAIN_NAME',
+                                            'domain'))
+        allow_emailing_context = self.swap(feconf, 'CAN_SEND_EMAILS', True)
         recipients = [feconf.ADMIN_EMAIL_ADDRESS]
 
-        # This data should have been sent in the requests.post().
+        # Data that we expect to have been sent in the requests.post().
         expected = ({'from': feconf.SYSTEM_EMAIL_ADDRESS, 'to': recipients,
                      'subject': 'subject', 'text': 'body', 'html': 'html',
                      'recipient-variables': '{}'})
@@ -177,10 +197,12 @@ class EmailTests(test_utils.GenericTestBase):
         req_post_lambda = (lambda domain_name, auth=None, data=None:
                            self.assertDictContainsSubset(expected, data))
 
-        modified_post_request = (self.swap(requests, 'post',
-                                           req_post_lambda))
+        post_request_context = (self.swap(requests, 'post',
+                                          req_post_lambda))
 
-        with mailgun_api, mailgun_domain, modified_post_request, allow_emailing:
+        with (
+            mailgun_api_context, mailgun_domain_context, post_request_context,
+            allow_emailing_context):
             mailgun_email_services.send_bulk_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, recipients,
                 'subject', 'body', 'html')

--- a/core/platform/email/mailgun_email_services_test.py
+++ b/core/platform/email/mailgun_email_services_test.py
@@ -29,7 +29,8 @@ class EmailTests(test_utils.GenericTestBase):
         """Will test the possible exceptions in the send_mail function.
 
         1) Emails are not sent if the CAN_SEND_EMAILS setting is not turned on.
-        2) Mailgun API key and/or domain name are not supplied (required for API).
+        2) Mailgun API key and/or domain name are not supplied
+        (required for API).
         """
         mailgun_api_exception = (
             self.assertRaisesRegexp(
@@ -63,18 +64,19 @@ class EmailTests(test_utils.GenericTestBase):
         """Verifies that the data sent in send_mail is correct."""
         mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
         mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
-        allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
 
         # This data should have been sent in the requests.post().
-        expected = {'from':feconf.SYSTEM_EMAIL_ADDRESS, 'to': feconf.ADMIN_EMAIL_ADDRESS, \
-                    'subject':'subject', 'text':'body', 'html':'html'}
+        expected = {'from': feconf.SYSTEM_EMAIL_ADDRESS, 'to':
+                    feconf.ADMIN_EMAIL_ADDRESS, 'subject': 'subject',
+                    'text': 'body', 'html': 'html'}
 
         # Lambda function, will replace requests.post() in send_mail.
-        requests_post_lambda = lambda domain_name, auth=None, data=None: \
-                                self.assertDictContainsSubset(expected, data)
-        modified_post_request = self.swap(requests, 'post', requests_post_lambda)
+        req_post_lambda = (lambda domain_name, auth=None, data=None:
+                           self.assertDictContainsSubset(expected, data))
+        modified_post_request = (self.swap(requests, 'post', req_post_lambda))
 
-        with mailgun_api, mailgun_domain, modified_post_request, allow_email_sending:
+        with mailgun_api, mailgun_domain, modified_post_request, allow_emailing:
             mailgun_email_services.send_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
                 'subject', 'body', 'html', bcc_admin=False)
@@ -83,20 +85,21 @@ class EmailTests(test_utils.GenericTestBase):
     def test_bcc_admin_flag(self):
         """Verifies that the bcc admin flag is working properly in send_mail.
 
-        Note that we replace the requests.post() function in send_mail with 
-        an alternate lambda that asserts the correct values were placed in 
+        Note that we replace the requests.post() function in send_mail with
+        an alternate lambda that asserts the correct values were placed in
         the data dictionary that is then passed to the mailgun api.
         """
         mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
         mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
-        allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
 
         # Lambda function, will replace requests.post() in send_mail.
-        requests_post_lambda = lambda domain_name, auth=None, data=None: \
-                        self.assertEqual(data['bcc'], feconf.ADMIN_EMAIL_ADDRESS)
-        modified_post_request = self.swap(requests, 'post', requests_post_lambda)
+        req_post_lambda = (lambda domain_name, auth=None, data=None:
+                           self.assertEqual(
+                               data['bcc'], feconf.ADMIN_EMAIL_ADDRESS))
+        modified_post_request = self.swap(requests, 'post', req_post_lambda)
 
-        with mailgun_api, mailgun_domain, modified_post_request, allow_email_sending:
+        with mailgun_api, mailgun_domain, modified_post_request, allow_emailing:
             mailgun_email_services.send_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
                 'subject', 'body', 'html', bcc_admin=True)
@@ -106,24 +109,27 @@ class EmailTests(test_utils.GenericTestBase):
         """Verifies that the reply_to_id flag is working properly."""
         mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
         mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
-        allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
         reply_id = 123
 
         # Lambda function, will replace requests.post() in send_mail.
-        requests_post_lambda = lambda domain_name, auth=None, data=None: \
-                        self.assertEqual(data['h:Reply-To'], \
-                            "reply+" + str(reply_id) + "@" + feconf.INCOMING_EMAILS_DOMAIN_NAME)
-        modified_post_request = self.swap(requests, 'post', requests_post_lambda)
+        req_post_lambda = (lambda domain_name, auth=None, data=None:
+                           self.assertEqual(data['h:Reply-To'],
+                                            'reply+' + str(reply_id) + '@' +
+                                            feconf.INCOMING_EMAILS_DOMAIN_NAME))
+        modified_post_request = (self.swap(requests, 'post',
+                                           req_post_lambda))
 
-        with mailgun_api, mailgun_domain, modified_post_request, allow_email_sending:
+        with mailgun_api, mailgun_domain, modified_post_request, allow_emailing:
             mailgun_email_services.send_mail(
                 feconf.SYSTEM_EMAIL_ADDRESS, feconf.ADMIN_EMAIL_ADDRESS,
-                'subject', 'body', 'html', bcc_admin=False, reply_to_id=reply_id)
+                'subject', 'body', 'html',
+                bcc_admin=False, reply_to_id=reply_id)
 
 
     def test_sending_bulk_email_exceptions(self):
-        """Will test the same exceptions as those in test_sending_email_exceptions,
-        but for the send bulk mail function.
+        """Will test the same exceptions as those in
+        test_sending_email_exceptions, but for the send bulk mail function.
         """
         mailgun_api_exception = (
             self.assertRaisesRegexp(
@@ -159,20 +165,22 @@ class EmailTests(test_utils.GenericTestBase):
         """
         mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
         mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
-        allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
+        allow_emailing = self.swap(feconf, 'CAN_SEND_EMAILS', True)
         recipients = [feconf.ADMIN_EMAIL_ADDRESS]
 
         # This data should have been sent in the requests.post().
-        expected = {'from':feconf.SYSTEM_EMAIL_ADDRESS, 'to': [feconf.ADMIN_EMAIL_ADDRESS], \
-                    'subject':'subject', 'text':'body', 'html':'html', 'recipient-variables': '{}'}
+        expected = ({'from': feconf.SYSTEM_EMAIL_ADDRESS, 'to': recipients,
+                     'subject': 'subject', 'text': 'body', 'html': 'html',
+                     'recipient-variables': '{}'})
 
         # Lambda function, will replace requests.post() in send_mail.
-        requests_post_lambda = lambda domain_name, auth=None, data=None: \
-                        self.assertDictContainsSubset(expected, data)
+        req_post_lambda = (lambda domain_name, auth=None, data=None:
+                           self.assertDictContainsSubset(expected, data))
 
-        modified_post_request = self.swap(requests, 'post', requests_post_lambda)
+        modified_post_request = (self.swap(requests, 'post',
+                                           req_post_lambda))
 
-        with mailgun_api, mailgun_domain, modified_post_request, allow_email_sending:
+        with mailgun_api, mailgun_domain, modified_post_request, allow_emailing:
             mailgun_email_services.send_bulk_mail(
-                feconf.SYSTEM_EMAIL_ADDRESS, [feconf.ADMIN_EMAIL_ADDRESS],
+                feconf.SYSTEM_EMAIL_ADDRESS, recipients,
                 'subject', 'body', 'html')

--- a/core/platform/email/mailgun_email_services_test.py
+++ b/core/platform/email/mailgun_email_services_test.py
@@ -26,8 +26,8 @@ class EmailTests(test_utils.GenericTestBase):
     """Tests for sending emails."""
 
     def test_sending_email_exceptions(self):
-        """
-        Will test the possible exceptions in the send_mail function.
+        """Will test the possible exceptions in the send_mail function.
+
         1) Emails are not sent if the CAN_SEND_EMAILS setting is not turned on.
         2) Mailgun API key and/or domain name are not supplied (required for API).
         """
@@ -60,9 +60,7 @@ class EmailTests(test_utils.GenericTestBase):
 
 
     def test_sending_email_data(self):
-        """
-        Verifies that the data sent in send_mail is correct.
-        """
+        """Verifies that the data sent in send_mail is correct."""
         mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
         mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
         allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
@@ -83,8 +81,7 @@ class EmailTests(test_utils.GenericTestBase):
 
 
     def test_bcc_admin_flag(self):
-        """
-        Verifies that the bcc admin flag is working properly in send_mail.
+        """Verifies that the bcc admin flag is working properly in send_mail.
 
         Note that we replace the requests.post() function in send_mail with 
         an alternate lambda that asserts the correct values were placed in 
@@ -106,9 +103,7 @@ class EmailTests(test_utils.GenericTestBase):
 
 
     def test_reply_to_id_flag(self):
-        """
-        Verifies that the reply_to_id flag is working properly.
-        """
+        """Verifies that the reply_to_id flag is working properly."""
         mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')
         mailgun_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
         allow_email_sending = self.swap(feconf, 'CAN_SEND_EMAILS', True)
@@ -127,8 +122,7 @@ class EmailTests(test_utils.GenericTestBase):
 
 
     def test_sending_bulk_email_exceptions(self):
-        """
-        Will test the same exceptions as those in test_sending_email_exceptions,
+        """Will test the same exceptions as those in test_sending_email_exceptions,
         but for the send bulk mail function.
         """
         mailgun_api_exception = (
@@ -160,8 +154,7 @@ class EmailTests(test_utils.GenericTestBase):
 
 
     def test_sending_bulk_email_data(self):
-        """
-        Verifies that the data sent in send_bulk_mail is correct
+        """Verifies that the data sent in send_bulk_mail is correct
         for each user in the recipient list.
         """
         mailgun_api = self.swap(feconf, 'MAILGUN_API_KEY', 'api')


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix part of #5134: Increased coverage to 100% for mailgun_email_services,py

Wrote test cases for the Mailgun API wrapper functions send_email() and send_bulk_email() (in mailgun_email_services.py). The tests can be found at mailgun_email_services_test.py. Essentially, I utilized the swap() function in the utility file to replace with requests.post() function with an alternate lambda/anonymous function that verifies that the correct data has been posted/passed in the requests.json() call. I also added specific tests for the several different flags in send_email(), in which I simply test the particular entry changed in the data dictionary passed to requests.json() (for when that flag is active). 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
