### PR TITLE
Wipeout 2.9: Check snapshot content models when looking for user_id

### DIFF
--- a/core/storage/base_model/gae_models.py
+++ b/core/storage/base_model/gae_models.py
@@ -45,6 +45,9 @@ DELETION_POLICY = utils.create_enum(  # pylint: disable=invalid-name
     'NOT_APPLICABLE'
 )
 
+# Constant used when retrieving big number of models.
+FETCH_BATCH_SIZE = 1000
+
 # Constants used for generating ids.
 MAX_RETRIES = 10
 RAND_RANGE = (1 << 30) - 1

--- a/core/storage/collection/gae_models.py
+++ b/core/storage/collection/gae_models.py
@@ -202,6 +202,13 @@ class CollectionRightsModel(base_models.VersionedModel):
         Returns:
             bool. Whether any models refer to the given user ID.
         """
+        for snapshot_content_model in cls.SNAPSHOT_CONTENT_CLASS.get_all():
+            reconstituted_model = cls(**snapshot_content_model.content)
+            if any((user_id in reconstituted_model.owner_ids,
+                    user_id in reconstituted_model.editor_ids,
+                    user_id in reconstituted_model.voice_artist_ids,
+                    user_id in reconstituted_model.viewer_ids)):
+                return True
         return (
             cls.query(ndb.OR(
                 cls.owner_ids == user_id,

--- a/core/storage/collection/gae_models.py
+++ b/core/storage/collection/gae_models.py
@@ -202,13 +202,19 @@ class CollectionRightsModel(base_models.VersionedModel):
         Returns:
             bool. Whether any models refer to the given user ID.
         """
-        for snapshot_content_model in cls.SNAPSHOT_CONTENT_CLASS.get_all():
-            reconstituted_model = cls(**snapshot_content_model.content)
-            if any((user_id in reconstituted_model.owner_ids,
-                    user_id in reconstituted_model.editor_ids,
-                    user_id in reconstituted_model.voice_artist_ids,
-                    user_id in reconstituted_model.viewer_ids)):
-                return True
+        more_results = True
+        cursor = None
+        while more_results:
+            snapshot_content_models, cursor, more_results = (
+                cls.SNAPSHOT_CONTENT_CLASS.query().fetch_page(
+                    base_models.FETCH_BATCH_SIZE, start_cursor=cursor))
+            for snapshot_content_model in snapshot_content_models:
+                reconstituted_model = cls(**snapshot_content_model.content)
+                if any((user_id in reconstituted_model.owner_ids,
+                        user_id in reconstituted_model.editor_ids,
+                        user_id in reconstituted_model.voice_artist_ids,
+                        user_id in reconstituted_model.viewer_ids)):
+                    return True
         return (
             cls.query(ndb.OR(
                 cls.owner_ids == user_id,

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -64,13 +64,15 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
 
 class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
     """Test the CollectionRightsModel class."""
-    COLLECTION_ID_1 = 1
-    COLLECTION_ID_2 = 2
-    COLLECTION_ID_3 = 3
+    COLLECTION_ID_1 = '1'
+    COLLECTION_ID_2 = '2'
+    COLLECTION_ID_3 = '3'
+    COLLECTION_ID_4 = '4'
     USER_ID_1 = 'id_1'  # Related to all three collections
     USER_ID_2 = 'id_2'  # Related to a subset of the three collections
     USER_ID_3 = 'id_3'  # Related to no collections
-    USER_ID_COMMITTER = 'id_4'  # User id used in commits
+    USER_ID_4 = 'id_4'  # Related to one collection and then removed from it
+    USER_ID_COMMITTER = 'id_5'  # User id used in commits
 
     def setUp(self):
         super(CollectionRightsModelUnitTest, self).setUp()
@@ -83,7 +85,7 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
             community_owned=False,
             status=constants.ACTIVITY_STATUS_PUBLIC,
             viewable_if_private=False,
-            first_published_msec=0.0
+            first_published_msec=0.1
         ).save(
             self.USER_ID_COMMITTER, 'Created new collection right',
             [{'cmd': rights_manager.CMD_CREATE_NEW}])
@@ -96,7 +98,7 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
             community_owned=False,
             status=constants.ACTIVITY_STATUS_PUBLIC,
             viewable_if_private=False,
-            first_published_msec=0.0
+            first_published_msec=0.2
         ).save(
             self.USER_ID_COMMITTER, 'Created new collection right',
             [{'cmd': rights_manager.CMD_CREATE_NEW}])
@@ -109,7 +111,20 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
             community_owned=False,
             status=constants.ACTIVITY_STATUS_PUBLIC,
             viewable_if_private=False,
-            first_published_msec=0.0
+            first_published_msec=0.3
+        ).save(
+            self.USER_ID_COMMITTER, 'Created new collection right',
+            [{'cmd': rights_manager.CMD_CREATE_NEW}])
+        collection_models.CollectionRightsModel(
+            id=self.COLLECTION_ID_4,
+            owner_ids=[self.USER_ID_4],
+            editor_ids=[self.USER_ID_4],
+            voice_artist_ids=[self.USER_ID_4],
+            viewer_ids=[self.USER_ID_4],
+            community_owned=False,
+            status=constants.ACTIVITY_STATUS_PUBLIC,
+            viewable_if_private=False,
+            first_published_msec=0.4
         ).save(
             self.USER_ID_COMMITTER, 'Created new collection right',
             [{'cmd': rights_manager.CMD_CREATE_NEW}])
