### PR TITLE
Fix #7648: Run third party dependencies lib script in pre commit linter

### DIFF
--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -23,15 +23,6 @@ it will only lint files that have been touched in this commit.
 
 This script ignores all filepaths contained within .eslintignore.
 
-IMPORTANT NOTES:
-
-1.  Before running this script, you must install third-party dependencies by
-    running
-
-        python -m scripts.install_third_party_libs
-
-    at least once.
-
 =====================
 CUSTOMIZATION OPTIONS
 =====================
@@ -70,6 +61,10 @@ import sys
 import tempfile
 import threading
 import time
+
+# Install third party dependencies before proceeding.
+from . import install_third_party_libs
+install_third_party_libs.main(args=[])
 
 import python_utils
 

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -66,7 +66,8 @@ import time
 from . import install_third_party_libs
 install_third_party_libs.main(args=[])
 
-import python_utils
+# pylint: disable=wrong-import-position
+import python_utils  # isort:skip
 
 _PARSER = argparse.ArgumentParser()
 _EXCLUSIVE_GROUP = _PARSER.add_mutually_exclusive_group()


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

Fixes #7648 by installing third party dependencies before running pre commit linter. 

A related PR: #7597 

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
