### PR TITLE
Fix #8007: Add one off job to regenerate skill opportunity models 

### DIFF
--- a/core/domain/opportunity_jobs_one_off.py
+++ b/core/domain/opportunity_jobs_one_off.py
@@ -76,16 +76,10 @@ class SkillOpportunityModelRegenerationJob(jobs.BaseMapReduceOneOffJobManager):
     def map(skill_model):
         if skill_model.deleted:
             return
-        try:
-            opportunity_services.create_skill_opportunity(
-                skill_model.id, skill_model.description)
-            yield ('SUCCESS', skill_model.id)
-        except Exception as e:
-            yield ('FAILED', e)
+        opportunity_services.create_skill_opportunity(
+            skill_model.id, skill_model.description)
+        yield ('SUCCESS', skill_model.id)
 
     @staticmethod
     def reduce(key, values):
-        if key == 'SUCCESS':
-            yield (key, len(values))
-        else:
-            yield ('%s (%s)' % (key, len(values)), values)
+        yield (key, len(values))

--- a/core/domain/opportunity_jobs_one_off_test.py
+++ b/core/domain/opportunity_jobs_one_off_test.py
@@ -25,6 +25,8 @@ from core.domain import exp_fetchers
 from core.domain import exp_services
 from core.domain import opportunity_jobs_one_off
 from core.domain import opportunity_services
+from core.domain import skill_domain
+from core.domain import skill_services
 from core.domain import story_domain
 from core.domain import story_services
 from core.domain import topic_domain
@@ -42,7 +44,7 @@ taskqueue_services = models.Registry.import_taskqueue_services()
 
 class ExplorationOpportunitySummaryModelRegenerationJobTest(
         test_utils.GenericTestBase):
