### PR TITLE
Added active content id service to fix translation tab issues.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
+++ b/core/templates/dev/head/pages/exploration_editor/ExplorationEditor.js
@@ -227,7 +227,6 @@ oppia.controller('ExplorationEditor', [
         if (ExplorationStatesService.getState(
           StateEditorService.getActiveStateName())) {
           $scope.$broadcast('refreshStateEditor');
-          $scope.$broadcast('refreshTranslationTab');
         }
 
         if (successCallback) {

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -278,6 +278,7 @@
   <script src="/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationDirective.js"></script>
 
   <script src="/templates/dev/head/pages/exploration_editor/translation_tab/TranslationStatusService.js"></script>
+  <script src="/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdService.js"></script>
   <script src="/templates/dev/head/pages/exploration_editor/translation_tab/AudioTranslationBarDirective.js"></script>
 
   <script src="/templates/dev/head/pages/exploration_editor/preview_tab/PreviewTab.js"></script>

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/AudioTranslationBarDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/AudioTranslationBarDirective.js
@@ -23,7 +23,6 @@ oppia.directive('audioTranslationBar', [
     return {
       restrict: 'E',
       scope: {
-        contentId: '=',
         isTranslationTabBusy: '='
       },
       link: function(scope, elm) {
@@ -62,18 +61,20 @@ oppia.directive('audioTranslationBar', [
         '/pages/exploration_editor/translation_tab/' +
         'audio_translation_bar_directive.html'),
       controller: [
-        '$scope', '$filter', '$timeout', '$uibModal', '$rootScope',
-        'StateContentIdsToAudioTranslationsService', 'IdGenerationService',
-        'AudioPlayerService', 'TranslationLanguageService', 'AlertsService',
-        'StateEditorService', 'ExplorationStatesService', 'EditabilityService',
-        'AssetsBackendApiService', 'recorderService', 'ContextService',
+        '$filter', '$rootScope', '$scope', '$timeout', '$uibModal',
+        'AlertsService', 'AssetsBackendApiService', 'AudioPlayerService',
+        'ContextService', 'EditabilityService', 'ExplorationStatesService',
+        'IdGenerationService', 'StateContentIdsToAudioTranslationsService',
+        'StateEditorService', 'TranslationLanguageService',
+        'recorderService', 'TranslationTabActiveContentIdService',
         'RECORDING_TIME_LIMIT',
         function(
-            $scope, $filter, $timeout, $uibModal, $rootScope,
-            StateContentIdsToAudioTranslationsService, IdGenerationService,
-            AudioPlayerService, TranslationLanguageService, AlertsService,
-            StateEditorService, ExplorationStatesService, EditabilityService,
-            AssetsBackendApiService, recorderService, ContextService,
+            $filter, $rootScope, $scope, $timeout, $uibModal,
+            AlertsService, AssetsBackendApiService, AudioPlayerService,
+            ContextService, EditabilityService, ExplorationStatesService,
+            IdGenerationService, StateContentIdsToAudioTranslationsService,
+            StateEditorService, TranslationLanguageService,
+            recorderService, TranslationTabActiveContentIdService,
             RECORDING_TIME_LIMIT) {
           $scope.RECORDER_ID = 'recorderId';
           $scope.recordingTimeLimit = RECORDING_TIME_LIMIT;
@@ -250,11 +251,7 @@ oppia.directive('audioTranslationBar', [
             $scope.audioBlob = null;
           });
 
-          $scope.$watch('contentId', function() {
-            $scope.initAudioBar();
-          });
-
-          $scope.$on('refreshAudioTranslationBar', function() {
+          $scope.$on('activeContentIdChanged', function() {
             $scope.initAudioBar();
           });
 
@@ -362,6 +359,8 @@ oppia.directive('audioTranslationBar', [
             $scope.languageCode = TranslationLanguageService
               .getActiveLanguageCode();
             $scope.canTranslate = EditabilityService.isTranslatable();
+            $scope.contentId = (
+              TranslationTabActiveContentIdService.getActiveContentId());
             var audioTranslationObject = getAvailableAudio(
               $scope.contentId, $scope.languageCode);
             if (audioTranslationObject) {
@@ -374,7 +373,6 @@ oppia.directive('audioTranslationBar', [
               $scope.audioBlob = null;
               $scope.selectedRecording = false;
             }
-            $rootScope.loadingMessage = '';
           };
 
           $scope.track = {
@@ -514,9 +512,7 @@ oppia.directive('audioTranslationBar', [
               $scope.initAudioBar();
             });
           };
-          $scope.$on('refreshAudioTranslationBar', function() {
-            $scope.initAudioBar();
-          });
+          $scope.initAudioBar();
         }]
     };
   }]);

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationDirective.js
@@ -27,20 +27,22 @@ oppia.directive('stateTranslation', [
         '/pages/exploration_editor/translation_tab/' +
         'state_translation_directive.html'),
       controller: [
-        '$scope', '$filter', '$rootScope', 'StateEditorService',
-        'ExplorationStatesService', 'ExplorationInitStateNameService',
-        'ExplorationCorrectnessFeedbackService', 'RouterService',
-        'StateContentIdsToAudioTranslationsService', 'TranslationStatusService',
-        'COMPONENT_NAME_CONTENT', 'COMPONENT_NAME_FEEDBACK',
-        'COMPONENT_NAME_HINT', 'COMPONENT_NAME_SOLUTION', 'INTERACTION_SPECS',
+        '$filter', '$rootScope', '$scope',
+        'ExplorationCorrectnessFeedbackService',
+        'ExplorationInitStateNameService', 'ExplorationStatesService',
+        'RouterService', 'StateEditorService', 'TranslationStatusService',
+        'TranslationTabActiveContentIdService', 'COMPONENT_NAME_CONTENT',
+        'COMPONENT_NAME_FEEDBACK', 'COMPONENT_NAME_HINT',
+        'COMPONENT_NAME_SOLUTION', 'INTERACTION_SPECS',
         'RULE_SUMMARY_WRAP_CHARACTER_COUNT',
         function(
-            $scope, $filter, $rootScope, StateEditorService,
-            ExplorationStatesService, ExplorationInitStateNameService,
-            ExplorationCorrectnessFeedbackService, RouterService,
-            StateContentIdsToAudioTranslationsService, TranslationStatusService,
-            COMPONENT_NAME_CONTENT, COMPONENT_NAME_FEEDBACK,
-            COMPONENT_NAME_HINT, COMPONENT_NAME_SOLUTION, INTERACTION_SPECS,
+            $filter, $rootScope, $scope,
+            ExplorationCorrectnessFeedbackService,
+            ExplorationInitStateNameService, ExplorationStatesService,
+            RouterService, StateEditorService, TranslationStatusService,
+            TranslationTabActiveContentIdService, COMPONENT_NAME_CONTENT,
+            COMPONENT_NAME_FEEDBACK, COMPONENT_NAME_HINT,
+            COMPONENT_NAME_SOLUTION, INTERACTION_SPECS,
             RULE_SUMMARY_WRAP_CHARACTER_COUNT) {
           // Define tab constants.
           $scope.TAB_ID_CONTENT = COMPONENT_NAME_CONTENT;
@@ -62,7 +64,6 @@ oppia.directive('stateTranslation', [
           $scope.stateDefaultOutcome = null;
           $scope.stateHints = [];
           $scope.stateSolution = null;
-          $scope.activeContentId = null;
           $scope.needsUpdateTooltipMessage = 'Audio needs update to match ' +
             'text. Please record new audio.';
 
@@ -79,25 +80,27 @@ oppia.directive('stateTranslation', [
               $rootScope.$broadcast('showTranslationTabBusyModal');
               return;
             }
+            var activecontentId = null;
             if (tabId === $scope.TAB_ID_CONTENT) {
-              $scope.activeContentId = $scope.stateContent.getContentId();
+              activeContentId = $scope.stateContent.getContentId();
             } else if (tabId === $scope.TAB_ID_FEEDBACK) {
               $scope.activeAnswerGroupIndex = 0;
               if ($scope.stateAnswerGroups.length > 0) {
-                $scope.activeContentId = $scope.stateAnswerGroups[0]
-                  .outcome.feedback.getContentId();
+                activeContentId = (
+                  $scope.stateAnswerGroups[0].outcome.feedback.getContentId());
               } else {
-                $scope.activeContentId = $scope.stateDefaultOutcome
-                  .feedback.getContentId();
+                activeContentId = (
+                  $scope.stateDefaultOutcome.feedback.getContentId());
               }
             } else if (tabId === $scope.TAB_ID_HINTS) {
               $scope.activeHintIndex = 0;
-              $scope.activeContentId = $scope.stateHints[0]
-                .hintContent.getContentId();
+              activeContentId = (
+                $scope.stateHints[0].hintContent.getContentId());
             } else if (tabId === $scope.TAB_ID_SOLUTION) {
-              $scope.activeContentId = $scope.stateSolution.explanation
-                .getContentId();
+              activeContentId = $scope.stateSolution.explanation.getContentId();
             }
+            TranslationTabActiveContentIdService.setActiveContentId(
+              activeContentId);
             $scope.activatedTabId = tabId;
           };
 
@@ -204,8 +207,10 @@ oppia.directive('stateTranslation', [
               return;
             }
             $scope.activeHintIndex = newIndex;
-            $scope.activeContentId = $scope.stateHints[newIndex]
-              .hintContent.getContentId();
+            var activeContentId = (
+              $scope.stateHints[newIndex].hintContent.getContentId());
+            TranslationTabActiveContentIdService.setActiveContentId(
+              activeContentId);
           };
 
           $scope.changeActiveAnswerGroupIndex = function(newIndex) {
@@ -213,16 +218,18 @@ oppia.directive('stateTranslation', [
               $rootScope.$broadcast('showTranslationTabBusyModal');
               return;
             }
-            if ($scope.activeAnswerGroupIndex === newIndex) {
-              return;
-            }
-            $scope.activeAnswerGroupIndex = newIndex;
-            if (newIndex === $scope.stateAnswerGroups.length) {
-              $scope.activeContentId = $scope.stateDefaultOutcome
-                .feedback.getContentId();
-            } else {
-              $scope.activeContentId = $scope.stateAnswerGroups[newIndex]
-                .outcome.feedback.getContentId();
+            if ($scope.activeAnswerGroupIndex !== newIndex) {
+              var activeContentId = null;
+              $scope.activeAnswerGroupIndex = newIndex;
+              if (newIndex === $scope.stateAnswerGroups.length) {
+                activeContentId = (
+                  $scope.stateDefaultOutcome.feedback.getContentId());
+              } else {
+                activeContentId = ($scope.stateAnswerGroups[newIndex]
+                  .outcome.feedback.getContentId());
+              }
+              TranslationTabActiveContentIdService.setActiveContentId(
+                activeContentId);
             }
           };
 
@@ -261,15 +268,7 @@ oppia.directive('stateTranslation', [
           });
 
           $scope.initStateTranslation = function() {
-            $scope.activatedTabId = $scope.TAB_ID_CONTENT;
-
-            if (!StateEditorService.getActiveStateName()) {
-              StateEditorService.setActiveStateName(
-                ExplorationInitStateNameService.displayed);
-            }
-
             $scope.stateName = StateEditorService.getActiveStateName();
-
             $scope.stateContent = ExplorationStatesService
               .getStateContentMemento($scope.stateName);
             $scope.stateSolution = ExplorationStatesService
@@ -284,14 +283,14 @@ oppia.directive('stateTranslation', [
               .getInteractionIdMemento($scope.stateName);
             $scope.activeHintIndex = null;
             $scope.activeAnswerGroupIndex = null;
-
             var currentCustomizationArgs = ExplorationStatesService
               .getInteractionCustomizationArgsMemento($scope.stateName);
             $scope.answerChoices = StateEditorService.getAnswerChoices(
               $scope.stateInteractionId, currentCustomizationArgs);
+
             $scope.onTabClick($scope.TAB_ID_CONTENT);
-            $scope.$broadcast('refreshAudioTranslationBar');
           };
+          $scope.initStateTranslation();
         }
       ]
     };

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationStatusGraphDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/StateTranslationStatusGraphDirective.js
@@ -51,7 +51,6 @@ oppia.directive('stateTranslationStatusGraph', [
                 StateEditorService.getActiveStateName(),
                 stateData.contentIdsToAudioTranslations);
               $rootScope.$broadcast('refreshStateTranslation');
-              $rootScope.$broadcast('refreshAudioTranslationBar');
             }
           };
         }

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdService.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdService.js
@@ -1,4 +1,4 @@
-// Copyright 2018 The Oppia Authors. All Rights Reserved.
+// Copyright 2019 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdService.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdService.js
@@ -27,9 +27,8 @@ oppia.factory('TranslationTabActiveContentIdService', [
       setActiveContentId: function(contentId) {
         var allContentIds = StateContentIdsToAudioTranslationsService.displayed
           .getAllContentId();
-        if (allContentIds.indexOf(contentId) < 0) {
-          $log.error('Invalid active content id: ' + contentId);
-          return;
+        if (allContentIds.indexOf(contentId) === -1) {
+          throw Error('Invalid active content id: ' + contentId);
         }
         activeContentId = contentId;
         $rootScope.$broadcast('activeContentIdChanged');

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdService.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdService.js
@@ -1,0 +1,38 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Service to get and set active content id in translation tab.
+ */
+
+oppia.factory('TranslationTabActiveContentIdService', [
+  '$log', '$rootScope', 'StateContentIdsToAudioTranslationsService',
+  function($log, $rootScope, StateContentIdsToAudioTranslationsService) {
+    var activeContentId = null;
+    return {
+      getActiveContentId: function() {
+        return activeContentId;
+      },
+      setActiveContentId: function(contentId) {
+        var allContentIds = StateContentIdsToAudioTranslationsService.displayed
+          .getAllContentId();
+        if (allContentIds.indexOf(contentId) < 0) {
+          $log.error('Invalid active content id: ' + contentId);
+          return;
+        }
+        activeContentId = contentId;
+        $rootScope.$broadcast('activeContentIdChanged');
+      }
+    };
+  }]);

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdServiceSpec.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdServiceSpec.js
@@ -33,12 +33,15 @@ describe('Translation tab active content id service', function() {
   }));
 
   it('should correctly set and get state names', function() {
+    expect(ttacis.getActiveContentId()).toBeNull();
     ttacis.setActiveContentId('content');
     expect(ttacis.getActiveContentId()).toBe('content');
   });
 
-  it('should not allow to set invalid content id', function() {
-    ttacis.setActiveContentId('feedback_2');
-    expect(ttacis.getActiveContentId()).toBeNull();
+  it('should throw error on setting invalid content id', function() {
+    expect(function() {
+      ttacis.setActiveContentId('feedback_2');
+    }).toThrowError(
+      'Invalid active content id: feedback_2');
   });
 });

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdServiceSpec.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdServiceSpec.js
@@ -1,4 +1,4 @@
-// Copyright 2018 The Oppia Authors. All Rights Reserved.
+// Copyright 2019 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdServiceSpec.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabActiveContentIdServiceSpec.js
@@ -1,0 +1,44 @@
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit test for the Translation tab active content id service.
+ */
+
+describe('Translation tab active content id service', function() {
+  beforeEach(module('oppia', function($provide) {
+    $provide.value('StateContentIdsToAudioTranslationsService', {
+      displayed: {
+        getAllContentId: function() {
+          return ['content', 'feedback_1'];
+        }
+      }
+    });
+  }));
+  var ttacis = null;
+
+  beforeEach(inject(function($injector) {
+    ttacis = $injector.get('TranslationTabActiveContentIdService');
+  }));
+
+  it('should correctly set and get state names', function() {
+    ttacis.setActiveContentId('content');
+    expect(ttacis.getActiveContentId()).toBe('content');
+  });
+
+  it('should not allow to set invalid content id', function() {
+    ttacis.setActiveContentId('feedback_2');
+    expect(ttacis.getActiveContentId()).toBeNull();
+  });
+});

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabDirective.js
@@ -47,7 +47,7 @@ oppia.directive('translationTab', [
             UrlInterpolationService) {
           $rootScope.loadingMessage = 'Loading';
           $scope.isTranslationTabBusy = false;
-          $scope.showSubDirectives = false;
+          $scope.showTranslationTabSubDirectives = false;
 
           var initTranslationTab = function() {
             var stateName = StateEditorService.getActiveStateName();

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslationTabDirective.js
@@ -47,6 +47,7 @@ oppia.directive('translationTab', [
             UrlInterpolationService) {
           $rootScope.loadingMessage = 'Loading';
           $scope.isTranslationTabBusy = false;
+          $scope.showSubDirectives = false;
 
           var initTranslationTab = function() {
             var stateName = StateEditorService.getActiveStateName();
@@ -54,7 +55,8 @@ oppia.directive('translationTab', [
               stateName,
               ExplorationStatesService.getContentIdsToAudioTranslationsMemento(
                 stateName));
-            $scope.$broadcast('refreshStateTranslation');
+            $scope.showTranslationTabSubDirectives = true;
+            $rootScope.loadingMessage = '';
           };
 
           $scope.$on('refreshTranslationTab', function() {
@@ -292,10 +294,6 @@ oppia.directive('translationTab', [
               StateTutorialFirstTimeService.markTranslationTutorialFinished();
             });
           };
-
-          $scope.$on('refreshTranslationTab', function() {
-            $scope.$broadcast('refreshStateTranslation');
-          });
           $scope.$on('enterTranslationForTheFirstTime',
             $scope.showWelcomeTranslationModal
           );

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslatorOverviewDirective.js
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/TranslatorOverviewDirective.js
@@ -76,7 +76,6 @@ oppia.directive('translatorOverview', [
             }
             TranslationLanguageService.setActiveLanguageCode(
               $scope.languageCode);
-            $rootScope.$broadcast('refreshAudioTranslationBar');
             $window.localStorage.setItem(
               LAST_SELECTED_TRANSLATION_LANGUAGE, $scope.languageCode);
           };

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/state_translation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/state_translation_directive.html
@@ -145,7 +145,7 @@
     </div>
   </div>
   <div id="tutorialTranslationAudioBar" class="oppia-audio-translation-bar">
-    <audio-translation-bar content-id="activeContentId" is-translation-tab-busy="isTranslationTabBusy"></audio-translation-bar>
+    <audio-translation-bar is-translation-tab-busy="isTranslationTabBusy"></audio-translation-bar>
   </div>
 </div>
 

--- a/core/templates/dev/head/pages/exploration_editor/translation_tab/translation_tab_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/translation_tab/translation_tab_directive.html
@@ -1,4 +1,4 @@
-<div class="oppia-translation-tab"
+<div class="oppia-translation-tab" ng-if="showTranslationTabSubDirectives"
      ng-joy-ride="translationTutorial"
      config="TRANSLATION_TUTORIAL_OPTIONS"
      on-finish="onFinishTutorial()"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
This PR fixes translation tab refresh issue reported by @rakshitkumarcse and it also fixes #6083.
## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
