### PR TITLE
Add a script for updating indexes. Move gcloud functions into a separate module.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,3 @@
-application: oppiaserver
-version: default
 runtime: python27
 api_version: 1
 threadsafe: false

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -17,9 +17,7 @@
 import os
 import subprocess
 
-GCLOUD_PATH = os.path.join(
-    '..', 'oppia_tools', 'google-cloud-sdk-222.0.0', 'google-cloud-sdk',
-    'bin', 'gcloud')
+RELEASE_BRANCH_NAME_PREFIX = 'release-'
 
 
 def ensure_directory_exists(d):
@@ -106,6 +104,16 @@ def get_current_branch_name():
     return git_status_first_line[len(branch_message_prefix):]
 
 
+def is_current_branch_a_release_branch():
+    """Returns whether the current branch is a release branch.
+
+    Returns:
+        bool. Whether the current branch is a release branch.
+    """
+    current_branch_name = get_current_branch_name()
+    return current_branch_name.startswith(RELEASE_BRANCH_NAME_PREFIX)
+
+
 def verify_current_branch_name(expected_branch_name):
     """Checks that the user is on the expected branch."""
     if get_current_branch_name() != expected_branch_name:
@@ -147,16 +155,6 @@ def ensure_release_scripts_folder_exists_and_is_up_to_date():
         remote_alias = get_remote_alias(
             'git@github.com:oppia/release-scripts.git')
         subprocess.call(['git', 'pull', remote_alias])
-
-
-def require_gcloud_to_be_available():
-    """Check whether gcloud is installed while undergoing deployment process."""
-    try:
-        subprocess.check_output([GCLOUD_PATH, '--version'])
-    except Exception:
-        raise Exception(
-            'gcloud required, but could not be found. Please run '
-            'scripts/start.sh to install gcloud.')
 
 
 class CD(object):

--- a/scripts/cut_release_branch.py
+++ b/scripts/cut_release_branch.py
@@ -66,8 +66,6 @@ else:
 
 # Construct the new branch name.
 NEW_BRANCH_NAME = 'release-%s' % TARGET_VERSION
-NEW_APP_YAML_VERSION = TARGET_VERSION.replace('.', '-')
-assert '.' not in NEW_APP_YAML_VERSION
 
 
 def _verify_target_branch_does_not_already_exist(remote_alias):
@@ -145,11 +143,8 @@ def _verify_target_version_is_consistent_with_latest_released_version():
 
 
 def _execute_branch_cut():
-    """Pushes the new release branch to Github.
+    """Pushes the new release branch to Github."""
 
-    Raises:
-         AssertionError: 'version: default' was not found in app.yaml.
-    """
     # Do prerequisite checks.
     common.require_cwd_to_be_oppia()
     common.verify_local_repo_is_clean()

--- a/scripts/cut_release_branch.py
+++ b/scripts/cut_release_branch.py
@@ -25,7 +25,6 @@ where x.y.z is the new version of Oppia, e.g. 2.5.3.
 
 import argparse
 import json
-import os
 import re
 import subprocess
 import sys
@@ -182,24 +181,6 @@ def _execute_branch_cut():
     # Cut a new release branch.
     print 'Cutting a new release branch: %s' % NEW_BRANCH_NAME
     subprocess.call(['git', 'checkout', '-b', NEW_BRANCH_NAME])
-
-    # Update the version in app.yaml.
-    print 'Updating the version number in app.yaml ...'
-    with open('app.yaml', 'r') as f:
-        content = f.read()
-        assert content.count('version: default') == 1
-    os.remove('app.yaml')
-    content = content.replace(
-        'version: default', 'version: %s' % NEW_APP_YAML_VERSION)
-    with open('app.yaml', 'w+') as f:
-        f.write(content)
-    print 'Version number updated.'
-
-    # Make a commit.
-    print 'Committing the change.'
-    subprocess.call([
-        'git', 'commit', '-a', '-m',
-        '"Update version number to %s"' % TARGET_VERSION])
 
     # Push the new release branch to GitHub.
     print 'Pushing new release branch to GitHub.'

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -20,26 +20,14 @@ the uploaded files to a deployment folder in the parent directory of the oppia/
 folder. It then pushes this build to the production server.
 
 IMPORTANT NOTES:
