### PR TITLE
Removes unwanted validation check and related tests from exploration.

### DIFF
--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -721,11 +721,6 @@ class Exploration(object):
                     raise utils.ValidationError(
                         'Expected outcome dest to be a string, received %s'
                         % state.interaction.default_outcome.dest)
-            if self.language_code in (
-                    state.written_translations.get_available_languages()):
-                raise utils.ValidationError(
-                    'This exploration has a text translation in its own '
-                    'language.')
 
         if self.states_schema_version is None:
             raise utils.ValidationError(

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -868,19 +868,6 @@ class WrittenTranslations(object):
 
                 written_translation.validate()
 
-    def get_available_languages(self):
-        """Returns a set of language available in the WrittenTranslations.
-
-        Returns:
-            set(str). A set of languages available in the WrittenTranslations.
-        """
-        language_codes_set = set([])
-        for language_code_to_written_translation in (
-                self.translations_mapping.itervalues()):
-            for language_code in language_code_to_written_translation:
-                language_codes_set.add(language_code)
-        return language_codes_set
-
     def get_content_ids_for_text_translation(self):
         """Returns a list of content_id available for text translation.
 

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -578,40 +578,6 @@ class WrittenTranslationsDomainUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             written_translations.to_dict(), written_translations_dict)
 
-    def test_get_available_languages_gives_correct_set_of_langauges(self):
-        written_translations_dict = {
-            'translations_mapping': {
-                'content1': {
-                    'en': {
-                        'html': 'hello',
-                        'needs_update': True
-                    },
-                    'hi': {
-                        'html': 'Hey!',
-                        'needs_update': False
-                    }
-                },
-                'content2': {
-                    'hi': {
-                        'html': 'Testing!',
-                        'needs_update': False
-                    },
-                    'en': {
-                        'html': 'hello!',
-                        'needs_update': False
-                    }
-                }
-            }
-        }
-
-        written_translations = state_domain.WrittenTranslations.from_dict(
-            written_translations_dict)
-        expected_available_languages = set(['en', 'hi'])
-
-        self.assertEqual(
-            written_translations.get_available_languages(),
-            expected_available_languages)
-
     def test_get_content_ids_for_text_translation_return_correct_list_of_content_id(self): # pylint: disable=line-too-long
         written_translations = state_domain.WrittenTranslations.from_dict({
             'translations_mapping': {}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
This PR removes a validation check for exploration having written translation in the language
of the exploration.

**Reason for removing this check:**
Assume a user creates an exploration in "X" language and assigned another user as a translator for translating the exploration in "Y" language. 

Now, If the exploration owner will change the exploration language to "Y" (Assuming the translator has written at least a few translations.) then the exploration will start failing validation check.


## Checklist
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
