### PR TITLE
Fixed the backend issues with some new structure models

### DIFF
--- a/core/controllers/question_editor.py
+++ b/core/controllers/question_editor.py
@@ -49,7 +49,7 @@ class QuestionCreationHandler(base.BaseHandler):
                 (question_dict['version'] != 1)):
             raise self.InvalidInputException
 
-        question_dict['question_state_schema_version'] = (
+        question_dict['question_state_data_schema_version'] = (
             feconf.CURRENT_STATES_SCHEMA_VERSION)
         question_dict['id'] = question_services.get_new_question_id()
         try:

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -389,7 +389,7 @@ class QuestionSuggestionTests(test_utils.GenericTestBase):
             'question_state_data': self._create_valid_question_data(
                 'default_state').to_dict(),
             'language_code': 'en',
-            'question_state_schema_version': (
+            'question_state_data_schema_version': (
                 feconf.CURRENT_STATES_SCHEMA_VERSION)
         }
         self.login(self.AUTHOR_EMAIL)

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -120,7 +120,7 @@ class Question(object):
 
     def __init__(
             self, question_id, question_state_data,
-            question_state_schema_version, language_code, version,
+            question_state_data_schema_version, language_code, version,
             created_on=None, last_updated=None):
         """Constructs a Question domain object.
 
@@ -128,7 +128,7 @@ class Question(object):
             question_id: str. The unique ID of the question.
             question_state_data: State. An object representing the question
                 state data.
-            question_state_schema_version: int. The schema version of the
+            question_state_data_schema_version: int. The schema version of the
                 question states (equivalent to the states schema version of
                 explorations).
             language_code: str. The ISO 639-1 code for the language this
@@ -142,7 +142,8 @@ class Question(object):
         self.id = question_id
         self.question_state_data = question_state_data
         self.language_code = language_code
-        self.question_state_schema_version = question_state_schema_version
+        self.question_state_data_schema_version = (
+            question_state_data_schema_version)
         self.version = version
         self.created_on = created_on
         self.last_updated = last_updated
@@ -156,7 +157,8 @@ class Question(object):
         return {
             'id': self.id,
             'question_state_data': self.question_state_data.to_dict(),
-            'question_state_schema_version': self.question_state_schema_version,
+            'question_state_data_schema_version': (
+                self.question_state_data_schema_version),
             'language_code': self.language_code,
             'version': self.version
         }
@@ -209,10 +211,10 @@ class Question(object):
                 'Expected language_code to be a string, received %s' %
                 self.language_code)
 
-        if not isinstance(self.question_state_schema_version, int):
+        if not isinstance(self.question_state_data_schema_version, int):
             raise utils.ValidationError(
                 'Expected schema version to be an integer, received %s' %
-                self.question_state_schema_version)
+                self.question_state_data_schema_version)
 
         if not isinstance(self.question_state_data, state_domain.State):
             raise utils.ValidationError(
@@ -286,7 +288,7 @@ class Question(object):
         question = cls(
             question_dict['id'],
             state_domain.State.from_dict(question_dict['question_state_data']),
-            question_dict['question_state_schema_version'],
+            question_dict['question_state_data_schema_version'],
             question_dict['language_code'], question_dict['version'])
 
         return question

--- a/core/domain/question_domain_test.py
+++ b/core/domain/question_domain_test.py
@@ -132,7 +132,7 @@ class QuestionDomainTest(test_utils.GenericTestBase):
         question_dict = {
             'id': 'col1.random',
             'question_state_data': default_question_state_data.to_dict(),
-            'question_state_schema_version': (
+            'question_state_data_schema_version': (
                 feconf.CURRENT_STATES_SCHEMA_VERSION),
             'language_code': 'en',
             'version': 1
@@ -218,7 +218,7 @@ class QuestionDomainTest(test_utils.GenericTestBase):
         self._assert_validation_error(
             'Expected question state data to be a State object')
 
-        self.question.question_state_schema_version = 'abc'
+        self.question.question_state_data_schema_version = 'abc'
         self._assert_validation_error(
             'Expected schema version to be an integer')
 

--- a/core/domain/question_jobs_one_off.py
+++ b/core/domain/question_jobs_one_off.py
@@ -69,11 +69,11 @@ class QuestionMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
         # Write the new question into the datastore if it's different from
         # the old version.
-        if (item.question_state_schema_version <=
+        if (item.question_state_data_schema_version <=
                 feconf.CURRENT_STATES_SCHEMA_VERSION):
             commit_cmds = [question_domain.QuestionChange({
                 'cmd': question_domain.CMD_MIGRATE_STATE_SCHEMA_TO_LATEST_VERSION, # pylint: disable=line-too-long
-                'from_version': item.question_state_schema_version,
+                'from_version': item.question_state_data_schema_version,
                 'to_version': feconf.CURRENT_STATES_SCHEMA_VERSION
             })]
             question_services.update_question(

--- a/core/domain/question_jobs_one_off_test.py
+++ b/core/domain/question_jobs_one_off_test.py
@@ -56,7 +56,7 @@ class QuestionMigrationOneOffJobTests(test_utils.GenericTestBase):
         question = (
             question_services.get_question_by_id(self.QUESTION_ID))
         self.assertEqual(
-            question.question_state_schema_version,
+            question.question_state_data_schema_version,
             feconf.CURRENT_STATES_SCHEMA_VERSION)
 
         # Start migration job.
@@ -70,7 +70,7 @@ class QuestionMigrationOneOffJobTests(test_utils.GenericTestBase):
         updated_question = (
             question_services.get_question_by_id(self.QUESTION_ID))
         self.assertEqual(
-            updated_question.question_state_schema_version,
+            updated_question.question_state_data_schema_version,
             feconf.CURRENT_STATES_SCHEMA_VERSION)
         self.assertEqual(question.question_state_data.to_dict(),
                          updated_question.question_state_data.to_dict())
@@ -121,7 +121,7 @@ class QuestionMigrationOneOffJobTests(test_utils.GenericTestBase):
             self.QUESTION_ID, self.albert_id)
         question = (
             question_services.get_question_by_id(self.QUESTION_ID))
-        self.assertEqual(question.question_state_schema_version, 27)
+        self.assertEqual(question.question_state_data_schema_version, 27)
 
         # Start migration job.
         with self.swap(constants, 'ENABLE_NEW_STRUCTURE_EDITORS', True):
@@ -134,7 +134,7 @@ class QuestionMigrationOneOffJobTests(test_utils.GenericTestBase):
         updated_question = (
             question_services.get_question_by_id(self.QUESTION_ID))
         self.assertEqual(
-            updated_question.question_state_schema_version,
+            updated_question.question_state_data_schema_version,
             feconf.CURRENT_STATES_SCHEMA_VERSION)
 
         output = question_jobs_one_off.QuestionMigrationOneOffJob.get_output(job_id) # pylint: disable=line-too-long

--- a/core/domain/question_services.py
+++ b/core/domain/question_services.py
@@ -77,7 +77,8 @@ def _create_new_question(committer_id, question, commit_message):
         question_state_data=question.question_state_data.to_dict(),
         language_code=question.language_code,
         version=question.version,
-        question_state_schema_version=question.question_state_schema_version
+        question_state_data_schema_version=(
+            question.question_state_data_schema_version)
     )
     model.commit(
         committer_id, commit_message, [{'cmd': question_domain.CMD_CREATE_NEW}])
@@ -193,13 +194,14 @@ def get_question_from_model(question_model):
 
     # Ensure the original question model does not get altered.
     versioned_question_state = {
-        'state_schema_version': question_model.question_state_schema_version,
+        'state_schema_version': (
+            question_model.question_state_data_schema_version),
         'state': copy.deepcopy(
             question_model.question_state_data)
     }
 
     # Migrate the question if it is not using the latest schema version.
-    if (question_model.question_state_schema_version !=
+    if (question_model.question_state_data_schema_version !=
             feconf.CURRENT_STATES_SCHEMA_VERSION):
         _migrate_state_schema(versioned_question_state)
 
@@ -459,8 +461,8 @@ def _save_question(committer_id, question, change_list, commit_message):
     question_model = question_models.QuestionModel.get(question.id)
     question_model.question_state_data = question.question_state_data.to_dict()
     question_model.language_code = question.language_code
-    question_model.question_state_schema_version = (
-        question.question_state_schema_version)
+    question_model.question_state_data_schema_version = (
+        question.question_state_data_schema_version)
     change_dicts = [change.to_dict() for change in change_list]
     question_model.commit(committer_id, commit_message, change_dicts)
     question.version += 1

--- a/core/domain/subtopic_page_domain_test.py
+++ b/core/domain/subtopic_page_domain_test.py
@@ -20,6 +20,7 @@ from constants import constants
 from core.domain import state_domain
 from core.domain import subtopic_page_domain
 from core.tests import test_utils
+import feconf
 import utils
 
 
@@ -52,6 +53,8 @@ class SubtopicPageDomainUnitTests(test_utils.GenericTestBase):
                     }
                 }
             },
+            'page_contents_schema_version': (
+                feconf.CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION),
             'language_code': constants.DEFAULT_LANGUAGE_CODE,
             'version': 0
         }
@@ -81,6 +84,8 @@ class SubtopicPageDomainUnitTests(test_utils.GenericTestBase):
                     }
                 }
             },
+            'page_contents_schema_version': (
+                feconf.CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION),
             'language_code': constants.DEFAULT_LANGUAGE_CODE,
             'version': 0
         }
@@ -138,6 +143,8 @@ class SubtopicPageDomainUnitTests(test_utils.GenericTestBase):
                     }
                 }
             },
+            'page_contents_schema_version': (
+                feconf.CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION),
             'language_code': constants.DEFAULT_LANGUAGE_CODE,
             'version': 0
         }
@@ -164,6 +171,8 @@ class SubtopicPageDomainUnitTests(test_utils.GenericTestBase):
                     }
                 }
             },
+            'page_contents_schema_version': (
+                feconf.CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION),
             'language_code': constants.DEFAULT_LANGUAGE_CODE,
             'version': 0
         }
@@ -198,6 +207,8 @@ class SubtopicPageDomainUnitTests(test_utils.GenericTestBase):
                 },
                 'written_translations': written_translations_dict
             },
+            'page_contents_schema_version': (
+                feconf.CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION),
             'language_code': constants.DEFAULT_LANGUAGE_CODE,
             'version': 0
         }

--- a/core/domain/subtopic_page_services.py
+++ b/core/domain/subtopic_page_services.py
@@ -16,6 +16,7 @@
 
 """Commands for operations on subtopic pages, and related models."""
 
+import copy
 from core.domain import subtopic_page_domain
 from core.platform import models
 import feconf
@@ -23,6 +24,36 @@ import feconf
 (topic_models,) = models.Registry.import_models([models.NAMES.topic])
 datastore_services = models.Registry.import_datastore_services()
 memcache_services = models.Registry.import_memcache_services()
+
+
+def _migrate_page_contents_to_latest_schema(versioned_page_contents):
+    """Holds the responsibility of performing a step-by-step, sequential update
+    of the page contents structure based on the schema version of the input
+    page contents dictionary. If the current page_contents schema changes, a
+    new conversion function must be added and some code appended to this
+    function to account for that new version.
+
+    Args:
+        versioned_page_contents: A dict with two keys:
+          - schema_version: int. The schema version for the page_contents dict.
+          - page_contents: dict. The dict comprising the page contents.
+
+    Raises:
+        Exception: The schema version of the page_contents is outside of what
+            is supported at present.
+    """
+    page_contents_schema_version = versioned_page_contents['schema_version']
+    if not (1 <= page_contents_schema_version
+            <= feconf.CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION):
+        raise Exception(
+            'Sorry, we can only process v1-v%d page schemas at '
+            'present.' % feconf.CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION)
+
+    while (page_contents_schema_version <
+           feconf.CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION):
+        subtopic_page_domain.SubtopicPage.update_page_contents_from_model(
+            versioned_page_contents, page_contents_schema_version)
+        page_contents_schema_version += 1
 
 
 def get_subtopic_page_from_model(subtopic_page_model):
@@ -34,12 +65,19 @@ def get_subtopic_page_from_model(subtopic_page_model):
     Returns:
         SubtopicPage.
     """
-
+    versioned_page_contents = {
+        'schema_version': subtopic_page_model.page_contents_schema_version,
+        'page_contents': copy.deepcopy(subtopic_page_model.page_contents)
+    }
+    if (subtopic_page_model.page_contents_schema_version !=
+            feconf.CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION):
+        _migrate_page_contents_to_latest_schema(versioned_page_contents)
     return subtopic_page_domain.SubtopicPage(
         subtopic_page_model.id,
         subtopic_page_model.topic_id,
         subtopic_page_domain.SubtopicPageContents.from_dict(
-            subtopic_page_model.page_contents),
+            versioned_page_contents['page_contents']),
+        versioned_page_contents['schema_version'],
         subtopic_page_model.language_code,
         subtopic_page_model.version
     )
