### PR TITLE
Fix part of #5939: Custom pylint extension for checking single character files and newline characters.

### DIFF
--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -247,8 +247,6 @@ EXCLUDED_PATHS = (
     'assets/scripts/*', 'core/tests/data/*', 'core/tests/build_sources/*',
     '*.mp3', '*.mp4')
 
-EXCLUDED_PATHS_EXT = EXCLUDED_PATHS + ('*.py',)
-
 GENERATED_FILE_PATHS = (
     'extensions/interactions/LogicProof/static/js/generatedDefaultData.js',
     'extensions/interactions/LogicProof/static/js/generatedParser.js',
@@ -869,7 +867,7 @@ def _check_newline_character(all_files):
     all_files = [
         filename for filename in all_files if not
         any(fnmatch.fnmatch(filename, pattern)
-            for pattern in EXCLUDED_PATHS_EXT)]
+            for pattern in EXCLUDED_PATHS) and not filename.endswith('.py')]
 
     for filename in all_files:
         content = FileCache.read(filename, mode='rb')

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -247,12 +247,7 @@ EXCLUDED_PATHS = (
     'assets/scripts/*', 'core/tests/data/*', 'core/tests/build_sources/*',
     '*.mp3', '*.mp4')
 
-EXCLUDED_PATHS_EXT = (
-    'third_party/*', 'build/*', '.git/*', '*.pyc', 'CHANGELOG',
-    'integrations/*', 'integrations_dev/*', '*.svg', '*.gif',
-    '*.png', '*.zip', '*.ico', '*.jpg', '*.min.js',
-    'assets/scripts/*', 'core/tests/data/*', 'core/tests/build_sources/*',
-    '*.mp3', '*.mp4', '*.py')
+EXCLUDED_PATHS_EXT = EXCLUDED_PATHS + ('*.py',)
 
 GENERATED_FILE_PATHS = (
     'extensions/interactions/LogicProof/static/js/generatedDefaultData.js',

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -247,6 +247,13 @@ EXCLUDED_PATHS = (
     'assets/scripts/*', 'core/tests/data/*', 'core/tests/build_sources/*',
     '*.mp3', '*.mp4')
 
+EXCLUDED_PATHS_EXT = (
+    'third_party/*', 'build/*', '.git/*', '*.pyc', 'CHANGELOG',
+    'integrations/*', 'integrations_dev/*', '*.svg', '*.gif',
+    '*.png', '*.zip', '*.ico', '*.jpg', '*.min.js',
+    'assets/scripts/*', 'core/tests/data/*', 'core/tests/build_sources/*',
+    '*.mp3', '*.mp4', '*.py')
+
 GENERATED_FILE_PATHS = (
     'extensions/interactions/LogicProof/static/js/generatedDefaultData.js',
     'extensions/interactions/LogicProof/static/js/generatedParser.js',
@@ -866,7 +873,8 @@ def _check_newline_character(all_files):
     summary_messages = []
     all_files = [
         filename for filename in all_files if not
-        any(fnmatch.fnmatch(filename, pattern) for pattern in EXCLUDED_PATHS)]
+        any(fnmatch.fnmatch(filename, pattern)
+            for pattern in EXCLUDED_PATHS_EXT)]
 
     for filename in all_files:
         content = FileCache.read(filename, mode='rb')

--- a/scripts/pylint_extensions.py
+++ b/scripts/pylint_extensions.py
@@ -795,8 +795,8 @@ class FunctionArgsOrderChecker(checkers.BaseChecker):
             self.add_message('function-args-order-cls', node=node)
 
 
-class NewlineAtEOFChecker(checkers.BaseChecker):
-    """Checker for newline at EOF."""
+class SingleCharAndNewlineAtEOFChecker(checkers.BaseChecker):
+    """Checker for single character files and newline at EOF."""
 
     __implements__ = interfaces.IRawChecker
     name = 'newline-at-eof'
@@ -841,4 +841,4 @@ def register(linter):
     linter.register_checker(ImportOnlyModulesChecker(linter))
     linter.register_checker(BackslashContinuationChecker(linter))
     linter.register_checker(FunctionArgsOrderChecker(linter))
-    linter.register_checker(NewlineAtEOFChecker(linter))
+    linter.register_checker(SingleCharAndNewlineAtEOFChecker(linter))

--- a/scripts/pylint_extensions.py
+++ b/scripts/pylint_extensions.py
@@ -805,11 +805,11 @@ class SingleCharAndNewlineAtEOFChecker(checkers.BaseChecker):
         'C0007': (
             'Files should end in a single newline character.',
             'newline-at-eof',
-            'Please enter a single newline at the end of the file'),
+            'Please enter a single newline at the end of the file.'),
         'C0008': (
             'Only one character in file',
             'only-one-character',
-            'Files with only one character are not allowed'),
+            'Files with only one character are not allowed.'),
     }
 
     def process_module(self, node):

