### PR TITLE
Retrain classifier models if they are not available for previous version of exploration states

### DIFF
--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -117,7 +117,7 @@ def handle_non_retrainable_states(exploration, state_names, exp_versions_diff):
             number 1.
 
     Returns:
-        List. State names which don't have classifier model for previous version
+        List (str). State names which don't have classifier model for previous version
             of exploration.
     """
     exp_id = exploration.id

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -115,6 +115,10 @@ def handle_non_retrainable_states(exploration, state_names, exp_versions_diff):
     Raises:
         Exception. This method should not be called by exploration with version
             number 1.
+
+    Returns:
+        List. State names which don't have classifier model for previous version
+            of exploration.
     """
     exp_id = exploration.id
     current_exp_version = exploration.version
@@ -135,12 +139,15 @@ def handle_non_retrainable_states(exploration, state_names, exp_versions_diff):
         exp_id, old_exp_version, state_names_to_retrieve)
 
     job_exploration_mappings = []
+    state_names_without_classifier = []
     for index, classifier_training_job in enumerate(classifier_training_jobs):
         if classifier_training_job is None:
             logging.error(
                 'The ClassifierTrainingJobModel for the %s state of Exploration'
                 ' with exp_id %s and exp_version %s does not exist.' % (
                     state_names_to_retrieve[index], exp_id, old_exp_version))
+            state_names_without_classifier.append(
+                state_names_to_retrieve[index])
             continue
         new_state_name = state_names[index]
         job_exploration_mapping = (
@@ -152,6 +159,8 @@ def handle_non_retrainable_states(exploration, state_names, exp_versions_diff):
 
     classifier_models.TrainingJobExplorationMappingModel.create_multi(
         job_exploration_mappings)
+
+    return state_names_without_classifier
 
 
 def convert_strings_to_float_numbers_in_classifier_data(

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -117,8 +117,8 @@ def handle_non_retrainable_states(exploration, state_names, exp_versions_diff):
             number 1.
 
     Returns:
-        List (str). State names which don't have classifier model for previous version
-            of exploration.
+        list(str). State names which don't have classifier model for previous
+            version of exploration.
     """
     exp_id = exploration.id
     current_exp_version = exploration.version

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -887,13 +887,17 @@ def _save_exploration(committer_id, exploration, commit_message, change_list):
             'state_names_with_changed_answer_groups']
         state_names_with_unchanged_answer_groups = trainable_states_dict[
             'state_names_with_unchanged_answer_groups']
-        if state_names_with_changed_answer_groups:
-            classifier_services.handle_trainable_states(
-                exploration, state_names_with_changed_answer_groups)
+        state_names_to_train_classifier = state_names_with_changed_answer_groups
         if state_names_with_unchanged_answer_groups:
-            classifier_services.handle_non_retrainable_states(
-                exploration, state_names_with_unchanged_answer_groups,
-                exp_versions_diff)
+            state_names_without_classifier = (
+                classifier_services.handle_non_retrainable_states(
+                    exploration, state_names_with_unchanged_answer_groups,
+                    exp_versions_diff))
+            state_names_to_train_classifier.extend(
+                state_names_without_classifier)
+        if state_names_to_train_classifier:
+            classifier_services.handle_trainable_states(
+                exploration, state_names_to_train_classifier)
 
     # Trigger exploration issues model updation.
     stats_services.update_exp_issues_for_new_exp_version(


### PR DESCRIPTION
This PR fixes the recently observed issue with ML training pipeline. The ML pipeline assumes that if a particular state of the exploration is not modified (training data) then the classifier model for previous version of the state should be present in the datastore if the latest version of the state is retrainable (has enough training data for training). However, this assumption is broken if ML gets disabled and re-enabled and between re-enabling, some exploration was updated but the trainable states were kept intact in this update. Now, if the model for the previous version is not found then it simply retrains model from scratch. 