### PR TITLE
Fix part of #6550: Write tests for summary_services and topic_jobs_one_off

### DIFF
--- a/core/domain/summary_services.py
+++ b/core/domain/summary_services.py
@@ -256,10 +256,7 @@ def get_exploration_metadata_dicts(exploration_ids, user):
     filtered_exploration_summaries = []
     for (exploration_summary, exploration_rights) in (
             zip(exploration_summaries, exploration_rights_objects)):
-        if exploration_summary is None:
-            continue
-
-        if exploration_rights is None:
+        if exploration_summary is None or exploration_rights is None:
             continue
 
         if exploration_summary.status == (
@@ -322,11 +319,9 @@ def get_displayable_exp_summary_dicts_matching_ids(exploration_ids, user=None):
     filtered_exploration_summaries = []
     for (exploration_summary, exploration_rights) in (
             zip(exploration_summaries, exploration_rights_objects)):
-        if exploration_summary is None:
+        if exploration_summary is None or exploration_rights is None:
             continue
 
-        if exploration_rights is None:
-            continue
         if exploration_summary.status == (
                 rights_manager.ACTIVITY_STATUS_PRIVATE):
             if user is None:
@@ -382,37 +377,35 @@ def get_displayable_exp_summary_dicts(exploration_summaries):
     displayable_exp_summaries = []
 
     for ind, exploration_summary in enumerate(exploration_summaries):
-        if not exploration_summary:
-            continue
+        if exploration_summary:
+            summary_dict = {
+                'id': exploration_summary.id,
+                'title': exploration_summary.title,
+                'activity_type': constants.ACTIVITY_TYPE_EXPLORATION,
+                'category': exploration_summary.category,
+                'created_on_msec': utils.get_time_in_millisecs(
+                    exploration_summary.exploration_model_created_on),
+                'objective': exploration_summary.objective,
+                'language_code': exploration_summary.language_code,
+                'last_updated_msec': utils.get_time_in_millisecs(
+                    exploration_summary.exploration_model_last_updated
+                ),
+                'human_readable_contributors_summary': (
+                    get_human_readable_contributors_summary(
+                        exploration_summary.contributors_summary)
+                ),
+                'status': exploration_summary.status,
+                'ratings': exploration_summary.ratings,
+                'community_owned': exploration_summary.community_owned,
+                'tags': exploration_summary.tags,
+                'thumbnail_icon_url': utils.get_thumbnail_icon_url_for_category(
+                    exploration_summary.category),
+                'thumbnail_bg_color': utils.get_hex_color_for_category(
+                    exploration_summary.category),
+                'num_views': view_counts[ind],
+            }
 
-        summary_dict = {
-            'id': exploration_summary.id,
-            'title': exploration_summary.title,
-            'activity_type': constants.ACTIVITY_TYPE_EXPLORATION,
-            'category': exploration_summary.category,
-            'created_on_msec': utils.get_time_in_millisecs(
-                exploration_summary.exploration_model_created_on),
-            'objective': exploration_summary.objective,
-            'language_code': exploration_summary.language_code,
-            'last_updated_msec': utils.get_time_in_millisecs(
-                exploration_summary.exploration_model_last_updated
-            ),
-            'human_readable_contributors_summary': (
-                get_human_readable_contributors_summary(
-                    exploration_summary.contributors_summary)
-            ),
-            'status': exploration_summary.status,
-            'ratings': exploration_summary.ratings,
-            'community_owned': exploration_summary.community_owned,
-            'tags': exploration_summary.tags,
-            'thumbnail_icon_url': utils.get_thumbnail_icon_url_for_category(
-                exploration_summary.category),
-            'thumbnail_bg_color': utils.get_hex_color_for_category(
-                exploration_summary.category),
-            'num_views': view_counts[ind],
-        }
-
-        displayable_exp_summaries.append(summary_dict)
+            displayable_exp_summaries.append(summary_dict)
 
     return displayable_exp_summaries
 

--- a/core/domain/summary_services_test.py
+++ b/core/domain/summary_services_test.py
@@ -24,7 +24,6 @@ from core.domain import collection_services
 from core.domain import exp_domain
 from core.domain import exp_services
 from core.domain import exp_services_test
-from core.domain import html_validation_service
 from core.domain import rating_services
 from core.domain import rights_manager
 from core.domain import summary_services
@@ -32,11 +31,6 @@ from core.domain import user_services
 from core.tests import test_utils
 import feconf
 import utils
-
-
-def mock_get_filename_with_dimensions(filename, unused_exp_id):
-    return html_validation_service.regenerate_image_filename_using_dimensions(
-        filename, 490, 120)
 
 
 class ExplorationDisplayableSummariesTest(
@@ -261,16 +255,12 @@ class LibraryGroupsTest(exp_services_test.ExplorationServicesUnitTests):
         response = self.get_html_response('/admin')
         csrf_token = self.get_csrf_token_from_response(response)
 
-        with self.swap(
-            html_validation_service, 'get_filename_with_dimensions',
-            mock_get_filename_with_dimensions):
-
-            self.post_json(
-                '/adminhandler', {
-                    'action': 'reload_exploration',
-                    'exploration_id': '2'
-                }, csrf_token=csrf_token)
-            self.logout()
+        self.post_json(
+            '/adminhandler', {
+                'action': 'reload_exploration',
+                'exploration_id': '2'
+            }, csrf_token=csrf_token)
+        self.logout()
 
     def test_get_library_groups(self):
         """The exploration with id '2' is an exploration in the Mathematics
@@ -1044,3 +1034,28 @@ class CollectionNodeMetadataDictsTest(
             'title': u'Exploration 3 Albert title',
         }]
         self.assertEqual(expected_metadata_dicts, metadata_dicts)
+
+    def test_guest_can_fetch_public_exploration_metadata_dicts(self):
+        new_guest_user = user_services.UserActionsInfo()
+        metadata_dicts = summary_services.get_exploration_metadata_dicts(
+            [self.EXP_ID3, self.EXP_ID4], new_guest_user)
+
+        expected_metadata_dicts = [{
+            'id': self.EXP_ID3,
+            'objective': u'An objective 3',
+            'title': u'Exploration 3 Albert title',
+        }, {
+            'id': self.EXP_ID4,
+            'objective': u'An objective 4',
+            'title': u'Exploration 4 Bob title',
+        }]
+
+        self.assertEqual(metadata_dicts, expected_metadata_dicts)
+
+    def test_guest_cannot_fetch_private_exploration_metadata_dicts(self):
+        new_guest_user = user_services.UserActionsInfo()
+        self.save_new_valid_exploration('exp_id', self.albert_id)
+        metadata_dicts = summary_services.get_exploration_metadata_dicts(
+            ['exp_id'], new_guest_user)
+
+        self.assertEqual(metadata_dicts, [])


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes part of #6550: Write tests for summary_services and topic_jobs_one_off
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
