### PR TITLE
Fix #6213: Add application_readable to directive htmls handler

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -60,6 +60,7 @@ handlers:
   upload: core/templates/dev/head/(.*directive\.html)$
   secure: always
   expiration: "0"
+  application_readable: true
 - url: /third_party/generated
   static_dir: third_party/generated
   secure: always


### PR DESCRIPTION
## Explanation
Fixes #6213: Some of the directives are still send to frontend by Jinja (mainly stuff regarding popups) so we still need `aplication_readadble: true`

In longer run we should get rid of these files, I have noted it in Speed team notes.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