@@ -164,6 +202,8 @@ def save_subtopic_page(
     subtopic_page_model.topic_id = subtopic_page.topic_id
     subtopic_page_model.page_contents = subtopic_page.page_contents.to_dict()
     subtopic_page_model.language_code = subtopic_page.language_code
+    subtopic_page_model.page_contents_schema_version = (
+        subtopic_page.page_contents_schema_version)
     change_dicts = [change.to_dict() for change in change_list]
     subtopic_page_model.commit(committer_id, commit_message, change_dicts)
     subtopic_page.version += 1

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -450,14 +450,14 @@ class SuggestionAddQuestion(BaseSuggestion):
         question = question_domain.Question(
             None, state_domain.State.from_dict(
                 self.change.question_dict['question_state_data']),
-            self.change.question_dict['question_state_schema_version'],
+            self.change.question_dict['question_state_data_schema_version'],
             self.change.question_dict['language_code'], None)
         question.partial_validate()
-        question_state_schema_version = (
-            self.change.question_dict['question_state_schema_version'])
+        question_state_data_schema_version = (
+            self.change.question_dict['question_state_data_schema_version'])
         if not (
-                question_state_schema_version >= 1 and
-                question_state_schema_version <=
+                question_state_data_schema_version >= 1 and
+                question_state_data_schema_version <=
                 feconf.CURRENT_STATES_SCHEMA_VERSION):
             raise utils.ValidationError(
                 'Expected question state schema version to be between 1 and '
@@ -473,7 +473,7 @@ class SuggestionAddQuestion(BaseSuggestion):
         question_dict = self.change.question_dict
         self.validate()
         if (
-                question_dict['question_state_schema_version'] !=
+                question_dict['question_state_data_schema_version'] !=
                 feconf.CURRENT_STATES_SCHEMA_VERSION):
             raise utils.ValidationError(
                 'Question state schema version is not up to date.')

--- a/core/domain/suggestion_registry_test.py
+++ b/core/domain/suggestion_registry_test.py
@@ -144,7 +144,7 @@ class SuggestionAddQuestionTest(test_utils.GenericTestBase):
                     'question_state_data': self._create_valid_question_data(
                         'default_state').to_dict(),
                     'language_code': 'en',
-                    'question_state_schema_version': (
+                    'question_state_data_schema_version': (
                         feconf.CURRENT_STATES_SCHEMA_VERSION)
                 },
                 'skill_id': 'skill_1'

--- a/core/storage/question/gae_models.py
+++ b/core/storage/question/gae_models.py
@@ -50,7 +50,7 @@ class QuestionModel(base_models.VersionedModel):
     # An object representing the question state data.
     question_state_data = ndb.JsonProperty(indexed=False, required=True)
     # The schema version for the question state data.
-    question_state_schema_version = ndb.IntegerProperty(
+    question_state_data_schema_version = ndb.IntegerProperty(
         required=True, indexed=True)
     # The ISO 639-1 code for the language this question is written in.
     language_code = ndb.StringProperty(required=True, indexed=True)
@@ -357,11 +357,13 @@ class QuestionSummaryModel(base_models.BaseModel):
     # Time when the question model was last updated (not to be
     # confused with last_updated, which is the time when the
     # question *summary* model was last updated).
-    question_model_last_updated = ndb.DateTimeProperty(indexed=True)
+    question_model_last_updated = ndb.DateTimeProperty(
+        indexed=True, required=True)
     # Time when the question model was created (not to be confused
     # with created_on, which is the time when the question *summary*
     # model was created).
-    question_model_created_on = ndb.DateTimeProperty(indexed=True)
+    question_model_created_on = ndb.DateTimeProperty(
+        indexed=True, required=True)
     # The html content for the question.
     question_content = ndb.TextProperty(indexed=False, required=True)
 

--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -47,15 +47,15 @@ class QuestionSummaryModelUnitTests(test_utils.GenericTestBase):
             id='question_1',
             creator_id='user',
             question_content='Question 1',
-            question_model_created_on=datetime.datetime.now(),
-            question_model_last_updated=datetime.datetime.now()
+            question_model_created_on=datetime.datetime.utcnow(),
+            question_model_last_updated=datetime.datetime.utcnow()
         )
         question_summary_model_2 = question_models.QuestionSummaryModel(
             id='question_2',
             creator_id='user',
             question_content='Question 2',
-            question_model_created_on=datetime.datetime.now(),
-            question_model_last_updated=datetime.datetime.now()
+            question_model_created_on=datetime.datetime.utcnow(),
+            question_model_last_updated=datetime.datetime.utcnow()
         )
         question_summary_model_1.put()
         question_summary_model_2.put()

--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -14,6 +14,8 @@
 
 """Tests for core.storage.question.gae_models."""
 
+import datetime
+
 from core.domain import state_domain
 from core.platform import models
 from core.tests import test_utils
@@ -44,12 +46,16 @@ class QuestionSummaryModelUnitTests(test_utils.GenericTestBase):
         question_summary_model_1 = question_models.QuestionSummaryModel(
             id='question_1',
             creator_id='user',
-            question_content='Question 1'
+            question_content='Question 1',
+            question_model_created_on=datetime.datetime.now(),
+            question_model_last_updated=datetime.datetime.now()
         )
         question_summary_model_2 = question_models.QuestionSummaryModel(
             id='question_2',
             creator_id='user',
-            question_content='Question 2'
+            question_content='Question 2',
+            question_model_created_on=datetime.datetime.now(),
+            question_model_last_updated=datetime.datetime.now()
         )
         question_summary_model_1.put()
         question_summary_model_2.put()

--- a/core/storage/story/gae_models.py
+++ b/core/storage/story/gae_models.py
@@ -57,7 +57,7 @@ class StoryModel(base_models.VersionedModel):
     story_contents = ndb.JsonProperty(default={}, indexed=False)
     # The schema version for the story_contents.
     story_contents_schema_version = (
-        ndb.IntegerProperty(required=True, default=1, indexed=True))
+        ndb.IntegerProperty(required=True, indexed=True))
 
     def _trusted_commit(
             self, committer_id, commit_type, commit_message, commit_cmds):

--- a/core/storage/story/gae_models_test.py
+++ b/core/storage/story/gae_models_test.py
@@ -14,10 +14,10 @@
 
 """Tests for Oppia story models."""
 import datetime
-import feconf
 
 from core.platform import models
 from core.tests import test_utils
+import feconf
 
 (story_models, base_models, ) = models.Registry.import_models(
     [models.NAMES.story, models.NAMES.base_model])

--- a/core/storage/story/gae_models_test.py
+++ b/core/storage/story/gae_models_test.py
@@ -14,6 +14,7 @@
 
 """Tests for Oppia story models."""
 import datetime
+import feconf
 
 from core.platform import models
 from core.tests import test_utils
@@ -36,6 +37,8 @@ class StoryModelTest(test_utils.GenericTestBase):
             title='title',
             description='description',
             notes='notes',
+            story_contents_schema_version=(
+                feconf.CURRENT_STORY_CONTENTS_SCHEMA_VERSION),
             language_code='language_code')
         story_instance.commit(committer_id, commit_message, commit_cmds)
         story_by_id = story_models.StoryModel.get_by_id('id')

