### PR TITLE
Fix part of #7690: Refine ACLs for Improvement Tasks

### DIFF
--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -781,7 +781,7 @@ class LearnerAnswerInfoHandler(EditorHandler):
 
     GET_HANDLER_ERROR_RETURN_TYPE = feconf.HANDLER_TYPE_JSON
 
-    @acl_decorators.can_edit_entity
+    @acl_decorators.can_play_entity
     def get(self, entity_type, entity_id):
         """Handles the GET requests for learner answer info for an
         exploration state.

--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -567,7 +567,7 @@ class ResolveIssueHandler(EditorHandler):
     instances are deleted.
     """
 
-    @acl_decorators.can_view_exploration_stats
+    @acl_decorators.can_edit_exploration
     def post(self, exp_id):
         """Handles POST requests."""
         exp_issue_dict = self.payload.get('exp_issue_dict')

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactory.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactory.ts
@@ -64,9 +64,8 @@ angular.module('oppia').factory('PlaythroughImprovementTaskObjectFactory', [
         playthroughIds: issue.playthroughIds,
       };
 
-      UserService.getUserInfoAsync().then(userInfo => {
-        this._isEnabled = userInfo.isLoggedIn();
-      });
+      UserService.getUserInfoAsync()
+        .then(userInfo => this._isEnabled = userInfo.isLoggedIn());
     };
 
     /** @returns {string} - The actionable status of this task. */

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactory.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactory.ts
@@ -27,12 +27,12 @@ require('services/PlaythroughIssuesService.ts');
 
 angular.module('oppia').factory('PlaythroughImprovementTaskObjectFactory', [
   'ImprovementActionButtonObjectFactory', 'ImprovementModalService',
-  'PlaythroughIssuesService', 'PLAYTHROUGH_IMPROVEMENT_TASK_TYPE',
-  'STATUS_NOT_ACTIONABLE', 'STATUS_OPEN',
+  'PlaythroughIssuesService', 'UserService',
+  'PLAYTHROUGH_IMPROVEMENT_TASK_TYPE', 'STATUS_NOT_ACTIONABLE', 'STATUS_OPEN',
   function(
       ImprovementActionButtonObjectFactory, ImprovementModalService,
-      PlaythroughIssuesService, PLAYTHROUGH_IMPROVEMENT_TASK_TYPE,
-      STATUS_NOT_ACTIONABLE, STATUS_OPEN) {
+      PlaythroughIssuesService, UserService,
+      PLAYTHROUGH_IMPROVEMENT_TASK_TYPE, STATUS_NOT_ACTIONABLE, STATUS_OPEN) {
     /**
      * @constructor
      * @param {PlaythroughIssue} issue - The issue this task is referring to.
@@ -50,16 +50,23 @@ angular.module('oppia').factory('PlaythroughImprovementTaskObjectFactory', [
               'Mark as Resolved', 'btn-danger')
               .result.then(() => PlaythroughIssuesService.resolveIssue(issue))
               .then(() => this._isObsolete = true);
-          }),
+          },
+          () => this._isEnabled),
       ];
       /** @type {boolean} */
       this._isObsolete = false;
+      /** @type {boolean} */
+      this._isEnabled = false;
       /** @type {Object} */
       this._directiveData = {
         title: this._title,
         suggestions: PlaythroughIssuesService.renderIssueSuggestions(issue),
         playthroughIds: issue.playthroughIds,
       };
+
+      UserService.getUserInfoAsync().then(userInfo => {
+        this._isEnabled = userInfo.isLoggedIn();
+      });
     };
 
     /** @returns {string} - The actionable status of this task. */

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -91,7 +91,6 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
   var $rootScope = null;
   var $uibModal = null;
   var PlaythroughImprovementTaskObjectFactory = null;
-  var playthroughIssueObjectFactory = null;
   var PlaythroughIssuesService = null;
   var UserService = null;
   var PLAYTHROUGH_IMPROVEMENT_TASK_TYPE = null;
@@ -173,31 +172,33 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     }
   }));
 
