### PR TITLE
Fix broken interaction previews in the exploration editor

### DIFF
--- a/extensions/interactions/DragAndDropSortInput/DragAndDropSortInput.html
+++ b/extensions/interactions/DragAndDropSortInput/DragAndDropSortInput.html
@@ -1,5 +1,5 @@
+<script src="/extensions/interactions/DragAndDropSortInput/directives/DragAndDropSortInputRulesService.js"></script>
+<script src="/extensions/interactions/DragAndDropSortInput/directives/DragAndDropSortInputValidationService.js"></script>
 <script src="/extensions/interactions/DragAndDropSortInput/directives/OppiaInteractiveDragAndDropSortInputDirective.js"></script>
 <script src="/extensions/interactions/DragAndDropSortInput/directives/OppiaResponseDragAndDropSortInputDirective.js"></script>
 <script src="/extensions/interactions/DragAndDropSortInput/directives/OppiaShortResponseDragAndDropSortInputDirective.js"></script>
-<script src="/extensions/interactions/DragAndDropSortInput/directives/DragAndDropSortInputRulesService.js"></script>
-<script src="/extensions/interactions/DragAndDropSortInput/directives/DragAndDropSortInputValidationService.js"></script>

--- a/extensions/interactions/DragAndDropSortInput/directives/OppiaInteractiveDragAndDropSortInputDirective.js
+++ b/extensions/interactions/DragAndDropSortInput/directives/OppiaInteractiveDragAndDropSortInputDirective.js
@@ -20,7 +20,7 @@ oppia.directive('oppiaInteractiveDragAndDropSortInput', [
   'DragAndDropSortInputRulesService', 'HtmlEscaperService',
   'UrlInterpolationService', function(
       DragAndDropSortInputRulesService, HtmlEscaperService,
-      UrlInterpolationService,) {
+      UrlInterpolationService) {
     return {
       restrict: 'E',
       scope: {},

--- a/extensions/interactions/DragAndDropSortInput/directives/OppiaInteractiveDragAndDropSortInputDirective.js
+++ b/extensions/interactions/DragAndDropSortInput/directives/OppiaInteractiveDragAndDropSortInputDirective.js
@@ -17,11 +17,10 @@
  */
 
 oppia.directive('oppiaInteractiveDragAndDropSortInput', [
-  'HtmlEscaperService', 'UrlInterpolationService',
-  'DragAndDropSortInputRulesService',
-  function(
-      HtmlEscaperService, UrlInterpolationService,
-      dragAndDropSortInputRulesService) {
+  'DragAndDropSortInputRulesService', 'HtmlEscaperService',
+  'UrlInterpolationService', function(
+      DragAndDropSortInputRulesService, HtmlEscaperService,
+      UrlInterpolationService,) {
     return {
       restrict: 'E',
       scope: {},

--- a/extensions/interactions/DragAndDropSortInput/directives/OppiaInteractiveDragAndDropSortInputDirective.js
+++ b/extensions/interactions/DragAndDropSortInput/directives/OppiaInteractiveDragAndDropSortInputDirective.js
@@ -18,7 +18,7 @@
 
 oppia.directive('oppiaInteractiveDragAndDropSortInput', [
   'HtmlEscaperService', 'UrlInterpolationService',
-  'dragAndDropSortInputRulesService',
+  'DragAndDropSortInputRulesService',
   function(
       HtmlEscaperService, UrlInterpolationService,
       dragAndDropSortInputRulesService) {

--- a/extensions/interactions/ImageClickInput/ImageClickInput.html
+++ b/extensions/interactions/ImageClickInput/ImageClickInput.html
@@ -1,5 +1,5 @@
+<script src="/extensions/interactions/ImageClickInput/directives/ImageClickInputRulesService.js"></script>
+<script src="/extensions/interactions/ImageClickInput/directives/ImageClickInputValidationService.js"></script>
 <script src="/extensions/interactions/ImageClickInput/directives/OppiaInteractiveImageClickInputDirective.js"></script>
 <script src="/extensions/interactions/ImageClickInput/directives/OppiaResponseImageClickInputDirective.js"></script>
 <script src="/extensions/interactions/ImageClickInput/directives/OppiaShortResponseImageClickInputDirective.js"></script>
-<script src="/extensions/interactions/ImageClickInput/directives/ImageClickInputRulesService.js"></script>
-<script src="/extensions/interactions/ImageClickInput/directives/ImageClickInputValidationService.js"></script>

--- a/extensions/interactions/ImageClickInput/directives/OppiaInteractiveImageClickInputDirective.js
+++ b/extensions/interactions/ImageClickInput/directives/OppiaInteractiveImageClickInputDirective.js
@@ -22,16 +22,14 @@
 
 oppia.directive('oppiaInteractiveImageClickInput', [
   '$sce', 'AssetsBackendApiService', 'ContextService',
-  'HtmlEscaperService', 'ImagePreloaderService',
-  'UrlInterpolationService', 'ImageClickInputRulesService',
-  'EVENT_NEW_CARD_AVAILABLE', 'EXPLORATION_EDITOR_TAB_CONTEXT',
-  'LOADING_INDICATOR_URL',
+  'HtmlEscaperService', 'ImageClickInputRulesService', 'ImagePreloaderService',
+  'UrlInterpolationService', 'EVENT_NEW_CARD_AVAILABLE',
+  'EXPLORATION_EDITOR_TAB_CONTEXT', 'LOADING_INDICATOR_URL',
   function(
       $sce, AssetsBackendApiService, ContextService,
-      HtmlEscaperService, ImagePreloaderService,
-      UrlInterpolationService, imageClickInputRulesService,
-      EVENT_NEW_CARD_AVAILABLE, EXPLORATION_EDITOR_TAB_CONTEXT,
-      LOADING_INDICATOR_URL) {
+      HtmlEscaperService, ImageClickInputRulesService, ImagePreloaderService,
+      UrlInterpolationService, EVENT_NEW_CARD_AVAILABLE,
+      EXPLORATION_EDITOR_TAB_CONTEXT, LOADING_INDICATOR_URL) {
     return {
       restrict: 'E',
       scope: {

--- a/extensions/interactions/ImageClickInput/directives/OppiaInteractiveImageClickInputDirective.js
+++ b/extensions/interactions/ImageClickInput/directives/OppiaInteractiveImageClickInputDirective.js
@@ -23,7 +23,7 @@
 oppia.directive('oppiaInteractiveImageClickInput', [
   '$sce', 'AssetsBackendApiService', 'ContextService',
   'HtmlEscaperService', 'ImagePreloaderService',
-  'UrlInterpolationService', 'imageClickInputRulesService',
+  'UrlInterpolationService', 'ImageClickInputRulesService',
   'EVENT_NEW_CARD_AVAILABLE', 'EXPLORATION_EDITOR_TAB_CONTEXT',
   'LOADING_INDICATOR_URL',
   function(

--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.html
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.html
@@ -1,7 +1,7 @@
 <link rel="stylesheet" type="text/css" href="/extensions/interactions/ItemSelectionInput/static/item_selection_input.css">
 
+<script src="/extensions/interactions/ItemSelectionInput/directives/ItemSelectionInputRulesService.js"></script>
+<script src="/extensions/interactions/ItemSelectionInput/directives/ItemSelectionInputValidationService.js"></script>
 <script src="/extensions/interactions/ItemSelectionInput/directives/OppiaInteractiveItemSelectionInputDirective.js"></script>
 <script src="/extensions/interactions/ItemSelectionInput/directives/OppiaResponseItemSelectionInputDirective.js"></script>
 <script src="/extensions/interactions/ItemSelectionInput/directives/OppiaShortResponseItemSelectionInputDirective.js"></script>
-<script src="/extensions/interactions/ItemSelectionInput/directives/ItemSelectionInputRulesService.js"></script>
-<script src="/extensions/interactions/ItemSelectionInput/directives/ItemSelectionInputValidationService.js"></script>

--- a/extensions/interactions/ItemSelectionInput/directives/OppiaInteractiveItemSelectionInputDirective.js
+++ b/extensions/interactions/ItemSelectionInput/directives/OppiaInteractiveItemSelectionInputDirective.js
@@ -21,11 +21,10 @@
  */
 
 oppia.directive('oppiaInteractiveItemSelectionInput', [
-  'HtmlEscaperService', 'UrlInterpolationService',
-  'ItemSelectionInputRulesService',
-  function(
-      HtmlEscaperService, UrlInterpolationService,
-      itemSelectionInputRulesService) {
+  'HtmlEscaperService', 'ItemSelectionInputRulesService',
+  'UrlInterpolationService', function(
+      HtmlEscaperService, ItemSelectionInputRulesService,
+      UrlInterpolationService) {
     return {
       restrict: 'E',
       scope: {},

--- a/extensions/interactions/ItemSelectionInput/directives/OppiaInteractiveItemSelectionInputDirective.js
+++ b/extensions/interactions/ItemSelectionInput/directives/OppiaInteractiveItemSelectionInputDirective.js
@@ -22,7 +22,7 @@
 
 oppia.directive('oppiaInteractiveItemSelectionInput', [
   'HtmlEscaperService', 'UrlInterpolationService',
-  'itemSelectionInputRulesService',
+  'ItemSelectionInputRulesService',
   function(
       HtmlEscaperService, UrlInterpolationService,
       itemSelectionInputRulesService) {


### PR DESCRIPTION
## Explanation
Interaction previews for certain interactions were broken (on the test server). This was possibly introduced during https://github.com/oppia/oppia/pull/6267. There were a few capitalization issues, and issues with ordering of imports in the HTML.

This fixes a blocking bug and needs to be cherry-picked into the current release.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
