### PR TITLE
Fix check for clean working tree in common.py

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -77,7 +77,7 @@ def verify_local_repo_is_clean():
     git_status_output = subprocess.check_output(
         ['git', 'status']).strip().split('\n')
 
-    branch_is_clean_message = 'nothing to commit, working directory clean'
+    branch_is_clean_message = 'nothing to commit, working tree clean'
     if not branch_is_clean_message in git_status_output:
         raise Exception(
             'ERROR: This script should be run from a clean branch.')

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -77,8 +77,11 @@ def verify_local_repo_is_clean():
     git_status_output = subprocess.check_output(
         ['git', 'status']).strip().split('\n')
 
-    branch_is_clean_message = 'nothing to commit, working tree clean'
-    if not branch_is_clean_message in git_status_output:
+    branch_is_clean_message_1 = 'nothing to commit, working directory clean'
+    branch_is_clean_message_2 = 'nothing to commit, working tree clean'
+    if (
+            not branch_is_clean_message_1 in git_status_output and
+            not branch_is_clean_message_2 in git_status_output):
         raise Exception(
             'ERROR: This script should be run from a clean branch.')
 


### PR DESCRIPTION
## Explanation
The wording of the "git status" log doesn't match the check. I tested this on both mac and ubuntu, and the log uses "tree".

This block the release cut :) 
 
## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
