### PR TITLE
Fixes  #6200:Decrease some margin between the <p> tag.

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -342,7 +342,7 @@ input.ng-dirty.ng-invalid, md-input-group.md-default-theme input.ng-dirty.ng-inv
 
 p {
   line-height: 1.2;
-  margin-bottom: 18px;
+  margin-bottom: 11px;
   text-align: left;
   word-spacing: 0;
   word-wrap: break-word;


### PR DESCRIPTION
This Pr fixes issue #6200, the issue says that the spacing below RTE bulleted list is off.
But after some time we get to know that the issue has been resolved.
But after further discussions, it found that there is still some small error is in spacing
So it just resolved that
![screenshot from 2019-03-08 10-56-54](https://user-images.githubusercontent.com/34139754/54010025-221f8600-4193-11e9-8ad5-525c7a8bf9b4.png)
![screenshot from 2019-03-08 11-01-25](https://user-images.githubusercontent.com/34139754/54010029-264ba380-4193-11e9-9ff7-ec73df50eb16.png)
