### PR TITLE
Fix #6832: Fix issues with ctrl and $scope

### DIFF
--- a/extensions/interactions/CodeRepl/directives/OppiaInteractiveCodeReplDirective.ts
+++ b/extensions/interactions/CodeRepl/directives/OppiaInteractiveCodeReplDirective.ts
@@ -45,7 +45,7 @@ oppia.directive('oppiaInteractiveCodeRepl', [
           var ctrl = this;
           ctrl.interactionIsActive = (ctrl.getLastAnswer() === null);
 
-          ctrl.$on(EVENT_NEW_CARD_AVAILABLE, function() {
+          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             ctrl.interactionIsActive = false;
           });
           ctrl.language = HtmlEscaperService.escapedJsonToObj(

--- a/extensions/interactions/ImageClickInput/directives/OppiaInteractiveImageClickInputDirective.ts
+++ b/extensions/interactions/ImageClickInput/directives/OppiaInteractiveImageClickInputDirective.ts
@@ -41,8 +41,8 @@ oppia.directive('oppiaInteractiveImageClickInput', [
         'image_click_input_interaction_directive.html'),
       controllerAs: '$ctrl',
       controller: [
-        '$element', '$attrs', 'CurrentInteractionService',
-        function($element, $attrs, CurrentInteractionService) {
+        '$element', '$attrs', '$scope', 'CurrentInteractionService',
+        function($element, $attrs, $scope, CurrentInteractionService) {
           var ctrl = this;
           var imageAndRegions = HtmlEscaperService.escapedJsonToObj(
             $attrs.imageAndRegionsWithValue);
@@ -148,7 +148,7 @@ oppia.directive('oppiaInteractiveImageClickInput', [
             }
             return 'inline';
           };
-          ctrl.$on(EVENT_NEW_CARD_AVAILABLE, function() {
+          $scope.$on(EVENT_NEW_CARD_AVAILABLE, function() {
             ctrl.interactionIsActive = false;
             ctrl.lastAnswer = {
               clickPosition: [ctrl.mouseX, ctrl.mouseY]

--- a/extensions/interactions/LogicProof/directives/OppiaInteractiveLogicProofDirective.ts
+++ b/extensions/interactions/LogicProof/directives/OppiaInteractiveLogicProofDirective.ts
@@ -176,7 +176,7 @@ oppia.directive('oppiaInteractiveLogicProof', [
             }
             // NOTE: this line is necessary to force angular to refresh the
             // displayed errorMessage.
-            ctrl.$apply();
+            $scope.$apply();
           };
 
           ctrl.clearMessage = function() {

--- a/extensions/objects/templates/ImageWithRegionsEditorDirective.ts
+++ b/extensions/objects/templates/ImageWithRegionsEditorDirective.ts
@@ -182,7 +182,7 @@ oppia.directive('imageWithRegionsEditor', [
                     <HTMLCanvasElement><any> this).width;
                   ctrl.originalImageHeight = (
                     <HTMLCanvasElement><any> this).height;
-                  ctrl.$apply();
+                  $scope.$apply();
                 }
               );
             }


### PR DESCRIPTION
## Explanation

Fixes #6832: Fix issues with `ctrl` & `$scope` in interactions by replacing `ctrl.$on` & `ctrl.$apply` with `$scope.$on` and `$scope.$apply`.