### PR TITLE
fix #6140 learner answer overflow

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_directive.html
@@ -244,6 +244,7 @@ otherwise they will interfere with the iframed conversation skin directive.
   .conversation-skin-learner-answer-content {
     margin-bottom: 12px;
     padding: 8px 12px;
+    overflow: auto;
     word-wrap: break-word;
   }
 


### PR DESCRIPTION
## Explanation
This PR fixes #6140 in which learner answer used to overflow  when interaction was math expression
![screenshot from 2019-01-25 15-53-11](https://user-images.githubusercontent.com/32756751/51740612-7e828680-20ba-11e9-8d10-f4150581c482.png)
## Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
 - [x] The linter/Karma presubmit checks have passed.
- [x] These should run automatically, but if not, you can manually trigger them locally using python  
                      - scripts/pre_commit_linter.py and bash scripts/run_frontend_tests.sh.
- [x] The PR is made from a branch that's not called "develop".
- [x] The PR follows the style guide.
- [x] The  PR is assigned to an appropriate reviewer.
- [x] If you're a new contributor, please ask on Gitter for someone to assign a reviewer.
- [x] If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.

