### PR TITLE
Revert "Rename ExplorationIssue* to PlaythroughIssue*"

### DIFF
--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -1522,7 +1522,7 @@ class FetchIssuesPlaythroughHandlerTests(test_utils.GenericTestBase):
                 },
                 'schema_version': 1
             }])
-        stats_models.PlaythroughIssuesModel.create(
+        stats_models.ExplorationIssuesModel.create(
             self.EXP_ID, 1,
             [{
                 'issue_type': 'EarlyQuit',
@@ -1565,10 +1565,10 @@ class FetchIssuesPlaythroughHandlerTests(test_utils.GenericTestBase):
 
     def test_invalid_issues_are_not_retrieved(self):
         """Test that invalid issues are not retrieved."""
-        playthrough_issues_model = (
-            stats_models.PlaythroughIssuesModel.get_model(self.EXP_ID, 1))
-        playthrough_issues_model.unresolved_issues[1]['is_valid'] = False
-        playthrough_issues_model.put()
+        exp_issues_model = stats_models.ExplorationIssuesModel.get_model(
+            self.EXP_ID, 1)
+        exp_issues_model.unresolved_issues[1]['is_valid'] = False
+        exp_issues_model.put()
 
         response = self.get_json(
             '/issuesdatahandler/%s' % (self.EXP_ID),
@@ -1664,7 +1664,7 @@ class ResolveIssueHandlerTests(test_utils.GenericTestBase):
                 'schema_version': 1
             }])
 
-        stats_models.PlaythroughIssuesModel.create(
+        stats_models.ExplorationIssuesModel.create(
             self.EXP_ID, 1,
             [{
                 'issue_type': 'EarlyQuit',
@@ -1682,7 +1682,7 @@ class ResolveIssueHandlerTests(test_utils.GenericTestBase):
             }]
         )
 
-        self.playthrough_issue_dict = {
+        self.exp_issue_dict = {
             'issue_type': 'EarlyQuit',
             'issue_customization_args': {
                 'state_name': {
@@ -1705,43 +1705,42 @@ class ResolveIssueHandlerTests(test_utils.GenericTestBase):
         self.post_json(
             '/resolveissuehandler/%s' % (self.EXP_ID),
             {
-                'playthrough_issue_dict': self.playthrough_issue_dict,
+                'exp_issue_dict': self.exp_issue_dict,
                 'exp_version': 1
             }, csrf_token=self.csrf_token)
 
-        playthrough_issues = (
-            stats_services.get_playthrough_issues(self.EXP_ID, 1))
-        self.assertEqual(playthrough_issues.unresolved_issues, [])
+        exp_issues = stats_services.get_exp_issues(self.EXP_ID, 1)
+        self.assertEqual(exp_issues.unresolved_issues, [])
 
         playthrough_instances = stats_models.PlaythroughModel.get_multi(
             [self.playthrough_id1, self.playthrough_id2])
         self.assertEqual(playthrough_instances, [None, None])
 
-    def test_error_on_passing_invalid_playthrough_issue_dict(self):
+    def test_error_on_passing_invalid_exp_issue_dict(self):
         """Test that error is raised on passing invalid exploration issue
         dict.
         """
-        del self.playthrough_issue_dict['issue_type']
+        del self.exp_issue_dict['issue_type']
         # Since we deleted the 'issue_type' key in the exploration issue dict,
         # the dict is invalid now and exception should be raised.
         self.post_json(
             '/resolveissuehandler/%s' % (self.EXP_ID),
             {
-                'playthrough_issue_dict': self.playthrough_issue_dict,
+                'exp_issue_dict': self.exp_issue_dict,
                 'exp_version': 1
             }, csrf_token=self.csrf_token,
             expected_status_int=404)
 
-    def test_error_on_passing_non_matching_playthrough_issue_dict(self):
+    def test_error_on_passing_non_matching_exp_issue_dict(self):
         """Test that error is raised on passing an exploration issue dict that
         doesn't match an issue in the exploration issues model.
         """
-        self.playthrough_issue_dict['issue_customization_args']['state_name'][
+        self.exp_issue_dict['issue_customization_args']['state_name'][
             'value'] = 'state_name2'
         self.post_json(
             '/resolveissuehandler/%s' % (self.EXP_ID),
             {
-                'playthrough_issue_dict': self.playthrough_issue_dict,
+                'exp_issue_dict': self.exp_issue_dict,
                 'exp_version': 1
             }, csrf_token=self.csrf_token,
             expected_status_int=404)

--- a/core/controllers/reader.py
+++ b/core/controllers/reader.py
@@ -346,17 +346,17 @@ class StorePlaythroughHandler(base.BaseHandler):
         """Method that initializes member variables for the handler.
 
         Attributes:
-            current_playthrough_issues: PlaythroughIssues. The exploration
-                issues domain object.
+            current_exp_issues: ExplorationIssues. The exploration issues domain
+                object.
             current_issue_schema_version: int. The issue schema version.
             current_playthrough_id: str|None. The Playthrough ID or None.
         """
         super(StorePlaythroughHandler, self).__init__(*args, **kwargs)
-        self.current_playthrough_issues = None
+        self.current_exp_issues = None
         self.current_issue_schema_version = None
         self.current_playthrough_id = None
 
-    def _find_matching_issue_in_playthrough_issues(self, playthrough):
+    def _find_matching_issue_in_exp_issues(self, playthrough):
         """Finds an issue with the equivalent issue_type and associated states
         as the given playthrough in the unresolved issues list of the
         exploration issues model.
@@ -368,7 +368,7 @@ class StorePlaythroughHandler(base.BaseHandler):
             int|None. The index at which the issue was found, None otherwise.
         """
         for index, issue in enumerate(
-                self.current_playthrough_issues.unresolved_issues):
+                self.current_exp_issues.unresolved_issues):
             if issue.issue_type == playthrough.issue_type:
                 issue_customization_args = issue.issue_customization_args
                 # In case issue_keyname is 'state_names', the ordering of the
@@ -390,31 +390,29 @@ class StorePlaythroughHandler(base.BaseHandler):
                 object which is in the now-incorrect issue list.
         """
         did_move_playthrough_to_new_issue = False
-        issue_index = (
-            self._find_matching_issue_in_playthrough_issues(playthrough))
+        issue_index = self._find_matching_issue_in_exp_issues(playthrough)
         # Check whether the playthrough can be added to its new issue,
         # if not, it stays in its old issue.
         if issue_index is not None:
-            issue = (
-                self.current_playthrough_issues.unresolved_issues[issue_index])
+            issue = self.current_exp_issues.unresolved_issues[issue_index]
             if len(issue.playthrough_ids) < feconf.MAX_PLAYTHROUGHS_FOR_ISSUE:
                 issue.playthrough_ids.append(self.current_playthrough_id)
                 did_move_playthrough_to_new_issue = True
         else:
-            issue = stats_domain.PlaythroughIssue(
+            issue = stats_domain.ExplorationIssue(
                 playthrough.issue_type,
                 playthrough.issue_customization_args,
                 [self.current_playthrough_id],
                 self.current_issue_schema_version, is_valid=True)
-            self.current_playthrough_issues.unresolved_issues.append(issue)
+            self.current_exp_issues.unresolved_issues.append(issue)
             did_move_playthrough_to_new_issue = True
 
         # Now, remove the playthrough from its old issue.
         if did_move_playthrough_to_new_issue:
-            orig_issue_index = self._find_matching_issue_in_playthrough_issues(
+            orig_issue_index = self._find_matching_issue_in_exp_issues(
                 orig_playthrough)
             if orig_issue_index is not None:
-                self.current_playthrough_issues.unresolved_issues[
+                self.current_exp_issues.unresolved_issues[
                     orig_issue_index].playthrough_ids.remove(
                         self.current_playthrough_id)
 
@@ -432,11 +430,9 @@ class StorePlaythroughHandler(base.BaseHandler):
             playthrough_id: int. The playthrough ID.
         """
         # Find whether an issue already exists for the new playthrough.
-        issue_index = (
-            self._find_matching_issue_in_playthrough_issues(playthrough))
+        issue_index = self._find_matching_issue_in_exp_issues(playthrough)
         if issue_index is not None:
-            issue = (
-                self.current_playthrough_issues.unresolved_issues[issue_index])
+            issue = self.current_exp_issues.unresolved_issues[issue_index]
             if len(issue.playthrough_ids) < feconf.MAX_PLAYTHROUGHS_FOR_ISSUE:
                 actions = [action.to_dict() for action in playthrough.actions]
                 playthrough_id = stats_models.PlaythroughModel.create(
@@ -452,13 +448,13 @@ class StorePlaythroughHandler(base.BaseHandler):
                 playthrough.exp_id, playthrough.exp_version,
                 playthrough.issue_type,
                 playthrough.issue_customization_args, actions)
-            issue = stats_domain.PlaythroughIssue(
+            issue = stats_domain.ExplorationIssue(
                 playthrough.issue_type,
                 playthrough.issue_customization_args,
                 [playthrough_id], self.current_issue_schema_version,
                 is_valid=True)
 
-            self.current_playthrough_issues.unresolved_issues.append(issue)
+            self.current_exp_issues.unresolved_issues.append(issue)
 
         return playthrough_id
 
@@ -490,12 +486,10 @@ class StorePlaythroughHandler(base.BaseHandler):
 
         exp_version = playthrough_data['exp_version']
 
-        playthrough_issues_model = (
-            stats_models.PlaythroughIssuesModel.get_model(
-                exploration_id, exp_version))
-        self.current_playthrough_issues = (
-            stats_services.get_playthrough_issues_from_model(
-                playthrough_issues_model))
+        exp_issues_model = stats_models.ExplorationIssuesModel.get_model(
+            exploration_id, exp_version)
+        self.current_exp_issues = stats_services.get_exp_issues_from_model(
+            exp_issues_model)
 
         playthrough = stats_domain.Playthrough.from_dict(playthrough_data)
 
@@ -509,8 +503,8 @@ class StorePlaythroughHandler(base.BaseHandler):
 
             stats_services.update_playthroughs_multi(
                 [self.current_playthrough_id], [playthrough])
-            stats_services.save_playthrough_issues_model_transactional(
-                self.current_playthrough_issues)
+            stats_services.save_exp_issues_model_transactional(
+                self.current_exp_issues)
             self.render_json({})
             return
 
@@ -522,8 +516,8 @@ class StorePlaythroughHandler(base.BaseHandler):
         except Exception:
             payload_return['playthrough_stored'] = False
 
-        stats_services.save_playthrough_issues_model_transactional(
-            self.current_playthrough_issues)
+        stats_services.save_exp_issues_model_transactional(
+            self.current_exp_issues)
         payload_return['playthrough_id'] = playthrough_id
         self.render_json(payload_return)
 
@@ -828,7 +822,7 @@ class ExplorationCompleteEventHandler(base.BaseHandler):
             collection_services.record_played_exploration_in_collection_context(
                 user_id, collection_id, exploration_id)
             next_exp_id_to_complete = (
-                collection_services.get_next_exploration_id_to_complete_by_user(
+                collection_services.get_next_exploration_id_to_complete_by_user( # pylint: disable=line-too-long
                     user_id, collection_id))
 
             if not next_exp_id_to_complete:

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -1310,7 +1310,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 },
                 'schema_version': 1
             }])
-        stats_models.PlaythroughIssuesModel.create(
+        stats_models.ExplorationIssuesModel.create(
             self.exp_id, 1, [{
                 'issue_type': 'EarlyQuit',
                 'issue_customization_args': {
@@ -1365,11 +1365,11 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             }, csrf_token=self.csrf_token)
         self.process_and_flush_pending_tasks()
 
-        model = stats_models.PlaythroughIssuesModel.get_model(self.exp_id, 1)
+        model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
         self.assertEqual(len(model.unresolved_issues), 1)
         self.assertEqual(len(model.unresolved_issues[0]['playthrough_ids']), 2)
 
-    def test_new_playthrough_issue_gets_created(self):
+    def test_new_exp_issue_gets_created(self):
         """Test that a new playthrough gets created and a new issue is created
         for it.
         """
@@ -1385,7 +1385,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             }, csrf_token=self.csrf_token)
         self.process_and_flush_pending_tasks()
 
-        model = stats_models.PlaythroughIssuesModel.get_model(self.exp_id, 1)
+        model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
         self.assertEqual(len(model.unresolved_issues), 2)
         self.assertEqual(len(model.unresolved_issues[0]['playthrough_ids']), 1)
         self.assertEqual(len(model.unresolved_issues[1]['playthrough_ids']), 1)
@@ -1411,7 +1411,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 'schema_version': 1
             }])
 
-        model = stats_models.PlaythroughIssuesModel.get_model(self.exp_id, 1)
+        model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
         model.unresolved_issues.append({
             'issue_type': 'CyclicStateTransitions',
             'issue_customization_args': {
@@ -1454,7 +1454,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             }, csrf_token=self.csrf_token)
         self.process_and_flush_pending_tasks()
 
-        model = stats_models.PlaythroughIssuesModel.get_model(self.exp_id, 1)
+        model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
         self.assertEqual(len(model.unresolved_issues), 2)
         self.assertEqual(len(model.unresolved_issues[0]['playthrough_ids']), 1)
         self.assertEqual(len(model.unresolved_issues[1]['playthrough_ids']), 2)
@@ -1480,7 +1480,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 'schema_version': 1
             }])
 
-        model = stats_models.PlaythroughIssuesModel.get_model(self.exp_id, 1)
+        model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
         model.unresolved_issues.append({
             'issue_type': 'CyclicStateTransitions',
             'issue_customization_args': {
@@ -1523,7 +1523,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             }, csrf_token=self.csrf_token)
         self.process_and_flush_pending_tasks()
 
-        model = stats_models.PlaythroughIssuesModel.get_model(self.exp_id, 1)
+        model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
         self.assertEqual(len(model.unresolved_issues), 3)
         self.assertEqual(len(model.unresolved_issues[0]['playthrough_ids']), 1)
         self.assertEqual(len(model.unresolved_issues[1]['playthrough_ids']), 1)
@@ -1533,7 +1533,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
         """Test that a playthrough is not stored when the maximum number of
         playthroughs per issue already exists.
         """
-        model = stats_models.PlaythroughIssuesModel.get_model(self.exp_id, 1)
+        model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
         model.unresolved_issues[0]['playthrough_ids'] = [
             'id1', 'id2', 'id3', 'id4', 'id5']
         model.put()
@@ -1547,7 +1547,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             }, csrf_token=self.csrf_token)
         self.process_and_flush_pending_tasks()
 
