### PR TITLE
Fixes #6468: Fixed the improper alignment of tick mark

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -133,6 +133,11 @@ md-input-group.md-default-theme label {
   margin-right: 20px;
 }
 
+.protractor-test-search-bar-dropdown-menu {
+  width: 170px;
+}
+
+
 /* Attributes for material-icons. */
 .material-icons {
   vertical-align: middle;


### PR DESCRIPTION
This PR solves the alignment issue of the tick mark in library page and category section. Before the bug was solved the page looked like as shown below
![Screenshot (29)](https://user-images.githubusercontent.com/36122870/54944389-9e82ca80-4ef0-11e9-903f-88181d5622d9.png)

After the Bug has been resolved the page looks like
![Screenshot (34)](https://user-images.githubusercontent.com/36122870/54944526-eb66a100-4ef0-11e9-8eb2-0d697d3eb78e.png)

Fixes #6468 
## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
