### PR TITLE
Fix backend test that caused failures for some developers due to a time-calculation discrepancy.

### DIFF
--- a/core/controllers/cron.py
+++ b/core/controllers/cron.py
@@ -134,8 +134,7 @@ class CronMapreduceCleanupHandler(base.BaseHandler):
         min_age_msec = recency_msec
         # Only consider jobs that started at most 1 week before recency_msec.
         max_age_msec = recency_msec + 7 * 24 * 60 * 60 * 1000
-        # Compute max_start_time_msec, which is the latest start time that a
-        # job scheduled for cleanup may have.
+        # The latest start time that a job scheduled for cleanup may have.
         max_start_time_msec = (
             utils.get_current_time_in_millisecs() - min_age_msec)
 

--- a/core/controllers/cron.py
+++ b/core/controllers/cron.py
@@ -31,7 +31,6 @@ from core.domain import user_jobs_one_off
 from core.platform import models
 import feconf
 import python_utils
-import utils
 
 from pipeline import pipeline
 

--- a/core/controllers/cron.py
+++ b/core/controllers/cron.py
@@ -30,6 +30,7 @@ from core.domain import suggestion_services
 from core.domain import user_jobs_one_off
 from core.platform import models
 import feconf
+import python_utils
 import utils
 
 from pipeline import pipeline
@@ -146,7 +147,7 @@ class CronMapreduceCleanupHandler(base.BaseHandler):
         current_datetime = datetime.datetime.utcnow()
         current_time_in_millisecs = int(
             float(time.mktime(current_datetime.utctimetuple()) * 1000.0) +
-            current_datetime.microsecond / 1000.0)
+            python_utils.divide(current_datetime.microsecond, 1000.0))
         max_start_time_msec = current_time_in_millisecs - min_age_msec
 
         # Get all pipeline ids from jobs that started between max_age_msecs

--- a/core/controllers/cron.py
+++ b/core/controllers/cron.py
@@ -15,9 +15,7 @@
 """Controllers for the cron jobs."""
 from __future__ import absolute_import  # pylint: disable=import-only-modules
 
-import datetime
 import logging
-import time
 
 from core import jobs
 from core.controllers import acl_decorators
@@ -30,7 +28,7 @@ from core.domain import suggestion_services
 from core.domain import user_jobs_one_off
 from core.platform import models
 import feconf
-import python_utils
+import utils
 
 from pipeline import pipeline
 
@@ -137,17 +135,9 @@ class CronMapreduceCleanupHandler(base.BaseHandler):
         # Only consider jobs that started at most 1 week before recency_msec.
         max_age_msec = recency_msec + 7 * 24 * 60 * 60 * 1000
         # Compute max_start_time_msec, which is the latest start time that a
-        # job scheduled for cleanup may have. Note that this cannot use
-        # utils.get_current_time_in_millisecs() -- we need to follow the method
-        # of generating a start time in the GAE pipeline third-party library,
-        # otherwise tests will break in some geographic locations due to the
-        # discrepancy between the two methods of calculating the current
-        # datetime.
-        current_datetime = datetime.datetime.utcnow()
-        current_time_in_millisecs = int(
-            float(time.mktime(current_datetime.utctimetuple()) * 1000.0) +
-            python_utils.divide(current_datetime.microsecond, 1000.0))
-        max_start_time_msec = current_time_in_millisecs - min_age_msec
+        # job scheduled for cleanup may have.
+        max_start_time_msec = (
+            utils.get_current_time_in_millisecs() - min_age_msec)
 
         # Get all pipeline ids from jobs that started between max_age_msecs
         # and max_age_msecs + 1 week, before now.

--- a/utils.py
+++ b/utils.py
@@ -407,7 +407,7 @@ def get_time_in_millisecs(datetime_obj):
     Returns:
         float. This returns the time in the millisecond since the Epoch.
     """
-    seconds = time.mktime(datetime_obj.timetuple()) * 1000
+    seconds = time.mktime(datetime_obj.utctimetuple()) * 1000
     return seconds + python_utils.divide(datetime_obj.microsecond, 1000.0)
 
 


### PR DESCRIPTION
## Explanation

@U8NWXD and @MartzGub reported an error in backend tests when running `bash scripts/run_backend_tests.sh --test_target=core.controllers.cron_test.CronJobTests.test_clean_data_items_of_completed_map_reduce_jobs`. However, @ankita240796 ran the test and found no errors. There are also no errors when running the backend tests on CircleCI.

On further investigation, this appears to be due to a difference in how one of our controller handlers calculates the current UTC time, and how the third-party pipeline library does the same calculation. The difference is due to using timetuple() vs utctimetuple(), hence the change in this PR.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.