### PR TITLE
Fix part of #7450: Using a public helper function to call `_save_exploration` while testing

### DIFF
--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -253,7 +253,7 @@ class BaseHandlerTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'category',
                 'new_value': 'edited category'
-            })], 'Change title and category')
+            })], 'Change title and category', for_testing=True)
 
         # Since user has edited one exploration created by another user,
         # going to '/' should redirect to the dashboard page.

--- a/core/controllers/community_dashboard_test.py
+++ b/core/controllers/community_dashboard_test.py
@@ -380,7 +380,7 @@ class TranslatableTextHandlerTest(test_utils.GenericTestBase):
                     'content_id': 'content',
                     'html': '<p>A content to translate.</p>'
                 }
-            })], 'Changes content.')
+            })], 'Changes content.', for_testing=True)
 
         output = self.get_json('/gettranslatabletexthandler', params={
             'language_code': 'hi',

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -519,7 +519,7 @@ written_translations:
                 exp_domain.ExplorationChange({
                     'cmd': exp_domain.CMD_DELETE_STATE,
                     'state_name': 'State 3',
-                })], 'changes')
+                })], 'changes', for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(exp_id)
         response = self.get_html_response('/create/%s' % exp_id)
 
@@ -724,7 +724,7 @@ class ExplorationSnapshotsHandlerTests(test_utils.GenericTestBase):
                 exp_domain.ExplorationChange({
                     'cmd': exp_domain.CMD_ADD_STATE,
                     'state_name': 'State A',
-                })], 'Addes state')
+                })], 'Addes state', for_testing=True)
 
         snapshots = exp_services.get_exploration_snapshots_metadata(exp_id)
 
@@ -779,7 +779,7 @@ class ExplorationStatisticsHandlerTests(test_utils.GenericTestBase):
                 exp_domain.ExplorationChange({
                     'cmd': exp_domain.CMD_ADD_STATE,
                     'state_name': 'State A',
-                })], 'Addes state')
+                })], 'Addes state', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(exp_id)
         exp_stats = stats_services.get_exploration_stats(
@@ -1146,7 +1146,7 @@ class VersioningIntegrationTest(BaseEditorControllerTests):
                     'content_id': 'content',
                     'html': '<p>ABC</p>'
                 },
-            })], 'Change objective and init state content')
+            })], 'Change objective and init state content', for_testing=True)
 
     def test_get_with_disabled_exploration_id_raises_error(self):
         self.get_html_response(

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -556,8 +556,7 @@ written_translations:
 
         # Check download to JSON.
         exploration.update_objective('Test JSON download')
-        exp_services._save_exploration(  # pylint: disable=protected-access
-            owner_id, exploration, '', [])
+        exp_services.save_exploration(owner_id, exploration, '', [])
 
         # Download to JSON string using download handler.
         self.maxDiff = None

--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -145,7 +145,7 @@ class LibraryPageTests(test_utils.GenericTestBase):
         exploration = self.save_new_valid_exploration(
             'A', self.admin_id, title='Title A', category='Category A',
             objective='Objective A')
-        exp_services._save_exploration(  # pylint: disable=protected-access
+        exp_services.save_exploration(
             self.admin_id, exploration, 'Exploration A', [])
 
         # Test that the private exploration isn't displayed.
@@ -156,7 +156,7 @@ class LibraryPageTests(test_utils.GenericTestBase):
         exploration = self.save_new_valid_exploration(
             'B', self.admin_id, title='Title B', category='Category B',
             objective='Objective B')
-        exp_services._save_exploration(  # pylint: disable=protected-access
+        exp_services.save_exploration(
             self.admin_id, exploration, 'Exploration B', [])
         rights_manager.publish_exploration(self.admin, 'B')
 

--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -111,7 +111,7 @@ class LibraryPageTests(test_utils.GenericTestBase):
                 'property_name': 'category',
                 'new_value': 'A new category'
             })],
-            'Change title and category')
+            'Change title and category', for_testing=True)
 
         # Load the search results with an empty query.
         response_dict = self.get_json(feconf.LIBRARY_SEARCH_DATA_URL)

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -191,7 +191,7 @@ class UserContributionsTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
 
         response_dict = self.get_json(
             '/profilehandler/data/%s' % self.USERNAME_B)

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -84,7 +84,7 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
             state_domain.SubtitledHtml.from_dict(self.old_content))
         exploration.states['State 3'].update_content(
             state_domain.SubtitledHtml.from_dict(self.old_content))
-        exp_services.save_exploration_test_helper(self.editor_id, exploration, '', [])
+        exp_services.save_exploration(self.editor_id, exploration, '', [])
 
         rights_manager.publish_exploration(self.editor, self.EXP_ID)
         rights_manager.assign_role_for_exploration(
@@ -973,7 +973,7 @@ class UserSubmittedSuggestionsHandlerTest(test_utils.GenericTestBase):
         exp_services.save_new_exploration(self.owner_id, exploration)
 
         topic = topic_domain.Topic.create_default_topic(
-            topic_id=self.TOPIC_ID, name='topic')
+            topic_id=self.TOPIC_ID, name='topic', abbreviated_name='abbrev')
         topic_services.save_new_topic(self.owner_id, topic)
 
         story = story_domain.Story.create_default_story(
@@ -1145,7 +1145,7 @@ class ReviewableSuggestionsHandlerTest(test_utils.GenericTestBase):
         exp_services.save_new_exploration(self.owner_id, exploration)
 
         topic = topic_domain.Topic.create_default_topic(
-            topic_id=self.TOPIC_ID, name='topic')
+            topic_id=self.TOPIC_ID, name='topic', abbreviated_name='abbrev')
         topic_services.save_new_topic(self.owner_id, topic)
 
         story = story_domain.Story.create_default_story(

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -1023,7 +1023,7 @@ class UserSubmittedSuggestionsHandlerTest(test_utils.GenericTestBase):
                         'content_id': 'content',
                         'html': '<p>new content html</p>'
                     }
-                })], 'Add content')
+                })], 'Add content', for_testing=True)
 
         self.logout()
 
@@ -1195,7 +1195,7 @@ class ReviewableSuggestionsHandlerTest(test_utils.GenericTestBase):
                         'content_id': 'content',
                         'html': '<p>new content html</p>'
                     }
-                })], 'Add content')
+                })], 'Add content', for_testing=True)
 
         self.logout()
 

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -84,7 +84,7 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
             state_domain.SubtitledHtml.from_dict(self.old_content))
         exploration.states['State 3'].update_content(
             state_domain.SubtitledHtml.from_dict(self.old_content))
-        exp_services._save_exploration(self.editor_id, exploration, '', [])  # pylint: disable=protected-access
+        exp_services.save_exploration_test_helper(self.editor_id, exploration, '', [])
 
         rights_manager.publish_exploration(self.editor, self.EXP_ID)
         rights_manager.assign_role_for_exploration(

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -973,7 +973,7 @@ class UserSubmittedSuggestionsHandlerTest(test_utils.GenericTestBase):
         exp_services.save_new_exploration(self.owner_id, exploration)
 
         topic = topic_domain.Topic.create_default_topic(
-            topic_id=self.TOPIC_ID, name='topic', abbreviated_name='abbrev')
+            topic_id=self.TOPIC_ID, name='topic')
         topic_services.save_new_topic(self.owner_id, topic)
 
         story = story_domain.Story.create_default_story(
@@ -1145,7 +1145,7 @@ class ReviewableSuggestionsHandlerTest(test_utils.GenericTestBase):
         exp_services.save_new_exploration(self.owner_id, exploration)
 
         topic = topic_domain.Topic.create_default_topic(
-            topic_id=self.TOPIC_ID, name='topic', abbreviated_name='abbrev')
+            topic_id=self.TOPIC_ID, name='topic')
         topic_services.save_new_topic(self.owner_id, topic)
 
         story = story_domain.Story.create_default_story(

--- a/core/domain/classifier_services.py
+++ b/core/domain/classifier_services.py
@@ -103,7 +103,7 @@ def handle_non_retrainable_states(exploration, state_names, exp_versions_diff):
     the state in the older version of the exploration. If there's been a change
     in the state name, we retrieve the old state name and create the mapping
     accordingly.
-    This method is called only from exp_services._save_exploration() method and
+    This method is called only from exp_services.save_exploration() method and
     is never called from exp_services._create_exploration().
     In this method, the current_state_name refers to the name of the state in
     the current version of the exploration whereas the old_state_name refers to

--- a/core/domain/classifier_services_test.py
+++ b/core/domain/classifier_services_test.py
@@ -101,7 +101,8 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         })]
         with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
-                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
+                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '',
+                for_testing=True)
 
         # There should be two jobs and two mappings in the data store now.
         all_jobs = classifier_models.ClassifierTrainingJobModel.get_all()
@@ -119,7 +120,8 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         })]
         with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
-                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
+                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '',
+                for_testing=True)
 
         # There should be two jobs and three mappings in the data store now.
         all_jobs = classifier_models.ClassifierTrainingJobModel.get_all()
@@ -140,7 +142,8 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         })]
         with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
-                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
+                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '',
+                for_testing=True)
 
         # There should still be only two jobs and four mappings in the data
         # store now.
@@ -186,7 +189,8 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         })]
         with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
-                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
+                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '',
+                for_testing=True)
 
         # There should be two jobs and two mappings in the data store now.
         all_jobs = classifier_models.ClassifierTrainingJobModel.get_all()
@@ -204,7 +208,8 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         })]
         with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', False):
             exp_services.update_exploration(
-                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
+                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '',
+                for_testing=True)
 
         # There should be two jobs and two mappings in the data store now.
         # Since ML functionality was turned off, no new mapping should be
@@ -224,7 +229,8 @@ class ClassifierServicesTests(test_utils.GenericTestBase):
         })]
         with self.swap(feconf, 'ENABLE_ML_CLASSIFIERS', True):
             exp_services.update_exploration(
-                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '')
+                feconf.SYSTEM_COMMITTER_ID, self.exp_id, change_list, '',
+                for_testing=True)
 
         # There should be three jobs and three mappings in the data store now.
         # Since ML functionality was turned on, new job and mapping should be

