### PR TITLE
Reverts tests for Improvement tab added in #7719

### DIFF
--- a/core/tests/protractor_desktop/explorationImprovementsTab.js
+++ b/core/tests/protractor_desktop/explorationImprovementsTab.js
@@ -365,14 +365,6 @@ describe('Suggestions on Explorations', function() {
     improvementsTab.rejectSuggestion();
     improvementsTab.closeModal();
 
-    improvementsTab.setShowOnlyOpenTasks(false);
-    var acceptedTask = improvementsTab.getSuggestionTask(
-      suggestionDescription1);
-    var rejectedTask = improvementsTab.getSuggestionTask(
-      suggestionDescription2);
-    expect(improvementsTab.getTaskStatus(acceptedTask)).toEqual('Fixed');
-    expect(improvementsTab.getTaskStatus(rejectedTask)).toEqual('Ignored');
-
     explorationEditorPage.navigateToPreviewTab();
     explorationPlayerPage.expectContentToMatch(forms.toRichText(suggestion1));
 


### PR DESCRIPTION
## Explanation
Reverts test for Improvements tab added in #7719 since the PR was cherrypicked but the changes in #7679 which renamed the functions being used in test was not included due to which the tests fail on release branch. This PR will be cherrypicked in the release branch and then reverted on develop.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
