### PR TITLE
Fix #6582: Set Title to inherit the width of the parent 

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3111,14 +3111,15 @@ md-card.preview-conversation-skin-supplemental-card {
   font-weight: normal;
   hyphens: auto;
   line-height: 1.2em;
-  margin: 0.3em 0.5em;
+  margin: 0.3em;
   -ms-hyphens: auto;
   -moz-hyphens: auto;
   overflow-wrap: break-word;
-  padding: 0.2em;
+  padding: 0.3em;
   position: absolute;
   word-wrap: break-word;
   -webkit-hyphens: auto;
+  width: inherit;
 }
 .oppia-activity-summary-tile.oppia-activity-playlist-tile .activity-title {
   font-size: 0.85em;

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -3117,9 +3117,9 @@ md-card.preview-conversation-skin-supplemental-card {
   overflow-wrap: break-word;
   padding: 0.3em;
   position: absolute;
+  width: inherit;
   word-wrap: break-word;
   -webkit-hyphens: auto;
-  width: inherit;
 }
 .oppia-activity-summary-tile.oppia-activity-playlist-tile .activity-title {
   font-size: 0.85em;


### PR DESCRIPTION
## Explanation
Fixes #6582, by setting the card title to inherit the width of the parent.
- The title in the card does not have any width causing an overflow. Now it inherits a width of the parent div to avoid overflow. 
- A small change in the margin and padding for display 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
