### PR TITLE
Fix #6562: Removed G+ from the footer and Readme.md

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -64,6 +64,6 @@ The Oppia code is released under the [Apache v2 license](https://github.com/oppi
   * [Blog](https://medium.com/oppia-org)
   * [Discussion forum](http://groups.google.com/group/oppia)
   * [Announcements mailing list](http://groups.google.com/group/oppia-announce)
-  * Social media: [G+](https://plus.google.com/109898456505810251700/about), [YouTube](https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw), [FB](https://www.facebook.com/oppiaorg), [Twitter](https://twitter.com/oppiaorg)
+  * Social media: [YouTube](https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw), [FB](https://www.facebook.com/oppiaorg), [Twitter](https://twitter.com/oppiaorg)
 
 We also have public chat rooms on Gitter: [https://gitter.im/oppia/oppia-chat](https://gitter.im/oppia/oppia-chat) and the #oppia channel on Freenode IRC. Drop by and say hello!

--- a/core/templates/dev/head/components/social_buttons/social_buttons_directive.html
+++ b/core/templates/dev/head/components/social_buttons/social_buttons_directive.html
@@ -6,13 +6,6 @@
   </div>
 
   <div class="oppia-footer-social-icons">
-    <div class="oppia-googleplus-follow">
-      <a href="https://plus.google.com/109898456505810251700/about" target="_blank">
-        <i class="oppia-follow-icons fa fa-google-plus"></i>
-        <span class="oppia-icon-accessibility-label">Google Plus</span>
-      </a>
-    </div>
-
     <div class="oppia-youtube-follow">
       <a href="https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw" target="_blank">
         <i class="oppia-follow-icons fa fa-youtube-play"></i>
@@ -57,11 +50,6 @@
     top: -10px;
   }
 
-  .oppia-footer-social .oppia-footer-social-icons .oppia-googleplus-follow {
-    background: #dd4b39;
-    margin-right: 6px;
-    padding: 5px 7px;
-  }
   .oppia-footer-social .oppia-footer-social-icons .oppia-youtube-follow {
     background: #cd201f;
     margin-right: 6px;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #6562: Due to the shutdown of the google plus service, the URL of the oppia google plus account has been removed from the footer in social icons section as well as from the ```README.md```

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
