### PR TITLE
Fix #6461: Changing error status for missing csrf_token from 500 to 401.

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -239,7 +239,7 @@ class BaseHandler(webapp2.RequestHandler):
                 csrf_token = self.request.get('csrf_token')
                 if not csrf_token:
                     raise self.UnauthorizedUserException(
-                        'Missing CSRF token. Changes were not saved,'
+                        'Missing CSRF token. Changes were not saved. '
                         'Please report this bug.')
 
                 is_csrf_token_valid = CsrfTokenManager.is_csrf_token_valid(

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -238,9 +238,9 @@ class BaseHandler(webapp2.RequestHandler):
                         'Registration session expired.')
                 csrf_token = self.request.get('csrf_token')
                 if not csrf_token:
-                    raise Exception(
-                        'Missing CSRF token. Changes were not saved. '
-                        'Please report this bug.')
+                    raise self.UnauthorizedUserException(
+                        'Missing CSRF Token , '
+                        'you are not authorized to view this page.')
 
                 is_csrf_token_valid = CsrfTokenManager.is_csrf_token_valid(
                     self.user_id, csrf_token)

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -239,8 +239,8 @@ class BaseHandler(webapp2.RequestHandler):
                 csrf_token = self.request.get('csrf_token')
                 if not csrf_token:
                     raise self.UnauthorizedUserException(
-                        'Missing CSRF Token , '
-                        'you are not authorized to view this page.')
+                        'Missing CSRF token. Changes were not saved,'
+                        'Please report this bug.')
 
                 is_csrf_token_valid = CsrfTokenManager.is_csrf_token_valid(
                     self.user_id, csrf_token)

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -105,6 +105,15 @@ class BaseHandlerTests(test_utils.GenericTestBase):
         #     POST, PUT and DELETE. Something needs to regulate what
         #     the fields in the payload should be.
 
+    def test_requests_for_missing_csrf_token(self):
+        """Tests request without csrf_token results in 401 error."""
+
+        self.post_json(
+            '/library/any', payload={}, expected_status_int=401)
+
+        self.put_json(
+            '/library/any', payload={}, expected_status_int=401)
+
     def test_requests_for_invalid_paths(self):
         """Test that requests for invalid paths result in a 404 error."""
         user_id = user_services.get_user_id_from_username('learneruser')


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
If CSRF_TOKEN is missing in a request the error thrown will be 401, before it was error 500.
 By this we've eliminated few more Internal Server Errors in production.
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
## Screenshot

![Screenshot from 2019-03-15 22-47-49](https://user-images.githubusercontent.com/41017303/54459156-d3be4880-478b-11e9-8482-3eaf23172d27.png)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
