### PR TITLE
Fix part of #6240: Add e2e tests for feedback threads

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/feedback_tab/feedback_tab.html
+++ b/core/templates/dev/head/pages/exploration_editor/feedback_tab/feedback_tab.html
@@ -67,7 +67,7 @@
 
                 <div class="col-lg-4 col-md-4 col-sm-4">
                   <span ng-if="m.message_id !== 0">
-                    <span ng-if="m.updated_status">
+                    <span ng-if="m.updated_status" class="protractor-feedback-message-status-banner">
                       <em>Status changed to '<[getHumanReadableStatus(m.updated_status)]>'</em>
                     </span>
                     <span ng-if="m.updated_subject">
@@ -83,7 +83,7 @@
 
               <div class="row">
                 <div class="col-lg-12 col-md-12 col-sm-12">
-                  <div style="white-space: pre-wrap;" class="protractor-test-exploration-feedback"><[m.text]></div>
+                  <div style="white-space: pre-wrap;" class="protractor-test-exploration-feedback-message"><[m.text]></div>
                   <div ng-if="activeThread.isSuggestionThread() && $index == 0">
                     <button class="btn btn-<[getSuggestionButtonType()]> protractor-test-view-suggestion-btn" style="margin-top: 6px; margin-bottom: 6px" ng-click="showSuggestionModal()">
                       View Suggestion
@@ -116,7 +116,8 @@
         <div>
           <span ng-show="EditabilityService.isEditable() && !activeThread.isSuggestionThread()">
             Change status (optional):
-            <select ng-model="tmpMessage.status"
+            <select class = "protractor-test-thread-status-dropdown"
+                    ng-model="tmpMessage.status"
                     ng-options="choice.id as choice.text for choice in STATUS_CHOICES"
                     ng-disabled="messageSendingInProgress">
             </select>

