### PR TITLE
Stops the e2e tests to run if port 9001 is blocked

### DIFF
--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -96,6 +96,15 @@ if ( nc -vz localhost 8181 ); then
   exit 1
 fi
 
+if(nc -vz localhost 9001 ); then
+  echo ""
+  echo " There is a already a server running on localhost:9001."
+  echo " Please terminate it before running the end-to-end tests."
+  echo " Exiting."
+  echo ""
+  exit 1
+fi
+
 
 # Forces the cleanup function to run on exit.
 # Developers: note that at the end of this script, the cleanup() function at

--- a/scripts/run_e2e_tests.sh
+++ b/scripts/run_e2e_tests.sh
@@ -96,7 +96,7 @@ if ( nc -vz localhost 8181 ); then
   exit 1
 fi
 
-if(nc -vz localhost 9001 ); then
+if ( nc -vz localhost 9001 ); then
   echo ""
   echo " There is a already a server running on localhost:9001."
   echo " Please terminate it before running the end-to-end tests."


### PR DESCRIPTION
The end to end tests run on localhost:9001. In few cases, I've seen the user ends up suspending the tests in between. This sometimes does not turn off the server at running at 9001 and after that re-running the tests leads to error which is kind of not good to have -- has happened with me quite a few times.

cc / @seanlip @kevinlee12 (As per our discussion)
## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
