### PR TITLE
Fix #7974: Fix Lateral Scroll Bug on Learner Dashboard Mobile

### DIFF
--- a/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.directive.html
+++ b/core/templates/dev/head/pages/learner-dashboard-page/learner-dashboard-page.directive.html
@@ -28,7 +28,7 @@
     </md-card>
   </div>
 
-  <div class="row"
+  <div class="row no-gutters"
        ng-style="$ctrl.checkMobileView() ? {'display': 'block'} : {'display': 'flex'}"
        style="display: flex;"
        ng-if="$ctrl.noActivity">


### PR DESCRIPTION
## Explanation

On the learner dashboard, bootstrap by default puts padding around the
elements in rows. Since on the learner dashboard the quote image extends
across the screen from edge to edge, this padding resulted in the user
being able to scroll slightly to the right, which we do not want. To
prevent this behavior, this commit adds the `no-gutters` class to the
row, which removes the left and right padding from the row.

Fixes #7974.

## Screenshots

Before:

![before](https://user-images.githubusercontent.com/19878639/69177028-a9135500-0abb-11ea-9f15-0bbf7d331a6c.gif)


After:

![after](https://user-images.githubusercontent.com/19878639/69177044-ad3f7280-0abb-11ea-9a53-d20bc5eae9f4.gif)

Note that here I am attempting to swipe laterally, but nothing happens as expected.

Works on Desktop too:

![desktop](https://user-images.githubusercontent.com/19878639/69314387-e1fd1800-0be8-11ea-9a49-438393285cc4.gif)

Here I am again attempting to scroll laterally.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
