### PR TITLE
Fix #6706: Overflowing of the exploratory summary card

### DIFF
--- a/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
+++ b/core/templates/dev/head/pages/creator_dashboard/creator_dashboard.html
@@ -599,7 +599,7 @@
     }
 
     .oppia-dashboard-card-view-item {
-      height: 250px;
+      height: 260px;
       margin-left: 7.5px;
       margin-right: 7.5px;
       position: static;
@@ -607,7 +607,7 @@
     }
 
     .oppia-dashboard-card-view-item .mask-wrap {
-      height: 64.8%;
+      height: 61.8%;
       margin-top: -88%;
       position: relative;
     }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #6706.
Okay so the social media icons were overflowing out of the exploratory card as can be seen in the issue #6706 .

![Screenshot from 2019-05-18 23-13-12](https://user-images.githubusercontent.com/30312043/57975147-8061b400-79e1-11e9-9c18-f534b72e2636.png)

Initially the card had a fixed height of 250px and then there is a dummy element with a height percentage to place the upper icons just after the image ends with a height of 64.8%.
So without making any breaking changes and adding or removing any classes or code, i simply increased the height of the card to 260px and reduced the height of dummy element from 64.8% to 61.8% and now they fit nicely. 
![Screenshot from 2019-05-18 23-13-12](https://user-images.githubusercontent.com/30312043/57975154-9a02fb80-79e1-11e9-8b1a-5ff1545c7363.png)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to

" label on the issue.
