### PR TITLE
Remove dependency on ConverterMapping name in pylint-quotes

### DIFF
--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -245,19 +245,35 @@ def main(args=None):
     # Do a little surgery on configparser in pylint-1.9.4 to remove dependency
     # on ConverterMapping, which is not implemented in some Python
     # distributions.
-    configparser_filepath = os.path.join(
+    pylint_configparser_filepath = os.path.join(
         common.OPPIA_TOOLS_DIR, 'pylint-1.9.4', 'configparser.py')
-    newlines = []
-    with python_utils.open_file(configparser_filepath, 'r') as f:
+    pylint_newlines = []
+    with python_utils.open_file(pylint_configparser_filepath, 'r') as f:
         for line in f.readlines():
             if line.strip() == 'ConverterMapping,':
                 continue
             if line.strip().endswith('"ConverterMapping",'):
-                newlines.append(line[:line.find('"ConverterMapping"')] + '\n')
+                pylint_newlines.append(
+                    line[:line.find('"ConverterMapping"')] + '\n')
             else:
-                newlines.append(line)
-    with python_utils.open_file(configparser_filepath, 'w+') as f:
-        f.writelines(newlines)
+                pylint_newlines.append(line)
+    with python_utils.open_file(pylint_configparser_filepath, 'w+') as f:
+        f.writelines(pylint_newlines)
+
+    # Do similar surgery on configparser in pylint-quotes-0.1.8 to remove
+    # dependency on ConverterMapping.
+    pq_configparser_filepath = os.path.join(
+        common.OPPIA_TOOLS_DIR, 'pylint-quotes-0.1.8', 'configparser.py')
+    pq_newlines = []
+    with python_utils.open_file(pq_configparser_filepath, 'r') as f:
+        for line in f.readlines():
+            if line.strip() == 'ConverterMapping,':
+                continue
+            if line.strip == '"ConverterMapping",':
+                continue
+            pq_newlines.append(line)
+    with python_utils.open_file(pq_configparser_filepath, 'w+') as f:
+        f.writelines(pq_newlines)
 
     # Download and install required JS and zip files.
     python_utils.PRINT('Installing third-party JS libraries and zip files.')

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -269,7 +269,7 @@ def main(args=None):
         for line in f.readlines():
             if line.strip() == 'ConverterMapping,':
                 continue
-            if line.strip == '"ConverterMapping",':
+            if line.strip() == '"ConverterMapping",':
                 continue
             pq_newlines.append(line)
     with python_utils.open_file(pq_configparser_filepath, 'w+') as f:

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -98,7 +98,7 @@ def pip_install(package, version, install_path):
                 'Windows%29')
         raise Exception
 
-    subprocess.call([
+    subprocess.check_call([
         'pip', 'install', '%s==%s' % (package, version), '--target',
         install_path])
 
@@ -229,7 +229,7 @@ def main(args=None):
     pip_dependencies = [
         ('pylint', '1.9.4', common.OPPIA_TOOLS_DIR),
         ('Pillow', '6.0.0', common.OPPIA_TOOLS_DIR),
-        ('pylint-quotes', '0.2.1', common.OPPIA_TOOLS_DIR),
+        ('pylint-quotes', '0.1.8', common.OPPIA_TOOLS_DIR),
         ('webtest', '2.0.33', common.OPPIA_TOOLS_DIR),
         ('isort', '4.3.20', common.OPPIA_TOOLS_DIR),
         ('pycodestyle', '2.5.0', common.OPPIA_TOOLS_DIR),

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -571,7 +571,7 @@ _PATHS_TO_INSERT = [
     os.path.join(_PARENT_DIR, 'oppia_tools', 'browsermob-proxy-0.8.0'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'esprima-4.0.1'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'pycodestyle-2.5.0'),
-    os.path.join(_PARENT_DIR, 'oppia_tools', 'pylint-quotes-0.2.1'),
+    os.path.join(_PARENT_DIR, 'oppia_tools', 'pylint-quotes-0.1.8'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'selenium-3.13.0'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'PyGithub-1.43.7'),
     os.path.join(_PARENT_DIR, 'oppia_tools', 'Pillow-6.0.0'),


### PR DESCRIPTION
## Explanation

This is similar to #7631 -- on some Linux systems, pylint fails with "Cannot import name ConverterMapping" because that name is not available in configparser for pylint-quotes. This change monkeypatches pylint-quotes to remove the dependency on that name. It also causes pip to fail noisily when it cannot install a package (the absence of a noisy failure is why this error got missed the first time).

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.