### PR TITLE
Fix #8118: Ensuring use of 'pip2' or 'pip2.7' during installati…

### DIFF
--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -22,20 +22,20 @@ import fileinput
 import os
 import shutil
 import subprocess
-from sys import executable
+import executable
 
 # These libraries need to be installed before running or importing any script.
 TOOLS_DIR = os.path.join('..', 'oppia_tools')
 # Download and install pyyaml.
 if not os.path.exists(os.path.join(TOOLS_DIR, 'pyyaml-5.1.2')):
     subprocess.check_call([
-        executable, '-m', 'pip', 'install', 'pyyaml==5.1.2', '--target',
+        sys.executable, '-m', 'pip', 'install', 'pyyaml==5.1.2', '--target',
         os.path.join(TOOLS_DIR, 'pyyaml-5.1.2')])
 
 # Download and install future.
 if not os.path.exists(os.path.join('third_party', 'future-0.17.1')):
     subprocess.check_call([
-        executable, '-m', 'pip', 'install', 'future==0.17.1', '--target',
+        sys.executable, '-m', 'pip', 'install', 'future==0.17.1', '--target',
         os.path.join('third_party', 'future-0.17.1')])
 
 # pylint: disable=wrong-import-position
@@ -124,8 +124,8 @@ def pip_install(package, version, install_path):
         raise Exception
 
     subprocess.check_call([
-        executable, '-m', 'pip', 'install', '%s==%s' % (package, version), '--target',
-        install_path])
+        sys.executable, '-m', 'pip', 'install', '%s==%s' % (package, version),
+        '--target', install_path])
 
 
 def install_skulpt(parsed_args):

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -22,38 +22,20 @@ import fileinput
 import os
 import shutil
 import subprocess
-
-EXPLICIT_CHECK_REQUIRED = False
-PIP_NAME = 'pip'
-try:
-    if 'python2' not in subprocess.check_output(['pip', '--version']).lower():
-        EXPLICIT_CHECK_REQUIRED = True
-except OSError:
-    EXPLICIT_CHECK_REQUIRED = True
-
-if EXPLICIT_CHECK_REQUIRED:
-    try:
-        subprocess.check_call(['pip2.7', '--version'])
-        PIP_NAME = 'pip2.7'
-    except OSError:
-        try:
-            subprocess.check_call(['pip2', '--version'])
-            PIP_NAME = 'pip2'
-        except OSError:
-            raise Exception
+from sys import executable
 
 # These libraries need to be installed before running or importing any script.
 TOOLS_DIR = os.path.join('..', 'oppia_tools')
 # Download and install pyyaml.
 if not os.path.exists(os.path.join(TOOLS_DIR, 'pyyaml-5.1.2')):
     subprocess.check_call([
-        PIP_NAME, 'install', 'pyyaml==5.1.2', '--target',
+        executable, '-m', 'pip', 'install', 'pyyaml==5.1.2', '--target',
         os.path.join(TOOLS_DIR, 'pyyaml-5.1.2')])
 
 # Download and install future.
 if not os.path.exists(os.path.join('third_party', 'future-0.17.1')):
     subprocess.check_call([
-        PIP_NAME, 'install', 'future==0.17.1', '--target',
+        executable, '-m', 'pip', 'install', 'future==0.17.1', '--target',
         os.path.join('third_party', 'future-0.17.1')])
 
 # pylint: disable=wrong-import-position
@@ -142,7 +124,7 @@ def pip_install(package, version, install_path):
         raise Exception
 
     subprocess.check_call([
-        PIP_NAME, 'install', '%s==%s' % (package, version), '--target',
+        executable, '-m', 'pip', 'install', '%s==%s' % (package, version), '--target',
         install_path])
 
 

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -23,18 +23,37 @@ import os
 import shutil
 import subprocess
 
