### PR TITLE
Fix #7249: Bound max memory used by YUI compressor.

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -178,8 +178,13 @@ def _minify(source_path, target_path):
         target_path: str. Absolute path to location where to copy
             the minified file.
     """
-    cmd = 'java -jar %s %s -o %s' % (
-        YUICOMPRESSOR_DIR, source_path, target_path)
+    # The -Xmxn argument is an attempt to limit the max memory used when the
+    # minification process is running on CircleCI. Note that, from local
+    # experiments, 18m seems to work, but 12m is too small and results in an
+    # out-of-memory error.
+    # https://circleci.com/blog/how-to-handle-java-oom-errors/
+    cmd = 'java -Xmx24m -jar %s -o %s %s' % (
+        YUICOMPRESSOR_DIR, target_path, source_path)
     subprocess.check_call(cmd, shell=True)
 
 


### PR DESCRIPTION
## Explanation

This PR attempts to fix #7249 by bounding the max memory used by YUI compressor.

We should rerun the backend tests on CircleCI multiple times on this PR to make sure they pass every time. I think let's try for at least 5 times. If it passes all 5 then we can probably merge this.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.