### PR TITLE
Fix Part of #6240: Added profileFeatures.js e2e test for profile feature functional capability.

### DIFF
--- a/core/tests/protractor_desktop/profileFeatures.js
+++ b/core/tests/protractor_desktop/profileFeatures.js
@@ -94,7 +94,7 @@ describe('Profile Features functionality', function() {
     users.logout();
   });
 
-  it('View number of explorations created by a User', function() {
+  it('should check number of explorations created by a user', function() {
     users.login('FirstUser@profileFeatures.com');
 
     // Creating some explorations.

--- a/core/tests/protractor_desktop/profileFeatures.js
+++ b/core/tests/protractor_desktop/profileFeatures.js
@@ -71,7 +71,7 @@ describe('Profile Features functionality', function() {
     users.logout();
   });
 
-  it('Subscribe to a particular User', function() {
+  it('should subscribe to a particular user', function() {
     users.login('FirstUser@profileFeatures.com');
 
     // Subscribe to both the creators.

--- a/core/tests/protractor_desktop/profileFeatures.js
+++ b/core/tests/protractor_desktop/profileFeatures.js
@@ -15,3 +15,108 @@
 /**
 * @fileoverview End-to-end tests for user profile features.
 */
+
+var general = require('../protractor_utils/general.js');
+var users = require('../protractor_utils/users.js');
+var workflow = require('../protractor_utils/workflow.js');
+
+
+var LearnerDashboardPage =
+  require('../protractor_utils/LearnerDashboardPage.js');
+var LibraryPage = require('../protractor_utils/LibraryPage.js');
+var SubscriptionDashboardPage =
+  require('../protractor_utils/SubscriptionDashboardPage.js');
+
+describe('Profile Features functionality', function() {
+    var libraryPage = null;
+    var learnerDashboardPage = null;
+    var subscriptionDashboardPage = null;
+
+    var creator1Id = 'FirstCreator';
+    var creator2Id = 'SecondCreator';
+    users.createUser('FirstUser@profileFeatures.com',
+      'FirstUserprofileFeatures');
+    users.createUser('SecondUser@profileFeatures.com',
+      'SecondUserprofileFeatures');
+    users.createUser(creator1Id + '@profileFeatures.com',
+      creator1Id);
+    users.createUser(creator2Id + '@profileFeatures.com',
+      creator2Id);
+  
+    beforeAll(function() {
+      libraryPage = new LibraryPage.LibraryPage();
+      learnerDashboardPage = new LearnerDashboardPage.LearnerDashboardPage();
+      subscriptionDashboardPage =
+        new SubscriptionDashboardPage.SubscriptionDashboardPage();
+    });
+
+    it('View a particular exploration created by another User', function() {
+      users.login(creator1Id + '@profileFeatures.com');
+      workflow.createAndPublishExploration(
+        'Activation',
+        'Chemistry',
+        'English'
+      );
+      users.logout();
+
+      users.login('FirstUser@profileFeatures.com');
+      // Subscribing to a User to get all his created explorations.
+      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
+      subscriptionDashboardPage.navigateToSubscriptionButton();
+
+      // finding a particular exploration on user's library and playing it.
+      libraryPage.get();
+      libraryPage.findExploration('Activations');
+      libraryPage.playExploration('Activations');
+      users.logout();
+    });
+
+    it('Subscribe to a particular User', function() {
+      users.login('FirstUser@profileFeatures.com');
+      // Subscribe to both the creators.
+      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
+      subscriptionDashboardPage.navigateToSubscriptionButton();
+      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator2Id);
+      subscriptionDashboardPage.navigateToSubscriptionButton();
+
+      // Checking all the users subscribed present in user's dashboard.
+      learnerDashboardPage.get();
+      learnerDashboardPage.navigateToSubscriptionsSection();
+      users.logout();
+
+      users.login('SecondUser@profileFeatures.com');
+      // Subscribe to both the creators.
+      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
+      subscriptionDashboardPage.navigateToSubscriptionButton();
+      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator2Id);
+      subscriptionDashboardPage.navigateToSubscriptionButton();
+
+      // Checking all the users subscribed present in user's dashboard.
+      learnerDashboardPage.get();
+      learnerDashboardPage.navigateToSubscriptionsSection();
+      users.logout();
+    });
+
+    it('View number of explorations created by a User', function() {
+      users.login('FirstUser@profileFeatures.com');
+
+      // Creating some explorations.
+      workflow.createAndPublishExploration(
+        'Activation',
+        'Chemistry',
+        'Introduction',
+        'English',
+        'BUS101',
+        'Business'
+      );
+
+      // Getting Number of explorations created by a User.
+      LibraryPage.get();
+      LibraryPage.getAllExplorationElements();
+      users.logout();
+    });
+
+    afterEach(function() {
+      general.checkForConsoleErrors([]);
+    });
+});

--- a/core/tests/protractor_desktop/profileFeatures.js
+++ b/core/tests/protractor_desktop/profileFeatures.js
@@ -28,95 +28,92 @@ var SubscriptionDashboardPage =
   require('../protractor_utils/SubscriptionDashboardPage.js');
 
 describe('Profile Features functionality', function() {
-    var libraryPage = null;
-    var learnerDashboardPage = null;
-    var subscriptionDashboardPage = null;
+  var libraryPage = null;
+  var learnerDashboardPage = null;
+  var subscriptionDashboardPage = null;
 
-    var creator1Id = 'FirstCreator';
-    var creator2Id = 'SecondCreator';
-    users.createUser('FirstUser@profileFeatures.com',
-      'FirstUserprofileFeatures');
-    users.createUser('SecondUser@profileFeatures.com',
-      'SecondUserprofileFeatures');
-    users.createUser(creator1Id + '@profileFeatures.com',
-      creator1Id);
-    users.createUser(creator2Id + '@profileFeatures.com',
-      creator2Id);
-  
-    beforeAll(function() {
-      libraryPage = new LibraryPage.LibraryPage();
-      learnerDashboardPage = new LearnerDashboardPage.LearnerDashboardPage();
-      subscriptionDashboardPage =
-        new SubscriptionDashboardPage.SubscriptionDashboardPage();
-    });
+  var creator1Id = 'FirstCreator';
+  var creator2Id = 'SecondCreator';
+  users.createUser('FirstUser@profileFeatures.com',
+    'FirstUserprofileFeatures');
+  users.createUser('SecondUser@profileFeatures.com',
+    'SecondUserprofileFeatures');
+  users.createUser(creator1Id + '@profileFeatures.com',
+    creator1Id);
+  users.createUser(creator2Id + '@profileFeatures.com',
+    creator2Id);
 
-    it('View a particular exploration created by another User', function() {
-      users.login(creator1Id + '@profileFeatures.com');
-      workflow.createAndPublishExploration(
-        'Activation',
-        'Chemistry',
-        'English'
-      );
-      users.logout();
+  beforeAll(function() {
+    libraryPage = new LibraryPage.LibraryPage();
+    learnerDashboardPage = new LearnerDashboardPage.LearnerDashboardPage();
+    subscriptionDashboardPage =
+      new SubscriptionDashboardPage.SubscriptionDashboardPage();
+  });
 
-      users.login('FirstUser@profileFeatures.com');
-      // Subscribing to a User to get all his created explorations.
-      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
-      subscriptionDashboardPage.navigateToSubscriptionButton();
+  it('View a particular exploration created by another User', function() {
+    users.login(creator1Id + '@profileFeatures.com');
+    workflow.createAndPublishExploration(
+      'Activation',
+      'Chemistry',
+      'English'
+    );
+    users.logout();
 
-      // finding a particular exploration on user's library and playing it.
-      libraryPage.get();
-      libraryPage.findExploration('Activations');
-      libraryPage.playExploration('Activations');
-      users.logout();
-    });
+    users.login('FirstUser@profileFeatures.com');
+    // Subscribing to a User to get all his created explorations.
+    subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
+    subscriptionDashboardPage.navigateToSubscriptionButton();
 
-    it('Subscribe to a particular User', function() {
-      users.login('FirstUser@profileFeatures.com');
-      // Subscribe to both the creators.
-      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
-      subscriptionDashboardPage.navigateToSubscriptionButton();
-      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator2Id);
-      subscriptionDashboardPage.navigateToSubscriptionButton();
+    // finding a particular exploration on user's library and playing it.
+    libraryPage.get();
+    libraryPage.findExploration('Activations');
+    libraryPage.playExploration('Activations');
+    users.logout();
+  });
 
-      // Checking all the users subscribed present in user's dashboard.
-      learnerDashboardPage.get();
-      learnerDashboardPage.navigateToSubscriptionsSection();
-      users.logout();
+  it('Subscribe to a particular User', function() {
+    users.login('FirstUser@profileFeatures.com');
+    
+    // Subscribe to both the creators.
+    subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
+    subscriptionDashboardPage.navigateToSubscriptionButton();
+    subscriptionDashboardPage.navigateToUserSubscriptionPage(creator2Id);
+    subscriptionDashboardPage.navigateToSubscriptionButton();
 
-      users.login('SecondUser@profileFeatures.com');
-      // Subscribe to both the creators.
-      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
-      subscriptionDashboardPage.navigateToSubscriptionButton();
-      subscriptionDashboardPage.navigateToUserSubscriptionPage(creator2Id);
-      subscriptionDashboardPage.navigateToSubscriptionButton();
+    // Checking all the users subscribed present in user's dashboard.
+    // Both creators should be present in the subscriptions section of the
+    // dashboard.
+    learnerDashboardPage.get();
+    learnerDashboardPage.navigateToSubscriptionsSection();
+    // The last user (SecondCreator) that learner subsribes to is placed first
+    // in the list.
+    learnerDashboardPage.expectSubscriptionFirstNameToMatch('Second...');
+    // The first user (FirstCreator) that learner subscribes to is placed
+    // last in the list.
+    learnerDashboardPage.expectSubscriptionLastNameToMatch('First...');
+    users.logout();
+  });
 
-      // Checking all the users subscribed present in user's dashboard.
-      learnerDashboardPage.get();
-      learnerDashboardPage.navigateToSubscriptionsSection();
-      users.logout();
-    });
+  it('View number of explorations created by a User', function() {
+    users.login('FirstUser@profileFeatures.com');
 
-    it('View number of explorations created by a User', function() {
-      users.login('FirstUser@profileFeatures.com');
+    // Creating some explorations.
+    workflow.createAndPublishExploration(
+      'Activation',
+      'Chemistry',
+      'Introduction',
+      'English',
+      'BUS101',
+      'Business'
+    );
 
-      // Creating some explorations.
-      workflow.createAndPublishExploration(
-        'Activation',
-        'Chemistry',
-        'Introduction',
-        'English',
-        'BUS101',
-        'Business'
-      );
+    // Getting Number of explorations created by a User.
+    LibraryPage.get();
+    LibraryPage.getAllExplorationElements();
+    users.logout();
+  });
 
-      // Getting Number of explorations created by a User.
-      LibraryPage.get();
-      LibraryPage.getAllExplorationElements();
-      users.logout();
-    });
-
-    afterEach(function() {
-      general.checkForConsoleErrors([]);
-    });
+  afterEach(function() {
+    general.checkForConsoleErrors([]);
+  });
 });

--- a/core/tests/protractor_desktop/profileFeatures.js
+++ b/core/tests/protractor_desktop/profileFeatures.js
@@ -50,7 +50,7 @@ describe('Profile Features functionality', function() {
       new SubscriptionDashboardPage.SubscriptionDashboardPage();
   });
 
-  it('View a particular exploration created by another User', function() {
+  it('should view a particular exploration created by another user', function() {
     users.login(creator1Id + '@profileFeatures.com');
     workflow.createAndPublishExploration(
       'Activation',

--- a/core/tests/protractor_desktop/profileFeatures.js
+++ b/core/tests/protractor_desktop/profileFeatures.js
@@ -73,7 +73,7 @@ describe('Profile Features functionality', function() {
 
   it('Subscribe to a particular User', function() {
     users.login('FirstUser@profileFeatures.com');
-    
+
     // Subscribe to both the creators.
     subscriptionDashboardPage.navigateToUserSubscriptionPage(creator1Id);
     subscriptionDashboardPage.navigateToSubscriptionButton();

--- a/core/tests/protractor_utils/LibraryPage.js
+++ b/core/tests/protractor_utils/LibraryPage.js
@@ -60,6 +60,10 @@ var LibraryPage = function() {
     );
   };
 
+  var getAllExplorationElements = function() {
+    return element.all(by.css('.protractor-test-exp-summary-tile')).length;
+  };
+
   var _submitSearchQuery = function(searchQuery) {
     // The library page has two search bar input elements.
     // The first search bar input element is visible only in a desktop


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

Fix part of #6240: Added e2e test for profile feature functionality. This PR adds an e2e test for profile features under the core/tests/protactor_desktop directory. This test covers the following features:-

1) View explorations created by another user on their profile page.
2) Subscribe to the user.
3) View number of created explorations.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