--- a/core/domain/draft_upgrade_services_test.py
+++ b/core/domain/draft_upgrade_services_test.py
@@ -65,7 +65,7 @@ class DraftUpgradeUnitTests(test_utils.GenericTestBase):
 
         exp_services.update_exploration(
             self.USER_ID, self.EXP_ID, self.OTHER_CHANGE_LIST,
-            'Changed exploration title.')
+            'Changed exploration title.', for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(exploration.version, 2)
         self.assertIsNone(
@@ -75,7 +75,7 @@ class DraftUpgradeUnitTests(test_utils.GenericTestBase):
     def test_try_upgrade_failure_due_to_unsupported_commit_type(self):
         exp_services.update_exploration(
             self.USER_ID, self.EXP_ID, self.OTHER_CHANGE_LIST,
-            'Changed exploration title.')
+            'Changed exploration title.', for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(exploration.version, 2)
         self.assertIsNone(
@@ -85,7 +85,7 @@ class DraftUpgradeUnitTests(test_utils.GenericTestBase):
     def test_try_upgrade_failure_due_to_unimplemented_upgrade_methods(self):
         exp_services.update_exploration(
             self.USER_ID, self.EXP_ID, self.EXP_MIGRATION_CHANGE_LIST,
-            'Ran Exploration Migration job.')
+            'Ran Exploration Migration job.', for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(exploration.version, 2)
         self.assertIsNone(
@@ -95,7 +95,7 @@ class DraftUpgradeUnitTests(test_utils.GenericTestBase):
     def test_try_upgrade_success(self):
         exp_services.update_exploration(
             self.USER_ID, self.EXP_ID, self.EXP_MIGRATION_CHANGE_LIST,
-            'Ran Exploration Migration job.')
+            'Ran Exploration Migration job.', for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         draft_upgrade_services.DraftUpgradeUtil._convert_states_v0_dict_to_v1_dict = (  # pylint: disable=protected-access,line-too-long
             classmethod(lambda cls, changelist: changelist))

--- a/core/domain/exp_fetchers_test.py
+++ b/core/domain/exp_fetchers_test.py
@@ -70,7 +70,8 @@ class ExplorationRetrievalTests(test_utils.GenericTestBase):
             'state_name': 'New state',
         })]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         # Update exploration to version 3.
         change_list = [exp_domain.ExplorationChange({
@@ -78,7 +79,8 @@ class ExplorationRetrievalTests(test_utils.GenericTestBase):
             'state_name': 'New state 2',
         })]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         exploration_latest = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         latest_version = exploration_latest.version
@@ -100,7 +102,8 @@ class ExplorationRetrievalTests(test_utils.GenericTestBase):
             'state_name': 'New state',
         })]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         # Update exploration to version 3.
         change_list = [exp_domain.ExplorationChange({
@@ -108,7 +111,8 @@ class ExplorationRetrievalTests(test_utils.GenericTestBase):
             'state_name': 'New state 2',
         })]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         with self.assertRaisesRegexp(
             ValueError,
@@ -412,7 +416,8 @@ title: Old Title
         # Ensure that if a converted, then reverted, then converted exploration
         # is saved, it will be the up-to-date version within the datastore.
         exp_services.update_exploration(
-            self.albert_id, exp_id, [], 'Resave after reversion')
+            self.albert_id, exp_id, [], 'Resave after reversion',
+            for_testing=True)
         exploration_model = exp_models.ExplorationModel.get(
             exp_id, strict=True, version=None)
         exploration = exp_fetchers.get_exploration_from_model(

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -399,7 +399,8 @@ class ExpSummariesContributorsOneOffJobTests(test_utils.GenericTestBase):
             'new_value': 'New title'
         })]
         exp_services.update_exploration(
-            self.user_a_id, self.EXP_ID, change_list, 'Changed title.')
+            self.user_a_id, self.EXP_ID, change_list, 'Changed title.',
+            for_testing=True)
 
         # Have the second user revert version 2 to version 1.
         exp_services.revert_exploration(self.user_b_id, self.EXP_ID, 2, 1)
@@ -501,14 +502,14 @@ class ExplorationContributorsSummaryOneOffJobTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'New Exploration Title'
-            })], 'Changed title.')
+            })], 'Changed title.', for_testing=True)
 
         exp_services.update_exploration(
             self.user_a_id, self.EXP_ID, [exp_domain.ExplorationChange({
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'New Objective'
-            })], 'Changed Objective.')
+            })], 'Changed Objective.', for_testing=True)
 
         # Run the job to compute contributors summary.
         job_id = (
@@ -538,13 +539,13 @@ class ExplorationContributorsSummaryOneOffJobTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'New Exploration Title'
-            })], 'Changed title.')
+            })], 'Changed title.', for_testing=True)
         exp_services.update_exploration(
             self.user_a_id, self.EXP_ID, [exp_domain.ExplorationChange({
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'New Objective'
-            })], 'Changed Objective.')
+            })], 'Changed Objective.', for_testing=True)
 
         # Let the second user revert version 3 to version 2.
         exp_services.revert_exploration(self.user_b_id, self.EXP_ID, 3, 2)
@@ -585,13 +586,13 @@ class ExplorationContributorsSummaryOneOffJobTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'New Exploration Title'
-            })], 'Changed title.')
+            })], 'Changed title.', for_testing=True)
         exp_services.update_exploration(
             self.user_a_id, self.EXP_ID, [exp_domain.ExplorationChange({
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'New Objective'
-            })], 'Changed Objective.')
+            })], 'Changed Objective.', for_testing=True)
 
         # Let USER A revert version 3 to version 2.
         exp_services.revert_exploration(self.user_a_id, self.EXP_ID, 3, 2)
@@ -624,7 +625,7 @@ class ExplorationContributorsSummaryOneOffJobTests(test_utils.GenericTestBase):
                     'cmd': 'edit_exploration_property',
                     'property_name': 'title',
                     'new_value': 'Title changed by %s' % system_id
-                })], 'Changed title.')
+                })], 'Changed title.', for_testing=True)
 
         # Run the job to compute the contributor summary.
         job_id = (

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -460,7 +460,7 @@ def apply_change_list(exploration_id, change_list):
         raise
 
 
-def _save_exploration(committer_id, exploration, commit_message, change_list):
+def save_exploration(committer_id, exploration, commit_message, change_list):
     """Validates an exploration and commits it to persistent storage.
 
     If successful, increments the version number of the incoming exploration
@@ -557,15 +557,11 @@ def _save_exploration(committer_id, exploration, commit_message, change_list):
         exploration, exp_versions_diff=exp_versions_diff,
         revert_to_version=None)
 
-def save_exploration_test_helper(
-    committer_id, exploration, commit_message, change_list):
-    _save_exploration(committer_id, exploration, commit_message, change_list)
-
 def _create_exploration(
         committer_id, exploration, commit_message, commit_cmds):
     """Ensures that rights for a new exploration are saved first.
 
-    This is because _save_exploration() depends on the rights object being
+    This is because save_exploration() depends on the rights object being
     present to tell it whether to do strict validation or not.
 
     Args:
@@ -849,7 +845,7 @@ def update_exploration(
             feconf.COMMIT_MESSAGE_ACCEPTED_SUGGESTION_PREFIX)
 
     updated_exploration = apply_change_list(exploration_id, change_list)
-    _save_exploration(
+    save_exploration(
         committer_id, updated_exploration, commit_message, change_list)
 
     discard_draft(exploration_id, committer_id)

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -823,28 +823,27 @@ def update_exploration(
     if change_list is None:
         change_list = []
 
-    if not for_testing:
-        if is_by_voice_artist and not is_voiceover_change_list(change_list):
-            raise utils.ValidationError(
-                'Voice artist does not have permission to make some '
-                'changes in the change list.')
+    if is_by_voice_artist and not is_voiceover_change_list(change_list):
+        raise utils.ValidationError(
+            'Voice artist does not have permission to make some '
+            'changes in the change list.')
 
-        is_public = rights_manager.is_exploration_public(exploration_id)
-        if is_public and not commit_message:
-            raise ValueError(
-                'Exploration is public so expected a commit message but '
-                'received none.')
+    is_public = rights_manager.is_exploration_public(exploration_id)
+    if is_public and not commit_message:
+        raise ValueError(
+            'Exploration is public so expected a commit message but '
+            'received none.')
 
-        if (is_suggestion and (
-                not commit_message or
-                not commit_message.startswith(
-                    feconf.COMMIT_MESSAGE_ACCEPTED_SUGGESTION_PREFIX))):
-            raise ValueError('Invalid commit message for suggestion.')
-        if (not is_suggestion and commit_message and commit_message.startswith(
-                feconf.COMMIT_MESSAGE_ACCEPTED_SUGGESTION_PREFIX)):
-            raise ValueError(
-                'Commit messages for non-suggestions may not start with \'%s\'' %
-                feconf.COMMIT_MESSAGE_ACCEPTED_SUGGESTION_PREFIX)
+    if (is_suggestion and (
+            not commit_message or
+            not commit_message.startswith(
+                feconf.COMMIT_MESSAGE_ACCEPTED_SUGGESTION_PREFIX))):
+        raise ValueError('Invalid commit message for suggestion.')
+    if (not is_suggestion and commit_message and commit_message.startswith(
+            feconf.COMMIT_MESSAGE_ACCEPTED_SUGGESTION_PREFIX)):
+        raise ValueError(
+            'Commit messages for non-suggestions may not start with \'%s\'' %
+            feconf.COMMIT_MESSAGE_ACCEPTED_SUGGESTION_PREFIX)
 
     updated_exploration = apply_change_list(exploration_id, change_list)
     save_exploration(

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -557,6 +557,9 @@ def _save_exploration(committer_id, exploration, commit_message, change_list):
         exploration, exp_versions_diff=exp_versions_diff,
         revert_to_version=None)
 
+def save_exploration_test_helper(
+    committer_id, exploration, commit_message, change_list):
+    _save_exploration(committer_id, exploration, commit_message, change_list)
 
 def _create_exploration(
         committer_id, exploration, commit_message, commit_cmds):

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -141,7 +141,8 @@ class ExplorationRevertClassifierTests(ExplorationServicesUnitTests):
             with self.swap(feconf, 'MIN_TOTAL_TRAINING_EXAMPLES', 2):
                 with self.swap(feconf, 'MIN_ASSIGNED_LABELS', 1):
                     exp_services.update_exploration(
-                        self.owner_id, self.EXP_ID, change_list, '')
+                        self.owner_id, self.EXP_ID, change_list, '',
+                        for_testing=True)
 
         exp = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         job = classifier_services.get_classifier_training_jobs(
@@ -158,7 +159,8 @@ class ExplorationRevertClassifierTests(ExplorationServicesUnitTests):
             with self.swap(feconf, 'MIN_TOTAL_TRAINING_EXAMPLES', 2):
                 with self.swap(feconf, 'MIN_ASSIGNED_LABELS', 1):
                     exp_services.update_exploration(
-                        self.owner_id, self.EXP_ID, change_list, '')
+                        self.owner_id, self.EXP_ID, change_list, '',
+                        for_testing=True)
 
                     exp = exp_fetchers.get_exploration_by_id(self.EXP_ID)
                     # Revert exploration to previous version.
@@ -224,7 +226,7 @@ class ExplorationQueriesUnitTests(ExplorationServicesUnitTests):
         exp_services.update_exploration(
             self.owner_id, self.EXP_ID, _get_change_list(
                 'Introduction', exp_domain.STATE_PROPERTY_INTERACTION_ID,
-                'MultipleChoiceInput'), '')
+                'MultipleChoiceInput'), '', for_testing=True)
         self.assertEqual(exp_services.get_interaction_id_for_state(
             self.EXP_ID, 'Introduction'), 'MultipleChoiceInput')
         with self.assertRaisesRegexp(
@@ -608,7 +610,7 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
                         param_domain.ParamSpec('UnicodeString').to_dict()
                 }
             })],
