### PR TITLE
Fixed ImagesAuditJob - Added image dimensions to names

### DIFF
--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -2132,7 +2132,7 @@ class ImagesAuditJobTests(test_utils.GenericTestBase):
                 mimetype='image/png'
             )
             fs_external.commit(
-                self.albert_id, 'image/abc.png', raw_image,
+                self.albert_id, 'image/abc_height_32_width_32.png', raw_image,
                 mimetype='image/png'
             )
 
@@ -2149,7 +2149,7 @@ class ImagesAuditJobTests(test_utils.GenericTestBase):
             # External directory can have other images, as all new images are
             # stored there.
             fs_external.commit(
-                self.albert_id, 'image/xyz.png', raw_image,
+                self.albert_id, 'image/xyz_height_32_width_32.png', raw_image,
                 mimetype='image/png'
             )
 
@@ -2164,20 +2164,20 @@ class ImagesAuditJobTests(test_utils.GenericTestBase):
             actual_output = exp_jobs_one_off.ImagesAuditJob.get_output(
                 job_id)
             expected_output = [
-                '[u\'exp_id_1\', [u"Missing Images: [\'def.png\', '
-                '\'ghi.png\']"]]',
-                '[u\'Images verified\', 0]'
+                '[u\'exp_id_1\', [u"Missing Images: [\''
+                'def_height_32_width_32.png\', \'ghi_height_32_width_32.png\']'
+                '"]]', '[u\'Images verified\', 0]'
             ]
             self.assertEqual(len(actual_output), 2)
             self.assertItemsEqual(actual_output, expected_output)
 
             fs_external.commit(
-                self.albert_id, 'image/def.png', raw_image,
+                self.albert_id, 'image/def_height_32_width_32.png', raw_image,
                 mimetype='image/png'
             )
 
             fs_external.commit(
-                self.albert_id, 'image/ghi.png', raw_image,
+                self.albert_id, 'image/ghi_height_32_width_32.png', raw_image,
                 mimetype='image/png'
             )
 
@@ -2194,7 +2194,7 @@ class ImagesAuditJobTests(test_utils.GenericTestBase):
                 mimetype='image/png'
             )
             fs_external.commit(
-                self.albert_id, 'image/abc.png', raw_image,
+                self.albert_id, 'image/abc_height_32_width_32.png', raw_image,
                 mimetype='image/png'
             )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4178,12 +4178,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4198,17 +4200,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4325,7 +4330,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4337,6 +4343,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4351,6 +4358,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4358,12 +4366,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4382,6 +4392,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4462,7 +4473,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4474,6 +4486,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4595,6 +4608,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4178,14 +4178,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4200,20 +4198,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4330,8 +4325,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4343,7 +4337,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4358,7 +4351,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4366,14 +4358,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4392,7 +4382,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4473,8 +4462,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4486,7 +4474,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4608,7 +4595,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
The images in `exploration/{{exp_id}}` was found to have image dimensions in their names, which was not there in those in `{{exp_id}}/`. Hence, the job has been modified to add this in the internal names when comparing.