+  beforeEach(angular.mock.inject(function(PlaythroughIssueObjectFactory) {
+    this.PlaythroughIssueObjectFactory = PlaythroughIssueObjectFactory;
+  }));
+
   beforeEach(angular.mock.inject(function(
       _$q_, _$rootScope_, _$uibModal_,
-      _PlaythroughImprovementTaskObjectFactory_,
-      _PlaythroughIssueObjectFactory_, _PlaythroughIssuesService_,
+      _PlaythroughImprovementTaskObjectFactory_, _PlaythroughIssuesService_,
       _UserService_, _PLAYTHROUGH_IMPROVEMENT_TASK_TYPE_) {
     $q = _$q_;
     $rootScope = _$rootScope_;
     $uibModal = _$uibModal_;
     PlaythroughImprovementTaskObjectFactory =
       _PlaythroughImprovementTaskObjectFactory_;
-    playthroughIssueObjectFactory = _PlaythroughIssueObjectFactory_;
     PlaythroughIssuesService = _PlaythroughIssuesService_;
     UserService = _UserService_;
     PLAYTHROUGH_IMPROVEMENT_TASK_TYPE = _PLAYTHROUGH_IMPROVEMENT_TASK_TYPE_;
 
-    PlaythroughIssuesService.initSession(expId, expVersion);
+    this.expId = '7';
+    this.expVersion = 1;
+    PlaythroughIssuesService.initSession(this.expId, this.expVersion);
 
-    var expId = '7';
-    var expVersion = 1;
     this.scope = $rootScope.$new();
   }));
 
   describe('.createNew', function() {
     it('retrieves data from passed issue', function() {
-      var issue = playthroughIssueObjectFactory.createFromBackendDict({
+      var issue = this.PlaythroughIssueObjectFactory.createFromBackendDict({
         issue_type: 'EarlyQuit',
         issue_customization_args: {
           state_name: {value: 'Hola'},
@@ -210,23 +211,22 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
 
       var task = PlaythroughImprovementTaskObjectFactory.createNew(issue);
 
-      expect(task.getTitle()).toEqual(
-        PlaythroughIssuesService.renderIssueStatement(issue));
+      expect(task.getTitle())
+        .toEqual(PlaythroughIssuesService.renderIssueStatement(issue));
       expect(task.getDirectiveData()).toEqual({
         title: PlaythroughIssuesService.renderIssueStatement(issue),
-        suggestions:
-          PlaythroughIssuesService.renderIssueSuggestions(issue),
+        suggestions: PlaythroughIssuesService.renderIssueSuggestions(issue),
         playthroughIds: ['1', '2'],
       });
-      expect(task.getDirectiveType()).toEqual(
-        PLAYTHROUGH_IMPROVEMENT_TASK_TYPE);
+      expect(task.getDirectiveType())
+        .toEqual(PLAYTHROUGH_IMPROVEMENT_TASK_TYPE);
     });
   });
 
   describe('.fetchTasks', function() {
     it('returns a task for each existing issue', function(done) {
       var earlyQuitIssue =
-        playthroughIssueObjectFactory.createFromBackendDict({
+        this.PlaythroughIssueObjectFactory.createFromBackendDict({
           issue_type: 'EarlyQuit',
           issue_customization_args: {
             state_name: {value: 'Hola'},
@@ -240,7 +240,7 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
         PlaythroughIssuesService.renderIssueStatement(earlyQuitIssue);
 
       var multipleIncorrectSubmissionsIssue =
-        playthroughIssueObjectFactory.createFromBackendDict({
+        this.PlaythroughIssueObjectFactory.createFromBackendDict({
           issue_type: 'MultipleIncorrectSubmissions',
           issue_customization_args: {
             state_name: {value: 'Hola'},
@@ -255,7 +255,7 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
           multipleIncorrectSubmissionsIssue);
 
       var cyclicTransitionsIssue =
-        playthroughIssueObjectFactory.createFromBackendDict({
+        this.PlaythroughIssueObjectFactory.createFromBackendDict({
           issue_type: 'CyclicTransitions',
           issue_customization_args: {
             state_names: {value: ['Hola', 'Me Llamo', 'Hola']},
@@ -290,7 +290,7 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
 
   describe('PlaythroughImprovementTask', function() {
     beforeEach(function() {
-      this.issue = playthroughIssueObjectFactory.createFromBackendDict({
+      this.issue = this.PlaythroughIssueObjectFactory.createFromBackendDict({
         issue_type: 'EarlyQuit',
         issue_customization_args: {
           state_name: {value: 'Hola'},

--- a/core/templates/dev/head/pages/exploration-editor-page/editor-navigation/editor-navigation.directive.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/editor-navigation/editor-navigation.directive.html
@@ -76,7 +76,7 @@
     </a>
   </li>
 
-  <li ng-if="isLargeScreen && userIsLoggedIn" ng-class="{'active': getActiveTabName() === 'stats'}"
+  <li ng-if="isLargeScreen" ng-class="{'active': getActiveTabName() === 'stats'}"
       class="nav-item">
     <a  href="#" uib-tooltip="Statistics" tooltip-placement="bottom" ng-click="selectStatsTab()"
        class="nav-link oppia-editor-navbar-tab-anchor protractor-test-stats-tab">

--- a/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/services/improvement-modal.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/services/improvement-modal.service.ts
@@ -58,6 +58,7 @@ angular.module('oppia').factory('ImprovementModalService', [
           controller: [
             '$scope', '$uibModalInstance', 'isUserLoggedIn',
             function($scope, $uibModalInstance, isUserLoggedIn) {
+              $scope.isUserLoggedIn = isUserLoggedIn;
               $scope.selectedLearnerAnswerInfo = [];
               $scope.learnerAnswerDetails = learnerAnswerDetails;
               $scope.currentLearnerAnswerInfo = null;

--- a/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/templates/answer-details-modal.template.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/templates/answer-details-modal.template.html
@@ -18,7 +18,7 @@
       <tr ng-repeat="learnerAnswerInfo in getLearnerAnswerInfos()" class="oppia-feedback-tab-row">
         <th scope="row">
           <input type="checkbox" ng-change="selectLearnerAnswerInfo(learnerAnswerInfo)"
-                 ng-model="myVal">
+                 ng-model="myVal" ng-disabled="!isUserLoggedIn">
         </th>
         <td ng-click="changeView(learnerAnswerInfo)">
           <angular-html-bind html-data="getLearnerAnswerHtml(learnerAnswerInfo)">
@@ -44,7 +44,7 @@
     </div>
   </div>
   <div class="modal-footer">
-    <button ng-disabled="!selectedLearnerAnswerInfo.length"
+    <button ng-disabled="!isUserLoggedIn || !selectedLearnerAnswerInfo.length"
             ng-click="deleteSelectedLearnerAnswerInfo()"
             class="btn btn-danger modal-button oppia-delete-select">
       Delete selected items

--- a/core/tests/protractor_desktop/explorationImprovementsTab.js
+++ b/core/tests/protractor_desktop/explorationImprovementsTab.js
@@ -34,7 +34,7 @@ var ExplorationPlayerPage =
 var LibraryPage = require('../protractor_utils/LibraryPage.js');
 
 
-fdescribe('Answer Details Improvements', function() {
+describe('Answer Details Improvements', function() {
   var EXPLORATION_TITLE = 'Check';
   var EXPLORATION_OBJECTIVE = 'To explore something';
   var EXPLORATION_CATEGORY = 'Algorithms';
@@ -104,7 +104,7 @@ fdescribe('Answer Details Improvements', function() {
     users.logout();
   });
 
-  fdescribe('checks solicit answer details feature', function() {
+  describe('checks solicit answer details feature', function() {
     beforeAll(function() {
       users.login('learner@user.com');
       libraryPage.get();
@@ -132,7 +132,7 @@ fdescribe('Answer Details Improvements', function() {
       users.logout();
     });
 
-    fit('is visible for guests', function() {
+    it('is visible for guests', function() {
       general.openEditor(this.expId);
       explorationEditorPage.navigateToImprovementsTab();
 

--- a/core/tests/protractor_desktop/explorationImprovementsTab.js
+++ b/core/tests/protractor_desktop/explorationImprovementsTab.js
@@ -57,15 +57,12 @@ describe('Answer Details Improvements', function() {
     explorationPlayerPage = new ExplorationPlayerPage.ExplorationPlayerPage();
     libraryPage = new LibraryPage.LibraryPage();
     creatorDashboardPage = new CreatorDashboardPage.CreatorDashboardPage();
-    explorationPlayerPage =
-      new ExplorationPlayerPage.ExplorationPlayerPage();
 
     improvementsTab = explorationEditorPage.getImprovementsTab();
 
-    users.createUser(
-      'learner@user.com', 'learnerUser');
+    users.createUser('learner@ExplorationAnswerDetails.com', 'learnerUser');
     users.createAndLoginAdminUser(
-      'creator@user.com', 'creatorUser');
+      'creator@ExplorationAnswerDetails.com', 'creatorUser');
 
     adminPage.editConfigProperty(
       'Always ask learners for answer details. For testing -- do not use',
@@ -104,9 +101,9 @@ describe('Answer Details Improvements', function() {
     users.logout();
   });
 
-  describe('checks solicit answer details feature', function() {
+  describe('Solicit answer details', function() {
     beforeAll(function() {
-      users.login('learner@user.com');
+      users.login('learner@ExplorationAnswerDetails.com');
       libraryPage.get();
       libraryPage.findExploration(EXPLORATION_TITLE);
       libraryPage.playExploration(EXPLORATION_TITLE);
@@ -120,7 +117,7 @@ describe('Answer Details Improvements', function() {
     });
 
     it('is visible for creators', function() {
-      users.login('creator@user.com');
+      users.login('creator@ExplorationAnswerDetails.com');
       creatorDashboardPage.get();
       creatorDashboardPage.navigateToExplorationEditor();
       explorationEditorPage.navigateToImprovementsTab();

--- a/core/tests/protractor_desktop/explorationImprovementsTab.js
+++ b/core/tests/protractor_desktop/explorationImprovementsTab.js
@@ -34,7 +34,7 @@ var ExplorationPlayerPage =
 var LibraryPage = require('../protractor_utils/LibraryPage.js');
 
 
-describe('Answer Details Improvements', function() {
+fdescribe('Answer Details Improvements', function() {
   var EXPLORATION_TITLE = 'Check';
   var EXPLORATION_OBJECTIVE = 'To explore something';
   var EXPLORATION_CATEGORY = 'Algorithms';
@@ -77,6 +77,7 @@ describe('Answer Details Improvements', function() {
 
     // Creator creates and publishes an exploration.
     workflow.createExplorationAsAdmin();
+    general.getExplorationIdFromEditor().then(expId => this.expId = expId);
     explorationEditorMainTab.exitTutorial();
 
     explorationEditorPage.navigateToSettingsTab();
@@ -100,30 +101,46 @@ describe('Answer Details Improvements', function() {
     explorationEditorMainTab.setInteraction('EndExploration');
     explorationEditorPage.saveChanges();
     workflow.publishExploration();
+    users.logout();
   });
 
-  it('checks solicit answer details feature', function() {
-    users.login('learner@user.com');
-    libraryPage.get();
-    libraryPage.findExploration(EXPLORATION_TITLE);
-    libraryPage.playExploration(EXPLORATION_TITLE);
-    explorationPlayerPage.submitAnswer('TextInput', 'One');
-    explorationPlayerPage.submitAnswerDetails('I liked this choice of answer');
-    explorationPlayerPage.expectExplorationToNotBeOver();
+  fdescribe('checks solicit answer details feature', function() {
+    beforeAll(function() {
+      users.login('learner@user.com');
+      libraryPage.get();
+      libraryPage.findExploration(EXPLORATION_TITLE);
+      libraryPage.playExploration(EXPLORATION_TITLE);
+      explorationPlayerPage.submitAnswer('TextInput', 'One');
+      explorationPlayerPage.submitAnswerDetails(
+        'I liked this choice of answer');
+      explorationPlayerPage.expectExplorationToNotBeOver();
+      oppiaLogo.click();
+      general.acceptAlert();
+      users.logout();
+    });
 
-    oppiaLogo.click();
-    general.acceptAlert();
-    users.logout();
-    users.login('creator@user.com');
-    creatorDashboardPage.get();
-    creatorDashboardPage.navigateToExplorationEditor();
-    explorationEditorPage.navigateToImprovementsTab();
+    it('is visible for creators', function() {
+      users.login('creator@user.com');
+      creatorDashboardPage.get();
+      creatorDashboardPage.navigateToExplorationEditor();
+      explorationEditorPage.navigateToImprovementsTab();
 
-    var task = improvementsTab.getAnswerDetailsTask('One');
-    improvementsTab.clickTaskActionButton(task, 'Review Answer Details');
-    improvementsTab.verifyAnswerDetails('I liked this choi...', 1);
-    improvementsTab.closeModal();
-    users.logout();
+      var task = improvementsTab.getAnswerDetailsTask('One');
+      improvementsTab.clickTaskActionButton(task, 'Review Answer Details');
+      improvementsTab.verifyAnswerDetails('I liked this choi...', 1);
+      improvementsTab.closeModal();
+      users.logout();
+    });
+
+    fit('is visible for guests', function() {
+      general.openEditor(this.expId);
+      explorationEditorPage.navigateToImprovementsTab();
+
+      var task = improvementsTab.getAnswerDetailsTask('One');
+      improvementsTab.clickTaskActionButton(task, 'Review Answer Details');
+      improvementsTab.verifyAnswerDetails('I liked this choi...', 1);
+      improvementsTab.closeModal();
+    });
   });
 
   afterAll(function() {
@@ -177,6 +194,7 @@ describe('Feedback Improvements', function() {
 
     // Creator creates and publishes an exploration.
     users.login('creator@ExplorationFeedback.com');
+
     workflow.createAndPublishExploration(
       EXPLORATION_TITLE_1,
       EXPLORATION_CATEGORY,

--- a/core/tests/protractor_desktop/explorationImprovementsTab.js
+++ b/core/tests/protractor_desktop/explorationImprovementsTab.js
@@ -191,7 +191,6 @@ describe('Feedback Improvements', function() {
 
     // Creator creates and publishes an exploration.
     users.login('creator@ExplorationFeedback.com');
-
     workflow.createAndPublishExploration(
       EXPLORATION_TITLE_1,
       EXPLORATION_CATEGORY,


### PR DESCRIPTION
Fixes part of #7690 

The ACL requirements for reading answer info is currently too strict, guests should be allowed to view the stats but the ACLs require edit-permissions. This PR updates the ACLs of getting answer infos, and protects guests from facing other errors by disabling elements which require them to have edit ACLs.