### PR TITLE
Fix part of #5914: GeneralFeedbackThreadUserModel Takeout

### DIFF
--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -506,6 +506,25 @@ class GeneralFeedbackThreadUserModel(base_models.BaseModel):
         return super(GeneralFeedbackThreadUserModel, cls).get_multi(
             instance_ids)
 
+    @classmethod
+    def export_data(cls, user_id):
+        """Takeout: Export GeneralFeedbackThreadUserModel user-based properties.
+
+        Args:
+            user_id: str. The user_id denotes which user's data to extract.
+
+        Returns:
+            dict. A dict containing the user-relevant properties of
+            GeneralFeedbackThreadUserModel, i.e., which messages have been
+            read from the user (as a list of ids) in each thread.
+        """
+        found_models = cls.get_all().filter(cls.user_id == user_id)
+        user_data = {}
+        for user_model in found_models:
+            user_data[user_model.thread_id] = (
+                user_model.message_ids_read_by_user)
+        return user_data
+
 
 class FeedbackAnalyticsModel(base_models.BaseMapReduceBatchResultsModel):
     """Model for storing feedback thread analytics for an exploration.

--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -516,7 +516,7 @@ class GeneralFeedbackThreadUserModel(base_models.BaseModel):
         Returns:
             dict. A dict containing the user-relevant properties of
             GeneralFeedbackThreadUserModel, i.e., which messages have been
-            read from the user (as a list of ids) in each thread.
+            read by the user (as a list of ids) in each thread.
         """
         found_models = cls.get_all().filter(cls.user_id == user_id)
         user_data = {}

--- a/core/storage/feedback/gae_models_test.py
+++ b/core/storage/feedback/gae_models_test.py
@@ -250,6 +250,28 @@ class GeneralFeedbackMessageModelTests(test_utils.GenericTestBase):
 
 class FeedbackThreadUserModelTest(test_utils.GenericTestBase):
     """Tests for the FeedbackThreadUserModel class."""
+    USER_ID_A = 'user.id.a'
+    USER_ID_B = 'user_id_b'
+    THREAD_ID_A = 'exploration.exp_id.thread_id_a'
+    THREAD_ID_B = 'exploration.exp_id.thread_id_b'
+    THREAD_ID_C = 'exploration.exp_id.thread_id_c'
+    MESSAGE_IDS_READ_IN_THREAD_A = [0, 1, 2]
+    MESSAGE_IDS_READ_IN_THREAD_B = [3, 4]
+    MESSAGE_IDS_READ_IN_THREAD_C = [5, 6, 7, 8, 9]
+
+    def setUp(self):
+        super(FeedbackThreadUserModelTest, self).setUp()
+        model = feedback_models.GeneralFeedbackThreadUserModel.create(
+            self.USER_ID_A, self.THREAD_ID_A)
+        model.message_ids_read_by_user = self.MESSAGE_IDS_READ_IN_THREAD_A
+
+        model = feedback_models.GeneralFeedbackThreadUserModel.create(
+            self.USER_ID_A, self.THREAD_ID_B)
+        model.message_ids_read_by_user = self.MESSAGE_IDS_READ_IN_THREAD_B
+
+        model = feedback_models.GeneralFeedbackThreadUserModel.create(
+            self.USER_ID_A, self.THREAD_ID_C)
+        model.message_ids_read_by_user = self.MESSAGE_IDS_READ_IN_THREAD_C
 
     def test_put_function(self):
         feedback_thread_model = feedback_models.GeneralFeedbackThreadUserModel(
@@ -354,6 +376,23 @@ class FeedbackThreadUserModelTest(test_utils.GenericTestBase):
         self.assertEqual(
             actual_model_2.message_ids_read_by_user,
             expected_model_2.message_ids_read_by_user)
+
+    def test_export_data_general_case(self):
+        """Ensure export_data returns well-formed data in general case."""
+        user_data = feedback_models.GeneralFeedbackThreadUserModel.export_data(
+            self.USER_ID_A)
+        expected_data = {
+            self.THREAD_ID_A: self.MESSAGE_IDS_READ_IN_THREAD_A,
+            self.THREAD_ID_B: self.MESSAGE_IDS_READ_IN_THREAD_B,
+            self.THREAD_ID_C: self.MESSAGE_IDS_READ_IN_THREAD_C
+        }
+        self.assertDictEqual(expected_data, user_data)
+
+    def test_export_data_nonexistent_case(self):
+        """Ensure export data returns empty dict when data is not found."""
+        user_data = feedback_models.GeneralFeedbackThreadUserModel.export_data(
+            self.USER_ID_B)
+        self.assertEqual({}, user_data)
 
 
 class FeedbackAnalyticsModelTests(test_utils.GenericTestBase):


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

This pull request exports data for the "Feedback messages read" portion of Takeout, which contains one affected model.

**Affected models**: GeneralFeedbackThreadUserModel.

The **GeneralFeedbackThreadUserModel** is used for storing the ids of the messages in the thread that are read by the user. Instances of the class are keyed by [user_id].[thread_id]. We will export “message_ids_read_by_user,” which is the only property of the model. We are exporting this property since it is data that we store about the user’s behavior, so it is suitable for takeout.

```
{
    thread_id: <Integer List of message ids read by user>,
    thread_id: <Integer List of message ids read by user>,
    thread_id: <Integer List of message ids read by user>,
    ...
}
```

Note: Exporting this model was previously blocked. The initial PR is here https://github.com/oppia/oppia/pull/7322 and the PR that unblocked this model is here https://github.com/oppia/oppia/pull/7415. To summarize, exporting this model required the user_id and thread_id to be attributes of the model, since that is necessary for efficient querying from the datastore.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
