### PR TITLE
Fix part of #6550: Raise code coverage of core.storage.question.gae_models to 100%

### DIFF
--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -39,25 +39,26 @@ class QuestionModelUnitTests(test_utils.GenericTestBase):
             question_model.question_state_data, question_state_data)
         self.assertEqual(question_model.language_code, language_code)
 
-    
+
     def test_raise_exception_by_mocking_collision(self):
         state = state_domain.State.create_default_state('ABC')
         question_state_data = state.to_dict()
         language_code = 'en'
         version = 1
-        question_model = None
 
         with self.assertRaisesRegexp(
             Exception, 'The id generator for QuestionModel is producing too '
             'many collisions.'
             ):
             # Swap dependent method get_by_id to simulate collision every time.
-            with self.swap(question_models.QuestionModel, 'get_by_id',
-                types.MethodType(lambda x, y: True,
+            with self.swap(
+                question_models.QuestionModel, 'get_by_id',
+                types.MethodType(
+                    lambda x, y: True,
                     question_models.QuestionModel)):
-                question_model = question_models.QuestionModel.create(
+                question_models.QuestionModel.create(
                     question_state_data, language_code, version)
-        
+
 
 class QuestionSummaryModelUnitTests(test_utils.GenericTestBase):
     """Tests the QuestionSummaryModel class."""

--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -20,6 +20,9 @@ from core.domain import state_domain
 from core.platform import models
 from core.tests import test_utils
 
+(base_models, skill_models) = models.Registry.import_models([
+    models.NAMES.base_model, models.NAMES.skill
+])
 (question_models,) = models.Registry.import_models([models.NAMES.question])
 
 
@@ -37,6 +40,21 @@ class QuestionModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             question_model.question_state_data, question_state_data)
         self.assertEqual(question_model.language_code, language_code)
+
+    def test_create_question_raise_exception(self):
+        state = state_domain.State.create_default_state('ABC')
+        question_state_data = state.to_dict()
+        language_code = 'en'
+        version = '1'
+
+        try:
+            base_models.MAX_RETRIES = 0
+            question_model = None
+            question_model = question_models.QuestionModel.create(
+                question_state_data, language_code, version)
+        except Exception:
+            base_models.MAX_RETRIES = 10
+            self.assertIsNone(question_model)
 
 
 class QuestionSummaryModelUnitTests(test_utils.GenericTestBase):

--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -40,21 +40,23 @@ class QuestionModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(question_model.language_code, language_code)
 
     
-    def test_raise_exception_by_forcing_collision(self):
+    def test_raise_exception_by_mocking_collision(self):
         state = state_domain.State.create_default_state('ABC')
         question_state_data = state.to_dict()
         language_code = 'en'
         version = 1
         question_model = None
 
-        try:
+        with self.assertRaisesRegexp(
+            Exception, 'The id generator for QuestionModel is producing too '
+            'many collisions.'
+            ):
+            # Swap dependent method 'get_by_id' to simulate collision every time
             with self.swap(question_models.QuestionModel, 'get_by_id',
                 types.MethodType(lambda x, y: True,
                     question_models.QuestionModel)):
                 question_model = question_models.QuestionModel.create(
                     question_state_data, language_code, version)
-        except Exception:
-            self.assertIsNone(question_model)
         
 
 class QuestionSummaryModelUnitTests(test_utils.GenericTestBase):

--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -51,7 +51,7 @@ class QuestionModelUnitTests(test_utils.GenericTestBase):
             Exception, 'The id generator for QuestionModel is producing too '
             'many collisions.'
             ):
-            # Swap dependent method 'get_by_id' to simulate collision every time
+            # Swap dependent method get_by_id to simulate collision every time.
             with self.swap(question_models.QuestionModel, 'get_by_id',
                 types.MethodType(lambda x, y: True,
                     question_models.QuestionModel)):

--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -15,11 +15,11 @@
 """Tests for core.storage.question.gae_models."""
 
 import datetime
+import types
 
 from core.domain import state_domain
 from core.platform import models
 from core.tests import test_utils
-import types
 
 (question_models,) = models.Registry.import_models([models.NAMES.question])
 


### PR DESCRIPTION
…e_models to 100%

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
This PR fixes part of issue #6550. Specifically, this PR adds a new test case for `core.storage.question.gae_models` to raise its code coverage to 100%.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
