### PR TITLE
Fix #7126: Removes html validation and associated tests

### DIFF
--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -16,6 +16,8 @@
 
 """Domain objects relating to questions."""
 
+import datetime
+
 from constants import constants
 from core.domain import change_domain
 from core.domain import html_cleaner
@@ -438,6 +440,17 @@ class QuestionSummary(object):
             raise utils.ValidationError(
                 'Expected question content to be a string, received %s' %
                 self.question_content)
+
+        if not isinstance(self.created_on, datetime.datetime):
+            raise utils.ValidationError(
+                'Expected created on to be a datetime, received %s' %
+                self.created_on)
+
+        if not isinstance(self.last_updated, datetime.datetime):
+            raise utils.ValidationError(
+                'Expected last updated to be a datetime, received %s' %
+                self.last_updated)
+
 
 
 class QuestionSkillLink(object):

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -452,7 +452,6 @@ class QuestionSummary(object):
                 self.last_updated)
 
 
-
 class QuestionSkillLink(object):
     """Domain object for Question Skill Link.
 

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -19,7 +19,6 @@
 from constants import constants
 from core.domain import change_domain
 from core.domain import html_cleaner
-from core.domain import html_validation_service
 from core.domain import interaction_registry
 from core.domain import state_domain
 from core.platform import models
@@ -401,13 +400,7 @@ class QuestionSummary(object):
         """
         self.id = question_id
         self.creator_id = creator_id
-        # The initial clean up of html by converting it to ckeditor format
-        # is required since user may copy and paste some stuff in the rte
-        # which is not a valid ckeditor html string but can be converted
-        # to a valid ckeditor string without errors. This initial clean up
-        # ensures that validation will not fail in such cases.
-        self.question_content = html_validation_service.convert_to_ckeditor(
-            html_cleaner.clean(question_content))
+        self.question_content = html_cleaner.clean(question_content)
         self.created_on = question_model_created_on
         self.last_updated = question_model_last_updated
 
