### PR TITLE
[WIP] Fix #5867: Exclude empty html contents for audio translation.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -271,6 +271,7 @@
   <script src="/templates/dev/head/pages/exploration_editor/editor_tab/SolutionVerificationService.js"></script>
   <script src="/templates/dev/head/pages/exploration_editor/editor_tab/SolutionValidityService.js"></script>
 
+  <script src="/templates/dev/head/pages/exploration_editor/translation_tab/TranslationRequirementQueryService.js"></script>
   <script src="/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabDirective.js"></script>
   <script src="/templates/dev/head/pages/exploration_editor/translation_tab/TranslatorOverviewDirective.js"></script>
   <script src="/templates/dev/head/pages/exploration_editor/translation_tab/TranslationLanguageService.js"></script>

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/AudioTranslationBarDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/AudioTranslationBarDirective.js
@@ -62,35 +62,38 @@ oppia.directive('audioTranslationBar', [
         '/pages/exploration_editor/translation_tab/' +
         'audio_translation_bar_directive.html'),
       controller: [
-        '$scope', '$filter', '$timeout', '$uibModal', '$rootScope',
-        'StateContentIdsToAudioTranslationsService', 'IdGenerationService',
-        'AudioPlayerService', 'TranslationLanguageService', 'AlertsService',
-        'StateEditorService', 'ExplorationStatesService', 'EditabilityService',
-        'AssetsBackendApiService', 'recorderService', 'ContextService',
-        'RECORDING_TIME_LIMIT',
-        function(
-            $scope, $filter, $timeout, $uibModal, $rootScope,
-            StateContentIdsToAudioTranslationsService, IdGenerationService,
-            AudioPlayerService, TranslationLanguageService, AlertsService,
-            StateEditorService, ExplorationStatesService, EditabilityService,
-            AssetsBackendApiService, recorderService, ContextService,
+        '$filter', '$rootScope', '$scope', '$timeout', '$uibModal',
+        'AlertsService', 'AssetsBackendApiService', 'AudioPlayerService',
+        'ContextService', 'EditabilityService', 'ExplorationStatesService',
+        'IdGenerationService', 'recorderService',
+        'StateContentIdsToAudioTranslationsService', 'StateEditorService',
+        'TranslationLanguageService', 'TranslationRequirementQueryService',
+        'RECORDING_TIME_LIMIT', function(
+            $filter, $rootScope, $scope, $timeout, $uibModal,
+            AlertsService, AssetsBackendApiService, AudioPlayerService,
+            ContextService, EditabilityService, ExplorationStatesService,
+            IdGenerationService, recorderService,
+            StateContentIdsToAudioTranslationsService, StateEditorService,
+            TranslationLanguageService, TranslationRequirementQueryService,
             RECORDING_TIME_LIMIT) {
           $scope.RECORDER_ID = 'recorderId';
-          $scope.recordingTimeLimit = RECORDING_TIME_LIMIT;
           $scope.audioBlob = null;
-          $scope.recorder = null;
-          $scope.unsupportedBrowser = false;
-          $scope.selectedRecording = false;
-          $scope.isAudioAvailable = false;
-          $scope.audioIsUpdating = false;
-          $scope.languageCode = null;
-          $scope.cannotRecord = false;
-          $scope.audioNeedsUpdate = false;
-          $scope.canTranslate = false;
-          $scope.showRecorderWarning = false;
-          $scope.audioLoadingIndicatorIsShown = false;
-          $scope.checkingMicrophonePermission = false;
           $scope.audioIsCurrentlyBeingSaved = false;
+          $scope.audioIsUpdating = false;
+          $scope.audioNeedsUpdate = false;
+          $scope.audioNotRequired = false;
+          $scope.audioLoadingIndicatorIsShown = false;
+          $scope.cannotRecord = false;
+          $scope.canTranslate = false;
+          $scope.checkingMicrophonePermission = false;
+          $scope.isAudioAvailable = false;
+          $scope.languageCode = null;
+          $scope.recorder = null;
+          $scope.recordingTimeLimit = RECORDING_TIME_LIMIT;
+          $scope.selectedRecording = false;
+          $scope.showRecorderWarning = false;
+          $scope.unsupportedBrowser = false;
+
 
           var saveContentIdsToAudioTranslationChanges = function() {
             StateContentIdsToAudioTranslationsService.saveDisplayedValue();
@@ -349,6 +352,10 @@ oppia.directive('audioTranslationBar', [
                 recorderService.getHandler().clear();
               }
             }
+            var activeStateName = StateEditorService.getActiveStateName();
+            $scope.audioNotRequired = (
+              TranslationRequirementQueryService.isNotRequired(
+                activeStateName, $scope.contentId));
             $scope.isTranslationTabBusy = false;
             AudioPlayerService.stop();
             AudioPlayerService.clear();

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationRequirementQueryService.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationRequirementQueryService.js
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 /**
-* @fileoverview A service that check s the requirement of translation for a
-* content using it's translation_id.
+* @fileoverview A service that checks the requirement of translation for a
+* content using it's content_id.
 */
 
 oppia.factory('TranslationRequirementQueryService', [

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationRequirementQueryService.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationRequirementQueryService.js
@@ -1,0 +1,91 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+* @fileoverview A service that check s the requirement of translation for a
+* content using it's translation_id.
+*/
+
+oppia.factory('TranslationRequirementQueryService', [
+  'ExplorationStatesService', 'INTERACTION_SPECS', function(
+      ExplorationStatesService, INTERACTION_SPECS) {
+    var stateToUnnecessaryContentIdList = {};
+    var _checkAndUpdateList = function(stateName, subtitledHtml) {
+      if (!subtitledHtml.getHtml()) {
+        stateToUnnecessaryContentIdList[stateName].push(
+          subtitledHtml.getContentId());
+      }
+    };
+    var _init = function() {
+      if (!ExplorationStatesService.isInitialized()) {
+        return;
+      }
+      var stateNames = ExplorationStatesService.getStateNames();
+      for (index in stateNames) {
+        var stateName = stateNames[index];
+        stateToUnnecessaryContentIdList[stateName] = [];
+        var stateContent = (
+          ExplorationStatesService.getStateContentMemento(stateName));
+        var stateInteractionId = (
+          ExplorationStatesService.getInteractionIdMemento(stateName));
+        var stateAnswerGroups = (
+          ExplorationStatesService.getInteractionAnswerGroupsMemento(
+            stateName));
+        var stateDefaultOutcome = (
+          ExplorationStatesService.getInteractionDefaultOutcomeMemento(
+            stateName));
+        var stateHints = ExplorationStatesService.getHintsMemento(stateName);
+        var stateSolution = (
+          ExplorationStatesService.getSolutionMemento(stateName));
+
+        _checkAndUpdateList(stateName, stateContent);
+        // This is used to prevent looking up for other parts of state when the
+        // interaction is linear or terminal, as of now we do not delete
+        // interaction.hints when a user deletes interaction.
+        if (!stateInteractionId ||
+        INTERACTION_SPECS[stateInteractionId].is_linear ||
+        INTERACTION_SPECS[stateInteractionId].is_terminal) {
+          break;
+        }
+        stateAnswerGroups.forEach(function(answerGroup) {
+          _checkAndUpdateList(stateName, answerGroup.outcome.feedback);
+        });
+
+        if (stateDefaultOutcome) {
+          _checkAndUpdateList(stateName, stateDefaultOutcome.feedback);
+        }
+
+        stateHints.forEach(function(hint) {
+          _checkAndUpdateList(stateName, hint.hintContent);
+        });
+
+        if (stateSolution) {
+          _checkAndUpdateList(stateName, stateSolution.explanation);
+        }
+      }
+    };
+    return {
+      init: function() {
+        _init();
+      },
+      getNotRequiredContentIdList: function(stateName) {
+        return angular.copy(stateToUnnecessaryContentIdList[stateName]);
+      },
+      isNotRequired: function(stateName, contentId) {
+        return (
+          stateToUnnecessaryContentIdList[stateName].indexOf(contentId) >= 0);
+      }
+    };
+  }
+]);

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabDirective.js
@@ -27,12 +27,15 @@ oppia.directive('translationTab', [
       templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
         '/pages/exploration_editor/translation_tab/' +
         'translation_tab_directive.html'),
-      controller: ['$scope', '$rootScope', function($scope, $rootScope) {
-        $rootScope.loadingMessage = 'Loading';
-        $scope.isTranslationTabBusy = false;
-        $scope.$on('refreshTranslationTab', function() {
-          $scope.$broadcast('refreshStateTranslation');
-        });
-      }]
+      controller: [
+        '$scope', '$rootScope', 'TranslationRequirementQueryService',
+        function($scope, $rootScope, TranslationRequirementQueryService) {
+          $rootScope.loadingMessage = 'Loading';
+          TranslationRequirementQueryService.init();
+          $scope.isTranslationTabBusy = false;
+          $scope.$on('refreshTranslationTab', function() {
+            $scope.$broadcast('refreshStateTranslation');
+          });
+        }]
     };
   }]);

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/audio_translation_bar_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/audio_translation_bar_directive.html
@@ -1,4 +1,4 @@
-<div  class="oppia-drop-area" ng-if="showDropArea">
+<div  class="oppia-drop-area" ng-if="showDropArea && !audioNotRequired">
   <div class="oppia-blur-background"></div>
   <div class="oppia-drop-area-message">Drop your file here!</div>
 </div>
@@ -7,7 +7,8 @@
     <i class="material-icons">&#xE039;</i>
   </button>
   <div class="oppia-audio-bar-info">
-    <div ng-if="!cannotRecord && !checkingMicrophonePermission">
+    <div ng-if="audioNotRequired" > Audio not required!</div>
+    <div ng-if="!cannotRecord && !audioNotRequired && !checkingMicrophonePermission">
       No audio recorded.<span ng-if="canTranslate"> Press <i class="material-icons">mic</i>  to start recording.</span>
     </div>
     <div ng-if="checkingMicrophonePermission">
@@ -20,13 +21,13 @@
       Sorry, your browser does not support recording feature.
     </div>
   </div>
-  <button class="btn oppia-audio-button"
+  <button ng-if="!audioNotRequired" class="btn oppia-audio-button"
           uib-tooltip="Record" tooltip-placement="bottom"
           ng-click="checkAndStartRecording()"
           ng-disabled="!canTranslate || cannotRecord">
     <i class="material-icons">&#xE029;</i>
   </button>
-  <button class="btn oppia-audio-button"
+  <button ng-if="!audioNotRequired" class="btn oppia-audio-button"
           uib-tooltip="Upload" tooltip-placement="bottom"
           ng-click="openAddAudioTranslationModal()"
           ng-disabled="!canTranslate">
@@ -147,6 +148,12 @@
 <div class="oppia-translation-bottom-right-container" ng-if="showRecorderWarning">
   <span>
     <strong>Warning: </strong>Don't navigate to other tabs of this page before saving recorded audio, otherwise the recorded audio will be lost.
+  </span>
+</div>
+
+<div class="oppia-translation-bottom-right-container" ng-if="isAudioAvailable && audioNotRequired">
+  <span>
+    <strong>Note: </strong>Text from this card has been removed try deleting audio if not required.
   </span>
 </div>
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #5867: Following the approach mentioned in the issue comment.

> **Idea:**
> - From backend expect all possible content_ids in state to be in the content_ids_to_audio_translations.
> - As we expect that the translation tab will just change one property of state let’s create a service to track all content id with empty html and use this while showing status.
> 
> **UI behavior:**
> - We will not count this content_id for status or progress.
> - Translators will see the green color status for those sections.
> - Audio recording bar will have a message "Audio not required!"
> 
> The only issue I found with this approach is this:
> - Creators add content.
> - Translator added audio.
> - Creators deleted content.
> 
> Possible solution:
> 1.  Ask editor to delete audio (currently we ask to mark update.)
> 2. Show this to translators and add a note for deletion. 
> 3. Delete all of the audio related to that content_id automatically (I'm not sure about this (above-mentioned issue) as I feel mostly this will happen unintentionally / by mistake ) 
> 

This PR fixes the edge scenrio with the solution 2.

Work left:
- [ ] Adding test for new service.
- [ ] Adding e2e for new functionality.

Assigning @suicide11 for UI review.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
