### PR TITLE
Fix part of #5002: Remove promo bar globals

### DIFF
--- a/assets/constants.js
+++ b/assets/constants.js
@@ -502,6 +502,8 @@ var constants = {
       }
   },
 
+  "ENABLE_PROMO_BAR": true,
+
   "ALLOW_YAML_FILE_UPLOAD": false,
 
   "CURRENT_STATES_SCHEMA_VERSION": 25,

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -336,16 +336,6 @@ class BaseHandler(webapp2.RequestHandler):
             'user_is_logged_in': user_services.has_fully_registered(
                 self.user_id)
         })
-        if feconf.ENABLE_PROMO_BAR:
-            promo_bar_enabled = config_domain.PROMO_BAR_ENABLED.value
-            promo_bar_message = config_domain.PROMO_BAR_MESSAGE.value
-        else:
-            promo_bar_enabled = False
-            promo_bar_message = ''
-        values.update({
-            'promo_bar_enabled': promo_bar_enabled,
-            'promo_bar_message': promo_bar_message,
-        })
 
         if 'status_code' not in values:
             values['status_code'] = 200

--- a/core/controllers/resources.py
+++ b/core/controllers/resources.py
@@ -20,6 +20,7 @@ import urllib
 from constants import constants
 from core.controllers import base
 from core.domain import acl_decorators
+from core.domain import config_domain
 from core.domain import fs_domain
 from core.domain import value_generators_domain
 import feconf
@@ -86,3 +87,24 @@ class AssetDevHandler(base.BaseHandler):
             self.response.write(raw)
         except:
             raise self.PageNotFoundException
+
+
+class PromoBarHandler(base.BaseHandler):
+    """The handler for checking if Promobar is enabled and fetching
+    promobar message.
+    """
+
+    GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
+
+    @acl_decorators.open_access
+    def get(self):
+        if constants.ENABLE_PROMO_BAR:
+            promo_bar_enabled = config_domain.PROMO_BAR_ENABLED.value
+            promo_bar_message = config_domain.PROMO_BAR_MESSAGE.value
+        else:
+            promo_bar_enabled = False
+            promo_bar_message = ''
+        self.render_json({
+            'promo_bar_enabled': promo_bar_enabled,
+            'promo_bar_message': promo_bar_message
+        })

--- a/core/templates/dev/head/components/promo/PromoBarDirective.js
+++ b/core/templates/dev/head/components/promo/PromoBarDirective.js
@@ -19,24 +19,32 @@
  */
 
 oppia.directive('promoBar', [
-  'UrlInterpolationService', function(UrlInterpolationService) {
+  'PromoBarService', 'UrlInterpolationService',
+  function(PromoBarService, UrlInterpolationService) {
     return {
       restrict: 'E',
-      scope: {
-        getPromoMessage: '&promoMessage'
-      },
       templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
         '/components/promo/' +
         'promo_bar_directive.html'),
       controller: [
-        '$scope',
-        function($scope) {
+        '$scope', '$window',
+        function($scope, $window) {
           var isPromoDismissed = function() {
             return !!angular.fromJson(sessionStorage.promoIsDismissed);
           };
           var setPromoDismissed = function(promoIsDismissed) {
             sessionStorage.promoIsDismissed = angular.toJson(promoIsDismissed);
           };
+
+          if ($window.location.pathname.split('/')[1] === 'signup') {
+            $scope.promoBarIsEnabled = false;
+            $scope.getPromoMessage = '';
+          } else {
+            PromoBarService.getPromoBar().then(function(promoBarObject) {
+              $scope.promoBarIsEnabled = promoBarObject.promo_bar_enabled;
+              $scope.getPromoMessage = promoBarObject.promo_bar_message;
+            });
+          }
 
           // TODO(bhenning): Utilize cookies for tracking when a promo is
           // dismissed. Cookies allow for a longer-lived memory of whether the
@@ -50,4 +58,5 @@ oppia.directive('promoBar', [
         }
       ]
     };
-  }]);
+  }
+]);

