### PR TITLE
Make new model IDs only contain alphanumeric characters.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -424,8 +424,11 @@ def convert_to_hash(input_string, max_length):
             'Expected string, received %s of type %s' %
             (input_string, type(input_string)))
 
-    encoded_string = base64.urlsafe_b64encode(
-        hashlib.sha1(input_string.encode('utf-8')).digest())
+    # Encodes strings using the character set [A-Za-z0-9].
+    encoded_string = base64.b64encode(
+        hashlib.sha1(input_string.encode('utf-8')).digest(),
+        altchars='ab'
+    ).replace('=', 'c')
 
     return encoded_string[:max_length]
 

--- a/utils_test.py
+++ b/utils_test.py
@@ -158,6 +158,7 @@ class UtilsTests(test_utils.GenericTestBase):
         self.assertEqual(len(full_hash), 28)
         self.assertEqual(len(abbreviated_hash), 5)
         self.assertEqual(full_hash[:5], abbreviated_hash)
+        self.assertTrue(full_hash.isalnum())
 
     def test_vfs_construct_path(self):
         """Test vfs_construct_path method."""


### PR DESCRIPTION
I just realized that this should go in the next release since we are creating new models for skills, topics, etc. It ensures that all new model IDs are alphanumeric only (no hyphens or underscores) which seems like a useful constraint to have.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [X] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.