### PR TITLE
Add env/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ libpeerconnection.log
 tsc_output_log.txt
 tmpcompiledjs*
 uploads/*
+env/
 venv/
 *.db
 .DS_Store


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

This PR adds the env/ directory to .gitignore.

**Reasons for:**
1) venv/ is listed in .gitignore, so it makes sense logical sense to have env/ (the other popular spelling for a virtual environment) in .gitignore.

2) The macOS installation instructions use "env" as the virtual environment name. Although the virtual environment is meant to be initialized in the opensource directory, it is a common error (one that I have made) to initialize the virtual environment in the oppia directory. Having env/ in .gitignore removes the occurrence of weird errors, namely "symbolic link errors" since the linter will attempt to lint the environment files if they aren't in .gitignore (or above the oppia/ directory).

**Counterarguments:**
1) It's better to omit it, since installation instructions specify opensource directory, so it shouldn't be an issue.
Response: It's an easy mistake to make and by that logic we should instead remove venv/ from .gitignore (though I anticipate that this will break various developers local repositories, those that have made this minor mistake but didn't notice since it was listed in .gitignore).

Note: The docs were recently changed to highlight the importance of placing the virtual environment in the opensource directory in response to this discrepancy Adding env/ to .gitignore is more of a convenience and fail-safe for the developer during the installation process than it is one of functionality (since it's arguably quite annoying to debug the errors you get from placing env/ in the oppia directory).

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
