### PR TITLE
Add more explanation to the top of the run_backend_tests script.

### DIFF
--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -18,7 +18,28 @@ This should not be run directly. Instead, navigate to the oppia/ folder and
 execute:
 
     python -m scripts.run_backend_tests
+
+You can also append the following options to the above command:
+
+    --verbose prints the output of the tests to the console.
+
+    --test_target=core.controllers.editor_test runs only the tests in the
+        core.controllers.editor_test module. (You can change
+        "core.controllers.editor_test" to any valid module path.)
+
+    --test_path=core/controllers runs all tests in test files in the
+        core/controllers directory. (You can change "core/controllers" to any
+        valid subdirectory path.)
+
+    --generate_coverage_report generates a coverage report as part of the final
+        test output (but it makes the tests slower).
+
+Note: If you've made some changes and tests are failing to run at all, this
+might mean that you have introduced a circular dependency (e.g. module A
+imports module B, which imports module C, which imports module A). This needs
+to be fixed before the tests will run.
 """
+
 from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 


### PR DESCRIPTION
## Explanation
Adds some details to run_backend_tests.py to explain the use of the various options.

This arose due to a question by @U8NWXD about why print output doesn't show up while the backend tests ran. (Turns out we already have a --verbose option in there, which I had completely forgotten about.)

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.