--- a/scripts/pylint_extensions.py
+++ b/scripts/pylint_extensions.py
@@ -805,7 +805,7 @@ class SingleCharAndNewlineAtEOFChecker(checkers.BaseChecker):
         'C0007': (
             'Files should end in a single newline character.',
             'newline-at-eof',
-            'Please enter a newline at the end of the file'),
+            'Please enter a single newline at the end of the file'),
         'C0008': (
             'Only one character in file',
             'only-one-character',

--- a/scripts/pylint_extensions.py
+++ b/scripts/pylint_extensions.py
@@ -821,8 +821,7 @@ class SingleCharAndNewlineAtEOFChecker(checkers.BaseChecker):
 
         file_content = node.stream().readlines()
         file_length = len(file_content)
-        print '@@@@@@@'
-        print len(file_content[0])
+
         if file_length == 1 and len(file_content[0]) == 1:
             self.add_message('only-one-character', line=file_length)
         if file_length >= 2 and not re.search(r'[^\n]\n', file_content[-1]):

--- a/scripts/pylint_extensions.py
+++ b/scripts/pylint_extensions.py
@@ -18,6 +18,7 @@
 presubmit checks.
 """
 
+import re
 import astroid
 import docstrings_checker  # pylint: disable=relative-import
 
@@ -794,6 +795,40 @@ class FunctionArgsOrderChecker(checkers.BaseChecker):
             self.add_message('function-args-order-cls', node=node)
 
 
+class NewlineAtEOFChecker(checkers.BaseChecker):
+    """Checker for newline at EOF."""
+
+    __implements__ = interfaces.IRawChecker
+    name = 'newline-at-eof'
+    priority = -1
+    msgs = {
+        'C0007': (
+            'Files should end in a single newline character.',
+            'newline-at-eof',
+            'Please enter a newline at the end of the file'),
+        'C0008': (
+            'Only one character in file',
+            'only-one-character',
+            'Files with only one character are not allowed'),
+    }
+
+    def process_module(self, node):
+        """Process a module.
+
+        Args:
+            node: astroid.scoped_nodes.Function. Node to access module content.
+        """
+
+        file_content = node.stream().readlines()
+        file_length = len(file_content)
+        print '@@@@@@@'
+        print len(file_content[0])
+        if file_length == 1 and len(file_content[0]) == 1:
+            self.add_message('only-one-character', line=file_length)
+        if file_length >= 2 and not re.search(r'[^\n]\n', file_content[-1]):
+            self.add_message('newline-at-eof', line=file_length)
+
+
 def register(linter):
     """Registers the checker with pylint.
 
@@ -806,3 +841,4 @@ def register(linter):
     linter.register_checker(ImportOnlyModulesChecker(linter))
     linter.register_checker(BackslashContinuationChecker(linter))
     linter.register_checker(FunctionArgsOrderChecker(linter))
+    linter.register_checker(NewlineAtEOFChecker(linter))

--- a/scripts/pylint_extensions_test.py
+++ b/scripts/pylint_extensions_test.py
@@ -259,3 +259,65 @@ class FunctionArgsOrderCheckerTests(unittest.TestCase):
             ),
         ):
             checker_test_object.checker.visit_functiondef(functiondef_node2)
