### PR TITLE
Fix Part of #6240: Added profileFeatures.js e2e test for profile feature functional capability.

### DIFF
--- a/core/tests/protractor_desktop/creatorDashboard.js
+++ b/core/tests/protractor_desktop/creatorDashboard.js
@@ -37,7 +37,7 @@ describe('Creator dashboard functionality', function() {
   var explorationPlayerPage = null;
   var libraryPage = null;
   var learnerDashboardPage = null;
-  
+
   beforeAll(function() {
     libraryPage = new LibraryPage.LibraryPage();
     collectionEditorPage = new CollectionEditorPage.CollectionEditorPage();
@@ -47,15 +47,17 @@ describe('Creator dashboard functionality', function() {
     explorationEditorSettingsTab = explorationEditorPage.getSettingsTab();
     explorationPlayerPage = new ExplorationPlayerPage.ExplorationPlayerPage();
   });
-  
+
   it('displays creators subscribers', function() {
-    //created a creator ID and 2 learner ID.
+    // created a creator ID and 2 learner ID.
     var creator1Id = 'creatorName';
-    users.createUser('learner1@learnerDashboard.com', 'learner1learnerDashboard');
-    users.createUser('learner2@learnerDashboard.com', 'learner2learnerDashboard');
+    users.createUser('learner1@learnerDashboard.com', 
+    'learner1learnerDashboard');
+    users.createUser('learner2@learnerDashboard.com', 
+    'learner2learnerDashboard');
     users.createUser(creator1Id + '@creatorDashboard.com', creator1Id);
 
-      //created a new exploration for the creator.
+      // created a new exploration for the creator.
     users.login(creator1Id + '@creatorDashboard.com');
     creatorDashboardPage.clickCreateExplorationButton();    
     workflow.createAndPublishExploration(
@@ -66,7 +68,7 @@ describe('Creator dashboard functionality', function() {
     );
     users.logout();
      
-    //both the learners will subscribe to the creator.
+    // both the learners will subscribe to the creator.
     users.login('learner1@learnerDashboard.com');
     subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
     subscriptionDashboardPage.navigateToSubscriptionButton();

--- a/core/tests/protractor_desktop/creatorDashboard.js
+++ b/core/tests/protractor_desktop/creatorDashboard.js
@@ -51,7 +51,7 @@ describe('Creator dashboard functionality', function() {
   it('displays creators subscribers', function() {
     // created a creator ID and 2 learner ID.
     var creator1Id = 'creatorName';
-    users.createUser('learner1@learnerDashboard.com', 
+    users.createUser('learner1@learnerDashboard.com',
     'learner1learnerDashboard');
     users.createUser('learner2@learnerDashboard.com', 
     'learner2learnerDashboard');
@@ -79,7 +79,7 @@ describe('Creator dashboard functionality', function() {
     subscriptionDashboardPage.navigateToSubscriptionButton();
     users.logout();
      
-      //exploration created by the creator.
+      // exploration created by the creator.
     users.login(creator1Id + '@creatorDashboard.com');
     workflow.createAndPublishExploration(
       'Activations',
@@ -88,7 +88,7 @@ describe('Creator dashboard functionality', function() {
       'English'
     );
     
-      //navigating to creator's subscribed dashboard.
+      // navigating to creator's subscribed dashboard.
     creatorDashboardPage.navigateToSubscriptionDashboard();
     users.logout();
   });
@@ -107,7 +107,7 @@ describe('Creator dashboard functionality', function() {
     );
     users.logout();
 
-      //learner gives a feedback to creator exploration.
+      // learner gives a feedback to creator exploration.
     users.login('learner2@learnerDashboard.com');
     var feedback = 'A good exploration. Would love to see a few more questions';
     libraryPage.get();
@@ -115,13 +115,13 @@ describe('Creator dashboard functionality', function() {
     explorationPlayerPage.submitFeedback(feedback);
     users.logout();
 
-    //creator checks all his feedback messages.
+    // creator checks all his feedback messages.
     users.login(creator1Id + '@creatorDashboard.com');
     creatorDashboardPage.getNumberOfFeedbackMessages();
     creatorDashboardPage.editExploration('Activations');
     users.logout();
   });
-      
+
   afterEach(function() {
     general.checkForConsoleErrors([]);
   });

--- a/core/tests/protractor_desktop/creatorDashboard.js
+++ b/core/tests/protractor_desktop/creatorDashboard.js
@@ -24,12 +24,18 @@ var waitFor = require('../protractor_utils/waitFor.js');
 var workflow = require('../protractor_utils/workflow.js');
 
 
-var AdminPage = require('../protractor_utils/AdminPage.js');
-var CreatorDashboardPage = require('../protractor_utils/CreatorDashboardPage.js');
-var CollectionEditorPage = require('../protractor_utils/CollectionEditorPage.js');
-var ExplorationEditorPage = require('../protractor_utils/ExplorationEditorPage.js');
-var ExplorationPlayerPage = require('../protractor_utils/ExplorationPlayerPage.js');
-var LibraryPage = require('../protractor_utils/LibraryPage.js');
+var AdminPage =
+require('../protractor_utils/AdminPage.js');
+var CreatorDashboardPage =
+require('../protractor_utils/CreatorDashboardPage.js');
+var CollectionEditorPage =
+require('../protractor_utils/CollectionEditorPage.js');
+var ExplorationEditorPage =
+require('../protractor_utils/ExplorationEditorPage.js');
+var ExplorationPlayerPage =
+require('../protractor_utils/ExplorationPlayerPage.js');
+var LibraryPage =
+require('../protractor_utils/LibraryPage.js');
 
 describe('Creator dashboard functionality', function() {
   var creatorDashboardPage = null;

--- a/core/tests/protractor_desktop/creatorDashboard.js
+++ b/core/tests/protractor_desktop/creatorDashboard.js
@@ -32,95 +32,95 @@ var ExplorationPlayerPage = require('../protractor_utils/ExplorationPlayerPage.j
 var LibraryPage = require('../protractor_utils/LibraryPage.js');
 
 describe('Creator dashboard functionality', function() {
-    var creatorDashboardPage = null;
-    var explorationEditorPage = null;
-    var explorationPlayerPage = null;
-    var libraryPage = null;
-    var learnerDashboardPage = null;
+  var creatorDashboardPage = null;
+  var explorationEditorPage = null;
+  var explorationPlayerPage = null;
+  var libraryPage = null;
+  var learnerDashboardPage = null;
   
-    beforeAll(function() {
-      libraryPage = new LibraryPage.LibraryPage();
-      collectionEditorPage = new CollectionEditorPage.CollectionEditorPage();
-      creatorDashboardPage = new CreatorDashboardPage.CreatorDashboardPage();
-      explorationEditorPage = new ExplorationEditorPage.ExplorationEditorPage();
-      explorationEditorMainTab = explorationEditorPage.getMainTab();
-      explorationEditorSettingsTab = explorationEditorPage.getSettingsTab();
-      explorationPlayerPage = new ExplorationPlayerPage.ExplorationPlayerPage();
-    });
+  beforeAll(function() {
+    libraryPage = new LibraryPage.LibraryPage();
+    collectionEditorPage = new CollectionEditorPage.CollectionEditorPage();
+    creatorDashboardPage = new CreatorDashboardPage.CreatorDashboardPage();
+    explorationEditorPage = new ExplorationEditorPage.ExplorationEditorPage();
+    explorationEditorMainTab = explorationEditorPage.getMainTab();
+    explorationEditorSettingsTab = explorationEditorPage.getSettingsTab();
+    explorationPlayerPage = new ExplorationPlayerPage.ExplorationPlayerPage();
+  });
   
-    it('displays creators subscribers', function() {
-      //created a creator ID and 2 learner ID.
-      var creator1Id = 'creatorName';
-      users.createUser('learner1@learnerDashboard.com', 'learner1learnerDashboard');
-      users.createUser('learner2@learnerDashboard.com', 'learner2learnerDashboard');
-      users.createUser(creator1Id + '@creatorDashboard.com', creator1Id);
+  it('displays creators subscribers', function() {
+    //created a creator ID and 2 learner ID.
+    var creator1Id = 'creatorName';
+    users.createUser('learner1@learnerDashboard.com', 'learner1learnerDashboard');
+    users.createUser('learner2@learnerDashboard.com', 'learner2learnerDashboard');
+    users.createUser(creator1Id + '@creatorDashboard.com', creator1Id);
 
       //created a new exploration for the creator.
-      users.login(creator1Id + '@creatorDashboard.com');
-      creatorDashboardPage.clickCreateExplorationButton();    
-      workflow.createAndPublishExploration(
-        'Activations',
-        'Chemistry',
-        'Learn about different types of chemistry activations.',
-        'English'
-      );
-      users.logout();
+    users.login(creator1Id + '@creatorDashboard.com');
+    creatorDashboardPage.clickCreateExplorationButton();    
+    workflow.createAndPublishExploration(
+      'Activations',
+      'Chemistry',
+      'Learn about different types of chemistry activations.',
+      'English'
+    );
+    users.logout();
      
-      //both the learners will subscribe to the creator.
-      users.login('learner1@learnerDashboard.com');
-      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
-      subscriptionDashboardPage.navigateToSubscriptionButton();
-      users.logout();
+    //both the learners will subscribe to the creator.
+    users.login('learner1@learnerDashboard.com');
+    subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
+    subscriptionDashboardPage.navigateToSubscriptionButton();
+    users.logout();
 
-      users.login('learner2@learnerDashboard.com');
-      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
-      subscriptionDashboardPage.navigateToSubscriptionButton();
-      users.logout();
+    users.login('learner2@learnerDashboard.com');
+    subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
+    subscriptionDashboardPage.navigateToSubscriptionButton();
+    users.logout();
      
       //exploration created by the creator.
-      users.login(creator1Id + '@creatorDashboard.com');
-      workflow.createAndPublishExploration(
-        'Activations',
-        'Chemistry',
-        'Learn about different types of chemistry activations.',
-        'English'
-      );
+    users.login(creator1Id + '@creatorDashboard.com');
+    workflow.createAndPublishExploration(
+      'Activations',
+      'Chemistry',
+      'Learn about different types of chemistry activations.',
+      'English'
+    );
     
       //navigating to creator's subscribed dashboard.
-      creatorDashboardPage.navigateToSubscriptionDashboard();
-      users.logout();
-    });
+    creatorDashboardPage.navigateToSubscriptionDashboard();
+    users.logout();
+  });
 
-    it('get all feedback messages count & edit exploration', function() {
-      var creator1Id = 'creatorName';
-      users.createUser(creator1Id + '@learnerDashboard.com', creator1Id);
-      users.createUser('learner1@learnerDashboard.com', 'learner1learnerDashboard');
-      users.login(creator1Id + '@creatorDashboard.com');
-      creatorDashboardPage.clickCreateExplorationButton();    
-      workflow.createAndPublishExploration(
-        'Activations',
-        'Chemistry',
-        'Learn about different types of chemistry activations.',
-        'English'
-      );
-      users.logout();
+  it('get all feedback messages count & edit exploration', function() {
+    var creator1Id = 'creatorName';
+    users.createUser(creator1Id + '@learnerDashboard.com', creator1Id);
+    users.createUser('learner1@learnerDashboard.com', 'learner1learnerDashboard');
+    users.login(creator1Id + '@creatorDashboard.com');
+    creatorDashboardPage.clickCreateExplorationButton();    
+    workflow.createAndPublishExploration(
+      'Activations',
+      'Chemistry',
+      'Learn about different types of chemistry activations.',
+      'English'
+    );
+    users.logout();
 
       //learner gives a feedback to creator exploration.
-      users.login('learner2@learnerDashboard.com');
-      var feedback = 'A good exploration. Would love to see a few more questions';
-      libraryPage.get();
-      libraryPage.findExploration('Activations');
-      explorationPlayerPage.submitFeedback(feedback);
-      users.logout();
+    users.login('learner2@learnerDashboard.com');
+    var feedback = 'A good exploration. Would love to see a few more questions';
+    libraryPage.get();
+    libraryPage.findExploration('Activations');
+    explorationPlayerPage.submitFeedback(feedback);
+    users.logout();
 
-      //creator checks all his feedback messages.
-      users.login(creator1Id + '@creatorDashboard.com');
-      creatorDashboardPage.getNumberOfFeedbackMessages();
-      creatorDashboardPage.editExploration('Activations');
-      users.logout();
-    });
+    //creator checks all his feedback messages.
+    users.login(creator1Id + '@creatorDashboard.com');
+    creatorDashboardPage.getNumberOfFeedbackMessages();
+    creatorDashboardPage.editExploration('Activations');
+    users.logout();
+  });
       
-    afterEach(function() {
-        general.checkForConsoleErrors([]);
-    });
+  afterEach(function() {
+    general.checkForConsoleErrors([]);
+  });
 });

--- a/core/tests/protractor_desktop/creatorDashboard.js
+++ b/core/tests/protractor_desktop/creatorDashboard.js
@@ -1,0 +1,126 @@
+
+// Copyright 2018 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview End-to-end tests for the creator dashboard page.
+ */
+
+var forms = require('../protractor_utils/forms.js');
+var general = require('../protractor_utils/general.js');
+var users = require('../protractor_utils/users.js');
+var waitFor = require('../protractor_utils/waitFor.js');
+var workflow = require('../protractor_utils/workflow.js');
+
+
+var AdminPage = require('../protractor_utils/AdminPage.js');
+var CreatorDashboardPage = require('../protractor_utils/CreatorDashboardPage.js');
+var CollectionEditorPage = require('../protractor_utils/CollectionEditorPage.js');
+var ExplorationEditorPage = require('../protractor_utils/ExplorationEditorPage.js');
+var ExplorationPlayerPage = require('../protractor_utils/ExplorationPlayerPage.js');
+var LibraryPage = require('../protractor_utils/LibraryPage.js');
+
+describe('Creator dashboard functionality', function() {
+    var creatorDashboardPage = null;
+    var explorationEditorPage = null;
+    var explorationPlayerPage = null;
+    var libraryPage = null;
+    var learnerDashboardPage = null;
+  
+    beforeAll(function() {
+      libraryPage = new LibraryPage.LibraryPage();
+      collectionEditorPage = new CollectionEditorPage.CollectionEditorPage();
+      creatorDashboardPage = new CreatorDashboardPage.CreatorDashboardPage();
+      explorationEditorPage = new ExplorationEditorPage.ExplorationEditorPage();
+      explorationEditorMainTab = explorationEditorPage.getMainTab();
+      explorationEditorSettingsTab = explorationEditorPage.getSettingsTab();
+      explorationPlayerPage = new ExplorationPlayerPage.ExplorationPlayerPage();
+    });
+  
+    it('displays creators subscribers', function() {
+      //created a creator ID and 2 learner ID.
+      var creator1Id = 'creatorName';
+      users.createUser('learner1@learnerDashboard.com', 'learner1learnerDashboard');
+      users.createUser('learner2@learnerDashboard.com', 'learner2learnerDashboard');
+      users.createUser(creator1Id + '@creatorDashboard.com', creator1Id);
+
+      //created a new exploration for the creator.
+      users.login(creator1Id + '@creatorDashboard.com');
+      creatorDashboardPage.clickCreateExplorationButton();    
+      workflow.createAndPublishExploration(
+        'Activations',
+        'Chemistry',
+        'Learn about different types of chemistry activations.',
+        'English'
+      );
+      users.logout();
+     
+      //both the learners will subscribe to the creator.
+      users.login('learner1@learnerDashboard.com');
+      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
+      subscriptionDashboardPage.navigateToSubscriptionButton();
+      users.logout();
+
+      users.login('learner2@learnerDashboard.com');
+      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
+      subscriptionDashboardPage.navigateToSubscriptionButton();
+      users.logout();
+     
+      //exploration created by the creator.
+      users.login(creator1Id + '@creatorDashboard.com');
+      workflow.createAndPublishExploration(
+        'Activations',
+        'Chemistry',
+        'Learn about different types of chemistry activations.',
+        'English'
+      );
+    
+      //navigating to creator's subscribed dashboard.
+      creatorDashboardPage.navigateToSubscriptionDashboard();
+      users.logout();
+    });
+
+    it('get all feedback messages count & edit exploration', function() {
+      var creator1Id = 'creatorName';
+      users.createUser(creator1Id + '@learnerDashboard.com', creator1Id);
+      users.createUser('learner1@learnerDashboard.com', 'learner1learnerDashboard');
+      users.login(creator1Id + '@creatorDashboard.com');
+      creatorDashboardPage.clickCreateExplorationButton();    
+      workflow.createAndPublishExploration(
+        'Activations',
+        'Chemistry',
+        'Learn about different types of chemistry activations.',
+        'English'
+      );
+      users.logout();
+
+      //learner gives a feedback to creator exploration.
+      users.login('learner2@learnerDashboard.com');
+      var feedback = 'A good exploration. Would love to see a few more questions';
+      libraryPage.get();
+      libraryPage.findExploration('Activations');
+      explorationPlayerPage.submitFeedback(feedback);
+      users.logout();
+
+      //creator checks all his feedback messages.
+      users.login(creator1Id + '@creatorDashboard.com');
+      creatorDashboardPage.getNumberOfFeedbackMessages();
+      creatorDashboardPage.editExploration('Activations');
+      users.logout();
+    });
+      
+    afterEach(function() {
+        general.checkForConsoleErrors([]);
+    });
+});

--- a/core/tests/protractor_desktop/creatorDashboard.js
+++ b/core/tests/protractor_desktop/creatorDashboard.js
@@ -58,14 +58,14 @@ describe('Creator dashboard functionality', function() {
     // created a creator ID and 2 learner ID.
     var creator1Id = 'creatorName';
     users.createUser('learner1@learnerDashboard.com',
-    'learner1learnerDashboard');
-    users.createUser('learner2@learnerDashboard.com', 
-    'learner2learnerDashboard');
+      'learner1learnerDashboard');
+    users.createUser('learner2@learnerDashboard.com',
+      'learner2learnerDashboard');
     users.createUser(creator1Id + '@creatorDashboard.com', creator1Id);
 
-      // created a new exploration for the creator.
+    // created a new exploration for the creator.
     users.login(creator1Id + '@creatorDashboard.com');
-    creatorDashboardPage.clickCreateExplorationButton();    
+    creatorDashboardPage.clickCreateExplorationButton();
     workflow.createAndPublishExploration(
       'Activations',
       'Chemistry',
@@ -73,7 +73,7 @@ describe('Creator dashboard functionality', function() {
       'English'
     );
     users.logout();
-     
+
     // both the learners will subscribe to the creator.
     users.login('learner1@learnerDashboard.com');
     subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
@@ -84,7 +84,7 @@ describe('Creator dashboard functionality', function() {
     subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
     subscriptionDashboardPage.navigateToSubscriptionButton();
     users.logout();
-     
+
       // exploration created by the creator.
     users.login(creator1Id + '@creatorDashboard.com');
     workflow.createAndPublishExploration(
@@ -93,8 +93,8 @@ describe('Creator dashboard functionality', function() {
       'Learn about different types of chemistry activations.',
       'English'
     );
-    
-      // navigating to creator's subscribed dashboard.
+
+    // navigating to creator's subscribed dashboard.
     creatorDashboardPage.navigateToSubscriptionDashboard();
     users.logout();
   });
@@ -102,7 +102,8 @@ describe('Creator dashboard functionality', function() {
   it('get all feedback messages count & edit exploration', function() {
     var creator1Id = 'creatorName';
     users.createUser(creator1Id + '@learnerDashboard.com', creator1Id);
-    users.createUser('learner1@learnerDashboard.com', 'learner1learnerDashboard');
+    users.createUser('learner1@learnerDashboard.com',
+      'learner1learnerDashboard');
     users.login(creator1Id + '@creatorDashboard.com');
     creatorDashboardPage.clickCreateExplorationButton();    
     workflow.createAndPublishExploration(
@@ -113,7 +114,7 @@ describe('Creator dashboard functionality', function() {
     );
     users.logout();
 
-      // learner gives a feedback to creator exploration.
+    // learner gives a feedback to creator exploration.
     users.login('learner2@learnerDashboard.com');
     var feedback = 'A good exploration. Would love to see a few more questions';
     libraryPage.get();

--- a/core/tests/protractor_desktop/creatorDashboard.js
+++ b/core/tests/protractor_desktop/creatorDashboard.js
@@ -85,7 +85,7 @@ describe('Creator dashboard functionality', function() {
     subscriptionDashboardPage.navigateToSubscriptionButton();
     users.logout();
 
-      // exploration created by the creator.
+    // exploration created by the creator.
     users.login(creator1Id + '@creatorDashboard.com');
     workflow.createAndPublishExploration(
       'Activations',
@@ -105,7 +105,7 @@ describe('Creator dashboard functionality', function() {
     users.createUser('learner1@learnerDashboard.com',
       'learner1learnerDashboard');
     users.login(creator1Id + '@creatorDashboard.com');
-    creatorDashboardPage.clickCreateExplorationButton();    
+    creatorDashboardPage.clickCreateExplorationButton();
     workflow.createAndPublishExploration(
       'Activations',
       'Chemistry',

--- a/core/tests/protractor_desktop/learnerDashboard.js
+++ b/core/tests/protractor_desktop/learnerDashboard.js
@@ -23,20 +23,14 @@ var waitFor = require('../protractor_utils/waitFor.js');
 var workflow = require('../protractor_utils/workflow.js');
 
 var AdminPage = require('../protractor_utils/AdminPage.js');
-var CreatorDashboardPage =
-  require('../protractor_utils/CreatorDashboardPage.js');
-var CollectionEditorPage =
-  require('../protractor_utils/CollectionEditorPage.js');
-var ExplorationEditorPage =
-  require('../protractor_utils/ExplorationEditorPage.js');
-var ExplorationPlayerPage =
-  require('../protractor_utils/ExplorationPlayerPage.js');
-var LearnerDashboardPage =
-  require('../protractor_utils/LearnerDashboardPage.js');
+var CreatorDashboardPage = require('../protractor_utils/CreatorDashboardPage.js');
+var CollectionEditorPage = require('../protractor_utils/CollectionEditorPage.js');
+var ExplorationEditorPage = require('../protractor_utils/ExplorationEditorPage.js');
+var ExplorationPlayerPage = require('../protractor_utils/ExplorationPlayerPage.js');
+var LearnerDashboardPage = require('../protractor_utils/LearnerDashboardPage.js');
 var LibraryPage = require('../protractor_utils/LibraryPage.js');
 var PreferencesPage = require('../protractor_utils/PreferencesPage.js');
-var SubscriptionDashboardPage =
-  require('../protractor_utils/SubscriptionDashboardPage.js');
+var SubscriptionDashboardPage = require('../protractor_utils/SubscriptionDashboardPage.js');
 
 describe('Learner dashboard functionality', function() {
   var creatorDashboardPage = null;

--- a/core/tests/protractor_desktop/learnerDashboard.js
+++ b/core/tests/protractor_desktop/learnerDashboard.js
@@ -23,14 +23,22 @@ var waitFor = require('../protractor_utils/waitFor.js');
 var workflow = require('../protractor_utils/workflow.js');
 
 var AdminPage = require('../protractor_utils/AdminPage.js');
-var CreatorDashboardPage = require('../protractor_utils/CreatorDashboardPage.js');
-var CollectionEditorPage = require('../protractor_utils/CollectionEditorPage.js');
-var ExplorationEditorPage = require('../protractor_utils/ExplorationEditorPage.js');
-var ExplorationPlayerPage = require('../protractor_utils/ExplorationPlayerPage.js');
-var LearnerDashboardPage = require('../protractor_utils/LearnerDashboardPage.js');
-var LibraryPage = require('../protractor_utils/LibraryPage.js');
-var PreferencesPage = require('../protractor_utils/PreferencesPage.js');
-var SubscriptionDashboardPage = require('../protractor_utils/SubscriptionDashboardPage.js');
+var CreatorDashboardPage = 
+require('../protractor_utils/CreatorDashboardPage.js');
+var CollectionEditorPage = 
+require('../protractor_utils/CollectionEditorPage.js');
+var ExplorationEditorPage = 
+require('../protractor_utils/ExplorationEditorPage.js');
+var ExplorationPlayerPage = 
+require('../protractor_utils/ExplorationPlayerPage.js');
+var LearnerDashboardPage = 
+require('../protractor_utils/LearnerDashboardPage.js');
+var LibraryPage = 
+require('../protractor_utils/LibraryPage.js');
+var PreferencesPage = 
+require('../protractor_utils/PreferencesPage.js');
+var SubscriptionDashboardPage = 
+require('../protractor_utils/SubscriptionDashboardPage.js');
 
 describe('Learner dashboard functionality', function() {
   var creatorDashboardPage = null;

--- a/core/tests/protractor_desktop/learnerDashboard.js
+++ b/core/tests/protractor_desktop/learnerDashboard.js
@@ -23,21 +23,21 @@ var waitFor = require('../protractor_utils/waitFor.js');
 var workflow = require('../protractor_utils/workflow.js');
 
 var AdminPage = require('../protractor_utils/AdminPage.js');
-var CreatorDashboardPage = 
+var CreatorDashboardPage =
 require('../protractor_utils/CreatorDashboardPage.js');
-var CollectionEditorPage = 
+var CollectionEditorPage =
 require('../protractor_utils/CollectionEditorPage.js');
-var ExplorationEditorPage = 
+var ExplorationEditorPage =
 require('../protractor_utils/ExplorationEditorPage.js');
-var ExplorationPlayerPage = 
+var ExplorationPlayerPage =
 require('../protractor_utils/ExplorationPlayerPage.js');
-var LearnerDashboardPage = 
+var LearnerDashboardPage =
 require('../protractor_utils/LearnerDashboardPage.js');
-var LibraryPage = 
+var LibraryPage =
 require('../protractor_utils/LibraryPage.js');
-var PreferencesPage = 
+var PreferencesPage =
 require('../protractor_utils/PreferencesPage.js');
-var SubscriptionDashboardPage = 
+var SubscriptionDashboardPage =
 require('../protractor_utils/SubscriptionDashboardPage.js');
 
 describe('Learner dashboard functionality', function() {

--- a/core/tests/protractor_desktop/profileFeatures.js
+++ b/core/tests/protractor_desktop/profileFeatures.js
@@ -15,3 +15,98 @@
 /**
 * @fileoverview End-to-end tests for user profile features.
 */
+
+var forms = require('../protractor_utils/forms.js');
+var general = require('../protractor_utils/general.js');
+var users = require('../protractor_utils/users.js');
+var waitFor = require('../protractor_utils/waitFor.js');
+var workflow = require('../protractor_utils/workflow.js');
+
+
+var AdminPage =
+require('../protractor_utils/AdminPage.js');
+var CreatorDashboardPage =
+require('../protractor_utils/CreatorDashboardPage.js');
+var CollectionEditorPage =
+require('../protractor_utils/CollectionEditorPage.js');
+var ExplorationEditorPage =
+require('../protractor_utils/ExplorationEditorPage.js');
+var ExplorationPlayerPage =
+require('../protractor_utils/ExplorationPlayerPage.js');
+var LibraryPage =
+require('../protractor_utils/LibraryPage.js');
+
+describe('Creator dashboard functionality', function() {
+  var creatorDashboardPage = null;
+  var explorationEditorPage = null;
+  var explorationPlayerPage = null;
+  var libraryPage = null;
+  var learnerDashboardPage = null;
+
+  var creator1Id = 'creatorName';
+  var creator2Id = 'creatorName2';
+  users.createUser('learner1@learnerDashboard.com',
+    'learner1learnerDashboard');
+  users.createUser('learner2@learnerDashboard.com',
+    'learner2learnerDashboard');
+  users.createUser(creator1Id + '@creatorDashboard.com', creator1Id);
+  users.createUser(creator2Id + '@creatorDashboard.com', creator2Id);
+
+  beforeAll(function() {
+    libraryPage = new LibraryPage.LibraryPage();
+    collectionEditorPage = new CollectionEditorPage.CollectionEditorPage();
+    creatorDashboardPage = new CreatorDashboardPage.CreatorDashboardPage();
+    explorationEditorPage = new ExplorationEditorPage.ExplorationEditorPage();
+    explorationEditorMainTab = explorationEditorPage.getMainTab();
+    explorationEditorSettingsTab = explorationEditorPage.getSettingsTab();
+    explorationPlayerPage = new ExplorationPlayerPage.ExplorationPlayerPage();
+  });
+
+  it('view exploration created by another user', function() {
+    users.login('learner1@learnerDashboard.com');
+    workflow.createAndPublishExploration(
+      'Activations',
+      'Chemistry',
+      'Learn about different types of chemistry activations.',
+      'English'
+    );
+    users.logout();
+
+    users.login('learner2@learnerDashboard.com');
+    libraryPage.findExploration('Activations');
+    users.logout();
+  });
+
+  it('subscribe to another user', function() {
+    users.login('learner1@learnerDashboard.com');
+    subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id +
+      '@creatorDashboard.com');
+    subscriptionDashboardPage.navigateToSubscriptionButton();
+    subscriptionDashboardPage.navigateToUserSubscriptionPage(creator2Id +
+      '@creatorDashboard.com');
+    subscriptionDashboardPage.navigateToSubscriptionButton();
+    users.logout();
+
+    users.login('learner2@learnerDashboard.com');
+    subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id +
+      '@creatorDashboard.com');
+    subscriptionDashboardPage.navigateToSubscriptionButton();
+    subscriptionDashboardPage.navigateToUserSubscriptionPage(creator2Id +
+      '@creatorDashboard.com');
+    subscriptionDashboardPage.navigateToSubscriptionButton();
+    users.logout();
+  });
+
+  it('get number of explorations of a user', function() {
+    users.login(creator1Id + 'creatorDashboard.com');
+    workflow.createAndPublishExploration(
+      'Activations',
+      'Chemistry',
+      'Learn about different types of chemistry activations.',
+      'English'
+    );
+
+    creatorDashboardPage.getNumberofExplorations();
+    users.logout();
+  });
+});

--- a/core/tests/protractor_utils/CreatorDashboardPage.js
+++ b/core/tests/protractor_utils/CreatorDashboardPage.js
@@ -1,4 +1,4 @@
-// Copyright 2017 The Oppia Authors. All Rights Reserved.
+// Copyright 2019 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -54,8 +54,8 @@ var CreatorDashboardPage = function() {
   var getNumberofExplorations = function() {
     var allExplorationDashboardCard = element.all(
       by.css('.protractor-test-exploration-dashboard-card'));
-      return allExplorationDashboardCard.length;
-  }
+    return allExplorationDashboardCard.length;
+  };
 
   this.get = function() {
     browser.get(CREATOR_DASHBOARD_URL);

--- a/core/tests/protractor_utils/CreatorDashboardPage.js
+++ b/core/tests/protractor_utils/CreatorDashboardPage.js
@@ -51,6 +51,12 @@ var CreatorDashboardPage = function() {
     });
   };
 
+  var getNumberofExplorations = function() {
+    var allExplorationDashboardCard = element.all(
+      by.css('.protractor-test-exploration-dashboard-card'));
+      return allExplorationDashboardCard.length;
+  }
+
   this.get = function() {
     browser.get(CREATOR_DASHBOARD_URL);
     return waitFor.pageToFullyLoad();

--- a/core/tests/protractor_utils/CreatorDashboardPage.js
+++ b/core/tests/protractor_utils/CreatorDashboardPage.js
@@ -1,4 +1,4 @@
-// Copyright 2017 The Oppia Authors. All Rights Reserved.
+// Copyright 2019 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,6 +49,12 @@ var CreatorDashboardPage = function() {
           return (tileTitle === explorationTitle);
         });
     });
+  };
+
+  var getNumberofExplorations = function() {
+    var allExplorationDashboardCard = element.all(
+      by.css('.protractor-test-exploration-dashboard-card'));
+    return allExplorationDashboardCard.length;
   };
 
   this.get = function() {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fix part of #6240: Added e2e test for profile feature functionality. This PR adds an e2e test for profile features under the core/tests/protactor_desktop directory. This test covers the following features:-
1) View explorations created by another user on their profile page.
2) Subscribe to the user.
3) View number of created explorations.

Kindly ignore the changes in file 'creatorDashboard.js' and 'learnerDashboard.js'. These files are still under review in PR no. #6477

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
