### PR TITLE
Fix #7660: Set maximum width for link field and set ellipsis on it

### DIFF
--- a/core/templates/dev/head/pages/exploration-editor-page/modal-templates/post-publish-modal.template.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/modal-templates/post-publish-modal.template.html
@@ -44,15 +44,15 @@
     background-color: #fcfcfc;
     border: 1px solid #d9d9d9;
     border-radius: 4px;
+    cursor: pointer;
     display: inline-block;
-    padding: 10px;
     margin-bottom: 2px;
     margin-top: 10px;
     max-width: 350px;
-    cursor: pointer;
+    overflow: hidden;
+    padding: 10px;
     text-overflow: ellipsis;
     white-space: nowrap;
-    overflow: hidden;
   }
 
   .oppia-share-publish-body .oppia-share-publish-link div:hover {

--- a/core/templates/dev/head/pages/exploration-editor-page/modal-templates/post-publish-modal.template.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/modal-templates/post-publish-modal.template.html
@@ -47,7 +47,12 @@
     display: inline-block;
     padding: 10px;
     margin-bottom: 2px;
+    margin-top: 10px;
+    max-width: 350px;
     cursor: pointer;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
   }
 
   .oppia-share-publish-body .oppia-share-publish-link div:hover {
@@ -57,7 +62,7 @@
   .oppia-share-publish-body .oppia-share-publish-link span {
     position: absolute;
     left: 481px;
-    top: 114px;
+    top: 124px;
   }
 
   .oppia-share-publish-body .oppia-share-publish-link i {


### PR DESCRIPTION
## Explanation
Fixes #7660: 
![image](https://user-images.githubusercontent.com/10142938/65660792-182a7b00-e030-11e9-9cf6-f0cbe9cf96b8.png)


## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
