### PR TITLE
Fix #6062: Alignment of the sharing logos at bottom set correctly.

### DIFF
--- a/core/templates/dev/head/components/share/sharing_links_directive.html
+++ b/core/templates/dev/head/components/share/sharing_links_directive.html
@@ -45,7 +45,7 @@
   .oppia-sharing-links .share-option-img {
     border-radius: 5px;
     height: 34px;
-    margin: 0 3px;
+    margin: 4px 3px;
     width: 34px;
     max-width: 34px;
 }
@@ -58,7 +58,7 @@
 
   ul.oppia-sharing-links {
     list-style: none;
-    padding-top: 15px;
+    padding-top: 8px;
     padding-left: 0px;
   }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation

  - "Fixes #6062 :" This is a bugfix of the alignment of the logos of Google+,Facebook and twiiter at the bottom right corner of the collections page in the library. After the bux fix the logos are aligned perfectly as below.
![ubuntu 64-bit - vmware workstation 21-01-2019 18_29_45](https://user-images.githubusercontent.com/45489945/51518130-e890f680-1e42-11e9-96b9-12c87e1473e3.png)

Before bugfix it was as shown below.
![ubuntu 64-bit - vmware workstation 21-01-2019 18_29_45](https://user-images.githubusercontent.com/30555544/50732462-ede31580-11a1-11e9-9bf3-7d9dc2cc27f8.png)

  

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
