### PR TITLE
Fixes #6414: REQUIRE_PAYLOAD_CSRF_CHECK Flag Flipped in Error404Handler class.

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -513,7 +513,7 @@ class BaseHandler(webapp2.RequestHandler):
 class Error404Handler(BaseHandler):
     """Handles 404 errors."""
 
-    REQUIRE_PAYLOAD_CSRF_CHECK = False
+    REQUIRE_PAYLOAD_CSRF_CHECK = True
 
 
 class CsrfTokenManager(object):

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -513,7 +513,7 @@ class BaseHandler(webapp2.RequestHandler):
 class Error404Handler(BaseHandler):
     """Handles 404 errors."""
 
-    REQUIRE_PAYLOAD_CSRF_CHECK = True
+    pass
 
 
 class CsrfTokenManager(object):

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -107,6 +107,8 @@ class BaseHandlerTests(test_utils.GenericTestBase):
 
     def test_requests_for_invalid_paths(self):
         """Test that requests for invalid paths result in a 404 error."""
+        user_id = user_services.get_user_id_from_username('learneruser')
+        csrf_token = base.CsrfTokenManager.create_csrf_token(user_id)
 
         self.get_html_response(
             '/library/extra', expected_status_int=404)
@@ -115,10 +117,12 @@ class BaseHandlerTests(test_utils.GenericTestBase):
             '/library/data/extra', expected_status_int=404)
 
         self.post_json(
-            '/library/extra', payload={}, expected_status_int=404)
+            '/library/extra', payload={}, csrf_token=csrf_token,
+            expected_status_int=404)
 
         self.put_json(
-            '/library/extra', payload={}, expected_status_int=404)
+            '/library/extra', payload={}, csrf_token=csrf_token,
+            expected_status_int=404)
 
     def test_redirect_in_logged_out_states(self):
         """Test for a redirect in logged out state on '/'."""


### PR DESCRIPTION
…Fix#6414

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation

REQUIRE_PAYLOAD_CSRF_CHECK  in Error404Handler class was initialised as False because of which   404error page was unable to generate CSRF_TOKENS hence, user was not allowed to create an exploration from 404error page.

The Flag is flipped in this PR and the CSRF_TOKENS are now generated in 404error pages also.
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
