### PR TITLE
Fix #6294: Upgrade BeautifulSoup version from 4.6.0 to 4.7.1

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -97,6 +97,7 @@ THIRD_PARTY_LIBS = [
     os.path.join(ROOT_PATH, 'third_party', 'simplejson-3.7.1'),
     os.path.join(ROOT_PATH, 'third_party', 'beautifulsoup4-4.7.1'),
     os.path.join(ROOT_PATH, 'third_party', 'mutagen-1.38'),
+    os.path.join(ROOT_PATH, 'third_party', 'soupsieve-1.8'),
 ]
 
 for lib_path in THIRD_PARTY_LIBS:

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -87,6 +87,7 @@ if os.path.isdir(oppia_tools_path):
     sys.path.insert(0, pil_path)
 
 THIRD_PARTY_LIBS = [
+    os.path.join(ROOT_PATH, 'third_party', 'backports.functools_lru_cache-1.5'),
     os.path.join(ROOT_PATH, 'third_party', 'bleach-1.2.2'),
     os.path.join(ROOT_PATH, 'third_party', 'html5lib-python-0.95'),
     os.path.join(ROOT_PATH, 'third_party', 'gae-mapreduce-1.9.17.0'),

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -95,7 +95,7 @@ THIRD_PARTY_LIBS = [
     os.path.join(ROOT_PATH, 'third_party', 'graphy-1.0.0'),
     os.path.join(ROOT_PATH, 'third_party', 'requests-2.10.0'),
     os.path.join(ROOT_PATH, 'third_party', 'simplejson-3.7.1'),
-    os.path.join(ROOT_PATH, 'third_party', 'beautifulsoup4-4.6.0'),
+    os.path.join(ROOT_PATH, 'third_party', 'beautifulsoup4-4.7.1'),
     os.path.join(ROOT_PATH, 'third_party', 'mutagen-1.38'),
 ]
 

--- a/core/domain/__init__.py
+++ b/core/domain/__init__.py
@@ -1,0 +1,2 @@
+import sys
+print(sys.path)

--- a/core/domain/__init__.py
+++ b/core/domain/__init__.py
@@ -1,2 +1,0 @@
-import sys
-print(sys.path)

--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -52,6 +52,7 @@ DIRS_TO_ADD_TO_SYS_PATH = [
     os.path.join(THIRD_PARTY_DIR, 'simplejson-3.7.1'),
     os.path.join(THIRD_PARTY_DIR, 'beautifulsoup4-4.7.1'),
     os.path.join(THIRD_PARTY_DIR, 'mutagen-1.38'),
+    os.path.join(THIRD_PARTY_DIR, 'soupsieve-1.8'),
 ]
 
 _PARSER = argparse.ArgumentParser()

--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -42,6 +42,7 @@ DIRS_TO_ADD_TO_SYS_PATH = [
     os.path.join(OPPIA_TOOLS_DIR, 'selenium-2.53.2'),
     os.path.join(OPPIA_TOOLS_DIR, 'PIL-1.1.7'),
     CURR_DIR,
+    os.path.join(THIRD_PARTY_DIR, 'backports.functools_lru_cache-1.5'),
     os.path.join(THIRD_PARTY_DIR, 'bleach-1.2.2'),
     os.path.join(THIRD_PARTY_DIR, 'gae-cloud-storage-1.9.15.0'),
     os.path.join(THIRD_PARTY_DIR, 'gae-mapreduce-1.9.17.0'),

--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -50,7 +50,7 @@ DIRS_TO_ADD_TO_SYS_PATH = [
     os.path.join(THIRD_PARTY_DIR, 'html5lib-python-0.95'),
     os.path.join(THIRD_PARTY_DIR, 'requests-2.10.0'),
     os.path.join(THIRD_PARTY_DIR, 'simplejson-3.7.1'),
-    os.path.join(THIRD_PARTY_DIR, 'beautifulsoup4-4.6.0'),
+    os.path.join(THIRD_PARTY_DIR, 'beautifulsoup4-4.7.1'),
     os.path.join(THIRD_PARTY_DIR, 'mutagen-1.38'),
 ]
 

--- a/manifest.json
+++ b/manifest.json
@@ -78,6 +78,14 @@
         "tarRootDirPrefix": "mutagen-",
         "rootDirPrefix": "mutagen-",
         "targetDirPrefix": "mutagen-"
+      },
+      "soupsieve": {
+        "version": "1.8",
+        "downloadFormat": "tar",
+        "url": "https://pypi.python.org/packages/0c/52/e9088bb9b96e2d39fc3b33fcda5b4fde9d71473536ac660a1ca9a0958a2f/soupsieve-1.8.tar.gz#md5=3b3d830576e5fa5148bc154e38e63ebc",
+        "tarRootDirPrefix": "soupsieve-",
+        "rootDirPrefix": "soupsieve-",
+        "targetDirPrefix": "soupsieve-"
       }
     },
     "frontend": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,14 @@
 {
   "dependencies": {
     "backend": {
+      "backports.functools_lru_cache ": {
+        "version": "1.5",
+        "downloadFormat": "tar",
+        "url": "https://pypi.python.org/packages/57/d4/156eb5fbb08d2e85ab0a632e2bebdad355798dece07d4752f66a8d02d1ea/backports.functools_lru_cache-1.5.tar.gz#md5=2e271cab23c4c4d1de2f7ee80a1736bb",
+        "tarRootDirPrefix": "backports.functools_lru_cache-",
+        "rootDirPrefix": "backports.functools_lru_cache-",
+        "targetDirPrefix": "backports.functools_lru_cache-"
+      },
       "bleach": {
         "version": "1.2.2",
         "downloadFormat": "zip",

--- a/manifest.json
+++ b/manifest.json
@@ -64,9 +64,9 @@
         "targetDirPrefix": "simplejson-"
       },
       "beautifulSoup": {
-        "version": "4.6.0",
+        "version": "4.7.1",
         "downloadFormat": "tar",
-        "url": "https://pypi.python.org/packages/fa/8d/1d14391fdaed5abada4e0f63543fef49b8331a34ca60c88bd521bcf7f782/beautifulsoup4-4.6.0.tar.gz#md5=c17714d0f91a23b708a592cb3c697728",
+        "url": "https://pypi.python.org/packages/80/f2/f6aca7f1b209bb9a7ef069d68813b091c8c3620642b568dac4eb0e507748/beautifulsoup4-4.7.1.tar.gz#md5=321d73746d06bd9a8fcc3787b3fb7598",
         "tarRootDirPrefix": "beautifulsoup4-",
         "rootDirPrefix": "beautifulsoup4-",
         "targetDirPrefix": "beautifulsoup4-"

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -294,6 +294,7 @@ _PATHS_TO_INSERT = [
     os.path.join('third_party', 'beautifulsoup4-4.7.1'),
     os.path.join('third_party', 'gae-mapreduce-1.9.17.0'),
     os.path.join('third_party', 'mutagen-1.38'),
+    os.path.join('third_party', 'soupsieve-1.8')
     os.path.join('third_party', 'gae-cloud-storage-1.9.15.0'),
 ]
 for path in _PATHS_TO_INSERT:

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -295,7 +295,7 @@ _PATHS_TO_INSERT = [
     os.path.join('third_party', 'beautifulsoup4-4.7.1'),
     os.path.join('third_party', 'gae-mapreduce-1.9.17.0'),
     os.path.join('third_party', 'mutagen-1.38'),
-    os.path.join('third_party', 'soupsieve-1.8')
+    os.path.join('third_party', 'soupsieve-1.8'),
     os.path.join('third_party', 'gae-cloud-storage-1.9.15.0'),
 ]
 for path in _PATHS_TO_INSERT:

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -289,6 +289,7 @@ _PATHS_TO_INSERT = [
     os.path.join(_PARENT_DIR, 'oppia_tools', 'pylint-quotes-0.1.9'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'selenium-2.53.2'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'PIL-1.1.7'),
+    os.path.join('third_party', 'backports.functools_lru_cache-1.5'),
     os.path.join('third_party', 'gae-pipeline-1.9.17.0'),
     os.path.join('third_party', 'bleach-1.2.2'),
     os.path.join('third_party', 'beautifulsoup4-4.7.1'),

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -291,7 +291,7 @@ _PATHS_TO_INSERT = [
     os.path.join(_PARENT_DIR, 'oppia_tools', 'PIL-1.1.7'),
     os.path.join('third_party', 'gae-pipeline-1.9.17.0'),
     os.path.join('third_party', 'bleach-1.2.2'),
-    os.path.join('third_party', 'beautifulsoup4-4.6.0'),
+    os.path.join('third_party', 'beautifulsoup4-4.7.1'),
     os.path.join('third_party', 'gae-mapreduce-1.9.17.0'),
     os.path.join('third_party', 'mutagen-1.38'),
     os.path.join('third_party', 'gae-cloud-storage-1.9.15.0'),


### PR DESCRIPTION
This PR is related to issue #6294 upgrade BeautifulSoup version.

After seeing all the commits, one discussion is need

After upgrading beautiful soup version to 4.7.1 then this
**warning** will come
![imageedit_2_3409887086](https://user-images.githubusercontent.com/34139754/53567666-ee869f80-3b85-11e9-8e62-a3d6fe79263f.png)

After further investigation the reason for this is
BeautifulSoup 4.7, have replaced the simple and limited internal CSS parser with the soupsieve project, which is a far more complete CSS implementation.
https://stackoverflow.com/a/54061697/9463686
https://facelessuser.github.io/soupsieve/

So to remove this warning we also have to install this.

I have manually tested the use case of new upgraded library
Here's the doc link
https://docs.google.com/document/d/14X8xs3msRslrxKxOpo6k_zS-JkMJ1I517AvQqubi-C4/edit#

please suggest what other test i should do so that nothing breaks.
So did we install or not discus