### PR TITLE
Add removal of app.yaml version field to deploy script.

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -106,6 +106,8 @@ def preprocess_release():
 
     (1) Substitutes files from the per-app deployment data.
     (2) Change the DEV_MODE constant in assets/constants.js.
+    (3) Removes the "version" field from app.yaml, since gcloud does not like
+        it (when deploying).
     """
     if not os.path.exists(DEPLOY_DATA_PATH):
         raise Exception(
@@ -149,6 +151,17 @@ def preprocess_release():
     content = content.replace('"DEV_MODE": true', '"DEV_MODE": false')
     with open(os.path.join('assets', 'constants.js'), 'w+') as new_assets_file:
         new_assets_file.write(content)
+
+    # Removes the version field from app.yaml.
+    print 'Removing the version field from app.yaml ...'
+    with open('app.yaml', 'r') as f:
+        content = f.read()
+        assert content.count('version: default') == 1
+    os.remove('app.yaml')
+    content = content.replace('version: default', '')
+    with open('app.yaml', 'w+') as f:
+        f.write(content)
+    print 'Version field removed.'
 
 
 def _execute_deployment():

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -159,7 +159,7 @@ def preprocess_release():
         assert content.count('version: default') == 1
     os.remove('app.yaml')
     content = content.replace('version: default', '')
-    with open('app.yaml', 'w+') as f:
+    with open('app.yaml', 'w') as f:
         f.write(content)
     print 'Version field removed.'
 


### PR DESCRIPTION
## Explanation
Removes version field from app.yaml prior to deployment. The need for this was discovered during the April release deployment to the test server.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.