### PR TITLE
Fix #6494: Added check for style properties to have a space between the colon and the property value.

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -16,5 +16,7 @@
     "block-opening-brace-newline-after": "always-multi-line",
     "block-opening-brace-space-after": "always-single-line",
     "block-opening-brace-space-before": "always",
+    "declaration-colon-space-after": "always",
+    "declaration-colon-space-before": "never",
   }
 }

--- a/core/templates/dev/head/components/share/sharing_links_directive.html
+++ b/core/templates/dev/head/components/share/sharing_links_directive.html
@@ -63,7 +63,7 @@
   }
 
   ul.oppia-sharing-links i.oppia-share-icons {
-    font-size:  40px;
+    font-size: 40px;
     padding: 0 5px;
   }
 

--- a/core/templates/dev/head/css/.stylelintrc
+++ b/core/templates/dev/head/css/.stylelintrc
@@ -7,6 +7,8 @@
     "block-opening-brace-newline-after": "always-multi-line",
     "block-opening-brace-space-after": "always-single-line",
     "block-opening-brace-space-before": "always",
+    "declaration-colon-space-after": "always",
+    "declaration-colon-space-before": "never",
     "indentation": 2,
     "no-descending-specificity": true,
     "no-duplicate-selectors": true,

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -102,10 +102,10 @@ md-input-group.md-default-theme label {
 }
 
 .md-button.oppia-learner-reload-image-button {
-  background:#ffffff;
+  background: #ffffff;
   border: 2px solid;
-  border-color:#0D48A1;
-  color:  #0D48A1;
+  border-color: #0D48A1;
+  color: #0D48A1;
   padding-bottom: 12px;
   padding-left: 20px;
   padding-right: 20px;
@@ -1931,16 +1931,16 @@ pre.oppia-pre-wrapped-text {
   -webkit-transform: rotate(-10deg);
 
   background-color: yellow;
-  border:1px solid black;
+  border: 1px solid black;
   color: firebrick;
   cursor: pointer;
   font-size: 20px;
   font-weight: bold;
-  height:22px;
+  height: 22px;
   line-height: 22px;
   text-align: center;
   transform: rotate(-10deg);
-  width:22px;
+  width: 22px;
 }
 
 .oppia-rule-details-header {
@@ -2516,7 +2516,7 @@ md-card.preview-conversation-skin-supplemental-card {
 }
 
 .oppia-modal-information-card .modal-dialog .modal-content md-card {
-  border-radius:0;
+  border-radius: 0;
   margin: 0;
   padding: 0;
 }

--- a/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
+++ b/core/templates/dev/head/pages/exploration_player/conversation_skin_embed_directive.html
@@ -85,11 +85,11 @@ directive. -->
     font-family: 'Roboto', Arial, sans-serif;
     font-size: 1.0em;
     height: 100%;
-    position:fixed;
-    top:0;
-    bottom:0;
-    width:100%;
-    overflow-y:auto;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    overflow-y: auto;
   }
 
   .oppia-progress-dot {

--- a/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
+++ b/core/templates/dev/head/pages/learner_dashboard/learner_dashboard.html
@@ -1054,7 +1054,7 @@
     }
 
     .oppia-learner-dashboard-feedback-section .feedback-thread-warning {
-      color:#0277BD;
+      color: #0277BD;
       margin-left: 4px;
     }
 


### PR DESCRIPTION
Fixes #6494: Add check for style properties to have a space between the colon and the property value.

I added rules declaration-colon-space-before and declaration-colon-space-after according to https://stylelint.io/user-guide/rules/declaration-colon-space-before/ and https://stylelint.io/user-guide/rules/declaration-colon-space-after/.

Apart from that I ran the check on all html files in ./extensions and ./core and also for oppia.css.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
