### PR TITLE
Fixes part of #6271: Refactor question domain update to accept objects

### DIFF
--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -385,14 +385,14 @@ class Question(object):
         """
         self.linked_skill_ids = list(set(linked_skill_ids))
 
-    def update_question_state_data(self, question_state_domain_object):
+    def update_question_state_data(self, question_state_data):
         """Updates the question data of the question.
 
         Args:
-            question_state_domain_object: object. A State domain object
+            question_state_data: State. A State domain object
                 representing the question state data.
         """
-        self.question_state_data = (question_state_domain_object)
+        self.question_state_data = question_state_data
 
 
 class QuestionSummary(object):

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -385,15 +385,14 @@ class Question(object):
         """
         self.linked_skill_ids = list(set(linked_skill_ids))
 
-    def update_question_state_data(self, question_state_data_dict):
+    def update_question_state_data(self, question_state_domain_object):
         """Updates the question data of the question.
 
         Args:
-            question_state_data_dict: dict. A dict representing the question
+            question_state_domain_object: object. A State domain object representing the question
                 state data.
         """
-        self.question_state_data = state_domain.State.from_dict(
-            question_state_data_dict)
+        self.question_state_data = question_state_domain_object
 
 
 class QuestionSummary(object):

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -389,8 +389,8 @@ class Question(object):
         """Updates the question data of the question.
 
         Args:
-            question_state_domain_object: object. A State domain object representing the question
-                state data.
+            question_state_domain_object: object. A State domain object 
+                representing the question state data.
         """
         self.question_state_data = (question_state_domain_object)
 

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -392,7 +392,7 @@ class Question(object):
             question_state_domain_object: object. A State domain object representing the question
                 state data.
         """
-        self.question_state_data = question_state_domain_object
+        self.question_state_data = (question_state_domain_object)
 
 
 class QuestionSummary(object):

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -389,7 +389,7 @@ class Question(object):
         """Updates the question data of the question.
 
         Args:
-            question_state_domain_object: object. A State domain object 
+            question_state_domain_object: object. A State domain object
                 representing the question state data.
         """
         self.question_state_data = (question_state_domain_object)

--- a/core/domain/question_domain_test.py
+++ b/core/domain/question_domain_test.py
@@ -292,7 +292,7 @@ class QuestionDomainTest(test_utils.GenericTestBase):
         """
         question_state_data = self._create_valid_question_data('Test')
 
-        self.question.update_question_state_data(question_state_data.to_dict())
+        self.question.update_question_state_data(question_state_data)
 
         self.assertEqual(
             question_state_data.to_dict(),

--- a/core/domain/question_services.py
+++ b/core/domain/question_services.py
@@ -551,7 +551,8 @@ def apply_change_list(question_id, change_list):
                     question.update_language_code(change.new_value)
                 elif (change.property_name ==
                       question_domain.QUESTION_PROPERTY_QUESTION_STATE_DATA):
-                    question.update_question_state_data(state_domain.State.from_dict(change.new_value))
+                    state_domain_object = state_domain.State.from_dict(change.new_value)
+                    question.update_question_state_data(state_domain_object)
                 elif (change.property_name ==
                       question_domain.QUESTION_PROPERTY_LINKED_SKILL_IDS):
                     question.update_linked_skill_ids(change.new_value)

--- a/core/domain/question_services.py
+++ b/core/domain/question_services.py
@@ -551,7 +551,8 @@ def apply_change_list(question_id, change_list):
                     question.update_language_code(change.new_value)
                 elif (change.property_name ==
                       question_domain.QUESTION_PROPERTY_QUESTION_STATE_DATA):
-                    state_domain_object = state_domain.State.from_dict(change.new_value)
+                    state_domain_object = state_domain.State.from_dict(
+                        change.new_value)
                     question.update_question_state_data(state_domain_object)
                 elif (change.property_name ==
                       question_domain.QUESTION_PROPERTY_LINKED_SKILL_IDS):

--- a/core/domain/question_services.py
+++ b/core/domain/question_services.py
@@ -551,7 +551,7 @@ def apply_change_list(question_id, change_list):
                     question.update_language_code(change.new_value)
                 elif (change.property_name ==
                       question_domain.QUESTION_PROPERTY_QUESTION_STATE_DATA):
-                    question.update_question_state_data(change.new_value)
+                    question.update_question_state_data(state_domain.State.from_dict(change.new_value))
                 elif (change.property_name ==
                       question_domain.QUESTION_PROPERTY_LINKED_SKILL_IDS):
                     question.update_linked_skill_ids(change.new_value)


### PR DESCRIPTION
## Explanation
Fixes question part of #6271 by changing the parameter of the update_question_state_data method to be an object, and then updating the references.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
