### PR TITLE
Fix part of #5134: Make test coverage of core.controllers.collection_editor 100% 

### DIFF
--- a/core/controllers/collection_editor_test.py
+++ b/core/controllers/collection_editor_test.py
@@ -262,9 +262,18 @@ class CollectionEditorTests(BaseCollectionEditorControllerTests):
         response = self.get_html_response(
             '%s/%s' % (feconf.COLLECTION_URL_PREFIX, self.COLLECTION_ID))
         csrf_token = self.get_csrf_token_from_response(response)
+
+        url = '/collection_editor_handler/unpublish/%s' % collection_id
+        # Check that a collection cannot be unpublished when the payload has no
+        # version.
+        self.put_json(
+            url, {}, csrf_token=csrf_token, expected_status_int=400)
+        # Check that a collection cannot be unpublished when the payload's version
+        # is different from the collection's version.
+        self.put_json(
+            url, {'version': -1}, csrf_token=csrf_token, expected_status_int=400)
+
         response_dict = self.put_json(
-            '/collection_editor_handler/unpublish/%s' % collection_id,
-            {'version': collection.version},
-            csrf_token=csrf_token)
+            url, {'version': collection.version}, csrf_token=csrf_token)
         self.assertTrue(response_dict['is_private'])
         self.logout()


### PR DESCRIPTION
## Explanation

This PR is aims to make test coverage for core.controllers.collection_editor to 100% as part of #5134.

Require some assistance with regard to the last function in `collection_editor`.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
