### PR TITLE
Fix #6383: Added regex to validate return_url in signup page

### DIFF
--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Controllers for the profile page."""
-
+import re
 from core.controllers import acl_decorators
 from core.controllers import base
 from core.domain import email_manager
@@ -251,7 +251,8 @@ class SignupPage(base.BaseHandler):
     def get(self):
         """Handles GET requests."""
         return_url = str(self.request.get('return_url', self.request.uri))
-
+        if re.match('^/[^//]', return_url) is None:
+            return_url = '/'
         if user_services.has_fully_registered(self.user_id):
             self.redirect(return_url)
             return

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 """Controllers for the profile page."""
+
 import re
+
 from core.controllers import acl_decorators
 from core.controllers import base
 from core.domain import email_manager

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -253,6 +253,7 @@ class SignupPage(base.BaseHandler):
     def get(self):
         """Handles GET requests."""
         return_url = str(self.request.get('return_url', self.request.uri))
+        #validating return_url for no external redirection.
         if re.match('^/[^//]', return_url) is None:
             return_url = '/'
         if user_services.has_fully_registered(self.user_id):

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -250,6 +250,7 @@ class SignupPage(base.BaseHandler):
     def get(self):
         """Handles GET requests."""
         return_url = str(self.request.get('return_url', self.request.uri))
+        #validating return_url for no external redirection.
         if re.match('^/[^//]', return_url) is None:
             return_url = '/'
         if user_services.has_fully_registered(self.user_id):

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -250,7 +250,7 @@ class SignupPage(base.BaseHandler):
     def get(self):
         """Handles GET requests."""
         return_url = str(self.request.get('return_url', self.request.uri))
-        # Validating return_url for no external redirection.
+        # Validating return_url for no external redirections.
         if re.match('^/[^//]', return_url) is None:
             return_url = '/'
         if user_services.has_fully_registered(self.user_id):

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -250,7 +250,7 @@ class SignupPage(base.BaseHandler):
     def get(self):
         """Handles GET requests."""
         return_url = str(self.request.get('return_url', self.request.uri))
-        #validating return_url for no external redirection.
+        # Validating return_url for no external redirection.
         if re.match('^/[^//]', return_url) is None:
             return_url = '/'
         if user_services.has_fully_registered(self.user_id):

--- a/core/controllers/profile.py
+++ b/core/controllers/profile.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Controllers for the profile page."""
-
+import re
 from core.controllers import acl_decorators
 from core.controllers import base
 from core.domain import email_manager
@@ -248,7 +248,8 @@ class SignupPage(base.BaseHandler):
     def get(self):
         """Handles GET requests."""
         return_url = str(self.request.get('return_url', self.request.uri))
-
+        if re.match('^/[^//]', return_url) is None:
+            return_url = '/'
         if user_services.has_fully_registered(self.user_id):
             self.redirect(return_url)
             return

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -59,7 +59,7 @@ class SignupTests(test_utils.GenericTestBase):
             csrf_token=csrf_token)
 
         def strip_domain_from_location_header(url):
-            """To strip the domain form the location url"""
+            """To strip the domain form the location url."""
             splitted_url = re.match(r'(http[s]?:\/\/)?([^\/\s]+\/)(.*)', url)
             return splitted_url.group(3)
 
@@ -74,9 +74,20 @@ class SignupTests(test_utils.GenericTestBase):
             response.headers['location']))
 
         response = self.get_html_response(
-            '/signup?return_url=/page', expected_status_int=302)
+            '/signup?return_url=/page#hello', expected_status_int=302)
         self.assertEqual('page', strip_domain_from_location_header(
             response.headers['location']))