-        model = stats_models.PlaythroughIssuesModel.get_model(self.exp_id, 1)
+        model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
         self.assertEqual(len(model.unresolved_issues), 1)
         self.assertEqual(len(model.unresolved_issues[0]['playthrough_ids']), 5)
 
@@ -1591,7 +1591,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             }, csrf_token=self.csrf_token)
         self.process_and_flush_pending_tasks()
 
-        model = stats_models.PlaythroughIssuesModel.get_model(self.exp_id, 1)
+        model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
         self.assertEqual(len(model.unresolved_issues), 1)
         self.assertEqual(len(model.unresolved_issues[0]['playthrough_ids']), 2)
         playthrough_id = model.unresolved_issues[0]['playthrough_ids'][1]
@@ -1623,7 +1623,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 'issue_schema_version': 1,
                 'playthrough_id': playthrough_id
             }, csrf_token=self.csrf_token)
-        model = stats_models.PlaythroughIssuesModel.get_model(self.exp_id, 1)
+        model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
         self.assertEqual(len(model.unresolved_issues), 1)
         self.assertEqual(len(model.unresolved_issues[0]['playthrough_ids']), 2)
         playthrough_id = model.unresolved_issues[0]['playthrough_ids'][1]
@@ -1661,7 +1661,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 'issue_schema_version': 1,
                 'playthrough_id': playthrough_id
             }, csrf_token=self.csrf_token)
-        model = stats_models.PlaythroughIssuesModel.get_model(self.exp_id, 1)
+        model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
         self.assertEqual(len(model.unresolved_issues), 2)
         self.assertEqual(len(model.unresolved_issues[0]['playthrough_ids']), 1)
         self.assertEqual(len(model.unresolved_issues[1]['playthrough_ids']), 1)

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -877,7 +877,7 @@ def _save_exploration(committer_id, exploration, commit_message, change_list):
                 exp_versions_diff)
 
     # Trigger exploration issues model updation.