@@ -125,13 +140,32 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
             .has_reference_to_user_id(self.USER_ID_1))
         self.assertTrue(
             collection_models.CollectionRightsModel
-            .has_reference_to_user_id(self.USER_ID_1))
+            .has_reference_to_user_id(self.USER_ID_2))
+        self.assertTrue(
+            collection_models.CollectionRightsModel
+            .has_reference_to_user_id(self.USER_ID_4))
         self.assertTrue(
             collection_models.CollectionRightsModel
             .has_reference_to_user_id(self.USER_ID_COMMITTER))
         self.assertFalse(
             collection_models.CollectionRightsModel
             .has_reference_to_user_id(self.USER_ID_3))
+
+        # We remove the USER_ID_4 from the exploration to see that the
+        # USER_ID_4 is still found in CollectionRightsSnapshotContentModel.
+        collection_model = collection_models.CollectionRightsModel.get_by_id(
+            self.COLLECTION_ID_4)
+        collection_model.owner_ids = [self.USER_ID_1]
+        collection_model.editor_ids = [self.USER_ID_1]
+        collection_model.voice_artist_ids = [self.USER_ID_1]
+        collection_model.viewer_ids = [self.USER_ID_1]
+        collection_model.commit(
+            self.USER_ID_COMMITTER, 'Changed collection rights',
+            [{'cmd': rights_manager.CMD_CHANGE_ROLE}])
+
+        self.assertTrue(
+            collection_models.CollectionRightsModel
+            .has_reference_to_user_id(self.USER_ID_4))
 
     def test_save(self):
         collection_models.CollectionRightsModel(

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -135,37 +135,39 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
             base_models.DELETION_POLICY.KEEP_IF_PUBLIC)
 
     def test_has_reference_to_user_id(self):
-        self.assertTrue(
-            collection_models.CollectionRightsModel
-            .has_reference_to_user_id(self.USER_ID_1))
-        self.assertTrue(
-            collection_models.CollectionRightsModel
-            .has_reference_to_user_id(self.USER_ID_2))
-        self.assertTrue(
-            collection_models.CollectionRightsModel
-            .has_reference_to_user_id(self.USER_ID_4))
-        self.assertTrue(
-            collection_models.CollectionRightsModel
-            .has_reference_to_user_id(self.USER_ID_COMMITTER))
-        self.assertFalse(
-            collection_models.CollectionRightsModel
-            .has_reference_to_user_id(self.USER_ID_3))
+        with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
+            self.assertTrue(
+                collection_models.CollectionRightsModel
+                .has_reference_to_user_id(self.USER_ID_1))
+            self.assertTrue(
+                collection_models.CollectionRightsModel
+                .has_reference_to_user_id(self.USER_ID_2))
+            self.assertTrue(
+                collection_models.CollectionRightsModel
+                .has_reference_to_user_id(self.USER_ID_4))
+            self.assertTrue(
+                collection_models.CollectionRightsModel
+                .has_reference_to_user_id(self.USER_ID_COMMITTER))
+            self.assertFalse(
+                collection_models.CollectionRightsModel
+                .has_reference_to_user_id(self.USER_ID_3))
 
-        # We remove the USER_ID_4 from the exploration to see that the
-        # USER_ID_4 is still found in CollectionRightsSnapshotContentModel.
-        collection_model = collection_models.CollectionRightsModel.get_by_id(
-            self.COLLECTION_ID_4)
-        collection_model.owner_ids = [self.USER_ID_1]
-        collection_model.editor_ids = [self.USER_ID_1]
-        collection_model.voice_artist_ids = [self.USER_ID_1]
-        collection_model.viewer_ids = [self.USER_ID_1]
-        collection_model.commit(
-            self.USER_ID_COMMITTER, 'Changed collection rights',
-            [{'cmd': rights_manager.CMD_CHANGE_ROLE}])
+            # We remove the USER_ID_4 from the exploration to verify that the
+            # USER_ID_4 is still found in CollectionRightsSnapshotContentModel.
+            collection_model = (
+                collection_models.CollectionRightsModel.get_by_id(
+                    self.COLLECTION_ID_4))
+            collection_model.owner_ids = [self.USER_ID_1]
+            collection_model.editor_ids = [self.USER_ID_1]
+            collection_model.voice_artist_ids = [self.USER_ID_1]
+            collection_model.viewer_ids = [self.USER_ID_1]
+            collection_model.commit(
+                self.USER_ID_COMMITTER, 'Changed collection rights',
+                [{'cmd': rights_manager.CMD_CHANGE_ROLE}])
 
