### PR TITLE
Fix #6161: Add a flag to override loading cached exploration data

### DIFF
--- a/core/templates/dev/head/pages/exploration-editor-page/preview-tab/preview-tab.directive.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/preview-tab/preview-tab.directive.ts
@@ -77,7 +77,7 @@ angular.module('oppia').directive('previewTab', [
             UrlInterpolationService) {
           var ctrl = this;
           ctrl.isExplorationPopulated = false;
-          ExplorationDataService.getData().then(function() {
+          ExplorationDataService.getData($.noop, true).then(function() {
             var initStateNameForPreview = StateEditorService
               .getActiveStateName();
             var manualParamChanges = [];

--- a/core/templates/dev/head/pages/exploration-editor-page/services/exploration-data.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/services/exploration-data.service.ts
@@ -104,8 +104,9 @@ angular.module('oppia').factory('ExplorationDataService', [
         });
       },
       // Returns a promise that supplies the data for the current exploration.
-      getData: function(errorCallback) {
-        if (explorationData.data) {
+      getData: function(errorCallback, overrideCache) {
+        var overrideCache = overrideCache || false;
+        if (explorationData.data && !overrideCache) {
           $log.info('Found exploration data in cache.');
           return $q.resolve(explorationData.data);
         } else {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #6161: Adds a flag to override loading cached data (since it doesn't contain unsaved draft changes).

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python scripts/pre_commit_linter.py` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