-1.  You will need to first create a folder called ../deploy_data/[APP_NAME],
-    where [APP_NAME] is the name of your app as defined in app.yaml. This
-    folder should contain a folder called /images, which in turn should
-    contain:
-    - four folders: /avatar, /general, /logo and /sidebar, containing
-        images used for the avatar, general-purpose usage, logo and sidebar,
-        respectively.
-    The folder should also contain:
-    - favicon.ico and robots.txt.
-    - one folder images/general which contains:
-        - warning.png
-
-2.  Before running this script, you must install third-party dependencies by
+1.  Before running this script, you must install third-party dependencies by
     running
 
         bash scripts/start.sh
 
     at least once.
 
-3.  This script should be run from the oppia root folder:
+2.  This script should be run from the oppia root folder:
 
         python scripts/deploy.py --app_name=[APP_NAME]
 
@@ -110,18 +98,9 @@ def preprocess_release():
     This function should be called from within RELEASE_DIR_NAME. Currently it
     does the following:
 
-    (1) Changes the app name in app.yaml to APP_NAME.
-    (2) Substitutes files from the per-app deployment data.
-    (3) Change the DEV_MODE constant in assets/constants.js.
+    (1) Substitutes files from the per-app deployment data.
+    (2) Change the DEV_MODE constant in assets/constants.js.
     """
-    # Change the app name in app.yaml.
-    with open('app.yaml', 'r') as app_yaml_file:
-        content = app_yaml_file.read()
-    os.remove('app.yaml')
-    content = content.replace('oppiaserver', APP_NAME)
-    with open('app.yaml', 'w+') as new_app_yaml_file:
-        new_app_yaml_file.write(content)
-
     if not os.path.exists(DEPLOY_DATA_PATH):
         raise Exception(
             'Could not find deploy_data directory at %s' % DEPLOY_DATA_PATH)

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -54,6 +54,8 @@ import gcloud_adapter  # pylint: disable=relative-import
 _PARSER = argparse.ArgumentParser()
 _PARSER.add_argument(
     '--app_name', help='name of the app to deploy to', type=str)
+_PARSER.add_argument(
+    '--version', help='version to deploy', type=str)
 
 APP_NAME_OPPIASERVER = 'oppiaserver'
 APP_NAME_OPPIATESTSERVER = 'oppiatestserver'
@@ -65,6 +67,10 @@ if PARSED_ARGS.app_name:
             APP_NAME_OPPIASERVER, APP_NAME_OPPIATESTSERVER] and (
                 'migration' not in APP_NAME):
         raise Exception('Invalid app name: %s' % APP_NAME)
+    if PARSED_ARGS.version and APP_NAME == APP_NAME_OPPIASERVER:
+        raise Exception('Cannot use custom version with production app.')
+    # Note that CUSTOM_VERSION may be None.
+    CUSTOM_VERSION = PARSED_ARGS.version
 else:
     raise Exception('No app name specified.')
 
@@ -240,7 +246,8 @@ def _execute_deployment():
         gcloud_adapter.deploy_application('export/app.yaml', APP_NAME)
         # Deploy app to GAE.
         gcloud_adapter.deploy_application(
-            './app.yaml', APP_NAME, version=current_release_version)
+            './app.yaml', APP_NAME, version=(
+                CUSTOM_VERSION if CUSTOM_VERSION else current_release_version))
 
         # Writing log entry.
         common.ensure_directory_exists(os.path.dirname(LOG_FILE_PATH))

--- a/scripts/gcloud_adapter.py
+++ b/scripts/gcloud_adapter.py
@@ -75,6 +75,7 @@ def deploy_application(app_yaml_path, app_name, version=None):
     """
     args = [
         GCLOUD_PATH, '--quiet', 'app', 'deploy', app_yaml_path,
+        '--no-promote', '--no-stop-previous-version',
         '--project=%s' % app_name]
     if version is not None:
         args.append('--version=%s' % version)

