### PR TITLE
Fix #6370: Fix Title and Goal label alignment

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
@@ -132,6 +132,9 @@ oppia.controller('SettingsTab', [
       value: 'viewer'
     }];
 
+    $scope.formStyle = {
+      display: 'table-cell', width: '16.66666667%', 'vertical-align': 'top'};
+
     $scope.saveExplorationTitle = function() {
       ExplorationTitleService.saveDisplayedValue();
     };

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/SettingsTab.js
@@ -133,7 +133,10 @@ oppia.controller('SettingsTab', [
     }];
 
     $scope.formStyle = {
-      display: 'table-cell', width: '16.66666667%', 'vertical-align': 'top'};
+      display: 'table-cell',
+      width: '16.66666667%',
+      'vertical-align': 'top'
+    };
 
     $scope.saveExplorationTitle = function() {
       ExplorationTitleService.saveDisplayedValue();

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -7,11 +7,11 @@
           <div role="form" class="form-horizontal">
             <exploration-title-editor label-text="Title"
                                       focus-label="<[::EXPLORATION_TITLE_INPUT_FOCUS_LABEL]>"
-                                      form-style="{display:'table-cell', width:'16.66666667%'}"
+                                      form-style="{display:'table-cell', width:'16.66666667%', 'vertical-align':'top'}"
                                       on-input-field-blur="saveExplorationTitle()">
             </exploration-title-editor>
             <exploration-objective-editor label-text="Goal"
-                                          form-style="{display:'table-cell', width:'16.66666667%'}"
+                                          form-style="{display:'table-cell', width:'16.66666667%', 'vertical-align':'top'}"
                                           on-input-field-blur="saveExplorationObjective()">
             </exploration-objective-editor>
 

--- a/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/settings_tab/settings_tab.html
@@ -7,11 +7,11 @@
           <div role="form" class="form-horizontal">
             <exploration-title-editor label-text="Title"
                                       focus-label="<[::EXPLORATION_TITLE_INPUT_FOCUS_LABEL]>"
-                                      form-style="{display:'table-cell', width:'16.66666667%', 'vertical-align':'top'}"
+                                      form-style="<[::formStyle]>"
                                       on-input-field-blur="saveExplorationTitle()">
             </exploration-title-editor>
             <exploration-objective-editor label-text="Goal"
-                                          form-style="{display:'table-cell', width:'16.66666667%', 'vertical-align':'top'}"
+                                          form-style="<[::formStyle]>"
                                           on-input-field-blur="saveExplorationObjective()">
             </exploration-objective-editor>
 


### PR DESCRIPTION
Fix #6370: Fix the alignment of labels Title and Goal in exploration editor settings tab.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