-        self.assertTrue(
-            collection_models.CollectionRightsModel
-            .has_reference_to_user_id(self.USER_ID_4))
+            self.assertTrue(
+                collection_models.CollectionRightsModel
+                .has_reference_to_user_id(self.USER_ID_4))
 
     def test_save(self):
         collection_models.CollectionRightsModel(

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -235,13 +235,19 @@ class ExplorationRightsModel(base_models.VersionedModel):
         Returns:
             bool. Whether any models refer to the given user ID.
         """
-        for snapshot_content_model in cls.SNAPSHOT_CONTENT_CLASS.get_all():
-            reconstituted_model = cls(**snapshot_content_model.content)
-            if any((user_id in reconstituted_model.owner_ids,
-                    user_id in reconstituted_model.editor_ids,
-                    user_id in reconstituted_model.voice_artist_ids,
-                    user_id in reconstituted_model.viewer_ids)):
-                return True
+        more_results = True
+        cursor = None
+        while more_results:
+            snapshot_content_models, cursor, more_results = (
+                cls.SNAPSHOT_CONTENT_CLASS.query().fetch_page(
+                    base_models.FETCH_BATCH_SIZE, start_cursor=cursor))
+            for snapshot_content_model in snapshot_content_models:
+                reconstituted_model = cls(**snapshot_content_model.content)
+                if any((user_id in reconstituted_model.owner_ids,
+                        user_id in reconstituted_model.editor_ids,
+                        user_id in reconstituted_model.voice_artist_ids,
+                        user_id in reconstituted_model.viewer_ids)):
+                    return True
         return (
             cls.query(ndb.OR(
                 cls.owner_ids == user_id,

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -235,6 +235,13 @@ class ExplorationRightsModel(base_models.VersionedModel):
         Returns:
             bool. Whether any models refer to the given user ID.
         """
+        for snapshot_content_model in cls.SNAPSHOT_CONTENT_CLASS.get_all():
+            reconstituted_model = cls(**snapshot_content_model.content)
+            if any((user_id in reconstituted_model.owner_ids,
+                    user_id in reconstituted_model.editor_ids,
+                    user_id in reconstituted_model.voice_artist_ids,
+                    user_id in reconstituted_model.viewer_ids)):
+                return True
         return (
             cls.query(ndb.OR(
                 cls.owner_ids == user_id,

--- a/core/storage/exploration/gae_models_test.py
+++ b/core/storage/exploration/gae_models_test.py
@@ -139,37 +139,39 @@ class ExplorationRightsModelUnitTest(test_utils.GenericTestBase):
             base_models.DELETION_POLICY.KEEP_IF_PUBLIC)
 
     def test_has_reference_to_user_id(self):
-        self.assertTrue(
-            exploration_models.ExplorationRightsModel
-            .has_reference_to_user_id(self.USER_ID_1))
-        self.assertTrue(
-            exploration_models.ExplorationRightsModel
-            .has_reference_to_user_id(self.USER_ID_2))
-        self.assertTrue(
-            exploration_models.ExplorationRightsModel
-            .has_reference_to_user_id(self.USER_ID_4))
-        self.assertTrue(
-            exploration_models.ExplorationRightsModel
-            .has_reference_to_user_id(self.USER_ID_COMMITTER))
-        self.assertFalse(
-            exploration_models.ExplorationRightsModel
-            .has_reference_to_user_id(self.USER_ID_3))
+        with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
+            self.assertTrue(
+                exploration_models.ExplorationRightsModel
+                .has_reference_to_user_id(self.USER_ID_1))
+            self.assertTrue(
+                exploration_models.ExplorationRightsModel
+                .has_reference_to_user_id(self.USER_ID_2))
+            self.assertTrue(
+                exploration_models.ExplorationRightsModel
+                .has_reference_to_user_id(self.USER_ID_4))
+            self.assertTrue(
+                exploration_models.ExplorationRightsModel
+                .has_reference_to_user_id(self.USER_ID_COMMITTER))
+            self.assertFalse(
+                exploration_models.ExplorationRightsModel
+                .has_reference_to_user_id(self.USER_ID_3))
 
-        # We remove the USER_ID_4 from the exploration to see that the
-        # USER_ID_4 is still found in ExplorationRightsSnapshotContentModel.
-        exploration_model = exploration_models.ExplorationRightsModel.get_by_id(
-            self.EXPLORATION_ID_4)
-        exploration_model.owner_ids = [self.USER_ID_1]
-        exploration_model.editor_ids = [self.USER_ID_1]
-        exploration_model.voice_artist_ids = [self.USER_ID_1]
-        exploration_model.viewer_ids = [self.USER_ID_1]
-        exploration_model.commit(
-            self.USER_ID_COMMITTER, 'Changed collection rights',
-            [{'cmd': rights_manager.CMD_CHANGE_ROLE}])
+            # We remove the USER_ID_4 from the exploration to verify that the
+            # USER_ID_4 is still found in ExplorationRightsSnapshotContentModel.
+            exploration_model = (
+                exploration_models.ExplorationRightsModel.get_by_id(
+                    self.EXPLORATION_ID_4))
+            exploration_model.owner_ids = [self.USER_ID_1]
+            exploration_model.editor_ids = [self.USER_ID_1]
+            exploration_model.voice_artist_ids = [self.USER_ID_1]
+            exploration_model.viewer_ids = [self.USER_ID_1]
+            exploration_model.commit(
+                self.USER_ID_COMMITTER, 'Changed collection rights',
+                [{'cmd': rights_manager.CMD_CHANGE_ROLE}])
 
-        self.assertTrue(
-            exploration_models.ExplorationRightsModel
-            .has_reference_to_user_id(self.USER_ID_4))
+            self.assertTrue(
+                exploration_models.ExplorationRightsModel
+                .has_reference_to_user_id(self.USER_ID_4))
 
     def test_save(self):
         exploration_models.ExplorationRightsModel(

--- a/core/storage/exploration/gae_models_test.py
+++ b/core/storage/exploration/gae_models_test.py
@@ -68,13 +68,15 @@ class ExplorationModelUnitTest(test_utils.GenericTestBase):
 
 class ExplorationRightsModelUnitTest(test_utils.GenericTestBase):
     """Test the ExplorationRightsModel class."""
-    EXPLORATION_ID_1 = 1
-    EXPLORATION_ID_2 = 2
-    EXPLORATION_ID_3 = 3
+    EXPLORATION_ID_1 = '1'
+    EXPLORATION_ID_2 = '2'
+    EXPLORATION_ID_3 = '3'
+    EXPLORATION_ID_4 = '4'
     USER_ID_1 = 'id_1'  # Related to all three explorations
     USER_ID_2 = 'id_2'  # Related to a subset of the three explorations
     USER_ID_3 = 'id_3'  # Related to no explorations
-    USER_ID_COMMITTER = 'id_4'  # User id used in commits
+    USER_ID_4 = 'id_4'  # Related to one collection and then removed from it
+    USER_ID_COMMITTER = 'id_5'  # User id used in commits
 
     def setUp(self):
         super(ExplorationRightsModelUnitTest, self).setUp()
@@ -117,6 +119,19 @@ class ExplorationRightsModelUnitTest(test_utils.GenericTestBase):
         ).save(
             self.USER_ID_COMMITTER, 'Created new exploration right',
             [{'cmd': rights_manager.CMD_CREATE_NEW}])
+        exploration_models.ExplorationRightsModel(
+            id=self.EXPLORATION_ID_4,
+            owner_ids=[self.USER_ID_4],
+            editor_ids=[self.USER_ID_4],
+            voice_artist_ids=[self.USER_ID_4],
+            viewer_ids=[self.USER_ID_4],
+            community_owned=False,
+            status=constants.ACTIVITY_STATUS_PUBLIC,
+            viewable_if_private=False,
+            first_published_msec=0.4
+        ).save(
+            self.USER_ID_COMMITTER, 'Created new collection right',
+            [{'cmd': rights_manager.CMD_CREATE_NEW}])
 
     def test_get_deletion_policy(self):
         self.assertEqual(
@@ -129,13 +144,32 @@ class ExplorationRightsModelUnitTest(test_utils.GenericTestBase):
             .has_reference_to_user_id(self.USER_ID_1))
         self.assertTrue(
             exploration_models.ExplorationRightsModel
-            .has_reference_to_user_id(self.USER_ID_1))
+            .has_reference_to_user_id(self.USER_ID_2))
+        self.assertTrue(
+            exploration_models.ExplorationRightsModel
+            .has_reference_to_user_id(self.USER_ID_4))
         self.assertTrue(
             exploration_models.ExplorationRightsModel
             .has_reference_to_user_id(self.USER_ID_COMMITTER))
         self.assertFalse(
             exploration_models.ExplorationRightsModel
             .has_reference_to_user_id(self.USER_ID_3))
+
+        # We remove the USER_ID_4 from the exploration to see that the
+        # USER_ID_4 is still found in ExplorationRightsSnapshotContentModel.
+        exploration_model = exploration_models.ExplorationRightsModel.get_by_id(
+            self.EXPLORATION_ID_4)
+        exploration_model.owner_ids = [self.USER_ID_1]
+        exploration_model.editor_ids = [self.USER_ID_1]
+        exploration_model.voice_artist_ids = [self.USER_ID_1]
+        exploration_model.viewer_ids = [self.USER_ID_1]
+        exploration_model.commit(
+            self.USER_ID_COMMITTER, 'Changed collection rights',
+            [{'cmd': rights_manager.CMD_CHANGE_ROLE}])
+
+        self.assertTrue(
+            exploration_models.ExplorationRightsModel
+            .has_reference_to_user_id(self.USER_ID_4))
 
     def test_save(self):
         exploration_models.ExplorationRightsModel(

--- a/core/storage/question/gae_models.py
+++ b/core/storage/question/gae_models.py
@@ -660,5 +660,9 @@ class QuestionRightsModel(base_models.VersionedModel):
         Returns:
             bool. Whether any models refer to the given user ID.
         """
+        for snapshot_content_model in cls.SNAPSHOT_CONTENT_CLASS.get_all():
+            reconstituted_model = cls(**snapshot_content_model.content)
+            if user_id == reconstituted_model.creator_id:
+                return True
         return (cls.query(cls.creator_id == user_id).get() is not None or
                 cls.SNAPSHOT_METADATA_CLASS.exists_for_user_id(user_id))

--- a/core/storage/question/gae_models.py
+++ b/core/storage/question/gae_models.py
@@ -660,9 +660,15 @@ class QuestionRightsModel(base_models.VersionedModel):
         Returns:
             bool. Whether any models refer to the given user ID.
         """
-        for snapshot_content_model in cls.SNAPSHOT_CONTENT_CLASS.get_all():
-            reconstituted_model = cls(**snapshot_content_model.content)
-            if user_id == reconstituted_model.creator_id:
-                return True
+        more_results = True
+        cursor = None
+        while more_results:
+            snapshot_content_models, cursor, more_results = (
+                cls.SNAPSHOT_CONTENT_CLASS.query().fetch_page(
+                    base_models.FETCH_BATCH_SIZE, start_cursor=cursor))
+            for snapshot_content_model in snapshot_content_models:
+                reconstituted_model = cls(**snapshot_content_model.content)
+                if user_id == reconstituted_model.creator_id:
+                    return True
         return (cls.query(cls.creator_id == user_id).get() is not None or
                 cls.SNAPSHOT_METADATA_CLASS.exists_for_user_id(user_id))

--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -573,44 +573,48 @@ class QuestionRightsModelUnitTest(test_utils.GenericTestBase):
             base_models.DELETION_POLICY.LOCALLY_PSEUDONYMIZE)
 
     def test_has_reference_to_user_id(self):
-        question_services.create_new_question_rights('question_id', 'owner_id')
-        self.assertTrue(
-            question_models.QuestionRightsModel
-            .has_reference_to_user_id('owner_id'))
-        # The question_rights.creator_id is by default the same as committer_id,
-        # we change it to different value so that we really check all
-        # separate fields.
-        question_rights = question_models.QuestionRightsModel.get('question_id')
-        question_rights.creator_id = 'creator_id'
-        question_rights.commit(
-            'committer_id',
-            'Update question rights',
-            [{'cmd': question_domain.CMD_CREATE_NEW}])
-        self.assertTrue(
-            question_models.QuestionRightsModel
-            .has_reference_to_user_id('owner_id'))
-        self.assertTrue(
-            question_models.QuestionRightsModel
-            .has_reference_to_user_id('creator_id'))
-        self.assertTrue(
-            question_models.QuestionRightsModel
-            .has_reference_to_user_id('committer_id'))
-        self.assertFalse(
-            question_models.QuestionRightsModel
-            .has_reference_to_user_id('x_id'))
+        with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
+            question_services.create_new_question_rights(
+                'question_id', 'owner_id')
+            self.assertTrue(
+                question_models.QuestionRightsModel
+                .has_reference_to_user_id('owner_id'))
+            # The question_rights.creator_id is by default the same as
+            # committer_id, we change it to different value so that we really
+            # check all separate fields.
+            question_rights = question_models.QuestionRightsModel.get(
+                'question_id')
+            question_rights.creator_id = 'creator_id'
+            question_rights.commit(
+                'committer_id',
+                'Update question rights',
+                [{'cmd': question_domain.CMD_CREATE_NEW}])
+            self.assertTrue(
+                question_models.QuestionRightsModel
+                .has_reference_to_user_id('owner_id'))
+            self.assertTrue(
+                question_models.QuestionRightsModel
+                .has_reference_to_user_id('creator_id'))
+            self.assertTrue(
+                question_models.QuestionRightsModel
+                .has_reference_to_user_id('committer_id'))
+            self.assertFalse(
+                question_models.QuestionRightsModel
+                .has_reference_to_user_id('x_id'))
 
-        # We change the creator_id to to see that the creator_id is still found
-        # in QuestionRightsSnapshotContentModel.
-        question_rights = question_models.QuestionRightsModel.get('question_id')
-        question_rights.creator_id = 'different_creator_id'
-        question_rights.commit(
-            'committer_id',
-            'Update question rights again',
-            [{'cmd': question_domain.CMD_CREATE_NEW}])
+            # We change the creator_id to to see that the creator_id is still
+            # found in QuestionRightsSnapshotContentModel.
+            question_rights = question_models.QuestionRightsModel.get(
+                'question_id')
+            question_rights.creator_id = 'different_creator_id'
+            question_rights.commit(
+                'committer_id',
+                'Update question rights again',
+                [{'cmd': question_domain.CMD_CREATE_NEW}])
 
-        self.assertTrue(
-            question_models.QuestionRightsModel
-            .has_reference_to_user_id('creator_id'))
-        self.assertTrue(
-            question_models.QuestionRightsModel
-            .has_reference_to_user_id('different_creator_id'))
+            self.assertTrue(
+                question_models.QuestionRightsModel
+                .has_reference_to_user_id('creator_id'))
+            self.assertTrue(
+                question_models.QuestionRightsModel
+                .has_reference_to_user_id('different_creator_id'))

--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -598,3 +598,19 @@ class QuestionRightsModelUnitTest(test_utils.GenericTestBase):
         self.assertFalse(
             question_models.QuestionRightsModel
             .has_reference_to_user_id('x_id'))
+
+        # We change the creator_id to to see that the creator_id is still found
+        # in QuestionRightsSnapshotContentModel.
+        question_rights = question_models.QuestionRightsModel.get('question_id')
+        question_rights.creator_id = 'different_creator_id'
+        question_rights.commit(
+            'committer_id',
+            'Update question rights again',
+            [{'cmd': question_domain.CMD_CREATE_NEW}])
+
+        self.assertTrue(
+            question_models.QuestionRightsModel
+            .has_reference_to_user_id('creator_id'))
+        self.assertTrue(
+            question_models.QuestionRightsModel
+            .has_reference_to_user_id('different_creator_id'))

--- a/core/storage/skill/gae_models.py
+++ b/core/storage/skill/gae_models.py
@@ -275,6 +275,10 @@ class SkillRightsModel(base_models.VersionedModel):
         Returns:
             bool. Whether any models refer to the given user ID.
         """
+        for snapshot_content_model in cls.SNAPSHOT_CONTENT_CLASS.get_all():
+            reconstituted_model = cls(**snapshot_content_model.content)
+            if user_id == reconstituted_model.creator_id:
+                return True
         return (cls.query(cls.creator_id == user_id).get() is not None or
                 cls.SNAPSHOT_METADATA_CLASS.exists_for_user_id(user_id))
 

--- a/core/storage/skill/gae_models.py
+++ b/core/storage/skill/gae_models.py
@@ -275,10 +275,16 @@ class SkillRightsModel(base_models.VersionedModel):
         Returns:
             bool. Whether any models refer to the given user ID.
         """
-        for snapshot_content_model in cls.SNAPSHOT_CONTENT_CLASS.get_all():
-            reconstituted_model = cls(**snapshot_content_model.content)
-            if user_id == reconstituted_model.creator_id:
-                return True
+        more_results = True
+        cursor = None
+        while more_results:
+            snapshot_content_models, cursor, more_results = (
+                cls.SNAPSHOT_CONTENT_CLASS.query().fetch_page(
+                    base_models.FETCH_BATCH_SIZE, start_cursor=cursor))
+            for snapshot_content_model in snapshot_content_models:
+                reconstituted_model = cls(**snapshot_content_model.content)
+                if user_id == reconstituted_model.creator_id:
+                    return True
         return (cls.query(cls.creator_id == user_id).get() is not None or
                 cls.SNAPSHOT_METADATA_CLASS.exists_for_user_id(user_id))
 

--- a/core/storage/skill/gae_models_test.py
+++ b/core/storage/skill/gae_models_test.py
@@ -131,35 +131,38 @@ class SkillRightsModelUnitTest(test_utils.GenericTestBase):
             [{'cmd': rights_manager.CMD_CREATE_NEW}])
 
     def test_has_reference_to_user_id(self):
-        self.assertTrue(
-            skill_models.SkillRightsModel
-            .has_reference_to_user_id('user_1_id'))
-        self.assertTrue(
-            skill_models.SkillRightsModel
-            .has_reference_to_user_id('user_2_id'))
-        self.assertTrue(
-            skill_models.SkillRightsModel
-            .has_reference_to_user_id('user_3_id'))
-        self.assertTrue(
-            skill_models.SkillRightsModel
-            .has_reference_to_user_id('user_4_id'))
-        self.assertFalse(
-            skill_models.SkillRightsModel
-            .has_reference_to_user_id('x_id'))
+        with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
+            self.assertTrue(
+                skill_models.SkillRightsModel
+                .has_reference_to_user_id('user_1_id'))
+            self.assertTrue(
+                skill_models.SkillRightsModel
+                .has_reference_to_user_id('user_2_id'))
+            self.assertTrue(
+                skill_models.SkillRightsModel
+                .has_reference_to_user_id('user_3_id'))
+            self.assertTrue(
+                skill_models.SkillRightsModel
+                .has_reference_to_user_id('user_4_id'))
+            self.assertFalse(
+                skill_models.SkillRightsModel
+                .has_reference_to_user_id('x_id'))
 
-        # We change the creator_id to to see that the user_5_id is still found
-        # in SkillRightsSnapshotContentModel.
-        skill_model = skill_models.SkillRightsModel.get('id_5')
-        skill_model.creator_id = 'user_7_id'
-        skill_model.commit(
-            'user_6_id',
-            'Update skill rights',
-            [{'cmd': rights_manager.CMD_CHANGE_ROLE}])
+            # We change the creator_id to to verify that the user_5_id is still
+            # found in SkillRightsSnapshotContentModel.
+            skill_model = skill_models.SkillRightsModel.get('id_5')
+            skill_model.creator_id = 'user_7_id'
+            skill_model.commit(
+                'user_6_id',
+                'Update skill rights',
+                [{'cmd': rights_manager.CMD_CHANGE_ROLE}])
 
-        self.assertTrue(
-            skill_models.SkillRightsModel.has_reference_to_user_id('user_5_id'))
-        self.assertTrue(
-            skill_models.SkillRightsModel.has_reference_to_user_id('user_7_id'))
+            self.assertTrue(
+                skill_models.SkillRightsModel.has_reference_to_user_id(
+                    'user_5_id'))
+            self.assertTrue(
+                skill_models.SkillRightsModel.has_reference_to_user_id(
+                    'user_7_id'))
 
     def test_get_unpublished_by_creator_id(self):
         results = (

--- a/core/storage/skill/gae_models_test.py
+++ b/core/storage/skill/gae_models_test.py
@@ -122,6 +122,13 @@ class SkillRightsModelUnitTest(test_utils.GenericTestBase):
         ).commit(
             'user_4_id', 'Created new skill rights',
             [{'cmd': rights_manager.CMD_CREATE_NEW}])
+        skill_models.SkillRightsModel(
+            id='id_5',
+            creator_id='user_5_id',
+            skill_is_private=True
+        ).commit(
+            'user_6_id', 'Created new skill rights',
+            [{'cmd': rights_manager.CMD_CREATE_NEW}])
 
     def test_has_reference_to_user_id(self):
         self.assertTrue(
@@ -140,6 +147,20 @@ class SkillRightsModelUnitTest(test_utils.GenericTestBase):
             skill_models.SkillRightsModel
             .has_reference_to_user_id('x_id'))
 
+        # We change the creator_id to to see that the user_5_id is still found
+        # in SkillRightsSnapshotContentModel.
+        skill_model = skill_models.SkillRightsModel.get('id_5')
+        skill_model.creator_id = 'user_7_id'
+        skill_model.commit(
+            'user_6_id',
+            'Update skill rights',
+            [{'cmd': rights_manager.CMD_CHANGE_ROLE}])
+
+        self.assertTrue(
+            skill_models.SkillRightsModel.has_reference_to_user_id('user_5_id'))
+        self.assertTrue(
+            skill_models.SkillRightsModel.has_reference_to_user_id('user_7_id'))
+
     def test_get_unpublished_by_creator_id(self):
         results = (
             skill_models.SkillRightsModel
@@ -154,4 +175,4 @@ class SkillRightsModelUnitTest(test_utils.GenericTestBase):
 
     def test_get_unpublished_fetches_all_unpublished_skills(self):
         self.assertEqual(
-            len(skill_models.SkillRightsModel.get_unpublished().fetch(4)), 3)
+            len(skill_models.SkillRightsModel.get_unpublished().fetch(5)), 4)

--- a/core/storage/topic/gae_models.py
+++ b/core/storage/topic/gae_models.py
@@ -403,10 +403,16 @@ class TopicRightsModel(base_models.VersionedModel):
         Returns:
             bool. Whether any models refer to the given user ID.
         """
-        for snapshot_content_model in cls.SNAPSHOT_CONTENT_CLASS.get_all():
-            reconstituted_model = cls(**snapshot_content_model.content)
-            if user_id in reconstituted_model.manager_ids:
-                return True
+        more_results = True
+        cursor = None
+        while more_results:
+            snapshot_content_models, cursor, more_results = (
+                cls.SNAPSHOT_CONTENT_CLASS.query().fetch_page(
+                    base_models.FETCH_BATCH_SIZE, start_cursor=cursor))
+            for snapshot_content_model in snapshot_content_models:
+                reconstituted_model = cls(**snapshot_content_model.content)
+                if user_id in reconstituted_model.manager_ids:
+                    return True
         return (cls.query(cls.manager_ids == user_id).get() is not None or
                 cls.SNAPSHOT_METADATA_CLASS.exists_for_user_id(user_id))
 

--- a/core/storage/topic/gae_models.py
+++ b/core/storage/topic/gae_models.py
@@ -403,6 +403,10 @@ class TopicRightsModel(base_models.VersionedModel):
         Returns:
             bool. Whether any models refer to the given user ID.
         """
+        for snapshot_content_model in cls.SNAPSHOT_CONTENT_CLASS.get_all():
+            reconstituted_model = cls(**snapshot_content_model.content)
+            if user_id in reconstituted_model.manager_ids:
+                return True
         return (cls.query(cls.manager_ids == user_id).get() is not None or
                 cls.SNAPSHOT_METADATA_CLASS.exists_for_user_id(user_id))
 

--- a/core/storage/topic/gae_models_test.py
+++ b/core/storage/topic/gae_models_test.py
@@ -289,3 +289,19 @@ class TopicRightsModelUnitTests(test_utils.GenericTestBase):
             .has_reference_to_user_id('committer_id'))
         self.assertFalse(
             topic_models.TopicRightsModel.has_reference_to_user_id('x_id'))
