### PR TITLE
Fix #6200: Fixes inconsistent spacing with the lists

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -348,6 +348,15 @@ p {
   word-wrap: break-word;
 }
 
+/* The properties should be in sync with the p tag so that we have consistent
+   spacing between the list, above the first bullet (point) and at the end of last
+   bullet (point). Line height has a value 1.846 and not 1.2 because all p tags
+   have value 1.846 and it comes from third party due to narrower css there.*/
+ul, ol {
+  line-height: 1.846;
+  margin-bottom: 18px;
+}
+
 p:last-child {
   margin: 0px;
 }


### PR DESCRIPTION
Fixes #6200. 
The problem arose because we have modified the `p` tag according to our need but we haven't take into account the `list` tags. The margin below all the `p` tags is `18px` but the margin below the `list` tags isn't `18`, its `10px`, the default value (since the `list` tags aren't nested inside the `p` tags). Similar, argument holds for the `line-height` as well. 

I have made the line-height and the margin below the `list` tags(ul and ol) equivalent to the `p` tag and it has to be global, since it should be consistent through out. 

Screenshot now:
![image](https://user-images.githubusercontent.com/22434689/55543264-5b8dd780-56e6-11e9-9bfb-18694005c57e.png)
