### PR TITLE
Fix #7780: Fix return code for frontend tests

### DIFF
--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -277,6 +277,7 @@ def _start_python_script(scriptname):
         os.path.join('scripts', scriptname).replace('/', '.')]
     task = subprocess.Popen(cmd)
     task.communicate()
+    task.wait()
     return task.returncode
 
 

--- a/scripts/run_frontend_tests.py
+++ b/scripts/run_frontend_tests.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals  # pylint: disable=import-only-modules
 import argparse
 import os
 import subprocess
+import sys
 
 import python_utils
 
@@ -65,9 +66,13 @@ def main(args=None):
 
     build.main(args=[])
 
-    subprocess.call([
+    cmd = [
         os.path.join(common.NODE_MODULES_PATH, 'karma', 'bin', 'karma'),
-        'start', os.path.join('core', 'tests', 'karma.conf.ts')])
+        'start', os.path.join('core', 'tests', 'karma.conf.ts')]
+
+    task = subprocess.Popen(cmd)
+    task.communicate()
+    task.wait()
 
     if parsed_args.run_minified_tests is True:
         python_utils.PRINT('Running test in production environment')
@@ -80,6 +85,7 @@ def main(args=None):
             '--prodEnv'])
 
     python_utils.PRINT('Done!')
+    sys.exit(task.returncode)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Explanation

Fixes #7780: Ensure that the return code is returned after the frontend test script completes. 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
