### PR TITLE
Fix part of #6271: Update update_worked_examples to accept object as a parameter instead of dict

### DIFF
--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -803,14 +803,13 @@ class Skill(python_utils.OBJECT):
         """Updates the worked examples list of the skill.
 
         Args:
-            worked_examples: list(dict). The new worked examples of the skill.
+            worked_examples: list(SubtitledHtml). The new worked examples of the skill.
         """
+
         old_content_ids = [worked_example.content_id for worked_example in (
             self.skill_contents.worked_examples)]
 
-        self.skill_contents.worked_examples = [
-            state_domain.SubtitledHtml.from_dict(worked_example)
-            for worked_example in worked_examples]
+        self.skill_contents.worked_examples = worked_examples
 
         new_content_ids = [worked_example.content_id for worked_example in (
             self.skill_contents.worked_examples)]

--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -803,13 +803,14 @@ class Skill(python_utils.OBJECT):
         """Updates the worked examples list of the skill.
 
         Args:
-            worked_examples: list(SubtitledHtml). The new worked examples of the skill.
+            worked_examples: list(SubtitledHtml). The new worked examples of
+                the skill.
         """
 
         old_content_ids = [worked_example.content_id for worked_example in (
             self.skill_contents.worked_examples)]
 
-        self.skill_contents.worked_examples = worked_examples
+        self.skill_contents.worked_examples = list(worked_examples)
 
         new_content_ids = [worked_example.content_id for worked_example in (
             self.skill_contents.worked_examples)]
@@ -827,6 +828,7 @@ class Skill(python_utils.OBJECT):
             new_ids_list: list(str). A list of content ids currently present
                 in worked_examples.
         """
+
         content_ids_to_delete = set(old_ids_list) - set(new_ids_list)
         content_ids_to_add = set(new_ids_list) - set(old_ids_list)
         written_translations = self.skill_contents.written_translations

--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -800,13 +800,13 @@ class Skill(python_utils.OBJECT):
         self._update_content_ids_in_assets(old_content_ids, new_content_ids)
 
     def update_worked_examples(self, worked_examples):
-        """Updates the worked examples list of the skill.
+        """Updates the worked examples list of the skill by performing a copy
+        of the provided list.
 
         Args:
             worked_examples: list(SubtitledHtml). The new worked examples of
                 the skill.
         """
-
         old_content_ids = [worked_example.content_id for worked_example in (
             self.skill_contents.worked_examples)]
 
