### PR TITLE
Switch download source for CKEditor libs to GitHub for better stability.

### DIFF
--- a/app_dev.yaml
+++ b/app_dev.yaml
@@ -137,7 +137,7 @@ handlers:
   login: admin
   script: main_mail.app
   secure: always
-  
+
 # STATIC PAGES.
 - url: /about
   static_files: webpack_bundles/about-page.mainpage.html
@@ -280,9 +280,90 @@ skip_files:
 # reduce deployed file count.
 # TODO(sll): Find a more structured way of doing this.
 - third_party/static/angular-audio-1.7.4
+- third_party/static/angular-drag-and-drop-lists-2.1.0
 - third_party/static/angular-scroll-1.0.0
 - third_party/static/angular-toastr-1.7.0
-- third_party/static/bower-material-0.6.0-rc1
+- third_party/static/bootstrap-4.3.1
+- third_party/static/bower-angular-translate-2.18.1
+- third_party/static/bower-angular-translate-interpolation-messageformat-2.18.1
+- third_party/static/bower-angular-translate-loader-partial-2.18.1
+- third_party/static/bower-angular-translate-loader-static-files-2.18.1
+- third_party/static/bower-angular-cookies-1.5.8
+- third_party/static/bower-angular-translate-storage-cookie-2.18.1,
+- third_party/static/bower-material-1.1.19
+# CKEditor-4.12.1 plugins in the download from the CKEditor website include
+# only a11yhelp, about, clipboard, colordialog, copyformatting, dialog, div,
+# find, flash, forms, iframe, image, link, liststyle, magicline, pagebreak,
+# pastefromword, preview, scayt, showblocks, smiley, specialchar, table,
+# tableselection, tabletools, templates, widget and wsc. Our code is also using
+# the sharedspace plugin. So, for now, we exclude all others, as well as flash,
+# a11yhelp, about, colordialog, iframe, and anything related to tables, which
+# we definitely don't use.
+- third_party/static/ckeditor-4.12.1/plugins/a11yhelp
+- third_party/static/ckeditor-4.12.1/plugins/about
+- third_party/static/ckeditor-4.12.1/plugins/adobeair
+- third_party/static/ckeditor-4.12.1/plugins/ajax
+- third_party/static/ckeditor-4.12.1/plugins/autocomplete
+- third_party/static/ckeditor-4.12.1/plugins/autoembed
+- third_party/static/ckeditor-4.12.1/plugins/autogrow
+- third_party/static/ckeditor-4.12.1/plugins/autolink
+- third_party/static/ckeditor-4.12.1/plugins/balloonpanel
+- third_party/static/ckeditor-4.12.1/plugins/balloontoolbar
+- third_party/static/ckeditor-4.12.1/plugins/bbcode
+- third_party/static/ckeditor-4.12.1/plugins/bidi
+- third_party/static/ckeditor-4.12.1/plugins/cloudservices
+- third_party/static/ckeditor-4.12.1/plugins/codesnippet
+- third_party/static/ckeditor-4.12.1/plugins/codesnippetgeshi
+- third_party/static/ckeditor-4.12.1/plugins/colorbutton
+- third_party/static/ckeditor-4.12.1/plugins/colordialog
+- third_party/static/ckeditor-4.12.1/plugins/devtools
+- third_party/static/ckeditor-4.12.1/plugins/dialogadvtab
+- third_party/static/ckeditor-4.12.1/plugins/divarea
+- third_party/static/ckeditor-4.12.1/plugins/docprops
+- third_party/static/ckeditor-4.12.1/plugins/easyimage
+- third_party/static/ckeditor-4.12.1/plugins/embed
+- third_party/static/ckeditor-4.12.1/plugins/embedbase
+- third_party/static/ckeditor-4.12.1/plugins/embedsemantic
+- third_party/static/ckeditor-4.12.1/plugins/emoji
+- third_party/static/ckeditor-4.12.1/plugins/flash
+- third_party/static/ckeditor-4.12.1/plugins/font
+- third_party/static/ckeditor-4.12.1/plugins/iframe
+- third_party/static/ckeditor-4.12.1/plugins/iframedialog
+- third_party/static/ckeditor-4.12.1/plugins/image2
+- third_party/static/ckeditor-4.12.1/plugins/imagebase
+- third_party/static/ckeditor-4.12.1/plugins/indentblock
+- third_party/static/ckeditor-4.12.1/plugins/justify
+- third_party/static/ckeditor-4.12.1/plugins/language
+- third_party/static/ckeditor-4.12.1/plugins/mathjax
+- third_party/static/ckeditor-4.12.1/plugins/mentions
+- third_party/static/ckeditor-4.12.1/plugins/newpage
+- third_party/static/ckeditor-4.12.1/plugins/panelbutton
+- third_party/static/ckeditor-4.12.1/plugins/placeholder
+- third_party/static/ckeditor-4.12.1/plugins/print
+- third_party/static/ckeditor-4.12.1/plugins/save
+- third_party/static/ckeditor-4.12.1/plugins/selectall
+- third_party/static/ckeditor-4.12.1/plugins/sourcedialog
+- third_party/static/ckeditor-4.12.1/plugins/stylesheetparser
+- third_party/static/ckeditor-4.12.1/plugins/table
+- third_party/static/ckeditor-4.12.1/plugins/tableresize
+- third_party/static/ckeditor-4.12.1/plugins/tableselection
+- third_party/static/ckeditor-4.12.1/plugins/tabletools
+- third_party/static/ckeditor-4.12.1/plugins/textmatch
+- third_party/static/ckeditor-4.12.1/plugins/textwatcher
+- third_party/static/ckeditor-4.12.1/plugins/uicolor
+- third_party/static/ckeditor-4.12.1/plugins/uploadfile
+- third_party/static/ckeditor-4.12.1/plugins/xml
+- third_party/static/ckeditor-4.12.1/samples
+- third_party/static/ckeditor-4.12.1/skins/kama
+- third_party/static/ckeditor-4.12.1/skins/moono
+- third_party/static/ckeditor-bootstrapck-1.0.0/core
+- third_party/static/ckeditor-bootstrapck-1.0.0/lang
+- third_party/static/ckeditor-bootstrapck-1.0.0/plugins
+- third_party/static/ckeditor-bootstrapck-1.0.0/skins/bootstrapck-dev
+- third_party/static/ckeditor-bootstrapck-1.0.0/skins/moono
+- third_party/static/ckeditor-bootstrapck-1.0.0/skins/ckbuilder.jar
+- third_party/static/ckeditor-bootstrapck-1.0.0/skins/bootstrapck/sample
+- third_party/static/ckeditor-bootstrapck-1.0.0/skins/bootstrapck/scss
 - third_party/static/fontawesome-free-5.9.0-web
 - third_party/static/guppy-b5055b/site
 - third_party/static/guppy-b5055b/test
