### PR TITLE
Remove dependency on ConverterMapping name in pylint

### DIFF
--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -34,4 +34,9 @@ sudo apt-get install python-dev
 sudo apt-get install python-pip
 sudo apt-get install unzip
 sudo apt-get install python-yaml
+# This is only done to address an
+#     "ImportError: No module named functools_lru_cache"
+# error. See the Troubleshooting page for details:
+#    https://github.com/oppia/oppia/wiki/Troubleshooting
+sudo apt-get install python-matplotlib
 sudo pip install --upgrade pip

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -229,7 +229,7 @@ def main(args=None):
     pip_dependencies = [
         ('pylint', '1.9.4', common.OPPIA_TOOLS_DIR),
         ('Pillow', '6.0.0', common.OPPIA_TOOLS_DIR),
-        ('pylint-quotes', '0.1.8', common.OPPIA_TOOLS_DIR),
+        ('pylint-quotes', '0.2.1', common.OPPIA_TOOLS_DIR),
         ('webtest', '2.0.33', common.OPPIA_TOOLS_DIR),
         ('isort', '4.3.20', common.OPPIA_TOOLS_DIR),
         ('pycodestyle', '2.5.0', common.OPPIA_TOOLS_DIR),

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -242,6 +242,23 @@ def main(args=None):
     for package, version, path in pip_dependencies:
         ensure_pip_library_is_installed(package, version, path)
 
+    # Do a little surgery on configparser in pylint-1.9.4 to remove dependency
+    # on ConverterMapping, which is not implemented in some Python
+    # distributions.
+    configparser_filepath = os.path.join(
+        common.OPPIA_TOOLS_DIR, 'pylint-1.9.4', 'configparser.py')
+    newlines = []
+    with python_utils.open_file(configparser_filepath, 'r') as f:
+        for line in f.readlines():
+            if line.strip() == 'ConverterMapping,':
+                continue
+            if line.strip().endswith('"ConverterMapping",'):
+                newlines.append(line[:line.find('"ConverterMapping"')] + '\n')
+            else:
+                newlines.append(line)
+    with python_utils.open_file(configparser_filepath, 'w+') as f:
+        f.writelines(newlines)
+
     # Download and install required JS and zip files.
     python_utils.PRINT('Installing third-party JS libraries and zip files.')
     install_third_party.main(args=[])

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -571,7 +571,7 @@ _PATHS_TO_INSERT = [
     os.path.join(_PARENT_DIR, 'oppia_tools', 'browsermob-proxy-0.8.0'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'esprima-4.0.1'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'pycodestyle-2.5.0'),
-    os.path.join(_PARENT_DIR, 'oppia_tools', 'pylint-quotes-0.1.8'),
+    os.path.join(_PARENT_DIR, 'oppia_tools', 'pylint-quotes-0.2.1'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'selenium-3.13.0'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'PyGithub-1.43.7'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'Pillow-6.0.0'),


### PR DESCRIPTION
## Explanation
On some Linux systems, pylint fails with "Cannot import name ConverterMapping" because that name is not available in backports.configparser. This change monkeypatches pylint to remove the dependency on that name.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.