### PR TITLE
Upgrade types/node dependency to 10.14.6.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -305,9 +305,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.14.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.5.tgz",
-      "integrity": "sha512-50PRp2qLJYjnFV/BWc839MN/9YeSrNz5DWzCiKYw3GVF/YyMClcHxTWGsVc0CPNpJpk3CIp0dOqLxqP3U/Pc+A==",
+      "version": "10.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
+      "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg==",
       "dev": true
     },
     "@types/q": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/mathjax": "0.0.35",
     "@types/mathjs": "^5.0.0",
     "@types/mousetrap": "^1.6.1",
-    "@types/node": "^6.14.3",
+    "@types/node": "^10.14.6",
     "@types/q": "^1.5.1",
     "@types/select2": "^4.0.48",
     "@types/selenium-webdriver": "^2.53.43",


### PR DESCRIPTION
## Explanation
Upgrades the `@types/node` dependency to 10.14.6, per @NishealJ's comment [here](https://github.com/oppia/oppia/pull/6659#discussion_r283088243).

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is assigned to an appropriate reviewer.