--- a/core/storage/topic/gae_models.py
+++ b/core/storage/topic/gae_models.py
@@ -221,6 +221,9 @@ class SubtopicPageModel(base_models.VersionedModel):
     # The json data of the subtopic consisting of subtitled_html,
     # content_ids_to_audio_translations and written_translations fields.
     page_contents = ndb.JsonProperty(required=True)
+    # The schema version for the page_contents field.
+    page_contents_schema_version = ndb.IntegerProperty(
+        required=True, indexed=True)
     # The ISO 639-1 code for the language this subtopic page is written in.
     language_code = ndb.StringProperty(required=True, indexed=True)
 

--- a/core/storage/topic/gae_models.py
+++ b/core/storage/topic/gae_models.py
@@ -96,10 +96,17 @@ class TopicModel(base_models.VersionedModel):
             committer_user_settings_model.username
             if committer_user_settings_model else '')
 
+        topic_rights = TopicRightsModel.get_by_id(self.id)
+        status = ''
+        if topic_rights.topic_is_published:
+            status = constants.ACTIVITY_STATUS_PUBLIC
+        else:
+            status = constants.ACTIVITY_STATUS_PRIVATE
+
         topic_commit_log_entry = TopicCommitLogEntryModel.create(
             self.id, self.version, committer_id, committer_username,
             commit_type, commit_message, commit_cmds,
-            constants.ACTIVITY_STATUS_PUBLIC, False
+            status, False
         )
         topic_commit_log_entry.topic_id = self.id
         topic_commit_log_entry.put()
