### PR TITLE
Fixes part of #6387: removes GLOBALS.DEFAULT_OBJECT_VALUES from HTML files

### DIFF
--- a/core/templates/dev/head/components/state/RuleEditorDirective.js
+++ b/core/templates/dev/head/components/state/RuleEditorDirective.js
@@ -41,7 +41,20 @@ oppia.directive('ruleEditor', [
             $scope, $timeout, StateEditorService,
             ValidatorsService, INTERACTION_SPECS,
             ResponsesService, StateInteractionIdService) {
-          var DEFAULT_OBJECT_VALUES = GLOBALS.DEFAULT_OBJECT_VALUES;
+          // get DEFAULT_OBJECT_VALUES from server
+          var DEFAULT_OBJECT_VALUES;
+          $.ajax({
+            type: "GET", 
+            url: 'extensions/objects/object_defaults.json',
+            dataType: "json", 
+            async: false,
+            success: function(data){
+                DEFAULT_OBJECT_VALUES = data; //or something similar
+            }
+            error: function(jqXHR, textStatus, errorThrown) {
+                console.log(textStatus, errorThrown);
+            }
+          });
 
           $scope.currentInteractionId = StateInteractionIdService.savedMemento;
           $scope.editRuleForm = {};

--- a/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
+++ b/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
@@ -10,8 +10,6 @@
     GLOBALS.DEFAULT_TWITTER_SHARE_MESSAGE_DASHBOARD = JSON.parse(
       '{{DEFAULT_TWITTER_SHARE_MESSAGE_DASHBOARD|js_string}}');
     GLOBALS.INTERACTION_SPECS = JSON.parse('{{INTERACTION_SPECS|js_string}}');
-    GLOBALS.DEFAULT_OBJECT_VALUES = JSON.parse(
-      '{{DEFAULT_OBJECT_VALUES|js_string}}');
   </script>
 {% endblock header_js %}
 

--- a/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_editor.html
@@ -14,8 +14,6 @@
     GLOBALS.can_edit = JSON.parse('{{can_edit|js_string}}');
     GLOBALS.can_publish = JSON.parse('{{can_publish|js_string}}');
     GLOBALS.can_translate = JSON.parse('{{can_translate|js_string}}');
-    GLOBALS.DEFAULT_OBJECT_VALUES = JSON.parse(
-      '{{DEFAULT_OBJECT_VALUES|js_string}}');
     GLOBALS.DEFAULT_TWITTER_SHARE_MESSAGE_EDITOR = JSON.parse(
       '{{DEFAULT_TWITTER_SHARE_MESSAGE_EDITOR|js_string}}');
     GLOBALS.INTERACTION_SPECS = JSON.parse('{{INTERACTION_SPECS|js_string}}');

--- a/core/templates/dev/head/pages/skill_editor/skill_editor.html
+++ b/core/templates/dev/head/pages/skill_editor/skill_editor.html
@@ -8,8 +8,6 @@
   {{ super() }}
   <script type="text/javascript">
     GLOBALS.INTERACTION_SPECS = JSON.parse('{{INTERACTION_SPECS|js_string}}');
-    GLOBALS.DEFAULT_OBJECT_VALUES = JSON.parse(
-      '{{DEFAULT_OBJECT_VALUES|js_string}}');
   </script>
 
 {% endblock header_js %}

--- a/core/templates/dev/head/pages/topic_editor/topic_editor.html
+++ b/core/templates/dev/head/pages/topic_editor/topic_editor.html
@@ -8,8 +8,6 @@
   {{ super() }}
   <script type="text/javascript">
     GLOBALS.INTERACTION_SPECS = JSON.parse('{{INTERACTION_SPECS|js_string}}');
-    GLOBALS.DEFAULT_OBJECT_VALUES = JSON.parse(
-      '{{DEFAULT_OBJECT_VALUES|js_string}}');
   </script>
 
 {% endblock header_js %}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes part of #6387: removes GLOBALS.DEFAULT_OBJECT_VALUES from HTML files. Makes an ajax request in RuleEditorDirective.js instead of the GLOBALS.DEFAULT_OBJECT_VALUES variable.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
