### PR TITLE
Fix #6952: Adds a backend test to ensure that all storage models have audit jobs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -318,6 +318,7 @@
 /core/controllers/tasks*.py @aks681
 /core/domain/email*.py @aks681
 /core/domain/prod_validation_jobs_one_off*.py @seanlip
+/core/domain/storage_model_audit_jobs_test.py @seanlip
 /core/jobs*.py @seanlip
 /core/platform/ @seanlip
 /core/templates/dev/head/App*.ts @ankita240796

--- a/core/domain/storage_model_audit_jobs_test.py
+++ b/core/domain/storage_model_audit_jobs_test.py
@@ -1,0 +1,102 @@
+# Copyright 2019 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Oppia storage model audit jobs."""
+import inspect
+
+from core.domain import prod_validation_jobs_one_off
+from core.platform import models
+from core.tests import test_utils
+
+
+# This list includes statistics models and deprecated StateIdMappingModel.
+# The statistics models are included here because the audit jobs for
+# statistics models are defined in core/domain/stats_jobs_one_off.py
+# These jobs should be updated and moved to
+# core/domain/prod_validation_jobs_one_off.py and the statistics model
+# class names can then be removed from this list.
+# The corresponding issue is #7100.
+MODEL_CLASS_NAMES_TO_EXCLUDE = {
+    'StateCounterModel',
+    'AnswerSubmittedEventLogEntryModel',
+    'ExplorationActualStartEventLogEntryModel',
+    'SolutionHitEventLogEntryModel',
+    'StartExplorationEventLogEntryModel',
+    'MaybeLeaveExplorationEventLogEntryModel',
+    'CompleteExplorationEventLogEntryModel',
+    'RateExplorationEventLogEntryModel',
+    'StateHitEventLogEntryModel',
+    'StateCompleteEventLogEntryModel',
+    'LeaveForRefresherExplorationEventLogEntryModel',
+    'ExplorationStatsModel',
+    'ExplorationIssuesModel',
+    'PlaythroughModel',
+    'LearnerAnswerDetailsModel',
+    'ExplorationAnnotationsModel',
+    'StateAnswersModel',
+    'StateAnswersCalcOutputModel',
+    'StateIdMappingModel'
+}
+
+
+class StorageModelAuditJobsTest(test_utils.GenericTestBase):
+    """Tests for Oppia storage model audit jobs."""
+
+    def test_all_models_have_audit_jobs(self):
+        all_model_module_names = []
+
+        # As models.NAMES is an enum, it cannot be iterated. So we use the
+        # __dict__ property which can be iterated.
+        for name in models.NAMES.__dict__:
+            if '__' not in name:
+                all_model_module_names.append(name)
+
+        names_of_ndb_model_subclasses = []
+        for module_name in all_model_module_names:
+            # We skip base models since there are no specific audit jobs
+            # for base models. The audit jobs for subclasses of base models
+            # cover the test cases for base models, so extra audit jobs
+            # for base models are not required.
+            if module_name == 'base_model':
+                continue
+            (module, ) = models.Registry.import_models([module_name])
+            for member_name, member_obj in inspect.getmembers(module):
+                if inspect.isclass(member_obj):
+                    clazz = getattr(module, member_name)
+                    if clazz.__name__ in MODEL_CLASS_NAMES_TO_EXCLUDE:
+                        continue
+                    all_base_classes = [
+                        base_class.__name__ for base_class in inspect.getmro(
+                            clazz)]
+                    if 'Model' in all_base_classes:
+                        names_of_ndb_model_subclasses.append(clazz.__name__)
+
+        names_of_all_audit_job_classes = []
+        for name, clazz in inspect.getmembers(
+                prod_validation_jobs_one_off, predicate=inspect.isclass):
+            all_base_classes = [
+                base_class.__name__ for base_class in inspect.getmro(clazz)]
+            if 'ProdValidationAuditOneOffJob' in all_base_classes:
+                names_of_all_audit_job_classes.append(name)
+
+        model_class_names_with_missing_audit_jobs = [
+            model_class_name
+            for model_class_name in names_of_ndb_model_subclasses if (
+                model_class_name + 'AuditOneOffJob' not in (
+                    names_of_all_audit_job_classes))]
+        self.assertFalse(
+            model_class_names_with_missing_audit_jobs,
+            msg=(
+                'Following model classes do not have an audit job: %s' % (
+                    (', ').join(model_class_names_with_missing_audit_jobs))))

--- a/core/storage/storage_models_test.py
+++ b/core/storage/storage_models_test.py
@@ -22,27 +22,25 @@ from core.tests import test_utils
 class StorageModelsTest(test_utils.GenericTestBase):
     """Tests for Oppia storage models."""
 
-    def test_all_model_names_unique(self):
-        all_model_names = []
+    def test_all_model_module_names_unique(self):
+        all_model_module_names = []
 
         # As models.NAMES is an enum, it cannot be iterated. So we use the
         # __dict__ property which can be iterated.
         for name in models.NAMES.__dict__:
             if '__' not in name:
-                all_model_names.append(name)
+                all_model_module_names.append(name)
 
         names_of_ndb_model_subclasses = []
-        for name in all_model_names:
-            (module, ) = models.Registry.import_models([name])
+        for module_name in all_model_module_names:
+            (module, ) = models.Registry.import_models([module_name])
             for member_name, member_obj in inspect.getmembers(module):
                 if inspect.isclass(member_obj):
                     clazz = getattr(module, member_name)
-                    ancestor_names = [
-                        base_class.__name__ for base_class in clazz.__bases__]
-                    if (
-                            'ndb.Model' in ancestor_names or
-                            'BaseModel' in ancestor_names or
-                            'VersionedModel' in ancestor_names):
+                    all_base_classes = [
+                        base_class.__name__ for base_class in inspect.getmro(
+                            clazz)]
+                    if 'Model' in all_base_classes:
                         names_of_ndb_model_subclasses.append(clazz.__name__)
 
         self.assertEqual(


### PR DESCRIPTION
##  Explanation
Fixes #6952: Added a backend test to ensure that all storage models have audit jobs

Addresses review comments in #7099 (I have also updated names in `storage_models_test.py` -- I used the code here for extracting model names)
  

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
