### PR TITLE
Fixes #7167: Move npm audit to pre submit hook

### DIFF
--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -2497,59 +2497,6 @@ class LintChecksManager(object):
 
         return summary_messages
 
-    def _check_npm_packages(self):
-        """Checks to ensure that npm packages are not identified as vulnerable
-        by npm audit.
-        """
-        parent_dir = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
-
-        npm_path = os.path.join(
-            parent_dir, 'oppia_tools', 'node-10.15.3', 'bin', 'npm')
-        if self.verbose_mode_enabled:
-            print 'Starting npm package vulnerability check...'
-            print '----------------------------------------'
-        print ''
-        if not self.verbose_mode_enabled:
-            print 'Checking npm packages.'
-
-        summary_messages = []
-        failed = False
-
-        proc_args = [npm_path, 'audit', '--parseable']
-        with _redirect_stdout(_TARGET_STDOUT):
-            proc = subprocess.Popen(
-                proc_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-            linter_stdout, _ = proc.communicate()
-
-            errors = linter_stdout.lstrip().rstrip()
-            if errors:
-                failed = True
-                error_list = errors.split('\n')
-                for line in error_list:
-                    line_tokens = line.split('\t')
-                    print ('%s package is vulnerable. Please run "%s" to '
-                           'update.' %
-                           (line_tokens[1], line_tokens[3]))
-
-            if failed:
-                print '(%s errors found)' % len(error_list)
-                summary_message = (
-                    '%s  npm package vulnerability check failed' % (
-                        _MESSAGE_TYPE_FAILED))
-            else:
-                summary_message = (
-                    '%s  npm package vulnerability check passed' % (
-                        _MESSAGE_TYPE_SUCCESS))
-            summary_messages.append(summary_message)
-
-            print ''
-            print summary_message
-            print ''
-
-        return summary_messages
-
-
     def perform_all_lint_checks(self):
         """Perform all the lint checks and returns the messages returned by all
         the checks.
@@ -2579,7 +2526,6 @@ class LintChecksManager(object):
         pattern_messages = self._check_bad_patterns()
         codeowner_messages = self._check_codeowner_file()
         constants_messages = self._check_constants_declaration()
-        npm_package_messages = self._check_npm_packages()
         all_messages = (
             extra_js_files_messages + js_and_ts_component_messages +
             directive_scope_messages + sorted_dependencies_messages +
@@ -2587,7 +2533,7 @@ class LintChecksManager(object):
             mandatory_patterns_messages + docstring_messages +
             comment_messages + html_tag_and_attribute_messages +
             html_linter_messages + linter_messages + pattern_messages +
-            codeowner_messages + constants_messages + npm_package_messages)
+            codeowner_messages + constants_messages)
         return all_messages
 
 

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -268,7 +268,7 @@ def _start_sh_script(scriptname):
     return task.returncode
 
 
-def _start_npm_audit(files):
+def _start_npm_audit():
     """Starts the npm audit checks and returns the returncode of the task."""
     task = subprocess.Popen([NPM_CMD, 'audit'])
     task.communicate()
@@ -378,7 +378,7 @@ def main():
                 lint_status = _start_linter(files_to_lint)
                 if lint_status != 0:
                     print ('Push failed, please correct the linting issues '
-                          ' above.')
+                           'above.')
                     sys.exit(1)
             if does_diff_include_package_json(files_to_lint):
                 npm_audit_status = _start_npm_audit()

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -50,8 +50,9 @@ SCRIPTS_DIR = os.path.join(OPPIA_DIR, 'scripts')
 LINTER_SCRIPT = 'pre_commit_linter.py'
 LINTER_FILE_FLAG = '--files'
 PYTHON_CMD = 'python'
+OPPIA_PARENT_DIR = os.path.join(FILE_DIR, os.pardir, os.pardir, os.pardir)
 NPM_CMD = os.path.join(
-    FILE_DIR, os.pardir, 'oppia_tools', 'node-10.15.3', 'bin', 'npm')
+    OPPIA_PARENT_DIR, 'oppia_tools', 'node-10.15.3', 'bin', 'npm')
 FRONTEND_TEST_SCRIPT = 'run_frontend_tests.sh'
 GIT_IS_DIRTY_CMD = 'git status --porcelain --untracked-files=no'
 

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -267,11 +267,13 @@ def _start_sh_script(scriptname):
     task.communicate()
     return task.returncode
 
+
 def _start_npm_audit(files):
     """Starts the npm audit checks and returns the returncode of the task."""
     task = subprocess.Popen([NPM_CMD, 'audit'])
     task.communicate()
     return task.returncode
+
 
 def _has_uncommitted_files():
     """Returns true if the repo contains modified files that are uncommitted.
@@ -328,6 +330,7 @@ def does_diff_include_js_or_ts_files(files_to_lint):
             return True
     return False
 
+
 def does_diff_include_package_json(files_to_lint):
     """Returns true if diff includes package.json or package-lock.json.
 
@@ -342,6 +345,7 @@ def does_diff_include_package_json(files_to_lint):
         if filename == 'package.json' or filename == 'package-lock.json':
             return True
     return False
+
 
 def main():
     """Main method for pre-push hook that executes the Python/JS linters on all

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -315,7 +315,7 @@ def _install_hook():
         raise ValueError(err_chmod_cmd)
 
 
-def does_diff_include_js_or_ts_files(files_to_lint):
+def _does_diff_include_js_or_ts_files(files_to_lint):
     """Returns true if diff includes JavaScript or TypeScript files.
 
     Args:
@@ -332,7 +332,7 @@ def does_diff_include_js_or_ts_files(files_to_lint):
     return False
 
 
-def does_diff_include_package_json(files_to_lint):
+def _does_diff_include_package_json(files_to_lint):
     """Returns true if diff includes package.json or package-lock.json.
 
     Args:
@@ -381,14 +381,14 @@ def main():
                     print ('Push failed, please correct the linting issues '
                            'above.')
                     sys.exit(1)
-            if does_diff_include_package_json(files_to_lint):
+            if _does_diff_include_package_json(files_to_lint):
                 npm_audit_status = _start_npm_audit()
                 if npm_audit_status != 0:
                     print ('Push failed, please correct the npm audit issues '
                            'above.')
                     sys.exit(1)
             frontend_status = 0
-            if does_diff_include_js_or_ts_files(files_to_lint):
+            if _does_diff_include_js_or_ts_files(files_to_lint):
                 frontend_status = _start_sh_script(FRONTEND_TEST_SCRIPT)
             if frontend_status != 0:
                 print 'Push aborted due to failing frontend tests.'

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -373,14 +373,14 @@ def main():
             if files_to_lint:
                 lint_status = _start_linter(files_to_lint)
                 if lint_status != 0:
-                    print "Push failed, please correct the linting issues "
-                        "above."
+                    print ('Push failed, please correct the linting issues '
+                          ' above.')
                     sys.exit(1)
             if does_diff_include_package_json(files_to_lint):
                 npm_audit_status = _start_npm_audit()
                 if npm_audit_status != 0:
-                    print "Push failed, please correct the npm audit issues "
-                        "above.'
+                    print ('Push failed, please correct the npm audit issues '
+                           'above.')
                     sys.exit(1)
             frontend_status = 0
             if does_diff_include_js_or_ts_files(files_to_lint):


### PR DESCRIPTION
## Explanation
Fixes #7167: Move the npm audit checks to the pre submit hook. This only activates if there are changes to package.json or package-lock.json.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
