### PR TITLE
Fixes #5530: Update collection title after save and refresh

### DIFF
--- a/core/controllers/collection_editor.py
+++ b/core/controllers/collection_editor.py
@@ -66,8 +66,8 @@ class CollectionEditorPage(CollectionEditorHandler):
             'SHOW_COLLECTION_NAVIGATION_TAB_STATS': (
                 feconf.SHOW_COLLECTION_NAVIGATION_TAB_STATS),
             'TAG_REGEX': feconf.TAG_REGEX,
+            'title': collection.title,
         })
-
         self.render_template('pages/collection_editor/collection_editor.html')
 
 

--- a/core/controllers/collection_editor.py
+++ b/core/controllers/collection_editor.py
@@ -68,6 +68,7 @@ class CollectionEditorPage(CollectionEditorHandler):
             'TAG_REGEX': feconf.TAG_REGEX,
             'title': collection.title,
         })
+
         self.render_template('pages/collection_editor/collection_editor.html')
 
 

--- a/core/controllers/collection_editor_test.py
+++ b/core/controllers/collection_editor_test.py
@@ -178,6 +178,9 @@ class CollectionEditorTests(BaseCollectionEditorControllerTests):
 
         self.assertEqual(self.COLLECTION_ID, json_response['collection']['id'])
         self.assertEqual(2, json_response['collection']['version'])
+        self.assertEqual(
+            self.json_dict['change_list'][0]['new_value'],
+            json_response['collection']['title'])
         self.logout()
 
     def test_collection_rights_handler(self):

--- a/core/controllers/collection_editor_test.py
+++ b/core/controllers/collection_editor_test.py
@@ -178,9 +178,13 @@ class CollectionEditorTests(BaseCollectionEditorControllerTests):
 
         self.assertEqual(self.COLLECTION_ID, json_response['collection']['id'])
         self.assertEqual(2, json_response['collection']['version'])
-        self.assertEqual(
-            self.json_dict['change_list'][0]['new_value'],
-            json_response['collection']['title'])
+
+        # Check that title is changed.
+        response = self.get_html_response(
+            '%s/%s' % (
+                feconf.COLLECTION_EDITOR_URL_PREFIX,
+                self.COLLECTION_ID))
+        response.mustcontain(self.json_dict['change_list'][0]['new_value'])
         self.logout()
 
     def test_collection_rights_handler(self):


### PR DESCRIPTION
Fixes #5530: Update collection title after draft save and refresh

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
