### PR TITLE
Fix #7434: Make shared constants accesible from AppConstants without Typescript error

### DIFF
--- a/core/templates/dev/head/pages/about-page/about-page.module.ts
+++ b/core/templates/dev/head/pages/about-page/about-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants'
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/admin-page/admin-page.module.ts
+++ b/core/templates/dev/head/pages/admin-page/admin-page.module.ts
@@ -32,13 +32,13 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+'../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
-import { ServicesConstants } from 'services/services.constants';
-import { AdminPageConstants } from 'pages/admin-page/admin-page.constants';
+'../../domain/objects/objects-domain.constants';
+import { ServicesConstants } from '../../services/services.constants';
+import { AdminPageConstants } from '../../pages/admin-page/admin-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/classroom-page/classroom-page.module.ts
+++ b/core/templates/dev/head/pages/classroom-page/classroom-page.module.ts
@@ -33,7 +33,7 @@ import { HttpClientModule } from '@angular/common/http';
 export class ServiceBootstrapComponent {}
 
 import { ClassroomDomainConstants } from
-  'domain/classroom/classroom-domain.constants';
+  '../../domain/classroom/classroom-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/collection-player-page/collection-player-page.module.ts
+++ b/core/templates/dev/head/pages/collection-player-page/collection-player-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+'../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/community-dashboard-page/community-dashboard-page.module.ts
+++ b/core/templates/dev/head/pages/community-dashboard-page/community-dashboard-page.module.ts
@@ -32,9 +32,9 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { CommunityDashboardConstants } from
-  'pages/community-dashboard-page/community-dashboard-page.constants';
+  './community-dashboard-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/contact-page/contact-page.module.ts
+++ b/core/templates/dev/head/pages/contact-page/contact-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/creator-dashboard-page/creator-dashboard-page.module.ts
+++ b/core/templates/dev/head/pages/creator-dashboard-page/creator-dashboard-page.module.ts
@@ -32,18 +32,18 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { ClassifiersExtensionConstants } from
-  'classifiers/classifiers-extension.constants';
+  '../../../../../../extensions/classifiers/classifiers-extension.constants';
 import { CollectionSummaryTileConstants } from
-  'components/summary-tile/collection-summary-tile.constants';
+  '../../components/summary-tile/collection-summary-tile.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
-import { ServicesConstants } from 'services/services.constants';
+  '../../domain/objects/objects-domain.constants';
+import { ServicesConstants } from '../../services/services.constants';
 import { CreatorDashboardConstants } from
-  'pages/creator-dashboard-page/creator-dashboard-page.constants';
+  '../../pages/creator-dashboard-page/creator-dashboard-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/donate-page/donate-page.module.ts
+++ b/core/templates/dev/head/pages/donate-page/donate-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/email-dashboard-pages/email-dashboard-page.module.ts
+++ b/core/templates/dev/head/pages/email-dashboard-pages/email-dashboard-page.module.ts
@@ -32,12 +32,12 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
-import { ServicesConstants } from 'services/services.constants';
+  '../../domain/objects/objects-domain.constants';
+import { ServicesConstants } from '../../services/services.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/error-pages/error-page.module.ts
+++ b/core/templates/dev/head/pages/error-pages/error-page.module.ts
@@ -32,12 +32,12 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
-import { ServicesConstants } from 'services/services.constants';
+  '../../domain/objects/objects-domain.constants';
+import { ServicesConstants } from '../../services/services.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/exploration-editor-page/exploration-editor-page.module.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/exploration-editor-page.module.ts
@@ -32,26 +32,26 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { ClassifiersExtensionConstants } from
-  'classifiers/classifiers-extension.constants';
+  '../../../../../../extensions/classifiers/classifiers-extension.constants';
 import { CollectionSummaryTileConstants } from
-  'components/summary-tile/collection-summary-tile.constants';
+  '../../components/summary-tile/collection-summary-tile.constants';
 import { EditorDomainConstants } from
-  'domain/editor/editor-domain.constants';
+  '../../domain/editor/editor-domain.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 import { QuestionDomainConstants } from
-  'domain/question/question-domain.constants';
-import { ServicesConstants } from 'services/services.constants';
+  '../../domain/question/question-domain.constants';
+import { ServicesConstants } from '../../services/services.constants';
 import { StateEditorConstants } from
