### PR TITLE
Fix #8178: Remove fit-content from codebase

### DIFF
--- a/core/templates/dev/head/css/oppia.css
+++ b/core/templates/dev/head/css/oppia.css
@@ -1554,16 +1554,10 @@ md-card.oppia-dashboard-tile {
 }
 
 @media(max-width: 1099px) {
-  .oppia-editor-publish-button {
-    padding-bottom: 3px;
-  }
-  .oppia-save-draft-button {
-    padding-bottom: 3px;
-    width: 40px;
-  }
+  .oppia-editor-publish-button,
+  .oppia-save-draft-button,
   .oppia-save-changes-button {
     padding-bottom: 3px;
-    width: 55px;
   }
 }
 
@@ -1573,16 +1567,10 @@ md-card.oppia-dashboard-tile {
     display: none;
   }
 
-  .oppia-editor-publish-button {
-    padding-bottom: 6px;
-  }
-  .oppia-save-draft-button {
-    padding-bottom: 6px;
-    width: 125px;
-  }
+  .oppia-editor-publish-button,
+  .oppia-save-draft-button,
   .oppia-save-changes-button {
     padding-bottom: 6px;
-    width: 136px;
   }
 }
 

--- a/core/templates/dev/head/pages/collection-editor-page/navbar/collection-editor-navbar.directive.html
+++ b/core/templates/dev/head/pages/collection-editor-page/navbar/collection-editor-navbar.directive.html
@@ -41,11 +41,10 @@
     <button class="btn btn-secondary oppia-save-draft-button protractor-test-save-draft-button"
             ng-class="{'btn-success': $ctrl.isCollectionSaveable()}"
             ng-click="$ctrl.saveChanges()"
-            ng-disabled="!$ctrl.isCollectionSaveable()"
-            style="width: fit-content;">
+            ng-disabled="!$ctrl.isCollectionSaveable()">
       <span ng-if="!$ctrl.isSaveInProgress()">
         <span ng-if="$ctrl.collectionRights.isPrivate()">
-          <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+          <i class="material-icons md-18 oppia-save-publish-button-icon"
              alt="Save Collection">
             &#xE161;
           </i>
@@ -56,7 +55,7 @@
           </span>
         </span>
         <span ng-if="$ctrl.collectionRights.isPublic()" title="Publish Changes">
-          <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+          <i class="material-icons md-18 oppia-save-publish-button-icon"
              alt="Publish Changes">
             &#xE2C3;
           </i>
@@ -76,7 +75,7 @@
             ng-class="{'btn-success': $ctrl.isCollectionPublishable()}"
             ng-click="$ctrl.publishCollection()"
             ng-disabled="!$ctrl.isCollectionPublishable()">
-      <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+      <i class="material-icons md-18 oppia-save-publish-button-icon"
          alt="Publish to Oppia Library">
         &#xE2C3;
       </i>

--- a/core/templates/dev/head/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.directive.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.directive.html
@@ -17,7 +17,7 @@
                   ng-disabled="isExplorationLockedForEditing() || countWarnings()"
                   style="border-color: black;">
             <span ng-if="!publishIsInProcess">
-              <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+              <i class="material-icons md-18 oppia-save-publish-button-icon"
                  alt="Publish to Oppia Library">
                 &#xE2C3;
               </i>
@@ -43,7 +43,7 @@
           <button class="btn btn-light oppia-save-draft-button protractor-test-save-changes-for-small-screens" ng-class="{'btn-success': isExplorationSaveable()}" ng-click="saveChanges()" ng-disabled="!isExplorationSaveable()" style="border-color: black;">
             <span ng-if="!saveIsInProcess">
               <span class="oppia-draft-label-container" ng-if="isPrivate()">
-                <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+                <i class="material-icons md-18 oppia-save-publish-button-icon"
                    alt="Save Draft">
                   &#xE161;
                 </i>
@@ -51,7 +51,7 @@
                 <span class="d-none d-md-block" ng-if="getChangeListLength()" style="opacity: 0.5;margin-left: 2px;">(<[getChangeListLength()]>)</span>
               </span>
               <span class="oppia-publish-label-container" ng-if="!isPrivate()" title="Publish Changes">
-                <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+                <i class="material-icons md-18 oppia-save-publish-button-icon"
                    alt="Publish Changes">
                   &#xE2C3;
                 </i>
@@ -92,7 +92,7 @@
               ng-click="showPublishExplorationModal()"
               ng-disabled="isExplorationLockedForEditing() || countWarnings()">
         <span ng-if="!publishIsInProcess">
-          <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+          <i class="material-icons md-18 oppia-save-publish-button-icon"
              alt="Publish to Oppia Library">
             &#xE2C3;
           </i>
@@ -115,10 +115,13 @@
   <li class="nav-item d-none d-sm-block" ng-if="isEditableOutsideTutorialMode()">
     <div uib-dropdown class="btn-group" style="margin-right: 10px; margin-top: 8px;"
          title="<[getSaveButtonTooltip()]>" ng-class="{'disable-save-button': !isExplorationSaveable()}">
-      <button id="tutorialSaveButton" class="btn btn-light oppia-save-draft-button protractor-test-save-changes" ng-class="{'btn-success': isExplorationSaveable()}" ng-click="saveChanges()" ng-disabled="!isExplorationSaveable()" style="width: fit-content">
+      <button id="tutorialSaveButton"
+              class="btn btn-light oppia-save-draft-button protractor-test-save-changes"
+              ng-class="{'btn-success': isExplorationSaveable()}"
+              ng-click="saveChanges()" ng-disabled="!isExplorationSaveable()">
         <span ng-if="!saveIsInProcess">
           <span class="oppia-draft-label-container" ng-if="isPrivate()">
