### PR TITLE
Fix mailgun issue arising due to Python encoding error

### DIFF
--- a/core/platform/email/mailgun_email_services.py
+++ b/core/platform/email/mailgun_email_services.py
@@ -85,9 +85,10 @@ def send_mail(
     data = {
         'from': sender_email,
         'to': recipient_email,
-        'subject': subject,
-        'text': plaintext_body,
-        'html': html_body}
+        'subject': subject.encode('utf-8'),
+        'text': plaintext_body.encode('utf-8'),
+        'html': html_body.encode('utf-8')
+    }
 
     if bcc_admin:
         data['bcc'] = feconf.ADMIN_EMAIL_ADDRESS
@@ -143,9 +144,9 @@ def send_bulk_mail(
         data = {
             'from': sender_email,
             'to': email_set,
-            'subject': subject,
-            'text': plaintext_body,
-            'html': html_body,
+            'subject': subject.encode('utf-8'),
+            'text': plaintext_body.encode('utf-8'),
+            'html': html_body.encode('utf-8'),
             'recipient-variables': '{}'}
 
         post_to_mailgun(data)

--- a/core/platform/email/mailgun_email_services.py
+++ b/core/platform/email/mailgun_email_services.py
@@ -85,9 +85,9 @@ def send_mail(
     data = {
         'from': sender_email,
         'to': recipient_email,
-        'subject': subject.encode('utf-8'),
-        'text': plaintext_body.encode('utf-8'),
-        'html': html_body.encode('utf-8')
+        'subject': subject.encode(encoding='utf-8'),
+        'text': plaintext_body.encode(encoding='utf-8'),
+        'html': html_body.encode(encoding='utf-8')
     }
 
     if bcc_admin:
@@ -144,9 +144,9 @@ def send_bulk_mail(
         data = {
             'from': sender_email,
             'to': email_set,
-            'subject': subject.encode('utf-8'),
-            'text': plaintext_body.encode('utf-8'),
-            'html': html_body.encode('utf-8'),
+            'subject': subject.encode(encoding='utf-8'),
+            'text': plaintext_body.encode(encoding='utf-8'),
+            'html': html_body.encode(encoding='utf-8'),
             'recipient-variables': '{}'}
 
         post_to_mailgun(data)

--- a/core/platform/email/mailgun_email_services_test.py
+++ b/core/platform/email/mailgun_email_services_test.py
@@ -38,9 +38,19 @@ class EmailTests(test_utils.GenericTestBase):
         swap_api = self.swap(feconf, 'MAILGUN_API_KEY', 'key')
         swap_domain = self.swap(feconf, 'MAILGUN_DOMAIN_NAME', 'domain')
         with swap_urlopen_context, swap_request_context, swap_api, swap_domain:
-            result = mailgun_email_services.post_to_mailgun({'data': 'data'})
+            result = mailgun_email_services.post_to_mailgun({
+                'from': 'a@a.com',
+                'to': 'b@b.com',
+                'subject': (
+                    'Hola 😂 - invitation to collaborate'.encode('utf-8')),
+                'text': 'plaintext_body 😂'.encode('utf-8'),
+                'html': 'Hi abc,<br> 😂'.encode('utf-8')
+            })
             expected = (
-                'https://api.mailgun.net/v3/domain/messages', 'data=data',
+                'https://api.mailgun.net/v3/domain/messages',
+                ('to=b%40b.com&text=plaintext_body+%F0%9F%98%82&html=Hi+abc'
+                 '%2C%3Cbr%3E+%F0%9F%98%82&from=a%40a.com&subject=Hola+%F0'
+                 '%9F%98%82+-+invitation+to+collaborate'),
                 {'Authorization': 'Basic YXBpOmtleQ=='})
             self.assertEqual(result, expected)
 

--- a/core/platform/email/mailgun_email_services_test.py
+++ b/core/platform/email/mailgun_email_services_test.py
@@ -41,10 +41,10 @@ class EmailTests(test_utils.GenericTestBase):
             result = mailgun_email_services.post_to_mailgun({
                 'from': 'a@a.com',
                 'to': 'b@b.com',
-                'subject': (
-                    'Hola 😂 - invitation to collaborate'.encode('utf-8')),
-                'text': 'plaintext_body 😂'.encode('utf-8'),
-                'html': 'Hi abc,<br> 😂'.encode('utf-8')
+                'subject': 'Hola 😂 - invitation to collaborate'.encode(
+                    encoding='utf-8'),
+                'text': 'plaintext_body 😂'.encode(encoding='utf-8'),
+                'html': 'Hi abc,<br> 😂'.encode(encoding='utf-8')
             })
             expected = (
                 'https://api.mailgun.net/v3/domain/messages',

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -175,7 +175,7 @@ class TaskThread(threading.Thread):
         except Exception as e:
             self.exception = e
             if 'KeyboardInterrupt' not in python_utils.convert_to_bytes(
-                    self.exception):
+                    self.exception.message):
                 log('ERROR %s: %.1f secs' %
                     (self.name, time.time() - self.start_time), show_time=True)
             self.finished = True
@@ -379,7 +379,7 @@ def main(args=None):
 
     for task in tasks:
         if task.exception:
-            log(python_utils.convert_to_bytes(task.exception))
+            log(python_utils.convert_to_bytes(task.exception.message))
 
     python_utils.PRINT('')
     python_utils.PRINT('+------------------+')
@@ -397,19 +397,20 @@ def main(args=None):
         if not task.finished:
             python_utils.PRINT('CANCELED  %s' % spec.test_target)
             test_count = 0
-        elif 'No tests were run' in python_utils.convert_to_bytes(
-                task.exception):
+        elif (task.exception and
+              'No tests were run' in python_utils.convert_to_bytes(
+                task.exception.message)):
             python_utils.PRINT(
                 'ERROR     %s: No tests found.' % spec.test_target)
             test_count = 0
         elif task.exception:
-            exc_str = python_utils.convert_to_bytes(task.exception)
+            exc_str = python_utils.convert_to_bytes(task.exception.message)
             python_utils.PRINT(exc_str[exc_str.find('='): exc_str.rfind('-')])
 
             tests_failed_regex_match = re.search(
                 r'Test suite failed: ([0-9]+) tests run, ([0-9]+) errors, '
                 '([0-9]+) failures',
-                python_utils.convert_to_bytes(task.exception))
+                python_utils.convert_to_bytes(task.exception.message))
 
             try:
                 test_count = int(tests_failed_regex_match.group(1))

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -175,7 +175,7 @@ class TaskThread(threading.Thread):
         except Exception as e:
             self.exception = e
             if 'KeyboardInterrupt' not in python_utils.convert_to_bytes(
-                    self.exception.message):
+                    self.exception.args[0]):
                 log('ERROR %s: %.1f secs' %
                     (self.name, time.time() - self.start_time), show_time=True)
             self.finished = True
@@ -379,7 +379,7 @@ def main(args=None):
 
     for task in tasks:
         if task.exception:
-            log(python_utils.convert_to_bytes(task.exception.message))
+            log(python_utils.convert_to_bytes(task.exception.args[0]))
 
     python_utils.PRINT('')
     python_utils.PRINT('+------------------+')
@@ -399,18 +399,18 @@ def main(args=None):
             test_count = 0
         elif (task.exception and
               'No tests were run' in python_utils.convert_to_bytes(
-                task.exception.message)):
+                task.exception.args[0])):
             python_utils.PRINT(
                 'ERROR     %s: No tests found.' % spec.test_target)
             test_count = 0
         elif task.exception:
