### PR TITLE
Fix part of #7690: Only fetch playthroughs when an exploration can record playthroughs

### DIFF
--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactory.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactory.ts
@@ -24,15 +24,16 @@ require(
   'pages/exploration-editor-page/improvements-tab/services/' +
   'improvement-modal.service.ts');
 require('services/PlaythroughIssuesService.ts');
+require('services/ExplorationFeaturesService.ts');
 
 angular.module('oppia').factory('PlaythroughImprovementTaskObjectFactory', [
-  'ImprovementActionButtonObjectFactory', 'ImprovementModalService',
-  'PlaythroughIssuesService', 'PLAYTHROUGH_IMPROVEMENT_TASK_TYPE',
-  'STATUS_NOT_ACTIONABLE', 'STATUS_OPEN',
+  '$q', 'ExplorationFeaturesService', 'ImprovementActionButtonObjectFactory',
+  'ImprovementModalService', 'PlaythroughIssuesService',
+  'PLAYTHROUGH_IMPROVEMENT_TASK_TYPE', 'STATUS_NOT_ACTIONABLE', 'STATUS_OPEN',
   function(
-      ImprovementActionButtonObjectFactory, ImprovementModalService,
-      PlaythroughIssuesService, PLAYTHROUGH_IMPROVEMENT_TASK_TYPE,
-      STATUS_NOT_ACTIONABLE, STATUS_OPEN) {
+      $q, ExplorationFeaturesService, ImprovementActionButtonObjectFactory,
+      ImprovementModalService, PlaythroughIssuesService,
+      PLAYTHROUGH_IMPROVEMENT_TASK_TYPE, STATUS_NOT_ACTIONABLE, STATUS_OPEN) {
     /**
      * @constructor
      * @param {PlaythroughIssue} issue - The issue this task is referring to.
@@ -117,6 +118,11 @@ angular.module('oppia').factory('PlaythroughImprovementTaskObjectFactory', [
        *    playthrough issues associated to the current exploration.
        */
       fetchTasks: function() {
+        // TODO(#7816): Remove this branch once all explorations maintain an
+        // ExplorationIssuesModel.
+        if (ExplorationFeaturesService.isPlaythroughRecordingEnabled()) {
+          return $q.resolve([]);
+        }
         return PlaythroughIssuesService.getIssues().then(function(issues) {
           return issues.map(function(issue) {
             return new PlaythroughImprovementTask(issue);

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactory.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactory.ts
@@ -120,7 +120,7 @@ angular.module('oppia').factory('PlaythroughImprovementTaskObjectFactory', [
       fetchTasks: function() {
         // TODO(#7816): Remove this branch once all explorations maintain an
         // ExplorationIssuesModel.
-        if (ExplorationFeaturesService.isPlaythroughRecordingEnabled()) {
+        if (!ExplorationFeaturesService.isPlaythroughRecordingEnabled()) {
           return $q.resolve([]);
         }
         return PlaythroughIssuesService.getIssues().then(function(issues) {

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -92,7 +92,6 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
   var $q = null;
   var $rootScope = null;
   var $uibModal = null;
-  var ExplorationFeaturesService = null;
   var PlaythroughImprovementTaskObjectFactory = null;
   var playthroughIssueObjectFactory = null;
   var PlaythroughIssuesService = null;
@@ -113,8 +112,8 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     $provide.value('EditabilityService', new EditabilityService());
     $provide.value(
       'ExplorationDraftObjectFactory', new ExplorationDraftObjectFactory());
-    ExplorationFeaturesService = new ExplorationFeaturesService();
-    $provide.value('ExplorationFeaturesService', ExplorationFeaturesService);
+    $provide.value(
+      'ExplorationFeaturesService', new ExplorationFeaturesService());
     $provide.value(
       'FeedbackThreadObjectFactory', new FeedbackThreadObjectFactory());
     $provide.value('FractionObjectFactory', new FractionObjectFactory());
@@ -177,6 +176,10 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     }
   }));
 
+  beforeEach(angular.mock.inject(function(ExplorationFeaturesService) {
+    this.ExplorationFeaturesService = ExplorationFeaturesService;
+  }));
+
   beforeEach(angular.mock.inject(function(
       _$q_, _$rootScope_, _$uibModal_,
       _ExplorationFeaturesService_, _PlaythroughImprovementTaskObjectFactory_,
@@ -230,7 +233,7 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     it(
       'returns a task for each existing issue when exploration is whitelisted',
       function(done) {
-        spyOn(ExplorationFeaturesService, 'isPlaythroughRecordingEnabled')
+        spyOn(this.ExplorationFeaturesService, 'isPlaythroughRecordingEnabled')
           .and.returnValue(true);
 
         var earlyQuitIssue =
@@ -294,54 +297,58 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
         this.scope.$digest(); // Forces all pending promises to evaluate.
       });
 
-    it('returns nothing when playthrough recording is disabled', function() {
-      spyOn(ExplorationFeaturesService, 'isPlaythroughRecordingEnabled')
-        .and.returnValue(false);
+    it(
+      'returns nothing when playthrough recording is disabled',
+      function(done) {
+        spyOn(this.ExplorationFeaturesService, 'isPlaythroughRecordingEnabled')
+          .and.returnValue(false);
 
-      var earlyQuitIssue =
-        playthroughIssueObjectFactory.createFromBackendDict({
-          issue_type: 'EarlyQuit',
-          issue_customization_args: {
-            state_name: {value: 'Hola'},
-            time_spent_in_exp_in_msecs: {value: 5000},
-          },
-          playthrough_ids: [],
-          schema_version: 1,
-          is_valid: true,
-        });
-      var multipleIncorrectSubmissionsIssue =
-        playthroughIssueObjectFactory.createFromBackendDict({
-          issue_type: 'MultipleIncorrectSubmissions',
-          issue_customization_args: {
-            state_name: {value: 'Hola'},
-            num_times_answered_incorrectly: {value: 4},
-          },
-          playthrough_ids: [],
-          schema_version: 1,
-          is_valid: true,
-        });
-      var cyclicTransitionsIssue =
-        playthroughIssueObjectFactory.createFromBackendDict({
-          issue_type: 'CyclicTransitions',
-          issue_customization_args: {
-            state_names: {value: ['Hola', 'Me Llamo', 'Hola']},
-          },
-          playthrough_ids: [],
-          schema_version: 1,
-          is_valid: true,
-        });
+        var earlyQuitIssue =
+          playthroughIssueObjectFactory.createFromBackendDict({
+            issue_type: 'EarlyQuit',
+            issue_customization_args: {
+              state_name: {value: 'Hola'},
+              time_spent_in_exp_in_msecs: {value: 5000},
+            },
+            playthrough_ids: [],
+            schema_version: 1,
+            is_valid: true,
+          });
+        var multipleIncorrectSubmissionsIssue =
+          playthroughIssueObjectFactory.createFromBackendDict({
+            issue_type: 'MultipleIncorrectSubmissions',
+            issue_customization_args: {
+              state_name: {value: 'Hola'},
+              num_times_answered_incorrectly: {value: 4},
+            },
+            playthrough_ids: [],
+            schema_version: 1,
+            is_valid: true,
+          });
+        var cyclicTransitionsIssue =
+          playthroughIssueObjectFactory.createFromBackendDict({
+            issue_type: 'CyclicTransitions',
+            issue_customization_args: {
+              state_names: {value: ['Hola', 'Me Llamo', 'Hola']},
+            },
+            playthrough_ids: [],
+            schema_version: 1,
+            is_valid: true,
+          });
 
-      spyOn(PlaythroughIssuesService, 'getIssues').and.returnValue(
-        $q.resolve([
-          earlyQuitIssue,
-          multipleIncorrectSubmissionsIssue,
-          cyclicTransitionsIssue,
-        ]));
+        spyOn(PlaythroughIssuesService, 'getIssues').and.returnValue(
+          $q.resolve([
+            earlyQuitIssue,
+            multipleIncorrectSubmissionsIssue,
+            cyclicTransitionsIssue,
+          ]));
 
-      expect(PlaythroughImprovementTaskObjectFactory.fetchTasks()).toEqual([]);
+        PlaythroughImprovementTaskObjectFactory.fetchTasks().then(tasks => {
+          expect(tasks).toEqual([]);
+        }).then(done, done.fail);
 
-      this.scope.$digest(); // Forces all pending promises to evaluate.
-    });
+        this.scope.$digest(); // Forces all pending promises to evaluate.
+      });
   });
 
   describe('PlaythroughImprovementTask', function() {

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -30,7 +30,7 @@ import { EditabilityService } from 'services/EditabilityService';
 import { ExplorationDraftObjectFactory } from
   'domain/exploration/ExplorationDraftObjectFactory';
 import { ExplorationFeaturesService } from
-  'domain/exploration/ExplorationFeaturesService';
+  'services/ExplorationFeaturesService';
 import { FeedbackThreadObjectFactory } from
   'domain/feedback_thread/FeedbackThreadObjectFactory';
 import { FractionObjectFactory } from 'domain/objects/FractionObjectFactory';

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -113,6 +113,8 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     $provide.value(
       'ExplorationDraftObjectFactory', new ExplorationDraftObjectFactory());
     $provide.value(
+      'ExplorationFeaturesService', new ExplorationFeaturesService());
+    $provide.value(
       'FeedbackThreadObjectFactory', new FeedbackThreadObjectFactory());
     $provide.value('FractionObjectFactory', new FractionObjectFactory());
     $provide.value(

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -230,7 +230,6 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     it(
       'returns a task for each existing issue when exploration is whitelisted',
       function(done) {
-        console.log(angular.toJson(ExplorationFeaturesService, true));
         spyOn(ExplorationFeaturesService, 'isPlaythroughRecordingEnabled')
           .and.returnValue(true);
 

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -92,6 +92,7 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
   var $q = null;
   var $rootScope = null;
   var $uibModal = null;
+  var ExplorationFeaturesService = null;
   var PlaythroughImprovementTaskObjectFactory = null;
   var playthroughIssueObjectFactory = null;
   var PlaythroughIssuesService = null;
@@ -112,8 +113,8 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     $provide.value('EditabilityService', new EditabilityService());
     $provide.value(
       'ExplorationDraftObjectFactory', new ExplorationDraftObjectFactory());
-    $provide.value(
-      'ExplorationFeaturesService', new ExplorationFeaturesService());
+    ExplorationFeaturesService = new ExplorationFeaturesService();
+    $provide.value('ExplorationFeaturesService', ExplorationFeaturesService);
     $provide.value(
       'FeedbackThreadObjectFactory', new FeedbackThreadObjectFactory());
     $provide.value('FractionObjectFactory', new FractionObjectFactory());
@@ -229,6 +230,7 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     it(
       'returns a task for each existing issue when exploration is whitelisted',
       function(done) {
+        console.log(angular.toJson(ExplorationFeaturesService, true));
         spyOn(ExplorationFeaturesService, 'isPlaythroughRecordingEnabled')
           .and.returnValue(true);
 

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -29,7 +29,8 @@ import { ClassifierObjectFactory } from
 import { EditabilityService } from 'services/EditabilityService';
 import { ExplorationDraftObjectFactory } from
   'domain/exploration/ExplorationDraftObjectFactory';
-import { ExplorationFeaturesService } from 'services/ExplorationFeaturesService';
+import { ExplorationFeaturesService } from
+  'services/ExplorationFeaturesService';
 import { FeedbackThreadObjectFactory } from
   'domain/feedback_thread/FeedbackThreadObjectFactory';
 import { FractionObjectFactory } from 'domain/objects/FractionObjectFactory';

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -182,7 +182,7 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
 
   beforeEach(angular.mock.inject(function(
       _$q_, _$rootScope_, _$uibModal_,
-      _ExplorationFeaturesService_, _PlaythroughImprovementTaskObjectFactory_,
+      _PlaythroughImprovementTaskObjectFactory_,
       _PlaythroughIssueObjectFactory_, _PlaythroughIssuesService_,
       _PLAYTHROUGH_IMPROVEMENT_TASK_TYPE_) {
     $q = _$q_;

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -336,7 +336,7 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
             is_valid: true,
           });
 
-        var backendCallSpy = spyOn(PlaythroughIssuesService, 'getIssues')
+        var getIssuesSpy = spyOn(PlaythroughIssuesService, 'getIssues')
           .and.returnValue(
             $q.resolve([
               earlyQuitIssue,
@@ -346,7 +346,7 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
 
         PlaythroughImprovementTaskObjectFactory.fetchTasks().then(tasks => {
           expect(tasks).toEqual([]);
-          expect(backendCallSpy).not.toHaveBeenCalled();
+          expect(getIssuesSpy).not.toHaveBeenCalled();
         }).then(done, done.fail);
 
         this.scope.$digest(); // Forces all pending promises to evaluate.

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -269,15 +269,6 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
             is_valid: true,
           });
 
-        var earlyQuitTaskTitle =
-          PlaythroughIssuesService.renderIssueStatement(earlyQuitIssue);
-        var multipleIncorrectSubmissionsTaskTitle =
-          PlaythroughIssuesService.renderIssueStatement(
-            multipleIncorrectSubmissionsIssue);
-        var cyclicTransitionsTaskTitle =
-          PlaythroughIssuesService.renderIssueStatement(
-            cyclicTransitionsIssue);
-
         spyOn(PlaythroughIssuesService, 'getIssues').and.returnValue(
           $q.resolve([
             earlyQuitIssue,
@@ -286,12 +277,16 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
           ]));
 
         PlaythroughImprovementTaskObjectFactory.fetchTasks()
-          .then(function(tasks) {
-            expect(tasks.length).toEqual(3);
-            expect(tasks[0].getTitle()).toEqual(earlyQuitTaskTitle);
-            expect(tasks[1].getTitle())
-              .toEqual(multipleIncorrectSubmissionsTaskTitle);
-            expect(tasks[2].getTitle()).toEqual(cyclicTransitionsTaskTitle);
+          .then(tasks => tasks.map(task => task.getTitle()))
+          .then(taskTitles => {
+            expect(taskTitles).toEqual([
+              PlaythroughIssuesService.renderIssueStatement(
+                earlyQuitIssue),
+              PlaythroughIssuesService.renderIssueStatement(
+                multipleIncorrectSubmissionsIssue),
+              PlaythroughIssuesService.renderIssueStatement(
+                cyclicTransitionsIssue)
+            ]);
           }).then(done, done.fail);
 
         this.scope.$digest(); // Forces all pending promises to evaluate.
@@ -336,8 +331,8 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
             is_valid: true,
           });
 
-        var getIssuesSpy = spyOn(PlaythroughIssuesService, 'getIssues')
-          .and.returnValue(
+        var getIssuesSpy =
+          spyOn(PlaythroughIssuesService, 'getIssues').and.returnValue(
             $q.resolve([
               earlyQuitIssue,
               multipleIncorrectSubmissionsIssue,

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -29,8 +29,6 @@ import { ClassifierObjectFactory } from
 import { EditabilityService } from 'services/EditabilityService';
 import { ExplorationDraftObjectFactory } from
   'domain/exploration/ExplorationDraftObjectFactory';
-import { ExplorationFeaturesService } from
-  'services/ExplorationFeaturesService';
 import { FeedbackThreadObjectFactory } from
   'domain/feedback_thread/FeedbackThreadObjectFactory';
 import { FractionObjectFactory } from 'domain/objects/FractionObjectFactory';
@@ -112,8 +110,6 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     $provide.value('EditabilityService', new EditabilityService());
     $provide.value(
       'ExplorationDraftObjectFactory', new ExplorationDraftObjectFactory());
-    $provide.value(
-      'ExplorationFeaturesService', new ExplorationFeaturesService());
     $provide.value(
       'FeedbackThreadObjectFactory', new FeedbackThreadObjectFactory());
     $provide.value('FractionObjectFactory', new FractionObjectFactory());

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -336,15 +336,17 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
             is_valid: true,
           });
 
-        spyOn(PlaythroughIssuesService, 'getIssues').and.returnValue(
-          $q.resolve([
-            earlyQuitIssue,
-            multipleIncorrectSubmissionsIssue,
-            cyclicTransitionsIssue,
-          ]));
+        var backendCallSpy = spyOn(PlaythroughIssuesService, 'getIssues')
+          .and.returnValue(
+            $q.resolve([
+              earlyQuitIssue,
+              multipleIncorrectSubmissionsIssue,
+              cyclicTransitionsIssue,
+            ]));
 
         PlaythroughImprovementTaskObjectFactory.fetchTasks().then(tasks => {
           expect(tasks).toEqual([]);
+          expect(backendCallSpy).not.toHaveBeenCalled();
         }).then(done, done.fail);
 
         this.scope.$digest(); // Forces all pending promises to evaluate.

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -92,7 +92,6 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
   var $q = null;
   var $rootScope = null;
   var $uibModal = null;
-  var ExplorationFeaturesService = null;
   var PlaythroughImprovementTaskObjectFactory = null;
   var playthroughIssueObjectFactory = null;
   var PlaythroughIssuesService = null;
@@ -113,8 +112,6 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     $provide.value('EditabilityService', new EditabilityService());
     $provide.value(
       'ExplorationDraftObjectFactory', new ExplorationDraftObjectFactory());
-    $provide.value(
-      'ExplorationFeaturesService', new ExplorationFeaturesService());
     $provide.value(
       'FeedbackThreadObjectFactory', new FeedbackThreadObjectFactory());
     $provide.value('FractionObjectFactory', new FractionObjectFactory());
@@ -185,7 +182,6 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     $q = _$q_;
     $rootScope = _$rootScope_;
     $uibModal = _$uibModal_;
-    ExplorationFeaturesService = _ExplorationFeaturesService_;
     PlaythroughImprovementTaskObjectFactory =
       _PlaythroughImprovementTaskObjectFactory_;
     playthroughIssueObjectFactory = _PlaythroughIssueObjectFactory_;

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -29,6 +29,8 @@ import { ClassifierObjectFactory } from
 import { EditabilityService } from 'services/EditabilityService';
 import { ExplorationDraftObjectFactory } from
   'domain/exploration/ExplorationDraftObjectFactory';
+import { ExplorationFeaturesService } from
+  'domain/exploration/ExplorationFeaturesService';
 import { FeedbackThreadObjectFactory } from
   'domain/feedback_thread/FeedbackThreadObjectFactory';
 import { FractionObjectFactory } from 'domain/objects/FractionObjectFactory';
@@ -110,6 +112,8 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     $provide.value('EditabilityService', new EditabilityService());
     $provide.value(
       'ExplorationDraftObjectFactory', new ExplorationDraftObjectFactory());
+    $provide.value(
+      'ExplorationFeaturesService', new ExplorationFeaturesService());
     $provide.value(
       'FeedbackThreadObjectFactory', new FeedbackThreadObjectFactory());
     $provide.value('FractionObjectFactory', new FractionObjectFactory());

--- a/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/statistics/PlaythroughImprovementTaskObjectFactorySpec.ts
@@ -29,6 +29,7 @@ import { ClassifierObjectFactory } from
 import { EditabilityService } from 'services/EditabilityService';
 import { ExplorationDraftObjectFactory } from
   'domain/exploration/ExplorationDraftObjectFactory';
+import { ExplorationFeaturesService } from 'services/ExplorationFeaturesService';
 import { FeedbackThreadObjectFactory } from
   'domain/feedback_thread/FeedbackThreadObjectFactory';
 import { FractionObjectFactory } from 'domain/objects/FractionObjectFactory';
@@ -110,6 +111,8 @@ describe('PlaythroughImprovementTaskObjectFactory', function() {
     $provide.value('EditabilityService', new EditabilityService());
     $provide.value(
       'ExplorationDraftObjectFactory', new ExplorationDraftObjectFactory());
+    $provide.value(
+      'ExplorationFeaturesService', new ExplorationFeaturesService());
     $provide.value(
       'FeedbackThreadObjectFactory', new FeedbackThreadObjectFactory());
     $provide.value('FractionObjectFactory', new FractionObjectFactory());

--- a/core/templates/dev/head/services/ImprovementTaskServiceSpec.ts
+++ b/core/templates/dev/head/services/ImprovementTaskServiceSpec.ts
@@ -30,7 +30,7 @@ import { EditabilityService } from 'services/EditabilityService';
 import { ExplorationDraftObjectFactory } from
   'domain/exploration/ExplorationDraftObjectFactory';
 import { ExplorationFeaturesService } from
-  'domain/exploration/ExplorationFeaturesService';
+  'services/ExplorationFeaturesService';
 import { FeedbackThreadObjectFactory } from
   'domain/feedback_thread/FeedbackThreadObjectFactory';
 import { FractionObjectFactory } from 'domain/objects/FractionObjectFactory';

--- a/core/templates/dev/head/services/ImprovementTaskServiceSpec.ts
+++ b/core/templates/dev/head/services/ImprovementTaskServiceSpec.ts
@@ -29,6 +29,8 @@ import { ClassifierObjectFactory } from
 import { EditabilityService } from 'services/EditabilityService';
 import { ExplorationDraftObjectFactory } from
   'domain/exploration/ExplorationDraftObjectFactory';
+import { ExplorationFeaturesService } from
+  'domain/exploration/ExplorationFeaturesService';
 import { FeedbackThreadObjectFactory } from
   'domain/feedback_thread/FeedbackThreadObjectFactory';
 import { FractionObjectFactory } from 'domain/objects/FractionObjectFactory';
@@ -113,6 +115,8 @@ describe('ImprovementTaskService', function() {
     $provide.value('EditabilityService', new EditabilityService());
     $provide.value(
       'ExplorationDraftObjectFactory', new ExplorationDraftObjectFactory());
+    $provide.value(
+      'ExplorationFeaturesService', new ExplorationFeaturesService());
     $provide.value(
       'FeedbackThreadObjectFactory', new FeedbackThreadObjectFactory());
     $provide.value('FractionObjectFactory', new FractionObjectFactory());


### PR DESCRIPTION
Fixes part of #7690 

Due to #7816, certain explorations do not have an associated playthrough and cause server errors as a result. This PR limits the fetching of playthroughs to explorations which are known to work.