### PR TITLE
Change the name of the schema_version field in story models.

### DIFF
--- a/core/domain/skill_jobs_one_off_test.py
+++ b/core/domain/skill_jobs_one_off_test.py
@@ -139,7 +139,7 @@ class SkillMigrationOneOffJobTests(test_utils.GenericTestBase):
                 }
             }
         }
-        self.save_new_skill_with_story_and_skill_contents_schema_version(
+        self.save_new_skill_with_defined_schema_versions(
             self.SKILL_ID, self.albert_id, 'A description', 0,
             misconceptions=[], skill_contents=skill_contents)
         skill = (

--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -554,8 +554,8 @@ class Story(object):
 
     def __init__(
             self, story_id, title, description, notes,
-            story_contents, schema_version, language_code, version,
-            created_on=None, last_updated=None):
+            story_contents, story_contents_schema_version, language_code,
+            version, created_on=None, last_updated=None):
         """Constructs a Story domain object.
 
         Args:
@@ -567,7 +567,8 @@ class Story(object):
             story_contents: StoryContents. The StoryContents instance
                 representing the contents (like nodes) that are part of the
                 story.
-            schema_version: int. The schema version for the story nodes object.
+            story_contents_schema_version: int. The schema version for the
+                story contents object.
             language_code: str. The ISO 639-1 code for the language this
                 story is written in.
             version: int. The version of the story.
@@ -581,7 +582,7 @@ class Story(object):
         self.description = description
         self.notes = html_cleaner.clean(notes)
         self.story_contents = story_contents
-        self.schema_version = schema_version
+        self.story_contents_schema_version = story_contents_schema_version
         self.language_code = language_code
         self.created_on = created_on
         self.last_updated = last_updated
@@ -604,16 +605,18 @@ class Story(object):
             raise utils.ValidationError(
                 'Expected notes to be a string, received %s' % self.notes)
 
-        if not isinstance(self.schema_version, int):
+        if not isinstance(self.story_contents_schema_version, int):
             raise utils.ValidationError(
-                'Expected schema version to be an integer, received %s' %
-                self.schema_version)
+                'Expected story contents schema version to be an integer, '
+                'received %s' % self.story_contents_schema_version)
 
-        if self.schema_version != feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION:
+        if (self.story_contents_schema_version !=
+                feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION):
             raise utils.ValidationError(
-                'Expected schema version to be %s, received %s' % (
+                'Expected story contents schema version to be %s, '
+                'received %s' % (
                     feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION,
-                    self.schema_version))
+                    self.story_contents_schema_version))
 
         if not isinstance(self.language_code, basestring):
             raise utils.ValidationError(
@@ -695,7 +698,7 @@ class Story(object):
             'description': self.description,
             'notes': self.notes,
             'language_code': self.language_code,
-            'schema_version': self.schema_version,
+            'story_contents_schema_version': self.story_contents_schema_version,
             'version': self.version,
             'story_contents': self.story_contents.to_dict()
         }

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -85,7 +85,8 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
                 'initial_node_id': None,
                 'next_node_id': self.NODE_ID_1
             },
-            'schema_version': feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION,
+            'story_contents_schema_version': (
+                feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION),
             'language_code': constants.DEFAULT_LANGUAGE_CODE,
             'version': 0
         }
@@ -129,15 +130,16 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         self._assert_validation_error('Invalid language code')
 
     def test_schema_version_validation(self):
-        self.story.schema_version = 'schema_version'
+        self.story.story_contents_schema_version = 'schema_version'
         self._assert_validation_error(
-            'Expected schema version to be an integer, received schema_version')
+            'Expected story contents schema version to be an integer, received '
+            'schema_version')
 
-        self.story.schema_version = 100
+        self.story.story_contents_schema_version = 100
         self._assert_validation_error(
-            'Expected schema version to be %s, received %s' % (
+            'Expected story contents schema version to be %s, received %s' % (
                 feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION,
-                self.story.schema_version)
+                self.story.story_contents_schema_version)
         )
 
     def test_add_node_validation(self):

--- a/core/domain/story_jobs_one_off.py
+++ b/core/domain/story_jobs_one_off.py
@@ -69,15 +69,16 @@ class StoryMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
         # Write the new story into the datastore if it's different from
         # the old version.
-        if item.schema_version <= feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION:
+        if (item.story_contents_schema_version <=
+                feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION):
             commit_cmds = [story_domain.StoryChange({
                 'cmd': story_domain.CMD_MIGRATE_SCHEMA_TO_LATEST_VERSION,
-                'from_version': item.schema_version,
+                'from_version': item.story_contents_schema_version,
                 'to_version': feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION
             })]
             story_services.update_story(
                 feconf.MIGRATION_BOT_USERNAME, item.id, commit_cmds,
-                'Update story schema version to %d.' % (
+                'Update story contents schema version to %d.' % (
                     feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION))
             yield (StoryMigrationOneOffJob._MIGRATED_KEY, 1)
 

--- a/core/domain/story_jobs_one_off_test.py
+++ b/core/domain/story_jobs_one_off_test.py
@@ -53,7 +53,7 @@ class StoryMigrationOneOffJobTests(test_utils.GenericTestBase):
             self.STORY_ID, title='A title')
         story_services.save_new_story(self.albert_id, story)
         self.assertEqual(
-            story.schema_version,
+            story.story_contents_schema_version,
             feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION)
 
         # Start migration job.
@@ -67,7 +67,7 @@ class StoryMigrationOneOffJobTests(test_utils.GenericTestBase):
         updated_story = (
             story_services.get_story_by_id(self.STORY_ID))
         self.assertEqual(
-            updated_story.schema_version,
+            updated_story.story_contents_schema_version,
             feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION)
 
         output = story_jobs_one_off.StoryMigrationOneOffJob.get_output(job_id) # pylint: disable=line-too-long
@@ -121,7 +121,7 @@ class StoryMigrationOneOffJobTests(test_utils.GenericTestBase):
             'A description', 'A note')
         story = (
             story_services.get_story_by_id(self.STORY_ID))
-        self.assertEqual(story.schema_version, 1)
+        self.assertEqual(story.story_contents_schema_version, 1)
 
         # Start migration job.
         with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
@@ -134,7 +134,7 @@ class StoryMigrationOneOffJobTests(test_utils.GenericTestBase):
         updated_story = (
             story_services.get_story_by_id(self.STORY_ID))
         self.assertEqual(
-            updated_story.schema_version,
+            updated_story.story_contents_schema_version,
             feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION)
 
         output = story_jobs_one_off.StoryMigrationOneOffJob.get_output(job_id) # pylint: disable=line-too-long

--- a/core/storage/story/gae_models.py
+++ b/core/storage/story/gae_models.py
@@ -51,13 +51,13 @@ class StoryModel(base_models.VersionedModel):
     notes = ndb.TextProperty(indexed=False)
     # The ISO 639-1 code for the language this story is written in.
     language_code = ndb.StringProperty(required=True, indexed=True)
-    # The schema version for the story_contents.
-    schema_version = (
-        ndb.IntegerProperty(required=True, default=1, indexed=True))
     # The story contents dict specifying the list of story nodes and the
     # connection between them. Modelled by class StoryContents
     # (see story_domain.py for its current schema).
     story_contents = ndb.JsonProperty(default={}, indexed=False)
+    # The schema version for the story_contents.
+    story_contents_schema_version = (
+        ndb.IntegerProperty(required=True, default=1, indexed=True))
 
     def _trusted_commit(
             self, committer_id, commit_type, commit_message, commit_cmds):

--- a/core/templates/dev/head/pages/story_editor/StoryEditorStateServiceSpec.js
+++ b/core/templates/dev/head/pages/story_editor/StoryEditorStateServiceSpec.js
@@ -88,7 +88,7 @@ describe('Story editor state service', function() {
         nodes: []
       },
       language_code: 'en',
-      schema_version: '1',
+      story_contents_schema_version: '1',
       version: '1'
     };
 
@@ -103,7 +103,7 @@ describe('Story editor state service', function() {
         nodes: []
       },
       language_code: 'en',
-      schema_version: '1',
+      story_contents_schema_version: '1',
       version: '1'
     };
   }));

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -1371,7 +1371,7 @@ tags: []
             description=description,
             title=title,
             language_code=language_code,
-            schema_version=1,
+            story_contents_schema_version=1,
             notes=notes,
             story_contents=self.VERSION_1_STORY_CONTENTS_DICT
         )
@@ -1557,13 +1557,12 @@ tags: []
         skill_services.save_new_skill(owner_id, skill)
         return skill
 
-    def save_new_skill_with_story_and_skill_contents_schema_version(
-            self, skill_id, owner_id,
-            description, next_misconception_id, misconceptions=None,
-            skill_contents=None, misconceptions_schema_version=1,
-            skill_contents_schema_version=1,
+    def save_new_skill_with_defined_schema_versions(
+            self, skill_id, owner_id, description, next_misconception_id,
+            misconceptions=None, skill_contents=None,
+            misconceptions_schema_version=1, skill_contents_schema_version=1,
             language_code=constants.DEFAULT_LANGUAGE_CODE):
-        """Saves a new default skill with a default version 1 misconceptions
+        """Saves a new default skill with the given versions for misconceptions
         and skill contents.
 
         This function should only be used for creating skills in tests


### PR DESCRIPTION
## Explanation
Change the name of schema_version to story_contents_schema_version to more accurately describe what it is a schema version of.

This probably needs to go in the next release before any story models are actually created in production.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.