### PR TITLE
Fix admin navbar icons

### DIFF
--- a/core/templates/dev/head/pages/admin-page/navbar/admin-navbar.directive.html
+++ b/core/templates/dev/head/pages/admin-page/navbar/admin-navbar.directive.html
@@ -20,13 +20,12 @@
 <nav class="navbar navbar-default navbar-light oppia-navbar oppia-prevent-selection oppia-navbar-admin" role="navigation">
   <div class="navbar-container" style="background-color: #00376d">
     <div class="navbar-header protractor-test-navbar-header float-left">
-      <a class="oppia-navbar-brand-name oppia-transition-200" href="/library">
+      <a class="oppia-navbar-brand-name oppia-transition-200 float-left" href="/library">
         <img ng-src="<[$ctrl.logoWhiteImgUrl]>" class="oppia-logo" ng-class="'oppia-logo-wide'">
       </a>
       <ul class="nav navbar-nav oppia-navbar-breadcrumb">
         <li>
-          <span class="oppia-navbar-breadcrumb-separator"></span>
-          Admin
+          <span class="oppia-navbar-breadcrumb-separator"></span>Admin
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Explanation
Fixes admin navbar

Before:
<img width="285" alt="Screenshot 2019-12-02 at 6 58 15 PM" src="https://user-images.githubusercontent.com/15226041/69963256-d4735680-1535-11ea-9086-99c649830266.png">

After:
<img width="443" alt="Screenshot 2019-12-02 at 6 57 11 PM" src="https://user-images.githubusercontent.com/15226041/69963267-d9380a80-1535-11ea-9e4e-0a08ef0c34fb.png">


## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
