### PR TITLE
Fix #6262 The help tooltip text is now fully visible.

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/editor_navigation_directive.html
@@ -120,6 +120,12 @@
     max-width: 200px;
     text-align: center;
   }
+  .popover-content {
+    position: relative;
+    font-size: 14px;
+    max-width: 150px;
+    text-align: center;
+  }
   .oppia-help-dropdown .uib-popover.bottom > .arrow {
     border-bottom-color: #000;
   }


### PR DESCRIPTION
Fix #6262
Redefined .popover-content class with relative position and assigned a fixed width to the tooltip box. 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
