### PR TITLE
Fixed minor issue in story editor

### DIFF
--- a/core/templates/dev/head/pages/story_editor/main_editor/StoryNodeEditorDirective.js
+++ b/core/templates/dev/head/pages/story_editor/main_editor/StoryNodeEditorDirective.js
@@ -90,7 +90,7 @@ oppia.directive('storyNodeEditor', [
           $scope.canSaveExpId = true;
           $scope.checkCanSaveExpId = function() {
             $scope.canSaveExpId = $scope.explorationIdPattern.test(
-            $scope.explorationId);
+              $scope.explorationId);
           };
           $scope.updateTitle = function(newTitle) {
             if (newTitle === $scope.currentTitle) {

--- a/core/templates/dev/head/pages/story_editor/main_editor/StoryNodeEditorDirective.js
+++ b/core/templates/dev/head/pages/story_editor/main_editor/StoryNodeEditorDirective.js
@@ -70,6 +70,7 @@ oppia.directive('storyNodeEditor', [
             $scope.oldOutline = $scope.getOutline();
             $scope.editableOutline = $scope.getOutline();
             $scope.explorationId = $scope.getExplorationId();
+            $scope.currentExplorationId = $scope.explorationId;
             $scope.nodeTitleEditorIsShown = false;
             $scope.OUTLINE_SCHEMA = {
               type: 'html',
@@ -89,7 +90,7 @@ oppia.directive('storyNodeEditor', [
           $scope.canSaveExpId = true;
           $scope.checkCanSaveExpId = function() {
             $scope.canSaveExpId = $scope.explorationIdPattern.test(
-              $scope.explorationId);
+            $scope.explorationId);
           };
           $scope.updateTitle = function(newTitle) {
             if (newTitle === $scope.currentTitle) {
@@ -112,6 +113,7 @@ oppia.directive('storyNodeEditor', [
           $scope.updateExplorationId = function(explorationId) {
             StoryUpdateService.setStoryNodeExplorationId(
               $scope.story, $scope.getId(), explorationId);
+            $scope.currentExplorationId = explorationId;
           };
 
           $scope.addPrerequisiteSkillId = function(skillId) {

--- a/core/templates/dev/head/pages/story_editor/main_editor/story_node_editor_directive.html
+++ b/core/templates/dev/head/pages/story_editor/main_editor/story_node_editor_directive.html
@@ -27,7 +27,7 @@
   <label style="padding-top: 2em;" class="form-heading"> Exploration ID </label>
   <form class="form-horizontal" role="form" ng-submit="updateExplorationId(explorationId)">
     <input type="text" ng-model="explorationId" ng-change="checkCanSaveExpId()">
-    <button type="submit" class="btn btn-success btn-sm" ng-disabled="!canSaveExpId">Save</button>
+    <button type="submit" class="btn btn-success btn-sm" ng-disabled="!canSaveExpId || (explorationId === currentExplorationId)">Save</button>
   </form>
   <label style="padding-top: 2em;" class="form-heading"> Prerequisite Skill IDs </label>
   <form class="form-horizontal" role="form" ng-submit="addPrerequisiteSkillId(prerequisiteSkillId)">


### PR DESCRIPTION
## Explanation
This PR fixes a minor issue in story editor where clicking the Save button for the exploration ID multiple times threw an error. In this PR, the button is disabled once the change is done.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
