### PR TITLE
Fix #7873: Removes arrow function with function to resolve undefined `this` issue.

### DIFF
--- a/core/templates/dev/head/services/SpeechSynthesisChunkerService.ts
+++ b/core/templates/dev/head/services/SpeechSynthesisChunkerService.ts
@@ -178,7 +178,7 @@ export class SpeechSynthesisChunkerService {
         }
       });
 
-    _this = this;
+    var _this = this;
     // Convert LaTeX to speakable text.
     elt.find('oppia-noninteractive-' + this.RTE_COMPONENT_NAMES.Math)
       .replaceWith(function() {

--- a/core/templates/dev/head/services/SpeechSynthesisChunkerService.ts
+++ b/core/templates/dev/head/services/SpeechSynthesisChunkerService.ts
@@ -170,7 +170,7 @@ export class SpeechSynthesisChunkerService {
     var elt = $('<div>' + html + '</div>');
     // Convert links into speakable text by extracting the readable value.
     elt.find('oppia-noninteractive-' + this.RTE_COMPONENT_NAMES.Link)
-      .replaceWith(() => {
+      .replaceWith(function() {
         if ((<HTMLElement><any> this).attributes[
           'text-with-value'] !== undefined) {
           return (<HTMLElement><any> this).attributes[
@@ -178,13 +178,14 @@ export class SpeechSynthesisChunkerService {
         }
       });
 
+    _this = this;
     // Convert LaTeX to speakable text.
     elt.find('oppia-noninteractive-' + this.RTE_COMPONENT_NAMES.Math)
-      .replaceWith(() => {
+      .replaceWith(function() {
         if (
           (<HTMLElement><any> this).attributes[
             'raw_latex-with-value'] !== undefined) {
-          return this._formatLatexToSpeakableText(
+          return _this._formatLatexToSpeakableText(
             (<HTMLElement><any> this).attributes[
               'raw_latex-with-value'].textContent);
         }


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #7873: Removes arrow function with function to resolve undefined `this` issue.
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
