### PR TITLE
Update deployment script to check for indexes in advance.

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -54,6 +54,16 @@ def open_new_tab_in_browser_if_possible(url):
         if subprocess.call(['which', cmd]) == 0:
             subprocess.call([cmd, url])
             return
+    print '******************************************************************'
+    print 'WARNING: Unable to open browser. Please manually open the following '
+    print 'URL in a browser window, then press Enter to confirm.'
+    print ''
+    print '    %s' % url
+    print ''
+    print 'NOTE: To get rid of this message, open scripts/common.py and fix'
+    print 'the function open_new_tab_in_browser_if_possible() to work on your'
+    print 'system.'
+    raw_input()
 
 
 def get_remote_alias(remote_url):

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -95,6 +95,7 @@ APPCFG_PATH = os.path.join(
     'appcfg.py')
 
 LOG_FILE_PATH = os.path.join('..', 'deploy.log')
+INDEX_YAML_PATH = os.path.join('.', 'index.yaml')
 THIRD_PARTY_DIR = os.path.join('.', 'third_party')
 DEPLOY_DATA_PATH = os.path.join(
     os.getcwd(), os.pardir, 'release-scripts', 'deploy_data', APP_NAME)
@@ -261,9 +262,32 @@ def _execute_deployment():
         if build_process.returncode > 0:
             raise Exception('Build failed.')
 
+        # Update indexes, then prompt for a check that they are all serving
+        # before continuing with the deployment.
+        assert os.path.isfile(INDEX_YAML_PATH)
+        subprocess.check_output([
+            common.GCLOUD_PATH, '--quiet', 'datastore', 'indexes', 'create',
+            INDEX_YAML_PATH, '--project=%s' % APP_NAME])
+        datastore_indexes_url = (
+            'https://console.cloud.google.com/datastore/indexes?project=%s' %
+            APP_NAME)
+        common.open_new_tab_in_browser_if_possible(datastore_indexes_url)
+        while True:
+            print '******************************************************'
+            print (
+                'PLEASE CONFIRM: are all datastore indexes serving? See %s '
+                '(y/n)' % datastore_indexes_url)
+            answer = raw_input().lower()
+            if answer in ['y', 'ye', 'yes']:
+                break
+            elif answer:
+                raise Exception(
+                    'Please wait for all indexes to serve, then run this '
+                    'script again to complete the deployment. Exiting.')
+
         # Deploy export service to GAE.
         subprocess.check_output([
-            common.GCLOUD_PATH, 'app', 'deploy', 'export/app.yaml',
+            common.GCLOUD_PATH, '--quiet', 'app', 'deploy', 'export/app.yaml',
             '--project=%s' % APP_NAME])
 
         # Deploy app to GAE.
@@ -285,11 +309,11 @@ def _execute_deployment():
     if (APP_NAME == APP_NAME_OPPIATESTSERVER or 'migration' in APP_NAME) and (
             _get_served_version() == _get_current_release_version()):
         common.open_new_tab_in_browser_if_possible(
+            'https://%s.appspot.com/library' % APP_NAME_OPPIATESTSERVER)
+        common.open_new_tab_in_browser_if_possible(
             'https://console.cloud.google.com/logs/viewer?'
             'project=%s&key1=default&minLogLevel=500'
             % APP_NAME_OPPIATESTSERVER)
-        common.open_new_tab_in_browser_if_possible(
-            'https://%s.appspot.com/library' % APP_NAME_OPPIATESTSERVER)
 
     print 'Done!'
 


### PR DESCRIPTION
## Explanation

Update deployment script to automatically check that datastore indexes are serving before proceeding with the rest of the update.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.