### PR TITLE
Fix #6738: changed direct usage of window.location

### DIFF
--- a/core/templates/dev/head/components/common-layout-directives/navigation-bars/side-navigation-bar.directive.ts
+++ b/core/templates/dev/head/components/common-layout-directives/navigation-bars/side-navigation-bar.directive.ts
@@ -28,9 +28,9 @@ angular.module('oppia').directive('sideNavigationBar', [
         '/components/common-layout-directives/navigation-bars/' +
         'side-navigation-bar.directive.html'),
       controllerAs: '$ctrl',
-      controller: ['$timeout', function($timeout) {
+      controller: ['$timeout', '$window', function($timeout, $window) {
         var ctrl = this;
-        ctrl.currentUrl = window.location.pathname;
+        ctrl.currentUrl = $window.location.pathname;
         ctrl.getStaticImageUrl = UrlInterpolationService.getStaticImageUrl;
       }]
     };


### PR DESCRIPTION
## Explanation
This PR fixes #6738 the direct usage of window.location and instead uses $window

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
