### PR TITLE
Fixed part of #5002:  Removed iframed from GLOBALS

### DIFF
--- a/core/templates/dev/head/components/attribution_guide/AttributionGuideDirective.js
+++ b/core/templates/dev/head/components/attribution_guide/AttributionGuideDirective.js
@@ -25,10 +25,10 @@ oppia.directive('attributionGuide', [
         '/components/attribution_guide/' +
         'attribution_guide_directive.html'),
       controller: [
-        '$scope', 'BrowserCheckerService', function(
-            $scope, BrowserCheckerService) {
+        '$scope', 'BrowserCheckerService', 'UrlService', function(
+            $scope, BrowserCheckerService, UrlService) {
           $scope.isMobileDevice = BrowserCheckerService.isMobileDevice();
-          $scope.iframed = GLOBALS.iframed;
+          $scope.iframed = UrlService.isIframed();
         }
       ]
     };

--- a/core/templates/dev/head/pages/Base.js
+++ b/core/templates/dev/head/pages/Base.js
@@ -18,13 +18,15 @@
 
 oppia.controller('Base', [
   '$document', '$rootScope', '$scope', 'AlertsService', 'BackgroundMaskService',
-  'SidebarStatusService', 'DEV_MODE', 'SITE_FEEDBACK_FORM_URL', 'SITE_NAME',
+  'SidebarStatusService', 'UrlService', 'DEV_MODE', 'SITE_FEEDBACK_FORM_URL',
+  'SITE_NAME',
   function($document, $rootScope, $scope, AlertsService, BackgroundMaskService,
-      SidebarStatusService, DEV_MODE, SITE_FEEDBACK_FORM_URL, SITE_NAME) {
+      SidebarStatusService, UrlService, DEV_MODE, SITE_FEEDBACK_FORM_URL,
+      SITE_NAME) {
     $scope.siteName = SITE_NAME;
     $scope.AlertsService = AlertsService;
     $scope.currentLang = 'en';
-    $scope.iframed = GLOBALS.iframed;
+    $scope.iframed = UrlService.isIframed();
     $scope.siteFeedbackFormUrl = SITE_FEEDBACK_FORM_URL;
 
     $rootScope.DEV_MODE = DEV_MODE;

--- a/core/templates/dev/head/pages/base.html
+++ b/core/templates/dev/head/pages/base.html
@@ -82,7 +82,6 @@
         csrf_token: JSON.parse('{{csrf_token|js_string}}'),
         status_code: JSON.parse('{{status_code}}'),
         GCS_RESOURCE_BUCKET_NAME: JSON.parse('{{GCS_RESOURCE_BUCKET_NAME|js_string}}'),
-        iframed: JSON.parse('{{iframed|js_string}}'),
         isTopicManager: JSON.parse('{{is_topic_manager|js_string}}'),
         logoutUrl: JSON.parse('{{logout_url|js_string}}'),
         userIsLoggedIn: JSON.parse('{{user_is_logged_in|js_string}}')

--- a/core/templates/dev/head/pages/exploration_player/ExplorationFooterDirective.js
+++ b/core/templates/dev/head/pages/exploration_player/ExplorationFooterDirective.js
@@ -28,13 +28,15 @@ oppia.directive('explorationFooter', [
         '/pages/exploration_player/exploration_footer_directive.html'),
       controller: [
         '$scope', '$http', '$log', 'ContextService',
-        'ExplorationSummaryBackendApiService', 'WindowDimensionsService',
+        'ExplorationSummaryBackendApiService', 'UrlService',
+        'WindowDimensionsService',
         function(
             $scope, $http, $log, ContextService,
-            ExplorationSummaryBackendApiService, WindowDimensionsService) {
+            ExplorationSummaryBackendApiService, UrlService,
+            WindowDimensionsService) {
           $scope.explorationId = ContextService.getExplorationId();
           $scope.getStaticImageUrl = UrlInterpolationService.getStaticImageUrl;
-          $scope.iframed = GLOBALS.iframed;
+          $scope.iframed = UrlService.isIframed();
 
           $scope.windowIsNarrow = WindowDimensionsService.isWindowNarrow();
           WindowDimensionsService.registerOnResizeHook(function() {

--- a/core/tests/build_sources/templates/base.html
+++ b/core/tests/build_sources/templates/base.html
@@ -83,7 +83,6 @@
         DEV_MODE: JSON.parse('{{DEV_MODE|js_string}}'),
         status_code: JSON.parse('{{status_code}}'),
         GCS_RESOURCE_BUCKET_NAME: JSON.parse('{{GCS_RESOURCE_BUCKET_NAME|js_string}}'),
-        iframed: JSON.parse('{{iframed|js_string}}'),
         isAdmin: JSON.parse('{{is_admin|js_string}}'),
         isModerator: JSON.parse('{{is_moderator|js_string}}'),
         isSuperAdmin: JSON.parse('{{is_super_admin|js_string}}'),

--- a/core/tests/build_sources/templates/pages/Base.js
+++ b/core/tests/build_sources/templates/pages/Base.js
@@ -18,13 +18,13 @@
 
 oppia.controller('Base', [
   '$scope', '$rootScope', '$document', 'AlertsService', 'BackgroundMaskService',
-  'SidebarStatusService', 'SITE_FEEDBACK_FORM_URL', 'SITE_NAME',
+  'SidebarStatusService', 'UrlService', 'SITE_FEEDBACK_FORM_URL', 'SITE_NAME',
   function($scope, $rootScope, $document, AlertsService, BackgroundMaskService,
-      SidebarStatusService, SITE_FEEDBACK_FORM_URL, SITE_NAME) {
+      SidebarStatusService, UrlService, SITE_FEEDBACK_FORM_URL, SITE_NAME) {
     $scope.siteName = SITE_NAME;
     $scope.AlertsService = AlertsService;
     $scope.currentLang = 'en';
-    $scope.iframed = GLOBALS.iframed;
+    $scope.iframed = UrlService.isIframed();
     $scope.siteFeedbackFormUrl = SITE_FEEDBACK_FORM_URL;
 
     $rootScope.DEV_MODE = GLOBALS.DEV_MODE;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes part of #5002 
I discovered that the only page that had iframed set to __true__ in the controller has `/embed/<explorationId>` route and there's already a method in the __UrlService__ Factory that checks the url and returns true or false based on the presence of  __embed__ in the url hence determining if it should be iframed so I changed all the usage of `GLOBALS.iframed` to use the UrlService instead.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