+
+
+class SingleCharAndNewlineAtEOFCheckerTests(unittest.TestCase):
+
+    def test_checks_single_char_and_newline_eof(self):
+        checker_test_object = testutils.CheckerTestCase()
+        checker_test_object.CHECKER_CLASS = (
+            pylint_extensions.SingleCharAndNewlineAtEOFChecker)
+        checker_test_object.setup_method()
+        node1 = astroid.scoped_nodes.Module(name='test', doc='Custom test')
+        temp_file = tempfile.NamedTemporaryFile()
+        filename = temp_file.name
+
+        with open(filename, 'w') as tmp:
+            tmp.write(
+                """c = 'something dummy'
+                """)
+        node1.file = filename
+        node1.path = filename
+
+        checker_test_object.checker.process_module(node1)
+
+        with checker_test_object.assertAddsMessages(
+            testutils.Message(
+                msg_id='newline-at-eof',
+                line=2
+            ),
+        ):
+            temp_file.close()
+
+        node2 = astroid.scoped_nodes.Module(name='test', doc='Custom test')
+
+        temp_file = tempfile.NamedTemporaryFile()
+        filename = temp_file.name
+        with open(filename, 'w') as tmp:
+            tmp.write("""1""")
+        node2.file = filename
+        node2.path = filename
+
+        checker_test_object.checker.process_module(node2)
+
+        with checker_test_object.assertAddsMessages(
+            testutils.Message(
+                msg_id='only-one-character',
+                line=1
+            ),
+        ):
+            temp_file.close()
+
+        node3 = astroid.scoped_nodes.Module(name='test', doc='Custom test')
+
+        temp_file = tempfile.NamedTemporaryFile()
+        filename = temp_file.name
+        with open(filename, 'w') as tmp:
+            tmp.write("""x = 'something dummy'""")
+        node3.file = filename
+        node3.path = filename
+
+        checker_test_object.checker.process_module(node3)
+
+        with checker_test_object.assertNoMessages():
+            temp_file.close()

--- a/scripts/pylint_extensions_test.py
+++ b/scripts/pylint_extensions_test.py
@@ -97,7 +97,9 @@ class HangingIndentCheckerTests(unittest.TestCase):
         checker_test_object.CHECKER_CLASS = (
             pylint_extensions.HangingIndentChecker)
         checker_test_object.setup_method()
-        node1 = astroid.scoped_nodes.Module(name='test', doc='Custom test')
+        node_break_after_hanging_indent = astroid.scoped_nodes.Module(
+            name='test',
+            doc='Custom test')
         temp_file = tempfile.NamedTemporaryFile()
         filename = temp_file.name
         with open(filename, 'w') as tmp:
@@ -105,10 +107,11 @@ class HangingIndentCheckerTests(unittest.TestCase):
                 """self.post_json('/ml/trainedclassifierhandler',
                 self.payload, expect_errors=True, expected_status_int=401)
                 """)
-        node1.file = filename
-        node1.path = filename
+        node_break_after_hanging_indent.file = filename
+        node_break_after_hanging_indent.path = filename
 
