### PR TITLE
Fixes #8184: Force refresh and prevent submitting new message while one message is being submitted

### DIFF
--- a/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/services/improvement-modal.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/services/improvement-modal.service.ts
@@ -248,6 +248,12 @@ angular.module('oppia').factory('ImprovementModalService', [
                     $scope.messageSendingInProgress = false;
                   }).then($uibModalInstance.close);
               };
+
+              $scope.onClickReviewSuggestion = function() {
+                $scope.messageSendingInProgress = true;
+                openSuggestionReviewer($scope.activeThread);
+              }
+
               $scope.close = function() {
                 $uibModalInstance.close();
               };

--- a/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/services/improvement-modal.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/services/improvement-modal.service.ts
@@ -212,7 +212,6 @@ angular.module('oppia').factory('ImprovementModalService', [
               $scope.getLocaleAbbreviatedDatetimeString = (
                 DateTimeFormatService.getLocaleAbbreviatedDatetimeString);
               $scope.EditabilityService = EditabilityService;
-              $scope.openSuggestionReviewer = openSuggestionReviewer;
 
               // Initial load of the thread list on page load.
               $scope.tmpMessage = {
@@ -251,7 +250,7 @@ angular.module('oppia').factory('ImprovementModalService', [
 
               $scope.onClickReviewSuggestion = function() {
                 $scope.messageSendingInProgress = true;
-                openSuggestionReviewer($scope.activeThread);
+                openSuggestionReviewModal($scope.activeThread);
               };
 
               $scope.close = function() {
@@ -264,7 +263,7 @@ angular.module('oppia').factory('ImprovementModalService', [
         });
       },
 
-      openSuggestionReviewer: function(suggestionThread) {
+      openSuggestionReviewModal: function(suggestionThread) {
         return SuggestionModalForExplorationEditorService.showSuggestionModal(
           suggestionThread.suggestion.suggestionType, {
             activeThread: suggestionThread,

--- a/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/services/improvement-modal.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/services/improvement-modal.service.ts
@@ -252,7 +252,7 @@ angular.module('oppia').factory('ImprovementModalService', [
               $scope.onClickReviewSuggestion = function() {
                 $scope.messageSendingInProgress = true;
                 openSuggestionReviewer($scope.activeThread);
-              }
+              };
 
               $scope.close = function() {
                 $uibModalInstance.close();

--- a/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/services/improvement-modal.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/services/improvement-modal.service.ts
@@ -188,7 +188,7 @@ angular.module('oppia').factory('ImprovementModalService', [
       },
 
       openSuggestionThread: function(thread) {
-        var openSuggestionReviewer = this.openSuggestionReviewer;
+        var openSuggestionReviewModal = this.openSuggestionReviewModal;
         return $uibModal.open({
           templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
             '/pages/exploration-editor-page/improvements-tab/templates/' +

--- a/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/templates/suggestion-thread-modal.template.html
+++ b/core/templates/dev/head/pages/exploration-editor-page/improvements-tab/templates/suggestion-thread-modal.template.html
@@ -44,7 +44,7 @@
       <p ng-if="m.message_id === 0" class="protractor-test-improvements-thread-message-body">
         <[activeThread.subject]>
       </p>
-      <button ng-click="openSuggestionReviewer(activeThread)" ng-if="m.message_id === 0"
+      <button ng-click="onClickReviewSuggestion()" ng-if="m.message_id === 0"
               class="btn btn-primary protractor-test-improvements-review-suggestion-button">
         Review Suggestion
       </button>

--- a/core/templates/dev/head/pages/exploration-editor-page/suggestion-modal-for-editor-view/suggestion-modal-for-exploration-editor.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/suggestion-modal-for-editor-view/suggestion-modal-for-exploration-editor.service.ts
@@ -26,11 +26,11 @@ require('services/editability.service.ts');
 require('services/suggestion-modal.service.ts');
 
 angular.module('oppia').factory('SuggestionModalForExplorationEditorService', [
-  '$log', '$rootScope', '$uibModal',
+  '$log', '$rootScope', '$uibModal', '$window',
   'ExplorationDataService', 'ExplorationStatesService',
   'StateObjectFactory', 'SuggestionModalService',
   'ThreadDataService', 'UrlInterpolationService',
-  function($log, $rootScope, $uibModal,
+  function($log, $rootScope, $uibModal, $window,
       ExplorationDataService, ExplorationStatesService,
       StateObjectFactory, SuggestionModalService,
       ThreadDataService, UrlInterpolationService) {
@@ -168,7 +168,7 @@ angular.module('oppia').factory('SuggestionModalForExplorationEditorService', [
               });
               $rootScope.$broadcast('refreshStateEditor');
             }
-            window.location.reload();
+            $window.location.reload();
           },
           function() {
             $log.error('Error resolving suggestion');

--- a/core/templates/dev/head/pages/exploration-editor-page/suggestion-modal-for-editor-view/suggestion-modal-for-exploration-editor.service.ts
+++ b/core/templates/dev/head/pages/exploration-editor-page/suggestion-modal-for-editor-view/suggestion-modal-for-exploration-editor.service.ts
@@ -168,6 +168,7 @@ angular.module('oppia').factory('SuggestionModalForExplorationEditorService', [
               });
               $rootScope.$broadcast('refreshStateEditor');
             }
+            window.location.reload();
           },
           function() {
             $log.error('Error resolving suggestion');

--- a/core/tests/protractor_desktop/explorationFeedbackTab.js
+++ b/core/tests/protractor_desktop/explorationFeedbackTab.js
@@ -325,7 +325,7 @@ describe('Suggestions on Explorations', function() {
         expect(threads[0]).toMatch(suggestionDescription2);
       });
     explorationEditorFeedbackTab.acceptSuggestion(suggestionDescription1);
-    explorationEditorFeedbackTab.goBackToAllFeedbacks();
+
     explorationEditorFeedbackTab.rejectSuggestion(suggestionDescription2);
 
     explorationEditorPage.navigateToPreviewTab();

--- a/core/tests/protractor_desktop/explorationImprovementsTab.js
+++ b/core/tests/protractor_desktop/explorationImprovementsTab.js
@@ -368,7 +368,6 @@ describe('Suggestions Improvements', function() {
     expect(improvementsTab.getThreadMessages()).toEqual(
       [suggestionDescription1]);
     improvementsTab.acceptSuggestion();
-    improvementsTab.closeModal();
 
     var taskToReject = improvementsTab.getSuggestionTask(
       suggestionDescription2);
@@ -376,7 +375,6 @@ describe('Suggestions Improvements', function() {
     expect(improvementsTab.getThreadMessages()).toEqual(
       [suggestionDescription2]);
     improvementsTab.rejectSuggestion();
-    improvementsTab.closeModal();
 
     improvementsTab.setShowOnlyOpenTasks(false);
     var acceptedTask = improvementsTab.getSuggestionTask(

--- a/core/tests/protractor_desktop/explorationImprovementsTab.js
+++ b/core/tests/protractor_desktop/explorationImprovementsTab.js
@@ -22,6 +22,7 @@
 var forms = require('../protractor_utils/forms.js');
 var general = require('../protractor_utils/general.js');
 var users = require('../protractor_utils/users.js');
+var waitFor = require('../protractor_utils/waitFor.js');
 var workflow = require('../protractor_utils/workflow.js');
 
 var AdminPage = require('../protractor_utils/AdminPage.js');
@@ -323,13 +324,13 @@ describe('Suggestions Improvements', function() {
     users.createAndLoginAdminUser(
       'user4@ExplorationSuggestions.com',
       'configExplorationSuggestions');
-    // TODO(#7569): Remove redundant set after feedback tab is phased out.
+    TODO(#7569): Remove redundant set after feedback tab is phased out.
     adminPage.editConfigProperty(
       'Exposes the Improvements Tab for creators in the exploration editor.',
       'Boolean', (element) => element.setValue(true));
   });
 
-  it('accepts & rejects a suggestion on a published exploration', function() {
+  fit('accepts & rejects a suggestion on a published exploration', function() {
     users.login('user1@ExplorationSuggestions.com');
     workflow.createAndPublishExploration(
       EXPLORATION_TITLE,
@@ -368,6 +369,7 @@ describe('Suggestions Improvements', function() {
     expect(improvementsTab.getThreadMessages()).toEqual(
       [suggestionDescription1]);
     improvementsTab.acceptSuggestion();
+    waitFor.pageToFullyLoad();
 
     var taskToReject = improvementsTab.getSuggestionTask(
       suggestionDescription2);
@@ -375,6 +377,7 @@ describe('Suggestions Improvements', function() {
     expect(improvementsTab.getThreadMessages()).toEqual(
       [suggestionDescription2]);
     improvementsTab.rejectSuggestion();
+    waitFor.pageToFullyLoad();
 
     improvementsTab.setShowOnlyOpenTasks(false);
     var acceptedTask = improvementsTab.getSuggestionTask(

--- a/core/tests/protractor_utils/ExplorationEditorFeedbackTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorFeedbackTab.js
@@ -72,6 +72,7 @@ var ExplorationEditorFeedbackTab = function() {
       acceptSuggestionButton.click();
       waitFor.invisibilityOf(
         acceptSuggestionButton, 'Suggestion modal takes too long to disappear');
+      waitFor.pageToFullyLoad();
     });
   };
 
@@ -133,6 +134,7 @@ var ExplorationEditorFeedbackTab = function() {
       rejectSuggestionButton.click();
       waitFor.invisibilityOf(
         acceptSuggestionButton, 'Suggestion modal takes too long to disappear');
+      waitFor.pageToFullyLoad();
     });
   };
 

--- a/core/tests/protractor_utils/ExplorationEditorImprovementsTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorImprovementsTab.js
@@ -189,7 +189,9 @@ var ExplorationEditorImprovementsTab = function() {
       acceptSuggestionButton,
       'Accept Suggestion button takes too long to become clickable');
     acceptSuggestionButton.click();
-    waitFor.pageToFullyLoad();
+    waitFor.elementToBeClickable(
+      onlyOpenInput,
+      'show only open tasks checkbox takes too long to become clickable');
   };
 
   this.rejectSuggestion = () => {
@@ -203,7 +205,9 @@ var ExplorationEditorImprovementsTab = function() {
       rejectSuggestionButton,
       'Accept Suggestion button takes too long to become clickable');
     rejectSuggestionButton.click();
-    waitFor.pageToFullyLoad();
+    waitFor.elementToBeClickable(
+      onlyOpenInput,
+      'show only open tasks checkbox takes too long to become clickable');
   };
 
   this.setShowOnlyOpenTasks = (choice = true) => {

--- a/core/tests/protractor_utils/ExplorationEditorImprovementsTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorImprovementsTab.js
@@ -189,9 +189,6 @@ var ExplorationEditorImprovementsTab = function() {
       acceptSuggestionButton,
       'Accept Suggestion button takes too long to become clickable');
     acceptSuggestionButton.click();
-    waitFor.elementToBeClickable(
-      onlyOpenInput,
-      'show only open tasks checkbox takes too long to become clickable');
   };
 
   this.rejectSuggestion = () => {
@@ -205,9 +202,6 @@ var ExplorationEditorImprovementsTab = function() {
       rejectSuggestionButton,
       'Accept Suggestion button takes too long to become clickable');
     rejectSuggestionButton.click();
-    waitFor.elementToBeClickable(
-      onlyOpenInput,
-      'show only open tasks checkbox takes too long to become clickable');
   };
 
   this.setShowOnlyOpenTasks = (choice = true) => {

--- a/core/tests/protractor_utils/ExplorationEditorImprovementsTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorImprovementsTab.js
@@ -189,6 +189,7 @@ var ExplorationEditorImprovementsTab = function() {
       acceptSuggestionButton,
       'Accept Suggestion button takes too long to become clickable');
     acceptSuggestionButton.click();
+    waitFor.pageToFullyLoad();
   };
 
   this.rejectSuggestion = () => {
@@ -202,6 +203,7 @@ var ExplorationEditorImprovementsTab = function() {
       rejectSuggestionButton,
       'Accept Suggestion button takes too long to become clickable');
     rejectSuggestionButton.click();
+    waitFor.pageToFullyLoad();
   };
 
   this.setShowOnlyOpenTasks = (choice = true) => {


### PR DESCRIPTION
## Explanation
Fix #8184. I have prevented submitting a new message while the review is being submitted, and also refreshed the page after to make sure that the status is updated.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