-    """Tests for the one-off dashboard subscriptions job."""
+    """Tests for the exploration opportunity summary model regenration job."""
 
     def setUp(self):
         super(
@@ -67,11 +69,11 @@ class ExplorationOpportunitySummaryModelRegenerationJobTest(
             exp_services.save_new_exploration(self.owner_id, exp)
 
         topic_1 = topic_domain.Topic.create_default_topic(
-            topic_id=self.topic_id_1, name='topic1', abbreviated_name='abbrev')
+            topic_id=self.topic_id_1, name='topic1')
         topic_services.save_new_topic(self.owner_id, topic_1)
 
         topic_2 = topic_domain.Topic.create_default_topic(
-            topic_id=self.topic_id_2, name='topic2', abbreviated_name='abbrev')
+            topic_id=self.topic_id_2, name='topic2')
         topic_services.save_new_topic(self.owner_id, topic_2)
 
         story_1 = story_domain.Story.create_default_story(
@@ -355,4 +357,107 @@ class ExplorationOpportunitySummaryModelRegenerationJobTest(
         self.process_and_flush_pending_tasks()
 
         output = exp_opp_summary_model_regen_job_class.get_output(job_id)
+        self.assertEqual(output, [])
+
+
+class SkillOpportunityModelRegenerationJobTest(test_utils.GenericTestBase):
+    """Tests for the Skill opportunity model regeneration job."""
+
+    def setUp(self):
+        super(SkillOpportunityModelRegenerationJobTest, self).setUp()
+        self.signup(self.ADMIN_EMAIL, self.ADMIN_USERNAME)
+
+        self.admin_id = self.get_user_id_from_email(self.ADMIN_EMAIL)
+
+        self.skill_id_1 = 'skill_1'
+        self.skill_desc_1 = 'skill 1'
+        self.skill_id_2 = 'skill_2'
+        self.skill_desc_2 = 'skill 2'
+
+        self.save_new_skill(self.skill_id_1, self.admin_id, self.skill_desc_1)
+        self.save_new_skill(self.skill_id_2, self.admin_id, self.skill_desc_2)
+
+    def test_regeneration_job_returns_the_initial_opportunity(self):
+        skill_opp_model_regen_job_class = (
+            opportunity_jobs_one_off.SkillOpportunityModelRegenerationJob)
+
+        all_opportunity_models = list(
+            opportunity_models.SkillOpportunityModel.get_all())
+
+        self.assertEqual(len(all_opportunity_models), 2)
+
+        old_opportunities, _, more = (
+            opportunity_services.get_skill_opportunities(None))
+
+        job_id = skill_opp_model_regen_job_class.create_new()
+        skill_opp_model_regen_job_class.enqueue(job_id)
+
+        self.assertEqual(
+            self.count_jobs_in_taskqueue(
+                taskqueue_services.QUEUE_NAME_ONE_OFF_JOBS), 1)
+        self.process_and_flush_pending_tasks()
+
+        output = skill_opp_model_regen_job_class.get_output(job_id)
+
+        expected = [['SUCCESS', 2]]
+        self.assertEqual(expected, [ast.literal_eval(x) for x in output])
+
+        all_opportunity_models = list(
+            opportunity_models.SkillOpportunityModel.get_all())
+        self.assertEqual(len(all_opportunity_models), 2)
+
+        new_opportunities, _, more = (
+            opportunity_services.get_skill_opportunities(None))
+        self.assertFalse(more)
+
+        old_opportunity_dicts = [opp.to_dict() for opp in old_opportunities]
+        new_opportunity_dicts = [opp.to_dict() for opp in new_opportunities]
+        self.assertEqual(old_opportunity_dicts, new_opportunity_dicts)
+
+    def test_regeneration_job_creates_new_models(self):
+        skill_opp_model_regen_job_class = (
+            opportunity_jobs_one_off.SkillOpportunityModelRegenerationJob)
+
+        all_opportunity_models = list(
+            opportunity_models.SkillOpportunityModel.get_all())
+        self.assertEqual(len(all_opportunity_models), 2)
+
+        old_creation_time = all_opportunity_models[0].created_on
+
+        job_id = skill_opp_model_regen_job_class.create_new()
+        skill_opp_model_regen_job_class.enqueue(job_id)
+
+        self.assertEqual(
+            self.count_jobs_in_taskqueue(
+                taskqueue_services.QUEUE_NAME_ONE_OFF_JOBS), 1)
+        self.process_and_flush_pending_tasks()
+
+        output = skill_opp_model_regen_job_class.get_output(job_id)
+        expected = [['SUCCESS', 2]]
+        self.assertEqual(expected, [ast.literal_eval(x) for x in output])
+
+        all_opportunity_models = list(
+            opportunity_models.SkillOpportunityModel.get_all())
+        self.assertEqual(len(all_opportunity_models), 2)
+
+        new_creation_time = all_opportunity_models[0].created_on
+
+        self.assertLess(old_creation_time, new_creation_time)
+
+    def test_regeneration_job_for_deleted_skill_returns_empty_list_output(self):
+        skill_opp_model_regen_job_class = (
+            opportunity_jobs_one_off.SkillOpportunityModelRegenerationJob)
+
+        skill_services.delete_skill(self.admin_id, self.skill_id_1)
+        skill_services.delete_skill(self.admin_id, self.skill_id_2)
+
+        job_id = skill_opp_model_regen_job_class.create_new()
+        skill_opp_model_regen_job_class.enqueue(job_id)
+
+        self.assertEqual(
+            self.count_jobs_in_taskqueue(
+                taskqueue_services.QUEUE_NAME_ONE_OFF_JOBS), 1)
+        self.process_and_flush_pending_tasks()
+
+        output = skill_opp_model_regen_job_class.get_output(job_id)
         self.assertEqual(output, [])

--- a/core/domain/opportunity_jobs_one_off_test.py
+++ b/core/domain/opportunity_jobs_one_off_test.py
@@ -25,7 +25,6 @@ from core.domain import exp_fetchers
 from core.domain import exp_services
 from core.domain import opportunity_jobs_one_off
 from core.domain import opportunity_services
-from core.domain import skill_domain
 from core.domain import skill_services
 from core.domain import story_domain
 from core.domain import story_services
@@ -69,11 +68,11 @@ class ExplorationOpportunitySummaryModelRegenerationJobTest(
             exp_services.save_new_exploration(self.owner_id, exp)
 
         topic_1 = topic_domain.Topic.create_default_topic(
-            topic_id=self.topic_id_1, name='topic1')
+            topic_id=self.topic_id_1, name='topic1', abbreviated_name='abbrev')
         topic_services.save_new_topic(self.owner_id, topic_1)
 
         topic_2 = topic_domain.Topic.create_default_topic(
-            topic_id=self.topic_id_2, name='topic2')
+            topic_id=self.topic_id_2, name='topic2', abbreviated_name='abbrev')
         topic_services.save_new_topic(self.owner_id, topic_2)
 
         story_1 = story_domain.Story.create_default_story(

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -763,3 +763,7 @@ def regenerate_opportunities_related_to_topic(
 def delete_all_exploration_opportunity_summary_models():
     """Deletes all of the ExplorationOpportunitySummaryModel."""
     opportunity_models.ExplorationOpportunitySummaryModel.delete_all()
+
+def delete_all_skill_opportunity_models():
+    """Deletes all of the SkillOpportunityModels from the datastore."""
+    opportunity_models.SkillOpportunityModel.delete_all()

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -764,6 +764,7 @@ def delete_all_exploration_opportunity_summary_models():
     """Deletes all of the ExplorationOpportunitySummaryModel."""
     opportunity_models.ExplorationOpportunitySummaryModel.delete_all()
 
+
 def delete_all_skill_opportunity_models():
     """Deletes all of the SkillOpportunityModels from the datastore."""
     opportunity_models.SkillOpportunityModel.delete_all()

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -57,6 +57,7 @@ ONE_OFF_JOB_MANAGERS = [
     exp_jobs_one_off.TranslatorToVoiceArtistOneOffJob,
     feedback_jobs_one_off.FeedbackThreadCacheOneOffJob,
     opportunity_jobs_one_off.ExplorationOpportunitySummaryModelRegenerationJob,
+    opportunity_jobs_one_off.SkillOpportunityModelRegenerationJob,
     question_jobs_one_off.QuestionMigrationOneOffJob,
     recommendations_jobs_one_off.ExplorationRecommendationsOneOffJob,
     skill_jobs_one_off.SkillMigrationOneOffJob,

--- a/core/storage/opportunity/gae_models.py
+++ b/core/storage/opportunity/gae_models.py
@@ -227,3 +227,9 @@ class SkillOpportunityModel(base_models.BaseModel):
         results, cursor, more = cls.get_all().order(
             cls.created_on).fetch_page(page_size, start_cursor=start_cursor)
         return (results, (cursor.urlsafe() if cursor else None), more)
+
+    @classmethod
+    def delete_all(cls):
+        """Deletes all entities of this class."""
+        keys = cls.query().fetch(keys_only=True)
+        ndb.delete_multi(keys)

--- a/core/storage/opportunity/gae_models_test.py
+++ b/core/storage/opportunity/gae_models_test.py
@@ -214,14 +214,15 @@ class SkillOpportunityModelTest(test_utils.GenericTestBase):
         self.assertTrue(isinstance(cursor, python_utils.BASESTRING))
 
     def test_delete_all_skill_opportunities(self):
-        results, cursor, more = (
-        opportunity_models.SkillOpportunityModel
-            .get_skill_opportunities(1, None))
+        results, _, more = (
+            opportunity_models.SkillOpportunityModel.get_skill_opportunities(
+                1, None))
         self.assertEqual(len(results), 1)
 
         opportunity_models.SkillOpportunityModel.delete_all()
 
-        results, cursor, more = (
-        opportunity_models.SkillOpportunityModel
-            .get_skill_opportunities(1, None))
+        results, _, more = (
+            opportunity_models.SkillOpportunityModel.get_skill_opportunities(
+                1, None))
         self.assertEqual(len(results), 0)
+        self.assertFalse(more)

--- a/core/storage/opportunity/gae_models_test.py
+++ b/core/storage/opportunity/gae_models_test.py
@@ -212,3 +212,16 @@ class SkillOpportunityModelTest(test_utils.GenericTestBase):
         self.assertEqual(results[0].id, 'opportunity_id2')
         self.assertFalse(more)
         self.assertTrue(isinstance(cursor, python_utils.BASESTRING))
+
+    def test_delete_all_skill_opportunities(self):
+        results, cursor, more = (
+        opportunity_models.SkillOpportunityModel
+            .get_skill_opportunities(1, None))
+        self.assertEqual(len(results), 1)
+
+        opportunity_models.SkillOpportunityModel.delete_all()
+
+        results, cursor, more = (
+        opportunity_models.SkillOpportunityModel
+            .get_skill_opportunities(1, None))
+        self.assertEqual(len(results), 0)

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -1382,7 +1382,7 @@ tags: []
             self, story_id, owner_id, title, description, notes,
             corresponding_topic_id,
             language_code=constants.DEFAULT_LANGUAGE_CODE):
-        """Saves a new skill with a default version 1 story contents
+        """Saves a new story with a default version 1 story contents
         data dictionary.
 
         This function should only be used for creating stories in tests


### PR DESCRIPTION
## Explanation
Fix #8007. Added a one off job to regenerate skill opportunity models in the community dashboard. PTAL @DubeySandeep @sagangwee 
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
