### PR TITLE
Fix part of #7427: Add Args and Returns to method docstring

### DIFF
--- a/main.py
+++ b/main.py
@@ -117,12 +117,12 @@ def get_redirect_route(regex_route, handler, defaults=None):
     with parameters should be formulated without the trailing slash.
 
     Args:
-        regex_route: string. The route to be redirected.
-        handler: callable or string. Custom handler method to be called.
-        defaults: dict or default. Default or extra keywords to be returned by this route.
+        regex_route: str. The route to be redirected.
+        handler: function | str. Custom handler method to be called.
+        defaults: dict | None. Default or extra keywords to be returned by this route.
 
     Returns:
-        string. Returns a route that redirects /foo/ to /foo.
+        Initializes the URL route
     """
     if defaults is None:
         defaults = {}

--- a/main.py
+++ b/main.py
@@ -115,6 +115,14 @@ def get_redirect_route(regex_route, handler, defaults=None):
 
     Warning: this method strips off parameters after the trailing slash. URLs
     with parameters should be formulated without the trailing slash.
+
+    Args:
+        regex_route: string. The route to be redirected.
+        handler: callable or string. Custom handler method to be called.
+        defaults: dict or default. Default or extra keywords to be returned by this route.
+
+    Returns:
+        string. Returns a route that redirects /foo/ to /foo.
     """
     if defaults is None:
         defaults = {}


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes part of #7427 : By adding Args and Returns in the docstring of the get_redirect_route function in the main.py file

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
