### PR TITLE
Fix part of #5914: UserStatsModel Takeout

### DIFF
--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -384,6 +384,29 @@ class UserStatsModel(base_models.BaseMapReduceBatchResultsModel):
             entity = cls(id=user_id)
         return entity
 
+    @staticmethod
+    def export_data(user_id):
+        """(Takeout) Export the user-relevant properties of UserStatsModel.
+
+        Args:
+            user_id: str. The user_id denotes which user's data to extract.
+
+        Returns:
+            dict. The user-relevant properties of UserStatsModel in a python
+                dict format.
+        """
+        user_model = UserStatsModel.get_or_create(user_id)
+        user_data = {
+            'impact_score': user_model.impact_score,
+            'total_plays': user_model.total_plays,
+            'average_ratings': user_model.average_ratings,
+            'num_ratings': user_model.num_ratings,
+            'weekly_creator_stats_list': user_model.weekly_creator_stats_list
+        }
+
+        return user_data
+
+
 
 class ExplorationUserDataModel(base_models.BaseModel):
     """User-specific data pertaining to a specific exploration.

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -407,7 +407,6 @@ class UserStatsModel(base_models.BaseMapReduceBatchResultsModel):
         return user_data
 
 
-
 class ExplorationUserDataModel(base_models.BaseModel):
     """User-specific data pertaining to a specific exploration.
 

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -401,7 +401,17 @@ class UserStatsModel(base_models.BaseMapReduceBatchResultsModel):
             return None
 
         weekly_stats = user_model.weekly_creator_stats_list