@@ -211,7 +218,8 @@ class SubtopicPageModel(base_models.VersionedModel):
 
     # The topic id that this subtopic is a part of.
     topic_id = ndb.StringProperty(required=True, indexed=True)
-    # The html data of the subtopic.
+    # The json data of the subtopic consisting of subtitled_html,
+    # content_ids_to_audio_translations and written_translations fields.
     page_contents = ndb.JsonProperty(required=True)
     # The ISO 639-1 code for the language this subtopic page is written in.
     language_code = ndb.StringProperty(required=True, indexed=True)
@@ -320,3 +328,51 @@ class TopicRightsModel(base_models.VersionedModel):
             cls.manager_ids == user_id
         )
         return topic_rights_models
+
+    def _trusted_commit(
+            self, committer_id, commit_type, commit_message, commit_cmds):
+        """Record the event to the commit log after the model commit.
+
+        Note that this extends the superclass method.
+
+        Args:
+            committer_id: str. The user_id of the user who committed the
+                change.
+            commit_type: str. The type of commit. Possible values are in
+                core.storage.base_models.COMMIT_TYPE_CHOICES.
+            commit_message: str. The commit description message.
+            commit_cmds: list(dict). A list of commands, describing changes
+                made in this model, which should give sufficient information to
+                reconstruct the commit. Each dict always contains:
+                    cmd: str. Unique command.
+                and then additional arguments for that command.
+        """
+        super(TopicRightsModel, self)._trusted_commit(
+            committer_id, commit_type, commit_message, commit_cmds)
+
+        committer_user_settings_model = (
+            user_models.UserSettingsModel.get_by_id(committer_id))
+        committer_username = (
+            committer_user_settings_model.username
+            if committer_user_settings_model else '')
+
+        topic_rights = TopicRightsModel.get_by_id(self.id)
+        status = ''
+        if topic_rights.topic_is_published:
+            status = constants.ACTIVITY_STATUS_PUBLIC
+        else:
+            status = constants.ACTIVITY_STATUS_PRIVATE
+
+        TopicCommitLogEntryModel(
+            id=('rights-%s-%s' % (self.id, self.version)),
+            user_id=committer_id,
+            username=committer_username,
+            topic_id=self.id,
+            commit_type=commit_type,
+            commit_message=commit_message,
+            commit_cmds=commit_cmds,
+            version=None,
+            post_commit_status=status,
+            post_commit_community_owned=False,
+            post_commit_is_private=not topic_rights.topic_is_published
+        ).put()

