### PR TITLE
Import Visualization Directives in Statistics Tab

### DIFF
--- a/core/templates/dev/head/pages/exploration-editor-page/statistics-tab/statistics-tab.directive.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/statistics-tab/statistics-tab.directive.ts
@@ -33,6 +33,10 @@ require('services/ComputeGraphService.ts');
 require('services/DateTimeFormatService.ts');
 require('services/ExplorationFeaturesService.ts');
 require('services/StateRulesStatsService.ts');
+require('visualizations/OppiaVisualizationBarChartDirective.ts');
+require(
+  'visualizations/OppiaVisualizationEnumeratedFrequencyTableDirective.ts');
+require('visualizations/OppiaVisualizationFrequencyTableDirective.ts');
 
 require('pages/exploration-editor-page/exploration-editor-page.constants.ts');
 


### PR DESCRIPTION
This change updates the Statistics Tab directive to require the visualizations for rendering the visualizations of statistics.