### PR TITLE
Fix #6285: Fixes issues while selecting an answer in the editor feedback tab.

### DIFF
--- a/core/templates/dev/head/components/forms/html_select_directive.html
+++ b/core/templates/dev/head/components/forms/html_select_directive.html
@@ -8,8 +8,8 @@
   </button>
   <ul uib-dropdown-menu style="max-width: 80%; overflow: auto; width: auto;">
     <li ng-repeat="choice in options" style="float: left;">
-      <a>
-        <angular-html-bind class="oppia-html-select-option protractor-test-html-select-option" html-data="choice.val" ng-click="select(choice.id)">
+      <a ng-click="select(choice.id)">
+        <angular-html-bind class="oppia-html-select-option protractor-test-html-select-option" html-data="choice.val">
         </angular-html-bind>
       </a>
     </li>
@@ -48,7 +48,7 @@
   }
   .oppia-html-select .oppia-html-select-option:hover {
     background: #1485E6;
-    color: white;
+    color: black;
   }
   .oppia-html-select .oppia-html-select-option oppia-noninteractive-image {
     display: inline-block;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #6285 : It was difficult to select an answer in the editor feedback tab for multiple-choice answer.
The click only worked for the texts, instead of the highlighted region when hovering over an answer.

The issue has been fixed, the editor can click anywhere in the highlighted region to select an answer.
Also, the hover color has been changed from White to Black, white was not visible.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