-        weekly_stats_constructed = [weekly_stat for weekly_stat in weekly_stats]
+        weekly_stats_constructed = []
+        for weekly_stat in weekly_stats:
+            date_key = weekly_stat.keys()[0]
+            stat_dict = weekly_stat[date_key]
+            constructed_stat = {
+                (date_key): {
+                    'average_ratings': stat_dict['average_ratings'],
+                    'total_plays': stat_dict['total_plays']
+                }
+            }
+            weekly_stats_constructed.append(constructed_stat)
 
         user_data = {
             'impact_score': user_model.impact_score,

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -400,21 +400,15 @@ class UserStatsModel(base_models.BaseMapReduceBatchResultsModel):
         if not user_model:
             return None
 
-        validated_weekly_creator_stats_list = []
-        for weekly_stat in user_model.weekly_creator_stats_list:
-            if isinstance(weekly_stat, dict) and len(weekly_stat) == 1:
-                key_obj = list(weekly_stat.keys())[0]
-                if isinstance(weekly_stat[key_obj], dict):
-                    key_entries = sorted(list(weekly_stat[key_obj].keys()))
-                    if key_entries == ['average_ratings', 'total_plays']:
-                        validated_weekly_creator_stats_list.append(weekly_stat)
+        weekly_stats = user_model.weekly_creator_stats_list
+        weekly_stats_constructed = [weekly_stat for weekly_stat in weekly_stats]
 
         user_data = {
             'impact_score': user_model.impact_score,
             'total_plays': user_model.total_plays,
             'average_ratings': user_model.average_ratings,
             'num_ratings': user_model.num_ratings,
-            'weekly_creator_stats_list': validated_weekly_creator_stats_list
+            'weekly_creator_stats_list': weekly_stats_constructed
         }
 
         return user_data

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -403,10 +403,10 @@ class UserStatsModel(base_models.BaseMapReduceBatchResultsModel):
         weekly_stats = user_model.weekly_creator_stats_list
         weekly_stats_constructed = []
         for weekly_stat in weekly_stats:
-            for date_key in weekly_stat.keys():
+            for date_key in weekly_stat:
                 stat_dict = weekly_stat[date_key]
                 constructed_stat = {
-                    (date_key): {
+                    date_key: {
                         'average_ratings': stat_dict['average_ratings'],
                         'total_plays': stat_dict['total_plays']
                     }

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -403,15 +403,15 @@ class UserStatsModel(base_models.BaseMapReduceBatchResultsModel):
         weekly_stats = user_model.weekly_creator_stats_list
         weekly_stats_constructed = []
         for weekly_stat in weekly_stats:
-            date_key = weekly_stat.keys()[0]
-            stat_dict = weekly_stat[date_key]
-            constructed_stat = {
-                (date_key): {
-                    'average_ratings': stat_dict['average_ratings'],
-                    'total_plays': stat_dict['total_plays']
+            for date_key in weekly_stat.keys():
+                stat_dict = weekly_stat[date_key]
+                constructed_stat = {
+                    (date_key): {
+                        'average_ratings': stat_dict['average_ratings'],
+                        'total_plays': stat_dict['total_plays']
+                    }
                 }
-            }
-            weekly_stats_constructed.append(constructed_stat)
+                weekly_stats_constructed.append(constructed_stat)
 
         user_data = {
             'impact_score': user_model.impact_score,

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -139,12 +139,11 @@ class UserStatsModelTest(test_utils.GenericTestBase):
         user_data = user_models.UserStatsModel.export_data(self.USER_ID_2)
         test_data = {
             'impact_score': None,
-            'total_plays': None,
+            'total_plays': 0,
             'average_ratings': None,
-            'num_ratings': None,
-            'weekly_creator_stats_list': None
+            'num_ratings': 0,
+            'weekly_creator_stats_list': []
         }
-        print(user_data) # what does empty user look like
         self.assertEqual(user_data, test_data)
 
 

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -89,6 +89,7 @@ class UserStatsModelTest(test_utils.GenericTestBase):
 
     USER_ID_1 = 1
     USER_ID_2 = 2
+    USER_ID_3 = 3
 
     USER_1_IMPACT_SCORE = 0.87
     USER_1_TOTAL_PLAYS = 33
@@ -109,6 +110,25 @@ class UserStatsModelTest(test_utils.GenericTestBase):
         }
     ]
 
+    USER_2_IMPACT_SCORE = 0.33
+    USER_2_TOTAL_PLAYS = 15
+    USER_2_AVERAGE_RATINGS = 2.50
+    USER_2_NUM_RATINGS = 10
+    USER_2_WEEKLY_CREATOR_STATS_LIST = [
+        {
+            ('2019-05-21'): {
+                'average_ratings': 2.50,
+                'total_plays': 4
+            }
+        },
+        {
+            ('2019-05-28'): {
+                'average_ratings': 2.50,
+                'total_plays': 6
+            }
+        }
+    ]
+
     def setUp(self):
         """Set up user models in datastore for use in testing."""
         super(UserStatsModelTest, self).setUp()
@@ -122,6 +142,15 @@ class UserStatsModelTest(test_utils.GenericTestBase):
             self.USER_1_WEEKLY_CREATOR_STATS_LIST)
         user_models.UserStatsModel.put(user_model_1)
 
+        user_model_2 = user_models.UserStatsModel(id=self.USER_ID_2)
+        user_model_2.impact_score = self.USER_2_IMPACT_SCORE
+        user_model_2.total_plays = self.USER_2_TOTAL_PLAYS
+        user_model_2.average_ratings = self.USER_2_AVERAGE_RATINGS
+        user_model_2.num_ratings = self.USER_2_NUM_RATINGS
+        user_model_2.weekly_creator_stats_list = (
+            self.USER_2_WEEKLY_CREATOR_STATS_LIST)
+        user_models.UserStatsModel.put(user_model_2)
+
     def test_export_data_on_existing_user(self):
         """Test if export_data works when user is in data store."""
         user_data = user_models.UserStatsModel.export_data(self.USER_ID_1)
@@ -134,16 +163,33 @@ class UserStatsModelTest(test_utils.GenericTestBase):
         }
         self.assertEqual(user_data, test_data)
 
-    def test_export_data_on_nonexistent_user(self):
-        """Test if export_data works when user is not in data store."""
-        user_data = user_models.UserStatsModel.export_data(self.USER_ID_2)
-        test_data = {
-            'impact_score': None,
-            'total_plays': 0,
-            'average_ratings': None,
-            'num_ratings': 0,
-            'weekly_creator_stats_list': []
+    def test_export_data_on_multiple_users(self):
+        """Test if export_data works on multiple users in data store."""
+        user_1_data = user_models.UserStatsModel.export_data(self.USER_ID_1)
+        test_1_data = {
+            'impact_score': self.USER_1_IMPACT_SCORE,
+            'total_plays': self.USER_1_TOTAL_PLAYS,
+            'average_ratings': self.USER_1_AVERAGE_RATINGS,
+            'num_ratings': self.USER_1_NUM_RATINGS,
+            'weekly_creator_stats_list': self.USER_1_WEEKLY_CREATOR_STATS_LIST
         }
+
+        user_2_data = user_models.UserStatsModel.export_data(self.USER_ID_2)
+        test_2_data = {
+            'impact_score': self.USER_2_IMPACT_SCORE,
+            'total_plays': self.USER_2_TOTAL_PLAYS,
+            'average_ratings': self.USER_2_AVERAGE_RATINGS,
+            'num_ratings': self.USER_2_NUM_RATINGS,
+            'weekly_creator_stats_list': self.USER_2_WEEKLY_CREATOR_STATS_LIST
+        }
+
+        self.assertEqual(user_1_data, test_1_data)
+        self.assertEqual(user_2_data, test_2_data)
+
+    def test_export_data_on_nonexistent_user(self):
+        """Test if export_data returns None when user is not in data store."""
+        user_data = user_models.UserStatsModel.export_data(self.USER_ID_3)
+        test_data = None
         self.assertEqual(user_data, test_data)
 
 

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -192,10 +192,10 @@ class UserStatsModelTest(test_utils.GenericTestBase):
         test_data = None
         self.assertEqual(user_data, test_data)
 
-    def test_export_data_stats_list_is_well_formed(self):
+    def test_weekly_creator_stats_list_is_fully_exported(self):
         """Test if weekly creator stats list has only the expected elements."""
-        user_data = user_models.UserStatsModel.export_data(self.USER_ID_1)
-        for weekly_stat in user_data['weekly_creator_stats_list']:
+        user_data = user_models.UserStatsModel.get(self.USER_ID_1)
+        for weekly_stat in user_data.weekly_creator_stats_list:
             self.assertEqual(dict, type(weekly_stat))
             self.assertEqual(1, len(weekly_stat))
             key_obj = list(weekly_stat.keys())[0]

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -192,6 +192,18 @@ class UserStatsModelTest(test_utils.GenericTestBase):
         test_data = None
         self.assertEqual(user_data, test_data)
 
+    def test_export_data_stats_list_is_well_formed(self):
+        """Test if weekly creator stats list has only the expected elements."""
+        user_data = user_models.UserStatsModel.export_data(self.USER_ID_1)
+        for weekly_stat in user_data['weekly_creator_stats_list']:
+            self.assertEqual(dict, type(weekly_stat))
+            self.assertEqual(1, len(weekly_stat))
+            key_obj = list(weekly_stat.keys())[0]
+            self.assertEqual(dict, type(weekly_stat[key_obj]))
+            key_entries = sorted(list(weekly_stat[key_obj].keys()))
+            expected_key_entries = ['average_ratings', 'total_plays']
+            self.assertEqual(expected_key_entries, key_entries)
+
 
 class ExplorationUserDataModelTest(test_utils.GenericTestBase):
     """Tests for the ExplorationUserDataModel class."""

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -84,6 +84,70 @@ class ExpUserLastPlaythroughModelTest(test_utils.GenericTestBase):
         self.assertEqual(retrieved_object, None)
 
 
+class UserStatsModelTest(test_utils.GenericTestBase):
+    """Tests for the UserStatsModel class."""
+
+    USER_ID_1 = 1
+    USER_ID_2 = 2
+
+    USER_1_IMPACT_SCORE = 0.87
+    USER_1_TOTAL_PLAYS = 33
+    USER_1_AVERAGE_RATINGS = 4.37
+    USER_1_NUM_RATINGS = 22
+    USER_1_WEEKLY_CREATOR_STATS_LIST = [
+        {
+            ('2019-05-21'): {
+                'average_ratings': 4.00,
+                'total_plays': 5
+            }
+        },
+        {
+            ('2019-05-28'): {
+                'average_ratings': 4.95,
+                'total_plays': 10
+            }
+        }
+    ]
+
+    def setUp(self):
+        """Set up user models in datastore for use in testing."""
+        super(UserStatsModelTest, self).setUp()
+
+        user_model_1 = user_models.UserStatsModel(id=self.USER_ID_1)
+        user_model_1.impact_score = self.USER_1_IMPACT_SCORE
+        user_model_1.total_plays = self.USER_1_TOTAL_PLAYS
+        user_model_1.average_ratings = self.USER_1_AVERAGE_RATINGS
+        user_model_1.num_ratings = self.USER_1_NUM_RATINGS
+        user_model_1.weekly_creator_stats_list = (
+            self.USER_1_WEEKLY_CREATOR_STATS_LIST)
+        user_models.UserStatsModel.put(user_model_1)
+
+    def test_export_data_on_existing_user(self):
+        """Test if export_data works when user is in data store."""
+        user_data = user_models.UserStatsModel.export_data(self.USER_ID_1)
+        test_data = {
+            'impact_score': self.USER_1_IMPACT_SCORE,
+            'total_plays': self.USER_1_TOTAL_PLAYS,
+            'average_ratings': self.USER_1_AVERAGE_RATINGS,
+            'num_ratings': self.USER_1_NUM_RATINGS,
+            'weekly_creator_stats_list': self.USER_1_WEEKLY_CREATOR_STATS_LIST
+        }
+        self.assertEqual(user_data, test_data)
+
+    def test_export_data_on_nonexistent_user(self):
+        """Test if export_data works when user is not in data store."""
+        user_data = user_models.UserStatsModel.export_data(self.USER_ID_2)
+        test_data = {
+            'impact_score': None,
+            'total_plays': None,
+            'average_ratings': None,
+            'num_ratings': None,
+            'weekly_creator_stats_list': None
+        }
+        print(user_data) # what does empty user look like
+        self.assertEqual(user_data, test_data)
+
+
 class ExplorationUserDataModelTest(test_utils.GenericTestBase):
     """Tests for the ExplorationUserDataModel class."""
 

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -192,18 +192,6 @@ class UserStatsModelTest(test_utils.GenericTestBase):
         test_data = None
         self.assertEqual(user_data, test_data)
 
-    def test_weekly_creator_stats_list_is_fully_exported(self):
-        """Test if weekly creator stats list has only the expected elements."""
-        user_data = user_models.UserStatsModel.get(self.USER_ID_1)
-        for weekly_stat in user_data.weekly_creator_stats_list:
-            self.assertEqual(dict, type(weekly_stat))
-            self.assertEqual(1, len(weekly_stat))
-            key_obj = list(weekly_stat.keys())[0]
-            self.assertEqual(dict, type(weekly_stat[key_obj]))
-            key_entries = sorted(list(weekly_stat[key_obj].keys()))
-            expected_key_entries = ['average_ratings', 'total_plays']
-            self.assertEqual(expected_key_entries, key_entries)
-
 
 class ExplorationUserDataModelTest(test_utils.GenericTestBase):
     """Tests for the ExplorationUserDataModel class."""


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes part of issue #5914. Implements Takeout functionality on UserStatsModel in core/storage/user/gae_models.py. Includes appropriate backend testing in core/storage/user/gae_models_test.py.

**Write-up:**
We will export the five properties relevant to the UserStatsModel. As Ben (Henning) suggested, we should include any data we want to potentially give to the user. None of the five properties reveal sensitive data about the user, so they are all safe to be exported. The five properties we are exporting are all useful and possibly wanted statistics related to the popularity of explorations the user has contributed to/owned*. We are not exporting the schema_version since that is not relevant to the user.

**Properties from UserStatsModel:**
- impact_score
- total_plays
- average_ratings
- num_ratings
- weekly_creator_stats_list

The _impact score_ (float) for a particular user (exact function defined in UserStatsModel documentation) is a metric calculated over the explorations for which a user is a contributor. A higher impact score is indicative of how well those explorations do, based on ratings.

The _total_plays_ (integer), _average_ratings_ (float), and _num_ratings_ (integer) variables are based on all the explorations owned by a user. total_plays is the sum of all the plays on those explorations and average_ratings is the average of all the ratings on those explorations. num_ratings is simply the number of ratings left in total across all of those (user-owned) explorations.

The _weekly_creator_stats_list_ is a list which stores JSON objects. Each JSON object contains the user’s average_ratings and total_plays for the specified date they are key’d on. See documentation of core/storage/user/gae_models.py UserStatsModel for more detail an example.

**Expected export structure** (This model will not need any special exporting from takeout_processor_service.py, since export_data already exports the data in the specified format.)
```
creator_impact_metrics:
    impact_score: <float_impact_score>
    total_plays: <integer_total_plays>
    average_ratings: <float_average_ratings>
    num_ratings: <integer_num_ratings>
    weekly_creator_stats_list: 
       - date_1: <datetime_when_following_stats_were_collected>
          average_ratings: <float_average_ratings>
          total_plays: <integer_total_plays>
       - date_2: <datetime_when_following_stats_were_collected>
          average_ratings: <float_average_ratings>
          total_plays: <integer_total_plays>
          ...
```
**

*Note that only impact score is based on explorations the user has contributed to. The rest are based specifically on explorations the user owns (according to documentation).
**The “ - “ here signifies a JSON object of the form
```
{
    date_k: {
        average_ratings: <float_average_ratings>
        total_plays: <integer_total_plays>
    }
}
```
where _date_k_ itself a python datetime specifying when the following _average_ratings_ and _total_plays_ metrics were recorded.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
