### PR TITLE
Fix #6229: Reordering Hints and Worked Examples in Safari 

### DIFF
--- a/core/templates/dev/head/pages/skill_editor/editor_tab/skill_concept_card_editor_directive.html
+++ b/core/templates/dev/head/pages/skill_editor/editor_tab/skill_concept_card_editor_directive.html
@@ -56,7 +56,8 @@
         <ul class="nav oppia-option-list nav-stacked nav-pills"
             role="tablist"
             ui-sortable="WORKED_EXAMPLES_SORTABLE_OPTIONS"
-            ng-model="bindableFieldsDict.displayedWorkedExamples">
+            ng-model="bindableFieldsDict.displayedWorkedExamples"
+            style="position: relative;">
           <li ng-repeat="workedExample in bindableFieldsDict.displayedWorkedExamples"
               ng-class="{'active': activeWorkedExampleIndex === $index, 'last-element': $index === bindableFieldsDict.displayedWorkedExamples.length - 1}"
               class="oppia-rule-block oppia-sortable-worked-example oppia-prevent-selection"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #6229 : In safari, the ui-sortable was showing unexpected behaviour due to untackled css-positions in the parent.

Has been fixed now.

## Screenshot



<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
