### PR TITLE
Fix #6468: Fixed the improper alignment of tick mark

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -187,6 +187,11 @@ body {
   width: 100%;
 }
 
+#oppia-dropdown-bar {
+  width: 170px;
+}
+
+
 .oppia-skip-to-content {
   left: -10000px;
   padding: 6px;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -187,11 +187,9 @@ body {
   width: 100%;
 }
 
-#oppia-dropdown-bar {
+.oppia-search-bar-dropdown-menu {
   width: 170px;
 }
-
-
 .oppia-skip-to-content {
   left: -10000px;
   padding: 6px;

--- a/core/templates/dev/head/pages/library/search_bar_directive.html
+++ b/core/templates/dev/head/pages/library/search_bar_directive.html
@@ -25,7 +25,7 @@
       <span class="caret"></span>
     </button>
     <!-- The $event.stopPropagation() prevents the dropdown from closing after an option is selected. -->
-    <ul uib-dropdown-menu class="protractor-test-search-bar-dropdown-menu" role="menu" style="max-height: 400px; overflow: auto;" ng-click="$event.stopPropagation()">
+    <ul uib-dropdown-menu id="oppia-dropdown-bar" class="protractor-test-search-bar-dropdown-menu" role="menu" style="max-height: 400px; overflow: auto;" ng-click="$event.stopPropagation()">
       <li ng-repeat="item in selectionDetails.categories.masterList track by $index"
           ng-if="selectionDetails.categories.selections[item.id]">
         <a href="" ng-click="toggleSelection('categories', item.id)" ng-if="!$first && !$last">

--- a/core/templates/dev/head/pages/library/search_bar_directive.html
+++ b/core/templates/dev/head/pages/library/search_bar_directive.html
@@ -63,7 +63,6 @@
     </ul>
   </div>
 </div>
-<div uib-dropdown-menu class="oppia-search-bar-dropdown-menu" role="menu"></div>
 <div ng-class="{'open' : activeMenuName === 'language'}" uib-dropdown class="navbar-left oppia-navbar-button-container oppia-search-bar-language-selector protractor-test-search-bar-language-selector">
   <button ng-click="openSubmenu($event, 'language')" ng-keydown="onMenuKeypress($event, 'language', {shiftTab: ACTION_CLOSE, enter: ACTION_OPEN})" uib-dropdown-toggle type="button" class="btn protractor-test-search-bar-dropdown-toggle oppia-search-bar-input ng-cloak"
           style="border-bottom-right-radius: 4px; border-top-right-radius: 4px; max-width: 130px;"

--- a/core/templates/dev/head/pages/library/search_bar_directive.html
+++ b/core/templates/dev/head/pages/library/search_bar_directive.html
@@ -25,7 +25,7 @@
       <span class="caret"></span>
     </button>
     <!-- The $event.stopPropagation() prevents the dropdown from closing after an option is selected. -->
-    <ul uib-dropdown-menu id="oppia-dropdown-bar" class="protractor-test-search-bar-dropdown-menu" role="menu" style="max-height: 400px; overflow: auto;" ng-click="$event.stopPropagation()">
+    <ul uib-dropdown-menu class="protractor-test-search-bar-dropdown-menu oppia-search-bar-dropdown-menu" role="menu" style="max-height: 400px; overflow: auto;" ng-click="$event.stopPropagation()">
       <li ng-repeat="item in selectionDetails.categories.masterList track by $index"
           ng-if="selectionDetails.categories.selections[item.id]">
         <a href="" ng-click="toggleSelection('categories', item.id)" ng-if="!$first && !$last">
@@ -63,6 +63,7 @@
     </ul>
   </div>
 </div>
+<div uib-dropdown-menu class="oppia-search-bar-dropdown-menu" role="menu"></div>
 <div ng-class="{'open' : activeMenuName === 'language'}" uib-dropdown class="navbar-left oppia-navbar-button-container oppia-search-bar-language-selector protractor-test-search-bar-language-selector">
   <button ng-click="openSubmenu($event, 'language')" ng-keydown="onMenuKeypress($event, 'language', {shiftTab: ACTION_CLOSE, enter: ACTION_OPEN})" uib-dropdown-toggle type="button" class="btn protractor-test-search-bar-dropdown-toggle oppia-search-bar-input ng-cloak"
           style="border-bottom-right-radius: 4px; border-top-right-radius: 4px; max-width: 130px;"


### PR DESCRIPTION
This PR solves the alignment issue of the tick mark in library page and category section. Before the bug was solved the page looked like as shown below
![Screenshot (30)](https://user-images.githubusercontent.com/36122870/55531570-cd6f0e00-565f-11e9-90c4-e31281801f44.png)

After the Bug has been resolved the page looks like
![Screenshot (34)](https://user-images.githubusercontent.com/36122870/55531586-e081de00-565f-11e9-8430-ea60adbb7cb4.png)

Fixes #6468