### PR TITLE
Fix 500 error when downloading old exploration versions.

### DIFF
--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -422,13 +422,12 @@ class ExplorationFileDownloader(EditorHandler):
             raise self.PageNotFoundException
 
         version_str = self.request.get('v', default_value=exploration.version)
+        output_format = self.request.get('output_format', default_value='zip')
+
         try:
             version = int(version_str)
         except ValueError:
             version = exploration.version
-
-        output_format = self.request.get('output_format', default_value='zip')
-        width = int(self.request.get('width', default_value=80))
 
         # If the title of the exploration has changed, we use the new title.
         filename = 'oppia-%s-v%s.zip' % (
@@ -441,7 +440,7 @@ class ExplorationFileDownloader(EditorHandler):
                 filename, 'text/plain')
         elif output_format == feconf.OUTPUT_FORMAT_JSON:
             self.render_json(exp_services.export_states_to_yaml(
-                exploration_id, version=version, width=width))
+                exploration_id, version=version, width=80))
         else:
             raise self.InvalidInputException(
                 'Unrecognized output format %s' % output_format)

--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -421,7 +421,12 @@ class ExplorationFileDownloader(EditorHandler):
         except:
             raise self.PageNotFoundException
 
-        version = self.request.get('v', default_value=exploration.version)
+        version_str = self.request.get('v', default_value=exploration.version)
+        try:
+            version = int(version_str)
+        except ValueError:
+            version = exploration.version
+
         output_format = self.request.get('output_format', default_value='zip')
         width = int(self.request.get('width', default_value=80))
 

--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -440,7 +440,7 @@ class ExplorationFileDownloader(EditorHandler):
                 filename, 'text/plain')
         elif output_format == feconf.OUTPUT_FORMAT_JSON:
             self.render_json(exp_services.export_states_to_yaml(
-                exploration_id, version=version, width=80))
+                exploration_id, version=version))
         else:
             raise self.InvalidInputException(
                 'Unrecognized output format %s' % output_format)

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -550,7 +550,7 @@ written_translations:
         # Download to JSON string using download handler.
         self.maxDiff = None
         download_url = (
-            '/createhandler/download/%s?output_format=%s&width=50' %
+            '/createhandler/download/%s?output_format=%s' %
             (exp_id, feconf.OUTPUT_FORMAT_JSON))
         response = self.get_json(download_url)
 
@@ -559,7 +559,7 @@ written_translations:
 
         # Check downloading a specific version.
         download_url = (
-            '/createhandler/download/%s?output_format=%s&width=50&v=1' %
+            '/createhandler/download/%s?output_format=%s&v=1' %
             (exp_id, feconf.OUTPUT_FORMAT_JSON))
         response = self.get_json(download_url)
         self.assertEqual(['Introduction'], response.keys())
@@ -567,7 +567,7 @@ written_translations:
         # Check downloading an invalid version results in downloading the
         # latest version.
         download_url = (
-            '/createhandler/download/%s?output_format=%s&width=50&v=xxx' %
+            '/createhandler/download/%s?output_format=%s&v=xxx' %
             (exp_id, feconf.OUTPUT_FORMAT_JSON))
         response = self.get_json(download_url)
         self.assertEqual(self.SAMPLE_JSON_CONTENT, response)

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -557,6 +557,23 @@ written_translations:
         # Check downloaded dict.
         self.assertEqual(self.SAMPLE_JSON_CONTENT, response)
 
+        # Check downloading a specific version.
+        download_url = (
+            '/createhandler/download/%s?output_format=%s&width=50&v=1' %
+            (exp_id, feconf.OUTPUT_FORMAT_JSON))
+        response = self.get_json(download_url)
+        self.assertEqual(['Introduction'], response.keys())
+
+        # Check downloading an invalid version results in downloading the
+        # latest version.
+        download_url = (
+            '/createhandler/download/%s?output_format=%s&width=50&v=xxx' %
+            (exp_id, feconf.OUTPUT_FORMAT_JSON))
+        response = self.get_json(download_url)
+        self.assertEqual(self.SAMPLE_JSON_CONTENT, response)
+        self.assertEqual(
+            ['Introduction', 'State A', 'State B'], response.keys())
+
         self.logout()
 
     def test_state_yaml_handler(self):


### PR DESCRIPTION
## Explanation
When preparing some data for @prasanna08 I found that the download handler is not working correctly (it raises a 500 error). This PR fixes the issue.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.