### PR TITLE
Changes word-break to word-wrap in oppia.css

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -345,7 +345,7 @@ p {
   margin-bottom: 18px;
   text-align: left;
   word-spacing: 0;
-  word-break: break-word;
+  word-wrap: break-word;
 }
 
 p:last-child {
@@ -825,7 +825,7 @@ textarea {
 .oppia-navbar-nav .uib-dropdown-menu {
   left: auto;
   right: 0;
-  word-break: break-all;
+  word-wrap: break-word;
 }
 
 .oppia-dropdown-submenu > .uib-dropdown-menu {
@@ -1461,7 +1461,7 @@ pre.oppia-pre-wrapped-text {
 
 .oppia-editor-card-section {
   padding: 20px 50px 20px 35px;
-  word-break: break-all;
+  word-wrap: break-word;
 }
 
 .oppia-state-content {
@@ -1694,7 +1694,6 @@ pre.oppia-pre-wrapped-text {
 }
 
 .oppia-learner-view-card-content {
-  word-break: break-all;
   word-wrap: break-word;
 }
 
@@ -2013,7 +2012,7 @@ oppia-parameter {
   font-size: 0.9em;
   margin: 8px -18px -11px;
   padding: 10px 18px;
-  word-break: break-all;
+  word-wrap: break-word;
 }
 
 .oppia-large-modal-window .modal-dialog {
@@ -3081,7 +3080,7 @@ md-card.preview-conversation-skin-supplemental-card {
   overflow-wrap: break-word;
   padding: 0.2em;
   position: absolute;
-  word-break: break-all;
+  word-wrap: break-word;
   -webkit-hyphens: auto;
 }
 .oppia-activity-summary-tile.oppia-activity-playlist-tile .activity-title {
@@ -3805,7 +3804,7 @@ md-card.preview-conversation-skin-supplemental-card {
   -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
   padding: 8px;
-  word-break: break-all;
+  word-wrap: break-word;
 }
 
 .oppia-rte:focus {


### PR DESCRIPTION
This PR replaces: 
- `word-break: break-word` to `word-wrap: break-word` 
- `word-break: break-all` to `word-wrap: break-word`

This PR is made in reference to https://github.com/oppia/oppia/pull/4608#issuecomment-459568943.