+EXPLICIT_CHECK_REQUIRED = False
+PIP_NAME = 'pip'
+try:
+    if 'python2' not in subprocess.check_output(['pip', '--version']).lower():
+        EXPLICIT_CHECK_REQUIRED = True
+except OSError:
+    EXPLICIT_CHECK_REQUIRED = True
+
+if EXPLICIT_CHECK_REQUIRED:
+    try:
+        subprocess.check_call(['pip2.7', '--version'])
+        PIP_NAME = 'pip2.7'
+    except OSError:
+        try:
+            subprocess.check_call(['pip2', '--version'])
+            PIP_NAME = 'pip2'
+        except OSError:
+            raise Exception
+
 # These libraries need to be installed before running or importing any script.
 TOOLS_DIR = os.path.join('..', 'oppia_tools')
 # Download and install pyyaml.
 if not os.path.exists(os.path.join(TOOLS_DIR, 'pyyaml-5.1.2')):
     subprocess.check_call([
-        'pip', 'install', 'pyyaml==5.1.2', '--target',
+        PIP_NAME, 'install', 'pyyaml==5.1.2', '--target',
         os.path.join(TOOLS_DIR, 'pyyaml-5.1.2')])
 
 # Download and install future.
 if not os.path.exists(os.path.join('third_party', 'future-0.17.1')):
     subprocess.check_call([
-        'pip', 'install', 'future==0.17.1', '--target',
+        PIP_NAME, 'install', 'future==0.17.1', '--target',
         os.path.join('third_party', 'future-0.17.1')])
 
 # pylint: disable=wrong-import-position
@@ -123,7 +142,7 @@ def pip_install(package, version, install_path):
         raise Exception
 
     subprocess.check_call([
-        'pip', 'install', '%s==%s' % (package, version), '--target',
+        PIP_NAME, 'install', '%s==%s' % (package, version), '--target',
         install_path])
 
 

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -22,7 +22,7 @@ import fileinput
 import os
 import shutil
 import subprocess
-import executable
+import sys
 
 # These libraries need to be installed before running or importing any script.
 TOOLS_DIR = os.path.join('..', 'oppia_tools')

--- a/scripts/install_third_party_libs_test.py
+++ b/scripts/install_third_party_libs_test.py
@@ -221,6 +221,29 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
                 'package', 'version', 'path')
         self.assertTrue(check_function_calls['pip_install_is_called'])
 
+    def test_check_pip_name_when_pip_two_is_default_pip(self):
+        def mock_check_output(unused_version):
+            return 'python2'
+
+        check_output_swap = self.swap(subprocess, 'check_output', mock_check_output)
+        
+        with check_output_swap:
+            self.assertEqual(install_third_party_libs.EXPLICIT_CHECK_REQUIRED, False)
+            self.assertEqual(install_third_party_libs.PIP_NAME, 'pip')
+
+    def test_check_pip_name_when_pip_two_is_not_default_pip(self):
+        def mock_check_output(unused_version):
+            return 'python3'
+        def mock_check_call(unused_version):
+            pass
+
+        check_output_swap = self.swap(subprocess, 'check_output', mock_check_output)
+        check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
+        
+        with check_output_swap, check_call_swap:
+            self.assertEqual(install_third_party_libs.EXPLICIT_CHECK_REQUIRED, True)
+            self.assertTrue('pip2' in install_third_party_libs.PIP_NAME)
+
     def test_function_calls(self):
         check_function_calls = {
             'ensure_pip_library_is_installed_is_called': False,

--- a/scripts/install_third_party_libs_test.py
+++ b/scripts/install_third_party_libs_test.py
@@ -225,10 +225,12 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         def mock_check_output(unused_version):
             return 'python2'
 
-        check_output_swap = self.swap(subprocess, 'check_output', mock_check_output)
-        
+        check_output_swap = self.swap(
+            subprocess, 'check_output', mock_check_output)
+
         with check_output_swap:
-            self.assertEqual(install_third_party_libs.EXPLICIT_CHECK_REQUIRED, False)
+            self.assertEqual(
+                install_third_party_libs.EXPLICIT_CHECK_REQUIRED, False)
             self.assertEqual(install_third_party_libs.PIP_NAME, 'pip')
 
     def test_check_pip_name_when_pip_two_is_not_default_pip(self):
@@ -237,11 +239,13 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         def mock_check_call(unused_version):
             pass
 
-        check_output_swap = self.swap(subprocess, 'check_output', mock_check_output)
+        check_output_swap = self.swap(
+            subprocess, 'check_output', mock_check_output)
         check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
-        
+
         with check_output_swap, check_call_swap:
-            self.assertEqual(install_third_party_libs.EXPLICIT_CHECK_REQUIRED, True)
+            self.assertEqual(
+                install_third_party_libs.EXPLICIT_CHECK_REQUIRED, True)
             self.assertTrue('pip2' in install_third_party_libs.PIP_NAME)
 
     def test_function_calls(self):

--- a/scripts/install_third_party_libs_test.py
+++ b/scripts/install_third_party_libs_test.py
@@ -221,33 +221,6 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
                 'package', 'version', 'path')
         self.assertTrue(check_function_calls['pip_install_is_called'])
 
