### PR TITLE
Fix Improvements Tab Navigation

### DIFF
--- a/core/templates/dev/head/pages/exploration-editor-page/editor-navigation/editor-navigation.directive.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/editor-navigation/editor-navigation.directive.html
@@ -75,7 +75,7 @@
     </a>
   </li>
 
-  <li ng-if="isLargeScreen && userIsLoggedIn && isImprovementsTabEnabled()" ng-class="{'active': getActiveTabName() === 'improvements'}" ng-click="selectImprovementsTab()">
+  <li ng-if="isLargeScreen && isImprovementsTabEnabled()" ng-class="{'active': getActiveTabName() === 'improvements'}" ng-click="selectImprovementsTab()">
     <a href="#" uib-tooltip="Improvements" tooltip-placement="bottom"
        class="oppia-editor-navbar-tab-anchor protractor-test-improvements-tab">
       <i class="material-icons">trending_up</i>
@@ -90,7 +90,7 @@
     </a>
   </li>
 
-  <li ng-if="isLargeScreen" ng-class="{'active': getActiveTabName() === 'feedback'}" ng-click="selectFeedbackTab()">
+  <li ng-if="isLargeScreen && isFeedbackTabEnabled()" ng-class="{'active': getActiveTabName() === 'feedback'}" ng-click="selectFeedbackTab()">
     <a href="#" uib-tooltip="Feedback" tooltip-placement="bottom"
        class="oppia-editor-navbar-tab-anchor protractor-test-feedback-tab">
       <i class="material-icons">&#xE87F;</i>

