### PR TITLE
Revert "Upgrades Requests  (#6965)"

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -97,10 +97,10 @@ THIRD_PARTY_LIBS = [
     os.path.join(ROOT_PATH, 'third_party', 'graphy-1.0.0'),
     os.path.join(ROOT_PATH, 'third_party', 'html5lib-python-1.0.1'),
     os.path.join(ROOT_PATH, 'third_party', 'mutagen-1.42.0'),
-    os.path.join(ROOT_PATH, 'third_party', 'requests-2.22.0'),
+    os.path.join(ROOT_PATH, 'third_party', 'requests-2.10.0'),
     os.path.join(ROOT_PATH, 'third_party', 'simplejson-3.16.0'),
     os.path.join(ROOT_PATH, 'third_party', 'six-1.12.0'),
-    os.path.join(ROOT_PATH, 'third_party', 'soupsieve-1.9.1'),    
+    os.path.join(ROOT_PATH, 'third_party', 'soupsieve-1.9.1'),
     os.path.join(ROOT_PATH, 'third_party', 'webencodings-0.5.1'),
 ]
 

--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -52,7 +52,7 @@ DIRS_TO_ADD_TO_SYS_PATH = [
     os.path.join(THIRD_PARTY_DIR, 'graphy-1.0.0'),
     os.path.join(THIRD_PARTY_DIR, 'html5lib-python-1.0.1'),
     os.path.join(THIRD_PARTY_DIR, 'mutagen-1.42.0'),
-    os.path.join(THIRD_PARTY_DIR, 'requests-2.22.0'),
+    os.path.join(THIRD_PARTY_DIR, 'requests-2.10.0'),
     os.path.join(THIRD_PARTY_DIR, 'simplejson-3.16.0'),
     os.path.join(THIRD_PARTY_DIR, 'six-1.12.0'),
     os.path.join(THIRD_PARTY_DIR, 'soupsieve-1.9.1'),

--- a/manifest.json
+++ b/manifest.json
@@ -56,9 +56,9 @@
         "targetDirPrefix": "html5lib-python-"
       },
       "requests": {
-        "version": "2.22.0",
+        "version": "2.10.0",
         "downloadFormat": "tar",
-        "url": "https://files.pythonhosted.org/packages/01/62/ddcf76d1d19885e8579acb1b1df26a852b03472c0e46d2b959a714c90608/requests-2.22.0.tar.gz",
+        "url": "https://pypi.python.org/packages/49/6f/183063f01aae1e025cf0130772b55848750a2f3a89bfa11b385b35d7329d/requests-2.10.0.tar.gz#md5=a36f7a64600f1bfec4d55ae021d232ae",
         "tarRootDirPrefix": "requests-",
         "rootDirPrefix": "requests-",
         "targetDirPrefix": "requests-"


### PR DESCRIPTION
This reverts commit f13a4102abdbc8155cb31c19b291543ca4a39714.

PR #6965 introduced a serious regression that is causing  the Oppia release process to break. The issue is when using Mailgun: requests-2.22.0 uses a direct import of urllib3 which cannot be found on the production server. (Earlier versions of the requests library actually included a bundled version of urllib3.)

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.