-            exc_str = python_utils.convert_to_bytes(task.exception.message)
+            exc_str = python_utils.convert_to_bytes(task.exception.args[0])
             python_utils.PRINT(exc_str[exc_str.find('='): exc_str.rfind('-')])
 
             tests_failed_regex_match = re.search(
                 r'Test suite failed: ([0-9]+) tests run, ([0-9]+) errors, '
                 '([0-9]+) failures',
-                python_utils.convert_to_bytes(task.exception.message))
+                python_utils.convert_to_bytes(task.exception.args[0]))
 
             try:
                 test_count = int(tests_failed_regex_match.group(1))

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -399,7 +399,7 @@ def main(args=None):
             test_count = 0
         elif (task.exception and
               'No tests were run' in python_utils.convert_to_bytes(
-                task.exception.args[0])):
+                  task.exception.args[0])):
             python_utils.PRINT(
                 'ERROR     %s: No tests found.' % spec.test_target)
             test_count = 0


### PR DESCRIPTION
## Explanation
This PR fixes an issue that's causing mailgun to barf and not send emails. It's due to a unicode encoding error.

Also I was having lots of trouble debugging this because the exceptions kept throwing encoding errors as well. As it turns out, exceptions were being passed to convert_to_bytes() directly which shouldn't actually happen because the intended argument is a string. Using .args[0] on the exception to retrieve its message fixes this, and is compatible with python 3.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.