@@ -338,6 +419,4 @@ skip_files:
 - third_party/static/messageformat-2.0.5
 - third_party/static/ng-img-crop-0.3.2
 - third_party/static/nginfinitescroll-1.0.0
-- third_party/static/perfectscrollbar-0.6.16
-- third_party/static/rangy-1.3.0
-- third_party/static/widget
+- third_party/static/popperJs-1.15.0

--- a/app_dev.yaml
+++ b/app_dev.yaml
@@ -280,7 +280,6 @@ skip_files:
 # reduce deployed file count.
 # TODO(sll): Find a more structured way of doing this.
 - third_party/static/angular-audio-1.7.4
-- third_party/static/angular-drag-and-drop-lists-2.1.0
 - third_party/static/angular-scroll-1.0.0
 - third_party/static/angular-toastr-1.7.0
 - third_party/static/bootstrap-4.3.1

--- a/core/templates/dev/head/components/ck-editor-helpers/ck-editor-4-rte.directive.ts
+++ b/core/templates/dev/head/components/ck-editor-helpers/ck-editor-4-rte.directive.ts
@@ -92,7 +92,8 @@ angular.module('oppia').directive('ckEditor4Rte', [
         // Add external plugins.
         CKEDITOR.plugins.addExternal(
           'sharedspace',
-          '/third_party/static/ckeditor-sharedspace-4.12.1/', 'plugin.js');
+          '/third_party/static/ckeditor-4.12.1/plugins/sharedspace/',
+          'plugin.js');
         // Pre plugin is not available for 4.12.1 version of CKEditor. This is
         // a self created plugin (other plugins are provided by CKEditor).
         CKEDITOR.plugins.addExternal(
@@ -115,7 +116,10 @@ angular.module('oppia').directive('ckEditor4Rte', [
           sharedSpaces: {
             top: <HTMLElement>el[0].children[0].children[0]
           },
-          skin: 'bootstrapck,/third_party/static/ckeditor-bootstrapck-1.0/',
+          skin: (
+            'bootstrapck,' +
+            '/third_party/static/ckeditor-bootstrapck-1.0.0/skins/bootstrapck/'
+          ),
           toolbar: [
             {
               name: 'basicstyles',

--- a/manifest.json
+++ b/manifest.json
@@ -476,22 +476,15 @@
       "ckeditor": {
         "version": "4.12.1",
         "downloadFormat": "zip",
-        "url": "https://download.cksource.com/CKEditor/CKEditor/CKEditor%204.12.1/ckeditor_4.12.1_full.zip",
-        "rootDir": "ckeditor",
+        "url": "https://github.com/ckeditor/ckeditor4-releases/archive/4.12.1.zip",
+        "rootDirPrefix": "ckeditor4-releases-",
         "targetDirPrefix": "ckeditor-"
       },
-      "ckeditorSharedspace": {
-        "version": "4.12.1",
-        "downloadFormat": "zip",
-        "url": "https://download.ckeditor.com/sharedspace/releases/sharedspace_4.12.1.zip",
-        "rootDir": "sharedspace",
-        "targetDirPrefix": "ckeditor-sharedspace-"
-      },
       "ckeditorBootstrapCK": {
-        "version": "1.0",
+        "version": "1.0.0",
         "downloadFormat": "zip",
-        "url": "https://download.ckeditor.com/bootstrapck/releases/bootstrapck_1.0_0.zip",
-        "rootDir": "bootstrapck",
+        "url": "https://github.com/Kunstmaan/BootstrapCK4-Skin/archive/v1.0.0.zip",
+        "rootDirPrefix": "BootstrapCK4-Skin-",
         "targetDirPrefix": "ckeditor-bootstrapck-"
       },
       "uiBootstrap": {


### PR DESCRIPTION
## Explanation

Travis CI builds are failing due to network issues downloading CKEditor libraries. This PR switches the source of those libraries to GitHub for better reliability, and in the process removes an unneeded download.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.