### PR TITLE
Fix #6738: Removed direct usage of window object in component and use $window 

### DIFF
--- a/core/templates/dev/head/components/side_navigation_bar/SideNavigationBarDirective.ts
+++ b/core/templates/dev/head/components/side_navigation_bar/SideNavigationBarDirective.ts
@@ -28,9 +28,9 @@ oppia.directive('sideNavigationBar', [
         '/components/side_navigation_bar/' +
         'side_navigation_bar_directive.html'),
       controllerAs: '$ctrl',
-      controller: ['$timeout', function($timeout) {
+      controller: ['$timeout', '$window', function($timeout, $window) {
         var ctrl = this;
-        ctrl.currentUrl = window.location.pathname;
+        ctrl.currentUrl = $window.location.pathname;
         ctrl.getStaticImageUrl = UrlInterpolationService.getStaticImageUrl;
       }]
     };


### PR DESCRIPTION
## Explanation
Fixes #6738 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is assigned to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue.
