### PR TITLE
Fix #6864: Fix console error in learner dashboard and empty suggestion modal

### DIFF
--- a/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.controller.ts
+++ b/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.controller.ts
@@ -27,6 +27,7 @@ require('components/summary-tile/collection-summary-tile.directive.ts');
 require('components/summary-tile/exploration-summary-tile.directive.ts');
 require('filters/string-utility-filters/truncate.filter.ts');
 
+require('directives/AngularHtmlBindDirective.ts');
 require('domain/feedback_message/FeedbackMessageSummaryObjectFactory.ts');
 require('domain/feedback_thread/FeedbackThreadSummaryObjectFactory.ts');
 require('domain/learner_dashboard/LearnerDashboardBackendApiService.ts');
@@ -473,6 +474,10 @@ oppia.directive('learnerDashboardPage', ['UrlInterpolationService', function(
 
         ctrl.showSuggestionModal = function(
             newContent, oldContent, description) {
+          console.log("in learner dashboard");
+          console.log(newContent);
+          console.log(oldContent);
+          console.log(description);
           SuggestionModalForLearnerDashboardService.showSuggestionModal(
             'edit_exploration_state_content',
             {

--- a/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.controller.ts
+++ b/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.controller.ts
@@ -474,10 +474,6 @@ oppia.directive('learnerDashboardPage', ['UrlInterpolationService', function(
 
         ctrl.showSuggestionModal = function(
             newContent, oldContent, description) {
-          console.log("in learner dashboard");
-          console.log(newContent);
-          console.log(oldContent);
-          console.log(description);
           SuggestionModalForLearnerDashboardService.showSuggestionModal(
             'edit_exploration_state_content',
             {

--- a/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.directive.html
+++ b/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.directive.html
@@ -639,7 +639,7 @@
                 <span ng-if="thread.lastMessageText"><[thread.lastMessageText | truncate:50]></span>
                 <span ng-if="!thread.lastMessageText && thread.totalMessageCount !== 1">
                   <i translate="I18N_LEARNER_DASHBOARD_FEEDBACK_THREAD_STATUS_CHANGE_MESSAGE"
-                     translate-values="{$ctrl.threadStatus: $ctrl.getHumanReadableStatus(thread.status)}">
+                     translate-values="{<[$ctrl.threadStatus]>: <[$ctrl.getHumanReadableStatus(thread.status)]>}">
                   </i>
                 </span>
                 <span ng-if="!thread.lastMessageText && thread.totalMessageCount === 1"><i translate="I18N_LEARNER_DASHBOARD_SUGGESTION_TEXT"></i></span>

--- a/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.directive.html
+++ b/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.directive.html
@@ -691,7 +691,7 @@
                     <span style="float: right; margin-right: 15px;"
                           ng-if="message.messageId !== 0 && message.updatedStatus">
                       <em translate="I18N_LEARNER_DASHBOARD_FEEDBACK_THREAD_STATUS_CHANGE_MESSAGE"
-                          translate-values="{$ctrl.threadStatus: $ctrl.getHumanReadableStatus(message.updatedStatus)}">
+                          translate-values="{<[$ctrl.threadStatus]>: <[$ctrl.getHumanReadableStatus(message.updatedStatus)]>}">
                       </em>
                     </span>
                   </div>


### PR DESCRIPTION
## Explanation
Fix #6864. Fixes a console error that occurs in the learner dashboard as reported in the issue. Also fix the empty suggestion modal which was caused by a missing import.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
