### PR TITLE
Fix #6799: Add restricted globals rule to eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -74,7 +74,17 @@
       "always"
     ],
     "no-restricted-globals": [
-      "error", "addEventListener", "blur", "close", "closed", "confirm", "defaultStatus", "event", "external", "defaultstatus", "find", "focus", "frameElement", "frames", "history", "innerHeight", "innerWidth", "length", "location", "locationbar", "menubar", "moveBy", "moveTo", "name", "onblur", "onerror", "onfocus", "onload", "onresize", "onunload", "open", "opener", "opera", "outerHeight", "outerWidth", "pageXOffset", "pageYOffset", "parent", "print", "removeEventListener", "resizeBy", "resizeTo", "screen", "screenLeft", "screenTop", "screenX", "screenY", "scroll", "scrollbars", "scrollBy", "scrollTo", "scrollX", "scrollY", "self", "sessionStorage", "status", "statusbar", "stop", "toolbar", "top"],
+      "error", "addEventListener", "blur", "close", "closed", "confirm",
+      "defaultStatus", "event", "external", "defaultstatus", "find", "focus",
+      "frameElement", "frames", "history", "innerHeight", "innerWidth",
+      "length", "location", "locationbar", "menubar", "moveBy", "moveTo",
+      "name", "onblur", "onerror", "onfocus", "onload", "onresize", "onunload",
+      "open", "opener", "opera", "outerHeight", "outerWidth", "pageXOffset",
+      "pageYOffset", "parent", "print", "removeEventListener", "resizeBy",
+      "resizeTo", "screen", "screenLeft", "screenTop", "screenX", "screenY",
+      "scroll", "scrollbars", "scrollBy", "scrollTo", "scrollX", "scrollY",
+      "self", "sessionStorage", "status", "statusbar", "stop",
+      "toolbar", "top"],
     "func-style": [
       "error",
       "expression"

--- a/.eslintrc
+++ b/.eslintrc
@@ -73,6 +73,8 @@
       "error",
       "always"
     ],
