### PR TITLE
Fix #7973: Fixes tutorial, navbar for small screens

### DIFF
--- a/core/templates/dev/head/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
+++ b/core/templates/dev/head/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
@@ -6,7 +6,7 @@
     <i class="material-icons oppia-navbar-close-icon" ng-if="$ctrl.isSidebarShown()" >&#10005;</i>
   </a>
 
-  <a class="oppia-navbar-brand-name oppia-transition-200 protractor-test-oppia-main-logo" href="/"
+  <a class="oppia-navbar-brand-name oppia-transition-200 protractor-test-oppia-main-logo d-none d-sm-block" href="/"
      focus-on="<[::$ctrl.LABEL_FOR_CLEARING_FOCUS]>">
     <img ng-src="<[$ctrl.getStaticImageUrl('/logo/288x128_logo_white.png')]>" class="oppia-logo"
          ng-class="$ctrl.windowIsNarrow ? 'oppia-logo-small' : 'oppia-logo-wide'" alt="Oppia Home">

--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -2604,7 +2604,7 @@ div#ng-curtain {
 }
 
 .oppia-navbar-brand-name {
-  float: left;
+  float: right;
   height: 56px;
   line-height: 20px;
   margin-left: -10px;

--- a/core/templates/dev/head/pages/exploration-editor-page/editor-navigation/editor-navigation.directive.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/editor-navigation/editor-navigation.directive.html
@@ -97,14 +97,14 @@
           </li>
         </ul>
       </li>
-      <li class="dropdown-item oppia-exploration-editor-tabs-dropdown-item" ng-if="userIsLoggedIn" id="tutorialTranslationTab" ng-class="{'active': getActiveTabName() === 'translation'}">
+      <li class="dropdown-item oppia-exploration-editor-tabs-dropdown-item" ng-if="userIsLoggedIn" ng-class="{'active': getActiveTabName() === 'translation'}">
         <a href="#" uib-tooltip="Tmaterial-iconsmaterial-iconsranslations and Voiceovers" tooltip-placement="bottom" ng-click="selectTranslationTab()"
            class="oppia-exploration-editor-tabs-dropdown-element">
           <i class="material-icons oppia-mobile-exploration-editor-tabs-icon">&#xE029;</i>
           <span class="oppia-exploration-editor-tabs-dropdown-inner">Translations</span>
         </a>
       </li>
-      <li class="dropdown-item oppia-exploration-editor-tabs-dropdown-item" ng-if="userIsLoggedIn" id="tutorialPreviewTab" ng-class="{'active': getActiveTabName() === 'preview'}">
+      <li class="dropdown-item oppia-exploration-editor-tabs-dropdown-item" ng-if="userIsLoggedIn" ng-class="{'active': getActiveTabName() === 'preview'}">
         <a href="#" uib-tooltip="Preview" tooltip-placement="bottom" ng-click="selectPreviewTab()"
            class="oppia-exploration-editor-tabs-dropdown-element">
           <i class="material-icons oppia-mobile-exploration-editor-tabs-icon">&#xE037;</i>
@@ -151,15 +151,6 @@
               <[getOpenThreadsCount()]>&nbsp;open
           </span>
         </div>
-      </li>
-      <li ng-if="userIsLoggedIn" uib-dropdown class="dropdown-item oppia-exploration-editor-tabs-dropdown-item uib-dropdown uib-popover ng-cloak" popover-is-open="popoverControlObject.postTutorialHelpPopoverIsShown"
-          popover-placement="bottom" popover-trigger="'none'"
-          uib-popover="To get help in the future, click here!">
-        <a href="#" uib-tooltip="Help" tooltip-placement="bottom"
-           ng-click="showUserHelpModal()" class="oppia-exploration-editor-tabs-dropdown-element">
-          <i class="material-icons oppia-mobile-exploration-editor-tabs-icon">&#xE887;</i>
-          <span class="oppia-exploration-editor-tabs-dropdown-inner">Help</span>
-        </a>
       </li>
     </ul>
   </li>

--- a/core/templates/dev/head/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.directive.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.directive.html
@@ -1,7 +1,7 @@
 <ul class="nav navbar-nav oppia-navbar-nav float-right ng-cloak">
 
   <!-- Start of html for small screens. -->
-  <li class="nav-item dropdown d-block d-lg-none">
+  <li class="nav-item dropdown d-block d-sm-none">
     <a class="btn dropdown-toggle oppia-save-publish-dropdown-toggle text-white" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
       Save/Publish
     </a>
@@ -11,7 +11,7 @@
              uib-tooltip="<[getPublishExplorationButtonTooltip()]>"
              tooltip-placement="bottom"
              ng-class="{'disable-publish-button': isExplorationLockedForEditing() || countWarnings()}">
-          <button type="button" class="btn btn-light oppia-editor-publish-button protractor-test-publish-exploration"
+          <button type="button" class="btn btn-light oppia-editor-publish-button protractor-test-publish-exploration-for-small-screens"
                   ng-class="{'btn-success': !isExplorationLockedForEditing() && !countWarnings()}"
                   ng-click="showPublishExplorationModal()"
                   ng-disabled="isExplorationLockedForEditing() || countWarnings()"
@@ -40,7 +40,7 @@
       <li class="dropdown-item" ng-if="isEditableOutsideTutorialMode()">
         <div uib-dropdown class="btn-group" style="margin-right: 10px; margin-top: 8px;"
              title="<[getSaveButtonTooltip()]>" ng-class="{'disable-save-button': !isExplorationSaveable()}">
-          <button id="tutorialSaveButton" class="btn btn-light oppia-save-draft-button protractor-test-save-changes" ng-class="{'btn-success': isExplorationSaveable()}" ng-click="saveChanges()" ng-disabled="!isExplorationSaveable()" style="border-color: black;">
+          <button class="btn btn-light oppia-save-draft-button protractor-test-save-changes-for-small-screens" ng-class="{'btn-success': isExplorationSaveable()}" ng-click="saveChanges()" ng-disabled="!isExplorationSaveable()" style="border-color: black;">
             <span ng-if="!saveIsInProcess">
               <span class="oppia-draft-label-container" ng-if="isPrivate()">
                 <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
@@ -69,11 +69,11 @@
               <loading-dots ng-show="loadingDotsAreShown"></loading-dots>
             </span>
           </button>
-          <button type="button" style="height: 34px; border-color: black;" class="btn btn-light uib-dropdown-toggle protractor-test-save-discard-toggle dropdown-toggle"
+          <button type="button" style="height: 34px; border-color: black;" class="btn btn-light uib-dropdown-toggle protractor-test-save-discard-toggle-for-small-screens dropdown-toggle"
                   ng-disabled="!getChangeListLength()" uib-dropdown-toggle>
           </button>
           <ul uib-dropdown-menu role="menu" style="min-width: 125px; right: inherit;" ng-style="{ width: getChangeListLength() && !isPrivate() ? '150px' : '120px' }">
-            <li title="Discard all pending changes"><a ng-click="discardChanges()" ng-class="{'oppia-disabled-link': !getChangeListLength()}" class="dropdown-item nav-item protractor-test-discard-changes">Discard Draft</a></li>
+            <li title="Discard all pending changes"><a ng-click="discardChanges()" ng-class="{'oppia-disabled-link': !getChangeListLength()}" class="dropdown-item nav-item protractor-test-discard-changes-for-small-screens">Discard Draft</a></li>
           </ul>
         </div>
       </li>
@@ -82,7 +82,7 @@
   <!-- End of html for small screens. -->
 
   <!-- Start of html for large screens. -->
-  <li class="nav-item d-none d-lg-block" ng-if="showPublishButton()">
+  <li class="nav-item d-none d-sm-block" ng-if="showPublishButton()">
     <div class="btn-group" style="margin-right: 10px; margin-top: 8px;"
          uib-tooltip="<[getPublishExplorationButtonTooltip()]>"
          tooltip-placement="bottom"
@@ -112,7 +112,7 @@
     </div>
   </li>
 
-  <li class="nav-item d-none d-lg-block" ng-if="isEditableOutsideTutorialMode()">
+  <li class="nav-item d-none d-sm-block" ng-if="isEditableOutsideTutorialMode()">
     <div uib-dropdown class="btn-group" style="margin-right: 10px; margin-top: 8px;"
          title="<[getSaveButtonTooltip()]>" ng-class="{'disable-save-button': !isExplorationSaveable()}">
       <button id="tutorialSaveButton" class="btn btn-light oppia-save-draft-button protractor-test-save-changes" ng-class="{'btn-success': isExplorationSaveable()}" ng-click="saveChanges()" ng-disabled="!isExplorationSaveable()" style="width: fit-content">

--- a/core/templates/dev/head/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.directive.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.directive.html
@@ -1,5 +1,88 @@
 <ul class="nav navbar-nav oppia-navbar-nav float-right ng-cloak">
-  <li class="nav-item" ng-if="showPublishButton()">
+
+  <!-- Start of html for small screens. -->
+  <li class="nav-item dropdown d-block d-lg-none">
+    <a class="btn dropdown-toggle oppia-save-publish-dropdown-toggle text-white" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      Save/Publish
+    </a>
+    <ul class="dropdown-menu oppia-save-publish-dropdown" aria-labelledby="dropdownMenuButton">
+      <li class="dropdown-item" ng-if="showPublishButton()">
+        <div class="btn-group" style="margin-right: 10px; margin-top: 8px;"
+             uib-tooltip="<[getPublishExplorationButtonTooltip()]>"
+             tooltip-placement="bottom"
+             ng-class="{'disable-publish-button': isExplorationLockedForEditing() || countWarnings()}">
+          <button type="button" class="btn btn-light oppia-editor-publish-button protractor-test-publish-exploration"
+                  ng-class="{'btn-success': !isExplorationLockedForEditing() && !countWarnings()}"
+                  ng-click="showPublishExplorationModal()"
+                  ng-disabled="isExplorationLockedForEditing() || countWarnings()"
+                  style="border-color: black;">
+            <span ng-if="!publishIsInProcess">
+              <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+                 alt="Publish to Oppia Library">
+                &#xE2C3;
+              </i>
+              <span class="oppia-save-publish-button-label">Publish</span>
+            </span>
+            <span ng-if="publishIsInProcess">
+              <i class="oppia-save-publish-loading oppia-save-publish-button-icon"
+                 alt="Publish to Oppia Library">
+                <loading-dots ng-show="loadingDotsAreShown"></loading-dots>
+              </i>
+              <span class="oppia-save-publish-button-label">
+                Publishing
+                <loading-dots ng-show="loadingDotsAreShown"></loading-dots>
+              </span>
+            </span>
+          </button>
+        </div>
+      </li>
+
+      <li class="dropdown-item" ng-if="isEditableOutsideTutorialMode()">
+        <div uib-dropdown class="btn-group" style="margin-right: 10px; margin-top: 8px;"
+             title="<[getSaveButtonTooltip()]>" ng-class="{'disable-save-button': !isExplorationSaveable()}">
+          <button id="tutorialSaveButton" class="btn btn-light oppia-save-draft-button protractor-test-save-changes" ng-class="{'btn-success': isExplorationSaveable()}" ng-click="saveChanges()" ng-disabled="!isExplorationSaveable()" style="border-color: black;">
+            <span ng-if="!saveIsInProcess">
+              <span class="oppia-draft-label-container" ng-if="isPrivate()">
+                <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+                   alt="Save Draft">
+                  &#xE161;
+                </i>
+                <span class="oppia-save-draft-button-label oppia-save-publish-button-label">Save Draft</span>
+                <span class="d-none d-md-block" ng-if="getChangeListLength()" style="opacity: 0.5;margin-left: 2px;">(<[getChangeListLength()]>)</span>
+              </span>
+              <span class="oppia-publish-label-container" ng-if="!isPrivate()" title="Publish Changes">
+                <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+                   alt="Publish Changes">
+                  &#xE2C3;
+                </i>
+                <span class="oppia-save-publish-button-label">Publish Changes</span>
+                <span class="d-none d-md-block" ng-if="getChangeListLength()" style="opacity: 0.5">(<[getChangeListLength()]>)</span>
+              </span>
+            </span>
+            <span ng-if="saveIsInProcess">
+              <span ng-if="isPrivate()" class="oppia-save-publish-button-label">
+                Saving
+              </span>
+              <span ng-if="!isPrivate()" class="oppia-save-publish-button-label">
+                Publishing
+              </span>
+              <loading-dots ng-show="loadingDotsAreShown"></loading-dots>
+            </span>
+          </button>
+          <button type="button" style="height: 34px; border-color: black;" class="btn btn-light uib-dropdown-toggle protractor-test-save-discard-toggle dropdown-toggle"
+                  ng-disabled="!getChangeListLength()" uib-dropdown-toggle>
+          </button>
+          <ul uib-dropdown-menu role="menu" style="min-width: 125px; right: inherit;" ng-style="{ width: getChangeListLength() && !isPrivate() ? '150px' : '120px' }">
+            <li title="Discard all pending changes"><a ng-click="discardChanges()" ng-class="{'oppia-disabled-link': !getChangeListLength()}" class="dropdown-item nav-item protractor-test-discard-changes">Discard Draft</a></li>
+          </ul>
+        </div>
+      </li>
+    </ul>
+  </li>
+  <!-- End of html for small screens. -->
+
+  <!-- Start of html for large screens. -->
+  <li class="nav-item d-none d-lg-block" ng-if="showPublishButton()">
     <div class="btn-group" style="margin-right: 10px; margin-top: 8px;"
          uib-tooltip="<[getPublishExplorationButtonTooltip()]>"
          tooltip-placement="bottom"
@@ -29,10 +112,10 @@
     </div>
   </li>
 
-  <li class="nav-item" ng-if="isEditableOutsideTutorialMode()">
+  <li class="nav-item d-none d-lg-block" ng-if="isEditableOutsideTutorialMode()">
     <div uib-dropdown class="btn-group" style="margin-right: 10px; margin-top: 8px;"
          title="<[getSaveButtonTooltip()]>" ng-class="{'disable-save-button': !isExplorationSaveable()}">
-      <button id="tutorialSaveButton" class="btn btn-light oppia-save-draft-button protractor-test-save-changes" ng-class="{'btn-success': isExplorationSaveable()}" ng-click="saveChanges()" ng-disabled="!isExplorationSaveable()">
+      <button id="tutorialSaveButton" class="btn btn-light oppia-save-draft-button protractor-test-save-changes" ng-class="{'btn-success': isExplorationSaveable()}" ng-click="saveChanges()" ng-disabled="!isExplorationSaveable()" style="width: fit-content">
         <span ng-if="!saveIsInProcess">
           <span class="oppia-draft-label-container" ng-if="isPrivate()">
             <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
@@ -69,6 +152,7 @@
       </ul>
     </div>
   </li>
+  <!-- End of html for large screens. -->
 </ul>
 
 <style>
@@ -84,6 +168,16 @@
     flex-direction: row;
   }
   .oppia-save-publish-button-label {
-    width: 80px;
+    width: fit-content;
+  }
+  .oppia-save-publish-dropdown {
+    border: 0;
+    max-width: 280px;
+    min-width: 170px;
+    padding: 8px 0;
+  }
+  .oppia-save-publish-dropdown-toggle {
+    border: none;
+    margin-top: 8px;
   }
 </style>


### PR DESCRIPTION
## Explanation
Fixes #7973 
- Fixes tutorial by removing it for mobile screens (Issue created to add the tutorial for mobile screens: #8043)
- Updates top nav bar to have hamburger on top left and save and publish buttons in correct position for mobile screens. 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
