### PR TITLE
Fix error in creator dashboard due to duplicate  prefixes.

### DIFF
--- a/core/templates/dev/head/pages/creator-dashboard-page/creator-dashboard-page.directive.html
+++ b/core/templates/dev/head/pages/creator-dashboard-page/creator-dashboard-page.directive.html
@@ -33,7 +33,7 @@
       <div class="total-open-feedback stats-card">
         <p class="stat-description" translate="I18N_DASHBOARD_STATS_TOTAL_SUBSCRIBERS"></p>
         <h1 class="stat-value-with-rating protractor-test-oppia-total-subscribers" ng-show="$ctrl.dashboardStats.num_ratings || $ctrl.relativeChangeInTotalPlays"><[$ctrl.subscribersList.length]></h1>
-        <h1 class="stat-value-without-rating" ng-hide="$ctrl.$ctrl.dashboardStats.num_ratings || $ctrl.relativeChangeInTotalPlays"><[$ctrl.subscribersList.length]></h1>
+        <h1 class="stat-value-without-rating" ng-hide="$ctrl.dashboardStats.num_ratings || $ctrl.relativeChangeInTotalPlays"><[$ctrl.subscribersList.length]></h1>
       </div>
     </md-card>
   </div>

--- a/core/templates/dev/head/pages/landing-pages/stewards-landing-page/stewards-landing-page.directive.html
+++ b/core/templates/dev/head/pages/landing-pages/stewards-landing-page/stewards-landing-page.directive.html
@@ -128,7 +128,7 @@
             <li ng-class="{active: $ctrl.isActiveTab($ctrl.TAB_NAME_PARENTS)}"><a ng-click="$ctrl.setActiveTabName($ctrl.TAB_NAME_PARENTS)">Parents</a></li>
             <li ng-class="{active: $ctrl.isActiveTab($ctrl.TAB_NAME_TEACHERS)}"><a ng-click="$ctrl.setActiveTabName($ctrl.TAB_NAME_TEACHERS)">Teachers</a></li>
             <li ng-class="{active: $ctrl.isActiveTab($ctrl.TAB_NAME_NONPROFITS)}"><a ng-click="$ctrl.setActiveTabName($ctrl.TAB_NAME_NONPROFITS)">NGOs</a></li>
-            <li ng-class="{active: $ctrl.isActiveTab($ctrl.TAB_NAME_VOLUNTEERS)}"><a ng-click="$ctrl.$ctrl.setActiveTabName($ctrl.TAB_NAME_VOLUNTEERS)">Volunteers</a></li>
+            <li ng-class="{active: $ctrl.isActiveTab($ctrl.TAB_NAME_VOLUNTEERS)}"><a ng-click="$ctrl.setActiveTabName($ctrl.TAB_NAME_VOLUNTEERS)">Volunteers</a></li>
           </ul>
         </div>
 


### PR DESCRIPTION
## Explanation

This fixes a bug in the creator dashboard which is leading to duplicate views of subscriber counts.

@ankita240796 -- please could we cherrypick this for the release, since it's a user-facing issue? Thanks!

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.