### PR TITLE
Fix part of #7427: Add valid args docstring for story_domain_test.py

### DIFF
--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -235,7 +235,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         """Checks that the story passes validation.
 
         Args:
-            expected_error_substring: string. String that should be a substring
+            expected_error_substring: str. String that should be a substring
                 of the expected error message.
         """
         with self.assertRaisesRegexp(
@@ -246,7 +246,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         """Checks that the story id is valid.
 
         Args:
-            expected_error_substring: string. String that should be a substring
+            expected_error_substring: str. String that should be a substring
                 of the expected error message.
             story_id: string. The story ID to validate.
         """

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -235,7 +235,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         """Checks that the story passes validation.
 
         Args:
-        expected_error_substring: string. String that should be a substring of the expected error message.
+            expected_error_substring: string. String that should be a substring of the expected error message.
         """
         with self.assertRaisesRegexp(
             utils.ValidationError, expected_error_substring):
@@ -245,8 +245,8 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         """Checks that the story id is valid.
 
         Args:
-        expected_error_substring: string. String that should be a substring of the expected error message.
-        story_id: string. The story ID to validate. 
+            expected_error_substring: string. String that should be a substring of the expected error message.
+            story_id: string. The story ID to validate.
         """
         with self.assertRaisesRegexp(
             utils.ValidationError, expected_error_substring):

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -235,7 +235,8 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         """Checks that the story passes validation.
 
         Args:
-            expected_error_substring: string. String that should be a substring of the expected error message.
+            expected_error_substring: string. String that should be a substring
+                of the expected error message.
         """
         with self.assertRaisesRegexp(
             utils.ValidationError, expected_error_substring):
@@ -245,7 +246,8 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         """Checks that the story id is valid.
 
         Args:
-            expected_error_substring: string. String that should be a substring of the expected error message.
+            expected_error_substring: string. String that should be a substring
+                of the expected error message.
             story_id: string. The story ID to validate.
         """
         with self.assertRaisesRegexp(

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -248,7 +248,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         Args:
             expected_error_substring: str. String that should be a substring
                 of the expected error message.
-            story_id: string. The story ID to validate.
+            story_id: str. The story ID to validate.
         """
         with self.assertRaisesRegexp(
             utils.ValidationError, expected_error_substring):

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -232,7 +232,11 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         self.signup('user1@example.com', 'user1')
 
     def _assert_validation_error(self, expected_error_substring):
-        """Checks that the story passes validation."""
+        """Checks that the story passes validation.
+
+        Args:
+        expected_error_substring: string. String that should be a substring of the expected error message.
+        """
         with self.assertRaisesRegexp(
             utils.ValidationError, expected_error_substring):
             self.story.validate()

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -242,7 +242,12 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
             self.story.validate()
 
     def _assert_valid_story_id(self, expected_error_substring, story_id):
-        """Checks that the story id is valid."""
+        """Checks that the story id is valid.
+
+        Args:
+        expected_error_substring: string. String that should be a substring of the expected error message.
+        story_id: string. The story ID to validate. 
+        """
         with self.assertRaisesRegexp(
             utils.ValidationError, expected_error_substring):
             story_domain.Story.require_valid_story_id(story_id)


### PR DESCRIPTION
## Explanation
 Fixes part of #7427: Add valid args docstring for story_domain_test.py

## Checklist
- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [X] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [X] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [X] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
