### PR TITLE
Fixes #6316: Remove unnecessary scripts import from base.html

### DIFF
--- a/core/templates/dev/head/pages/base.html
+++ b/core/templates/dev/head/pages/base.html
@@ -206,12 +206,6 @@
     <script src="/templates/dev/head/components/social_buttons/SocialButtonsDirective.js"></script>
     <script src="/templates/dev/head/components/top_navigation_bar/TopNavigationBarDirective.js"></script>
 
-    <script src="/templates/dev/head/components/CollectionCreationService.js"></script>
-    <script src="/templates/dev/head/components/ExplorationCreationService.js"></script>
-    <script src="/templates/dev/head/components/TopicCreationService.js"></script>
-    <script src="/templates/dev/head/components/SkillCreationService.js"></script>
-    <script src="/templates/dev/head/components/StoryCreationService.js"></script>
-
     <script src="/templates/dev/head/components/CkEditorRteDirective.js"></script>
     <script src="/templates/dev/head/domain/sidebar/SidebarStatusService.js"></script>
     <script src="/templates/dev/head/domain/user/UserInfoObjectFactory.js"></script>

--- a/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
+++ b/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
@@ -948,6 +948,8 @@
   <script src="/templates/dev/head/services/StateTopAnswersStatsService.js"></script>
   <script src="/templates/dev/head/services/AutoplayedVideosService.js"></script>
 
+  <script src="/templates/dev/head/components/CollectionCreationService.js"></script>
+  <script src="/templates/dev/head/components/ExplorationCreationService.js"></script>
   <script src="/templates/dev/head/components/loading/LoadingDotsDirective.js"></script>
   <script src="/templates/dev/head/components/QuestionCreationService.js"></script>
   <script src="/templates/dev/head/services/AutoplayedVideosService.js"></script>

--- a/core/templates/dev/head/pages/topic_editor/topic_editor.html
+++ b/core/templates/dev/head/pages/topic_editor/topic_editor.html
@@ -47,6 +47,7 @@
   <script src="/templates/dev/head/mathjaxConfig.js"></script>
   <script src="/third_party/static/MathJax-2.6.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
+  <script src="/templates/dev/head/components/StoryCreationService.js"></script>
   <script src="/templates/dev/head/components/forms/FormBuilder.js"></script>
   <script src="/templates/dev/head/components/forms/schema_editors/SchemaBasedBoolEditorDirective.js"></script>
   <script src="/templates/dev/head/components/forms/schema_editors/SchemaBasedChoicesEditorDirective.js"></script>

--- a/core/templates/dev/head/pages/topics_and_skills_dashboard/topics_and_skills_dashboard.html
+++ b/core/templates/dev/head/pages/topics_and_skills_dashboard/topics_and_skills_dashboard.html
@@ -238,6 +238,8 @@
 {% block footer_js %}
   {{ super() }}
   <script src="/templates/dev/head/components/background/BackgroundBannerDirective.js"></script>
+  <script src="/templates/dev/head/components/SkillCreationService.js"></script>
+  <script src="/templates/dev/head/components/TopicCreationService.js"></script>
 
   <script src="/templates/dev/head/pages/topics_and_skills_dashboard/SelectTopicsDirective.js"></script>
   <script src="/templates/dev/head/pages/topics_and_skills_dashboard/SkillsListDirective.js"></script>


### PR DESCRIPTION
This issue fixes #6316 remove scripts from base.html which doesn't require import on every page.
Like ``` <script src="/templates/dev/head/components/CollectionCreationService.js"></script> ``` which only requires in ``` creator dashboard ``` page.