### PR TITLE
Fix part of #5134: 100% coverage for core.storage.classifer.gae_models

### DIFF
--- a/core/storage/classifier/gae_models_test.py
+++ b/core/storage/classifier/gae_models_test.py
@@ -177,12 +177,18 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(training_job2.classifier_data, None)
         self.assertEqual(training_job2.data_schema_version, 1)
 
-    def test_ID_collision_exception(self):
-        base_model_initial_retries = base_models.MAX_RETRIES
-        base_models.MAX_RETRIES = 0
-        with self.assertRaisesRegexp(Exception, ('The id generator for ClassifierTrainingJobModel is producing too many collisions.')):
-            classifier_models.ClassifierTrainingJobModel._generate_id(1)
-        base_models.MAX_RETRIES = base_model_initial_retries
+
+    def test_id_collisions_exception(self):
+        next_scheduled_check_time = datetime.datetime.utcnow()
+        with self.swap(base_models, 'MAX_RETRIES', 0):
+            with self.assertRaisesRegexp(Exception, (
+                'The id generator for ClassifierTrainingJobModel '
+                'is producing too many collisions.')):
+                classifier_models.ClassifierTrainingJobModel.create(
+                    'TextClassifier', 'TextInput', 'exp_id1', 1,
+                    next_scheduled_check_time,
+                    [{'answer_group_index': 1, 'answers': ['a1', 'a2']}],
+                    'state_name2', feconf.TRAINING_JOB_STATUS_NEW, None, 1)
 
 
 

--- a/core/storage/classifier/gae_models_test.py
+++ b/core/storage/classifier/gae_models_test.py
@@ -23,8 +23,8 @@ from core.platform import models
 from core.tests import test_utils
 import feconf
 
-(classifier_models,) = models.Registry.import_models(
-    [models.NAMES.classifier])
+(classifier_models, base_models) = models.Registry.import_models(
+    [models.NAMES.classifier, models.NAMES.base_model])
 
 
 class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
@@ -176,6 +176,17 @@ class ClassifierTrainingJobModelUnitTests(test_utils.GenericTestBase):
             feconf.TRAINING_JOB_STATUS_NEW)
         self.assertEqual(training_job2.classifier_data, None)
         self.assertEqual(training_job2.data_schema_version, 1)
+
+    def test_ID_collision_exception(self):
+        base_model_initial_retries = base_models.MAX_RETRIES
+        base_models.MAX_RETRIES = 0
+        with self.assertRaisesRegexp(Exception, ('The id generator for ClassifierTrainingJobModel is producing too many collisions.')):
+            classifier_models.ClassifierTrainingJobModel._generate_id(1)
+        base_models.MAX_RETRIES = base_model_initial_retries
+
+
+
+
 
 
 class TrainingJobExplorationMappingModelUnitTests(test_utils.GenericTestBase):


### PR DESCRIPTION
## Explanation
Fixes part of  #5134 . 100% coverage for core.storage.classifer.gae_models


## Checklist
- [x] The PR title starts with "Fix #5666 : ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
