### PR TITLE
Remove Open Sans and Rubik fonts

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2911,7 +2911,7 @@ md-card.preview-conversation-skin-supplemental-card {
   text-align: center;
 }
 .oppia-splash-bullet-block {
-  font-family: "Rubik", "Roboto", Arial, sans-serif;
+  font-family: "Roboto", Arial, sans-serif;
   font-size: 1.17em;
   line-height: 128%;
   margin-bottom: 10px;
@@ -3250,7 +3250,7 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 .oppia-activity-summary-tile .objective {
   display: -webkit-box;
-  font-family: "Rubik", "Roboto", Arial, sans-serif;
+  font-family: "Roboto", Arial, sans-serif;
   font-size: 0.85em;
   height: 70px;
   line-height: 1.26;
@@ -3271,7 +3271,7 @@ md-card.preview-conversation-skin-supplemental-card {
 
 .oppia-activity-summary-tile-mobile .objective {
   height: 75px;
-  font-family: "Rubik", "Roboto", Arial, sans-serif;
+  font-family: "Roboto", Arial, sans-serif;
   font-size: 0.85em;
   padding: 12px;
 }

--- a/core/templates/dev/head/pages/header_css_libs.html
+++ b/core/templates/dev/head/pages/header_css_libs.html
@@ -1,5 +1,5 @@
 <link rel="stylesheet" type="text/css" media="screen"
-      href="https://fonts.googleapis.com/css?family=Capriola|Rubik|Roboto|Material+Icons|Open+Sans:400,600">
+      href="https://fonts.googleapis.com/css?family=Capriola|Roboto|Material+Icons">
 {% if not DEV_MODE %}
   <link rel="stylesheet" type="text/css" media="screen"
         href="/third_party/generated/css/third_party.min.css">


### PR DESCRIPTION
## Explanation
When investigating `font-display` I discovered that we don't use some of the fonts we retrieve from Google Fonts (since `@font-face`is quite smart it only downloads the fonts that are used in the page, so it's more matter of clean code).

Open Sans is not used anywhere. 

Rubik is used in two places, it is quite similar to Roboto (Roboto is even used as fallback font), I think we should just use Roboto instead of Rubik, here are comparisons:
#### Splash when using Rubik
![before](https://user-images.githubusercontent.com/10142938/52224467-5c51eb00-28a8-11e9-8640-8a42b0955bf6.png)
#### Splash when using Roboto
![after](https://user-images.githubusercontent.com/10142938/52224478-64118f80-28a8-11e9-9e8d-bcb3883689c1.png)
#### Library when using Rubik
![before2](https://user-images.githubusercontent.com/10142938/52224551-928f6a80-28a8-11e9-9fb8-0bb458bb5d2d.png)
#### Library when using Roboto
![after2](https://user-images.githubusercontent.com/10142938/52224583-a33fe080-28a8-11e9-8c71-dfb5fea73b4a.png)

@rachelwchen Can I get you opinion about removing the Rubik font?
## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