+
+        response = self.get_html_response(
+            '/signup?return_url=/page/hello', expected_status_int=302)
+        self.assertEqual('page/hello', strip_domain_from_location_header(
+            response.headers['location']))
+
+        response = self.get_html_response(
+            '/signup?return_url=/page/hello?id=test', expected_status_int=302)
+        self.assertEqual(
+            'page/hello?id=test', strip_domain_from_location_header(
+                response.headers['location']))
 
         self.logout()
 

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -84,9 +84,9 @@ class SignupTests(test_utils.GenericTestBase):
             response.headers['location']))
 
         response = self.get_html_response(
-            '/signup?return_url=/page/hello?id=test', expected_status_int=302)
+            '/signup?return_url=/page/hello?id=tests', expected_status_int=302)
         self.assertEqual(
-            'page/hello?id=test', strip_domain_from_location_header(
+            'page/hello?id=tests', strip_domain_from_location_header(
                 response.headers['location']))
 
         self.logout()

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -45,6 +45,31 @@ class SignupTests(test_utils.GenericTestBase):
 
         self.logout()
 
+    def test_to_check_url_redirection_in_signup(self):
+        """To validate the redirections from return_url"""
+        self.login(self.EDITOR_EMAIL)
+        response = self.get_html_response(feconf.SIGNUP_URL)
+        csrf_token = self.get_csrf_token_from_response(response)
+
+        # Registering this user fully.
+        self.post_json(
+            feconf.SIGNUP_DATA_URL,
+            {'username': 'abc', 'agreed_to_terms': True},
+            csrf_token=csrf_token)
+
+        response = self.get_html_response('/signup?return_url=https://google.com',
+            expected_status_int=302)
+        response = self.get_html_response('/signup?return_url=//google.com',
+            expected_status_int=302)
+        response = self.get_html_response('/signup?return_url=/page',
+            expected_status_int=302)
+
+        self.assertIn('/', response.headers['location'])
+        self.assertIn('/', response.headers['location'])
+        self.assertIn('/page', response.headers['location'])
+
+        self.logout()
+
     def test_accepting_terms_is_handled_correctly(self):
         self.login(self.EDITOR_EMAIL)
         response = self.get_html_response(feconf.SIGNUP_URL)

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -46,7 +46,7 @@ class SignupTests(test_utils.GenericTestBase):
         self.logout()
 
     def test_to_check_url_redirection_in_signup(self):
-        """To validate the redirections from return_url"""
+        """To validate the redirections from return_url."""
         self.login(self.EDITOR_EMAIL)
         response = self.get_html_response(feconf.SIGNUP_URL)
         csrf_token = self.get_csrf_token_from_response(response)
@@ -57,12 +57,12 @@ class SignupTests(test_utils.GenericTestBase):
             {'username': 'abc', 'agreed_to_terms': True},
             csrf_token=csrf_token)
 
-        response = self.get_html_response('/signup?return_url=https://google.com',
-            expected_status_int=302)
-        response = self.get_html_response('/signup?return_url=//google.com',
-            expected_status_int=302)
-        response = self.get_html_response('/signup?return_url=/page',
-            expected_status_int=302)
+        response = self.get_html_response(
+            '/signup?return_url=https://google.com', expected_status_int=302)
+        response = self.get_html_response(
+            '/signup?return_url=//google.com', expected_status_int=302)
+        response = self.get_html_response(
+            '/signup?return_url=/page', expected_status_int=302)
 
         self.assertIn('/', response.headers['location'])
         self.assertIn('/', response.headers['location'])

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Tests for the profile page."""
+import re
 
 from constants import constants
 from core.domain import exp_domain
@@ -57,16 +58,25 @@ class SignupTests(test_utils.GenericTestBase):
             {'username': 'abc', 'agreed_to_terms': True},
             csrf_token=csrf_token)
 
+        def strip_domain_from_location_header(url):
+            """To strip the domain form the location url"""
+            splitted_url = re.match(r'(http[s]?:\/\/)?([^\/\s]+\/)(.*)', url)
+            return splitted_url.group(3)
+
         response = self.get_html_response(
             '/signup?return_url=https://google.com', expected_status_int=302)
+        self.assertEqual('', strip_domain_from_location_header(
+            response.headers['location']))
+
         response = self.get_html_response(
             '/signup?return_url=//google.com', expected_status_int=302)
+        self.assertEqual('', strip_domain_from_location_header(
+            response.headers['location']))
+
         response = self.get_html_response(
             '/signup?return_url=/page', expected_status_int=302)
-
-        self.assertIn('/', response.headers['location'])
-        self.assertIn('/', response.headers['location'])
-        self.assertIn('/page', response.headers['location'])
+        self.assertEqual('page', strip_domain_from_location_header(
+            response.headers['location']))
 
         self.logout()
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #6383 : To patch the open url redirection in signup page, i've added regex to validate return_url.
Now, https://www.oppia.org/signup?return_url=https://google.com will redirect to '/'
and https://www.oppia.org/signup?return_url=/hello will redirect = '/hello'
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