--- a/core/templates/dev/head/components/promo/promo_bar_directive.html
+++ b/core/templates/dev/head/components/promo/promo_bar_directive.html
@@ -1,6 +1,6 @@
-<div class="oppia-toast-container toast-top-center" ng-if="promoIsVisible">
+<div class="oppia-toast-container toast-top-center" ng-if="promoBarIsEnabled && promoIsVisible">
   <div class="toast toast-info oppia-toast">
     <button type="button" class="toast-close-button" ng-click="dismissPromo()" role="button">&times;</button>
-    <div class="toast-message"><[getPromoMessage()]></div>
+    <div class="toast-message"><[getPromoMessage]></div>
   </div>
 </div>

--- a/core/templates/dev/head/pages/Base.js
+++ b/core/templates/dev/head/pages/Base.js
@@ -26,8 +26,6 @@ oppia.controller('Base', [
     $scope.currentLang = 'en';
     $scope.iframed = GLOBALS.iframed;
     $scope.siteFeedbackFormUrl = GLOBALS.SITE_FEEDBACK_FORM_URL;
-    $scope.promoBarIsEnabled = GLOBALS.PROMO_BAR_IS_ENABLED;
-    $scope.promoBarMessage = GLOBALS.PROMO_BAR_MESSAGE;
 
     $rootScope.DEV_MODE = DEV_MODE;
     // If this is nonempty, the whole page goes into 'Loading...' mode.

--- a/core/templates/dev/head/pages/base.html
+++ b/core/templates/dev/head/pages/base.html
@@ -86,9 +86,7 @@
         iframed: JSON.parse('{{iframed|js_string}}'),
         isTopicManager: JSON.parse('{{is_topic_manager|js_string}}'),
         logoutUrl: JSON.parse('{{logout_url|js_string}}'),
-        userIsLoggedIn: JSON.parse('{{user_is_logged_in|js_string}}'),
-        PROMO_BAR_IS_ENABLED: JSON.parse('{{promo_bar_enabled|js_string}}'),
-        PROMO_BAR_MESSAGE: JSON.parse('{{promo_bar_message|js_string}}')
+        userIsLoggedIn: JSON.parse('{{user_is_logged_in|js_string}}')
       };
     </script>
 
@@ -105,7 +103,7 @@
     </div>
     <div ng-if="!iframed">
       <div role="button" tabindex="0" ng-click="skipToMainContent()" class="oppia-skip-to-content protractor-test-skip-link">Skip to Main Content</div>
-      <promo-bar ng-if="promoBarIsEnabled" promo-message="promoBarMessage">
+      <promo-bar>
       </promo-bar>
       <div ng-if="isBackgroundMaskActive()" class="ng-cloak oppia-background-mask">
       </div>
@@ -191,6 +189,7 @@
     <script src="/templates/dev/head/services/StateRulesStatsService.js"></script>
     <script src="/templates/dev/head/services/ConstructTranslationIdsService.js"></script>
     <script src="/templates/dev/head/services/UserService.js"></script>
+    <script src="/templates/dev/head/services/PromoBarService.js"></script>
     <script src="/templates/dev/head/services/contextual/DeviceInfoService.js"></script>
     <script src="/templates/dev/head/services/contextual/UrlService.js"></script>
     <script src="/templates/dev/head/services/contextual/WindowDimensionsService.js"></script>

--- a/core/templates/dev/head/services/PromoBarService.js
+++ b/core/templates/dev/head/services/PromoBarService.js
@@ -1,0 +1,34 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Service for Promo Bar.
+ */
+
+oppia.factory('PromoBarService', ['$http',
+  function($http) {
+    return {
+      getPromoBar: function() {
+        return $http.get('/promo_bar_handler', {}).then(
+          function(response) {
+            return {
+              promo_bar_enabled: response.data.promo_bar_enabled,
+              promo_bar_message: response.data.promo_bar_message
+            };
+          }
+        );
+      }
+    };
+  }
+]);

--- a/core/tests/build_sources/assets/constants.js
+++ b/core/tests/build_sources/assets/constants.js
@@ -498,5 +498,7 @@ var constants = {
       }
   },
 
+  "ENABLE_PROMO_BAR": true,
+  
   "CURRENT_STATES_SCHEMA_VERSION": 25
 };

