### PR TITLE
Run lint tests on Travis until fixed on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,9 @@ workflows:
   circleci_tests:
     jobs:
       - setup
-      - lint_tests:
-          requires:
-            - setup
+      # - lint_tests:
+      #     requires:
+      #       - setup
       - frontend_tests:
           requires:
             - setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ branches:
 
 env:
   matrix:
+    - RUN_LINT=true
     # These lines are commented out because these checks are being run on CircleCI
     # here: https://circleci.com/gh/oppia/oppia
-    # - RUN_LINT=true
     # - RUN_FRONTEND_TESTS=true
     # - RUN_BACKEND_TESTS=true REPORT_BACKEND_COVERAGE=false EXCLUDE_LOAD_TESTS=true
     # TODO(sll): Reinstate this when we can get it to run in reasonable time.
@@ -103,9 +103,9 @@ install:
 - bash scripts/install_third_party.sh
 
 script:
+- if [ "$RUN_LINT" == 'true' ]; then python scripts/third_party_size_check.py; python scripts/pre_commit_linter.py --path=.; fi
 # These lines are commented out because these checks are being run on CircleCI
 # here: https://circleci.com/gh/oppia/oppia
-# - if [ "$RUN_LINT" == 'true' ]; then python scripts/third_party_size_check.py; python scripts/pre_commit_linter.py --path=.; fi
 # Travis aborts test run if nothing is printed back to STDOUT for some time.
 # -x is used to avoid that.
 # - if [ "$RUN_FRONTEND_TESTS" == 'true' ]; then travis_retry bash -x scripts/run_frontend_tests.sh --run-minified-tests=true; fi


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
The @oppia/dev-workflow-team observed that the lint checks were failing due to some third party error (pyjsparser was unable to parse the files), on CircleCI, [here](https://circleci.com/gh/oppia/oppia/52).
As an immediate fix, I have migrated the lint checks back to Travis to unblock PRs while we are looking into this.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [X] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [X] The PR is made from a branch that's **not** called "develop".
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
