### PR TITLE
Fix #6903: added required share link directive to exploration save service to force wrapping

### DIFF
--- a/core/templates/dev/head/pages/exploration-editor-page/modal-templates/post-publish-modal.template.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/modal-templates/post-publish-modal.template.html
@@ -2,9 +2,6 @@
   .oppia-share-publish-modal .oppia-share-publish-body,
   .oppia-share-publish-body p {
     text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
   }
 
   .oppia-share-publish-modal .oppia-share-publish-close {

--- a/core/templates/dev/head/pages/exploration-editor-page/modal-templates/post-publish-modal.template.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/modal-templates/post-publish-modal.template.html
@@ -2,6 +2,9 @@
   .oppia-share-publish-modal .oppia-share-publish-body,
   .oppia-share-publish-body p {
     text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 
   .oppia-share-publish-modal .oppia-share-publish-close {

--- a/core/templates/dev/head/pages/exploration-editor-page/services/exploration-save.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/services/exploration-save.service.ts
@@ -18,6 +18,9 @@
 
 require(
   'components/common-layout-directives/common-elements/' +
+  'sharing-links.directive.ts');
+require(
+  'components/common-layout-directives/common-elements/' +
   'loading-dots.directive.ts');
 
 require('domain/exploration/StatesObjectFactory.ts');

--- a/core/templates/dev/head/pages/exploration-editor-page/services/exploration-save.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/services/exploration-save.service.ts
@@ -18,11 +18,10 @@
 
 require(
   'components/common-layout-directives/common-elements/' +
-  'sharing-links.directive.ts');
+  'loading-dots.directive.ts');
 require(
   'components/common-layout-directives/common-elements/' +
-  'loading-dots.directive.ts');
-
+  'sharing-links.directive.ts');
 require('domain/exploration/StatesObjectFactory.ts');
 require('domain/utilities/UrlInterpolationService.ts');
 require(


### PR DESCRIPTION
* editted CSS in post-publish-modal.html to use flex

* now the elements are aligned in column as seen in the prod version

## Explanation
~~Fixes #6903: added CSS to stying in post-publish-modal.html so that the post publish modal has the close button below the link. This follows the placement of items seen in the prod website.~~

Fixes #6903: require the share link directive in the exploration save service

Before:
<img width="598" alt="Screen Shot 2019-06-11 at 10 34 58 AM" src="https://user-images.githubusercontent.com/35872018/59374742-84e86680-8d1a-11e9-8364-12b11a7240a0.png">

After:
@import-keshav not sure what you mean by different sizes...I tried making the width of the window much smaller to see the behavior.
<img width="1676" alt="Screen Shot 2019-06-12 at 8 56 17 PM" src="https://user-images.githubusercontent.com/35872018/59395943-951d3780-8d54-11e9-953b-3c743c5c72f3.png">

<img width="498" alt="Screen Shot 2019-06-12 at 8 55 05 PM" src="https://user-images.githubusercontent.com/35872018/59395919-7454e200-8d54-11e9-8dfb-b4b25c6261c9.png">


## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.

Need a reviewer.
