### PR TITLE
Fixes #6244: Fixing the cancel button in hint editor

### DIFF
--- a/core/templates/dev/head/components/HintEditorDirective.js
+++ b/core/templates/dev/head/components/HintEditorDirective.js
@@ -65,7 +65,8 @@ oppia.directive('hintEditor', [
           };
 
           $scope.cancelThisHintEdit = function() {
-            $scope.hint = angular.copy($scope.hintMemento);
+            $scope.hint.hintContent._html =
+              $scope.hintMemento.hintContent._html;
             $scope.hintMemento = null;
             $scope.hintEditorIsOpen = false;
           };

--- a/core/templates/dev/head/components/HintEditorDirective.js
+++ b/core/templates/dev/head/components/HintEditorDirective.js
@@ -65,8 +65,8 @@ oppia.directive('hintEditor', [
           };
 
           $scope.cancelThisHintEdit = function() {
-            $scope.hint.hintContent._html =
-              $scope.hintMemento.hintContent._html;
+            $scope.hint.hintContent =
+              angular.copy($scope.hintMemento.hintContent);
             $scope.hintMemento = null;
             $scope.hintEditorIsOpen = false;
           };


### PR DESCRIPTION
Fixes #6244: Fixing the cancel button in hint editor. Earlier due to line `$scope.hint = angular.copy($scope.hintMemento);` in `HintEditorDirective.js` the two way binding between `hint` in `HintEditorDirective.js` and `StateHintsEditorDirective.js` was destroyed. Hence changes made in `hint` of `HintEditorDirective.js` were not seen in  `StateHintsEditorDirective.js`.
 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
