### PR TITLE
Fix #6561: Corrected the "About-->Get Involved" link on the top navigation bar

### DIFF
--- a/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
+++ b/core/templates/dev/head/components/top_navigation_bar/top_navigation_bar_directive.html
@@ -46,7 +46,7 @@
           <li><a class="oppia-navbar-tab-content protractor-test-playbook-link " href="/teach#playbook" translate="I18N_TOPNAV_PARTICIPATION_PLAYBOOK"></a></li>
           <li><a class="oppia-navbar-tab-content" href="https://medium.com/oppia-org" target="_blank"  translate="I18N_TOPNAV_BLOG">Blog</a></li>
           <li><a class="oppia-navbar-tab-content" href="http://oppiafoundation.org"  target="_blank" translate="I18N_TOPNAV_OPPIA_FOUNDATION"></a></li>
-          <li><a ng-keydown="onMenuKeypress($event, 'aboutMenu', {tab: ACTION_CLOSE})" class="oppia-navbar-tab-content" href="http://oppiafoundation.org/get-involved" target="_blank" translate="I18N_TOPNAV_GET_INVOLVED"></a></li>
+          <li><a ng-keydown="onMenuKeypress($event, 'aboutMenu', {tab: ACTION_CLOSE})" class="oppia-navbar-tab-content" href="https://oppiafoundation.org/volunteer" target="_blank" translate="I18N_TOPNAV_GET_INVOLVED"></a></li>
         </ul>
       </li>
       <li ng-mouseover="blurNavigationLinks($event)" ng-show="navElementsVisibilityStatus.I18N_TOPNAV_DONATE">


### PR DESCRIPTION
## Explanation
Fixes #6561…
Fixes the link `https://oppiafoundation.org/get-involved/` -> `https://oppiafoundation.org/volunteer` in the top navigation bar under `About` --> Get Involved`

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
