### PR TITLE
Fix Part of #6240: Write e2e tests for editting exploration properties (coreEditorAndPlayerFeatures.js)

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/exploration_objective_editor_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_objective_editor_directive.html
@@ -5,7 +5,7 @@
            class="form-control protractor-test-exploration-objective-input"
            ng-model="explorationObjectiveService.displayed"
            ng-blur="onInputFieldBlur()" placeholder="Learn how to..." ng-trim="false">
-    <span class="help-block" style="font-size: smaller">
+    <span class="help-block protractor-test-exploration-objective-warning" style="font-size: smaller">
       <em>In a complete sentence, tell people what they'll learn from this exploration.</em>
       <span ng-if="explorationObjectiveService.displayed.length > 0">
         <em>Characters used: <[explorationObjectiveService.displayed.length]>/100</em>

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -243,7 +243,7 @@ describe('Core exploration functionality', function() {
     users.logout();
   });
 
-  fit('should be able to edit title', function() {
+  it('should be able to edit title', function() {
     users.createUser('user6@stateEditor.com', 'user6StateEditor');
     users.login('user6@stateEditor.com');
 

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -270,10 +270,10 @@ describe('Core exploration functionality', function() {
 
     // Color grey when there is no warning, red when there is a warning
     explorationEditorSettingsTab.expectWarningsColorToBe(
-      "rgba(115, 115, 115, 1)");
+      'rgba(115, 115, 115, 1)');
     explorationEditorSettingsTab.setObjective('short goal');
     explorationEditorSettingsTab.expectWarningsColorToBe(
-      "rgba(169, 68, 66, 1)");
+      'rgba(169, 68, 66, 1)');
   });
 
   it('should be able to select category from the dropdown menu', function() {

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -249,7 +249,7 @@ describe('Core exploration functionality', function() {
 
     workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
-    
+
     explorationEditorSettingsTab.expectTitleToBe('');
     explorationEditorSettingsTab.setTitle('title1');
     explorationEditorPage.navigateToMainTab();
@@ -291,7 +291,8 @@ describe('Core exploration functionality', function() {
     users.logout();
   });
 
-  it('should be able to create new category which is not in the dropdown menu', function() {
+  it('should be able to create new category which is not' +
+  ' in the dropdown menu', function() {
     users.createUser('user9@stateEditor.com', 'user9StateEditor');
     users.login('user9@stateEditor.com');
 
@@ -333,7 +334,7 @@ describe('Core exploration functionality', function() {
     explorationEditorMainTab.setInteraction('Continue');
     explorationEditorMainTab.getResponseEditor('default').setDestination(
       'card 2', true, null);
-    
+
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectFirstStateToBe('card 1');
     explorationEditorSettingsTab.setFirstState('card 2');

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -255,6 +255,8 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectTitleToBe('title1');
+
+    users.logout();
   });
 
   it('should be able to edit goal', function() {
@@ -269,6 +271,8 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectObjectiveToBe('It is just a test.');
+
+    users.logout();
   });
 
   it('should be able to select category from the dropdown menu', function() {
@@ -283,6 +287,8 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectCategoryToBe('Biology');
+
+    users.logout();
   });
 
   it('should be able to create new category which is not in the dropdown menu', function() {
@@ -297,6 +303,8 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectCategoryToBe('New');
+
+    users.logout();
   });
 
   it('should be able to select language from the dropdown menu', function() {
@@ -311,6 +319,8 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectLanguageToBe('italiano (Italian)');
+
+    users.logout();
   });
 
   it('should change the first card of the exploration', function() {
@@ -330,6 +340,8 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectFirstStateToBe('card 2');
+
+    users.logout();
   });
 
   afterEach(function() {

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -40,19 +40,23 @@ describe('Core exploration functionality', function() {
   var explorationEditorPage = null;
   var explorationEditorMainTab = null;
   var explorationEditorSettingsTab = null;
+  var userNumber = 1;
 
   beforeEach(function() {
     explorationEditorPage = new ExplorationEditorPage.ExplorationEditorPage();
     explorationEditorMainTab = explorationEditorPage.getMainTab();
     explorationEditorSettingsTab = explorationEditorPage.getSettingsTab();
     explorationPlayerPage = new ExplorationPlayerPage.ExplorationPlayerPage();
+
+    users.createUser(
+      `user${userNumber}@stateEditor.com`, `user${userNumber}StateEditor`);
+    users.login(`user${userNumber}@stateEditor.com`);
+    workflow.createExploration();
+
+    userNumber++;
   });
 
   it('should display plain text content', function() {
-    users.createUser('user1@stateEditor.com', 'user1StateEditor');
-    users.login('user1@stateEditor.com');
-
-    workflow.createExploration();
     explorationEditorMainTab.setContent(forms.toRichText('plain text'));
     explorationEditorMainTab.setInteraction('Continue', 'click here');
     explorationEditorMainTab.getResponseEditor('default')
@@ -72,9 +76,6 @@ describe('Core exploration functionality', function() {
   });
 
   it('should create content and multiple choice interactions', function() {
-    users.createUser('user2@stateEditor.com', 'user2StateEditor');
-    users.login('user2@stateEditor.com');
-    workflow.createExploration();
     explorationEditorMainTab.setContent(function(richTextEditor) {
       richTextEditor.appendBoldText('bold text');
       richTextEditor.appendPlainText(' ');
@@ -105,10 +106,6 @@ describe('Core exploration functionality', function() {
   });
 
   it('should obey numeric interaction rules and display feedback', function() {
-    users.createUser('user3@stateEditor.com', 'user3StateEditor');
-    users.login('user3@stateEditor.com');
-
-    workflow.createExploration();
     explorationEditorMainTab.setContent(forms.toRichText('some content'));
     explorationEditorMainTab.setInteraction('NumericInput');
     explorationEditorMainTab.addResponse('NumericInput',
@@ -151,10 +148,6 @@ describe('Core exploration functionality', function() {
 
   it('should skip the customization modal for interactions having no ' +
       'customization options', function() {
-    users.createUser('user4@stateEditor.com', 'user4StateEditor');
-    users.login('user4@stateEditor.com');
-
-    workflow.createExploration();
     explorationEditorMainTab.setContent(forms.toRichText('some content'));
 
     // Numeric input does not have any customization arguments. Therefore the
@@ -168,10 +161,6 @@ describe('Core exploration functionality', function() {
 
   it('should open appropriate modal on re-clicking an interaction to ' +
      'customize it', function() {
-    users.createUser('user5@stateEditor.com', 'user5StateEditor');
-    users.login('user5@stateEditor.com');
-
-    workflow.createExploration();
     explorationEditorMainTab.setContent(forms.toRichText('some content'));
 
     // Numeric input does not have any customization arguments. Therefore, on
@@ -200,9 +189,6 @@ describe('Core exploration functionality', function() {
 
   it('should correctly display contents, rule parameters, feedback' +
   ' instructions and newly created state', function() {
-    users.createUser('stateEditorUser1@example.com', 'stateEditorUser1');
-    users.login('stateEditorUser1@example.com');
-    workflow.createExploration();
     // Verify exploration's text content.
     explorationEditorMainTab.setContent(forms.toRichText('Happiness Checker'));
     explorationEditorMainTab.expectContentToMatch(
@@ -234,10 +220,6 @@ describe('Core exploration functionality', function() {
   });
 
   it('should be able to edit title', function() {
-    users.createUser('user6@stateEditor.com', 'user6StateEditor');
-    users.login('user6@stateEditor.com');
-
-    workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
 
     explorationEditorSettingsTab.expectTitleToBe('');
@@ -248,10 +230,6 @@ describe('Core exploration functionality', function() {
   });
 
   it('should be able to edit goal', function() {
-    users.createUser('user7@stateEditor.com', 'user7StateEditor');
-    users.login('user7@stateEditor.com');
-
-    workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
 
     explorationEditorSettingsTab.expectObjectiveToBe('');
@@ -262,10 +240,6 @@ describe('Core exploration functionality', function() {
   });
 
   it('should show warnings when the length of goal < 15', function() {
-    users.createUser('user8@stateEditor.com', 'user8StateEditor');
-    users.login('user8@stateEditor.com');
-
-    workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
 
     // Color grey when there is no warning, red when there is a warning
@@ -277,10 +251,6 @@ describe('Core exploration functionality', function() {
   });
 
   it('should be able to select category from the dropdown menu', function() {
-    users.createUser('user9@stateEditor.com', 'user9StateEditor');
-    users.login('user9@stateEditor.com');
-
-    workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
 
     explorationEditorSettingsTab.expectCategoryToBe('');
@@ -292,10 +262,6 @@ describe('Core exploration functionality', function() {
 
   it('should be able to create new category which is not' +
   ' in the dropdown menu', function() {
-    users.createUser('user10@stateEditor.com', 'user10StateEditor');
-    users.login('user10@stateEditor.com');
-
-    workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
 
     explorationEditorSettingsTab.expectCategoryToBe('');
@@ -306,10 +272,6 @@ describe('Core exploration functionality', function() {
   });
 
   it('should be able to select language from the dropdown menu', function() {
-    users.createUser('user11@stateEditor.com', 'user11StateEditor');
-    users.login('user11@stateEditor.com');
-
-    workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
 
     explorationEditorSettingsTab.expectLanguageToBe('English');
@@ -320,10 +282,6 @@ describe('Core exploration functionality', function() {
   });
 
   it('should change the first card of the exploration', function() {
-    users.createUser('user12@stateEditor.com', 'user12StateEditor');
-    users.login('user12@stateEditor.com');
-    workflow.createExploration();
-
     explorationEditorMainTab.setStateName('card 1');
     explorationEditorMainTab.setContent(forms.toRichText('this is card 1'));
     explorationEditorMainTab.setInteraction('Continue');

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -243,6 +243,95 @@ describe('Core exploration functionality', function() {
     users.logout();
   });
 
+  it('should be able to edit title', function() {
+    users.createUser('user6@stateEditor.com', 'user6StateEditor');
+    users.login('user6@stateEditor.com');
+
+    workflow.createExploration();
+    explorationEditorPage.navigateToSettingsTab();
+    
+    explorationEditorSettingsTab.expectTitleToBe('');
+    explorationEditorSettingsTab.setTitle('title1');
+    explorationEditorPage.navigateToMainTab();
+    explorationEditorPage.navigateToSettingsTab();
+    explorationEditorSettingsTab.expectTitleToBe('title1');
+  });
+
+  it('should be able to edit goal', function() {
+    users.createUser('user6@stateEditor.com', 'user6StateEditor');
+    users.login('user6@stateEditor.com');
+
+    workflow.createExploration();
+    explorationEditorPage.navigateToSettingsTab();
+
+    explorationEditorSettingsTab.expectObjectiveToBe('');
+    explorationEditorSettingsTab.setObjective('It is just a test.');
+    explorationEditorPage.navigateToMainTab();
+    explorationEditorPage.navigateToSettingsTab();
+    explorationEditorSettingsTab.expectObjectiveToBe('It is just a test.');
+  });
+
+  it('should be able to select category from the dropdown menu', function() {
+    users.createUser('user7@stateEditor.com', 'user7StateEditor');
+    users.login('user7@stateEditor.com');
+
+    workflow.createExploration();
+    explorationEditorPage.navigateToSettingsTab();
+
+    explorationEditorSettingsTab.expectCategoryToBe('');
+    explorationEditorSettingsTab.setCategory('Biology');
+    explorationEditorPage.navigateToMainTab();
+    explorationEditorPage.navigateToSettingsTab();
+    explorationEditorSettingsTab.expectCategoryToBe('Biology');
+  });
+
+  it('should be able to create new category which is not in the dropdown menu', function() {
+    users.createUser('user8@stateEditor.com', 'user8StateEditor');
+    users.login('user8@stateEditor.com');
+
+    workflow.createExploration();
+    explorationEditorPage.navigateToSettingsTab();
+
+    explorationEditorSettingsTab.expectCategoryToBe('');
+    explorationEditorSettingsTab.setCategory('New');
+    explorationEditorPage.navigateToMainTab();
+    explorationEditorPage.navigateToSettingsTab();
+    explorationEditorSettingsTab.expectCategoryToBe('New');
+  });
+
+  it('should be able to select language from the dropdown menu', function() {
+    users.createUser('user9@stateEditor.com', 'user9StateEditor');
+    users.login('user9@stateEditor.com');
+
+    workflow.createExploration();
+    explorationEditorPage.navigateToSettingsTab();
+
+    explorationEditorSettingsTab.expectLanguageToBe('English');
+    explorationEditorSettingsTab.setLanguage('italiano (Italian)');
+    explorationEditorPage.navigateToMainTab();
+    explorationEditorPage.navigateToSettingsTab();
+    explorationEditorSettingsTab.expectLanguageToBe('italiano (Italian)');
+  });
+
+  it('should change the first card of the exploration', function() {
+    users.createUser('user10@stateEditor.com', 'user10StateEditor');
+    users.login('user10@stateEditor.com');
+    workflow.createExploration();
+
+    explorationEditorMainTab.setStateName('card 1');
+    explorationEditorMainTab.setContent(forms.toRichText('this is card 1'));
+    explorationEditorMainTab.setInteraction('Continue');
+    explorationEditorMainTab.getResponseEditor('default').setDestination(
+      'card 2', true, null);
+    
+    explorationEditorPage.navigateToSettingsTab();
+    explorationEditorSettingsTab.expectFirstStateToBe('card 1');
+    explorationEditorSettingsTab.setFirstState('card 2');
+    explorationEditorPage.navigateToMainTab();
+    explorationEditorPage.navigateToSettingsTab();
+    explorationEditorSettingsTab.expectFirstStateToBe('card 2');
+  });
+
   afterEach(function() {
     general.checkForConsoleErrors([]);
   });

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -69,8 +69,6 @@ describe('Core exploration functionality', function() {
     explorationPlayerPage.expectInteractionToMatch('Continue', 'click here');
     explorationPlayerPage.submitAnswer('Continue', null);
     explorationPlayerPage.expectExplorationToBeOver();
-
-    users.logout();
   });
 
   it('should create content and multiple choice interactions', function() {
@@ -104,7 +102,6 @@ describe('Core exploration functionality', function() {
       [forms.toRichText('option A'), forms.toRichText('option B')]);
     explorationPlayerPage.submitAnswer('MultipleChoiceInput', 'option B');
     explorationPlayerPage.expectExplorationToBeOver();
-    users.logout();
   });
 
   it('should obey numeric interaction rules and display feedback', function() {
@@ -150,8 +147,6 @@ describe('Core exploration functionality', function() {
       });
     explorationPlayerPage.clickThroughToNextCard();
     explorationPlayerPage.expectExplorationToBeOver();
-
-    users.logout();
   });
 
   it('should skip the customization modal for interactions having no ' +
@@ -169,8 +164,6 @@ describe('Core exploration functionality', function() {
     // The Continue input has customization options. Therefore the
     // customization modal does appear and so does the save interaction button.
     explorationEditorMainTab.setInteraction('Continue');
-
-    users.logout();
   });
 
   it('should open appropriate modal on re-clicking an interaction to ' +
@@ -203,8 +196,6 @@ describe('Core exploration functionality', function() {
       by.css('.protractor-test-save-interaction'));
     expect(saveInteractionBtn.isPresent()).toBe(true);
     saveInteractionBtn.click();
-
-    users.logout();
   });
 
   it('should correctly display contents, rule parameters, feedback' +
@@ -240,7 +231,6 @@ describe('Core exploration functionality', function() {
     explorationEditorMainTab.getResponseEditor(1).expectRuleToBe(
       'TextInput', 'FuzzyEquals', ['"sad"']);
     explorationEditorPage.saveChanges();
-    users.logout();
   });
 
   it('should be able to edit title', function() {
@@ -255,8 +245,6 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectTitleToBe('title1');
-
-    users.logout();
   });
 
   it('should be able to edit goal', function() {
@@ -271,13 +259,26 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectObjectiveToBe('It is just a test.');
+  });
 
-    users.logout();
+  it('should show warnings when the length of goal < 15', function() {
+    users.createUser('user8@stateEditor.com', 'user8StateEditor');
+    users.login('user8@stateEditor.com');
+
+    workflow.createExploration();
+    explorationEditorPage.navigateToSettingsTab();
+
+    // Color grey when there is no warning, red when there is a warning
+    explorationEditorSettingsTab.expectWarningsColorToBe(
+      "rgba(115, 115, 115, 1)");
+    explorationEditorSettingsTab.setObjective('short goal');
+    explorationEditorSettingsTab.expectWarningsColorToBe(
+      "rgba(169, 68, 66, 1)");
   });
 
   it('should be able to select category from the dropdown menu', function() {
-    users.createUser('user8@stateEditor.com', 'user8StateEditor');
-    users.login('user8@stateEditor.com');
+    users.createUser('user9@stateEditor.com', 'user9StateEditor');
+    users.login('user9@stateEditor.com');
 
     workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
@@ -287,14 +288,12 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectCategoryToBe('Biology');
-
-    users.logout();
   });
 
   it('should be able to create new category which is not' +
   ' in the dropdown menu', function() {
-    users.createUser('user9@stateEditor.com', 'user9StateEditor');
-    users.login('user9@stateEditor.com');
+    users.createUser('user10@stateEditor.com', 'user10StateEditor');
+    users.login('user10@stateEditor.com');
 
     workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
@@ -304,13 +303,11 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectCategoryToBe('New');
-
-    users.logout();
   });
 
   it('should be able to select language from the dropdown menu', function() {
-    users.createUser('user10@stateEditor.com', 'user10StateEditor');
-    users.login('user10@stateEditor.com');
+    users.createUser('user11@stateEditor.com', 'user11StateEditor');
+    users.login('user11@stateEditor.com');
 
     workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
@@ -320,13 +317,11 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectLanguageToBe('italiano (Italian)');
-
-    users.logout();
   });
 
   it('should change the first card of the exploration', function() {
-    users.createUser('user11@stateEditor.com', 'user11StateEditor');
-    users.login('user11@stateEditor.com');
+    users.createUser('user12@stateEditor.com', 'user12StateEditor');
+    users.login('user12@stateEditor.com');
     workflow.createExploration();
 
     explorationEditorMainTab.setStateName('card 1');
@@ -341,11 +336,10 @@ describe('Core exploration functionality', function() {
     explorationEditorPage.navigateToMainTab();
     explorationEditorPage.navigateToSettingsTab();
     explorationEditorSettingsTab.expectFirstStateToBe('card 2');
-
-    users.logout();
   });
 
   afterEach(function() {
     general.checkForConsoleErrors([]);
+    users.logout();
   });
 });

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -243,7 +243,7 @@ describe('Core exploration functionality', function() {
     users.logout();
   });
 
-  it('should be able to edit title', function() {
+  fit('should be able to edit title', function() {
     users.createUser('user6@stateEditor.com', 'user6StateEditor');
     users.login('user6@stateEditor.com');
 
@@ -258,8 +258,8 @@ describe('Core exploration functionality', function() {
   });
 
   it('should be able to edit goal', function() {
-    users.createUser('user6@stateEditor.com', 'user6StateEditor');
-    users.login('user6@stateEditor.com');
+    users.createUser('user7@stateEditor.com', 'user7StateEditor');
+    users.login('user7@stateEditor.com');
 
     workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
@@ -272,8 +272,8 @@ describe('Core exploration functionality', function() {
   });
 
   it('should be able to select category from the dropdown menu', function() {
-    users.createUser('user7@stateEditor.com', 'user7StateEditor');
-    users.login('user7@stateEditor.com');
+    users.createUser('user8@stateEditor.com', 'user8StateEditor');
+    users.login('user8@stateEditor.com');
 
     workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
@@ -286,8 +286,8 @@ describe('Core exploration functionality', function() {
   });
 
   it('should be able to create new category which is not in the dropdown menu', function() {
-    users.createUser('user8@stateEditor.com', 'user8StateEditor');
-    users.login('user8@stateEditor.com');
+    users.createUser('user9@stateEditor.com', 'user9StateEditor');
+    users.login('user9@stateEditor.com');
 
     workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
@@ -300,8 +300,8 @@ describe('Core exploration functionality', function() {
   });
 
   it('should be able to select language from the dropdown menu', function() {
-    users.createUser('user9@stateEditor.com', 'user9StateEditor');
-    users.login('user9@stateEditor.com');
+    users.createUser('user10@stateEditor.com', 'user10StateEditor');
+    users.login('user10@stateEditor.com');
 
     workflow.createExploration();
     explorationEditorPage.navigateToSettingsTab();
@@ -314,8 +314,8 @@ describe('Core exploration functionality', function() {
   });
 
   it('should change the first card of the exploration', function() {
-    users.createUser('user10@stateEditor.com', 'user10StateEditor');
-    users.login('user10@stateEditor.com');
+    users.createUser('user11@stateEditor.com', 'user11StateEditor');
+    users.login('user11@stateEditor.com');
     workflow.createExploration();
 
     explorationEditorMainTab.setStateName('card 1');

--- a/core/tests/protractor_utils/ExplorationEditorSettingsTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorSettingsTab.js
@@ -147,23 +147,28 @@ var ExplorationEditorSettingsTab = function() {
   };
 
   this.expectCategoryToBe = function(category) {
-    expect(explorationCategoryInput.$('option:checked').getText()).toEqual(category);
+    expect(explorationCategoryInput.$('option:checked').getText()).
+      toEqual(category);
   };
 
   this.expectFirstStateToBe = function(firstState) {
-    expect(initialStateSelect.$('option:checked').getText()).toEqual(firstState);
+    expect(initialStateSelect.$('option:checked').getText()).
+      toEqual(firstState);
   };
 
   this.expectLanguageToBe = function(language) {
-    expect(explorationLanguageInput.$('option:checked').getText()).toEqual(language);
+    expect(explorationLanguageInput.$('option:checked').getText()).
+      toEqual(language);
   };
 
   this.expectObjectiveToBe = function(objective) {
-    expect(explorationObjectiveInput.getAttribute('value')).toEqual(objective);
+    expect(explorationObjectiveInput.getAttribute('value')).
+      toEqual(objective);
   };
 
   this.expectTitleToBe = function(title) {
-    expect(explorationTitleInput.getAttribute('value')).toEqual(title);
+    expect(explorationTitleInput.getAttribute('value')).
+      toEqual(title);
   };
 };
 

--- a/core/tests/protractor_utils/ExplorationEditorSettingsTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorSettingsTab.js
@@ -32,6 +32,8 @@ var ExplorationEditorSettingsTab = function() {
     by.css('.protractor-test-exploration-language-select'));
   var explorationObjectiveInput = element(
     by.css('.protractor-test-exploration-objective-input'));
+  var explorationObjectiveWarning = element(
+    by.css('.protractor-test-exploration-objective-warning'));
   var explorationSummaryTile = element(
     by.css('.protractor-test-exploration-summary-tile'));
   var explorationTitleInput = element(
@@ -169,6 +171,11 @@ var ExplorationEditorSettingsTab = function() {
   this.expectTitleToBe = function(title) {
     expect(explorationTitleInput.getAttribute('value')).
       toEqual(title);
+  };
+
+  this.expectWarningsColorToBe = function(color) {
+    expect(explorationObjectiveWarning.getCssValue('color')).
+      toEqual(color);
   };
 };
 

--- a/core/tests/protractor_utils/ExplorationEditorSettingsTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorSettingsTab.js
@@ -28,6 +28,8 @@ var ExplorationEditorSettingsTab = function() {
     by.css('.protractor-test-exploration-edit-param-changes'));
   var explorationCategoryInput = element(
     by.css('.protractor-test-exploration-category-input'));
+  var explorationLanguageInput = element(
+    by.css('.protractor-test-exploration-language-select'));
   var explorationObjectiveInput = element(
     by.css('.protractor-test-exploration-objective-input'));
   var explorationSummaryTile = element(
@@ -142,6 +144,26 @@ var ExplorationEditorSettingsTab = function() {
   this.setTitle = function(title) {
     explorationTitleInput.clear();
     explorationTitleInput.sendKeys(title);
+  };
+
+  this.expectCategoryToBe = function(category) {
+    expect(explorationCategoryInput.$('option:checked').getText()).toEqual(category);
+  };
+
+  this.expectFirstStateToBe = function(firstState) {
+    expect(initialStateSelect.$('option:checked').getText()).toEqual(firstState);
+  };
+
+  this.expectLanguageToBe = function(language) {
+    expect(explorationLanguageInput.$('option:checked').getText()).toEqual(language);
+  };
+
+  this.expectObjectiveToBe = function(objective) {
+    expect(explorationObjectiveInput.getAttribute('value')).toEqual(objective);
+  };
+
+  this.expectTitleToBe = function(title) {
+    expect(explorationTitleInput.getAttribute('value')).toEqual(title);
   };
 };
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fix Part of #6240: This PR adds e2e tests for editting exploration properties (title, category, goal, language, etc) in coreEditorAndPlayerFeatures.js.


## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
