### PR TITLE
Fix #6219: Stay anonymous aligned correctly with respect to the checkbox

### DIFF
--- a/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
@@ -6,6 +6,12 @@
     resize: none;
     width: 200px;
   }
+  .checkbox {
+    font-size: 0.9em;
+    margin: 12px 0 4px 0;
+    line-height: 1.725;
+}
+
 </style>
 <div style="min-width: 200px;">
   <div ng-show="!feedbackSubmitted">
@@ -27,7 +33,7 @@
                ng-disabled="!feedbackText"
                translate="I18N_PLAYER_SUBMIT_BUTTON">
     </md-button>
-    <div class="checkbox" style="font-size: 0.9em; margin: 12px 0 4px 0;" ng-show="isLoggedIn">
+    <div class="checkbox" ng-show="isLoggedIn">
       <label>
         <input type="checkbox" ng-model="isSubmitterAnonymized">
         <span translate="I18N_PLAYER_STAY_ANONYMOUS"></span>

--- a/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
@@ -6,11 +6,13 @@
     resize: none;
     width: 200px;
   }
-  .oppia-popover-checkbox {
+  .checkbox {
     font-size: 0.9em;
-    line-height: 1.825;
     margin: 12px 0 4px 0;
 }
+  .oppia-align-checkbox {
+    line-height: 1.745;
+  }
 </style>
 <div style="min-width: 200px;">
   <div ng-show="!feedbackSubmitted">
@@ -32,7 +34,7 @@
                ng-disabled="!feedbackText"
                translate="I18N_PLAYER_SUBMIT_BUTTON">
     </md-button>
-    <div class="oppia-popover-checkbox" ng-show="isLoggedIn">
+    <div class="checkbox oppia-align-checkbox" ng-show="isLoggedIn">
       <label>
         <input type="checkbox" ng-model="isSubmitterAnonymized">
         <span translate="I18N_PLAYER_STAY_ANONYMOUS"></span>

--- a/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
@@ -11,7 +11,6 @@
     line-height: 1.725;
     margin: 12px 0 4px 0;
 }
-
 </style>
 <div style="min-width: 200px;">
   <div ng-show="!feedbackSubmitted">

--- a/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
@@ -6,10 +6,10 @@
     resize: none;
     width: 200px;
   }
-  .checkbox {
+  .oppia-stay-anonymous-checkbox {
     font-size: 0.9em;
-    margin: 12px 0 4px 0;
     line-height: 1.725;
+    margin: 12px 0 4px 0;
 }
 
 </style>
@@ -35,7 +35,7 @@
     </md-button>
     <div class="checkbox" ng-show="isLoggedIn">
       <label>
-        <input type="checkbox" ng-model="isSubmitterAnonymized">
+        <input type="oppia-stay-anonymous-checkbox" ng-model="isSubmitterAnonymized">
         <span translate="I18N_PLAYER_STAY_ANONYMOUS"></span>
       </label>
     </div>

--- a/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
@@ -6,9 +6,9 @@
     resize: none;
     width: 200px;
   }
-  .oppia-stay-anonymous-checkbox {
+  .oppia-popover-checkbox {
     font-size: 0.9em;
-    line-height: 1.725;
+    line-height: 1.825;
     margin: 12px 0 4px 0;
 }
 </style>
@@ -32,9 +32,9 @@
                ng-disabled="!feedbackText"
                translate="I18N_PLAYER_SUBMIT_BUTTON">
     </md-button>
-    <div class="checkbox" ng-show="isLoggedIn">
+    <div class="oppia-popover-checkbox" ng-show="isLoggedIn">
       <label>
-        <input type="oppia-stay-anonymous-checkbox" ng-model="isSubmitterAnonymized">
+        <input type="checkbox" ng-model="isSubmitterAnonymized">
         <span translate="I18N_PLAYER_STAY_ANONYMOUS"></span>
       </label>
     </div>

--- a/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/feedback_popup_directive.html
@@ -9,7 +9,7 @@
   .checkbox {
     font-size: 0.9em;
     margin: 12px 0 4px 0;
-}
+  }
   .oppia-align-checkbox {
     line-height: 1.745;
   }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
This PR fixes #6219 by resolving the alignment of stay anonymous with respect to checkbox. A minor tweak is made in height of the text "Stay Anonymous".

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
