### PR TITLE
Fix part of #5914: Add testing for nonexistent users in export_data

### DIFF
--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -210,6 +210,7 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
         }
         self.assertEqual(expected_collection_ids, collection_ids)
 
+
 class CollectionCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
     """Test the CollectionCommitLogEntryModel class."""
 

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -197,6 +197,18 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
         }
         self.assertEqual(expected_collection_ids, collection_ids)
 
+    def test_export_data_on_invalid_user(self):
+        """Test for empty lists when the user_id is invalid."""
+        collection_ids = (
+            collection_models.CollectionRightsModel.export_data(
+                'fake_user'))
+        expected_collection_ids = {
+            'owned_collection_ids': [],
+            'editable_collection_ids': [],
+            'voiced_collection_ids': [],
+            'viewable_collection_ids': []
+        }
+        self.assertEqual(expected_collection_ids, collection_ids)
 
 class CollectionCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
     """Test the CollectionCommitLogEntryModel class."""

--- a/core/storage/email/gae_models_test.py
+++ b/core/storage/email/gae_models_test.py
@@ -474,3 +474,11 @@ class GeneralFeedbackEmailReplyToIdTests(test_utils.GenericTestBase):
                 self.USER_ID_1))
         expected_data = {}
         self.assertEqual(expected_data, user_data)
+    
+    def test_export_data_on_nonexistent_user(self):
+        """Verify proper export data output on nonexistent user."""
+        user_data = (
+            email_models.GeneralFeedbackEmailReplyToIdModel.export_data(
+                'fake_user'))
+        expected_data = {}
+        self.assertEqual(expected_data, user_data) 

--- a/core/storage/email/gae_models_test.py
+++ b/core/storage/email/gae_models_test.py
@@ -474,11 +474,11 @@ class GeneralFeedbackEmailReplyToIdTests(test_utils.GenericTestBase):
                 self.USER_ID_1))
         expected_data = {}
         self.assertEqual(expected_data, user_data)
-    
+
     def test_export_data_on_nonexistent_user(self):
         """Verify proper export data output on nonexistent user."""
         user_data = (
             email_models.GeneralFeedbackEmailReplyToIdModel.export_data(
                 'fake_user'))
         expected_data = {}
-        self.assertEqual(expected_data, user_data) 
+        self.assertEqual(expected_data, user_data)

--- a/core/storage/exploration/gae_models_test.py
+++ b/core/storage/exploration/gae_models_test.py
@@ -203,6 +203,19 @@ class ExplorationRightsModelUnitTest(test_utils.GenericTestBase):
             'viewable_exploration_ids': []
         }
         self.assertEqual(expected_exploration_ids, exploration_ids)
+    
+    def test_export_data_on_nonexistent_user(self):
+        """Test for empty lists when user has no exploration involvement."""
+        exploration_ids = (
+            exploration_models.ExplorationRightsModel.export_data(
+                'fake_user'))
+        expected_exploration_ids = {
+            'owned_exploration_ids': [],
+            'editable_exploration_ids': [],
+            'voiced_exploration_ids': [],
+            'viewable_exploration_ids': []
+        }
+        self.assertEqual(expected_exploration_ids, exploration_ids) 
 
 
 class ExplorationCommitLogEntryModelUnitTest(test_utils.GenericTestBase):

--- a/core/storage/exploration/gae_models_test.py
+++ b/core/storage/exploration/gae_models_test.py
@@ -203,7 +203,7 @@ class ExplorationRightsModelUnitTest(test_utils.GenericTestBase):
             'viewable_exploration_ids': []
         }
         self.assertEqual(expected_exploration_ids, exploration_ids)
-    
+
     def test_export_data_on_nonexistent_user(self):
         """Test for empty lists when user has no exploration involvement."""
         exploration_ids = (
@@ -215,7 +215,7 @@ class ExplorationRightsModelUnitTest(test_utils.GenericTestBase):
             'voiced_exploration_ids': [],
             'viewable_exploration_ids': []
         }
-        self.assertEqual(expected_exploration_ids, exploration_ids) 
+        self.assertEqual(expected_exploration_ids, exploration_ids)
 
 
 class ExplorationCommitLogEntryModelUnitTest(test_utils.GenericTestBase):

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -132,7 +132,7 @@ class UserSettingsModel(base_models.BaseModel):
         """
         try:
             user = UserSettingsModel.get(user_id)
-        except UserSettingsModel.EntityNotFoundError as e:
+        except UserSettingsModel.EntityNotFoundError:
             return {}
         return {
             'email': user.email,

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -130,7 +130,10 @@ class UserSettingsModel(base_models.BaseModel):
         Returns:
             dict. Dictionary of the data from UserSettingsModel.
         """