@@ -828,7 +828,6 @@ class Skill(python_utils.OBJECT):
             new_ids_list: list(str). A list of content ids currently present
                 in worked_examples.
         """
-
         content_ids_to_delete = set(old_ids_list) - set(new_ids_list)
         content_ids_to_add = set(new_ids_list) - set(old_ids_list)
         written_translations = self.skill_contents.written_translations

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -372,17 +372,17 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
             'html': '<p>Another worked example</p>'
         }]
 
-        worked_examples_object_list = [
+        worked_examples_list = [
             state_domain.SubtitledHtml.from_dict(worked_example)
             for worked_example in worked_examples_dict]
 
-        self.skill.update_worked_examples(worked_examples_object_list)
+        self.skill.update_worked_examples(worked_examples_list)
         self.skill.validate()
 
         # Delete the last worked_example.
-        worked_examples_object_list.pop()
+        worked_examples_list.pop()
 
-        self.skill.update_worked_examples(worked_examples_object_list)
+        self.skill.update_worked_examples(worked_examples_list)
         self.skill.validate()
 
     def test_skill_rights_is_creator(self):

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -372,16 +372,17 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
             'html': '<p>Another worked example</p>'
         }]
 
-        worked_examples_list = [state_domain.SubtitledHtml.from_dict(worked_example)
+        worked_examples_object_list = [
+            state_domain.SubtitledHtml.from_dict(worked_example)
             for worked_example in worked_examples_dict]
 
-        self.skill.update_worked_examples(worked_examples_list)
+        self.skill.update_worked_examples(worked_examples_object_list)
         self.skill.validate()
 
         # Delete the last worked_example.
-        worked_examples_list.pop()
+        worked_examples_object_list.pop()
 
-        self.skill.update_worked_examples(worked_examples_list)
+        self.skill.update_worked_examples(worked_examples_object_list)
         self.skill.validate()
 
     def test_skill_rights_is_creator(self):

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -364,7 +364,7 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
         self.assertDictEqual(expected_dict, skill_rights.to_dict())
 
     def test_update_worked_examples(self):
-        worked_examples_dict = [{
+        worked_examples_dict_list = [{
             'content_id': 'worked_example_1',
             'html': '<p>Worked example</p>'
         }, {
@@ -372,17 +372,17 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
             'html': '<p>Another worked example</p>'
         }]
 
-        worked_examples_list = [
+        worked_examples_object_list = [
             state_domain.SubtitledHtml.from_dict(worked_example)
-            for worked_example in worked_examples_dict]
+            for worked_example in worked_examples_dict_list]
 
-        self.skill.update_worked_examples(worked_examples_list)
+        self.skill.update_worked_examples(worked_examples_object_list)
         self.skill.validate()
 
         # Delete the last worked_example.
-        worked_examples_list.pop()
+        worked_examples_object_list.pop()
 
-        self.skill.update_worked_examples(worked_examples_list)
+        self.skill.update_worked_examples(worked_examples_object_list)
         self.skill.validate()
 
     def test_skill_rights_is_creator(self):

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -372,13 +372,16 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
             'html': '<p>Another worked example</p>'
         }]
 
-        self.skill.update_worked_examples(worked_examples_dict)
+        worked_examples_list = [state_domain.SubtitledHtml.from_dict(worked_example)
+            for worked_example in worked_examples_dict]
+
+        self.skill.update_worked_examples(worked_examples_list)
         self.skill.validate()
 
         # Delete the last worked_example.
-        worked_examples_dict.pop()
+        worked_examples_list.pop()
 
-        self.skill.update_worked_examples(worked_examples_dict)
+        self.skill.update_worked_examples(worked_examples_list)
         self.skill.validate()
 
     def test_skill_rights_is_creator(self):

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -486,10 +486,10 @@ def apply_change_list(skill_id, change_list, committer_id):
                     skill.update_explanation(change.new_value)
                 elif (change.property_name ==
                       skill_domain.SKILL_CONTENTS_PROPERTY_WORKED_EXAMPLES):
-                    worked_examples_object_list = [
+                    worked_examples_list = [
                         state_domain.SubtitledHtml.from_dict(worked_example)
                         for worked_example in change.new_value]
-                    skill.update_worked_examples(worked_examples_object_list)
+                    skill.update_worked_examples(worked_examples_list)
             elif change.cmd == skill_domain.CMD_ADD_SKILL_MISCONCEPTION:
                 skill.add_misconception(change.new_misconception_dict)
             elif change.cmd == skill_domain.CMD_DELETE_SKILL_MISCONCEPTION:

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -24,6 +24,7 @@ from core.domain import opportunity_services
 from core.domain import role_services
 from core.domain import skill_domain
 from core.domain import user_services
+from core.domain import state_domain
 from core.platform import models
 import feconf
 import python_utils

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -486,7 +486,10 @@ def apply_change_list(skill_id, change_list, committer_id):
                     skill.update_explanation(change.new_value)
                 elif (change.property_name ==
                       skill_domain.SKILL_CONTENTS_PROPERTY_WORKED_EXAMPLES):
-                    skill.update_worked_examples(change.new_value)
+                    worked_examples_object_list = [
+                        state_domain.SubtitledHtml.from_dict(worked_example)
+                        for worked_example in change.new_value]
+                    skill.update_worked_examples(worked_examples_object_list)
             elif change.cmd == skill_domain.CMD_ADD_SKILL_MISCONCEPTION:
                 skill.add_misconception(change.new_misconception_dict)
             elif change.cmd == skill_domain.CMD_DELETE_SKILL_MISCONCEPTION:

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -23,8 +23,8 @@ from core.domain import email_manager
 from core.domain import opportunity_services
 from core.domain import role_services
 from core.domain import skill_domain
-from core.domain import user_services
 from core.domain import state_domain
+from core.domain import user_services
 from core.platform import models
 import feconf
 import python_utils


### PR DESCRIPTION
## Explanation
Fixes part of #6271: Update update_worked_examples to accept object as a parameter instead of dict

## Checklist
- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [X] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [X] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [X] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