--- a/core/tests/protractor.conf.js
+++ b/core/tests/protractor.conf.js
@@ -88,7 +88,7 @@ exports.config = {
     ],
 
     explorationFeedbackTab: [
-      'protractor_desktop/explorationFeedbackTab.js'
+      'protractor_desktop/ExplorationFeedbackTab.js'
     ],
 
     explorationHistoryTab: [

--- a/core/tests/protractor_desktop/ExplorationFeedbackTab.js
+++ b/core/tests/protractor_desktop/ExplorationFeedbackTab.js
@@ -42,34 +42,35 @@ describe('ExplorationFeedback', function() {
   var libraryPage = null;
   var explorationPlayerPage = null;
 
-  beforeEach(function() {
+  beforeAll(function() {
     explorationEditorPage = new ExplorationEditorPage.ExplorationEditorPage();
     explorationEditorFeedbackTab = explorationEditorPage.getFeedbackTab();
     creatorDashboardPage = new CreatorDashboardPage.CreatorDashboardPage();
     libraryPage = new LibraryPage.LibraryPage();
     explorationPlayerPage = new ExplorationPlayerPage.ExplorationPlayerPage();
-  });
 
-  beforeEach(function() {
     users.createUser(
       'user1@ExplorationFeedback.com',
       'creatorExplorationFeedback');
     users.createUser(
       'user2@ExplorationFeedback.com',
       'learnerExplorationFeedback');
-  });
 
-  it('adds feedback to an exploration', function() {
-    var feedback = 'A good exploration. Would love to see a few more questions';
-    var feedbackResponse = 'Thanks for the feedback';
-
-    // Creator creates and publishes an exploration.
     users.login('user1@ExplorationFeedback.com');
     workflow.createAndPublishExploration(
       EXPLORATION_TITLE,
       EXPLORATION_CATEGORY,
       EXPLORATION_OBJECTIVE,
       EXPLORATION_LANGUAGE);
+    users.logout()
+  });
+
+  it('adds feedback to an exploration', function() {
+    var feedback = 'A good exploration. Would love to see a few more questions';
+    var feedbackResponse = 'Thanks for the feedback';
+
+    // Creator expects 0 feedback messages initially.
+    users.login('user1@ExplorationFeedback.com');
     creatorDashboardPage.get();
     expect(
       creatorDashboardPage.getNumberOfFeedbackMessages()
@@ -87,9 +88,7 @@ describe('ExplorationFeedback', function() {
     // Creator reads the feedback and responds.
     users.login('user1@ExplorationFeedback.com');
     creatorDashboardPage.get();
-    expect(
-      creatorDashboardPage.getNumberOfFeedbackMessages()
-    ).toEqual(1);
+    expect(creatorDashboardPage.getNumberOfFeedbackMessages()).toEqual(1);
     creatorDashboardPage.navigateToExplorationEditor();
 
     explorationEditorPage.navigateToFeedbackTab();
@@ -101,6 +100,32 @@ describe('ExplorationFeedback', function() {
       });
     explorationEditorPage.navigateToFeedbackTab();
     explorationEditorFeedbackTab.sendResponseToLatestFeedback(feedbackResponse);
+    users.logout();
+  });
+
+  it('adds message and changes status of feedback threads', function() {
+    var feedback = 'A good exploration. Would love to see a few more questions';
+    var feedbackResponse = 'Thanks for the feedback';
+
+    // Learner plays the exploration and submits a feedback.
+    users.login('user2@ExplorationFeedback.com');
+    libraryPage.get();
+    libraryPage.findExploration(EXPLORATION_TITLE);
+    libraryPage.playExploration(EXPLORATION_TITLE);
+    explorationPlayerPage.submitFeedback(feedback);
+    users.logout();
+
+    // Creator reads the feedback and responds.
+    users.login('user1@ExplorationFeedback.com');
+    creatorDashboardPage.get();
+    expect(creatorDashboardPage.getNumberOfFeedbackMessages()).toEqual(1);
+    creatorDashboardPage.navigateToExplorationEditor();
+
+    explorationEditorPage.navigateToFeedbackTab();
+    explorationEditorFeedbackTab.expectToHaveFeedbackThread();
+    explorationEditorFeedbackTab.changeThreadStatusOfLatestFeedback(
+      'Fixed', feedbackResponse);
+
     users.logout();
   });
 

--- a/core/tests/protractor_utils/ExplorationEditorFeedbackTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorFeedbackTab.js
@@ -17,6 +17,7 @@
  * use in Protractor tests.
  */
 
+var until = protractor.ExpectedConditions;
 var general = require('./general.js');
 var waitFor = require('./waitFor.js');
 
@@ -28,8 +29,8 @@ var ExplorationEditorFeedbackTab = function() {
     by.css('.protractor-test-exploration-feedback-subject'));
   var feedbackTabRow = element(
     by.css('.protractor-test-oppia-feedback-tab-row'));
-  var explorationFeedback = element(
-    by.css('.protractor-test-exploration-feedback'));
+  var explorationFeedbackMessage = element(
+    by.css('.protractor-test-exploration-feedback-message'));
   var feedbackBackButton = element(
     by.css('.protractor-test-oppia-feedback-back-button'));
   var feedbackResponseTextArea = element(
@@ -39,6 +40,10 @@ var ExplorationEditorFeedbackTab = function() {
     by.css('.protractor-test-suggestion-commit-message'));
   var suggestionReviewMessageInput = element(
     by.css('.protractor-test-suggestion-review-message'));
+  var threadStatusDropdown = element(
+    by.css('.protractor-test-thread-status-dropdown'));
+  var feedbackMessageStatusBanners = element.all(
+    by.css('.protractor-feedback-message-status-banner'));
   /*
    * Buttons
    */
@@ -105,8 +110,8 @@ var ExplorationEditorFeedbackTab = function() {
       rows.forEach(function(row) {
         row.click();
         waitFor.visibilityOf(
-          explorationFeedback, 'Feedback message text is not visible');
-        explorationFeedback.getText().then(function(message) {
+          explorationFeedbackMessage, 'Feedback message text is not visible');
+        explorationFeedbackMessage.getText().then(function(message) {
           messages.push(message);
         });
         feedbackBackButton.click();
@@ -139,6 +144,23 @@ var ExplorationEditorFeedbackTab = function() {
       first().click();
     feedbackResponseTextArea.sendKeys(feedbackResponse);
     feedbackSendResponseButton.click();
+  };
+
+  this.changeThreadStatusOfLatestFeedback = function(status, feedbackResponse) {
+    element.all(by.css('.protractor-test-oppia-feedback-tab-row')).
+      first().click();
+    var statusOption = threadStatusDropdown.element(
+      by.cssContainingText('option', status));
+    statusOption.click();
+    feedbackResponseTextArea.sendKeys(feedbackResponse);
+    feedbackSendResponseButton.click();
+    browser.wait(
+      until.textToBePresentInElement(
+        element.all(by.css('.protractor-test-exploration-feedback'),
+        feedbackResponse).last()), 50000,
+      'Feedback message takes too long to appear');
+    expect(feedbackMessageStatusBanners.last().getText()).toEqual(
+      feedbackResponse);
   };
 };
 


### PR DESCRIPTION
## Explanation
Fixes part of #6240. Adds tests for the following functional capabilites:
- Add a message to a feedback thread.
- Change the status of the thread.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
