### PR TITLE
Fix part of #7427: Addresses docstring issues in one of the files (prod_validation_jobs_one_off.py)

### DIFF
--- a/core/domain/prod_validation_jobs_one_off.py
+++ b/core/domain/prod_validation_jobs_one_off.py
@@ -164,7 +164,7 @@ class BaseModelValidator(python_utils.OBJECT):
             unused_item: ndb.Model. Entity to validate.
 
         Returns:
-            *: A domain object to validate.
+            *. A domain object to validate.
         """
         return None
 
@@ -201,6 +201,9 @@ class BaseModelValidator(python_utils.OBJECT):
             dict(str, (ndb.Model, list(str)). A dictionary whose keys are
             field names of the model to validate, and whose values are tuples
             that consist of the external model class and list of keys to fetch.
+
+        Raises:
+            NotImplementedError. This function has not yet been implemented.
         """
         raise NotImplementedError
 
@@ -280,6 +283,9 @@ class BaseModelValidator(python_utils.OBJECT):
 
         Each validation function should accept only a single arg, which is the
         model instance to validate.
+
+        Returns:
+            list(function). The list of custom validation functions to run.
         """
         return []
 
@@ -313,11 +319,14 @@ class BaseSummaryModelValidator(BaseModelValidator):
         This should be implemented by subclasses.
 
         Returns:
-            tuple(str, list(tuple), dict): A tuple with first element as
+            tuple(str, list(tuple), dict). A tuple with first element as
                 external model name, second element as a tuple of
                 cls.external_instance_details and the third element
                 as a properties dict with key as property name in summary
                 model and value as property name in external model.
+
+        Raises:
+            NotImplementedError. This function has not yet been implemented.
         """
         raise NotImplementedError
 
@@ -475,8 +484,11 @@ class BaseSnapshotMetadataModelValidator(BaseSnapshotContentModelValidator):
             unused_item: ndb.Model. Entity to validate.
 
         Returns:
-            change_domain.BaseChange: A domain object class for the
+            change_domain.BaseChange. A domain object class for the
                 changes made by commit commands of the model.
+
+        Raises:
+            NotImplementedError. This function has not yet been implemented.
         """
         raise NotImplementedError
 
@@ -656,7 +668,7 @@ class BaseUserModelValidator(BaseModelValidator):
             unused_item: ndb.Model. BaseUserModel to validate.
 
         Returns:
-            list(tuple(str, str, list, str, list):
+            list(tuple(str, str, list, str, list).
                 A list of tuple which consists of External model name,
                 property name in model, list of property value in model,
                 property name in external model, list of property value
@@ -3401,7 +3413,7 @@ class GeneralVoiceoverApplicationModelValidator(BaseModelValidator):
             item: GeneralVoiceoverApplicationModel. Entity to validate.
 
         Returns:
-            *: A domain object to validate.
+            *. A domain object to validate.
         """
         return suggestion_services.get_voiceover_application(item.id)
 

--- a/core/domain/prod_validation_jobs_one_off_test.py
+++ b/core/domain/prod_validation_jobs_one_off_test.py
@@ -93,8 +93,13 @@ OriginalDatetimeType = datetime.datetime
 class PatchedDatetimeType(type):
     """Validates the datetime instances."""
     def __instancecheck__(cls, other):
-        """Validates whether the given instance is a datatime
-        instance.
+        """Validates whether the given instance is a datatime instance.
+
+        Args:
+            other: *. The instance to check.
+
+        Returns:
+            bool. Whether or not the instance is an OriginalDateTimeType.
         """
         return isinstance(other, OriginalDatetimeType)
 
@@ -103,13 +108,23 @@ class MockDatetime13Hours( # pylint: disable=inherit-non-class
         python_utils.with_metaclass(PatchedDatetimeType, datetime.datetime)):
     @classmethod
     def utcnow(cls):
-        """Returns the current date and time 13 hours behind UTC."""
+        """Returns the current date and time 13 hours behind UTC.
+
+        Returns:
+            datetime. A datetime that is 13 hours behind the current time.
+        """
         return CURRENT_DATETIME - datetime.timedelta(hours=13)
 
 
 def run_job_and_check_output(
         self, expected_output, sort=False, literal_eval=False):
-    """Helper function to run job and compare output."""
+    """Helper function to run job and compare output.
+
+    Args:
+        expected_output: list(*). The expected result of the job.
+        sort: bool. Whether to sort the outputs before comparison.
+        literal_eval: bool. Whether to use ast.literal_eval before comparison.
+    """
     job_id = self.job_class.create_new()
     self.assertEqual(
         self.count_jobs_in_taskqueue(


### PR DESCRIPTION
Fixes part of #7427: Corrects incomplete docstrings in prod_validation_jobs_one_off.py and, by extension, prod_validation_jobs_one_off_test.py.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
