### PR TITLE
Fix ckeditor tableselection issue

### DIFF
--- a/app_dev.yaml
+++ b/app_dev.yaml
@@ -345,7 +345,6 @@ skip_files:
 - third_party/static/ckeditor-4.12.1/plugins/stylesheetparser
 - third_party/static/ckeditor-4.12.1/plugins/table
 - third_party/static/ckeditor-4.12.1/plugins/tableresize
-- third_party/static/ckeditor-4.12.1/plugins/tableselection
 - third_party/static/ckeditor-4.12.1/plugins/tabletools
 - third_party/static/ckeditor-4.12.1/plugins/textmatch
 - third_party/static/ckeditor-4.12.1/plugins/textwatcher


### PR DESCRIPTION
## Explanation
Fixes missing tableselection file issue by removing it from skipped files.

<img width="1674" alt="Screenshot 2019-12-22 at 1 23 46 PM" src="https://user-images.githubusercontent.com/15226041/71319013-7d222f80-24be-11ea-9499-0a9d777b4355.png">

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
