### PR TITLE
Fixed #5138 : "ReferenceError: URL is not defined" from ImagePreloaderService

### DIFF
--- a/core/templates/dev/head/pages/exploration-player-page/services/image-preloader.service.ts
+++ b/core/templates/dev/head/pages/exploration-player-page/services/image-preloader.service.ts
@@ -63,7 +63,10 @@ angular.module('oppia').factory('ImagePreloaderService', [
           if (_isInFailedDownload(loadedImageFile.filename)) {
             _removeFromFailedDownload(loadedImageFile.filename);
           }
-          var objectUrl = URL.createObjectURL(loadedImageFile.data);
+          var objectUrl = (
+            window.URL || window.webkitURL || window ||
+            {}).createObjectURL(loadedImageFile.data);
+
           onLoadCallback(objectUrl);
         }, function(filename) {
           onErrorCallback();


### PR DESCRIPTION
Fixes #5138 
We were getting an error ``` URL is not defined ``` for browser Android 4.2.2, Mobile Safari 534.30.