### PR TITLE
Fix #6931: Fix functionality of Download exploration button 

### DIFF
--- a/core/templates/dev/head/pages/exploration-editor-page/history-tab/history-tab.directive.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/history-tab/history-tab.directive.ts
@@ -59,6 +59,8 @@ angular.module('oppia').directive('historyTab', [
               '/createhandler/snapshots/' + ctrl.explorationId;
           ctrl.revertExplorationUrl =
             '/createhandler/revert/' + ctrl.explorationId;
+          ctrl.explorationDownloadUrl =
+            '/createhandler/download/' + ctrl.explorationId;
 
           /* Variable definitions:
           *


### PR DESCRIPTION
## Explanation
Fix #6931. Adds a missing variable to the directive which caused the downloads to break. /cc @aks681 this needs to be cherry picked
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