-  'components/state-editor/state-editor.constants';
+  '../../components/state-editor/state-editor.constants';
 import { StatisticsDomainConstants } from
-  'domain/statistics/statistics-domain.constants';
+  '../../domain/statistics/statistics-domain.constants';
 import { ExplorationEditorPageConstants } from
-  'pages/exploration-editor-page/exploration-editor-page.constants';
+  '../../pages/exploration-editor-page/exploration-editor-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/exploration-player-page/exploration-player-page.module.ts
+++ b/core/templates/dev/head/pages/exploration-player-page/exploration-player-page.module.ts
@@ -32,21 +32,21 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { ClassifiersExtensionConstants } from
-  'classifiers/classifiers-extension.constants';
+  '../../../../../../extensions/classifiers/classifiers-extension.constants';
 import { CollectionSummaryTileConstants } from
-  'components/summary-tile/collection-summary-tile.constants';
+  '../../components/summary-tile/collection-summary-tile.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 import { QuestionDomainConstants } from
-  'domain/question/question-domain.constants';
-import { ServicesConstants } from 'services/services.constants';
-import { SkillDomainConstants } from 'domain/skill/skill-domain.constants';
+  '../../domain/question/question-domain.constants';
+import { ServicesConstants } from '../../services/services.constants';
+import { SkillDomainConstants } from '../../domain/skill/skill-domain.constants';
 import { ExplorationPlayerConstants } from
-  'pages/exploration-player-page/exploration-player-page.constants';
+  '../../pages/exploration-player-page/exploration-player-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/get-started-page/get-started-page.module.ts
+++ b/core/templates/dev/head/pages/get-started-page/get-started-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/landing-pages/stewards-landing-page/stewards-landing-page.module.ts
+++ b/core/templates/dev/head/pages/landing-pages/stewards-landing-page/stewards-landing-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/landing-pages/topic-landing-page/topic-landing-page.module.ts
+++ b/core/templates/dev/head/pages/landing-pages/topic-landing-page/topic-landing-page.module.ts
@@ -32,14 +32,14 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
-import { ServicesConstants } from 'services/services.constants';
+  '../../../domain/objects/objects-domain.constants';
+import { ServicesConstants } from '../../../services/services.constants';
 import { TopicLandingPageConstants } from
-  'pages/landing-pages/topic-landing-page/topic-landing-page.constants';
+  '../../../pages/landing-pages/topic-landing-page/topic-landing-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.module.ts
+++ b/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.module.ts
@@ -32,16 +32,16 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { CollectionSummaryTileConstants } from
-  'components/summary-tile/collection-summary-tile.constants';
+  '../../components/summary-tile/collection-summary-tile.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
-import { ServicesConstants } from 'services/services.constants';
+  '../../domain/objects/objects-domain.constants';
+import { ServicesConstants } from '../../services/services.constants';
 import { LearnerDashboardPageConstants } from
-  'pages/learner-dashboard-page/learner-dashboard-page.constants';
+  '../../pages/learner-dashboard-page/learner-dashboard-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/library-page/library-page.module.ts
+++ b/core/templates/dev/head/pages/library-page/library-page.module.ts
@@ -32,16 +32,16 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { CollectionSummaryTileConstants } from
-  'components/summary-tile/collection-summary-tile.constants';
+  '../../components/summary-tile/collection-summary-tile.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
-import { ServicesConstants } from 'services/services.constants';
+  '../../domain/objects/objects-domain.constants';
+import { ServicesConstants } from '../../services/services.constants';
 import { LibraryPageConstants } from
-  'pages/library-page/library-page.constants';
+  '../../pages/library-page/library-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/maintenance-page/maintenance-page.module.ts
+++ b/core/templates/dev/head/pages/maintenance-page/maintenance-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/moderator-page/moderator-page.module.ts
+++ b/core/templates/dev/head/pages/moderator-page/moderator-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/notifications-dashboard-page/notifications-dashboard-page.module.ts
+++ b/core/templates/dev/head/pages/notifications-dashboard-page/notifications-dashboard-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/practice-session-page/practice-session-page.module.ts
+++ b/core/templates/dev/head/pages/practice-session-page/practice-session-page.module.ts
@@ -32,16 +32,16 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 import { QuestionPlayerConstants } from
-  'components/question-directives/question-player/question-player.constants';
-import { ServicesConstants } from 'services/services.constants';
+  '../../components/question-directives/question-player/question-player.constants';
+import { ServicesConstants } from '../../services/services.constants';
 import { PracticeSessionPageConstants } from
