### PR TITLE
Fix #6920 - Made the translation editor scrollable, added max height

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1684,6 +1684,9 @@ pre.oppia-pre-wrapped-text {
 .oppia-editor-card-section {
   padding: 20px 50px 20px 35px;
   word-wrap: break-word;
+  max-height: 400px;
+  min-height: 100px;
+  overflow: scroll;
 }
 
 .oppia-state-content {


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixed #6920. The translation editor was small and hidden, so it was made larger. A max height and scrollable property was added to prevent overflow.

This is the change we made:

![Screenshot from 2019-10-03 12-29-49](https://user-images.githubusercontent.com/12968896/66153280-dcb81f80-e5e0-11e9-95a9-f05400215f03.png)

This is how it was before: 

![Screenshot from 2019-10-03 12-31-11](https://user-images.githubusercontent.com/12968896/66153282-dcb81f80-e5e0-11e9-8b68-ee3cac0a074c.png)
![Screenshot from 2019-10-03 12-31-19](https://user-images.githubusercontent.com/12968896/66153284-dcb81f80-e5e0-11e9-8c0b-084151ca534a.png)


## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.




