### PR TITLE
Fix #7855: Change e.message() to e.message

### DIFF
--- a/extensions/interactions/MathExpressionInput/directives/math-expression-input-rules.service.ts
+++ b/extensions/interactions/MathExpressionInput/directives/math-expression-input-rules.service.ts
@@ -31,7 +31,7 @@ export class MathExpressionInputRulesService {
       MathExpression.fromLatex(answer.latex);
     } catch (e) {
       throw Error(
-        'Bad expression in answer.latex: ' + e.message() + ' inputs: ' +
+        'Bad expression in answer.latex: ' + e.message + ' inputs: ' +
         JSON.stringify(answer));
     }
 
@@ -39,7 +39,7 @@ export class MathExpressionInputRulesService {
       MathExpression.fromLatex(inputs.x);
     } catch (e) {
       throw Error(
-        'Bad expression in inputs.x: ' + e.message() + ' inputs: ' +
+        'Bad expression in inputs.x: ' + e.message + ' inputs: ' +
         JSON.stringify(inputs));
     }
 


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->
Fixes #7855: message should be accessed as a property and not a function (see [this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message) and [this](https://www.w3schools.com/jsref/prop_error_message.asp)).

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
