### PR TITLE
Fix part of #7450: modify private methods in html_validation_service files 

### DIFF
--- a/core/domain/html_validation_service.py
+++ b/core/domain/html_validation_service.py
@@ -602,7 +602,7 @@ def validate_rte_format(html_list, rte_format, run_migration=False):
         soup = bs4.BeautifulSoup(
             soup_data.replace('<br>', '<br/>'), 'html.parser')
 
-        is_invalid = _validate_soup_for_rte(soup, rte_format, err_dict)
+        is_invalid = validate_soup_for_rte(soup, rte_format, err_dict)
 
         if is_invalid:
             err_dict['strings'].append(html_data)
@@ -617,7 +617,7 @@ def validate_rte_format(html_list, rte_format, run_migration=False):
                     unescape_html(collapsible['content-with-value']))
                 soup_for_collapsible = bs4.BeautifulSoup(
                     content_html.replace('<br>', '<br/>'), 'html.parser')
-                is_invalid = _validate_soup_for_rte(
+                is_invalid = validate_soup_for_rte(
                     soup_for_collapsible, rte_format, err_dict)
             if is_invalid:
                 err_dict['strings'].append(html_data)
@@ -629,7 +629,7 @@ def validate_rte_format(html_list, rte_format, run_migration=False):
                 content_html = tab_content['content']
                 soup_for_tabs = bs4.BeautifulSoup(
                     content_html.replace('<br>', '<br/>'), 'html.parser')
-                is_invalid = _validate_soup_for_rte(
+                is_invalid = validate_soup_for_rte(
                     soup_for_tabs, rte_format, err_dict)
                 if is_invalid:
                     err_dict['strings'].append(html_data)
@@ -640,7 +640,7 @@ def validate_rte_format(html_list, rte_format, run_migration=False):
     return err_dict
 
 
-def _validate_soup_for_rte(soup, rte_format, err_dict):
+def validate_soup_for_rte(soup, rte_format, err_dict):
     """Validate content in given soup for given RTE format.
 
     Args:
@@ -739,7 +739,7 @@ def validate_customization_args(html_list):
 
     for tag in tags_to_original_html_strings:
         html_string = tags_to_original_html_strings[tag]
-        err_msg_list = list(_validate_customization_args_in_tag(tag))
+        err_msg_list = list(validate_customization_args_in_tag(tag))
         for err_msg in err_msg_list:
             if err_msg:
                 if err_msg not in err_dict:
@@ -750,7 +750,7 @@ def validate_customization_args(html_list):
     return err_dict
 
 
-def _validate_customization_args_in_tag(tag):
+def validate_customization_args_in_tag(tag):
     """Validates customization arguments of Rich Text Components in a soup.
 
     Args:
@@ -779,7 +779,7 @@ def _validate_customization_args_in_tag(tag):
             for component_name in simple_component_tag_names:
                 for component_tag in soup_for_collapsible.findAll(
                         name=component_name):
-                    for err_msg in _validate_customization_args_in_tag(
+                    for err_msg in validate_customization_args_in_tag(
                             component_tag):
                         yield err_msg
 
@@ -792,7 +792,7 @@ def _validate_customization_args_in_tag(tag):
                 for component_name in simple_component_tag_names:
                     for component_tag in soup_for_tabs.findAll(
                             name=component_name):
-                        for err_msg in _validate_customization_args_in_tag(
+                        for err_msg in validate_customization_args_in_tag(
                                 component_tag):
                             yield err_msg
     except Exception as e:

--- a/core/domain/html_validation_service_test.py
+++ b/core/domain/html_validation_service_test.py
@@ -484,7 +484,7 @@ class ContentMigrationTests(test_utils.GenericTestBase):
 
         for index, test_case in enumerate(test_cases_for_textangular):
             actual_output_for_textangular = (
-                html_validation_service._validate_soup_for_rte( # pylint: disable=protected-access
+                html_validation_service.validate_soup_for_rte( # pylint: disable=protected-access
                     bs4.BeautifulSoup(test_case, 'html.parser'),
                     feconf.RTE_FORMAT_TEXTANGULAR, err_dict))
 
@@ -512,7 +512,7 @@ class ContentMigrationTests(test_utils.GenericTestBase):
 
         for index, test_case in enumerate(test_cases_for_ckeditor):
             actual_output_for_ckeditor = (
-                html_validation_service._validate_soup_for_rte( # pylint: disable=protected-access
+                html_validation_service.validate_soup_for_rte( # pylint: disable=protected-access
                     bs4.BeautifulSoup(test_case, 'html.parser'),
                     feconf.RTE_FORMAT_CKEDITOR, err_dict))
 
@@ -1268,7 +1268,7 @@ class ContentMigrationTests(test_utils.GenericTestBase):
             soup = bs4.BeautifulSoup(
                 html_string.encode(encoding='utf-8'), 'html.parser')
             actual_output.append(list(
-                html_validation_service._validate_customization_args_in_tag( # pylint: disable=protected-access
+                html_validation_service.validate_customization_args_in_tag( # pylint: disable=protected-access
                     soup.find(name=tag_name))))
 
         self.assertEqual(actual_output, expected_output)

--- a/core/domain/html_validation_service_test.py
+++ b/core/domain/html_validation_service_test.py
@@ -484,7 +484,7 @@ class ContentMigrationTests(test_utils.GenericTestBase):
 
         for index, test_case in enumerate(test_cases_for_textangular):
             actual_output_for_textangular = (
-                html_validation_service.validate_soup_for_rte( # pylint: disable=protected-access
+                html_validation_service.validate_soup_for_rte(
                     bs4.BeautifulSoup(test_case, 'html.parser'),
                     feconf.RTE_FORMAT_TEXTANGULAR, err_dict))
 
@@ -512,7 +512,7 @@ class ContentMigrationTests(test_utils.GenericTestBase):
 
         for index, test_case in enumerate(test_cases_for_ckeditor):
             actual_output_for_ckeditor = (
-                html_validation_service.validate_soup_for_rte( # pylint: disable=protected-access
+                html_validation_service.validate_soup_for_rte(
                     bs4.BeautifulSoup(test_case, 'html.parser'),
                     feconf.RTE_FORMAT_CKEDITOR, err_dict))
 
@@ -1268,7 +1268,7 @@ class ContentMigrationTests(test_utils.GenericTestBase):
             soup = bs4.BeautifulSoup(
                 html_string.encode(encoding='utf-8'), 'html.parser')
             actual_output.append(list(
-                html_validation_service.validate_customization_args_in_tag( # pylint: disable=protected-access
+                html_validation_service.validate_customization_args_in_tag(
                     soup.find(name=tag_name))))
 
         self.assertEqual(actual_output, expected_output)


### PR DESCRIPTION
## Explanation
- Fixes part of issue #7450 
- In html_validation_service_test.py, changed both private methods to public since they are being called by a different public function. Changing the naming scheme meant changing the function calls in html_validation_service.py as well. 

## Checklist
- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [X] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
