### PR TITLE
Fix part of #5134: Make test coverage of core.controllers.collection_viewer 100%

### DIFF
--- a/core/controllers/collection_viewer_test.py
+++ b/core/controllers/collection_viewer_test.py
@@ -97,6 +97,7 @@ class CollectionViewerPermissionsTests(test_utils.GenericTestBase):
             expected_status_int=404)
         self.logout()
 
+
 class CollectionViewerControllerEndToEndTests(test_utils.GenericTestBase):
     """Test the collection viewer controller using a sample collection."""
 
@@ -113,7 +114,7 @@ class CollectionViewerControllerEndToEndTests(test_utils.GenericTestBase):
         # Login as the user who will play the collection.
         self.login(self.VIEWER_EMAIL)
 
-        # Request invalid collection from data handler
+        # Request invalid collection from data handler.
         response_dict = self.get_json(
             '%s/1' % feconf.COLLECTION_DATA_URL_PREFIX,
             expected_status_int=404)

--- a/core/controllers/collection_viewer_test.py
+++ b/core/controllers/collection_viewer_test.py
@@ -90,6 +90,12 @@ class CollectionViewerPermissionsTests(test_utils.GenericTestBase):
         self.get_html_response(
             '%s/%s' % (feconf.COLLECTION_URL_PREFIX, self.COLLECTION_ID))
 
+    def test_invalid_collection_error(self):
+        self.login(self.EDITOR_EMAIL)
+        self.get_html_response(
+            '%s/%s' % (feconf.COLLECTION_URL_PREFIX, 'none'),
+            expected_status_int=404)
+        self.logout()
 
 class CollectionViewerControllerEndToEndTests(test_utils.GenericTestBase):
     """Test the collection viewer controller using a sample collection."""
@@ -106,6 +112,11 @@ class CollectionViewerControllerEndToEndTests(test_utils.GenericTestBase):
 
         # Login as the user who will play the collection.
         self.login(self.VIEWER_EMAIL)
+
+        # Request invalid collection from data handler
+        response_dict = self.get_json(
+            '%s/1' % feconf.COLLECTION_DATA_URL_PREFIX,
+            expected_status_int=404)
 
         # Request the collection from the data handler.
         response_dict = self.get_json(


### PR DESCRIPTION
This PR is aims to make test coverage for core.controllers.collection_view to 100% as part of #5134.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
