### PR TITLE
Fix #7529: Adds a strict check for Outcome object before executing hasNonemptyFeedback

### DIFF
--- a/core/templates/dev/head/components/state-directives/outcome-editor/outcome-editor.directive.ts
+++ b/core/templates/dev/head/components/state-directives/outcome-editor/outcome-editor.directive.ts
@@ -132,7 +132,7 @@ angular.module('oppia').directive('outcomeEditor', [
           };
 
           ctrl.isSelfLoopWithNoFeedback = function(outcome) {
-            if (typeof outcome === 'object' &&
+            if (outcome && typeof outcome === 'object' &&
               outcome.constructor.name === 'Outcome') {
               return ctrl.isSelfLoop(outcome) &&
                 !outcome.hasNonemptyFeedback();

--- a/core/templates/dev/head/components/state-directives/outcome-editor/outcome-editor.directive.ts
+++ b/core/templates/dev/head/components/state-directives/outcome-editor/outcome-editor.directive.ts
@@ -132,7 +132,8 @@ angular.module('oppia').directive('outcomeEditor', [
           };
 
           ctrl.isSelfLoopWithNoFeedback = function(outcome) {
-            if (outcome) {
+            if (typeof outcome === 'object' &&
+              outcome.constructor.name === 'Outcome') {
               return ctrl.isSelfLoop(outcome) &&
                 !outcome.hasNonemptyFeedback();
             }

--- a/core/templates/dev/head/components/state-directives/outcome-editor/outcome-editor.directive.ts
+++ b/core/templates/dev/head/components/state-directives/outcome-editor/outcome-editor.directive.ts
@@ -132,11 +132,11 @@ angular.module('oppia').directive('outcomeEditor', [
           };
 
           ctrl.isSelfLoopWithNoFeedback = function(outcome) {
-            if (!outcome) {
-              return false;
+            if (outcome) {
+              return ctrl.isSelfLoop(outcome) &&
+                !outcome.hasNonemptyFeedback();
             }
-            return ctrl.isSelfLoop(outcome) &&
-              !outcome.hasNonemptyFeedback();
+            return false;
           };
 
           ctrl.invalidStateAfterFeedbackSave = function() {

--- a/core/templates/dev/head/components/state-editor/state-responses-editor/state-responses.directive.ts
+++ b/core/templates/dev/head/components/state-editor/state-responses-editor/state-responses.directive.ts
@@ -275,7 +275,7 @@ angular.module('oppia').directive('stateResponses', [
             // feedback
             if (outcome) {
               return $scope.isCurrentInteractionLinear() &&
-                !outcome.hasNonemptyFeedback();;
+                !outcome.hasNonemptyFeedback();
             }
             return false;
           };

--- a/core/templates/dev/head/components/state-editor/state-responses-editor/state-responses.directive.ts
+++ b/core/templates/dev/head/components/state-editor/state-responses-editor/state-responses.directive.ts
@@ -273,11 +273,11 @@ angular.module('oppia').directive('stateResponses', [
           $scope.isLinearWithNoFeedback = function(outcome) {
             // Returns false if current interaction is linear and has no
             // feedback
-            if (!outcome) {
-              return false;
+            if (outcome) {
+              return $scope.isCurrentInteractionLinear() &&
+                !outcome.hasNonemptyFeedback();;
             }
-            return $scope.isCurrentInteractionLinear() &&
-              !outcome.hasNonemptyFeedback();
+            return false;
           };
 
           $scope.getOutcomeTooltip = function(outcome) {

--- a/core/templates/dev/head/components/state-editor/state-responses-editor/state-responses.directive.ts
+++ b/core/templates/dev/head/components/state-editor/state-responses-editor/state-responses.directive.ts
@@ -226,10 +226,11 @@ angular.module('oppia').directive('stateResponses', [
           };
 
           $scope.isSelfLoopWithNoFeedback = function(outcome) {
-            if (!outcome) {
-              return false;
+            if (typeof outcome === 'object' &&
+              outcome.constructor.name === 'Outcome') {
+              return outcome.isConfusing($scope.stateName);
             }
-            return outcome.isConfusing($scope.stateName);
+            return false;
           };
 
           $scope.isSelfLoopThatIsMarkedCorrect = function(outcome) {
@@ -273,7 +274,8 @@ angular.module('oppia').directive('stateResponses', [
           $scope.isLinearWithNoFeedback = function(outcome) {
             // Returns false if current interaction is linear and has no
             // feedback
-            if (outcome) {
+            if (typeof outcome === 'object' &&
+              outcome.constructor.name === 'Outcome') {
               return $scope.isCurrentInteractionLinear() &&
                 !outcome.hasNonemptyFeedback();
             }

--- a/core/templates/dev/head/components/state-editor/state-responses-editor/state-responses.directive.ts
+++ b/core/templates/dev/head/components/state-editor/state-responses-editor/state-responses.directive.ts
@@ -226,7 +226,7 @@ angular.module('oppia').directive('stateResponses', [
           };
 
           $scope.isSelfLoopWithNoFeedback = function(outcome) {
-            if (typeof outcome === 'object' &&
+            if (outcome && typeof outcome === 'object' &&
               outcome.constructor.name === 'Outcome') {
               return outcome.isConfusing($scope.stateName);
             }
@@ -274,7 +274,7 @@ angular.module('oppia').directive('stateResponses', [
           $scope.isLinearWithNoFeedback = function(outcome) {
             // Returns false if current interaction is linear and has no
             // feedback
-            if (typeof outcome === 'object' &&
+            if (outcome && typeof outcome === 'object' &&
               outcome.constructor.name === 'Outcome') {
               return $scope.isCurrentInteractionLinear() &&
                 !outcome.hasNonemptyFeedback();


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #7529: This PR adds a strict check for Outcome object before executing hasNonemptyFeedback.

The previous implicit check might have caused an empty object to slip through causing the server error.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