@@ -432,20 +425,19 @@ class QuestionSummary(object):
             ValidationError: One or more attributes of question summary are
                 invalid.
         """
-        err_dict = html_validation_service.validate_rte_format(
-            [self.question_content], feconf.RTE_FORMAT_CKEDITOR)
-        for key in err_dict:
-            if err_dict[key]:
-                raise utils.ValidationError(
-                    'Invalid html: %s for rte with invalid tags and '
-                    'strings: %s' % (self.question_content, err_dict))
-
-        err_dict = html_validation_service.validate_customization_args([
-            self.question_content])
-        if err_dict:
+        if not isinstance(self.id, basestring):
             raise utils.ValidationError(
-                'Invalid html: %s due to errors in customization_args: %s' % (
-                    self.question_content, err_dict))
+                'Expected id to be a string, received %s' % self.id)
+
+        if not isinstance(self.creator_id, basestring):
+            raise utils.ValidationError(
+                'Expected creator id to be a string, received %s' %
+                self.creator_id)
+
+        if not isinstance(self.question_content, basestring):
+            raise utils.ValidationError(
+                'Expected question content to be a string, received %s' %
+                self.question_content)
 
 
 class QuestionSkillLink(object):

--- a/core/domain/question_domain_test.py
+++ b/core/domain/question_domain_test.py
@@ -492,6 +492,20 @@ class QuestionSummaryTest(test_utils.GenericTestBase):
             'Expected question content to be a string, received 1'):
             self.observed_object.validate()
 
+    def test_validation_with_invalid_created_on(self):
+        self.observed_object.created_on = 1
+        with self.assertRaisesRegexp(
+            utils.ValidationError,
+            'Expected created on to be a datetime, received 1'):
+            self.observed_object.validate()
+
+    def test_validation_with_invalid_last_updated(self):
+        self.observed_object.last_updated = 1
+        with self.assertRaisesRegexp(
+            utils.ValidationError,
+            'Expected last updated to be a datetime, received 1'):
+            self.observed_object.validate()
+
 
 class QuestionSkillLinkDomainTest(test_utils.GenericTestBase):
     """Test for Question Skill Link Domain object."""

--- a/core/domain/question_domain_test.py
+++ b/core/domain/question_domain_test.py
@@ -472,34 +472,24 @@ class QuestionSummaryTest(test_utils.GenericTestBase):
     def test_validation_with_valid_properties(self):
         self.observed_object.validate()
 
-    def test_validation_with_invalid_html_in_question_content(self):
-        """Test validation fails with invalid html in question
-        content.
-        """
-        self.observed_object.question_content = '<a>Test</a>'
+    def test_validation_with_invalid_id(self):
+        self.observed_object.id = 1
         with self.assertRaisesRegexp(
-            utils.ValidationError, (
-                'Invalid html: <a>Test</a> for rte with invalid tags and '
-                'strings: {\'invalidTags\': \\[u\'a\'], '
-                '\'strings\': \\[\'<a>Test</a>\']}')):
+            utils.ValidationError, 'Expected id to be a string, received 1'):
             self.observed_object.validate()
 
-    def test_validation_with_invalid_customization_args_in_question_content(
-            self):
-        """Test validation fails with invalid customization args in question
-        content.
-        """
-        self.observed_object.question_content = (
-            '<oppia-noninteractive-image></oppia-noninteractive-image>')
+    def test_validation_with_invalid_creator_id(self):
+        self.observed_object.creator_id = 1
         with self.assertRaisesRegexp(
-            utils.ValidationError, (
-                'Invalid html: <oppia-noninteractive-image>'
-                '</oppia-noninteractive-image> due to errors in '
-                'customization_args: {"Missing attributes: '
-                '\\[u\'alt-with-value\', u\'caption-with-value\', '
-                'u\'filepath-with-value\'], Extra attributes: \\[]": '
-                '\\[\'<oppia-noninteractive-image>'
-                '</oppia-noninteractive-image>\']}')):
+            utils.ValidationError,
+            'Expected creator id to be a string, received 1'):
+            self.observed_object.validate()
+
+    def test_validation_with_invalid_question_content(self):
+        self.observed_object.question_content = 1
+        with self.assertRaisesRegexp(
+            utils.ValidationError,
+            'Expected question content to be a string, received 1'):
             self.observed_object.validate()
 
 

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -121,45 +121,6 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
         self.skill.misconceptions = ''
         self._assert_validation_error('Expected misconceptions to be a list')
 
-    def test_misconception_validation_with_invalid_html_in_notes(self):
-        self.skill.misconceptions[0].notes = '<a>Test</a>'
-        self._assert_validation_error(
-            'Invalid html: <a>Test</a> for rte with invalid tags and '
-            'strings: {\'invalidTags\': \\[u\'a\'], '
-            '\'strings\': \\[\'<a>Test</a>\']}')
-
-    def test_misconception_validation_with_invalid_customization_args_in_notes(
-            self):
-        self.skill.misconceptions[0].notes = (
-            '<oppia-noninteractive-image></oppia-noninteractive-image>')
-        self._assert_validation_error(
-            'Invalid html: <oppia-noninteractive-image>'
-            '</oppia-noninteractive-image> due to errors in '
-            'customization_args: {"Missing attributes: '
-            '\\[u\'alt-with-value\', u\'caption-with-value\', '
-            'u\'filepath-with-value\'], Extra attributes: \\[]": '
-            '\\[\'<oppia-noninteractive-image>'
-            '</oppia-noninteractive-image>\']}')
-
-    def test_misconception_validation_with_invalid_html_in_feedback(self):
-        self.skill.misconceptions[0].feedback = '<a>Test</a>'
-        self._assert_validation_error(
-            'Invalid html: <a>Test</a> for rte with invalid tags and '
-            'strings: {\'invalidTags\': \\[u\'a\'], '
-            '\'strings\': \\[\'<a>Test</a>\']}')
-
-    def test_misconception_validation_with_invalid_customization_args_in_feedback(self): # pylint: disable=line-too-long
-        self.skill.misconceptions[0].feedback = (
-            '<oppia-noninteractive-image></oppia-noninteractive-image>')
-        self._assert_validation_error(
-            'Invalid html: <oppia-noninteractive-image>'
-            '</oppia-noninteractive-image> due to errors in '
-            'customization_args: {"Missing attributes: '
-            '\\[u\'alt-with-value\', u\'caption-with-value\', '
-            'u\'filepath-with-value\'], Extra attributes: \\[]": '
-            '\\[\'<oppia-noninteractive-image>'
-            '</oppia-noninteractive-image>\']}')
-
     def test_skill_contents_validation(self):
         self.skill.skill_contents.worked_examples = ''
         self._assert_validation_error('Expected worked examples to be a list')

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -22,7 +22,6 @@ import logging
 from constants import constants
 from core.domain import customization_args_util
 from core.domain import html_cleaner
-from core.domain import html_validation_service
 from core.domain import interaction_registry
 from core.domain import param_domain
 import feconf
@@ -1200,13 +1199,7 @@ class SubtitledHtml(object):
                 a way as to contain a restricted set of HTML tags.
         """
         self.content_id = content_id
