### PR TITLE
Fix #6534: make MR jobs runnable on localhost.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,8 +1,10 @@
-version: default
 runtime: python27
 api_version: 1
 threadsafe: false
 instance_class: F2
+# The "version" line is added here so that MR jobs can run locally (see issue
+# #6534 on oppia/oppia).
+version: default
 
 builtins:
 - appstats: on

--- a/app.yaml
+++ b/app.yaml
@@ -1,3 +1,4 @@
+version: default
 runtime: python27
 api_version: 1
 threadsafe: false


### PR DESCRIPTION
## Explanation
Fixes #6534. This reinstates the "version" field in app.yaml (it was removed in #6305) so that MR jobs can be run locally. It also adds an explanation of why the field should not be removed in the future.

/cc @sshou14 for info.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.