### PR TITLE
Fix #5134: 100% coverage for learner playlist services

### DIFF
--- a/core/domain/learner_playlist_services_test.py
+++ b/core/domain/learner_playlist_services_test.py
@@ -80,6 +80,9 @@ class LearnerPlaylistTests(test_utils.GenericTestBase):
             category='Welcome')
 
     def _get_all_learner_playlist_exp_ids(self, user_id):
+        """Returns the list of all the exploration ids in the learner's playlist
+        corresponding to the given user id.
+        """
         learner_playlist_model = user_models.LearnerPlaylistModel.get(
             user_id, strict=False)
 
@@ -88,6 +91,9 @@ class LearnerPlaylistTests(test_utils.GenericTestBase):
             learner_playlist_model else [])
 
     def _get_all_learner_playlist_collection_ids(self, user_id):
+        """Returns the list of all the collection ids in the learner's playlist
+        corresponding to the given user id.
+        """
         learner_playlist_model = user_models.LearnerPlaylistModel.get(
             user_id, strict=False)
 
@@ -202,11 +208,12 @@ class LearnerPlaylistTests(test_utils.GenericTestBase):
             self._get_all_learner_playlist_exp_ids(
                 self.user_id), exp_ids)
 
-        # Now if we try to add another exploration at any given position, it
-        # shouldn't be added as the list length would exceed
+        # Now if we try to add another explorations at the end of the list, 
+        # it shouldn't be added as the list length would exceed
         # MAX_LEARNER_PLAYLIST_ACTIVITY_COUNT.
         learner_playlist_services.mark_exploration_to_be_played_later(
-            self.user_id, 'SAMPLE_EXP_ID', position_to_be_inserted=1)
+            self.user_id, 'SAPMLE_EXP_ID', 
+            position_to_be_inserted=MAX_LEARNER_PLAYLIST_ACTIVITY_COUNT)
 
         # The list still remains the same.
         self.assertEqual(
@@ -319,11 +326,12 @@ class LearnerPlaylistTests(test_utils.GenericTestBase):
             self._get_all_learner_playlist_collection_ids(
                 self.user_id), collection_ids)
 
-        # Now if we try to add another exploration at any given position, it
-        # shouldn't be added as the list length would exceed
+        # Now if we try to add another explorations at the end of the list, 
+        # it shouldn't be added as the list length would exceed
         # MAX_LEARNER_PLAYLIST_ACTIVITY_COUNT.
         learner_playlist_services.mark_collection_to_be_played_later(
-            self.user_id, 'SAMPLE_COLLECTION_ID', position_to_be_inserted=1)
+            self.user_id, 'SAPMLE_COLLECTION_ID', 
+            position_to_be_inserted=MAX_LEARNER_PLAYLIST_ACTIVITY_COUNT)
 
         # The list still remains the same.
         self.assertEqual(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Improves the coverage for core.domain.learner_playlist_services to 100%. Submitted on behalf of @ezl-13

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.