+
+        # We remove the manager_id form manager_ids to to see that the
+        # manager_id is still found in TopicRightsSnapshotContentModel.
+        topic_rights = topic_models.TopicRightsModel.get_by_id('topic_id')
+        topic_rights.manager_ids = ['different_manager_id']
+        topic_rights.commit(
+            'committer_id',
+            'Change topic rights',
+            [{'cmd': topic_domain.CMD_CREATE_NEW}])
+
+        self.assertTrue(
+            topic_models.TopicRightsModel
+            .has_reference_to_user_id('manager_id'))
+        self.assertTrue(
+            topic_models.TopicRightsModel
+            .has_reference_to_user_id('different_manager_id'))

--- a/core/storage/topic/gae_models_test.py
+++ b/core/storage/topic/gae_models_test.py
@@ -275,33 +275,34 @@ class TopicRightsModelUnitTests(test_utils.GenericTestBase):
             base_models.DELETION_POLICY.KEEP_IF_PUBLIC)
 
     def test_has_reference_to_user_id(self):
-        topic_rights = topic_models.TopicRightsModel(
-            id='topic_id', manager_ids=['manager_id'])
-        topic_rights.commit(
-            'committer_id',
-            'New topic rights',
-            [{'cmd': topic_domain.CMD_CREATE_NEW}])
-        self.assertTrue(
-            topic_models.TopicRightsModel
-            .has_reference_to_user_id('manager_id'))
-        self.assertTrue(
-            topic_models.TopicRightsModel
-            .has_reference_to_user_id('committer_id'))
-        self.assertFalse(
-            topic_models.TopicRightsModel.has_reference_to_user_id('x_id'))
+        with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
+            topic_rights = topic_models.TopicRightsModel(
+                id='topic_id', manager_ids=['manager_id'])
+            topic_rights.commit(
+                'committer_id',
+                'New topic rights',
+                [{'cmd': topic_domain.CMD_CREATE_NEW}])
+            self.assertTrue(
+                topic_models.TopicRightsModel
+                .has_reference_to_user_id('manager_id'))
+            self.assertTrue(
+                topic_models.TopicRightsModel
+                .has_reference_to_user_id('committer_id'))
+            self.assertFalse(
+                topic_models.TopicRightsModel.has_reference_to_user_id('x_id'))
 