--- a/core/storage/topic/gae_models_test.py
+++ b/core/storage/topic/gae_models_test.py
@@ -35,6 +35,11 @@ class TopicModelUnitTests(test_utils.GenericTestBase):
     def test_that_subsidiary_models_are_created_when_new_model_is_saved(self):
         """Tests the _trusted_commit() method."""
 
+        topic_rights = topic_models.TopicRightsModel(
+            id=self.TOPIC_ID,
+            manager_ids=[],
+            topic_is_published=True
+        )
         # Topic is created but not committed/saved.
         topic = topic_models.TopicModel(
             id=self.TOPIC_ID,
@@ -48,6 +53,11 @@ class TopicModelUnitTests(test_utils.GenericTestBase):
         self.assertIsNone(topic_models.TopicModel.get_by_name(self.TOPIC_NAME))
         # We call commit() expecting that _trusted_commit works fine
         # and saves topic to datastore.
+        topic_rights.commit(
+            committer_id=feconf.SYSTEM_COMMITTER_ID,
+            commit_message='Created new topic rights',
+            commit_cmds=[{'cmd': topic_domain.CMD_CREATE_NEW}]
+        )
         topic.commit(
             committer_id=feconf.SYSTEM_COMMITTER_ID,
             commit_message='Created new topic',
@@ -112,6 +122,8 @@ class SubtopicPageModelUnitTest(test_utils.GenericTestBase):
             id=self.SUBTOPIC_PAGE_ID,
             topic_id='topic_id',
             page_contents={},
+            page_contents_schema_version=(
+                feconf.CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION),
             language_code='en'
         )
         # We check that subtopic page has not been saved before calling

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -1447,6 +1447,11 @@ tags: []
             language_code: str. The ISO 639-1 code for the language this
                 topic is written in.
         """
+        topic_rights_model = topic_models.TopicRightsModel(
+            id=topic_id,
+            manager_ids=[],
+            topic_is_published=True
+        )
         topic_model = topic_models.TopicModel(
             id=topic_id,
             name=name,
@@ -1462,6 +1467,11 @@ tags: []
         )
         commit_message = (
             'New topic created with name \'%s\'.' % name)
+        topic_rights_model.commit(
+            committer_id=owner_id,
+            commit_message='Created new topic rights',
+            commit_cmds=[{'cmd': topic_domain.CMD_CREATE_NEW}]
+        )
         topic_model.commit(
             owner_id, commit_message, [{
                 'cmd': topic_domain.CMD_CREATE_NEW,

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -1516,7 +1516,7 @@ tags: []
             question_state_data=self.VERSION_27_STATE_DICT,
             language_code=language_code,
             version=1,
-            question_state_schema_version=27
+            question_state_data_schema_version=27
         )
         question_model.commit(
             owner_id, 'New question created',

--- a/feconf.py
+++ b/feconf.py
@@ -170,6 +170,9 @@ CURRENT_MISCONCEPTIONS_SCHEMA_VERSION = 1
 # The current version of subtopics dict in the topic schema.
 CURRENT_SUBTOPIC_SCHEMA_VERSION = 1
 
+# The current version of page_contents dict in the subtopic page schema.
+CURRENT_SUBTOPIC_PAGE_CONTENTS_SCHEMA_VERSION = 1
+
 # This value should be updated in the event of any
 # StateAnswersModel.submitted_answer_list schema change.
 CURRENT_STATE_ANSWERS_SCHEMA_VERSION = 1


### PR DESCRIPTION
In this PR, the following have been fixed:

- For topics and skills, commit logs are now logged for rights changes.
- Added schema version for subtopic page contents
- Renamed `question_state_schema_version` to `question_state_data_schema_version`
- Changed `question_model_last_updated`, `question_model_created_on` to be required properties.
- Dropped default value for `story_contents_schema_version`.