### PR TITLE
Fix #7802: Fix indexing of explorations after update

### DIFF
--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -1053,18 +1053,24 @@ class ExplorationDeletionRightsTests(BaseEditorControllerTests):
             self.delete_json(
                 '/createhandler/data/%s' % exp_id)
 
-            # Observed_log_messages[1] is 'Attempting to delete documents
+            # Observed_log_messaged[0] is 'adding the following docs to
+            # index %s: %s' % (index.name, documents). It is logged from the
+            # function add_documents_to_index in
+            # oppia/core/platform/search/gae_search_services.py,
+            # not to be checked here (same for admin and moderator). The
+            # function is called when an exploration is saved.
+            # Observed_log_messages[2] is 'Attempting to delete documents
             # from index %s, ids: %s' % (index.name, ', '.join(doc_ids)). It
             # is logged by function delete_documents_from_index in
             # oppia/core/platform/search/gae_search_services.py,
             # not to be checked here (same for admin and moderator).
-            self.assertEqual(len(observed_log_messages), 3)
+            self.assertEqual(len(observed_log_messages), 4)
             self.assertEqual(
-                observed_log_messages[0],
+                observed_log_messages[1],
                 '(%s) %s tried to delete exploration %s' %
                 (feconf.ROLE_ID_EXPLORATION_EDITOR, self.owner_id, exp_id))
             self.assertEqual(
-                observed_log_messages[2],
+                observed_log_messages[3],
                 '(%s) %s deleted exploration %s' %
                 (feconf.ROLE_ID_EXPLORATION_EDITOR, self.owner_id, exp_id))
             self.logout()
@@ -1078,13 +1084,13 @@ class ExplorationDeletionRightsTests(BaseEditorControllerTests):
 
             self.login(self.ADMIN_EMAIL)
             self.delete_json('/createhandler/data/%s' % exp_id)
-            self.assertEqual(len(observed_log_messages), 3)
+            self.assertEqual(len(observed_log_messages), 4)
             self.assertEqual(
-                observed_log_messages[0],
+                observed_log_messages[1],
                 '(%s) %s tried to delete exploration %s' %
                 (feconf.ROLE_ID_ADMIN, self.admin_id, exp_id))
             self.assertEqual(
-                observed_log_messages[2],
+                observed_log_messages[3],
                 '(%s) %s deleted exploration %s' %
                 (feconf.ROLE_ID_ADMIN, self.admin_id, exp_id))
             self.logout()
@@ -1098,13 +1104,13 @@ class ExplorationDeletionRightsTests(BaseEditorControllerTests):
 
             self.login(self.MODERATOR_EMAIL)
             self.delete_json('/createhandler/data/%s' % exp_id)
-            self.assertEqual(len(observed_log_messages), 3)
+            self.assertEqual(len(observed_log_messages), 4)
             self.assertEqual(
-                observed_log_messages[0],
+                observed_log_messages[1],
                 '(%s) %s tried to delete exploration %s' %
                 (feconf.ROLE_ID_MODERATOR, self.moderator_id, exp_id))
             self.assertEqual(
-                observed_log_messages[2],
+                observed_log_messages[3],
                 '(%s) %s deleted exploration %s' %
                 (feconf.ROLE_ID_MODERATOR, self.moderator_id, exp_id))
             self.logout()

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -521,7 +521,6 @@ def _save_exploration(committer_id, exploration, commit_message, change_list):
     exploration_model.commit(committer_id, commit_message, change_list_dict)
     exp_memcache_key = exp_fetchers.get_exploration_memcache_key(exploration.id)
     memcache_services.delete(exp_memcache_key)
-    index_explorations_given_ids([exploration.id])
 
     exploration.version += 1
 
@@ -1041,6 +1040,12 @@ def save_exploration_summary(exp_summary):
     )
 
     exp_summary_model.put()
+
+    # The index should be updated after saving the exploration
+    # summary instead of after saving the exploration since the
+    # index contains documents computed on basis of exploration
+    # summary.
+    index_explorations_given_ids([exp_summary.id])
 
 
 def delete_exploration_summary(exploration_id):


### PR DESCRIPTION
## Explanation
Fixes #7802: Fixes indexing of explorations after update and adds test for the same.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
