### PR TITLE
Fix skulpt install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
   - /^release-\d+\.\d+\.\d+-hotfix-\d+$/
 
 env:
-  matrix:
+  jobs:
     # These lines are commented out because these checks are being run on CircleCI
     # here: https://circleci.com/gh/oppia/oppia
     # - RUN_LINT=true
@@ -51,7 +51,7 @@ env:
     - RUN_E2E_TESTS_TOPIC_AND_STORY_EDITOR=true
     - RUN_E2E_TESTS_USERS=true
 
-matrix:
+jobs:
   allow_failures: []
   fast_finish: true
 

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -179,7 +179,9 @@ def install_skulpt(parsed_args):
                     line.replace('ret = rununits(opt=True)', 'ret = 0'),
                     end='')
 
-            subprocess.check_call(['python', skulpt_filepath, 'dist'])
+            # NB: Check call cannot be used because the commands above make the
+            # git tree for skulpt dirty.
+            subprocess.call(['python', skulpt_filepath, 'dist'])
 
             # Return to the Oppia root folder.
             os.chdir(common.CURR_DIR)

--- a/scripts/install_third_party_libs_test.py
+++ b/scripts/install_third_party_libs_test.py
@@ -127,13 +127,13 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         check_function_calls = {
             'chdir_is_called': False,
             'mkdir_is_called': False,
-            'check_call_is_called': False,
+            'call_is_called': False,
             'copytree_is_called': False
         }
         expected_check_function_calls = {
             'chdir_is_called': True,
             'mkdir_is_called': True,
-            'check_call_is_called': True,
+            'call_is_called': True,
             'copytree_is_called': True
         }
         expected_lines_in_print_arr = [
@@ -147,8 +147,8 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
             check_function_calls['chdir_is_called'] = True
         def mock_mkdir(unused_path):
             check_function_calls['mkdir_is_called'] = True
-        def mock_check_call(unused_cmd_tokens):
-            check_function_calls['check_call_is_called'] = True
+        def mock_call(unused_cmd_tokens):
+            check_function_calls['call_is_called'] = True
         def mock_copytree(unused_path1, unused_path2):
             check_function_calls['copytree_is_called'] = True
         # pylint: disable=unused-argument
@@ -163,7 +163,7 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         exists_swap = self.swap(os.path, 'exists', mock_exists)
         chdir_swap = self.swap(os, 'chdir', mock_chdir)
         mkdir_swap = self.swap(os, 'mkdir', mock_mkdir)
-        check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
+        check_call_swap = self.swap(subprocess, 'call', mock_call)
         copytree_swap = self.swap(shutil, 'copytree', mock_copytree)
         input_swap = self.swap(fileinput, 'input', mock_input)
 


### PR DESCRIPTION
## Explanation

Skulpt install doesn't work on the initial install for Oppia as a result of the `call` to `check_call` conversion, this PR undos that. 

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
