### PR TITLE
Persist Improvements Tab Cards while in Exploration Editor

### DIFF
--- a/core/templates/dev/head/pages/exploration-editor-page/exploration-editor-page.controller.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/exploration-editor-page.controller.ts
@@ -477,6 +477,7 @@ angular.module('oppia').directive('explorationEditorPage', [
               }
 
               $scope.$broadcast('refreshStatisticsTab');
+              $scope.$broadcast('refreshImprovementsTab');
               $scope.$broadcast('refreshVersionHistory', {
                 forceRefresh: true
               });

--- a/core/templates/dev/head/pages/exploration-editor-page/exploration-editor-page.directive.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/exploration-editor-page.directive.html
@@ -21,7 +21,7 @@
     <statistics-tab ng-show="$ctrl.getActiveTabName() === 'stats'">
     </statistics-tab>
 
-    <improvements-tab ng-if="$ctrl.getActiveTabName() === 'improvements'">
+    <improvements-tab ng-show="$ctrl.getActiveTabName() === 'improvements'">
     </improvements-tab>
 
     <settings-tab ng-show="$ctrl.getActiveTabName() === 'settings'" current-user-is-admin="$ctrl.currentUserIsAdmin" current-user-is-moderator="$ctrl.currentUserIsModerator">

--- a/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/improvements-tab.directive.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/improvements-tab.directive.ts
@@ -45,8 +45,10 @@ angular.module('oppia').directive('improvementsTab', [
         '$scope', 'ImprovementCardService',
         function($scope, ImprovementCardService) {
           var fetchedCards = [];
-          ImprovementCardService.fetchCards().then(function(cards) {
-            fetchedCards = cards;
+          $scope.$on('refreshImprovementsTab', function() {
+            ImprovementCardService.fetchCards().then(function(cards) {
+              fetchedCards = cards;
+            });
           });
 
           $scope.getCards = function() {


### PR DESCRIPTION
The Improvements Tab currently reloads all cards every time it the tab is navigated to, even though an actual page-reload doesn't happen. After this, the Improvements Tab will keep its cards around and work solely on those.