### PR TITLE
Revert "Reverts tests for Improvement tab added in #7719"

### DIFF
--- a/core/tests/protractor_desktop/explorationImprovementsTab.js
+++ b/core/tests/protractor_desktop/explorationImprovementsTab.js
@@ -365,6 +365,14 @@ describe('Suggestions on Explorations', function() {
     improvementsTab.rejectSuggestion();
     improvementsTab.closeModal();
 
+    improvementsTab.setShowOnlyOpenTasks(false);
+    var acceptedTask = improvementsTab.getSuggestionTask(
+      suggestionDescription1);
+    var rejectedTask = improvementsTab.getSuggestionTask(
+      suggestionDescription2);
+    expect(improvementsTab.getTaskStatus(acceptedTask)).toEqual('Fixed');
+    expect(improvementsTab.getTaskStatus(rejectedTask)).toEqual('Ignored');
+
     explorationEditorPage.navigateToPreviewTab();
     explorationPlayerPage.expectContentToMatch(forms.toRichText(suggestion1));
 


### PR DESCRIPTION
This Reverts the changes made in #7758 and re-introduces the required e2e tests.