### PR TITLE
Fix Content-Disposition headers being unicode instead of str.

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -284,8 +284,8 @@ class BaseHandler(webapp2.RequestHandler):
     def render_downloadable_file(self, values, filename, content_type):
         """Prepares downloadable content to be sent to the client."""
         self.response.headers['Content-Type'] = content_type
-        self.response.headers['Content-Disposition'] = (
-            'attachment; filename=%s' % (filename))
+        self.response.headers['Content-Disposition'] = str(
+            'attachment; filename=%s' % filename)
         self.response.write(values)
 
     def _get_logout_url(self, redirect_url_on_logout):


### PR DESCRIPTION
This was breaking "download old exploration from history tab" in the production server.

@nithusha21 @bansalnitish  could we add this flow to the critical-user-journeys / e2e tests please? Thanks!