### PR TITLE
Fixes part of #7176: Converted dict keys to camelcase for ConceptCardObjectFactory

### DIFF
--- a/core/templates/dev/head/domain/skill/ConceptCardBackendApiServiceSpec.ts
+++ b/core/templates/dev/head/domain/skill/ConceptCardBackendApiServiceSpec.ts
@@ -36,7 +36,7 @@ describe('Concept card backend API service', function() {
         html: 'test explanation 1',
         content_id: 'explanation_1'
       },
-      worked_examples: [
+      workedExamples: [
         {
           html: 'test worked example 1',
           content_id: 'worked_example_1'
@@ -46,7 +46,7 @@ describe('Concept card backend API service', function() {
           content_id: 'worked_example_2'
         }
       ],
-      recorded_voiceovers: {
+      recordedVoiceovers: {
         voiceovers_mapping: {
           explanation: {},
           worked_example_1: {},
@@ -60,7 +60,7 @@ describe('Concept card backend API service', function() {
         html: 'test explanation 2',
         content_id: 'explanation_2'
       },
-      worked_examples: [
+      workedExamples: [
         {
           html: 'test worked example 3',
           content_id: 'worked_example_3'
@@ -70,7 +70,7 @@ describe('Concept card backend API service', function() {
           content_id: 'worked_example_4'
         }
       ],
-      recorded_voiceovers: {
+      recordedVoiceovers: {
         voiceovers_mapping: {
           explanation: {},
           worked_example_3: {},

--- a/core/templates/dev/head/domain/skill/ConceptCardObjectFactory.ts
+++ b/core/templates/dev/head/domain/skill/ConceptCardObjectFactory.ts
@@ -36,10 +36,10 @@ angular.module('oppia').factory('ConceptCardObjectFactory', [
     ConceptCard.prototype.toBackendDict = function() {
       return {
         explanation: this._explanation.toBackendDict(),
-        worked_examples: this._workedExamples.map(function(workedExample) {
+        workedExamples: this._workedExamples.map(function(workedExample) {
           return workedExample.toBackendDict();
         }),
-        recorded_voiceovers: this._recordedVoiceovers.toBackendDict()
+        recordedVoiceovers: this._recordedVoiceovers.toBackendDict()
       };
     };
 
@@ -74,9 +74,9 @@ angular.module('oppia').factory('ConceptCardObjectFactory', [
         SubtitledHtmlObjectFactory.createFromBackendDict(
           conceptCardBackendDict.explanation),
         _generateWorkedExamplesFromBackendDict(
-          conceptCardBackendDict.worked_examples),
+          conceptCardBackendDict.workedExamples),
         RecordedVoiceoversObjectFactory.createFromBackendDict(
-          conceptCardBackendDict.recorded_voiceovers));
+          conceptCardBackendDict.recordedVoiceovers));
     };
 
     ConceptCard.prototype.getExplanation = function() {

--- a/core/templates/dev/head/domain/skill/ConceptCardObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/skill/ConceptCardObjectFactorySpec.ts
@@ -64,7 +64,7 @@ describe('Concept card object factory', function() {
           html: 'test explanation',
           content_id: 'explanation',
         },
-        worked_examples: [
+        workedExamples: [
           {
             html: 'worked example 1',
             content_id: 'worked_example_1'
@@ -74,7 +74,7 @@ describe('Concept card object factory', function() {
             content_id: 'worked_example_2'
           }
         ],
-        recorded_voiceovers: {
+        recordedVoiceovers: {
           voiceovers_mapping: {
             explanation: {},
             worked_example_1: {},


### PR DESCRIPTION
## #7176  Explanation
There are a number of files that are currently using snake case key names - this switched them to camel case for two keys in the `ConceptCardObjectFactory`.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