-  'pages/practice-session-page/practice-session-page.constants';
+  '../../pages/practice-session-page/practice-session-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/preferences-page/preferences-page.module.ts
+++ b/core/templates/dev/head/pages/preferences-page/preferences-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/privacy-page/privacy-page.module.ts
+++ b/core/templates/dev/head/pages/privacy-page/privacy-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/profile-page/profile-page.module.ts
+++ b/core/templates/dev/head/pages/profile-page/profile-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/review-test-page/review-test-page.module.ts
+++ b/core/templates/dev/head/pages/review-test-page/review-test-page.module.ts
@@ -32,16 +32,16 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+'../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 import { QuestionPlayerConstants } from
-  'components/question-directives/question-player/question-player.constants';
-import { ServicesConstants } from 'services/services.constants';
+  '../../components/question-directives/question-player/question-player.constants';
+import { ServicesConstants } from '../../services/services.constants';
 import { ReviewTestPageConstants } from
-  'pages/review-test-page/review-test-page.constants';
+  '../../pages/review-test-page/review-test-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/signup-page/signup-page.module.ts
+++ b/core/templates/dev/head/pages/signup-page/signup-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+'../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/skill-editor-page/skill-editor-page.module.ts
+++ b/core/templates/dev/head/pages/skill-editor-page/skill-editor-page.module.ts
@@ -32,21 +32,21 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { EditorDomainConstants } from
-  'domain/editor/editor-domain.constants';
+  '../../domain/editor/editor-domain.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+'../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 import { QuestionDomainConstants } from
-  'domain/question/question-domain.constants';
+  '../../domain/question/question-domain.constants';
 import { QuestionsListConstants } from
-  'components/question-directives/questions-list/questions-list.constants';
-import { ServicesConstants } from 'services/services.constants';
-import { SkillDomainConstants } from 'domain/skill/skill-domain.constants';
+  '../../components/question-directives/questions-list/questions-list.constants';
+import { ServicesConstants } from '../../services/services.constants';
+import { SkillDomainConstants } from '../../domain/skill/skill-domain.constants';
 import { SkillEditorPageConstants } from
-  'pages/skill-editor-page/skill-editor-page.constants';
+  '../../pages/skill-editor-page/skill-editor-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/splash-page/splash-page.module.ts
+++ b/core/templates/dev/head/pages/splash-page/splash-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+'../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/story-editor-page/story-editor-page.module.ts
+++ b/core/templates/dev/head/pages/story-editor-page/story-editor-page.module.ts
@@ -32,18 +32,18 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { EditorDomainConstants } from
-  'domain/editor/editor-domain.constants';
+  '../../domain/editor/editor-domain.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+'../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
-import { ServicesConstants } from 'services/services.constants';
-import { SkillDomainConstants } from 'domain/skill/skill-domain.constants';
-import { StoryDomainConstants } from 'domain/story/story-domain.constants';
+  '../../domain/objects/objects-domain.constants';
+import { ServicesConstants } from '../../services/services.constants';
+import { SkillDomainConstants } from '../../domain/skill/skill-domain.constants';
+import { StoryDomainConstants } from '../../domain/story/story-domain.constants';
 import { StoryEditorPageConstants } from
-  'pages/story-editor-page/story-editor-page.constants';
+  '../../pages/story-editor-page/story-editor-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/story-viewer-page/story-viewer-page.module.ts
+++ b/core/templates/dev/head/pages/story-viewer-page/story-viewer-page.module.ts
@@ -32,13 +32,13 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+'../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 import { StoryViewerDomainConstants } from
-  'domain/story_viewer/story-viewer-domain.constants';
+  '../../domain/story_viewer/story-viewer-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/subtopic-viewer-page/subtopic-viewer-page.module.ts
+++ b/core/templates/dev/head/pages/subtopic-viewer-page/subtopic-viewer-page.module.ts
@@ -33,7 +33,7 @@ import { HttpClientModule } from '@angular/common/http';
 export class ServiceBootstrapComponent {}
 
 import { SubtopicViewerDomainConstants } from
