### PR TITLE
Correct comment string in UserSubscriptionsModel

### DIFF
--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -291,7 +291,7 @@ class UserSubscriptionsModel(base_models.BaseModel):
     # IDs of feedback thread ids that this user subscribes to.
     general_feedback_thread_ids = ndb.StringProperty(
         repeated=True, indexed=True)
-    # IDs of the learners who have subscribed to this user.
+    # IDs of the creators to whom this learner has subscribed.
     creator_ids = ndb.StringProperty(repeated=True, indexed=True)
     # When the user last checked notifications. May be None.
     last_checked = ndb.DateTimeProperty(default=None)


### PR DESCRIPTION
The original string seemed backwards based on how this is used. See:

https://github.com/oppia/oppia/blob/0d676f9c73d16639b05273e61be683e19fd604e2/core/domain/subscription_services.py#L146

It appears that this field, as expected, is actually storing the IDs of creators this user is subscribed to.