### PR TITLE
Fix #6301 , Fix Dev mode showing up on page load

### DIFF
--- a/core/templates/dev/head/pages/base.html
+++ b/core/templates/dev/head/pages/base.html
@@ -18,6 +18,8 @@
     <div ng-show="loadingMessage" class="oppia-loading-fullpage">
       <div class="oppia-align-center">
         <span translate="<[loadingMessage]>"></span>
+You’re editing a file in a project you don’t have write access to. Submitting a change to this file will write it to a new branch in your fork amey-kudari/oppia, so you can send a pull request.
+
         <span class="oppia-loading-dot-one">.</span>
         <span class="oppia-loading-dot-two">.</span>
         <span class="oppia-loading-dot-three">.</span>
@@ -89,6 +91,12 @@
         userIsLoggedIn: JSON.parse('{{user_is_logged_in|js_string}}')
       };
     </script>
+    
+    <style>
+      [ng\:cloak], [ng-cloak], [data-ng-cloak], [x-ng-cloak], .ng-cloak, .x-ng-cloak{
+        display: none !important;
+      }
+    </style>
 
     {% block header_js %}
       {% include 'pages/header_js_libs.html' %}
@@ -155,7 +163,7 @@
         </div>
       </div>
 
-      <div ng-if="DEV_MODE" class="oppia-dev-mode">
+      <div ng-if="DEV_MODE" class="oppia-dev-mode ng-cloak">
         Dev Mode
       </div>
 


### PR DESCRIPTION


<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
fix #6301  
The problem, I think was that the rest of angular was not loaded yet, so the browser does not known what "ng-if" is. So I used ngCloak directive to prevent the base.html from being showed up in its raw form, This fixes #6301  

Note: I tried figuring out a way to run it without using !important, and the only way I found was to use ngBind. Alternatively, I suggest we can load the angular.js script inside the head tag. (i did not do it, as I di not  know if we has to follow the usual format, of placing all script lags/links on bottom of page)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