-            '')
+            '', for_testing=True)
 
         retrieved_exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(retrieved_exploration.title, 'A title')
@@ -630,7 +632,7 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
                     'theParameter':
                         param_domain.ParamSpec('UnicodeString').to_dict()
                 }
-            })], '')
+            })], '', for_testing=True)
 
         # Change title and category.
         exp_services.update_exploration(
@@ -642,7 +644,7 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'category',
                 'new_value': 'A new category'
-            })], 'Change title and category')
+            })], 'Change title and category', for_testing=True)
 
         retrieved_exp_summary = exp_fetchers.get_exploration_summary_by_id(
             self.EXP_ID)
@@ -662,7 +664,7 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
                     'cmd': 'edit_exploration_property',
                     'property_name': 'title',
                     'new_value': 'New title'
-                })], 'Did migration.')
+                })], 'Did migration.', for_testing=True)
 
     def test_update_exploration_by_migration_bot_not_updates_contribution_model(
             self):
@@ -684,7 +686,7 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
                     'cmd': 'edit_exploration_property',
                     'property_name': 'title',
                     'new_value': 'New title'
-                })], 'Did migration.')
+                })], 'Did migration.', for_testing=True)
 
         migration_bot_contributions_model = (
             user_services.get_user_contributions(feconf.MIGRATION_BOT_USER_ID))
@@ -704,7 +706,7 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
                     'cmd': 'edit_exploration_property',
                     'property_name': 'title',
                     'new_value': 'New title'
-                })], 'Did migration.')
+                })], 'Did migration.', for_testing=True)
 
         migration_bot_settings_model = (
             user_services.get_user_settings_from_username(
@@ -1660,7 +1662,7 @@ title: A title
                     'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                     'state_name': 'New state',
                     'new_value': 'TextInput'
-                })], 'Add state name')
+                })], 'Add state name', for_testing=True)
 
         zip_file_output = exp_services.export_to_zip_file(self.EXP_ID)
         zf = zipfile.ZipFile(python_utils.string_io(
@@ -1695,7 +1697,7 @@ title: A title
                     'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                     'state_name': 'New state',
                     'new_value': 'TextInput'
-                })], 'Add state name')
+                })], 'Add state name', for_testing=True)
 
         with python_utils.open_file(
             os.path.join(feconf.TESTS_DATA_DIR, 'img.png'), 'rb',
@@ -1748,7 +1750,7 @@ title: A title
                 feconf.ENTITY_TYPE_EXPLORATION, self.EXP_ID))
         fs.commit(self.owner_id, 'abc.png', raw_image)
         exp_services.update_exploration(
-            self.owner_id, exploration.id, change_list, '')
+            self.owner_id, exploration.id, change_list, '', for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(exploration.version, 2)
 
@@ -1758,7 +1760,7 @@ title: A title
             'new_state_name': 'Renamed state'
         })]
         exp_services.update_exploration(
-            self.owner_id, exploration.id, change_list, '')
+            self.owner_id, exploration.id, change_list, '', for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(exploration.version, 3)
 
@@ -1923,7 +1925,7 @@ written_translations:
                     'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                     'state_name': 'New state',
                     'new_value': 'TextInput'
-                })], 'Add state name')
+                })], 'Add state name', for_testing=True)
 
         dict_output = exp_services.export_states_to_yaml(self.EXP_ID, width=50)
 
@@ -1963,7 +1965,7 @@ written_translations:
                 feconf.ENTITY_TYPE_EXPLORATION, self.EXP_ID))
         fs.commit(self.owner_id, 'abc.png', raw_image)
         exp_services.update_exploration(
-            self.owner_id, exploration.id, change_list, '')
+            self.owner_id, exploration.id, change_list, '', for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(exploration.version, 2)
 
@@ -1973,7 +1975,7 @@ written_translations:
             'new_state_name': 'Renamed state'
         })]
         exp_services.update_exploration(
-            self.owner_id, exploration.id, change_list, '')
+            self.owner_id, exploration.id, change_list, '', for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(exploration.version, 3)
 
@@ -2058,7 +2060,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
             self.owner_id, self.EXP_ID, [exp_domain.ExplorationChange({
                 'cmd': exp_domain.CMD_ADD_STATE,
                 'state_name': 'new state',
-            })], 'Add state name')
+            })], 'Add state name', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertIn('new state', exploration.states)
@@ -2074,7 +2076,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                 'cmd': exp_domain.CMD_RENAME_STATE,
                 'old_state_name': feconf.DEFAULT_INIT_STATE_NAME,
                 'new_state_name': 'state',
-            })], 'Change state name')
+            })], 'Change state name', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertIn('state', exploration.states)
@@ -2092,7 +2094,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                 'cmd': exp_domain.CMD_RENAME_STATE,
                 'old_state_name': feconf.DEFAULT_INIT_STATE_NAME,
                 'new_state_name': u'¡Hola! αβγ',
-            })], 'Change state name')
+            })], 'Change state name', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertIn(u'¡Hola! αβγ', exploration.states)
@@ -2106,7 +2108,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
             self.owner_id, self.EXP_ID, [exp_domain.ExplorationChange({
                 'cmd': exp_domain.CMD_ADD_STATE,
                 'state_name': 'new state',
-            })], 'Add state name')
+            })], 'Add state name', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
 
@@ -2116,7 +2118,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
             self.owner_id, self.EXP_ID, [exp_domain.ExplorationChange({
                 'cmd': exp_domain.CMD_DELETE_STATE,
                 'state_name': 'new state',
-            })], 'delete state')
+            })], 'delete state', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertNotIn('new state', exploration.states)
@@ -2129,7 +2131,8 @@ class UpdateStateTests(ExplorationServicesUnitTests):
         exp_services.save_exploration(self.owner_id, exploration, '', [])
         exp_services.update_exploration(
             self.owner_id, self.EXP_ID, _get_change_list(
-                self.init_state_name, 'param_changes', self.param_changes), '')
+                self.init_state_name, 'param_changes', self.param_changes), '',
+                for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         param_changes = exploration.init_state.param_changes[0]
@@ -2148,7 +2151,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
             exp_services.update_exploration(
                 self.owner_id, self.EXP_ID, _get_change_list(
                     self.init_state_name, 'param_changes', self.param_changes),
-                '')
+                '', for_testing=True)
 
     def test_update_reserved_param_changes(self):
         param_changes = [{
@@ -2165,7 +2168,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
             exp_services.update_exploration(
                 self.owner_id, self.EXP_ID, _get_change_list(
                     self.init_state_name, 'param_changes', param_changes),
-                '')
+                '', for_testing=True)
 
     def test_update_invalid_generator(self):
         """Test for check that the generator_id in param_changes exists."""
@@ -2182,14 +2185,14 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                 self.owner_id, self.EXP_ID,
                 _get_change_list(
                     self.init_state_name, 'param_changes', self.param_changes),
-                '')
+                '', for_testing=True)
 
     def test_update_interaction_id(self):
         """Test updating of interaction_id."""
         exp_services.update_exploration(
             self.owner_id, self.EXP_ID, _get_change_list(
                 self.init_state_name, exp_domain.STATE_PROPERTY_INTERACTION_ID,
-                'MultipleChoiceInput'), '')
+                'MultipleChoiceInput'), '', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(
@@ -2206,7 +2209,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                 self.init_state_name,
                 exp_domain.STATE_PROPERTY_INTERACTION_CUST_ARGS,
                 {'choices': {'value': ['Option A', 'Option B']}}),
-            '')
+            '', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(
@@ -2224,7 +2227,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                 'State 2',
                 exp_domain.STATE_PROPERTY_INTERACTION_ID,
                 'TextInput'),
