### PR TITLE
Fix part of #7450: Modify test method in InteractionUnitTests

### DIFF
--- a/extensions/interactions/base_test.py
+++ b/extensions/interactions/base_test.py
@@ -101,32 +101,32 @@ class InteractionUnitTests(test_utils.GenericTestBase):
         """Validates the customization arg specs for the interaction.
 
         Args:
-            customization_args: list(dict(str, *)). The customization args for
-                the interaction.
+            customization_args: list(CustomizationArgSpec). The customization
+                args for the interaction.
         """
         for ca_spec in customization_args:
-            self.assertEqual(set(ca_spec.keys()), set([
+            self.assertTrue(all(hasattr(ca_spec, attr) for attr in [
                 'name', 'description', 'schema', 'default_value']))
 
             self.assertTrue(
-                isinstance(ca_spec['name'], python_utils.BASESTRING))
-            self.assertTrue(self._is_alphanumeric_string(ca_spec['name']))
+                isinstance(ca_spec.name, python_utils.BASESTRING))
+            self.assertTrue(self._is_alphanumeric_string(ca_spec.name))
             self.assertTrue(
-                isinstance(ca_spec['description'], python_utils.BASESTRING))
-            self.assertGreater(len(ca_spec['description']), 0)
+                isinstance(ca_spec.description, python_utils.BASESTRING))
+            self.assertGreater(len(ca_spec.description), 0)
 
-            schema_utils_test.validate_schema(ca_spec['schema'])
+            schema_utils_test.validate_schema(ca_spec.schema)
             self.assertEqual(
-                ca_spec['default_value'],
+                ca_spec.default_value,
                 schema_utils.normalize_against_schema(
-                    ca_spec['default_value'], ca_spec['schema']))
+                    ca_spec.default_value, ca_spec.schema))
 
-            if ca_spec['schema']['type'] == 'custom':
+            if ca_spec.schema['type'] == 'custom':
                 obj_class = obj_services.Registry.get_object_class_by_type(
-                    ca_spec['schema']['obj_type'])
+                    ca_spec.schema['obj_type'])
                 self.assertEqual(
-                    ca_spec['default_value'],
-                    obj_class.normalize(ca_spec['default_value']))
+                    ca_spec.default_value,
+                    obj_class.normalize(ca_spec.default_value))
 
     def _validate_answer_visualization_specs(self, answer_visualization_specs):
         """Validates all the answer_visualization_specs for the interaction.
@@ -472,7 +472,7 @@ class InteractionUnitTests(test_utils.GenericTestBase):
                     interaction.answer_type)
 
             self._validate_customization_arg_specs(
-                interaction._customization_arg_specs)  # pylint: disable=protected-access
+                interaction.customization_arg_specs)
 
             answer_visualization_specs = (
                 interaction.answer_visualization_specs)


### PR DESCRIPTION
… to test CustomizationArgSpec object instead of dictionary

<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
- Fixes part of #7450 by removing reference to private  #members
- Call to private attribute _customization_arg_specs has been replaced with call to public getter customization_arg_specs
- _validate_customization_arg_specs method has been refactored to test the CustomizationArgSpec objects returned by the public getter

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