--- a/scripts/gcloud_adapter.py
+++ b/scripts/gcloud_adapter.py
@@ -1,0 +1,77 @@
+# Copyright 2019 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module with GCloud-related functions."""
+
+import os
+import subprocess
+
+GCLOUD_PATH = os.path.join(
+    '..', 'oppia_tools', 'google-cloud-sdk-222.0.0', 'google-cloud-sdk',
+    'bin', 'gcloud')
+
+
+def require_gcloud_to_be_available():
+    """Check whether gcloud is installed while undergoing deployment process."""
+    try:
+        subprocess.check_output([GCLOUD_PATH, '--version'])
+    except Exception:
+        raise Exception(
+            'gcloud required, but could not be found. Please run '
+            'scripts/start.sh to install gcloud.')
+
+
+def update_indexes(index_yaml_path, app_name):
+    """Update indexes on the production server.
+
+    Args:
+        index_yaml_path: str. The path to the index.yaml file.
+        app_name: str. The name of the GCloud project.
+    """
+    assert os.path.isfile(index_yaml_path)
+    subprocess.check_output([
+        GCLOUD_PATH, '--quiet', 'datastore', 'indexes', 'create',
+        index_yaml_path, '--project=%s' % app_name])
+
+
+def get_currently_served_version(app_name):
+    """Retrieves the default version being served on the specified App Engine
+    application.
+
+    Args:
+        app_name: str. The name of the GCloud project.
+
+    Returns:
+        str: The current serving version.
+    """
+    listed_versions = subprocess.check_output([
+        GCLOUD_PATH, 'app', 'versions', 'list', '--hide-no-traffic',
+        '--service=default', '--project=%s' % app_name])
+    default_version_line_start_str = 'default  '
+    listed_versions = listed_versions[
+        listed_versions.index(default_version_line_start_str) + len(
+            default_version_line_start_str):]
+    return listed_versions[:listed_versions.index(' ')]
+
+
+def deploy_application(app_yaml_path, app_name):
+    """Deploys the service corresponding to the given app.yaml path to GAE.
+
+    Args:
+        app_yaml_path: str. The path to the app.yaml file.
+        app_name: str. The name of the GCloud project.
+    """
+    subprocess.check_output([
+        GCLOUD_PATH, '--quiet', 'app', 'deploy', app_yaml_path,
+        '--project=%s' % app_name])

--- a/scripts/gcloud_adapter.py
+++ b/scripts/gcloud_adapter.py
@@ -65,13 +65,17 @@ def get_currently_served_version(app_name):
     return listed_versions[:listed_versions.index(' ')]
 
 
-def deploy_application(app_yaml_path, app_name):
+def deploy_application(app_yaml_path, app_name, version=None):
     """Deploys the service corresponding to the given app.yaml path to GAE.
 
     Args:
         app_yaml_path: str. The path to the app.yaml file.
         app_name: str. The name of the GCloud project.
+        version: str or None. If provided, the version to use.
     """
-    subprocess.check_output([
+    args = [
         GCLOUD_PATH, '--quiet', 'app', 'deploy', app_yaml_path,
-        '--project=%s' % app_name])
+        '--project=%s' % app_name]
+    if version is not None:
+        args.append('--version=%s' % version)
+    subprocess.check_output(args)

--- a/scripts/update_indexes.py
+++ b/scripts/update_indexes.py
@@ -1,0 +1,59 @@
+# Copyright 2019 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper script used for updating indexes.
+
+ONLY RELEASE COORDINATORS SHOULD USE THIS SCRIPT.
+
+Usage: Run this script from your oppia root folder:
+
+    python scripts/update_indexes.py
+"""
+
+import argparse
+import os
+
+import common  # pylint: disable=relative-import
+import gcloud_adapter  # pylint: disable=relative-import
+
+_PARSER = argparse.ArgumentParser()
+_PARSER.add_argument(
+    '--app_name', help='name of the app whose indexes should be updated',
+    type=str)
+
+PARSED_ARGS = _PARSER.parse_args()
+if PARSED_ARGS.app_name:
+    APP_NAME = PARSED_ARGS.app_name
+else:
+    raise Exception('No app name specified.')
+
+INDEX_YAML_PATH = os.path.join('.', 'index.yaml')
+
+
+def _update_indexes():
+    """Updates production indexes after doing the prerequisite checks."""
+
+    # Do prerequisite checks.
+    common.require_cwd_to_be_oppia()
+    gcloud_adapter.require_gcloud_to_be_available()
+    if not common.is_current_branch_a_release_branch():
+        raise Exception(
+            'Indexes should only be updated from a release branch.')
+
+    # Update the indexes.
+    gcloud_adapter.update_indexes(INDEX_YAML_PATH, APP_NAME)
+
+
+if __name__ == '__main__':
+    _update_indexes()

--- a/scripts/update_indexes.py
+++ b/scripts/update_indexes.py
@@ -16,9 +16,7 @@
 
 ONLY RELEASE COORDINATORS SHOULD USE THIS SCRIPT.
 
-Usage: Run this script from your oppia root folder:
-
-    python scripts/update_indexes.py
+Make sure to run this script from the oppia/ root folder:
 """
 
 import argparse


### PR DESCRIPTION
This PR:
- Adds a script for updating indexes.
- Moves gcloud functions into a separate module.
- Uses gcloud throughout (removes usage of appcfg). Note that this requires removing the application and version fields from app.yaml.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.