-    stats_services.update_playthrough_issues_for_new_exp_version(
+    stats_services.update_exp_issues_for_new_exp_version(
         exploration, exp_versions_diff=exp_versions_diff,
         revert_to_version=None)
 
@@ -945,7 +945,7 @@ def _create_exploration(
                 exploration, state_names_to_train)
 
     # Trigger exploration issues model creation.
-    stats_services.create_playthrough_issues_for_new_exploration(
+    stats_services.create_exp_issues_for_new_exploration(
         exploration.id, exploration.version)
 
     # Save state id mapping model for new exploration.
@@ -1408,7 +1408,7 @@ def revert_exploration(
 
     current_exploration = get_exploration_by_id(
         exploration_id, version=current_version)
-    stats_services.update_playthrough_issues_for_new_exp_version(
+    stats_services.update_exp_issues_for_new_exp_version(
         current_exploration, exp_versions_diff=None,
         revert_to_version=revert_to_version)
 

--- a/core/domain/playthrough_issue_registry.py
+++ b/core/domain/playthrough_issue_registry.py
@@ -62,7 +62,7 @@ class Registry(object):
 
             ancestor_names = [
                 base_class.__name__ for base_class in clazz.__bases__]
-            if 'BasePlaythroughIssueSpec' in ancestor_names:
+            if 'BaseExplorationIssueSpec' in ancestor_names:
                 cls._issues[clazz.__name__] = clazz()
 
     @classmethod

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -406,18 +406,18 @@ class StateStats(object):
                     '%s cannot have negative values' % (stat_property))
 
 
-class PlaythroughIssues(object):
+class ExplorationIssues(object):
     """Domain object representing the exploration to issues mapping for an
     exploration.
     """
 
     def __init__(self, exp_id, exp_version, unresolved_issues):
-        """Constructs an PlaythroughIssues domain object.
+        """Constructs an ExplorationIssues domain object.
 
         Args:
             exp_id: str. ID of the exploration.
             exp_version: int. Version of the exploration.
-            unresolved_issues: list(PlaythroughIssue). List of exploration
+            unresolved_issues: list(ExplorationIssue). List of exploration
                 issues.
         """
         self.exp_id = exp_id
@@ -426,22 +426,22 @@ class PlaythroughIssues(object):
 
     @classmethod
     def create_default(cls, exp_id, exp_version):
-        """Creates a default PlaythroughIssues domain object.
+        """Creates a default ExplorationIssues domain object.
 
         Args:
             exp_id: str. ID of the exploration.
             exp_version: int. Version of the exploration.
 
         Returns:
-            PlaythroughIssues. The exploration issues domain object.
+            ExplorationIssues. The exploration issues domain object.
         """
         return cls(exp_id, exp_version, [])
 
     def to_dict(self):
-        """Returns a dict representation of the PlaythroughIssues domain object.
+        """Returns a dict representation of the ExplorationIssues domain object.
 
         Returns:
-            dict. A dict mapping of all fields of PlaythroughIssues object.
+            dict. A dict mapping of all fields of ExplorationIssues object.
         """
         unresolved_issue_dicts = [
             unresolved_issue.to_dict()
@@ -453,28 +453,26 @@ class PlaythroughIssues(object):
         }
 
     @classmethod
-    def from_dict(cls, playthrough_issues_dict):
-        """Returns an PlaythroughIssues object from a dict.
+    def from_dict(cls, exp_issues_dict):
+        """Returns an ExplorationIssues object from a dict.
 
         Args:
-            playthrough_issues_dict: dict. A dict mapping of all fields of
-                PlaythroughIssues object.
+            exp_issues_dict: dict. A dict mapping of all fields of
+                ExplorationIssues object.
 
         Returns:
-            PlaythroughIssues. The corresponding PlaythroughIssues domain
+            ExplorationIssues. The corresponding ExplorationIssues domain
                 object.
         """
-        unresolved_issues_dict = playthrough_issues_dict['unresolved_issues']
         unresolved_issues = [
-            PlaythroughIssue.from_dict(unresolved_issue_dict)
-            for unresolved_issue_dict in unresolved_issues_dict]
+            ExplorationIssue.from_dict(unresolved_issue_dict)
+            for unresolved_issue_dict in exp_issues_dict['unresolved_issues']]
         return cls(
-            playthrough_issues_dict['exp_id'],
-            playthrough_issues_dict['exp_version'],
+            exp_issues_dict['exp_id'], exp_issues_dict['exp_version'],
             unresolved_issues)
 
     def validate(self):
-        """Validates the PlaythroughIssues domain object."""
+        """Validates the ExplorationIssues domain object."""
         if not isinstance(self.exp_id, basestring):
             raise utils.ValidationError(
                 'Expected exp_id to be a string, received %s' % type(
@@ -630,13 +628,13 @@ class Playthrough(object):
             action.validate()
 
 
-class PlaythroughIssue(object):
+class ExplorationIssue(object):
     """Domain object representing an exploration issue."""
 
     def __init__(
             self, issue_type, issue_customization_args, playthrough_ids,
             schema_version, is_valid):
-        """Constructs an PlaythroughIssue domain object.
+        """Constructs an ExplorationIssue domain object.
 
         Args:
             issue_type: str. Type of the issue.
@@ -656,10 +654,10 @@ class PlaythroughIssue(object):
         self.is_valid = is_valid
 
     def to_dict(self):
-        """Returns a dict representation of the PlaythroughIssue domain object.
+        """Returns a dict representation of the ExplorationIssue domain object.
 
         Returns:
-            dict. A dict mapping of all fields of PlaythroughIssue object.
+            dict. A dict mapping of all fields of ExplorationIssue object.
         """
         return {
             'issue_type': self.issue_type,
@@ -675,14 +673,14 @@ class PlaythroughIssue(object):
 
     @classmethod
     def from_dict(cls, issue_dict):
-        """Returns an PlaythroughIssue object from a dict.
+        """Returns an ExplorationIssue object from a dict.
 
         Args:
-            issue_dict: dict. A dict mapping of all fields of PlaythroughIssue
+            issue_dict: dict. A dict mapping of all fields of ExplorationIssue
                 object.
 
         Returns:
-            PlaythroughIssue. The corresponding PlaythroughIssue domain object.
+            ExplorationIssue. The corresponding ExplorationIssue domain object.
         """
         return cls(
             issue_dict['issue_type'],
@@ -692,44 +690,41 @@ class PlaythroughIssue(object):
             issue_dict['is_valid'])
 
     @classmethod
-    def from_backend_dict(cls, playthrough_issue_dict):
+    def from_backend_dict(cls, exp_issue_dict):
         """Checks whether the exploration issue dict has the correct keys and
         then returns a domain object instance.
 
         Args:
-            playthrough_issue_dict: dict. Dict representing an exploration
-                issue.
+            exp_issue_dict: dict. Dict representing an exploration issue.
 
         Returns:
-            PlaythroughIssue. The exploration issue domain object.
+            ExplorationIssue. The exploration issue domain object.
         """
-        playthrough_issue_properties = [
+        exp_issue_properties = [
             'issue_type', 'schema_version', 'issue_customization_args',
             'playthrough_ids', 'is_valid']
 
-        for playthrough_issue_property in playthrough_issue_properties:
-            if playthrough_issue_property not in playthrough_issue_dict:
+        for exp_issue_property in exp_issue_properties:
+            if exp_issue_property not in exp_issue_dict:
                 raise utils.ValidationError(
-                    '%s not in exploration issue dict.' % (
-                        playthrough_issue_property))
+                    '%s not in exploration issue dict.' % (exp_issue_property))
 
-        dummy_playthrough_issue = cls(
-            playthrough_issue_dict['issue_type'],
-            playthrough_issue_dict['issue_customization_args'], [],
-            playthrough_issue_dict['schema_version'],
-            playthrough_issue_dict['is_valid'])
+        dummy_exp_issue = cls(
+            exp_issue_dict['issue_type'],
+            exp_issue_dict['issue_customization_args'], [],
+            exp_issue_dict['schema_version'], exp_issue_dict['is_valid'])
 
-        dummy_playthrough_issue.validate()
-        return dummy_playthrough_issue
+        dummy_exp_issue.validate()
+        return dummy_exp_issue
 
     @classmethod
-    def update_playthrough_issue_from_model(cls, issue_dict):
+    def update_exp_issue_from_model(cls, issue_dict):
         """Converts the exploration issue blob given from
         current issue_schema_version to current issue_schema_version + 1.
         Note that the issue_dict being passed in is modified in-place.
 
         Args:
-            issue_dict: dict. Dict representing the PlaythroughIssue object.
+            issue_dict: dict. Dict representing the ExplorationIssue object.
         """
         current_issue_schema_version = issue_dict['schema_version']
         issue_dict['schema_version'] += 1
@@ -747,7 +742,7 @@ class PlaythroughIssue(object):
         raise NotImplementedError
 
     def validate(self):
-        """Validates the PlaythroughIssue domain object."""
+        """Validates the ExplorationIssue domain object."""
         if not isinstance(self.issue_type, basestring):
             raise utils.ValidationError(
                 'Expected issue_type to be a string, received %s' % (

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -273,20 +273,19 @@ class StateStatsTests(test_utils.GenericTestBase):
             state_stats.validate()
 
 
-class PlaythroughIssuesTests(test_utils.GenericTestBase):
-    """Tests the PlaythroughIssues domain object."""
+class ExplorationIssuesTests(test_utils.GenericTestBase):
+    """Tests the ExplorationIssues domain object."""
 
     def test_create_default(self):
-        playthrough_issues = (
-            stats_domain.PlaythroughIssues.create_default('exp_id1', 1))
-        self.assertEqual(playthrough_issues.exp_id, 'exp_id1')
-        self.assertEqual(playthrough_issues.exp_version, 1)
-        self.assertEqual(playthrough_issues.unresolved_issues, [])
+        exp_issues = stats_domain.ExplorationIssues.create_default('exp_id1', 1)
+        self.assertEqual(exp_issues.exp_id, 'exp_id1')
+        self.assertEqual(exp_issues.exp_version, 1)
+        self.assertEqual(exp_issues.unresolved_issues, [])
 
     def test_to_dict(self):
-        playthrough_issues = stats_domain.PlaythroughIssues(
+        exp_issues = stats_domain.ExplorationIssues(
             'exp_id1', 1, [
-                stats_domain.PlaythroughIssue.from_dict({
+                stats_domain.ExplorationIssue.from_dict({
                     'issue_type': 'EarlyQuit',
                     'issue_customization_args': {
                         'state_name': {
@@ -301,12 +300,12 @@ class PlaythroughIssuesTests(test_utils.GenericTestBase):
                     'is_valid': True})
                 ])
 
-        playthrough_issues_dict = playthrough_issues.to_dict()
+        exp_issues_dict = exp_issues.to_dict()
 
-        self.assertEqual(playthrough_issues_dict['exp_id'], 'exp_id1')
-        self.assertEqual(playthrough_issues_dict['exp_version'], 1)
+        self.assertEqual(exp_issues_dict['exp_id'], 'exp_id1')
+        self.assertEqual(exp_issues_dict['exp_version'], 1)
         self.assertEqual(
-            playthrough_issues_dict['unresolved_issues'], [{
+            exp_issues_dict['unresolved_issues'], [{
                 'issue_type': 'EarlyQuit',
                 'issue_customization_args': {
                     'state_name': {
@@ -322,7 +321,7 @@ class PlaythroughIssuesTests(test_utils.GenericTestBase):
             }])
 
     def test_from_dict(self):
-        playthrough_issues_dict = {
+        exp_issues_dict = {
             'exp_id': 'exp_id1',
             'exp_version': 1,
             'unresolved_issues': [{
@@ -341,13 +340,12 @@ class PlaythroughIssuesTests(test_utils.GenericTestBase):
             }]
         }
 
-        playthrough_issues = (
-            stats_domain.PlaythroughIssues.from_dict(playthrough_issues_dict))
+        exp_issues = stats_domain.ExplorationIssues.from_dict(exp_issues_dict)
 
-        self.assertEqual(playthrough_issues.exp_id, 'exp_id1')
-        self.assertEqual(playthrough_issues.exp_version, 1)
+        self.assertEqual(exp_issues.exp_id, 'exp_id1')
+        self.assertEqual(exp_issues.exp_version, 1)
         self.assertEqual(
-            playthrough_issues.unresolved_issues[0].to_dict(),
+            exp_issues.unresolved_issues[0].to_dict(),
             {
                 'issue_type': 'EarlyQuit',
                 'issue_customization_args': {
@@ -363,9 +361,9 @@ class PlaythroughIssuesTests(test_utils.GenericTestBase):
                 'is_valid': True})
 
     def test_validate(self):
-        playthrough_issues = stats_domain.PlaythroughIssues(
+        exp_issues = stats_domain.ExplorationIssues(
             'exp_id1', 1, [
-                stats_domain.PlaythroughIssue.from_dict({
+                stats_domain.ExplorationIssue.from_dict({
                     'issue_type': 'EarlyQuit',
                     'issue_customization_args': {
                         'state_name': {
@@ -379,13 +377,13 @@ class PlaythroughIssuesTests(test_utils.GenericTestBase):
                     'schema_version': 1,
                     'is_valid': True})
                 ])
-        playthrough_issues.validate()
+        exp_issues.validate()
 
         # Change ID to int.
-        playthrough_issues.exp_id = 5
+        exp_issues.exp_id = 5
         with self.assertRaisesRegexp(utils.ValidationError, (
             'Expected exp_id to be a string, received %s' % (type(5)))):
-            playthrough_issues.validate()
+            exp_issues.validate()
 
 
 class PlaythroughTests(test_utils.GenericTestBase):
@@ -550,8 +548,8 @@ class PlaythroughTests(test_utils.GenericTestBase):
             playthrough.validate()
 
 
-class PlaythroughIssueTests(test_utils.GenericTestBase):
-    """Tests the PlaythroughIssue domain object."""
+class ExplorationIssueTests(test_utils.GenericTestBase):
+    """Tests the ExplorationIssue domain object."""
 
     def _dummy_convert_issue_v1_dict_to_v2_dict(self, issue_dict):
         """A test implementation of schema conversion function."""
@@ -563,9 +561,8 @@ class PlaythroughIssueTests(test_utils.GenericTestBase):
         return issue_dict
 
     def test_to_dict(self):
-        playthrough_issue = (
-            stats_domain.PlaythroughIssue('EarlyQuit', {}, [], 1, True))
-        playthrough_issue_dict = playthrough_issue.to_dict()
+        exp_issue = stats_domain.ExplorationIssue('EarlyQuit', {}, [], 1, True)
+        exp_issue_dict = exp_issue.to_dict()
         expected_customization_args = {
             'time_spent_in_exp_in_msecs': {
                 'value': 0
@@ -575,7 +572,7 @@ class PlaythroughIssueTests(test_utils.GenericTestBase):
             }
         }
         self.assertEqual(
-            playthrough_issue_dict, {
+            exp_issue_dict, {
                 'issue_type': 'EarlyQuit',
                 'issue_customization_args': expected_customization_args,
                 'playthrough_ids': [],
@@ -587,7 +584,7 @@ class PlaythroughIssueTests(test_utils.GenericTestBase):
         """Test the from_backend_dict() method."""
         # Test that an exploration issue dict without 'issue_type' key raises
         # exception.
-        playthrough_issue_dict = {
+        exp_issue_dict = {
             'issue_customization_args': {},
             'playthrough_ids': [],
             'schema_version': 1,
@@ -596,56 +593,52 @@ class PlaythroughIssueTests(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(
             utils.ValidationError,
             'issue_type not in exploration issue dict.'):
-            stats_domain.PlaythroughIssue.from_backend_dict(
-                playthrough_issue_dict)
+            stats_domain.ExplorationIssue.from_backend_dict(exp_issue_dict)
 
-    def test_update_playthrough_issue_from_model(self):
+    def test_update_exp_issue_from_model(self):
         """Test the migration of exploration issue domain objects."""
-        playthrough_issue = (
-            stats_domain.PlaythroughIssue('EarlyQuit', {}, [], 1, True))
-        playthrough_issue_dict = playthrough_issue.to_dict()
+        exp_issue = stats_domain.ExplorationIssue('EarlyQuit', {}, [], 1, True)
+        exp_issue_dict = exp_issue.to_dict()
 
         with self.swap(
-            stats_domain.PlaythroughIssue,
+            stats_domain.ExplorationIssue,
             '_convert_issue_v1_dict_to_v2_dict',
             self._dummy_convert_issue_v1_dict_to_v2_dict):
-            stats_domain.PlaythroughIssue.update_playthrough_issue_from_model(
-                playthrough_issue_dict)
-        self.assertEqual(playthrough_issue_dict['issue_type'], 'EarlyQuit1')
+            stats_domain.ExplorationIssue.update_exp_issue_from_model(
+                exp_issue_dict)
+        self.assertEqual(exp_issue_dict['issue_type'], 'EarlyQuit1')
         self.assertEqual(
-            playthrough_issue_dict['issue_customization_args']['new_key'], 5)
+            exp_issue_dict['issue_customization_args']['new_key'], 5)
 
         # For other issue types, no changes happen during migration.
-        playthrough_issue1 = stats_domain.PlaythroughIssue(
+        exp_issue1 = stats_domain.ExplorationIssue(
             'MultipleIncorrectSubmissions', {}, [], 1, True)
-        playthrough_issue_dict1 = playthrough_issue1.to_dict()
+        exp_issue_dict1 = exp_issue1.to_dict()
         with self.swap(
-            stats_domain.PlaythroughIssue,
+            stats_domain.ExplorationIssue,
             '_convert_issue_v1_dict_to_v2_dict',
             self._dummy_convert_issue_v1_dict_to_v2_dict):
-            stats_domain.PlaythroughIssue.update_playthrough_issue_from_model(
-                playthrough_issue_dict1)
+            stats_domain.ExplorationIssue.update_exp_issue_from_model(
+                exp_issue_dict1)
         self.assertEqual(
-            playthrough_issue_dict1['issue_type'],
-            'MultipleIncorrectSubmissions')
+            exp_issue_dict1['issue_type'], 'MultipleIncorrectSubmissions')
 
     def test_validate(self):
-        playthrough_issue = (
-            stats_domain.PlaythroughIssue('EarlyQuit', {}, [], 1, True))
-        playthrough_issue.validate()
+        exp_issue = stats_domain.ExplorationIssue('EarlyQuit', {}, [], 1, True)
+        exp_issue.validate()
 
         # Change issue_type to int.
-        playthrough_issue.issue_type = 5
+        exp_issue.issue_type = 5
         with self.assertRaisesRegexp(utils.ValidationError, (
             'Expected issue_type to be a string, received %s' % (type(5)))):
-            playthrough_issue.validate()
+            exp_issue.validate()
 
         # Change schema_version to string.
-        playthrough_issue.issue_type = 'EarlyQuit'
-        playthrough_issue.schema_version = '1'
+        exp_issue.issue_type = 'EarlyQuit'
+        exp_issue.schema_version = '1'
         with self.assertRaisesRegexp(utils.ValidationError, (
             'Expected schema_version to be an int, received %s' % (type('1')))):
-            playthrough_issue.validate()
+            exp_issue.validate()
 
 
 class LearnerActionTests(test_utils.GenericTestBase):

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -60,16 +60,16 @@ class DeleteIllegalPlaythroughsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
     Ensures:
         All Playthrough models deleted are removed as a reference from their
-            associated PlaythroughIssue model.
-        PlaythroughIssues models without any legal playthrough references are
+            associated ExplorationIssue model.
+        ExplorationIssues models without any legal playthrough references are
             deleted.
-        Individual PlaythroughIssues without any legal playthrough references
+        Individual ExplorationIssues without any legal playthrough references
             are deleted.
     """
 
     @classmethod
     def entity_classes_to_map_over(cls):
-        return [stats_models.PlaythroughIssuesModel]
+        return [stats_models.ExplorationIssuesModel]
 
     @classmethod
     def is_illegal(cls, playthrough_model):
@@ -95,7 +95,7 @@ class DeleteIllegalPlaythroughsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
         Args:
             playthrough_issue_backend_dict: dict(str : *). The backend dict
-                representation of a stats_domain.PlaythroughIssue object.
+                representation of a stats_domain.ExplorationIssue object.
 
         Returns:
             tuple(int, int). A 2-tuple with the structure:
@@ -125,7 +125,7 @@ class DeleteIllegalPlaythroughsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
         be declared @staticmethod.
 
         Args:
-            playthrough_issues_model: PlaythroughIssuesModel.
+            playthrough_issues_model: ExplorationIssuesModel.
 
         Yields:
             tuple(str, int). Returns the exploration id the given model is
@@ -261,10 +261,10 @@ class PlaythroughAudit(jobs.BaseMapReduceOneOffJobManager):
                     'therefore not exist.' % (key, audit_data['created_on']),)
 
 
-class PlaythroughIssuesModelCreatorOneOffJob(
+class ExplorationIssuesModelCreatorOneOffJob(
         jobs.BaseMapReduceOneOffJobManager):
     """A one-off job for creating a default ExplorationIsssues model instance
-    for all the explorations in the datastore. If an PlaythroughIssues model
+    for all the explorations in the datastore. If an ExplorationIssues model
     already exists for an exploration, it is refreshed to a default instance.
     """
 
@@ -277,23 +277,23 @@ class PlaythroughIssuesModelCreatorOneOffJob(
         if not exploration_model.deleted:
             current_version = exploration_model.version
             for exp_version in xrange(1, current_version + 1):
-                playthrough_issues_model = (
-                    stats_models.PlaythroughIssuesModel.get_model(
+                exp_issues_model = (
+                    stats_models.ExplorationIssuesModel.get_model(
                         exploration_model.id, exp_version))
-                if not playthrough_issues_model:
-                    playthrough_issues_default = (
-                        stats_domain.PlaythroughIssues.create_default(
+                if not exp_issues_model:
+                    exp_issues_default = (
+                        stats_domain.ExplorationIssues.create_default(
                             exploration_model.id, exp_version))
-                    stats_models.PlaythroughIssuesModel.create(
-                        playthrough_issues_default.exp_id,
-                        playthrough_issues_default.exp_version,
-                        playthrough_issues_default.unresolved_issues)
+                    stats_models.ExplorationIssuesModel.create(
+                        exp_issues_default.exp_id,
+                        exp_issues_default.exp_version,
+                        exp_issues_default.unresolved_issues)
                 else:
-                    playthrough_issues_model.unresolved_issues = []
-                    playthrough_issues_model.put()
+                    exp_issues_model.unresolved_issues = []
+                    exp_issues_model.put()
             yield(
                 exploration_model.id,
-                'PlaythroughIssuesModel created')
+                'ExplorationIssuesModel created')
 
     @staticmethod
     def reduce(exp_id, values):

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -33,7 +33,7 @@ transaction_services = models.Registry.import_transaction_services()
 VERSION_ALL = 'all'
 
 
-def _migrate_to_latest_issue_schema(playthrough_issue_dict):
+def _migrate_to_latest_issue_schema(exp_issue_dict):
     """Holds the responsibility of performing a step-by-step sequential update
     of an exploration issue dict based on its schema version. If the current
     issue schema version changes (stats_models.CURRENT_ISSUE_SCHEMA_VERSION), a
@@ -41,12 +41,12 @@ def _migrate_to_latest_issue_schema(playthrough_issue_dict):
     function to account for that new version.
 
     Args:
-        playthrough_issue_dict: dict. Dict representing the exploration issue.
+        exp_issue_dict: dict. Dict representing the exploration issue.
 
     Raises:
         Exception. The issue_schema_version is invalid.
     """
-    issue_schema_version = playthrough_issue_dict['schema_version']
+    issue_schema_version = exp_issue_dict['schema_version']
     if issue_schema_version is None or issue_schema_version < 1:
         issue_schema_version = 0
 
@@ -58,8 +58,8 @@ def _migrate_to_latest_issue_schema(playthrough_issue_dict):
             stats_models.CURRENT_ISSUE_SCHEMA_VERSION)
 
     while issue_schema_version < stats_models.CURRENT_ISSUE_SCHEMA_VERSION:
-        stats_domain.PlaythroughIssue.update_playthrough_issue_from_model(
-            playthrough_issue_dict)
+        stats_domain.ExplorationIssue.update_exp_issue_from_model(
+            exp_issue_dict)
         issue_schema_version += 1
 
 
@@ -234,46 +234,44 @@ def handle_stats_creation_for_new_exp_version(
     create_stats_model(exploration_stats)
 
 
-def create_playthrough_issues_for_new_exploration(exp_id, exp_version):
-    """Creates the PlaythroughIssuesModel instance for the exploration.
+def create_exp_issues_for_new_exploration(exp_id, exp_version):
+    """Creates the ExplorationIssuesModel instance for the exploration.
 
     Args:
         exp_id: str. ID of the exploration.
         exp_version: int. Version of the exploration.
     """
-    stats_models.PlaythroughIssuesModel.create(exp_id, exp_version, [])
+    stats_models.ExplorationIssuesModel.create(exp_id, exp_version, [])
 
 
-def _handle_playthrough_issues_after_state_deletion(
-        state_name, playthrough_issue, deleted_state_names):
+def _handle_exp_issues_after_state_deletion(
+        state_name, exp_issue, deleted_state_names):
     """Checks if the exploration issue's concerned state is a deleted state and
     invalidates the exploration issue accoridngly.
 
     Args:
         state_name: str. The issue's concerened state name.
-        playthrough_issue: PlaythroughIssue. The exploration issue domain
-            object.
+        exp_issue: ExplorationIssue. The exploration issue domain object.
         deleted_state_names: list(str). The list of deleted state names in this
             commit.
 
     Returns:
-        PlaythroughIssue. The exploration issue domain object.
+        ExplorationIssue. The exploration issue domain object.
     """
     if state_name in deleted_state_names:
-        playthrough_issue.is_valid = False
-    return playthrough_issue
+        exp_issue.is_valid = False
+    return exp_issue
 
 
-def _handle_playthrough_issues_after_state_rename(
-        state_name, playthrough_issue, old_to_new_state_names,
+def _handle_exp_issues_after_state_rename(
+        state_name, exp_issue, old_to_new_state_names,
         playthrough_ids_by_state_name):
     """Checks if the exploration issue's concerned state is a renamed state and
     modifies the exploration issue accoridngly.
 
     Args:
         state_name: str. The issue's concerened state name.
-        playthrough_issue: PlaythroughIssue. The exploration issue domain
-            object.
+        exp_issue: ExplorationIssue. The exploration issue domain object.
         old_to_new_state_names: dict. The dict mapping state names to their
             renamed versions. This mapping contains state names only if it is
             actually renamed.
@@ -281,34 +279,34 @@ def _handle_playthrough_issues_after_state_rename(
             their new ones
 
     Returns:
-        PlaythroughIssue. The exploration issue domain object.
+        ExplorationIssue. The exploration issue domain object.
     """
     if state_name not in old_to_new_state_names:
-        return playthrough_issue, playthrough_ids_by_state_name
+        return exp_issue, playthrough_ids_by_state_name
 
     old_state_name = state_name
     new_state_name = old_to_new_state_names[old_state_name]
     if stats_models.ISSUE_TYPE_KEYNAME_MAPPING[
-            playthrough_issue.issue_type] == 'state_names':
-        state_names = playthrough_issue.issue_customization_args['state_names'][
+            exp_issue.issue_type] == 'state_names':
+        state_names = exp_issue.issue_customization_args['state_names'][
             'value']
-        playthrough_issue.issue_customization_args['state_names']['value'] = [
+        exp_issue.issue_customization_args['state_names']['value'] = [
             new_state_name
             if state_name == old_state_name else state_name
             for state_name in state_names]
     else:
-        playthrough_issue.issue_customization_args['state_name']['value'] = (
+        exp_issue.issue_customization_args['state_name']['value'] = (
             new_state_name)
 
     playthrough_ids_by_state_name[old_state_name].extend(
-        playthrough_issue.playthrough_ids)
+        exp_issue.playthrough_ids)
 
-    return playthrough_issue, playthrough_ids_by_state_name
+    return exp_issue, playthrough_ids_by_state_name
 
 
-def update_playthrough_issues_for_new_exp_version(
+def update_exp_issues_for_new_exp_version(
         exploration, exp_versions_diff, revert_to_version):
-    """Retrieves the PlaythroughIssuesModel for the old exp_version and makes
+    """Retrieves the ExplorationIssuesModel for the old exp_version and makes
     any required changes to the structure of the model.
 
     Args:
@@ -318,66 +316,58 @@ def update_playthrough_issues_for_new_exp_version(
         revert_to_version: int|None. If the change is a revert, the version.
             Otherwise, None.
     """
-    playthrough_issues = (
-        get_playthrough_issues(exploration.id, exploration.version - 1))
-    if playthrough_issues is None:
-        create_playthrough_issues_for_new_exploration(
+    exp_issues = get_exp_issues(exploration.id, exploration.version - 1)
+    if exp_issues is None:
+        create_exp_issues_for_new_exploration(
             exploration.id, exploration.version - 1)
         return
 
     # Handling reverts.
     if revert_to_version:
-        old_playthrough_issues = (
-            get_playthrough_issues(exploration.id, revert_to_version))
+        old_exp_issues = get_exp_issues(exploration.id, revert_to_version)
         # If the old exploration issues model doesn't exist, the current model
         # is carried over (this is a fallback case for some tests, and can
         # never happen in production.)
-        if old_playthrough_issues:
-            playthrough_issues.unresolved_issues = (
-                old_playthrough_issues.unresolved_issues)
-        playthrough_issues.exp_version = exploration.version + 1
-        create_playthrough_issues_model(playthrough_issues)
+        if old_exp_issues:
+            exp_issues.unresolved_issues = old_exp_issues.unresolved_issues
+        exp_issues.exp_version = exploration.version + 1
+        create_exp_issues_model(exp_issues)
         return
 
     playthrough_ids_by_state_name = collections.defaultdict(list)
 
-    enumerated_unresolved_issues = (
-        enumerate(playthrough_issues.unresolved_issues))
-    for i_idx, playthrough_issue in enumerated_unresolved_issues:
-        keyname = stats_models.ISSUE_TYPE_KEYNAME_MAPPING[
-            playthrough_issue.issue_type]
+    for i_idx, exp_issue in enumerate(exp_issues.unresolved_issues):
+        keyname = stats_models.ISSUE_TYPE_KEYNAME_MAPPING[exp_issue.issue_type]
         if keyname == 'state_names':
-            state_names = (
-                playthrough_issue.issue_customization_args[keyname]['value'])
+            state_names = exp_issue.issue_customization_args[keyname]['value']
             for state_name in state_names:
                 # Handle exp issues changes for deleted states.
-                playthrough_issues.unresolved_issues[i_idx] = (
-                    _handle_playthrough_issues_after_state_deletion(
-                        state_name, playthrough_issue,
+                exp_issues.unresolved_issues[i_idx] = (
+                    _handle_exp_issues_after_state_deletion(
+                        state_name, exp_issue,
                         exp_versions_diff.deleted_state_names))
 
                 # Handle exp issues changes for renamed states.
-                playthrough_issues.unresolved_issues[
+                exp_issues.unresolved_issues[
                     i_idx], playthrough_ids_by_state_name = (
-                        _handle_playthrough_issues_after_state_rename(
-                            state_name, playthrough_issue,
+                        _handle_exp_issues_after_state_rename(
+                            state_name, exp_issue,
                             exp_versions_diff.old_to_new_state_names,
                             playthrough_ids_by_state_name))
         else:
-            state_name = (
-                playthrough_issue.issue_customization_args[keyname]['value'])
+            state_name = exp_issue.issue_customization_args[keyname]['value']
 
             # Handle exp issues changes for deleted states.
-            playthrough_issues.unresolved_issues[i_idx] = (
-                _handle_playthrough_issues_after_state_deletion(
-                    state_name, playthrough_issue,
+            exp_issues.unresolved_issues[i_idx] = (
+                _handle_exp_issues_after_state_deletion(
+                    state_name, exp_issue,
                     exp_versions_diff.deleted_state_names))
 
             # Handle exp issues changes for renamed states.
-            playthrough_issues.unresolved_issues[
+            exp_issues.unresolved_issues[
                 i_idx], playthrough_ids_by_state_name = (
-                    _handle_playthrough_issues_after_state_rename(
-                        state_name, playthrough_issue,
+                    _handle_exp_issues_after_state_rename(
+                        state_name, exp_issue,
                         exp_versions_diff.old_to_new_state_names,
                         playthrough_ids_by_state_name))
 
@@ -414,29 +404,28 @@ def update_playthrough_issues_for_new_exp_version(
 
     update_playthroughs_multi(all_playthrough_ids, all_playthroughs)
 
-    playthrough_issues.exp_version += 1
+    exp_issues.exp_version += 1
 
-    create_playthrough_issues_model(playthrough_issues)
+    create_exp_issues_model(exp_issues)
 
 
-def get_playthrough_issues(exp_id, exp_version):
-    """Retrieves the PlaythroughIssues domain object.
+def get_exp_issues(exp_id, exp_version):
+    """Retrieves the ExplorationIssues domain object.
 
     Args:
         exp_id: str. ID of the exploration.
         exp_version: int. Version of the exploration.
 
     Returns:
-        PlaythroughIssues|None: The domain object for exploration issues or
+        ExplorationIssues|None: The domain object for exploration issues or
             None if the exp_id is invalid.
     """
-    playthrough_issues = None
-    playthrough_issues_model = stats_models.PlaythroughIssuesModel.get_model(
+    exp_issues = None
+    exp_issues_model = stats_models.ExplorationIssuesModel.get_model(
         exp_id, exp_version)
-    if playthrough_issues_model is not None:
-        playthrough_issues = (
-            get_playthrough_issues_from_model(playthrough_issues_model))
-    return playthrough_issues
+    if exp_issues_model is not None:
+        exp_issues = get_exp_issues_from_model(exp_issues_model)
+    return exp_issues
 
 
 def get_playthrough_by_id(playthrough_id):
@@ -541,24 +530,24 @@ def get_multiple_exploration_stats_by_version(exp_id, version_numbers):
     return exploration_stats
 
 
-def get_playthrough_issues_from_model(playthrough_issues_model):
-    """Gets an PlaythroughIssues domain object from an PlaythroughIssuesModel
+def get_exp_issues_from_model(exp_issues_model):
+    """Gets an ExplorationIssues domain object from an ExplorationIssuesModel
     instance.
 
     Args:
-        playthrough_issues_model: PlaythroughIssuesModel. Exploration issues
-            model in datastore.
+        exp_issues_model: ExplorationIssuesModel. Exploration issues model in
+            datastore.
 
     Returns:
-        PlaythroughIssues. The domain object for exploration issues.
+        ExplorationIssues. The domain object for exploration issues.
     """
     unresolved_issues = []
-    for unresolved_issue_dict in playthrough_issues_model.unresolved_issues:
+    for unresolved_issue_dict in exp_issues_model.unresolved_issues:
         _migrate_to_latest_issue_schema(copy.deepcopy(unresolved_issue_dict))
         unresolved_issues.append(
-            stats_domain.PlaythroughIssue.from_dict(unresolved_issue_dict))
-    return stats_domain.PlaythroughIssues(
-        playthrough_issues_model.exp_id, playthrough_issues_model.exp_version,
+            stats_domain.ExplorationIssue.from_dict(unresolved_issue_dict))
+    return stats_domain.ExplorationIssues(
+        exp_issues_model.exp_id, exp_issues_model.exp_version,
         unresolved_issues)
 
 
@@ -681,50 +670,48 @@ def save_stats_model_transactional(exploration_stats):
         _save_stats_model, exploration_stats)
 
 
-def create_playthrough_issues_model(playthrough_issues):
-    """Creates a new PlaythroughIssuesModel in the datastore.
+def create_exp_issues_model(exp_issues):
+    """Creates a new ExplorationIssuesModel in the datastore.
 
     Args:
-        playthrough_issues: PlaythroughIssues. The exploration issues domain
+        exp_issues: ExplorationIssues. The exploration issues domain object.
+    """
+    unresolved_issues_dicts = [
+        unresolved_issue.to_dict()
+        for unresolved_issue in exp_issues.unresolved_issues]
+    stats_models.ExplorationIssuesModel.create(
+        exp_issues.exp_id, exp_issues.exp_version, unresolved_issues_dicts)
+
+
+def _save_exp_issues_model(exp_issues):
+    """Updates the ExplorationIssuesModel datastore instance with the passed
+    ExplorationIssues domain object.
+
+    Args:
+        exp_issues: ExplorationIssues. The exploration issues domain
             object.
     """
     unresolved_issues_dicts = [
         unresolved_issue.to_dict()
-        for unresolved_issue in playthrough_issues.unresolved_issues]
-    stats_models.PlaythroughIssuesModel.create(
-        playthrough_issues.exp_id, playthrough_issues.exp_version,
-        unresolved_issues_dicts)
+        for unresolved_issue in exp_issues.unresolved_issues]
+    exp_issues_model = stats_models.ExplorationIssuesModel.get_model(
+        exp_issues.exp_id, exp_issues.exp_version)
+    exp_issues_model.exp_version = exp_issues.exp_version
+    exp_issues_model.unresolved_issues = unresolved_issues_dicts
+
+    exp_issues_model.put()
 
 
-def _save_playthrough_issues_model(playthrough_issues):
-    """Updates the PlaythroughIssuesModel datastore instance with the passed
-    PlaythroughIssues domain object.
-
-    Args:
-        playthrough_issues: PlaythroughIssues. The exploration issues domain
-            object.
-    """
-    unresolved_issues_dicts = [
-        unresolved_issue.to_dict()
-        for unresolved_issue in playthrough_issues.unresolved_issues]
-    playthrough_issues_model = stats_models.PlaythroughIssuesModel.get_model(
-        playthrough_issues.exp_id, playthrough_issues.exp_version)
-    playthrough_issues_model.exp_version = playthrough_issues.exp_version
-    playthrough_issues_model.unresolved_issues = unresolved_issues_dicts
-
-    playthrough_issues_model.put()
-
-
-def save_playthrough_issues_model_transactional(playthrough_issues):
-    """Updates the PlaythroughIssuesModel datastore instance with the passed
-    PlaythroughIssues domain object in a transaction.
+def save_exp_issues_model_transactional(exp_issues):
+    """Updates the ExplorationIssuesModel datastore instance with the passed
+    ExplorationIssues domain object in a transaction.
 
     Args:
-        playthrough_issues: PlaythroughIssues. The exploration issues domain
+        exp_issues: ExplorationIssues. The exploration issues domain
             object.
     """
     transaction_services.run_in_transaction(
-        _save_playthrough_issues_model, playthrough_issues)
+        _save_exp_issues_model, exp_issues)
 
 
 def get_exploration_stats_multi(exp_version_references):

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -61,7 +61,7 @@ ONE_OFF_JOB_MANAGERS = [
     question_jobs_one_off.QuestionMigrationOneOffJob,
     recommendations_jobs_one_off.ExplorationRecommendationsOneOffJob,
     skill_jobs_one_off.SkillMigrationOneOffJob,
-    stats_jobs_one_off.PlaythroughIssuesModelCreatorOneOffJob,
+    stats_jobs_one_off.ExplorationIssuesModelCreatorOneOffJob,
     stats_jobs_one_off.PlaythroughAudit,
     stats_jobs_one_off.RecomputeStatisticsOneOffJob,
     stats_jobs_one_off.RecomputeStatisticsValidationCopyOneOffJob,

--- a/core/storage/statistics/gae_models.py
+++ b/core/storage/statistics/gae_models.py
@@ -978,7 +978,7 @@ class ExplorationStatsModel(base_models.BaseModel):
         cls.put_multi(exploration_stats_models)
 
 
-class PlaythroughIssuesModel(base_models.BaseModel):
+class ExplorationIssuesModel(base_models.BaseModel):
     """Model for storing the list of playthroughs for an exploration grouped by
     issues.
     """
@@ -1001,13 +1001,13 @@ class PlaythroughIssuesModel(base_models.BaseModel):
             exp_version: int. Version of the exploration.
 
         Returns:
-            str. ID of the new PlaythroughIssuesModel instance.
+            str. ID of the new ExplorationIssuesModel instance.
         """
         return '%s.%s' % (exp_id, exp_version)
 
     @classmethod
     def get_model(cls, exp_id, exp_version):
-        """Retrieves PlaythroughIssuesModel given exploration ID and version.
+        """Retrieves ExplorationIssuesModel given exploration ID and version.
 
         Args:
             exp_id: str. ID of the exploration.
@@ -1018,12 +1018,12 @@ class PlaythroughIssuesModel(base_models.BaseModel):
                 datastore.
         """
         instance_id = cls.get_entity_id(exp_id, exp_version)
-        playthrough_issues_model = cls.get(instance_id, strict=False)
-        return playthrough_issues_model
+        exp_issues_model = cls.get(instance_id, strict=False)
+        return exp_issues_model
 
     @classmethod
     def create(cls, exp_id, exp_version, unresolved_issues):
-        """Creates an PlaythroughIssuesModel instance and writes it to the
+        """Creates an ExplorationIssuesModel instance and writes it to the
         datastore.
 
         Args:
@@ -1034,13 +1034,13 @@ class PlaythroughIssuesModel(base_models.BaseModel):
                 represents an issue along with the associated playthroughs.
 
         Returns:
-            str. ID of the new PlaythroughIssuesModel instance.
+            str. ID of the new ExplorationIssuesModel instance.
         """
         instance_id = cls.get_entity_id(exp_id, exp_version)
-        playthrough_issues_instance = cls(
+        exp_issues_instance = cls(
             id=instance_id, exp_id=exp_id, exp_version=exp_version,
             unresolved_issues=unresolved_issues)
-        playthrough_issues_instance.put()
+        exp_issues_instance.put()
         return instance_id
 
 

--- a/core/storage/statistics/gae_models_test.py
+++ b/core/storage/statistics/gae_models_test.py
@@ -229,15 +229,15 @@ class ExplorationStatsModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(stats_models[2].exp_version, 1)
 
 
-class PlaythroughIssuesModelUnitTests(test_utils.GenericTestBase):
-    """Test the PlaythroughIssuesModel class."""
+class ExplorationIssuesModelUnitTests(test_utils.GenericTestBase):
+    """Test the ExplorationIssuesModel class."""
 
-    def test_create_and_get_playthrough_issues_model(self):
+    def test_create_and_get_exp_issues_model(self):
         model_id = (
-            stat_models.PlaythroughIssuesModel.create(
+            stat_models.ExplorationIssuesModel.create(
                 'exp_id1', 1, []))
 
-        model = stat_models.PlaythroughIssuesModel.get(model_id)
+        model = stat_models.ExplorationIssuesModel.get(model_id)
 
         self.assertEqual(model.id, model_id)
         self.assertEqual(model.exp_id, 'exp_id1')

--- a/core/templates/dev/head/domain/statistics/PlaythroughIssueObjectFactory.js
+++ b/core/templates/dev/head/domain/statistics/PlaythroughIssueObjectFactory.js
@@ -27,7 +27,7 @@ oppia.factory('PlaythroughIssueObjectFactory', [function() {
    * @param {number} schemaVersion - schema version of the class instance.
    * @param {boolean} isValid - whether the issue is valid.
    */
-  var PlaythroughIssue = function(
+  var ExplorationIssue = function(
       issueType, issueCustomizationArgs, playthroughIds, schemaVersion,
       isValid) {
     /** @type {string} */
@@ -43,7 +43,7 @@ oppia.factory('PlaythroughIssueObjectFactory', [function() {
   };
 
   /**
-   * @typedef PlaythroughIssueBackendDict
+   * @typedef ExplorationIssueBackendDict
    * @property {string} issueType - type of an issue.
    * @property {Object.<string, *>} issueCustomizationArgs - customization dict
    *   for an issue.
@@ -52,12 +52,12 @@ oppia.factory('PlaythroughIssueObjectFactory', [function() {
    * @property {boolean} isValid - whether the issue is valid.
    */
   /**
-   * @param {PlaythroughIssueBackendDict} explorationIssueBackendDict
-   * @returns {PlaythroughIssue}
+   * @param {ExplorationIssueBackendDict} explorationIssueBackendDict
+   * @returns {ExplorationIssue}
    */
-  PlaythroughIssue.createFromBackendDict = function(
+  ExplorationIssue.createFromBackendDict = function(
       explorationIssueBackendDict) {
-    return new PlaythroughIssue(
+    return new ExplorationIssue(
       explorationIssueBackendDict.issue_type,
       explorationIssueBackendDict.issue_customization_args,
       explorationIssueBackendDict.playthrough_ids,
@@ -66,9 +66,9 @@ oppia.factory('PlaythroughIssueObjectFactory', [function() {
   };
 
   /**
-   * @returns {PlaythroughIssueBackendDict}
+   * @returns {ExplorationIssueBackendDict}
    */
-  PlaythroughIssue.prototype.toBackendDict = function() {
+  ExplorationIssue.prototype.toBackendDict = function() {
     return {
       issue_type: this.issueType,
       issue_customization_args: this.issueCustomizationArgs,
@@ -78,5 +78,5 @@ oppia.factory('PlaythroughIssueObjectFactory', [function() {
     };
   };
 
-  return PlaythroughIssue;
+  return ExplorationIssue;
 }]);

--- a/core/templates/dev/head/services/PlaythroughIssuesBackendApiService.js
+++ b/core/templates/dev/head/services/PlaythroughIssuesBackendApiService.js
@@ -77,7 +77,7 @@ oppia.factory('PlaythroughIssuesBackendApiService', [
       },
       resolveIssue: function(issue, expId, expVersion) {
         $http.post(getFullResolveIssueUrl(expId), {
-          playthrough_issue_dict: issue.toBackendDict(),
+          exp_issue_dict: issue.toBackendDict(),
           exp_version: expVersion
         });
       },

--- a/core/tests/protractor_desktop/explorationStatisticsTab.js
+++ b/core/tests/protractor_desktop/explorationStatisticsTab.js
@@ -60,11 +60,11 @@ describe('Issues visualization', function() {
     adminPage = new AdminPage.AdminPage();
 
     users.createUser(
-      'user2@PlaythroughIssues.com',
-      'learnerPlaythroughIssues');
+      'user2@ExplorationIssues.com',
+      'learnerExplorationIssues');
     users.createAndLoginAdminUser(
-      'user1@PlaythroughIssues.com',
-      'authorPlaythroughIssues');
+      'user1@ExplorationIssues.com',
+      'authorExplorationIssues');
 
     workflow.createExplorationAsAdmin();
     explorationEditorMainTab.exitTutorial();
@@ -133,7 +133,7 @@ describe('Issues visualization', function() {
   });
 
   it('records early quit issue.', function() {
-    users.login('user2@PlaythroughIssues.com');
+    users.login('user2@ExplorationIssues.com');
     libraryPage.get();
     libraryPage.findExploration(EXPLORATION_TITLE);
     libraryPage.playExploration(EXPLORATION_TITLE);
@@ -146,7 +146,7 @@ describe('Issues visualization', function() {
     general.acceptAlert();
     users.logout();
 
-    users.login('user1@PlaythroughIssues.com');
+    users.login('user1@ExplorationIssues.com');
     libraryPage.get();
     libraryPage.findExploration(EXPLORATION_TITLE);
     libraryPage.playExploration(EXPLORATION_TITLE);
@@ -161,7 +161,7 @@ describe('Issues visualization', function() {
   });
 
   it('records multiple incorrect issue.', function() {
-    users.login('user2@PlaythroughIssues.com');
+    users.login('user2@ExplorationIssues.com');
     libraryPage.get();
     libraryPage.findExploration(EXPLORATION_TITLE);
     libraryPage.playExploration(EXPLORATION_TITLE);
@@ -181,7 +181,7 @@ describe('Issues visualization', function() {
     general.acceptAlert();
     users.logout();
 
-    users.login('user1@PlaythroughIssues.com');
+    users.login('user1@ExplorationIssues.com');
     creatorDashboardPage.get();
     creatorDashboardPage.editExploration(EXPLORATION_TITLE);
     explorationEditorPage.navigateToStatsTab();
@@ -194,7 +194,7 @@ describe('Issues visualization', function() {
   });
 
   it('records cyclic transitions issue.', function() {
-    users.login('user2@PlaythroughIssues.com');
+    users.login('user2@ExplorationIssues.com');
     libraryPage.get();
     libraryPage.findExploration(EXPLORATION_TITLE);
     libraryPage.playExploration(EXPLORATION_TITLE);
@@ -231,7 +231,7 @@ describe('Issues visualization', function() {
     general.acceptAlert();
     users.logout();
 
-    users.login('user1@PlaythroughIssues.com');
+    users.login('user1@ExplorationIssues.com');
     libraryPage.get();
     libraryPage.findExploration(EXPLORATION_TITLE);
     libraryPage.playExploration(EXPLORATION_TITLE);

--- a/extensions/issues/CyclicStateTransitions/CyclicStateTransitions.py
+++ b/extensions/issues/CyclicStateTransitions/CyclicStateTransitions.py
@@ -19,7 +19,7 @@
 from extensions.issues import base
 
 
-class CyclicStateTransitions(base.BasePlaythroughIssueSpec):
+class CyclicStateTransitions(base.BaseExplorationIssueSpec):
     """Issue that's recorded when the learner transitions between states in a
     cyclic manner multiple times.
     """

--- a/extensions/issues/EarlyQuit/EarlyQuit.py
+++ b/extensions/issues/EarlyQuit/EarlyQuit.py
@@ -19,7 +19,7 @@
 from extensions.issues import base
 
 
-class EarlyQuit(base.BasePlaythroughIssueSpec):
+class EarlyQuit(base.BaseExplorationIssueSpec):
     """Issue that's recorded when the learner quits the exploration early."""
 
     _customization_arg_specs = [{

--- a/extensions/issues/MultipleIncorrectSubmissions/MultipleIncorrectSubmissions.py
+++ b/extensions/issues/MultipleIncorrectSubmissions/MultipleIncorrectSubmissions.py
@@ -19,7 +19,7 @@
 from extensions.issues import base
 
 
-class MultipleIncorrectSubmissions(base.BasePlaythroughIssueSpec):
+class MultipleIncorrectSubmissions(base.BaseExplorationIssueSpec):
     """Issue that's recorded when the learner answers multiple times incorrectly
     in the same card and quits the exploration.
     """

--- a/extensions/issues/base.py
+++ b/extensions/issues/base.py
@@ -19,7 +19,7 @@
 from extensions import domain
 
 
-class BasePlaythroughIssueSpec(object):
+class BaseExplorationIssueSpec(object):
     """Base issue definition class.
 
     This class is not meant to be user-editable. The only methods in it should


### PR DESCRIPTION
Reverts oppia/oppia#6198

There needs to be a one-off job to migrate off of ExplorationIssuesModel first before we can use this PR.