### PR TITLE
Fix #6325 : modify style of active and inactive submenus on learner dashboard

### DIFF
--- a/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
+++ b/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
@@ -824,7 +824,7 @@
 
     .oppia-learner-dashboard-main-menu .oppia-learner-dashboard-sub-section-active {
       color: black;
-      background-color: lightblue;
+      background-color: lightcyan;
       border: 1px solid lightgreen;
     }
 

--- a/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
+++ b/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
@@ -814,7 +814,7 @@
 
     .oppia-learner-dashboard-menu {
       border: 1px solid #d0d0d0;
-      color: #009688;
+      color: black;
       font-family: 'Capriola', 'Roboto', Arial, sans-serif;
       font-size: 1em;
       font-weight: normal;
@@ -824,6 +824,8 @@
 
     .oppia-learner-dashboard-main-menu .oppia-learner-dashboard-sub-section-active {
       color: black;
+      background-color: lightblue;
+      border: 1px solid lightgreen;
     }
 
     .oppia-learner-dashboard-submenu {

--- a/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
+++ b/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
@@ -824,7 +824,7 @@
 
     .oppia-learner-dashboard-main-menu .oppia-learner-dashboard-sub-section-active {
       color: black;
-      background-color: lightcyan;
+      background-color: #aed2e9;
       border: 1px solid lightgreen;
     }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->
Fixes bug #6325 by doing the following changes
1) set all li to black ( normally grey colored text is used to say there is nothing under that link )
2) set active element properties as:
        a) subtle background color of lightcyan
        b) subtle border of lightgreen to make the li sink in, and look like its been selected (or pushed down) 
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
