### PR TITLE
Fix #7536: fa-times not loading correctly in the learner dashboard

### DIFF
--- a/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.directive.html
+++ b/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.directive.html
@@ -227,7 +227,7 @@
           <div ng-repeat="tile in $ctrl.incompleteExplorationsList | orderBy:$ctrl.getValueOfExplorationSortKey:$ctrl.isCurrentExpSortDescending | limitTo:$ctrl.PAGE_SIZE:$ctrl.startIncompleteExpIndex track by tile.id"
                style="display: inline-block; margin-left: 1px;"
                ng-mouseenter="showRemoveIcon=true" ng-mouseleave="showRemoveIcon=false">
-            <i class="remove-icon fab fa-times"
+            <i class="remove-icon fa fa-times"
                ng-show="showRemoveIcon"
                aria-hidden="true"
                ng-click="$ctrl.openRemoveActivityModal($ctrl.activeSection, $ctrl.activeSubsection, tile)"
@@ -339,7 +339,7 @@
                  ng-repeat="tile in $ctrl.explorationPlaylist track by $index"
                  ng-mouseenter="showRemoveIcon=true" ng-mouseleave="showRemoveIcon=false"
                  style="height: 145px; display: block;">
-              <i class="remove-icon fab fa-times"
+              <i class="remove-icon fa fa-times"
                  ng-show="showRemoveIcon"
                  aria-hidden="true"
                  style="color: black;"
@@ -393,7 +393,7 @@
           <div ng-repeat="tile in $ctrl.incompleteCollectionsList"
                style="display: inline-block; margin-left: 1px;"
                ng-mouseenter="showRemoveIcon=true" ng-mouseleave="showRemoveIcon=false">
-            <i class="remove-icon fab fa-times"
+            <i class="remove-icon fa fa-times"
                ng-show="showRemoveIcon"
                aria-hidden="true"
                ng-click="$ctrl.openRemoveActivityModal($ctrl.activeSection, $ctrl.activeSubsection, tile)"
@@ -455,7 +455,7 @@
                  ng-repeat="tile in $ctrl.collectionPlaylist track by $index"
                  style="display: inline-block; margin-left: 1px; height: 145px;"
                  ng-mouseenter="showRemoveIcon=true" ng-mouseleave="showRemoveIcon=false">
-              <i class="remove-icon fab fa-times"
+              <i class="remove-icon fa fa-times"
                  ng-show="showRemoveIcon"
                  style="color: black;"
                  aria-hidden="true"


### PR DESCRIPTION
## Explanation
Fix #7536. I have fixed 4 occurrences of "fab fa-times" to be "fa fa-times". The x loads correctly now. 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