-        user = UserSettingsModel.get(user_id)
+        try:
+            user = UserSettingsModel.get(user_id)
+        except UserSettingsModel.EntityNotFoundError as e:
+            return {}
         return {
             'email': user.email,
             'role': user.role,

--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -130,10 +130,7 @@ class UserSettingsModel(base_models.BaseModel):
         Returns:
             dict. Dictionary of the data from UserSettingsModel.
         """
-        try:
-            user = UserSettingsModel.get(user_id)
-        except UserSettingsModel.EntityNotFoundError:
-            return {}
+        user = UserSettingsModel.get(user_id)
         return {
             'email': user.email,
             'role': user.role,

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -112,8 +112,8 @@ class UserSettingsModelTest(test_utils.GenericTestBase):
         self.assertEqual(user[0].role, feconf.ROLE_ID_ADMIN)
 
     def test_export_data_nonexistent_user(self):
-        user_data = user_models.UserSettingsModel.export_data('fake_user')
-        self.assertEqual(user_data, {})
+        with self.assertRaises(user_models.UserSettingsModel.EntityNotFoundError):
+            user_data = user_models.UserSettingsModel.export_data('fake_user')
 
     def test_export_data_trivial(self):
         user = user_models.UserSettingsModel.get_by_id(self.USER_1_ID)

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -110,7 +110,7 @@ class UserSettingsModelTest(test_utils.GenericTestBase):
         user = user_models.UserSettingsModel.get_by_role(
             feconf.ROLE_ID_ADMIN)
         self.assertEqual(user[0].role, feconf.ROLE_ID_ADMIN)
-    
+
     def test_export_data_nonexistent_user(self):
         user_data = user_models.UserSettingsModel.export_data('fake_user')
         self.assertEqual(user_data, {})

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -110,6 +110,10 @@ class UserSettingsModelTest(test_utils.GenericTestBase):
         user = user_models.UserSettingsModel.get_by_role(
             feconf.ROLE_ID_ADMIN)
         self.assertEqual(user[0].role, feconf.ROLE_ID_ADMIN)
+    
+    def test_export_data_nonexistent_user(self):
+        user_data = user_models.UserSettingsModel.export_data('fake_user')
+        self.assertEqual(user_data, {})
 
     def test_export_data_trivial(self):
         user = user_models.UserSettingsModel.get_by_id(self.USER_1_ID)
@@ -985,6 +989,11 @@ class ExplorationUserDataModelTest(test_utils.GenericTestBase):
             self.USER_1_ID, 'unknown_exp_id')
 
         self.assertEqual(retrieved_object, None)
+
+    def test_export_data_nonexistent_user(self):
+        user_data = user_models.ExplorationUserDataModel.export_data(
+            'fake_user')
+        self.assertEqual(user_data, {})
 
     def test_export_data_one_exploration(self):
         """Test export data when user has one exploration."""

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -112,8 +112,9 @@ class UserSettingsModelTest(test_utils.GenericTestBase):
         self.assertEqual(user[0].role, feconf.ROLE_ID_ADMIN)
 
     def test_export_data_nonexistent_user(self):
-        with self.assertRaises(user_models.UserSettingsModel.EntityNotFoundError):
-            user_data = user_models.UserSettingsModel.export_data('fake_user')
+        with self.assertRaises(user_models.UserSettingsModel
+                                          .EntityNotFoundError):
+            user_models.UserSettingsModel.export_data('fake_user')
 
     def test_export_data_trivial(self):
         user = user_models.UserSettingsModel.get_by_id(self.USER_1_ID)

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -113,7 +113,7 @@ class UserSettingsModelTest(test_utils.GenericTestBase):
 
     def test_export_data_nonexistent_user(self):
         with self.assertRaises(user_models.UserSettingsModel
-                                          .EntityNotFoundError):
+                               .EntityNotFoundError):
             user_models.UserSettingsModel.export_data('fake_user')
 
     def test_export_data_trivial(self):


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Adds testing for nonexistent users in export_data.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