--- a/core/templates/dev/head/pages/exploration-editor-page/editor-navigation/editor-navigation.directive.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/editor-navigation/editor-navigation.directive.ts
@@ -56,8 +56,14 @@ angular.module('oppia').directive('editorNavigation', [
             postTutorialHelpPopoverIsShown: false
           };
           $scope.isLargeScreen = (WindowDimensionsService.getWidth() >= 1024);
-          $scope.isImprovementsTabEnabled =
-            ExplorationFeaturesService.isImprovementsTabEnabled;
+          $scope.isImprovementsTabEnabled = function() {
+            return ExplorationFeaturesService.isInitialized() &&
+              ExplorationFeaturesService.isImprovementsTabEnabled();
+          };
+          $scope.isFeedbackTabEnabled = function() {
+            return ExplorationFeaturesService.isInitialized() &&
+              !ExplorationFeaturesService.isImprovementsTabEnabled();
+          };
 
           $scope.$on('openPostTutorialHelpPopover', function() {
             if ($scope.isLargeScreen) {

--- a/core/templates/dev/head/pages/exploration-editor-page/exploration-editor-page.controller.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/exploration-editor-page.controller.ts
@@ -697,6 +697,16 @@ angular.module('oppia').directive('explorationEditorPage', [
             });
           };
 
+          ctrl.isImprovementsTabEnabled = function() {
+            return ExplorationFeaturesService.isInitialized() &&
+              ExplorationFeaturesService.isImprovementsTabEnabled();
+          };
+
+          ctrl.isFeedbackTabEnabled = function() {
+            return ExplorationFeaturesService.isInitialized() &&
+              !ExplorationFeaturesService.isImprovementsTabEnabled();
+          };
+
           ctrl.showWelcomeExplorationModal = function() {
             var modalInstance = $uibModal.open({
               templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(

--- a/core/templates/dev/head/pages/exploration-editor-page/exploration-editor-page.directive.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/exploration-editor-page.directive.html
@@ -21,7 +21,7 @@
     <statistics-tab ng-show="$ctrl.getActiveTabName() === 'stats'">
     </statistics-tab>
 
-    <improvements-tab ng-if="$ctrl.getActiveTabName() === 'improvements'">
+    <improvements-tab ng-if="$ctrl.isImprovementsTabEnabled()" ng-show="$ctrl.getActiveTabName() === 'improvements'">
     </improvements-tab>
 
     <settings-tab ng-show="$ctrl.getActiveTabName() === 'settings'" current-user-is-admin="$ctrl.currentUserIsAdmin" current-user-is-moderator="$ctrl.currentUserIsModerator">
@@ -30,7 +30,7 @@
     <history-tab ng-show="$ctrl.getActiveTabName() === 'history'">
     </history-tab>
 
-    <feedback-tab ng-show="$ctrl.getActiveTabName() === 'feedback'">
+    <feedback-tab ng-if="$ctrl.isFeedbackTabEnabled()" ng-show="$ctrl.getActiveTabName() === 'feedback'">
     </feedback-tab>
   </div>
 </div>

--- a/core/templates/dev/head/pages/exploration-editor-page/services/router.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/services/router.service.ts
@@ -94,9 +94,9 @@ angular.module('oppia').factory('RouterService', [
         $rootScope.$broadcast('refreshStatisticsTab');
       } else if (newPath === TABS.IMPROVEMENTS.path) {
         activeTabName = TABS.IMPROVEMENTS.name;
-        var waitForFeaturesServiceToLoad = $interval(function() {
+        var waitToCheckThatImprovementsTabIsEnabled = $interval(function() {
           if (ExplorationFeaturesService.isInitialized()) {
-            $interval.cancel(waitForFeaturesServiceToLoad);
+            $interval.cancel(waitToCheckThatImprovementsTabIsEnabled);
             if (!ExplorationFeaturesService.isImprovementsTabEnabled()) {
               RouterService.navigateToMainTab();
             }
@@ -110,9 +110,9 @@ angular.module('oppia').factory('RouterService', [
         activeTabName = TABS.HISTORY.name;
       } else if (newPath === TABS.FEEDBACK.path) {
         activeTabName = TABS.FEEDBACK.name;
-        var waitForFeaturesServiceToLoad = $interval(function() {
+        var waitToCheckThatFeedbackTabIsEnabled = $interval(function() {
           if (ExplorationFeaturesService.isInitialized()) {
-            $interval.cancel(waitForFeaturesServiceToLoad);
+            $interval.cancel(waitToCheckThatFeedbackTabIsEnabled);
             if (ExplorationFeaturesService.isImprovementsTabEnabled()) {
               RouterService.navigateToMainTab();
             }

--- a/core/templates/dev/head/pages/exploration-editor-page/services/router.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/services/router.service.ts
@@ -92,9 +92,16 @@ angular.module('oppia').factory('RouterService', [
       } else if (newPath === TABS.STATS.path) {
         activeTabName = TABS.STATS.name;
         $rootScope.$broadcast('refreshStatisticsTab');
-      } else if (newPath === TABS.IMPROVEMENTS.path &&
-                 isImprovementsTabEnabled()) {
+      } else if (newPath === TABS.IMPROVEMENTS.path) {
         activeTabName = TABS.IMPROVEMENTS.name;
+        var waitForFeaturesServiceToLoad = $interval(function() {
+          if (ExplorationFeaturesService.isInitialized()) {
+            $interval.cancel(waitForFeaturesServiceToLoad);
+            if (!ExplorationFeaturesService.isImprovementsTabEnabled()) {
+              RouterService.navigateToMainTab();
+            }
+          }
+        }, 5);
       } else if (newPath === TABS.HISTORY.path) {
         // TODO(sll): Do this on-hover rather than on-click.
         $rootScope.$broadcast('refreshVersionHistory', {
@@ -103,6 +110,14 @@ angular.module('oppia').factory('RouterService', [
         activeTabName = TABS.HISTORY.name;
       } else if (newPath === TABS.FEEDBACK.path) {
         activeTabName = TABS.FEEDBACK.name;
+        var waitForFeaturesServiceToLoad = $interval(function() {
+          if (ExplorationFeaturesService.isInitialized()) {
+            $interval.cancel(waitForFeaturesServiceToLoad);
+            if (ExplorationFeaturesService.isImprovementsTabEnabled()) {
+              RouterService.navigateToMainTab();
+            }
+          }
+        }, 5);
       } else if (newPath.indexOf('/gui/') === 0) {
         activeTabName = TABS.MAIN.name;
         _doNavigationWithState(newPath, SLUG_GUI);
@@ -180,8 +195,7 @@ angular.module('oppia').factory('RouterService', [
           currentPath === TABS.TRANSLATION.path ||
           currentPath === TABS.PREVIEW.path ||
           currentPath === TABS.STATS.path ||
-          (isImprovementsTabEnabled() &&
-            currentPath === TABS.IMPROVEMENTS.path) ||
+          currentPath === TABS.IMPROVEMENTS.path ||
           currentPath === TABS.SETTINGS.path ||
           currentPath === TABS.HISTORY.path ||
           currentPath === TABS.FEEDBACK.path);

--- a/core/templates/dev/head/services/ExplorationFeaturesService.ts
+++ b/core/templates/dev/head/services/ExplorationFeaturesService.ts
@@ -24,10 +24,11 @@ import { downgradeInjectable } from '@angular/upgrade/static';
   providedIn: 'root'
 })
 export class ExplorationFeaturesService {
+  static isInitialized = false;
   static settings = {
     isImprovementsTabEnabled: false,
     isPlaythroughRecordingEnabled: false,
-    areParametersEnabled: false
+    areParametersEnabled: false,
   }
 
   // TODO(#7176): Replace 'any' with the exact type. This has been kept as
@@ -35,6 +36,9 @@ export class ExplorationFeaturesService {
   // underscore_cased keys which give tslint errors against underscore_casing
   // in favor of camelCasing.
   init(explorationData: any, featuresData: any): void {
+    if (ExplorationFeaturesService.isInitialized) {
+      return;
+    }
     ExplorationFeaturesService.settings.isImprovementsTabEnabled =
       featuresData.is_improvements_tab_enabled;
     ExplorationFeaturesService.settings.isPlaythroughRecordingEnabled =
@@ -50,6 +54,11 @@ export class ExplorationFeaturesService {
         }
       }
     }
+    ExplorationFeaturesService.isInitialized = true;
+  }
+
+  isInitialized(): boolean {
+    return ExplorationFeaturesService.isInitialized;
   }
 
   areParametersEnabled(): boolean {

--- a/core/templates/dev/head/services/ExplorationFeaturesService.ts
+++ b/core/templates/dev/head/services/ExplorationFeaturesService.ts
@@ -24,7 +24,7 @@ import { downgradeInjectable } from '@angular/upgrade/static';
   providedIn: 'root'
 })
 export class ExplorationFeaturesService {
-  static isInitialized = false;
+  static serviceIsInitialized = false;
   static settings = {
     isImprovementsTabEnabled: false,
     isPlaythroughRecordingEnabled: false,
@@ -36,7 +36,7 @@ export class ExplorationFeaturesService {
   // underscore_cased keys which give tslint errors against underscore_casing
   // in favor of camelCasing.
   init(explorationData: any, featuresData: any): void {
-    if (ExplorationFeaturesService.isInitialized) {
+    if (ExplorationFeaturesService.serviceIsInitialized) {
       return;
     }
     ExplorationFeaturesService.settings.isImprovementsTabEnabled =
@@ -54,11 +54,11 @@ export class ExplorationFeaturesService {
         }
       }
     }
-    ExplorationFeaturesService.isInitialized = true;
+    ExplorationFeaturesService.serviceIsInitialized = true;
   }
 
   isInitialized(): boolean {
-    return ExplorationFeaturesService.isInitialized;
+    return ExplorationFeaturesService.serviceIsInitialized;
   }
 
   areParametersEnabled(): boolean {


### PR DESCRIPTION
This change fixes navigation to/from the Improvements Tab by:
- Hiding the Feedback Tab when the Improvements Tab is enabled (because the improvements tab already holds all the key functionality of the feedback tab).
- Allowing direct navigation to the improvements tab (when navigating to `/explore/expid#/improvements`)
- Caching improvement cards at page-load, instead of reloading them every time the tab is navigated to.