-            <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+            <i class="material-icons md-18 oppia-save-publish-button-icon"
                alt="Save Draft">
               &#xE161;
             </i>
@@ -126,7 +129,7 @@
             <span class="d-none d-md-block" ng-if="getChangeListLength()" style="opacity: 0.5;margin-left: 2px;">(<[getChangeListLength()]>)</span>
           </span>
           <span class="oppia-publish-label-container" ng-if="!isPrivate()" title="Publish Changes">
-            <i class="material-icons md-18 md-dark oppia-save-publish-button-icon"
+            <i class="material-icons md-18 oppia-save-publish-button-icon"
                alt="Publish Changes">
               &#xE2C3;
             </i>
@@ -166,9 +169,6 @@
   .oppia-publish-label-container {
     display: flex;
     flex-direction: row;
-  }
-  .oppia-save-publish-button-label {
-    width: fit-content;
   }
   .oppia-save-publish-dropdown {
     border: 0;

--- a/core/templates/dev/head/pages/library-page/library-page.directive.html
+++ b/core/templates/dev/head/pages/library-page/library-page.directive.html
@@ -46,7 +46,7 @@
           <h2 class="oppia-library-h2" translate="I18N_LIBRARY_SUB_HEADER"></h2>
         </div>
 
-        <div class="d-lg-none" style="margin: 0 auto; width: fit-content; padding-right: 15px">
+        <div class="d-lg-none" style="margin: 0 auto; width: max-content;">
           <search-bar></search-bar>
         </div>
 

--- a/core/templates/dev/head/pages/library-page/search-results/search-results.directive.html
+++ b/core/templates/dev/head/pages/library-page/search-results/search-results.directive.html
@@ -17,7 +17,7 @@
 </style>
 
 <div>
-  <div class="d-lg-none" style="margin: 0 auto 20px; width: fit-content; height: 50px;">
+  <div class="d-lg-none" style="margin: 0 auto 20px; width: max-content; height: 50px;">
     <search-bar></search-bar>
   </div>
   <div ng-if="!$ctrl.someResultsExist" class="oppia-search-results-intro" ng-cloak>

--- a/core/templates/dev/head/pages/topic-viewer-page/topic-viewer-page.directive.html
+++ b/core/templates/dev/head/pages/topic-viewer-page/topic-viewer-page.directive.html
@@ -102,7 +102,7 @@
 
   .oppia-story-tab, .oppia-subtopics-tab {
     margin: 0 auto;
-    width: fit-content;
+    width: max-content;
   }
 
   .oppia-practice-tab {


### PR DESCRIPTION
## Explanation
Fixes #8178: Remove `fit-content` from our codebase since it is not supported by all the browsers (Firefox for example). 

Also, did some color changes from `md-dark` to white.

## Screenshots
Firefox on the left side, Chromium on the right side.

### Exploration editor — Publish Changes
![Screenshot from 2019-12-19 20-26-36](https://user-images.githubusercontent.com/10142938/71203482-55ed1780-229e-11ea-8cc9-ceced217bdfd.png)
![Screenshot from 2019-12-19 20-27-12](https://user-images.githubusercontent.com/10142938/71203498-5a193500-229e-11ea-9787-0571e33450db.png)
![Screenshot from 2019-12-19 20-27-38](https://user-images.githubusercontent.com/10142938/71203511-5dacbc00-229e-11ea-8168-ca4445c51c43.png)
![Screenshot from 2019-12-19 20-27-52](https://user-images.githubusercontent.com/10142938/71203521-61404300-229e-11ea-9b5e-828b608af169.png)
![image](https://user-images.githubusercontent.com/10142938/71203397-2e964a80-229e-11ea-9e98-ac50cd690895.png)
![image](https://user-images.githubusercontent.com/10142938/71203434-3bb33980-229e-11ea-96bb-bd9b33545d10.png)

### Collection editor — Save draft
![image](https://user-images.githubusercontent.com/10142938/71203679-c005bc80-229e-11ea-9103-f9dc7a6728bc.png)
![image](https://user-images.githubusercontent.com/10142938/71203708-cbf17e80-229e-11ea-8c06-e57ccc0b1bcf.png)
![image](https://user-images.githubusercontent.com/10142938/71203731-dad83100-229e-11ea-8f7d-83480f0cf2fc.png)

### Library — Search bar
![Screenshot from 2019-12-19 19-47-36](https://user-images.githubusercontent.com/10142938/71202877-4ae5b780-229d-11ea-8917-893f25c3e469.png)

### Search — Search bar
![Screenshot from 2019-12-19 20-23-52](https://user-images.githubusercontent.com/10142938/71203073-a617aa00-229d-11ea-9a31-49bcf624bd1b.png)

### Topic viewer — story/subtopics tabs
![image](https://user-images.githubusercontent.com/10142938/71203849-1541ce00-229f-11ea-8489-2810bca2d728.png)
![image](https://user-images.githubusercontent.com/10142938/71203866-1d9a0900-229f-11ea-82c6-acc6dd39bdc5.png)
![image](https://user-images.githubusercontent.com/10142938/71203898-2db1e880-229f-11ea-8fb2-32ef4c0984a9.png)


## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
