### PR TITLE
Update release info script for new changelog labels

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,6 @@
 - [ ] The linter/Karma presubmit checks have passed.
   - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
 - [ ] The PR is made from a branch that's **not** called "develop".
-- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
 - [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
 - [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
 - [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)

--- a/scripts/release_scripts/generate_release_info.py
+++ b/scripts/release_scripts/generate_release_info.py
@@ -196,7 +196,8 @@ def get_changelog_categories(pulls):
         formatted_title = '%s (#%d)' % (pull.title, pull.number)
         for label in labels:
             if 'CHANGELOG:' in label.name:
-                category = label.name[label.name.find(':') + 2:]
+                category = label.name[
+                    label.name.find(':') + 2:label.name.find(' --')]
                 added_to_dict = True
                 result[category].append(formatted_title)
                 break

--- a/scripts/release_scripts/generate_release_info_test.py
+++ b/scripts/release_scripts/generate_release_info_test.py
@@ -220,18 +220,20 @@ class GenerateReleaseInfoTests(test_utils.GenericTestBase):
             requester='', headers='',
             attributes={
                 'title': 'PR1', 'number': 1, 'labels': [
-                    {'name': 'CHANGELOG: Test-changes-1'},
+                    {'name': 'CHANGELOG: Test-changes-1 -- @owner1'},
                     {'name': 'Test-label'}]}, completed='')
         pull2 = github.PullRequest.PullRequest(
             requester='', headers='',
             attributes={
                 'title': 'PR2', 'number': 2, 'labels': [
-                    {'name': 'CHANGELOG: Test-changes-1'}]}, completed='')
+                    {'name': 'CHANGELOG: Test-changes-1 -- @owner1'}]},
+                    completed='')
         pull3 = github.PullRequest.PullRequest(
             requester='', headers='',
             attributes={
                 'title': 'PR3', 'number': 3, 'labels': [
-                    {'name': 'CHANGELOG: Test-changes-2'}]}, completed='')
+                    {'name': 'CHANGELOG: Test-changes-2 -- @owner2'}]},
+                    completed='')
         pull4 = github.PullRequest.PullRequest(
             requester='', headers='',
             attributes={


### PR DESCRIPTION
## Explanation
Updated release info script for new changelog labels. (Oppiabot updates: https://github.com/oppia/oppiabot/pull/44)

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PROJECT: ..." label (Please add this label for the first-pass review of the PR).
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
