### PR TITLE
Fix #7007: Allows adding proper tags for the exploration by replacing parent with ctrl

### DIFF
--- a/core/templates/dev/head/pages/exploration-editor-page/settings-tab/settings-tab.directive.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/settings-tab/settings-tab.directive.html
@@ -59,8 +59,8 @@
               <label for="explorationTags" class="col-lg-2 col-md-2 col-sm-2">Tags</label>
               <div class="col-lg-10 col-md-10 col-sm-10">
                 <div ng-if="$ctrl.hasPageLoaded">
-                  <select2-dropdown item="$parent.explorationTagsService.displayed"
-                                    choices="$parent.explorationTagsService.displayed"
+                  <select2-dropdown item="$ctrl.explorationTagsService.displayed"
+                                    choices="$ctrl.explorationTagsService.displayed"
                                     allow-multiple-choices="true"
                                     invalid-search-term-message="Add a new tag (using lowercase letters and spaces)..."
                                     new-choice-regex="<[::$ctrl.TAG_REGEX]>"


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #7007, allows adding proper tags for the exploration by replacing parent with ctrl.

After changes:
![image](https://user-images.githubusercontent.com/16653571/60390123-fa12b480-9aec-11e9-81fc-b0ff2427c65e.png)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
