### PR TITLE
Fixed an import error when running backend tests

### DIFF
--- a/scripts/backend_tests.py
+++ b/scripts/backend_tests.py
@@ -182,12 +182,12 @@ class TestingTaskSpec(object):
         """Runs all tests corresponding to the given test target."""
         test_target_flag = '--test_target=%s' % self.test_target
 
+        # This is done because PYTHONPATH is modified while using importlib
+        # to import modules. PYTHONPATH is changed to comma separated list
+        # after which python is unable to find certain modules. So, the old
+        # PYTHONPATH is copied here to avoid import errors.
+        os.environ['PYTHONPATH'] = PYTHONPATH
         if self.generate_coverage_report:
-            # This is done because PYTHONPATH is modified while using importlib
-            # to import modules. PYTHONPATH is changed to comma separated list
-            # after which python is unable to find coverage module. So, the old
-            # PYTHONPATH is copied here to avoid import errors.
-            os.environ['PYTHONPATH'] = PYTHONPATH
             exc_list = [
                 'python', COVERAGE_PATH, 'run', '-p', TEST_RUNNER_PATH,
                 test_target_flag]


### PR DESCRIPTION
## Explanation
This PR fixes an issue that I had encountered when running backend tests locally, where when importing the package 'bleach' in some file, a lot of import paths became a single comma separated string and caused an import error, though the same didn't happen when running with coverage report enabled.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
