### PR TITLE
Update app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -16,6 +16,7 @@ inbound_services:
 
 default_expiration: "10m"
 handlers:
+# PRODUCTION STATIC
 - url: /favicon.ico
   static_files: assets/favicon.ico
   upload: assets/favicon.ico
@@ -32,6 +33,15 @@ handlers:
   static_dir: build
   secure: always
   expiration: "90d"
+- url: /third_party/static
+  static_dir: third_party/static
+  secure: always
+  expiration: "90d"
+- url: /mapreduce/pipeline/images
+  static_dir: third_party/gae-mapreduce-1.9.17.0/mapreduce/lib/pipeline/ui/images
+  secure: always
+
+# DEVELOPMENT STATIC
 - url: /assets
   static_dir: assets
   secure: always
@@ -47,10 +57,6 @@ handlers:
   static_files: core/templates/dev/head/\1
   upload: core/templates/dev/head/(.*directive\.html)$
   secure: always
-- url: /third_party/static
-  static_dir: third_party/static
-  secure: always
-  expiration: "90d"
 - url: /third_party/generated
   static_dir: third_party/generated
   secure: always
@@ -78,9 +84,8 @@ handlers:
   static_files: extensions/objects/templates/\1
   upload: extensions/objects/templates/(.*\.html)
   secure: always
-- url: /mapreduce/pipeline/images
-  static_dir: third_party/gae-mapreduce-1.9.17.0/mapreduce/lib/pipeline/ui/images
-  secure: always
+
+# DYNAMIC
 - url: /mapreduce(/.*)?
   script: mapreduce.main.APP
   login: admin

--- a/app.yaml
+++ b/app.yaml
@@ -29,6 +29,9 @@ handlers:
   static_files: assets/sitemap.xml
   upload: assets/sitemap.xml
   secure: always
+- url: /mapreduce/pipeline/images
+  static_dir: third_party/gae-mapreduce-1.9.17.0/mapreduce/lib/pipeline/ui/images
+  secure: always
 - url: /build
   static_dir: build
   secure: always
@@ -37,15 +40,13 @@ handlers:
   static_dir: third_party/static
   secure: always
   expiration: "90d"
-- url: /mapreduce/pipeline/images
-  static_dir: third_party/gae-mapreduce-1.9.17.0/mapreduce/lib/pipeline/ui/images
-  secure: always
 
 # DEVELOPMENT STATIC
 - url: /assets
   static_dir: assets
   secure: always
   application_readable: true
+  expiration: "0"
 # Serve js scripts and css files under core/templates/dev/head.
 # This regex allows us to recursively serve js scripts.
 # "\1" inserts text captured by the capture group in the URL pattern.
@@ -53,21 +54,26 @@ handlers:
   static_files: core/templates/dev/head/\1
   upload: core/templates/dev/head/(.*\.(js|css))$
   secure: always
+  expiration: "0"
 - url: /templates/dev/head/(.*directive\.html)$
   static_files: core/templates/dev/head/\1
   upload: core/templates/dev/head/(.*directive\.html)$
   secure: always
+  expiration: "0"
 - url: /third_party/generated
   static_dir: third_party/generated
   secure: always
+  expiration: "0"
 - url: /extensions/interactions/(.*)/static/(.*)
   static_files: extensions/interactions/\1/static/\2
   upload: extensions/interactions/(.*)/static/(.*)
   secure: always
+  expiration: "0"
 - url: /extensions/(interactions|rich_text_components)/(.*)/directives/(.*\.(html))
   static_files: extensions/\1/\2/directives/\3
   upload: extensions/(interactions|rich_text_components)/(.*)/directives/(.*\.(html))
   secure: always
+  expiration: "0"
 # Serve js scripts for gadgets, interactions, rich_text_components, custom ckeditor plugins
 # and objects under extensions in dev mode. This regex allows us to recursively serve js
 # scripts under the three specified directories. "\1" and "\2" insert capture
@@ -76,14 +82,17 @@ handlers:
   static_files: extensions/\1/\2
   upload: extensions/(interactions|rich_text_components|objects|classifiers|ckeditor_plugins)/(.*\.(js|png))$
   secure: always
+  expiration: "0"
 - url: /extensions/visualizations/(.*\.html)
   static_files: extensions/visualizations/\1
   upload: extensions/visualizations/(.*\.html)
   secure: always
+  expiration: "0"
 - url: /extensions/objects/templates/(.*\.html)
   static_files: extensions/objects/templates/\1
   upload: extensions/objects/templates/(.*\.html)
   secure: always
+  expiration: "0"
 
 # DYNAMIC
 - url: /mapreduce(/.*)?
@@ -123,7 +132,6 @@ libraries:
 
 env_variables:
   PYTHONHTTPSVERIFY: 1
-
 
 skip_files:
 # .pyc and .pyo files

--- a/app.yaml
+++ b/app.yaml
@@ -14,40 +14,28 @@ inbound_services:
 - warmup
 - mail
 