-    def test_check_pip_name_when_pip_two_is_default_pip(self):
-        def mock_check_output(unused_version):
-            return 'python2'
-
-        check_output_swap = self.swap(
-            subprocess, 'check_output', mock_check_output)
-
-        with check_output_swap:
-            self.assertEqual(
-                install_third_party_libs.EXPLICIT_CHECK_REQUIRED, False)
-            self.assertEqual(install_third_party_libs.PIP_NAME, 'pip')
-
-    def test_check_pip_name_when_pip_two_is_not_default_pip(self):
-        def mock_check_output(unused_version):
-            return 'python3'
-        def mock_check_call(unused_version):
-            pass
-
-        check_output_swap = self.swap(
-            subprocess, 'check_output', mock_check_output)
-        check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
-
-        with check_output_swap, check_call_swap:
-            self.assertEqual(
-                install_third_party_libs.EXPLICIT_CHECK_REQUIRED, True)
-            self.assertTrue('pip2' in install_third_party_libs.PIP_NAME)
-
     def test_function_calls(self):
         check_function_calls = {
             'ensure_pip_library_is_installed_is_called': False,

--- a/scripts/script_import_test.py
+++ b/scripts/script_import_test.py
@@ -65,7 +65,7 @@ class InstallThirdPartyLibsImportTests(test_utils.GenericTestBase):
             from scripts import install_third_party_libs # pylint: disable=unused-variable
         self.assertEqual(
             self.commands, [
-                sys.executable, '-m', 'pip', 'install', 'pyyaml==5.1.2', 
-                '--target', '../oppia_tools/pyyaml-5.1.2', sys.executable, 
-                '-m', 'pip', 'install', 'future==0.17.1', '--target', 
+                sys.executable, '-m', 'pip', 'install', 'pyyaml==5.1.2',
+                '--target', '../oppia_tools/pyyaml-5.1.2', sys.executable,
+                '-m', 'pip', 'install', 'future==0.17.1', '--target',
                 'third_party/future-0.17.1'])

--- a/scripts/script_import_test.py
+++ b/scripts/script_import_test.py
@@ -27,6 +27,7 @@ from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import os
 import subprocess
+import sys
 
 from core.tests import test_utils
 
@@ -64,6 +65,7 @@ class InstallThirdPartyLibsImportTests(test_utils.GenericTestBase):
             from scripts import install_third_party_libs # pylint: disable=unused-variable
         self.assertEqual(
             self.commands, [
-                'pip', 'install', 'pyyaml==5.1.2', '--target',
-                '../oppia_tools/pyyaml-5.1.2', 'pip', 'install',
-                'future==0.17.1', '--target', 'third_party/future-0.17.1'])
+                sys.executable, '-m', 'pip', 'install', 'pyyaml==5.1.2', 
+                '--target', '../oppia_tools/pyyaml-5.1.2', sys.executable, 
+                '-m', 'pip', 'install', 'future==0.17.1', '--target', 
+                'third_party/future-0.17.1'])


### PR DESCRIPTION
## Explanation
Fixes #8118 : oppia_tools Invalid Syntax
Ensuring use of `pip2` in [install_third_party_libs.py](https://github.com/oppia/oppia/blob/develop/scripts/install_third_party_libs.py) by:
* Check for default pip using `subprocess.check_output(["pip", "--version"])`
* If default pip is `pip2`, can proceed without any modifications.
* Else, check for `pip2` explicitly.
If `pip2` present, use `pip2` instead of `pip`.
Else, `raise Exception`

[EDIT] Now using `sys.executable` to ensure use of `python-pip`. 

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