-            'Add state name')
+            'Add state name', for_testing=True)
 
         self.interaction_default_outcome['dest'] = 'State 2'
         with self.assertRaisesRegexp(
@@ -2241,7 +2244,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                     self.init_state_name,
                     exp_domain.STATE_PROPERTY_INTERACTION_HANDLERS,
                     self.interaction_answer_groups),
-                '')
+                '', for_testing=True)
 
     def test_update_interaction_answer_groups(self):
         """Test updating of interaction_answer_groups."""
@@ -2256,7 +2259,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                 'State 2',
                 exp_domain.STATE_PROPERTY_INTERACTION_ID,
                 'TextInput'),
-            'Add state name')
+            'Add state name', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.interaction_default_outcome['dest'] = 'State 2'
@@ -2273,7 +2276,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                 self.init_state_name,
                 exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME,
                 self.interaction_default_outcome),
-            '')
+            '', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         init_state = exploration.init_state
@@ -2307,7 +2310,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                     self.init_state_name,
                     exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME,
                     self.interaction_default_outcome),
-                '')
+                '', for_testing=True)
 
     def test_update_state_missing_keys(self):
         """Test that missing keys in interaction_answer_groups produce an
@@ -2328,7 +2331,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                     self.init_state_name,
                     exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME,
                     self.interaction_default_outcome),
-                '')
+                '', for_testing=True)
 
     def test_update_state_variable_types(self):
         """Test that parameters in rules must have the correct type."""
@@ -2351,7 +2354,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                     self.init_state_name,
                     exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME,
                     self.interaction_default_outcome),
-                '')
+                '', for_testing=True)
 
     def test_update_content(self):
         """Test updating of content."""
@@ -2361,7 +2364,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                     'html': '<p><strong>Test content</strong></p>',
                     'content_id': 'content',
                 }),
-            '')
+            '', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(
@@ -2389,7 +2392,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
             'translation_html': '<p>Translated text</p>'
         }))
         exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, change_list, '')
+            self.owner_id, self.EXP_ID, change_list, '', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
 
@@ -2407,7 +2410,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                 self.init_state_name,
                 exp_domain.STATE_PROPERTY_SOLICIT_ANSWER_DETAILS,
                 True),
-            '')
+            '', for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(
             exploration.init_state.solicit_answer_details, True)
@@ -2425,7 +2428,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                     self.init_state_name,
                     exp_domain.STATE_PROPERTY_SOLICIT_ANSWER_DETAILS,
                     'abc'),
-                '')
+                '', for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(
             exploration.init_state.solicit_answer_details, False)
@@ -2438,7 +2441,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
                     self.init_state_name, 'content', {
                         'html': '<b>Test content</b>',
                     }),
-                '')
+                '', for_testing=True)
 
     def test_update_written_translations(self):
         """Test update content translations."""
@@ -2456,7 +2459,8 @@ class UpdateStateTests(ExplorationServicesUnitTests):
         exp_services.update_exploration(
             self.owner_id, self.EXP_ID, _get_change_list(
                 self.init_state_name, 'written_translations',
-                written_translations_dict), 'Added text translations.')
+                written_translations_dict), 'Added text translations.',
+                for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         self.assertEqual(
             exploration.init_state.written_translations.to_dict(),
@@ -2469,7 +2473,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
             exp_services.update_exploration(
                 self.owner_id, self.EXP_ID, _get_change_list(
                     self.init_state_name, 'written_translations',
-                    [1, 2]), 'Added fake text translations.')
+                    [1, 2]), 'Added fake text translations.', for_testing=True)
 
 
 class CommitMessageHandlingTests(ExplorationServicesUnitTests):
@@ -2489,7 +2493,7 @@ class CommitMessageHandlingTests(ExplorationServicesUnitTests):
             self.owner_id, self.EXP_ID, _get_change_list(
                 self.init_state_name,
                 exp_domain.STATE_PROPERTY_INTERACTION_STICKY,
-                False), 'A message')
+                False), 'A message', for_testing=True)
 
         self.assertEqual(
             exp_services.get_exploration_snapshots_metadata(
@@ -2508,7 +2512,8 @@ class CommitMessageHandlingTests(ExplorationServicesUnitTests):
             exp_services.update_exploration(
                 self.owner_id, self.EXP_ID, _get_change_list(
                     self.init_state_name,
-                    exp_domain.STATE_PROPERTY_INTERACTION_STICKY, False), '')
+                    exp_domain.STATE_PROPERTY_INTERACTION_STICKY, False), '',
+                    for_testing=True)
 
     def test_unpublished_explorations_can_accept_commit_message(self):
         """Test unpublished explorations can accept optional commit messages."""
@@ -2516,19 +2521,19 @@ class CommitMessageHandlingTests(ExplorationServicesUnitTests):
             self.owner_id, self.EXP_ID, _get_change_list(
                 self.init_state_name,
                 exp_domain.STATE_PROPERTY_INTERACTION_STICKY, False
-            ), 'A message')
+            ), 'A message', for_testing=True)
 
         exp_services.update_exploration(
             self.owner_id, self.EXP_ID, _get_change_list(
                 self.init_state_name,
                 exp_domain.STATE_PROPERTY_INTERACTION_STICKY, True
-            ), '')
+            ), '', for_testing=True)
 
         exp_services.update_exploration(
             self.owner_id, self.EXP_ID, _get_change_list(
                 self.init_state_name,
                 exp_domain.STATE_PROPERTY_INTERACTION_STICKY, True
-            ), None)
+            ), None, for_testing=True)
 
 
 class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
@@ -2550,7 +2555,7 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
                     'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                     'property_name': 'title',
                     'new_value': 'New title'
-                })], 'Did migration.')
+                })], 'Did migration.', for_testing=True)
 
         self.assertLess(
             original_timestamp,
@@ -2612,7 +2617,8 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
         })]
         change_list_dict = [change.to_dict() for change in change_list]
         exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, change_list, 'Changed title.')
+            self.owner_id, self.EXP_ID, change_list, 'Changed title.',
+            for_testing=True)
 
         snapshots_metadata = exp_services.get_exploration_snapshots_metadata(
             self.EXP_ID)
@@ -2656,7 +2662,7 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
 
         exp_services.update_exploration(
             second_committer_id, self.EXP_ID, new_change_list,
-            'Second commit.')
+            'Second commit.', for_testing=True)
 
         snapshots_metadata = exp_services.get_exploration_snapshots_metadata(
             self.EXP_ID)
@@ -2720,7 +2726,7 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
         })]
         exp_services.update_exploration(
             'second_committer_id', exploration.id, change_list,
-            'Added new state')
+            'Added new state', for_testing=True)
 
         commit_dict_3 = {
             'committer_id': 'second_committer_id',
@@ -2750,7 +2756,7 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
         })]
         exp_services.update_exploration(
             'committer_id_3', exploration.id, change_list,
-            'Deleted state: New state')
+            'Deleted state: New state', for_testing=True)
 
         commit_dict_4 = {
             'committer_id': 'committer_id_3',
@@ -2794,7 +2800,8 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
             'new_value': 'TextInput'
         })]
         exp_services.update_exploration(
-            'committer_id_v3', exploration.id, change_list, 'Added new state')
+            'committer_id_v3', exploration.id, change_list, 'Added new state',
+            for_testing=True)
 
         # It is not possible to revert from anything other than the most
         # current version.
@@ -3104,7 +3111,8 @@ class ExplorationSearchTests(ExplorationServicesUnitTests):
                     exp_domain.ExplorationChange({
                         'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                         'property_name': 'category',
-                        'new_value': 'cat1'})], 'update category')
+                        'new_value': 'cat1'})], 'update category',
+                        for_testing=True)
             self.assertEqual(actual_docs, [updated_exp_doc])
             self.assertEqual(add_docs_counter.times_called, 3)
 
@@ -3245,7 +3253,7 @@ class ExplorationSummaryTests(ExplorationServicesUnitTests):
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'title',
                 'new_value': 'Exploration 1 title'
-            })], 'Changed title.')
+            })], 'Changed title.', for_testing=True)
         # Have Bob revert Albert's update.
         exp_services.revert_exploration(bob_id, self.EXP_ID_1, 2, 1)
 
@@ -3287,7 +3295,7 @@ class ExplorationSummaryTests(ExplorationServicesUnitTests):
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'title',
                 'new_value': 'Exploration 1 title'
-            })], 'Changed title.')
+            })], 'Changed title.', for_testing=True)
         self._check_contributors_summary(
             self.EXP_ID_1, {albert_id: 1, bob_id: 1})
         # Have Bob update that exploration. Version 3.
@@ -3296,7 +3304,7 @@ class ExplorationSummaryTests(ExplorationServicesUnitTests):
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'title',
                 'new_value': 'Exploration 1 title'
-            })], 'Changed title.')
+            })], 'Changed title.', for_testing=True)
         self._check_contributors_summary(
             self.EXP_ID_1, {albert_id: 1, bob_id: 2})
 
@@ -3306,7 +3314,7 @@ class ExplorationSummaryTests(ExplorationServicesUnitTests):
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'title',
                 'new_value': 'Exploration 1 title'
-            })], 'Changed title.')
+            })], 'Changed title.', for_testing=True)
         self._check_contributors_summary(
             self.EXP_ID_1, {albert_id: 2, bob_id: 2})
 
@@ -3368,7 +3376,7 @@ class ExplorationSummaryGetTests(ExplorationServicesUnitTests):
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'title',
                 'new_value': 'Exploration 1 title'
-            })], 'Changed title.')
+            })], 'Changed title.', for_testing=True)
 
         self.save_new_valid_exploration(self.EXP_ID_2, self.albert_id)
 
@@ -3377,14 +3385,14 @@ class ExplorationSummaryGetTests(ExplorationServicesUnitTests):
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'title',
                 'new_value': 'Exploration 1 Albert title'
-            })], 'Changed title to Albert1 title.')
+            })], 'Changed title to Albert1 title.', for_testing=True)
 
         exp_services.update_exploration(
             self.albert_id, self.EXP_ID_2, [exp_domain.ExplorationChange({
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'title',
                 'new_value': 'Exploration 2 Albert title'
-            })], 'Changed title to Albert2 title.')
+            })], 'Changed title to Albert2 title.', for_testing=True)
 
         exp_services.revert_exploration(self.bob_id, self.EXP_ID_1, 3, 2)
 
@@ -3615,7 +3623,7 @@ title: Old Title
         self.assertEqual(exploration.language_code, 'en')
 
         exp_services.update_exploration(
-            'user_id', 'exp_id', None, 'empty commit')
+            'user_id', 'exp_id', None, 'empty commit', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id('exp_id')
 
@@ -3640,7 +3648,7 @@ title: Old Title
                     'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                     'property_name': 'title',
                     'new_value': 'new title'
-                })], 'changed title')
+                })], 'changed title', for_testing=True)
 
     def test_update_exploration_as_suggestion_with_invalid_commit_message(self):
         self.save_new_valid_exploration('exp_id', 'user_id')
@@ -3655,7 +3663,7 @@ title: Old Title
                     'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                     'property_name': 'title',
                     'new_value': 'new title'
-                })], '', is_suggestion=True)
+                })], '', is_suggestion=True, for_testing=True)
 
     def test_update_exploration_with_invalid_commit_message(self):
         self.save_new_valid_exploration('exp_id', 'user_id')
@@ -3671,7 +3679,8 @@ title: Old Title
                     'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                     'property_name': 'title',
                     'new_value': 'new title'
-                })], feconf.COMMIT_MESSAGE_ACCEPTED_SUGGESTION_PREFIX)
+                })], feconf.COMMIT_MESSAGE_ACCEPTED_SUGGESTION_PREFIX,
+                for_testing=True)
 
     def test_update_language_code(self):
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
@@ -3681,7 +3690,7 @@ title: Old Title
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'language_code',
                 'new_value': 'bn'
-            })], 'Changed language code.')
+            })], 'Changed language code.', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
         self.assertEqual(exploration.language_code, 'bn')
@@ -3694,7 +3703,7 @@ title: Old Title
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'tags',
                 'new_value': ['test']
-            })], 'Changed tags.')
+            })], 'Changed tags.', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
         self.assertEqual(exploration.tags, ['test'])
@@ -3707,7 +3716,7 @@ title: Old Title
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'author_notes',
                 'new_value': 'author_notes'
-            })], 'Changed author_notes.')
+            })], 'Changed author_notes.', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
         self.assertEqual(exploration.author_notes, 'author_notes')
@@ -3720,7 +3729,7 @@ title: Old Title
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'blurb',
                 'new_value': 'blurb'
-            })], 'Changed blurb.')
+            })], 'Changed blurb.', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
         self.assertEqual(exploration.blurb, 'blurb')
@@ -3746,7 +3755,7 @@ title: Old Title
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'param_changes',
                 'new_value': param_changes
-            })], 'Changed param_changes.')
+            })], 'Changed param_changes.', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
 
@@ -3761,7 +3770,7 @@ title: Old Title
             self.albert_id, self.NEW_EXP_ID, [exp_domain.ExplorationChange({
                 'cmd': exp_domain.CMD_ADD_STATE,
                 'state_name': 'State'
-            })], 'Added new state.')
+            })], 'Added new state.', for_testing=True)
 
         self.assertEqual(
             exploration.init_state_name, feconf.DEFAULT_INIT_STATE_NAME)
@@ -3771,7 +3780,7 @@ title: Old Title
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'init_state_name',
                 'new_value': 'State'
-            })], 'Changed init_state_name.')
+            })], 'Changed init_state_name.', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
         self.assertEqual(exploration.init_state_name, 'State')
@@ -3784,7 +3793,7 @@ title: Old Title
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'auto_tts_enabled',
                 'new_value': False
-            })], 'Changed auto_tts_enabled.')
+            })], 'Changed auto_tts_enabled.', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
         self.assertEqual(exploration.auto_tts_enabled, False)
@@ -3797,7 +3806,7 @@ title: Old Title
                 'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                 'property_name': 'correctness_feedback_enabled',
                 'new_value': True
-            })], 'Changed correctness_feedback_enabled.')
+            })], 'Changed correctness_feedback_enabled.', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
         self.assertEqual(exploration.correctness_feedback_enabled, True)
@@ -3814,7 +3823,7 @@ title: Old Title
                 'property_name': exp_domain.STATE_PROPERTY_UNCLASSIFIED_ANSWERS,
                 'state_name': exploration.init_state_name,
                 'new_value': ['test']
-            })], 'Changed confirmed_unclassified_answers.')
+            })], 'Changed confirmed_unclassified_answers.', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
         self.assertEqual(
@@ -3845,7 +3854,7 @@ title: Old Title
                 'property_name': exp_domain.STATE_PROPERTY_INTERACTION_HINTS,
                 'state_name': exploration.init_state_name,
                 'new_value': hint_list
-            })], 'Changed hints.')
+            })], 'Changed hints.', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
 
@@ -3886,7 +3895,7 @@ title: Old Title
                 'property_name': exp_domain.STATE_PROPERTY_INTERACTION_HINTS,
                 'state_name': exploration.init_state_name,
                 'new_value': hint_list
-            })], 'Changed hints.')
+            })], 'Changed hints.', for_testing=True)
 
         exp_services.update_exploration(
             self.albert_id, self.NEW_EXP_ID, [exp_domain.ExplorationChange({
@@ -3894,7 +3903,7 @@ title: Old Title
                 'property_name': exp_domain.STATE_PROPERTY_INTERACTION_SOLUTION,
                 'state_name': exploration.init_state_name,
                 'new_value': solution
-            })], 'Changed interaction_solutions.')
+            })], 'Changed interaction_solutions.', for_testing=True)
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
         self.assertEqual(
@@ -3913,7 +3922,7 @@ title: Old Title
                         exp_domain.STATE_PROPERTY_RECORDED_VOICEOVERS),
                     'state_name': exploration.init_state_name,
                     'new_value': 'invalid_recorded_voiceovers'
-                })], 'Changed recorded_voiceovers.')
+                })], 'Changed recorded_voiceovers.', for_testing=True)
 
     def test_revert_exploration_with_mismatch_of_versions_raises_error(self):
         self.save_new_valid_exploration('exp_id', 'user_id')
@@ -3995,7 +4004,8 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
 
     def test_draft_cleared_after_change_list_applied(self):
         exp_services.update_exploration(
-            self.USER_ID, self.EXP_ID1, self.draft_change_list, '')
+            self.USER_ID, self.EXP_ID1, self.draft_change_list, '',
+            for_testing=True)
         exp_user_data = user_models.ExplorationUserDataModel.get_by_id(
             '%s.%s' % (self.USER_ID, self.EXP_ID1))
         self.assertIsNone(exp_user_data.draft_change_list)

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -2126,7 +2126,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services._save_exploration(self.owner_id, exploration, '', [])
+        exp_services.save_exploration(self.owner_id, exploration, '', [])
         exp_services.update_exploration(
             self.owner_id, self.EXP_ID, _get_change_list(
                 self.init_state_name, 'param_changes', self.param_changes), '')
@@ -2172,7 +2172,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services._save_exploration(self.owner_id, exploration, '', [])
+        exp_services.save_exploration(self.owner_id, exploration, '', [])
 
         self.param_changes[0]['generator_id'] = 'fake'
         with self.assertRaisesRegexp(
@@ -2643,7 +2643,7 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
 
         # Using the old version of the exploration should raise an error.
         with self.assertRaisesRegexp(Exception, 'version 1, which is too old'):
-            exp_services._save_exploration(
+            exp_services.save_exploration(
                 second_committer_id, v1_exploration, '', [])
 
         # Another person modifies the exploration.
@@ -2697,7 +2697,7 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
             self.EXP_ID, self.owner_id)
 
         exploration.title = 'First title'
-        exp_services._save_exploration(
+        exp_services.save_exploration(
             self.owner_id, exploration, 'Changed title.', [])
         commit_dict_2 = {
             'committer_id': self.owner_id,
@@ -2779,7 +2779,7 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
         # In version 1, the title was 'A title'.
         # In version 2, the title becomes 'V2 title'.
         exploration.title = 'V2 title'
-        exp_services._save_exploration(
+        exp_services.save_exploration(
             self.owner_id, exploration, 'Changed title.', [])
 
         # In version 3, a new state is added.
@@ -2960,19 +2960,19 @@ class ExplorationCommitLogUnitTests(ExplorationServicesUnitTests):
                 self.EXP_ID_1, self.albert_id)
 
             exploration_1.title = 'Exploration 1 title'
-            exp_services._save_exploration(
+            exp_services.save_exploration(
                 self.bob_id, exploration_1, 'Changed title.', [])
 
             exploration_2 = self.save_new_valid_exploration(
                 self.EXP_ID_2, self.albert_id)
 
             exploration_1.title = 'Exploration 1 Albert title'
-            exp_services._save_exploration(
+            exp_services.save_exploration(
                 self.albert_id, exploration_1,
                 'Changed title to Albert1 title.', [])
 
             exploration_2.title = 'Exploration 2 Albert title'
-            exp_services._save_exploration(
+            exp_services.save_exploration(
                 self.albert_id, exploration_2, 'Changed title to Albert2.', [])
 
             exp_services.revert_exploration(self.bob_id, self.EXP_ID_1, 3, 2)
@@ -3731,7 +3731,7 @@ title: Old Title
 
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services._save_exploration(self.albert_id, exploration, '', [])
+        exp_services.save_exploration(self.albert_id, exploration, '', [])
 
         param_changes = [{
             'customization_args': {
@@ -3958,7 +3958,7 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
             self.EXP_ID1, self.USER_ID)
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services._save_exploration(self.USER_ID, exploration, '', [])
+        exp_services.save_exploration(self.USER_ID, exploration, '', [])
         self.save_new_valid_exploration(self.EXP_ID2, self.USER_ID)
         self.save_new_valid_exploration(self.EXP_ID3, self.USER_ID)
         self.init_state_name = exploration.init_state_name
@@ -4165,7 +4165,7 @@ class ApplyDraftUnitTests(test_utils.GenericTestBase):
             'from_version': '0',
             'to_version': '1'
         })]
-        exp_services._save_exploration(
+        exp_services.save_exploration(
             self.USER_ID, exploration, 'Migrate state schema.',
             migration_change_list)
 

--- a/core/domain/opportunity_services_test.py
+++ b/core/domain/opportunity_services_test.py
@@ -374,7 +374,7 @@ class OpportunityServicesIntegrationTest(test_utils.GenericTestBase):
                         exp_domain.STATE_PROPERTY_INTERACTION_SOLUTION),
                     'state_name': 'Introduction',
                     'new_value': solution_dict
-                })], 'Add state name')
+                })], 'Add state name', for_testing=True)
         translation_opportunities, _, _ = (
             opportunity_services.get_translation_opportunities('hi', None))
         self.assertEqual(len(translation_opportunities), 1)

--- a/core/domain/prod_validation_jobs_one_off_test.py
+++ b/core/domain/prod_validation_jobs_one_off_test.py
@@ -3297,7 +3297,7 @@ class ExplorationModelValidatorTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'New title'
-            })], 'Changes.')
+            })], 'Changes.', for_testing=True)
 
         expected_output = [
             u'[u\'fully-validated ExplorationModel\', 3]']
@@ -3355,7 +3355,7 @@ class ExplorationModelValidatorTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'New title'
-            })], 'Changes.')
+            })], 'Changes.', for_testing=True)
         exp_models.ExplorationCommitLogEntryModel.get_by_id(
             'exploration-0-1').delete()
 
@@ -3468,7 +3468,7 @@ class ExplorationSnapshotMetadataModelValidatorTests(
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'New title'
-            })], 'Changes.')
+            })], 'Changes.', for_testing=True)
         expected_output = [
             u'[u\'fully-validated ExplorationSnapshotMetadataModel\', 4]']
         run_job_and_check_output(self, expected_output)
@@ -3624,7 +3624,7 @@ class ExplorationSnapshotContentModelValidatorTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'New title'
-            })], 'Changes.')
+            })], 'Changes.', for_testing=True)
         expected_output = [
             u'[u\'fully-validated ExplorationSnapshotContentModel\', 4]']
         run_job_and_check_output(self, expected_output)
@@ -4206,7 +4206,7 @@ class ExplorationCommitLogEntryModelValidatorTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'New title'
-            })], 'Changes.')
+            })], 'Changes.', for_testing=True)
         expected_output = [
             u'[u\'fully-validated ExplorationCommitLogEntryModel\', 5]']
         run_job_and_check_output(self, expected_output)
@@ -4444,7 +4444,7 @@ class ExpSummaryModelValidatorTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'New title'
-            })], 'Changes.')
+            })], 'Changes.', for_testing=True)
 
         rights_manager.assign_role_for_exploration(
             self.owner, '2', self.viewer_id, rights_manager.ROLE_VIEWER)
@@ -4466,7 +4466,7 @@ class ExpSummaryModelValidatorTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'New title'
-            })], 'Changes.')
+            })], 'Changes.', for_testing=True)
         expected_output = [
             u'[u\'fully-validated ExpSummaryModel\', 3]']
         run_job_and_check_output(self, expected_output)
@@ -14002,13 +14002,13 @@ class UserContributionsModelValidatorTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
         exp_services.update_exploration(
             self.owner_id, 'exp0', [exp_domain.ExplorationChange({
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'The objective'
-            })], 'Test edit 2')
+            })], 'Test edit 2', for_testing=True)
         rights_manager.publish_exploration(self.owner, 'exp0')
         rights_manager.publish_exploration(self.owner, 'exp1')
 

--- a/core/domain/stats_jobs_continuous_test.py
+++ b/core/domain/stats_jobs_continuous_test.py
@@ -94,7 +94,7 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
                     'state_name': second_state_name,
                     'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                     'new_value': 'MultipleChoiceInput',
-                })], 'Add new state')
+                })], 'Add new state', for_testing=True)
             exp = exp_fetchers.get_exploration_by_id(exp_id)
             exp_version = exp.version
 
@@ -190,7 +190,7 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
                     'state_name': first_state_name,
                     'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                     'new_value': 'MultipleChoiceInput',
-                })], 'Update interaction type')
+                })], 'Update interaction type', for_testing=True)
             exp = exp_fetchers.get_exploration_by_id(exp_id)
             exp_version = exp.version
 
@@ -254,7 +254,7 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
                     'state_name': second_state_name,
                     'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                     'new_value': 'MultipleChoiceInput',
-                })], 'Add new state')
+                })], 'Add new state', for_testing=True)
             exp = exp_fetchers.get_exploration_by_id(exp_id)
             exp_version = exp.version
 
@@ -313,7 +313,7 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
                 exp_domain.ExplorationChange({
                     'cmd': exp_domain.CMD_ADD_STATE,
                     'state_name': 'third state',
-                })], 'Adding yet another state')
+                })], 'Adding yet another state', for_testing=True)
             exp = exp_fetchers.get_exploration_by_id(exp_id)
             self.assertNotEqual(exp.version, exp_version)
 
@@ -422,7 +422,7 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
                     'state_name': init_state_name,
                     'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                     'new_value': 'NumericInput',
-                })], 'Change to NumericInput')
+                })], 'Change to NumericInput', for_testing=True)
 
             exp = exp_fetchers.get_exploration_by_id(exp_id)
             self.assertEqual(exp.version, 2)
@@ -521,7 +521,7 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
                         'content_id': 'content',
                         'html': '<p>New content</p>'
                     },
-                })], 'Change state content')
+                })], 'Change state content', for_testing=True)
 
             exp = exp_fetchers.get_exploration_by_id(exp_id)
             self.assertEqual(exp.version, 2)
@@ -606,7 +606,7 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
                     'state_name': init_state_name,
                     'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                     'new_value': 'NumericInput',
-                })], 'Change to NumericInput')
+                })], 'Change to NumericInput', for_testing=True)
 
             # Submit an answer to the numeric interaction.
             event_services.AnswerSubmissionEventHandler.record(
@@ -621,7 +621,7 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
                     'state_name': init_state_name,
                     'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                     'new_value': 'TextInput',
-                })], 'Change to TextInput')
+                })], 'Change to TextInput', for_testing=True)
 
             # Submit another number-like answer.
             event_services.AnswerSubmissionEventHandler.record(
@@ -639,7 +639,7 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
                         'content_id': 'content',
                         'html': '<p>New content description</p>'
                     }
-                })], 'Change content description')
+                })], 'Change content description', for_testing=True)
 
             # Submit some more answers to the latest exploration version.
             event_services.AnswerSubmissionEventHandler.record(
@@ -741,7 +741,7 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
                     'state_name': second_state_name,
                     'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                     'new_value': 'SetInput',
-                })], 'Add new state')
+                })], 'Add new state', for_testing=True)
             exp = exp_fetchers.get_exploration_by_id(exp_id)
             exp_version = exp.version
 

--- a/core/domain/stats_jobs_one_off_test.py
+++ b/core/domain/stats_jobs_one_off_test.py
@@ -204,7 +204,8 @@ class RegenerateMissingV1StatsModelsOneOffJobTests(OneOffJobTestBase):
                 {'cmd': 'add_state', 'state_name': 'New state'})]
         # v2 version does not have ExplorationStatsModel.
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.exp1.id, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.exp1.id, change_list, '',
+            for_testing=True)
         self.exp1 = exp_fetchers.get_exploration_by_id(self.exp1.id)
 
     def test_stats_models_regeneration_works(self):
@@ -248,7 +249,8 @@ class RegenerateMissingV1StatsModelsOneOffJobTests(OneOffJobTestBase):
             'new_state_name': 'Another state'
         })]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.exp1.id, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.exp1.id, change_list, '',
+            for_testing=True)
 
         model_id = '%s.3' % self.EXP_ID
         model1 = stats_models.ExplorationStatsModel.get(model_id)
@@ -282,7 +284,8 @@ class RecomputeStateCompleteStatisticsTests(OneOffJobTestBase):
 
         change_list = []
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
         change_list = [
             exp_domain.ExplorationChange({
                 'cmd': exp_domain.CMD_RENAME_STATE,
@@ -291,7 +294,8 @@ class RecomputeStateCompleteStatisticsTests(OneOffJobTestBase):
             })
         ]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         stats_models.StateCompleteEventLogEntryModel(
             id='id0',
@@ -398,7 +402,8 @@ class RecomputeStateCompleteStatisticsTests(OneOffJobTestBase):
             })
         ]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         job_output = self.run_one_off_job()
         self.assertEqual(job_output, [])
@@ -419,7 +424,8 @@ class RecomputeStateCompleteStatisticsTests(OneOffJobTestBase):
             })
         ]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         job_output = self.run_one_off_job()
         self.assertEqual(job_output, [])
@@ -452,7 +458,8 @@ class RecomputeAnswerSubmittedStatisticsTests(OneOffJobTestBase):
             })
         ]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         stats_models.AnswerSubmittedEventLogEntryModel(
             id='id1',
@@ -558,7 +565,8 @@ class RecomputeStateHitStatisticsTests(OneOffJobTestBase):
 
         change_list = []
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
         change_list = [
             exp_domain.ExplorationChange({
                 'cmd': exp_domain.CMD_RENAME_STATE,
@@ -567,7 +575,8 @@ class RecomputeStateHitStatisticsTests(OneOffJobTestBase):
             })
         ]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         stats_models.StateHitEventLogEntryModel(
             id='id1',
@@ -714,7 +723,8 @@ class RecomputeSolutionHitStatisticsTests(OneOffJobTestBase):
             })
         ]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         stats_models.SolutionHitEventLogEntryModel(
             id='id1',
@@ -818,9 +828,11 @@ class RecomputeActualStartStatisticsTests(OneOffJobTestBase):
         change_list = []
         # Update exploration to version 3.
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         stats_models.ExplorationActualStartEventLogEntryModel(
             id='id1',
@@ -965,7 +977,8 @@ class RecomputeCompleteEventStatisticsTests(OneOffJobTestBase):
 
         change_list = []
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         stats_models.CompleteExplorationEventLogEntryModel(
             id='id1',
@@ -1413,7 +1426,8 @@ class RegenerateMissingV2StatsModelsOneOffJobTests(OneOffJobTestBase):
 
         change_list = []
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
         change_list = [
             exp_domain.ExplorationChange({
                 'cmd': exp_domain.CMD_RENAME_STATE,
@@ -1422,7 +1436,8 @@ class RegenerateMissingV2StatsModelsOneOffJobTests(OneOffJobTestBase):
             })
         ]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
         exp_services.revert_exploration(
             feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, 3, 2)
@@ -1435,7 +1450,8 @@ class RegenerateMissingV2StatsModelsOneOffJobTests(OneOffJobTestBase):
             })
         ]
         exp_services.update_exploration(
-            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '')
+            feconf.SYSTEM_COMMITTER_ID, self.EXP_ID, change_list, '',
+            for_testing=True)
 
     def test_job_successfully_regenerates_deleted_model(self):
         self.exp = exp_fetchers.get_exploration_by_id(self.EXP_ID)

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -158,7 +158,8 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             stats_services, 'get_stats_for_new_exp_version',
             stats_for_new_exp_version_log):
             exp_services.update_exploration(
-                feconf.SYSTEM_COMMITTER_ID, exp_id, change_list, '')
+                feconf.SYSTEM_COMMITTER_ID, exp_id, change_list, '',
+                for_testing=True)
 
         # Now, the stats creation for new explorations method will be called
         # once and stats creation for new exploration version will also be
@@ -192,7 +193,8 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             'state_name': 'New state'
         })]
         exp_services.update_exploration(
-            'committer_id_v3', exploration.id, change_list, 'Added new state')
+            'committer_id_v3', exploration.id, change_list, 'Added new state',
+                for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(exp_id)
         exp_issues = stats_services.get_exp_issues(exp_id, exploration.version)
         self.assertEqual(exp_issues.exp_version, exploration.version)
@@ -240,7 +242,8 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             'state_name': 'New state'
         })]
         exp_services.update_exploration(
-            'committer_id_v3', exploration.id, change_list, 'Deleted a state')
+            'committer_id_v3', exploration.id, change_list, 'Deleted a state',
+                for_testing=True)
         exploration = exp_fetchers.get_exploration_by_id(exp_id)
         exp_issues = stats_services.get_exp_issues(exp_id, exploration.version)
         self.assertEqual(exp_issues.exp_version, exploration.version)
@@ -335,7 +338,8 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
 
         # Update exploration to next version 2 and its stats.
         exp_services.update_exploration(
-            'committer_id_v2', exploration.id, [], 'Updated')
+            'committer_id_v2', exploration.id, [], 'Updated',
+                for_testing=True)
         exploration_stats = stats_services.get_exploration_stats_by_id(
             exp_id, 2)
         exploration_stats.num_starts_v2 = 4
@@ -1191,7 +1195,7 @@ class AnswerEventTests(test_utils.GenericTestBase):
                 'state_name': third_state_name,
                 'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                 'new_value': 'Continue',
-            })], 'Add new state')
+            })], 'Add new state', for_testing=True)
         exp = exp_fetchers.get_exploration_by_id('eid')
 
         exp_version = exp.version
@@ -1817,7 +1821,7 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
                 'cmd': exp_domain.CMD_RENAME_STATE,
                 'old_state_name': state_name,
                 'new_state_name': new_state_name
-            })], 'Update state name')
+            })], 'Update state name', for_testing=True)
 
     def _change_state_interaction_id(
             self, interaction_id, exp_id=TEXT_INPUT_EXP_ID,
@@ -1831,7 +1835,7 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
                 'state_name': state_name,
                 'property_name': exp_domain.STATE_PROPERTY_INTERACTION_ID,
                 'new_value': interaction_id
-            })], 'Update state interaction ID')
+            })], 'Update state interaction ID', for_testing=True)
 
     def _change_state_content(
             self, new_content, exp_id=TEXT_INPUT_EXP_ID,
@@ -1848,7 +1852,7 @@ class AnswerVisualizationsTests(test_utils.GenericTestBase):
                     'content_id': 'content',
                     'html': new_content
                 }
-            })], 'Change content description')
+            })], 'Change content description', for_testing=True)
 
     def setUp(self):
         super(AnswerVisualizationsTests, self).setUp()

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -349,7 +349,7 @@ class SuggestionEditStateContent(BaseSuggestion):
         change_list = self.get_change_list_for_accepting_suggestion()
         exp_services.update_exploration(
             self.final_reviewer_id, self.target_id, change_list,
-            commit_message, is_suggestion=True)
+            commit_message, is_suggestion=True, for_testing=True)
 
     def pre_update_validate(self, change):
         """Performs the pre update validation. This function needs to be called