--- a/core/tests/build_sources/templates/base.html
+++ b/core/tests/build_sources/templates/base.html
@@ -91,9 +91,7 @@
         logoutUrl: JSON.parse('{{logout_url|js_string}}'),
         userIsLoggedIn: JSON.parse('{{user_is_logged_in|js_string}}'),
         username: JSON.parse('{{username|js_string}}'),
-        allowYamlFileUpload: JSON.parse('{{allow_yaml_file_upload|js_string}}'),
-        PROMO_BAR_IS_ENABLED: JSON.parse('{{promo_bar_enabled|js_string}}'),
-        PROMO_BAR_MESSAGE: JSON.parse('{{promo_bar_message|js_string}}')
+        allowYamlFileUpload: JSON.parse('{{allow_yaml_file_upload|js_string}}')
       };
     </script>
 
@@ -110,7 +108,7 @@
     </div>
     <div ng-if="!iframed">
       <div role="button" tabindex="0" ng-click="skipToMainContent()" class="oppia-skip-to-content protractor-test-skip-link">Skip to Main Content</div>
-      <promo-bar ng-if="promoBarIsEnabled" promo-message="promoBarMessage">
+      <promo-bar>
       </promo-bar>
       <div ng-if="isBackgroundMaskActive()" class="ng-cloak oppia-background-mask">
       </div>
@@ -195,6 +193,7 @@
     <script src="/templates/dev/head/services/StateRulesStatsService.js"></script>
     <script src="/templates/dev/head/services/ConstructTranslationIdsService.js"></script>
     <script src="/templates/dev/head/services/UserService.js"></script>
+    <script src="/templates/dev/head/services/PromoBarService.js"></script>
     <script src="/templates/dev/head/services/contextual/DeviceInfoService.js"></script>
     <script src="/templates/dev/head/services/contextual/UrlService.js"></script>
     <script src="/templates/dev/head/services/contextual/WindowDimensionsService.js"></script>

--- a/core/tests/build_sources/templates/pages/Base.js
+++ b/core/tests/build_sources/templates/pages/Base.js
@@ -26,8 +26,6 @@ oppia.controller('Base', [
     $scope.currentLang = 'en';
     $scope.iframed = GLOBALS.iframed;
     $scope.siteFeedbackFormUrl = GLOBALS.SITE_FEEDBACK_FORM_URL;
-    $scope.promoBarIsEnabled = GLOBALS.PROMO_BAR_IS_ENABLED;
-    $scope.promoBarMessage = GLOBALS.PROMO_BAR_MESSAGE;
 
     $rootScope.DEV_MODE = GLOBALS.DEV_MODE;
     // If this is nonempty, the whole page goes into 'Loading...' mode.

--- a/feconf.py
+++ b/feconf.py
@@ -357,11 +357,6 @@ DUPLICATE_EMAIL_INTERVAL_MINS = 2
 # Number of digits after decimal to which the average ratings value in the
 # dashboard is rounded off to.
 AVERAGE_RATINGS_DASHBOARD_PRECISION = 2
-# Whether to enable the promo bar functionality. This does not actually turn on
-# the promo bar, as that is gated by a config value (see config_domain). This
-# merely avoids checking for whether the promo bar is enabled for every Oppia
-# page visited.
-ENABLE_PROMO_BAR = True
 # Whether to enable maintenance mode on the site. For non-admins, this redirects
 # all HTTP requests to the maintenance page. This is the only check which
 # determines whether the site is in maintenance mode to avoid queries to the

--- a/main.py
+++ b/main.py
@@ -282,6 +282,7 @@ URLS = MAPREDUCE_HANDLERS + [
     get_redirect_route(
         r'/value_generator_handler/<generator_id>',
         resources.ValueGeneratorHandler),
+    get_redirect_route(r'/promo_bar_handler', resources.PromoBarHandler),
 
     get_redirect_route(
         r'%s' % feconf.FRACTIONS_LANDING_PAGE_URL,


### PR DESCRIPTION
Fix part of #5002: This pr removes  PROMO_BAR_IS_ENABLED, PROMO_BAR_MESSAGE from globals. A backend handler was created for promobar message. Promobar message was retrieved from frontend by AJAX. feconf.ENABLE_PROMO_BAR was moved to constants.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