-        # We remove the manager_id form manager_ids to to see that the
-        # manager_id is still found in TopicRightsSnapshotContentModel.
-        topic_rights = topic_models.TopicRightsModel.get_by_id('topic_id')
-        topic_rights.manager_ids = ['different_manager_id']
-        topic_rights.commit(
-            'committer_id',
-            'Change topic rights',
-            [{'cmd': topic_domain.CMD_CREATE_NEW}])
+            # We remove the manager_id form manager_ids to to verify that the
+            # manager_id is still found in TopicRightsSnapshotContentModel.
+            topic_rights = topic_models.TopicRightsModel.get_by_id('topic_id')
+            topic_rights.manager_ids = ['different_manager_id']
+            topic_rights.commit(
+                'committer_id',
+                'Change topic rights',
+                [{'cmd': topic_domain.CMD_CREATE_NEW}])
 
-        self.assertTrue(
-            topic_models.TopicRightsModel
-            .has_reference_to_user_id('manager_id'))
-        self.assertTrue(
-            topic_models.TopicRightsModel
-            .has_reference_to_user_id('different_manager_id'))
+            self.assertTrue(
+                topic_models.TopicRightsModel
+                .has_reference_to_user_id('manager_id'))
+            self.assertTrue(
+                topic_models.TopicRightsModel
+                .has_reference_to_user_id('different_manager_id'))


### PR DESCRIPTION
## Explanation
Add code that checks snapshot contetnt models in has_reference_to_user_id for models when some of the user IDs can be located in the snapshot models.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