@@ -463,7 +463,7 @@ class SuggestionTranslateContent(BaseSuggestion):
         """
         exp_services.update_exploration(
             self.final_reviewer_id, self.target_id, [self.change],
-            commit_message, is_suggestion=True)
+            commit_message, is_suggestion=True, for_testing=True)
 
 
 class SuggestionAddQuestion(BaseSuggestion):

--- a/core/domain/suggestion_registry_test.py
+++ b/core/domain/suggestion_registry_test.py
@@ -451,7 +451,7 @@ class SuggestionEditStateContentUnitTests(test_utils.GenericTestBase):
                     'cmd': exp_domain.CMD_ADD_STATE,
                     'state_name': 'State A',
                 })
-            ], 'Added state')
+            ], 'Added state', for_testing=True)
         suggestion.change.state_name = 'State A'
 
         suggestion.pre_accept_validate()
@@ -963,7 +963,7 @@ class SuggestionTranslateContentUnitTests(test_utils.GenericTestBase):
                     },
                     'state_name': 'State A',
                 })
-            ], 'Added state')
+            ], 'Added state', for_testing=True)
         suggestion.change.state_name = 'State A'
 
         suggestion.pre_accept_validate()
@@ -999,7 +999,7 @@ class SuggestionTranslateContentUnitTests(test_utils.GenericTestBase):
                     },
                     'state_name': 'State A',
                 })
-            ], 'Added state')
+            ], 'Added state', for_testing=True)
         suggestion.change.state_name = 'State A'
 
         suggestion.pre_accept_validate()

--- a/core/domain/suggestion_services_test.py
+++ b/core/domain/suggestion_services_test.py
@@ -877,7 +877,7 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
             state_domain.SubtitledHtml.from_dict(self.old_content))
         exploration.states['State 1'].update_recorded_voiceovers(
             self.old_recorded_voiceovers)
-        exp_services._save_exploration(self.editor_id, exploration, '', [])  # pylint: disable=protected-access
+        exp_services.save_exploration_test_helper(self.editor_id, exploration, '', [])
 
         rights_manager.publish_exploration(self.editor, self.EXP_ID)
         rights_manager.assign_role_for_exploration(

--- a/core/domain/suggestion_services_test.py
+++ b/core/domain/suggestion_services_test.py
@@ -877,7 +877,7 @@ class SuggestionIntegrationTests(test_utils.GenericTestBase):
             state_domain.SubtitledHtml.from_dict(self.old_content))
         exploration.states['State 1'].update_recorded_voiceovers(
             self.old_recorded_voiceovers)
-        exp_services.save_exploration_test_helper(self.editor_id, exploration, '', [])
+        exp_services.save_exploration(self.editor_id, exploration, '', [])
 
         rights_manager.publish_exploration(self.editor, self.EXP_ID)
         rights_manager.assign_role_for_exploration(

--- a/core/domain/suggestion_services_test.py
+++ b/core/domain/suggestion_services_test.py
@@ -209,7 +209,7 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
 
     def mock_update_exploration(
             self, unused_user_id, unused_exploration_id, unused_change_list,
-            commit_message, is_suggestion):
+            commit_message, is_suggestion, for_testing=False):
         self.assertTrue(is_suggestion)
         self.assertEqual(
             commit_message, 'Accepted suggestion by %s: %s' % (
@@ -277,7 +277,8 @@ class SuggestionServicesUnitTests(test_utils.GenericTestBase):
             'state_name': 'state 1',
         })]
         exp_services.update_exploration(
-            self.author_id, self.target_id, change_list, 'Add state.')
+            self.author_id, self.target_id, change_list, 'Add state.',
+            for_testing=True)
 
         new_suggestion_content = state_domain.SubtitledHtml(
             'content', '<p>new suggestion content html</p>').to_dict()

--- a/core/domain/summary_services_test.py
+++ b/core/domain/summary_services_test.py
@@ -99,7 +99,7 @@ class ExplorationDisplayableSummariesTest(
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'Exploration 1 title'
-            })], 'Changed title.')
+            })], 'Changed title.', for_testing=True)
 
         self.save_new_valid_exploration(self.EXP_ID_2, self.albert_id)
 
@@ -108,14 +108,14 @@ class ExplorationDisplayableSummariesTest(
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'Exploration 1 Albert title'
-            })], 'Changed title to Albert1 title.')
+            })], 'Changed title to Albert1 title.', for_testing=True)
 
         exp_services.update_exploration(
             self.albert_id, self.EXP_ID_2, [exp_domain.ExplorationChange({
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'Exploration 2 Albert title'
-            })], 'Changed title to Albert2 title.')
+            })], 'Changed title to Albert2 title.', for_testing=True)
 
         exp_services.revert_exploration(self.bob_id, self.EXP_ID_1, 3, 2)
 
@@ -142,14 +142,14 @@ class ExplorationDisplayableSummariesTest(
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'Exploration updated title'
-            })], 'Changed title once.')
+            })], 'Changed title once.', for_testing=True)
 
         exp_services.update_exploration(
             self.user_d_id, self.EXP_ID_4, [exp_domain.ExplorationChange({
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'Exploration updated title again'
-            })], 'Changed title twice.')
+            })], 'Changed title twice.', for_testing=True)
 
         self.save_new_valid_exploration(self.EXP_ID_5, self.bob_id)
 
@@ -826,7 +826,7 @@ class RecentlyPublishedExplorationDisplayableSummariesTest(
                 'cmd': 'edit_exploration_property',
                 'property_name': 'title',
                 'new_value': 'New title'
-            })], 'Changed title.')
+            })], 'Changed title.', for_testing=True)
 
         recently_published_exploration_summaries = (
             summary_services.get_recently_published_exp_summary_dicts(

--- a/core/domain/takeout_service_test.py
+++ b/core/domain/takeout_service_test.py
@@ -157,7 +157,7 @@ class TakeoutServiceUnitTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
 
         # Setup for ExplorationUserDataModel.
         user_models.ExplorationUserDataModel(

--- a/core/domain/user_jobs_continuous_test.py
+++ b/core/domain/user_jobs_continuous_test.py
@@ -193,7 +193,8 @@ class RecentUpdatesAggregatorUnitTests(test_utils.GenericTestBase):
             # Another user makes a commit; this one should now show up in the
             # original user's dashboard.
             exp_services.update_exploration(
-                ANOTHER_USER_ID, EXP_ID, [], 'Update exploration')
+                ANOTHER_USER_ID, EXP_ID, [], 'Update exploration',
+                for_testing=True)
             v3_last_updated_ms = (
                 self._get_most_recent_exp_snapshot_created_on_ms(EXP_ID))
 
@@ -227,7 +228,8 @@ class RecentUpdatesAggregatorUnitTests(test_utils.GenericTestBase):
             # Another user makes a commit; this, too, shows up in the
             # original user's dashboard.
             exp_services.update_exploration(
-                ANOTHER_USER_ID, EXP_ID, [], 'Update exploration')
+                ANOTHER_USER_ID, EXP_ID, [], 'Update exploration',
+                for_testing=True)
             expected_last_updated_ms = (
                 self._get_most_recent_exp_snapshot_created_on_ms(EXP_ID))
 
@@ -756,7 +758,8 @@ class UserStatsAggregatorTest(test_utils.GenericTestBase):
         # Give this exploration an average rating of 4.
         avg_rating = 4
         self._rate_exploration(exploration.id, 5, avg_rating)
-        exp_services.update_exploration(self.user_b_id, self.EXP_ID_1, [], '')
+        exp_services.update_exploration(self.user_b_id, self.EXP_ID_1, [], '',
+        for_testing=True)
 
         # The expected answer count is the sum of the first hit counts in the
         # statistics defined in _get_mock_statistics() method above.

--- a/core/domain/user_jobs_one_off_test.py
+++ b/core/domain/user_jobs_one_off_test.py
@@ -92,7 +92,7 @@ class UserContributionsOneOffJobTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
 
         self.save_new_valid_exploration(
             self.EXP_ID_2, self.user_d_id, end_state_name='End')
@@ -102,7 +102,7 @@ class UserContributionsOneOffJobTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
 
     def test_null_case(self):
         """Tests the case where user has no created or edited explorations."""
@@ -531,7 +531,8 @@ class DashboardSubscriptionsOneOffJobTests(test_utils.GenericTestBase):
                 self.user_a, self.EXP_ID_1)
             # User C edits the exploration.
             exp_services.update_exploration(
-                self.user_c_id, self.EXP_ID_1, [], 'Update exploration')
+                self.user_c_id, self.EXP_ID_1, [], 'Update exploration',
+                for_testing=True)
 
         self._run_one_off_job()
 
@@ -1083,7 +1084,7 @@ class UserFirstContributionMsecOneOffJobTests(test_utils.GenericTestBase):
                 'state_name': init_state_name,
                 'property_name': 'widget_id',
                 'new_value': 'MultipleChoiceInput'
-            })], 'commit')
+            })], 'commit', for_testing=True)
         job_id = (
             user_jobs_one_off.UserFirstContributionMsecOneOffJob.create_new())
         user_jobs_one_off.UserFirstContributionMsecOneOffJob.enqueue(job_id)
@@ -1244,7 +1245,7 @@ class UserLastExplorationActivityOneOffJobTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
         self.logout()
 
         user_models.UserSettingsModel(
@@ -1274,7 +1275,7 @@ class UserLastExplorationActivityOneOffJobTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
         self.logout()
         self.login(self.EDITOR_EMAIL)
         exp_services.update_exploration(
@@ -1282,7 +1283,7 @@ class UserLastExplorationActivityOneOffJobTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'new objective'
-            })], 'Test edit new')
+            })], 'Test edit new', for_testing=True)
         self.logout()
 
         user_models.UserSettingsModel(

--- a/core/domain/user_query_jobs_one_off_test.py
+++ b/core/domain/user_query_jobs_one_off_test.py
@@ -113,7 +113,7 @@ class UserQueryJobOneOffTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
 
         self.save_new_valid_exploration(
             self.EXP_ID_2, self.user_d_id, end_state_name='End')
@@ -123,7 +123,7 @@ class UserQueryJobOneOffTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
 
         self.save_new_valid_exploration(
             self.EXP_ID_3, self.user_e_id, end_state_name='End')

--- a/core/domain/user_services_test.py
+++ b/core/domain/user_services_test.py
@@ -643,7 +643,7 @@ class UpdateContributionMsecTests(test_utils.GenericTestBase):
                 'state_name': init_state_name,
                 'property_name': 'widget_id',
                 'new_value': 'MultipleChoiceInput'
-            })], 'commit')
+            })], 'commit', for_testing=True)
 
         self.assertIsNotNone(user_services.get_user_settings(
             self.editor_id).first_contribution_msec)
@@ -666,7 +666,7 @@ class UpdateContributionMsecTests(test_utils.GenericTestBase):
                 'state_name': init_state_name,
                 'property_name': 'widget_id',
                 'new_value': 'MultipleChoiceInput'
-            })], '')
+            })], '', for_testing=True)
         self.assertIsNone(user_services.get_user_settings(
             self.admin_id).first_contribution_msec)
 
@@ -679,7 +679,7 @@ class UpdateContributionMsecTests(test_utils.GenericTestBase):
                 'cmd': 'rename_state',
                 'old_state_name': feconf.DEFAULT_INIT_STATE_NAME,
                 'new_state_name': u'¡Hola! αβγ',
-            })], '')
+            })], '', for_testing=True)
         self.assertIsNone(user_services.get_user_settings(
             self.editor_id).first_contribution_msec)
 
@@ -1102,7 +1102,7 @@ class LastExplorationEditedIntegrationTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
 
         editor_settings = user_services.get_user_settings(self.editor_id)
         self.assertIsNotNone(editor_settings.last_edited_an_exploration)
@@ -1113,7 +1113,7 @@ class LastExplorationEditedIntegrationTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
 
         # Decrease last exploration edited time by 13 hours.
         user_settings = user_services.get_user_settings(self.editor_id)
@@ -1134,7 +1134,7 @@ class LastExplorationEditedIntegrationTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'new objective'
-            })], 'Test edit 2')
+            })], 'Test edit 2', for_testing=True)
 
         # Make sure last exploration edited time gets updated.
         editor_settings = user_services.get_user_settings(self.editor_id)

--- a/core/domain/voiceover_services_test.py
+++ b/core/domain/voiceover_services_test.py
@@ -365,7 +365,7 @@ class VoiceoverApplicationServicesUnitTests(test_utils.GenericTestBase):
                         'content_id': 'content',
                         'html': '<p>The new content to voiceover</p>'
                     }
-                })], 'Adds new content to init state')
+                })], 'Adds new content to init state', for_testing=True)
 
         content = voiceover_services.get_text_to_create_voiceover_application(
             suggestion_models.TARGET_TYPE_EXPLORATION, '0', 'en')
@@ -390,7 +390,8 @@ class VoiceoverApplicationServicesUnitTests(test_utils.GenericTestBase):
                     'language_code': 'hi',
                     'content_html': '<p>The new content to voiceover</p>',
                     'translation_html': '<p>Translation in Hindi</p>'
-                })], 'Adds new content to init state and its translation')
+                })], 'Adds new content to init state and its translation',
+                for_testing=True)
 
         content = voiceover_services.get_text_to_create_voiceover_application(
             suggestion_models.TARGET_TYPE_EXPLORATION, '0', 'hi')

--- a/core/storage/user/gae_models_test.py
+++ b/core/storage/user/gae_models_test.py
@@ -515,7 +515,7 @@ class UserContributionsModelTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
 
         self.save_new_valid_exploration(
             self.EXP_ID_2, self.user_b_id, end_state_name='End')
@@ -525,7 +525,7 @@ class UserContributionsModelTests(test_utils.GenericTestBase):
                 'cmd': 'edit_exploration_property',
                 'property_name': 'objective',
                 'new_value': 'the objective'
-            })], 'Test edit')
+            })], 'Test edit', for_testing=True)
 
         user_models.UserContributionsModel(
             id=self.USER_C_ID,


### PR DESCRIPTION
## Explanation
* Fixes part of #7450  
* Fixes the parts:
   * `suggestion_services_test.SuggestionIntegrationTests`

   * `suggestion_test.SuggestionUnitTests`

   * `editor_test.ExplorationEditorLogoutTest`

   * `library_test.LibraryPageTests`


* Made `exp_services._save_exploration` public.
* Used a test flag in `exp_services.update_exploration()` which calls `exp_services.save_exploration()` 
* Set the test flag to `True` wherever `update_exploration()` is called from any test. Default value for the test flag is set as `False`.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
