### PR TITLE
Update release script to use SSH Git URL instead of HTTPS

### DIFF
--- a/scripts/cut_release_branch.py
+++ b/scripts/cut_release_branch.py
@@ -151,7 +151,7 @@ def _execute_branch_cut():
     common.verify_current_branch_name('develop')
 
     # Update the local repo.
-    remote_alias = common.get_remote_alias('https://github.com/oppia/oppia')
+    remote_alias = common.get_remote_alias('git@github.com:oppia/oppia.git')
     subprocess.call(['git', 'pull', remote_alias])
 
     _verify_target_branch_does_not_already_exist(remote_alias)


### PR DESCRIPTION
This change is done per a discussion in a past release engineering meeting. After this change, release coordinators will be required to have SSH set up for GitHub authentication otherwise the script will fail for them (like it does now for coordinators who do use SSH).