-        checker_test_object.checker.process_module(node1)
+        checker_test_object.checker.process_module(
+            node_break_after_hanging_indent)
 
         with checker_test_object.assertAddsMessages(
             testutils.Message(
@@ -118,7 +121,9 @@ class HangingIndentCheckerTests(unittest.TestCase):
         ):
             temp_file.close()
 
-        node2 = astroid.scoped_nodes.Module(name='test', doc='Custom test')
+        node_no_err_message = astroid.scoped_nodes.Module(
+            name='test',
+            doc='Custom test')
 
         temp_file = tempfile.NamedTemporaryFile()
         filename = temp_file.name
@@ -128,10 +133,10 @@ class HangingIndentCheckerTests(unittest.TestCase):
                 utils.get_file_contents(os.path.join(
                 os.getcwd(), 'assets', 'i18n', 'en.json')))
                 """)
-        node2.file = filename
-        node2.path = filename
+        node_no_err_message.file = filename
+        node_no_err_message.path = filename
 
-        checker_test_object.checker.process_module(node2)
+        checker_test_object.checker.process_module(node_no_err_message)
 
         with checker_test_object.assertNoMessages():
             temp_file.close()

--- a/scripts/pylint_extensions_test.py
+++ b/scripts/pylint_extensions_test.py
@@ -268,7 +268,9 @@ class SingleCharAndNewlineAtEOFCheckerTests(unittest.TestCase):
         checker_test_object.CHECKER_CLASS = (
             pylint_extensions.SingleCharAndNewlineAtEOFChecker)
         checker_test_object.setup_method()
-        node1 = astroid.scoped_nodes.Module(name='test', doc='Custom test')
+        node_missing_newline_at_eof = astroid.scoped_nodes.Module(
+            name='test',
+            doc='Custom test')
         temp_file = tempfile.NamedTemporaryFile()
         filename = temp_file.name
 
@@ -276,10 +278,10 @@ class SingleCharAndNewlineAtEOFCheckerTests(unittest.TestCase):
             tmp.write(
                 """c = 'something dummy'
                 """)
-        node1.file = filename
-        node1.path = filename
+        node_missing_newline_at_eof.file = filename
+        node_missing_newline_at_eof.path = filename
 
-        checker_test_object.checker.process_module(node1)
+        checker_test_object.checker.process_module(node_missing_newline_at_eof)
 
         with checker_test_object.assertAddsMessages(
             testutils.Message(
@@ -289,16 +291,18 @@ class SingleCharAndNewlineAtEOFCheckerTests(unittest.TestCase):
         ):
             temp_file.close()
 
-        node2 = astroid.scoped_nodes.Module(name='test', doc='Custom test')
+        node_single_char_file = astroid.scoped_nodes.Module(
+            name='test',
+            doc='Custom test')
 
         temp_file = tempfile.NamedTemporaryFile()
         filename = temp_file.name
         with open(filename, 'w') as tmp:
             tmp.write("""1""")
-        node2.file = filename
-        node2.path = filename
+        node_single_char_file.file = filename
+        node_single_char_file.path = filename
 
-        checker_test_object.checker.process_module(node2)
+        checker_test_object.checker.process_module(node_single_char_file)
 
         with checker_test_object.assertAddsMessages(
             testutils.Message(
@@ -308,16 +312,18 @@ class SingleCharAndNewlineAtEOFCheckerTests(unittest.TestCase):
         ):
             temp_file.close()
 
-        node3 = astroid.scoped_nodes.Module(name='test', doc='Custom test')
+        node_no_err_message = astroid.scoped_nodes.Module(
+            name='test',
+            doc='Custom test')
 
         temp_file = tempfile.NamedTemporaryFile()
         filename = temp_file.name
         with open(filename, 'w') as tmp:
             tmp.write("""x = 'something dummy'""")
-        node3.file = filename
-        node3.path = filename
+        node_no_err_message.file = filename
+        node_no_err_message.path = filename
 
-        checker_test_object.checker.process_module(node3)
+        checker_test_object.checker.process_module(node_no_err_message)
 
         with checker_test_object.assertNoMessages():
             temp_file.close()


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
This PR Fixes part of #5939 and implements a custom pylint extension that aims to replace `_check_newline_character` method in _scripts/pre_commit_linter.py_ for python files.
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
