### PR TITLE
Fix #7031: Add missing $ctrl

### DIFF
--- a/extensions/interactions/ItemSelectionInput/directives/item_selection_input_interaction_directive.html
+++ b/extensions/interactions/ItemSelectionInput/directives/item_selection_input_interaction_directive.html
@@ -15,7 +15,7 @@
       </span>
     </small>
     <div class="item-selection-input-container" ng-repeat="choice in $ctrl.choices track by $index">
-      <div ng-if="displayCheckboxes">
+      <div ng-if="$ctrl.displayCheckboxes">
         <label class="item-selection-input-item">
           <md-checkbox class="item-selection-input-checkbox" ng-model="$ctrl.userSelections[choice]" ng-checked="$ctrl.userSelections[choice]"
                        ng-change="$ctrl.onToggleCheckbox()" ng-disabled="$ctrl.preventAdditionalSelections && !$ctrl.userSelections[choice]" tabindex="0">


### PR DESCRIPTION
## Explanation
Fixes #7031 : Add missing $ctrl for item selection

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