+    "no-restricted-globals": [
+      "error", "addEventListener", "blur", "close", "closed", "confirm", "defaultStatus", "event", "external", "defaultstatus", "find", "focus", "frameElement", "frames", "history", "innerHeight", "innerWidth", "length", "location", "locationbar", "menubar", "moveBy", "moveTo", "name", "onblur", "onerror", "onfocus", "onload", "onresize", "onunload", "open", "opener", "opera", "outerHeight", "outerWidth", "pageXOffset", "pageYOffset", "parent", "print", "removeEventListener", "resizeBy", "resizeTo", "screen", "screenLeft", "screenTop", "screenX", "screenY", "scroll", "scrollbars", "scrollBy", "scrollTo", "scrollX", "scrollY", "self", "sessionStorage", "status", "statusbar", "stop", "toolbar", "top"],
     "func-style": [
       "error",
       "expression"

--- a/core/templates/dev/head/components/common-layout-directives/common-elements/promo-bar.directive.ts
+++ b/core/templates/dev/head/components/common-layout-directives/common-elements/promo-bar.directive.ts
@@ -22,8 +22,8 @@ require('domain/utilities/UrlInterpolationService.ts');
 require('services/PromoBarService.ts');
 
 oppia.directive('promoBar', [
-  'PromoBarService', 'UrlInterpolationService',
-  function(PromoBarService, UrlInterpolationService) {
+  '$window', 'PromoBarService', 'UrlInterpolationService',
+  function($window, PromoBarService, UrlInterpolationService) {
     return {
       restrict: 'E',
       scope: {},
@@ -36,10 +36,11 @@ oppia.directive('promoBar', [
         function() {
           var ctrl = this;
           var isPromoDismissed = function() {
-            return !!angular.fromJson(sessionStorage.promoIsDismissed);
+            return !!angular.fromJson($window.sessionStorage.promoIsDismissed);
           };
           var setPromoDismissed = function(promoIsDismissed) {
-            sessionStorage.promoIsDismissed = angular.toJson(promoIsDismissed);
+            $window.sessionStorage.promoIsDismissed = angular.toJson(
+              promoIsDismissed);
           };
 
           PromoBarService.getPromoBarData().then(function(promoBarObject) {

--- a/core/templates/dev/head/pages/about-page/about-page.controller.ts
+++ b/core/templates/dev/head/pages/about-page/about-page.controller.ts
@@ -24,8 +24,8 @@ require('domain/utilities/UrlInterpolationService.ts');
  */
 
 oppia.controller('About', [
-  '$scope', 'UrlInterpolationService',
-  function($scope, UrlInterpolationService) {
+  '$scope', '$window', 'UrlInterpolationService',
+  function($scope, $window, UrlInterpolationService) {
     // Define constants
     $scope.TAB_ID_ABOUT = 'about';
     $scope.TAB_ID_FOUNDATION = 'foundation';
@@ -62,7 +62,7 @@ oppia.controller('About', [
         activateTab($scope.TAB_ID_FOUNDATION);
         // Ensure page goes to the license section
         if (hashChange === 'license') {
-          location.reload(true);
+          $window.location.reload(true);
         }
       } else if (hashChange === $scope.TAB_ID_CREDITS) {
         activateTab($scope.TAB_ID_CREDITS);

--- a/core/templates/dev/head/pages/admin-page/activities-tab/admin-dev-mode-activities-tab.directive.ts
+++ b/core/templates/dev/head/pages/admin-page/activities-tab/admin-dev-mode-activities-tab.directive.ts
@@ -24,9 +24,9 @@ require('pages/admin-page/services/admin-task-manager.service.ts');
 require('pages/admin-page/admin-page.constants.ts');
 
 oppia.directive('adminDevModeActivitiesTab', [
-  '$http', 'AdminTaskManagerService', 'UrlInterpolationService',
+  '$http', '$window', 'AdminTaskManagerService', 'UrlInterpolationService',
   'ADMIN_HANDLER_URL',
-  function($http, AdminTaskManagerService, UrlInterpolationService,
+  function($http, $window, AdminTaskManagerService, UrlInterpolationService,
       ADMIN_HANDLER_URL) {
     return {
       restrict: 'E',
@@ -44,7 +44,7 @@ oppia.directive('adminDevModeActivitiesTab', [
           if (AdminTaskManagerService.isTaskRunning()) {
             return;
           }
-          if (!confirm('This action is irreversible. Are you sure?')) {
+          if (!$window.confirm('This action is irreversible. Are you sure?')) {
             return;
           }
 
@@ -73,7 +73,7 @@ oppia.directive('adminDevModeActivitiesTab', [
           if (AdminTaskManagerService.isTaskRunning()) {
             return;
           }
-          if (!confirm('This action is irreversible. Are you sure?')) {
+          if (!$window.confirm('This action is irreversible. Are you sure?')) {
             return;
           }
 
@@ -142,7 +142,7 @@ oppia.directive('adminDevModeActivitiesTab', [
           if (AdminTaskManagerService.isTaskRunning()) {
             return;
           }
-          if (!confirm('This action is irreversible. Are you sure?')) {
+          if (!$window.confirm('This action is irreversible. Are you sure?')) {
             return;
           }
 

--- a/core/templates/dev/head/pages/admin-page/config-tab/admin-config-tab.directive.ts
+++ b/core/templates/dev/head/pages/admin-page/config-tab/admin-config-tab.directive.ts
@@ -22,8 +22,8 @@ require('pages/admin-page/services/admin-task-manager.service.ts');
 require('pages/admin-page/admin-page.constants.ts');
 
 oppia.directive('adminConfigTab', [
-  '$http', 'AdminTaskManagerService', 'UrlInterpolationService',
-  'ADMIN_HANDLER_URL', function($http, AdminTaskManagerService,
+  '$http', '$window', 'AdminTaskManagerService', 'UrlInterpolationService',
+  'ADMIN_HANDLER_URL', function($http, $window, AdminTaskManagerService,
       UrlInterpolationService, ADMIN_HANDLER_URL) {
     return {
       restrict: 'E',
@@ -53,7 +53,7 @@ oppia.directive('adminConfigTab', [
         };
 
         ctrl.revertToDefaultConfigPropertyValue = function(configPropertyId) {
-          if (!confirm('This action is irreversible. Are you sure?')) {
+          if (!$window.confirm('This action is irreversible. Are you sure?')) {
             return;
           }
 
@@ -73,7 +73,7 @@ oppia.directive('adminConfigTab', [
           if (AdminTaskManagerService.isTaskRunning()) {
             return;
           }
-          if (!confirm('This action is irreversible. Are you sure?')) {
+          if (!$window.confirm('This action is irreversible. Are you sure?')) {
             return;
           }
 

--- a/core/templates/dev/head/pages/admin-page/misc-tab/admin-misc-tab.directive.ts
+++ b/core/templates/dev/head/pages/admin-page/misc-tab/admin-misc-tab.directive.ts
@@ -45,7 +45,7 @@ oppia.directive('adminMiscTab', [
           if (AdminTaskManagerService.isTaskRunning()) {
             return;
           }
-          if (!confirm('This action is irreversible. Are you sure?')) {
+          if (!$window.confirm('This action is irreversible. Are you sure?')) {
             return;
           }
 

--- a/core/templates/dev/head/pages/exploration-editor-page/history-tab/history-tab.directive.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/history-tab/history-tab.directive.ts
@@ -41,13 +41,13 @@ oppia.directive('historyTab', ['UrlInterpolationService', function(
       '/pages/exploration-editor-page/history-tab/history-tab.directive.html'),
     controllerAs: '$ctrl',
     controller: [
-      '$http', '$log', '$rootScope', '$scope', '$window',
-      '$uibModal', 'CompareVersionsService',
+      '$http', '$log', '$rootScope', '$scope',
+      '$uibModal', '$window', 'CompareVersionsService',
       'DateTimeFormatService', 'EditabilityService', 'ExplorationDataService',
       'UrlInterpolationService', 'VersionTreeService',
       function(
-          $http, $log, $rootScope, $scope, $window,
-          $uibModal, CompareVersionsService,
+          $http, $log, $rootScope, $scope,
+          $uibModal, $window, CompareVersionsService,
           DateTimeFormatService, EditabilityService, ExplorationDataService,
           UrlInterpolationService, VersionTreeService) {
         var ctrl = this;

--- a/core/templates/dev/head/pages/exploration-editor-page/history-tab/history-tab.directive.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/history-tab/history-tab.directive.ts
@@ -41,12 +41,12 @@ oppia.directive('historyTab', ['UrlInterpolationService', function(
       '/pages/exploration-editor-page/history-tab/history-tab.directive.html'),
     controllerAs: '$ctrl',
     controller: [
-      '$http', '$log', '$rootScope', '$scope',
+      '$http', '$log', '$rootScope', '$scope', '$window',
       '$uibModal', 'CompareVersionsService',
       'DateTimeFormatService', 'EditabilityService', 'ExplorationDataService',
       'UrlInterpolationService', 'VersionTreeService',
       function(
-          $http, $log, $rootScope, $scope,
+          $http, $log, $rootScope, $scope, $window,
           $uibModal, CompareVersionsService,
           DateTimeFormatService, EditabilityService, ExplorationDataService,
           UrlInterpolationService, VersionTreeService) {
@@ -295,7 +295,7 @@ oppia.directive('historyTab', ['UrlInterpolationService', function(
               current_version: ExplorationDataService.data.version,
               revert_to_version: version
             }).then(function() {
-              location.reload();
+              $window.location.reload();
             });
           });
         };

--- a/core/templates/dev/head/pages/exploration-editor-page/services/exploration-save.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/services/exploration-save.service.ts
@@ -52,7 +52,7 @@ require('services/SiteAnalyticsService.ts');
 require('services/stateful/FocusManagerService.ts');
 
 oppia.factory('ExplorationSaveService', [
-  '$log', '$q', '$rootScope', '$timeout', '$uibModal',
+  '$log', '$q', '$rootScope', '$timeout', '$uibModal', '$window',
   'AlertsService', 'AutosaveInfoModalsService', 'ChangeListService',
   'ExplorationCategoryService', 'ExplorationDataService',
   'ExplorationDiffService', 'ExplorationInitStateNameService',
@@ -64,7 +64,7 @@ oppia.factory('ExplorationSaveService', [
   'RouterService', 'SiteAnalyticsService', 'StatesObjectFactory',
   'UrlInterpolationService',
   function(
-      $log, $q, $rootScope, $timeout, $uibModal,
+      $log, $q, $rootScope, $timeout, $uibModal, $window,
       AlertsService, AutosaveInfoModalsService, ChangeListService,
       ExplorationCategoryService, ExplorationDataService,
       ExplorationDiffService, ExplorationInitStateNameService,

--- a/core/templates/dev/head/pages/exploration-editor-page/services/exploration-save.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/services/exploration-save.service.ts
@@ -299,7 +299,7 @@ oppia.factory('ExplorationSaveService', [
           // The reload is necessary because, otherwise, the
           // exploration-with-draft-changes will be reloaded
           // (since it is already cached in ExplorationDataService).
-          location.reload();
+          $window.location.reload();
         });
       },
 

--- a/core/templates/dev/head/pages/preferences-page/preferences-page.controller.ts
+++ b/core/templates/dev/head/pages/preferences-page/preferences-page.controller.ts
@@ -33,13 +33,13 @@ require('services/UtilsService.ts');
 
 oppia.controller('Preferences', [
   '$http', '$q', '$rootScope', '$scope', '$timeout', '$translate', '$uibModal',
-  'AlertsService', 'LanguageUtilService', 'UrlInterpolationService',
+  '$window', 'AlertsService', 'LanguageUtilService', 'UrlInterpolationService',
   'UserService', 'UtilsService', 'DASHBOARD_TYPE_CREATOR',
   'DASHBOARD_TYPE_LEARNER', 'SUPPORTED_AUDIO_LANGUAGES',
   'SUPPORTED_SITE_LANGUAGES',
   function(
       $http, $q, $rootScope, $scope, $timeout, $translate, $uibModal,
-      AlertsService, LanguageUtilService, UrlInterpolationService,
+      $window, AlertsService, LanguageUtilService, UrlInterpolationService,
       UserService, UtilsService, DASHBOARD_TYPE_CREATOR,
       DASHBOARD_TYPE_LEARNER, SUPPORTED_AUDIO_LANGUAGES,
       SUPPORTED_SITE_LANGUAGES) {
@@ -243,7 +243,7 @@ oppia.controller('Preferences', [
           .then(function() {
             // The reload is needed in order to update the profile picture in
             // the top-right corner.
-            location.reload();
+            $window.location.reload();
           });
       });
     };

--- a/extensions/interactions/MusicNotesInput/directives/MusicNotesInputRulesService.ts
+++ b/extensions/interactions/MusicNotesInput/directives/MusicNotesInputRulesService.ts
@@ -43,7 +43,7 @@ oppia.factory('MusicNotesInputRulesService', [
       // TODO(wxy): validate that inputs.a <= inputs.b
       HasLengthInclusivelyBetween: function(answer, inputs) {
         var answerLength = _convertSequenceToMidi(answer).length;
-        return length >= inputs.a && length <= inputs.b;
+        return answerLength >= inputs.a && answerLength <= inputs.b;
       },
       IsEqualToExceptFor: function(answer, inputs) {
         var targetSequence = _convertSequenceToMidi(inputs.x);

--- a/extensions/interactions/MusicNotesInput/directives/MusicNotesInputRulesService.ts
+++ b/extensions/interactions/MusicNotesInput/directives/MusicNotesInputRulesService.ts
@@ -38,7 +38,7 @@ oppia.factory('MusicNotesInputRulesService', [
           _convertSequenceToMidi(inputs.x));
       },
       IsLongerThan: function(answer, inputs) {
-        return _convertSequenceToMidi(answer).length > inputs.x;
+        return _convertSequenceToMidi(answer).length > inputs.k;
       },
       // TODO(wxy): validate that inputs.a <= inputs.b
       HasLengthInclusivelyBetween: function(answer, inputs) {

--- a/extensions/interactions/MusicNotesInput/directives/MusicNotesInputRulesServiceSpec.ts
+++ b/extensions/interactions/MusicNotesInput/directives/MusicNotesInputRulesServiceSpec.ts
@@ -612,4 +612,137 @@ describe('Music Notes Input rules service', function() {
       })).toBe(false);
     }
   );
+  it('should have a correct \'is longer than\' rule', function() {
+    expect(mnirs.IsLongerThan([{
+      readableNoteName: 'A4',
+      noteDuration: {
+        num: 1,
+        den: 1
+      }
+    }, {
+      readableNoteName: 'D4',
+      noteDuration: {
+        num: 1,
+        den: 1
+      }
+    }], {
+      x: [{
+        readableNoteName: 'A4',
+        noteDuration: {
+          num: 1,
+          den: 1
+        }
+      }],
+      k: 1
+    })).toBe(true);
+
+    expect(mnirs.IsLongerThan([{
+      readableNoteName: 'C4',
+      noteDuration: {
+        num: 1,
+        den: 1
+      }
+    }, {
+      readableNoteName: 'D4',
+      noteDuration: {
+        num: 1,
+        den: 1
+      }
+    }, {
+      readableNoteName: 'E4',
+      noteDuration: {
+        num: 1,
+        den: 1
+      }
+    }], {
+      x: [{
+        readableNoteName: 'C4',
+        noteDuration: {
+          num: 1,
+          den: 1
+        }
+      }, {
+        readableNoteName: 'D4',
+        noteDuration: {
+          num: 1,
+          den: 1
+        }
+      }, {
+        readableNoteName: 'E4',
+        noteDuration: {
+          num: 1,
+          den: 1
+        }
+      }],
+      k: 5
+    })).toBe(false);
+  });
+  it('should have a correct \'has length inclusively between\' rule',
+    function() {
+      expect(mnirs.HasLengthInclusivelyBetween([{
+        readableNoteName: 'A4',
+        noteDuration: {
+          num: 1,
+          den: 1
+        }
+      }, {
+        readableNoteName: 'D4',
+        noteDuration: {
+          num: 1,
+          den: 1
+        }
+      }], {
+        x: [{
+          readableNoteName: 'A4',
+          noteDuration: {
+            num: 1,
+            den: 1
+          }
+        }],
+        a: 1,
+        b: 3
+      })).toBe(true);
+
+      expect(mnirs.HasLengthInclusivelyBetween([{
+        readableNoteName: 'C4',
+        noteDuration: {
+          num: 1,
+          den: 1
+        }
+      }, {
+        readableNoteName: 'D4',
+        noteDuration: {
+          num: 1,
+          den: 1
+        }
+      }, {
+        readableNoteName: 'E4',
+        noteDuration: {
+          num: 1,
+          den: 1
+        }
+      }], {
+        x: [{
+          readableNoteName: 'C4',
+          noteDuration: {
+            num: 1,
+            den: 1
+          }
+        }, {
+          readableNoteName: 'D4',
+          noteDuration: {
+            num: 1,
+            den: 1
+          }
+        }, {
+          readableNoteName: 'E4',
+          noteDuration: {
+            num: 1,
+            den: 1
+          }
+        }],
+        a: 5,
+        b: 10
+      })).toBe(false);
+    });
 });


### PR DESCRIPTION
## Explanation
Fixes #6799: Adds restricted globals rule to eslint and removes direct use of globals from codebase.
