### PR TITLE
Release Automation [Milestone 6]: Automate backup restoration for migrations on backup server

### DIFF
--- a/scripts/restore_backup.py
+++ b/scripts/restore_backup.py
@@ -16,7 +16,10 @@
 
 This script should be run from the oppia root folder:
 
-    python -m scripts.restore_backup --project_name='Name of project'
+    python -m scripts.restore_backup --project_name={{name_of_project}}
+
+The name of the project can be checked in release process instructions doc in
+section 3.2 (Performing Migrations).
 
 If the status of a backup restoration is to be checked, run the script as:
 

--- a/scripts/restore_backup.py
+++ b/scripts/restore_backup.py
@@ -16,8 +16,7 @@
 
 This script should be run from the oppia root folder:
 
-    python -m scripts.restore_backup
-    --project_name='oppiaserver-backup-migration'
+    python -m scripts.restore_backup --project_name='Name of project'
 
 If the status of a backup restoration is to be checked, run the script as:
 

--- a/scripts/restore_backup.py
+++ b/scripts/restore_backup.py
@@ -1,0 +1,109 @@
+# Copyright 2019 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Script for backup restoration on backup migration server.
+
+This script should be run from the oppia root folder:
+
+    python -m scripts.restore_backup
+
+If the status of a backup restoration is to be checked, run the script as:
+
+    python -m scripts.restore_backup --check_status
+"""
+
+from __future__ import absolute_import  # pylint: disable=import-only-modules
+from __future__ import unicode_literals  # pylint: disable=import-only-modules
+
+import argparse
+import os
+import sys
+
+import python_utils
+
+from . import common
+
+GCLOUD_PATH = os.path.join(
+    '..', 'oppia_tools', 'google-cloud-sdk-251.0.0', 'google-cloud-sdk',
+    'bin', 'gcloud')
+
+CURR_DIR = os.path.abspath(os.getcwd())
+OPPIA_TOOLS_DIR = os.path.join(CURR_DIR, '..', 'oppia_tools')
+GAE_DIR = os.path.join(
+    OPPIA_TOOLS_DIR, 'google_appengine_1.9.67', 'google_appengine')
+
+_PARSER = argparse.ArgumentParser()
+_PARSER.add_argument(
+    '--check_status', action='store_true', default=False, dest='check_status')
+
+
+def set_project(project_name):
+    """Sets the project to the given project name.
+
+    Args:
+        project_name: str. The name of the project.
+    """
+    common.run_cmd([GCLOUD_PATH, 'config', 'set', 'project', project_name])
+
+
+def initiate_backup_restore_process():
+    """Initiate the backup restoration process on backup migration server."""
+    list_of_buckets_url = (
+        'https://console.cloud.google.com/storage/browser/'
+        'oppia-export-backups?project=oppiaserver')
+    common.open_new_tab_in_browser_if_possible(list_of_buckets_url)
+    python_utils.PRINT(
+        'Navigate into the newest backup folder. \n'
+        'There should be a file here of the form '
+        '<date_time>.overall_export_metadata. \n'
+        'For example, "20181122-090002.overall_export_metadata". '
+        'This is the file you want to import.\n'
+        'Please copy and enter the name of this file\n')
+    export_metadata_filepath = python_utils.INPUT()
+    common.run_cmd([
+        GCLOUD_PATH, 'datastore', 'import',
+        'gs://%s' % export_metadata_filepath, '--async'])
+
+
+def check_backup_restoration_status():
+    """Checks the status of backup restoration process."""
+    python_utils.PRINT(
+        common.run_cmd([GCLOUD_PATH, 'datastore', 'operations', 'list']))
+
+
+def main(args=None):
+    """Performs task to restore backup or check the status of
+    backup restoration.
+    """
+    if not os.path.exists(os.path.dirname(GAE_DIR)):
+        raise Exception('Directory %s does not exist.' % GAE_DIR)
+    sys.path.insert(0, GAE_DIR)
+
+    if not common.is_current_branch_a_release_branch():
+        raise Exception(
+            'This script should only be run from the latest release branch.')
+
+    options = _PARSER.parse_args(args=args)
+
+    if options.check_status:
+        check_backup_restoration_status()
+    else:
+        set_project('oppiaserver-backup-migration')
+        initiate_backup_restore_process()
+
+
+# The 'no coverage' pragma is used as this line is un-testable. This is because
+# it will only be called when restore_backup.py is used as a script.
+if __name__ == '__main__': # pragma: no cover
+    main()

--- a/scripts/restore_backup.py
+++ b/scripts/restore_backup.py
@@ -18,8 +18,7 @@ This script should be run from the oppia root folder:
 
     python -m scripts.restore_backup --project_name={{name_of_project}}
 
-The name of the project can be checked in release process instructions doc in
-section 3.2 (Performing Migrations).
+The name of the project should match the project name on App Engine.
 
 If the status of a backup restoration is to be checked, run the script as:
 

--- a/scripts/restore_backup_test.py
+++ b/scripts/restore_backup_test.py
@@ -93,14 +93,13 @@ class RestoreBackupTests(test_utils.GenericTestBase):
         input_swap = self.swap(python_utils, 'INPUT', mock_input)
         with self.exists_swap, self.branch_check_swap, self.run_cmd_swap:
             with open_tab_swap, input_swap:
-                restore_backup.main(
-                    args=['--project_name=oppiaserver-backup-migration'])
+                restore_backup.main(args=['--project_name=project_name'])
 
         self.assertEqual(
             self.all_cmd_tokens,
             [
                 restore_backup.GCLOUD_PATH, 'config', 'set', 'project',
-                'oppiaserver-backup-migration',
+                'project_name',
                 restore_backup.GCLOUD_PATH, 'datastore', 'import',
                 'gs://export_metadata_filepath', '--async'])
         self.assertEqual(check_function_calls, expected_check_function_calls)

--- a/scripts/restore_backup_test.py
+++ b/scripts/restore_backup_test.py
@@ -93,13 +93,13 @@ class RestoreBackupTests(test_utils.GenericTestBase):
         input_swap = self.swap(python_utils, 'INPUT', mock_input)
         with self.exists_swap, self.branch_check_swap, self.run_cmd_swap:
             with open_tab_swap, input_swap:
-                restore_backup.main(args=['--project_name=project_name'])
+                restore_backup.main(args=['--project_name=sample_project_name'])
 
         self.assertEqual(
             self.all_cmd_tokens,
             [
                 restore_backup.GCLOUD_PATH, 'config', 'set', 'project',
-                'project_name',
+                'sample_project_name',
                 restore_backup.GCLOUD_PATH, 'datastore', 'import',
                 'gs://export_metadata_filepath', '--async'])
         self.assertEqual(check_function_calls, expected_check_function_calls)

--- a/scripts/restore_backup_test.py
+++ b/scripts/restore_backup_test.py
@@ -1,0 +1,108 @@
+# coding: utf-8
+#
+# Copyright 2019 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for scripts/restore_backup.py."""
+
+from __future__ import absolute_import  # pylint: disable=import-only-modules
+from __future__ import unicode_literals  # pylint: disable=import-only-modules
+
+import os
+
+from core.tests import test_utils
+
+import python_utils
+
+from . import common
+from . import restore_backup
+
+
+class RestoreBackupTests(test_utils.GenericTestBase):
+    """Test the methods for restoring backup."""
+
+    def setUp(self):
+        super(RestoreBackupTests, self).setUp()
+        self.all_cmd_tokens = []
+        def mock_run_cmd(cmd_tokens):
+            self.all_cmd_tokens.extend(cmd_tokens)
+        def mock_exists(unused_path):
+            return True
+        def mock_is_current_branch_a_release_branch():
+            return True
+
+        self.run_cmd_swap = self.swap(common, 'run_cmd', mock_run_cmd)
+        self.exists_swap = self.swap(os.path, 'exists', mock_exists)
+        self.branch_check_swap = self.swap(
+            common, 'is_current_branch_a_release_branch',
+            mock_is_current_branch_a_release_branch)
+
+    def test_missing_gae_dir(self):
+        def mock_exists(unused_path):
+            return False
+        exists_swap = self.swap(os.path, 'exists', mock_exists)
+        with exists_swap, self.assertRaisesRegexp(
+            Exception, 'Directory %s does not exist.' % restore_backup.GAE_DIR):
+            restore_backup.main(args=[])
+
+    def test_invalid_branch(self):
+        def mock_is_current_branch_a_release_branch():
+            return False
+        branch_check_swap = self.swap(
+            common, 'is_current_branch_a_release_branch',
+            mock_is_current_branch_a_release_branch)
+        with self.exists_swap, branch_check_swap, self.assertRaisesRegexp(
+            Exception,
+            'This script should only be run from the latest '
+            'release branch.'):
+            restore_backup.main(args=[])
+
+    def test_backup_restoration(self):
+        check_function_calls = {
+            'open_tab_is_called': False,
+            'input_is_called': False
+        }
+        expected_check_function_calls = {
+            'open_tab_is_called': True,
+            'input_is_called': True
+        }
+        def mock_open_tab(unused_url):
+            check_function_calls['open_tab_is_called'] = True
+        def mock_input():
+            check_function_calls['input_is_called'] = True
+            return 'export_metadata_filepath'
+
+        open_tab_swap = self.swap(
+            common, 'open_new_tab_in_browser_if_possible', mock_open_tab)
+        input_swap = self.swap(python_utils, 'INPUT', mock_input)
+        with self.exists_swap, self.branch_check_swap, self.run_cmd_swap:
+            with open_tab_swap, input_swap:
+                restore_backup.main(args=[])
+
+        self.assertEqual(
+            self.all_cmd_tokens,
+            [
+                restore_backup.GCLOUD_PATH, 'config', 'set', 'project',
+                'oppiaserver-backup-migration',
+                restore_backup.GCLOUD_PATH, 'datastore', 'import',
+                'gs://export_metadata_filepath', '--async'])
+        self.assertEqual(check_function_calls, expected_check_function_calls)
+
+    def test_check_status(self):
+        with self.exists_swap, self.branch_check_swap, self.run_cmd_swap:
+            restore_backup.main(args=['--check_status'])
+
+        self.assertEqual(
+            self.all_cmd_tokens,
+            [restore_backup.GCLOUD_PATH, 'datastore', 'operations', 'list'])

--- a/scripts/restore_backup_test.py
+++ b/scripts/restore_backup_test.py
@@ -68,6 +68,11 @@ class RestoreBackupTests(test_utils.GenericTestBase):
             'release branch.'):
             restore_backup.main(args=[])
 
+    def test_missing_project_name(self):
+        with self.exists_swap, self.branch_check_swap, self.assertRaisesRegexp(
+            Exception, 'Please provide project name for backup restoration.'):
+            restore_backup.main(args=[])
+
     def test_backup_restoration(self):
         check_function_calls = {
             'open_tab_is_called': False,
@@ -88,7 +93,8 @@ class RestoreBackupTests(test_utils.GenericTestBase):
         input_swap = self.swap(python_utils, 'INPUT', mock_input)
         with self.exists_swap, self.branch_check_swap, self.run_cmd_swap:
             with open_tab_swap, input_swap:
-                restore_backup.main(args=[])
+                restore_backup.main(
+                    args=['--project_name=oppiaserver-backup-migration'])
 
         self.assertEqual(
             self.all_cmd_tokens,


### PR DESCRIPTION
## Explanation
Automated backup restoration for migrations on backup server.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
