### PR TITLE
Fix part of #7450: Modify private methods in BaseCalculationUnitTests

### DIFF
--- a/extensions/answer_summarizers/models.py
+++ b/extensions/answer_summarizers/models.py
@@ -62,7 +62,7 @@ UNRESOLVED_ANSWER_CLASSIFICATION_CATEGORIES = frozenset([
 ])
 
 
-class _HashableAnswer(python_utils.OBJECT):
+class HashableAnswer(python_utils.OBJECT):
     """Wraps answer with object that can be placed into sets and dicts."""
 
     def __init__(self, answer):
@@ -73,7 +73,7 @@ class _HashableAnswer(python_utils.OBJECT):
         return hash(self.hashable_answer)
 
     def __eq__(self, other):
-        if isinstance(other, _HashableAnswer):
+        if isinstance(other, HashableAnswer):
             return self.hashable_answer == other.hashable_answer
         return False
 
@@ -92,7 +92,7 @@ def _get_top_answers_by_frequency(answers, limit=None):
     Returns:
         stats_domain.AnswerFrequencyList. A list of the top "limit" answers.
     """
-    answer_counter = utils.OrderedCounter(_HashableAnswer(a) for a in answers)
+    answer_counter = utils.OrderedCounter(HashableAnswer(a) for a in answers)
     return stats_domain.AnswerFrequencyList([
         stats_domain.AnswerOccurrence(hashable_answer.answer, frequency)
         for hashable_answer, frequency in answer_counter.most_common(n=limit)
@@ -125,10 +125,10 @@ def _get_top_unresolved_answers_by_frequency(
     # classification categorization of each answer.
     for ans in answers_with_classification:
         frequency = 0
-        if _HashableAnswer(ans['answer']) in classification_results_dict:
-            frequency = classification_results_dict[_HashableAnswer(
+        if HashableAnswer(ans['answer']) in classification_results_dict:
+            frequency = classification_results_dict[HashableAnswer(
                 ans['answer'])]['frequency']
-        classification_results_dict[_HashableAnswer(ans['answer'])] = {
+        classification_results_dict[HashableAnswer(ans['answer'])] = {
             'classification_categorization': (
                 ans['classification_categorization']),
             'frequency': frequency + 1

--- a/extensions/answer_summarizers/models_test.py
+++ b/extensions/answer_summarizers/models_test.py
@@ -22,6 +22,7 @@ from core.domain import calculation_registry
 from core.domain import exp_domain
 from core.tests import test_utils
 from extensions.answer_summarizers import models as answer_models
+import utils
 
 
 class BaseCalculationUnitTests(test_utils.GenericTestBase):
@@ -33,9 +34,9 @@ class BaseCalculationUnitTests(test_utils.GenericTestBase):
                 state_answers_dict={})
 
     def test_equality_of_hashable_answers(self):
-        hashable_answer_1 = answer_models._HashableAnswer('answer_1')  # pylint: disable=protected-access
-        hashable_answer_2 = answer_models._HashableAnswer('answer_2')  # pylint: disable=protected-access
-        hashable_answer_3 = answer_models._HashableAnswer('answer_1')  # pylint: disable=protected-access
+        hashable_answer_1 = utils.get_hashable_value('answer_1') # pylint: disable=protected-access
+        hashable_answer_2 = utils.get_hashable_value('answer_2') # pylint: disable=protected-access
+        hashable_answer_3 = utils.get_hashable_value('answer_1') # pylint: disable=protected-access
 
         self.assertFalse(hashable_answer_1 == hashable_answer_2)
         self.assertTrue(hashable_answer_1 == hashable_answer_3)

--- a/extensions/answer_summarizers/models_test.py
+++ b/extensions/answer_summarizers/models_test.py
@@ -22,7 +22,6 @@ from core.domain import calculation_registry
 from core.domain import exp_domain
 from core.tests import test_utils
 from extensions.answer_summarizers import models as answer_models
-import utils
 
 
 class BaseCalculationUnitTests(test_utils.GenericTestBase):
@@ -34,9 +33,9 @@ class BaseCalculationUnitTests(test_utils.GenericTestBase):
                 state_answers_dict={})
 
     def test_equality_of_hashable_answers(self):
-        hashable_answer_1 = utils.get_hashable_value('answer_1')
-        hashable_answer_2 = utils.get_hashable_value('answer_2')
-        hashable_answer_3 = utils.get_hashable_value('answer_1')
+        hashable_answer_1 = answer_models.HashableAnswer('answer_1')
+        hashable_answer_2 = answer_models.HashableAnswer('answer_2')
+        hashable_answer_3 = answer_models.HashableAnswer('answer_1')
 
         self.assertFalse(hashable_answer_1 == hashable_answer_2)
         self.assertTrue(hashable_answer_1 == hashable_answer_3)

--- a/extensions/answer_summarizers/models_test.py
+++ b/extensions/answer_summarizers/models_test.py
@@ -34,9 +34,9 @@ class BaseCalculationUnitTests(test_utils.GenericTestBase):
                 state_answers_dict={})
 
     def test_equality_of_hashable_answers(self):
-        hashable_answer_1 = utils.get_hashable_value('answer_1') # pylint: disable=protected-access
-        hashable_answer_2 = utils.get_hashable_value('answer_2') # pylint: disable=protected-access
-        hashable_answer_3 = utils.get_hashable_value('answer_1') # pylint: disable=protected-access
+        hashable_answer_1 = utils.get_hashable_value('answer_1')
+        hashable_answer_2 = utils.get_hashable_value('answer_2')
+        hashable_answer_3 = utils.get_hashable_value('answer_1')
 
         self.assertFalse(hashable_answer_1 == hashable_answer_2)
         self.assertTrue(hashable_answer_1 == hashable_answer_3)


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
  - Modify calls to private methods from BaseCalculationUnitTests test file
  - Fixes #7450
  

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
