### PR TITLE
Fix #8024: Decrease 'min-width' of feedback editor

### DIFF
--- a/core/templates/dev/head/components/question-directives/question-editor/question-editor.directive.html
+++ b/core/templates/dev/head/components/question-directives/question-editor/question-editor.directive.html
@@ -20,4 +20,7 @@
   question-editor .oppia-editor-cards-container {
     padding-bottom: 5vh;
   }
+  question-editor outcome-feedback-editor {
+    min-width: 100%;
+  }
 </style>


### PR DESCRIPTION
## Explanation
Fixes #8024 by setting min-width of the feedback editor to 100% when in question editor, which was 619px, globally.

Screenshot:
![image](https://user-images.githubusercontent.com/22347970/69234412-135bf080-0bb5-11ea-8bdb-420b4f4c1d6b.png)


## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
