### PR TITLE
Fix small error in pre-commit hook to prevent .pyc file from being copied.

### DIFF
--- a/scripts/pre_commit_hook.py
+++ b/scripts/pre_commit_hook.py
@@ -67,9 +67,10 @@ def install_hook():
     if os.path.islink(pre_commit_file):
         python_utils.PRINT('Symlink already exists')
     else:
+        # This is needed, because otherwise some systems symlink/copy the .pyc
+        # file instead of the .py file.
+        this_file = __file__.replace('pyc', 'py')
         try:
-            # On Windows, it will try to copy the pyc file instead the py file.
-            this_file = __file__.replace('pyc', 'py')
             os.symlink(os.path.abspath(this_file), pre_commit_file)
             python_utils.PRINT('Created symlink in .git/hooks directory')
         # Raises AttributeError on windows, OSError added as failsafe.


### PR DESCRIPTION
## Explanation
This PR attempts to fix an issue encountered by @jamesxu0 where he was having some trouble getting the pre-commit hook to run prior to a push. Here is the (abridged) log that he encountered. The fix here is to use the correct file for both the symlink and copy operations, not just for the symlink operation in the "try" branch.

```
> python -m scripts.start
Checking if node.js is installed in /Desktop/opensource/oppia/../oppia_tools
[...]
Checking whether Skulpt is installed in third_party
Installing pre-commit hook for git
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Desktop/opensource/oppia/scripts/start.py", line 32, in <module>
    install_third_party_libs.main(args=[])
  File "scripts/install_third_party_libs.py", line 271, in main
    pre_commit_hook.main(args=['--install'])
  File "scripts/pre_commit_hook.py", line 118, in main
    _install_hook()
  File "scripts/pre_commit_hook.py", line 60, in _install_hook
    shutil.copy(__file__, pre_commit_file)
  File "/usr/lib/python2.7/shutil.py", line 139, in copy
    copyfile(src, dst)
  File "/usr/lib/python2.7/shutil.py", line 96, in copyfile
    with open(src, 'rb') as fsrc:
IOError: [Errno 2] No such file or directory: 'scripts/pre_commit_hook.pyc'
```

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.