### PR TITLE
Fix #7540: Changes max-width value of .oppia-library-group

### DIFF
--- a/core/templates/dev/head/pages/library-page/library-page.directive.html
+++ b/core/templates/dev/head/pages/library-page/library-page.directive.html
@@ -198,7 +198,7 @@
     height: 350px;
     margin-bottom: 72px;
     margin-top: 36px;
-    max-width: 928px;
+    max-width: 944px;
     width: 100vw;
   }
   .oppia-library-group-header-container {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #7540, changed max-width value of .oppia-library-group

I think this issue is happening because of max-width property on .oppia-library-group.

https://drive.google.com/file/d/1tUA7kPOLCNSIrPb4jzjvm2866X7Zh06N/view

(8 + 40 + 8)px + 832px + (8 + 40 + 8 )px = 944px > 928px, so I think it should be 944px instead of 928 px over here.

![image](https://user-images.githubusercontent.com/16653571/64564878-2ad65c00-d370-11e9-9c8b-009117c51d21.png)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `bash scripts/run_frontend_tests.sh`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