-  'domain/subtopic_viewer/subtopic-viewer-domain.constants';
+  '../../domain/subtopic_viewer/subtopic-viewer-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/teach-page/teach-page.module.ts
+++ b/core/templates/dev/head/pages/teach-page/teach-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+'../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/terms-page/terms-page.module.ts
+++ b/core/templates/dev/head/pages/terms-page/terms-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/thanks-page/thanks-page.module.ts
+++ b/core/templates/dev/head/pages/thanks-page/thanks-page.module.ts
@@ -32,11 +32,11 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/topic-editor-page/topic-editor-page.module.ts
+++ b/core/templates/dev/head/pages/topic-editor-page/topic-editor-page.module.ts
@@ -32,22 +32,22 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { EditorDomainConstants } from
-  'domain/editor/editor-domain.constants';
+  '../../domain/editor/editor-domain.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 import { QuestionDomainConstants } from
-  'domain/question/question-domain.constants';
+  '../../domain/question/question-domain.constants';
 import { QuestionsListConstants } from
-  'components/question-directives/questions-list/questions-list.constants';
-import { ServicesConstants } from 'services/services.constants';
-import { StoryDomainConstants } from 'domain/story/story-domain.constants';
-import { TopicDomainConstants } from 'domain/topic/topic-domain.constants';
+  '../../components/question-directives/questions-list/questions-list.constants';
+import { ServicesConstants } from '../../services/services.constants';
+import { StoryDomainConstants } from '../../domain/story/story-domain.constants';
+import { TopicDomainConstants } from '../../domain/topic/topic-domain.constants';
 import { TopicEditorPageConstants } from
-  'pages/topic-editor-page/topic-editor-page.constants';
+  '../../pages/topic-editor-page/topic-editor-page.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/topic-viewer-page/topic-viewer-page.module.ts
+++ b/core/templates/dev/head/pages/topic-viewer-page/topic-viewer-page.module.ts
@@ -32,13 +32,13 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
+  '../../domain/objects/objects-domain.constants';
 import { TopicViewerDomainConstants } from
-  'domain/topic_viewer/topic-viewer-domain.constants';
+  '../../domain/topic_viewer/topic-viewer-domain.constants';
 
 @NgModule({
   imports: [

--- a/core/templates/dev/head/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.module.ts
+++ b/core/templates/dev/head/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.module.ts
@@ -32,19 +32,19 @@ import { HttpClientModule } from '@angular/common/http';
 })
 export class ServiceBootstrapComponent {}
 
-import { AppConstants } from 'app.constants';
+import { AppConstants } from '../../app.constants';
 import { InteractionsExtensionsConstants } from
-  'interactions/interactions-extension.constants';
+  '../../../../../../extensions/interactions/interactions-extension.constants';
 import { ObjectsDomainConstants } from
-  'domain/objects/objects-domain.constants';
-import { ServicesConstants } from 'services/services.constants';
-import { SkillDomainConstants } from 'domain/skill/skill-domain.constants';
-import { TopicDomainConstants } from 'domain/topic/topic-domain.constants';
+  '../../domain/objects/objects-domain.constants';
+import { ServicesConstants } from '../../services/services.constants';
+import { SkillDomainConstants } from '../../domain/skill/skill-domain.constants';
+import { TopicDomainConstants } from '../../domain/topic/topic-domain.constants';
 /* eslint-disable max-len */
 import { TopicsAndSkillsDashboardDomainConstants } from
-  'domain/topics_and_skills_dashboard/topics-and-skills-dashboard-domain.constants';
+  '../../domain/topics_and_skills_dashboard/topics-and-skills-dashboard-domain.constants';
 import { TopicsAndSkillsDashboardPageConstants } from
-  'pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.constants';
+  '../../pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.constants';
 /* eslint-enable max-len */
 
 @NgModule({


### PR DESCRIPTION
- ### Fixes #7434 

- I have fixed all import issues for constants in the App. 

- 7434 issue is fixed now. 

- I have made shared constants accessible from AppConstants without Typescript error.

- It include all the modules file in the App.