+default_expiration: "10m"
 handlers:
 - url: /favicon.ico
   static_files: assets/favicon.ico
   upload: assets/favicon.ico
   secure: always
-  http_headers:
-    Cache-Control: 'public, max-age=2592000'
-    Vary: Accept-Encoding
 - url: /robots.txt
   static_files: assets/robots.txt
   upload: assets/robots.txt
   secure: always
-  http_headers:
-    Cache-Control: 'public, max-age=2592000'
-    Vary: Accept-Encoding
 - url: /sitemap.xml
   static_files: assets/sitemap.xml
   upload: assets/sitemap.xml
   secure: always
-  http_headers:
-    Cache-Control: 'public, max-age=2592000'
-    Vary: Accept-Encoding
 - url: /build
   static_dir: build
   secure: always
-  expiration: 30d
-  http_headers:
-    Cache-Control: 'public, max-age=2592000'
+  expiration: "90d"
 - url: /assets
   static_dir: assets
   secure: always
   application_readable: true
-  http_headers:
-    Cache-Control: 'public, max-age=60'
 # Serve js scripts and css files under core/templates/dev/head.
 # This regex allows us to recursively serve js scripts.
 # "\1" inserts text captured by the capture group in the URL pattern.
@@ -55,38 +43,25 @@ handlers:
   static_files: core/templates/dev/head/\1
   upload: core/templates/dev/head/(.*\.(js|css))$
   secure: always
-- url: /templates/dev/head/(.*\.(html))$
+- url: /templates/dev/head/(.*directive\.html)$
   static_files: core/templates/dev/head/\1
-  upload: core/templates/dev/head/(.*\.(html))$
-  # TODO(vojtechjelinek): Remove application_readable after all
-  # components are referenced directly by URL
-  application_readable: true
+  upload: core/templates/dev/head/(.*directive\.html)$
   secure: always
 - url: /third_party/static
   static_dir: third_party/static
   secure: always
-  http_headers:
-    Cache-Control: 'public, max-age=2592000'
-    Vary: Accept-Encoding
+  expiration: "90d"
 - url: /third_party/generated
   static_dir: third_party/generated
   secure: always
-  http_headers:
-  # TODO(Sean Lip): Add cache when system to break cache during
-  # new release is figured out.
-    Cache-Control: 'no-cache'
 - url: /extensions/interactions/(.*)/static/(.*)
   static_files: extensions/interactions/\1/static/\2
   upload: extensions/interactions/(.*)/static/(.*)
   secure: always
-  http_headers:
-    Cache-Control: 'no-cache'
 - url: /extensions/(interactions|rich_text_components)/(.*)/directives/(.*\.(html))
   static_files: extensions/\1/\2/directives/\3
   upload: extensions/(interactions|rich_text_components)/(.*)/directives/(.*\.(html))
   secure: always
-  http_headers:
-    Cache-Control: 'no-cache'
 # Serve js scripts for gadgets, interactions, rich_text_components, custom ckeditor plugins
 # and objects under extensions in dev mode. This regex allows us to recursively serve js
 # scripts under the three specified directories. "\1" and "\2" insert capture
@@ -99,14 +74,10 @@ handlers:
   static_files: extensions/visualizations/\1
   upload: extensions/visualizations/(.*\.html)
   secure: always
-  http_headers:
-    Cache-Control: 'no-cache'
 - url: /extensions/objects/templates/(.*\.html)
   static_files: extensions/objects/templates/\1
   upload: extensions/objects/templates/(.*\.html)
   secure: always
-  http_headers:
-    Cache-Control: 'no-cache'
 - url: /mapreduce/pipeline/images
   static_dir: third_party/gae-mapreduce-1.9.17.0/mapreduce/lib/pipeline/ui/images
   secure: always

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -506,5 +506,5 @@ var constants = {
 
   "CURRENT_STATES_SCHEMA_VERSION": 25,
 
-  "DEV_MODE": true
+  "DEV_MODE": false
 };

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -506,5 +506,5 @@ var constants = {
 
   "CURRENT_STATES_SCHEMA_VERSION": 25,
 
-  "DEV_MODE": true 
+  "DEV_MODE": true
 };

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -506,5 +506,5 @@ var constants = {
 
   "CURRENT_STATES_SCHEMA_VERSION": 25,
 
-  "DEV_MODE": false
+  "DEV_MODE": true 
 };


### PR DESCRIPTION
## Explanation
Currently we cache everything in `/build` by 30 days. This PR changes that to 90 days because the cache invalidation by adding hashes to filenames works correctly and so we can extend the time for what we cache the files.

Use `expiration: value` instead of setting the caching header directly since `expiration` handles setting of the headers. Also remove `Vary: Accept-Encoding` since it's set by `expiration` too.

Remove `application_readable: true` from html files in /templates/dev/head/ but serve just directive html files

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