-        # The initial clean up of html by converting it to ckeditor format
-        # is required since user may copy and paste some stuff in the rte
-        # which is not a valid ckeditor html string but can be converted
-        # to a valid ckeditor string without errors. This initial clean up
-        # ensures that validation will not fail in such cases.
-        self.html = html_validation_service.convert_to_ckeditor(
-            html_cleaner.clean(html))
+        self.html = html_cleaner.clean(html)
         self.validate()
 
     def to_dict(self):
@@ -1249,21 +1242,6 @@ class SubtitledHtml(object):
         if not isinstance(self.html, basestring):
             raise utils.ValidationError(
                 'Invalid content HTML: %s' % self.html)
-
-        err_dict = html_validation_service.validate_rte_format(
-            [self.html], feconf.RTE_FORMAT_CKEDITOR)
-        for key in err_dict:
-            if err_dict[key]:
-                raise utils.ValidationError(
-                    'Invalid html: %s for rte with invalid tags and '
-                    'strings: %s' % (self.html, err_dict))
-
-        err_dict = html_validation_service.validate_customization_args([
-            self.html])
-        if err_dict:
-            raise utils.ValidationError(
-                'Invalid html: %s due to errors in customization_args: %s' % (
-                    self.html, err_dict))
 
     @classmethod
     def create_default_subtitled_html(cls, content_id):

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -407,40 +407,6 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             with self.swap(subtitled_html, 'html', 20):
                 subtitled_html.validate()
 
-    def test_subtitled_html_validation_with_invalid_html_for_rte(self):
-        """Test validation of subtitled HTML with invalid html for rte."""
-        subtitled_html = state_domain.SubtitledHtml(
-            'content_id', '<p>some html</p>')
-        subtitled_html.validate()
-
-        with self.assertRaisesRegexp(
-            utils.ValidationError, (
-                'Invalid html: <a>Test</a> for rte with invalid tags and '
-                'strings: {\'invalidTags\': \\[u\'a\'], '
-                '\'strings\': \\[\'<a>Test</a>\']}')):
-            with self.swap(subtitled_html, 'html', '<a>Test</a>'):
-                subtitled_html.validate()
-
-    def test_subtitled_html_validation_with_invalid_customization_args(self):
-        """Test validation of subtitled HTML with invalid customization args."""
-        subtitled_html = state_domain.SubtitledHtml(
-            'content_id', '<p>some html</p>')
-        subtitled_html.validate()
-
-        with self.assertRaisesRegexp(
-            utils.ValidationError, (
-                'Invalid html: <oppia-noninteractive-image>'
-                '</oppia-noninteractive-image> due to errors in '
-                'customization_args: {"Missing attributes: '
-                '\\[u\'alt-with-value\', u\'caption-with-value\', '
-                'u\'filepath-with-value\'], Extra attributes: \\[]": '
-                '\\[\'<oppia-noninteractive-image>'
-                '</oppia-noninteractive-image>\']}')):
-            with self.swap(
-                subtitled_html, 'html',
-                '<oppia-noninteractive-image></oppia-noninteractive-image>'):
-                subtitled_html.validate()
-
     def test_subtitled_html_validation_with_invalid_content(self):
         """Test validation of subtitled HTML with invalid content."""
         subtitled_html = state_domain.SubtitledHtml(


### PR DESCRIPTION
## Explanation
Fixes #7126, removes html validation to unblock the release process. The html validation will be added back once we figure out the issue causing the failure and fix it.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
