### PR TITLE
Add setup.cfg

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -391,6 +391,10 @@
 /core/templates/dev/head/pages/exploration-editor-page/feedback-tab/ @nithusha21
 
 
+# Setup
+/setup.cfg @ankita240796
+
+
 # Simple pages.
 /core/controllers/pages*.py @vojtechjelinek
 /core/controllers/custom_landing_pages*.py @vojtechjelinek
@@ -423,10 +427,6 @@
 /webpack.config.ts @vojtechjelinek
 /webpack.dev.config.ts @vojtechjelinek
 /webpack.prod.config.ts @vojtechjelinek
-
-
-# Typings.
-/typings @ankita240796
 
 
 # User’s profile page.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+# This file is added to avoid pip setup issues while installing Oppia on MacOS.
+# Ref: https://stackoverflow.com/a/44728772.
+[install]
+prefix=


### PR DESCRIPTION
## Explanation
Added setup.cfg file to avoid setup issues with pip on MacOs. 

I have also removed typings from codeowners file since it was added twice ([Ref](https://github.com/oppia/oppia/pull/7256/files#diff-5cfb934ca0ec4c1743905a51dc428b84R15))

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
