### PR TITLE
Update thread status when suggestion is resolved

### DIFF
--- a/core/templates/dev/head/pages/exploration-editor-page/feedback-tab/services/thread-data.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/feedback-tab/services/thread-data.service.ts
@@ -20,6 +20,7 @@
 require('domain/feedback_thread/FeedbackThreadObjectFactory.ts');
 require('domain/suggestion/SuggestionObjectFactory.ts');
 require('domain/suggestion/SuggestionThreadObjectFactory.ts');
+require('pages/exploration-editor-page/exploration-editor-page.constants.ts');
 require('pages/exploration-editor-page/services/exploration-data.service.ts');
 require('services/AlertsService.ts');
 
@@ -29,11 +30,13 @@ require(
 angular.module('oppia').factory('ThreadDataService', [
   '$http', '$log', '$q', 'AlertsService', 'ExplorationDataService',
   'FeedbackThreadObjectFactory', 'SuggestionObjectFactory',
-  'SuggestionThreadObjectFactory', 'ACTION_ACCEPT_SUGGESTION',
+  'SuggestionThreadObjectFactory', 'ACTION_ACCEPT_SUGGESTION', 'STATUS_FIXED',
+  'STATUS_IGNORED',
   function(
       $http, $log, $q, AlertsService, ExplorationDataService,
       FeedbackThreadObjectFactory, SuggestionObjectFactory,
-      SuggestionThreadObjectFactory, ACTION_ACCEPT_SUGGESTION) {
+      SuggestionThreadObjectFactory, ACTION_ACCEPT_SUGGESTION, STATUS_FIXED,
+      STATUS_IGNORED) {
     var _expId = ExplorationDataService.explorationId;
     var _FEEDBACK_STATS_HANDLER_URL = '/feedbackstatshandler/' + _expId;
     var _THREAD_LIST_HANDLER_URL = '/threadlisthandler/' + _expId;
@@ -184,6 +187,8 @@ angular.module('oppia').factory('ThreadDataService', [
           review_message: reviewMsg,
           commit_message: action === ACTION_ACCEPT_SUGGESTION ? commitMsg : null
         }).then(function() {
+          thread.status =
+            action === ACTION_ACCEPT_SUGGESTION ? STATUS_FIXED : STATUS_IGNORED;
           _openThreadsCount -= 1;
         }).then(onSuccess, onFailure);
       }

--- a/core/tests/protractor_desktop/explorationImprovementsTab.js
+++ b/core/tests/protractor_desktop/explorationImprovementsTab.js
@@ -365,6 +365,14 @@ describe('Suggestions on Explorations', function() {
     improvementsTab.rejectSuggestion();
     improvementsTab.closeModal();
 
+    improvementsTab.setShowOnlyOpenTasks(false);
+    var acceptedTask = improvementsTab.getSuggestionTask(
+      suggestionDescription1);
+    var rejectedTask = improvementsTab.getSuggestionTask(
+      suggestionDescription2);
+    expect(improvementsTab.getTaskStatus(acceptedTask)).toEqual('Fixed');
+    expect(improvementsTab.getTaskStatus(rejectedTask)).toEqual('Ignored');
+
     explorationEditorPage.navigateToPreviewTab();
     explorationPlayerPage.expectContentToMatch(forms.toRichText(suggestion1));
 


### PR DESCRIPTION
Currently suggestion tasks which are resolved remain open until a hard-refresh. This PR fixes them so that they update immediately and disappear from the open-task view.