### PR TITLE
Fix #7852: Update skulpt to v1.1.0 and get rid of the requirement to build it locally.

### DIFF
--- a/extensions/interactions/skulpt.html
+++ b/extensions/interactions/skulpt.html
@@ -1,4 +1,4 @@
-<script src="/third_party/static/skulpt-0.10.0/skulpt.min.js">
+<script src="/third_party/static/skulpt-dist-1.1.0/skulpt.min.js">
 </script>
-<script src="/third_party/static/skulpt-0.10.0/skulpt-stdlib.js">
+<script src="/third_party/static/skulpt-dist-1.1.0/skulpt-stdlib.js">
 </script>

--- a/manifest.json
+++ b/manifest.json
@@ -497,6 +497,13 @@
           "js": ["ui-bootstrap-tpls-2.5.0.js"]
         }
       },
+      "skulpt-dist": {
+        "version": "1.1.0",
+        "downloadFormat": "zip",
+        "url": "https://github.com/skulpt/skulpt-dist/archive/1.1.0.zip",
+        "rootDirPrefix": "skulpt-dist-",
+        "targetDirPrefix": "skulpt-dist-"
+      },
       "uiCodemirror": {
         "version": "5d04fa5c991f915e4578be5f1175e22d94696633",
         "downloadFormat": "zip",

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -18,9 +18,7 @@ from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import argparse
-import fileinput
 import os
-import shutil
 import subprocess
 import sys
 
@@ -54,15 +52,6 @@ from . import setup_gae  # isort:skip
 _PARSER = argparse.ArgumentParser(description="""
 Installation script for Oppia third-party libraries.
 """)
-
-_PARSER.add_argument(
-    '--nojsrepl',
-    help='optional; if specified, skips installation of skulpt.',
-    action='store_true')
-_PARSER.add_argument(
-    '--noskulpt',
-    help='optional; if specified, skips installation of skulpt.',
-    action='store_true')
 
 PYLINT_CONFIGPARSER_FILEPATH = os.path.join(
     common.OPPIA_TOOLS_DIR, 'pylint-1.9.4', 'configparser.py')
@@ -146,91 +135,6 @@ def pip_install(package, version, install_path):
         raise Exception('Error installing package')
 
 
-def install_skulpt(parsed_args):
-    """Download and install Skulpt. Skulpt is built using a Python script
-    included within the Skulpt repository (skulpt.py). This script normally
-    requires GitPython, however the patches to it below
-    (with the fileinput.replace) lead to it no longer being required. The Python
-    script is used to avoid having to manually recreate the Skulpt dist build
-    process in install_third_party.py. Note that skulpt.py will issue a
-    warning saying its dist command will not work properly without GitPython,
-    but it does actually work due to the patches.
-    """
-    no_skulpt = parsed_args.nojsrepl or parsed_args.noskulpt
-
-    python_utils.PRINT('Checking whether Skulpt is installed in third_party')
-    if not os.path.exists(
-            os.path.join(
-                common.THIRD_PARTY_DIR,
-                'static/skulpt-0.10.0')) and not no_skulpt:
-        if not os.path.exists(
-                os.path.join(common.OPPIA_TOOLS_DIR, 'skulpt-0.10.0')):
-            python_utils.PRINT('Downloading Skulpt')
-            skulpt_filepath = os.path.join(
-                common.OPPIA_TOOLS_DIR, 'skulpt-0.10.0', 'skulpt', 'skulpt.py')
-            os.chdir(common.OPPIA_TOOLS_DIR)
-            os.mkdir('skulpt-0.10.0')
-            os.chdir('skulpt-0.10.0')
-            subprocess.check_call([
-                'git', 'clone', 'https://github.com/skulpt/skulpt'])
-            os.chdir('skulpt')
-
-            # Use a specific Skulpt release.
-            subprocess.check_call(['git', 'checkout', '0.10.0'])
-
-            python_utils.PRINT('Compiling Skulpt')
-            # The Skulpt setup function needs to be tweaked. It fails without
-            # certain third party commands. These are only used for unit tests
-            # and generating documentation and are not necessary when building
-            # Skulpt.
-            for line in fileinput.input(
-                    files=[skulpt_filepath], inplace=True):
-                # Inside this loop the STDOUT will be redirected to the file,
-                # skulpt.py. The end='' is needed to avoid double line breaks.
-                python_utils.PRINT(
-                    line.replace('ret = test()', 'ret = 0'),
-                    end='')
-
-            for line in fileinput.input(
-                    files=[skulpt_filepath], inplace=True):
-                # Inside this loop the STDOUT will be redirected to the file,
-                # skulpt.py. The end='' is needed to avoid double line breaks.
-                python_utils.PRINT(
-                    line.replace('  doc()', '  pass#doc()'),
-                    end='')
-
-            for line in fileinput.input(
-                    files=[skulpt_filepath], inplace=True):
-                # This and the next command disable unit and compressed unit
-                # tests for the compressed distribution of Skulpt. These
-                # tests don't work on some Ubuntu environments and cause a
-                # libreadline dependency issue.
-                python_utils.PRINT(
-                    line.replace(
-                        'ret = os.system(\'{0}',
-                        'ret = 0 #os.system(\'{0}'),
-                    end='')
-
-            for line in fileinput.input(
-                    files=[skulpt_filepath], inplace=True):
-                python_utils.PRINT(
-                    line.replace('ret = rununits(opt=True)', 'ret = 0'),
-                    end='')
-
-            # NB: Check call cannot be used because the commands above make the
-            # git tree for skulpt dirty.
-            subprocess.call([sys.executable, skulpt_filepath, 'dist'])
-
-            # Return to the Oppia root folder.
-            os.chdir(common.CURR_DIR)
-
-        # Move the build directory to the static resources folder.
-        shutil.copytree(
-            os.path.join(
-                common.OPPIA_TOOLS_DIR, 'skulpt-0.10.0/skulpt/dist/'),
-            os.path.join(common.THIRD_PARTY_DIR, 'static/skulpt-0.10.0'))
-
-
 def ensure_pip_library_is_installed(package, version, path):
     """Installs the pip library after ensuring its not already installed.
 
@@ -248,10 +152,8 @@ def ensure_pip_library_is_installed(package, version, path):
         pip_install(package, version, exact_lib_path)
 
 
-def main(args=None):
+def main():
     """Install third-party libraries for Oppia."""
-    parsed_args = _PARSER.parse_args(args=args)
-
     setup.main(args=[])
     setup_gae.main(args=[])
     pip_dependencies = [
@@ -309,8 +211,6 @@ def main(args=None):
 
     # Install third-party node modules needed for the build process.
     subprocess.check_call([get_yarn_command()])
-
-    install_skulpt(parsed_args)
 
     # Install pre-commit script.
     python_utils.PRINT('Installing pre-commit hook for git')

--- a/scripts/install_third_party_libs_test.py
+++ b/scripts/install_third_party_libs_test.py
@@ -19,10 +19,7 @@
 from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
-import argparse
-import fileinput
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -182,59 +179,6 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
             'Windows%29' in self.print_arr)
         self.assertFalse(self.check_function_calls['check_call_is_called'])
 
-    def test_install_skulpt(self):
-        check_function_calls = {
-            'chdir_is_called': False,
-            'mkdir_is_called': False,
-            'call_is_called': False,
-            'copytree_is_called': False
-        }
-        expected_check_function_calls = {
-            'chdir_is_called': True,
-            'mkdir_is_called': True,
-            'call_is_called': True,
-            'copytree_is_called': True
-        }
-        expected_lines_in_print_arr = [
-            'Test line 1: ret = 0',
-            'Test line 2:  pass#doc()',
-            'Test line 3: ret = 0 #os.system(\'{0}',
-            'Test line 4: ret = 0']
-        def mock_exists(unused_path):
-            return False
-        def mock_chdir(unused_path):
-            check_function_calls['chdir_is_called'] = True
-        def mock_mkdir(unused_path):
-            check_function_calls['mkdir_is_called'] = True
-        def mock_call(unused_cmd_tokens):
-            check_function_calls['call_is_called'] = True
-        def mock_copytree(unused_path1, unused_path2):
-            check_function_calls['copytree_is_called'] = True
-        # pylint: disable=unused-argument
-        def mock_input(files, inplace):
-            return [
-                'Test line 1: ret = test()',
-                'Test line 2:  doc()',
-                'Test line 3: ret = os.system(\'{0}',
-                'Test line 4: ret = rununits(opt=True)']
-        # pylint: enable=unused-argument
-
-        exists_swap = self.swap(os.path, 'exists', mock_exists)
-        chdir_swap = self.swap(os, 'chdir', mock_chdir)
-        mkdir_swap = self.swap(os, 'mkdir', mock_mkdir)
-        call_swap = self.swap(subprocess, 'call', mock_call)
-        copytree_swap = self.swap(shutil, 'copytree', mock_copytree)
-        input_swap = self.swap(fileinput, 'input', mock_input)
-
-        with exists_swap, chdir_swap, mkdir_swap, call_swap:
-            with copytree_swap, input_swap, self.print_swap:
-                install_third_party_libs.install_skulpt(
-                    argparse.Namespace(nojsrepl=False, noskulpt=False))
-        self.assertEqual(check_function_calls, expected_check_function_calls)
-
-        for line in expected_lines_in_print_arr:
-            self.assertTrue(line in self.print_arr)
-
     def test_ensure_pip_library_is_installed(self):
         check_function_calls = {
             'pip_install_is_called': False
@@ -256,7 +200,6 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
     def test_function_calls(self):
         check_function_calls = {
             'ensure_pip_library_is_installed_is_called': False,
-            'install_skulpt_is_called': False,
             'install_third_party_main_is_called': False,
             'setup_main_is_called': False,
             'setup_gae_main_is_called': False,
@@ -266,7 +209,6 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         }
         expected_check_function_calls = {
             'ensure_pip_library_is_installed_is_called': True,
-            'install_skulpt_is_called': True,
             'install_third_party_main_is_called': True,
             'setup_main_is_called': True,
             'setup_gae_main_is_called': True,
@@ -278,8 +220,6 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
                 unused_package, unused_version, unused_path):
             check_function_calls[
                 'ensure_pip_library_is_installed_is_called'] = True
-        def mock_install_skulpt(unused_parsed_args):
-            check_function_calls['install_skulpt_is_called'] = True
         def mock_check_call(unused_cmd_tokens):
             pass
         # pylint: disable=unused-argument
@@ -300,8 +240,6 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         ensure_pip_install_swap = self.swap(
             install_third_party_libs, 'ensure_pip_library_is_installed',
             mock_ensure_pip_library_is_installed)
-        install_skulpt_swap = self.swap(
-            install_third_party_libs, 'install_skulpt', mock_install_skulpt)
         check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
         install_third_party_main_swap = self.swap(
             install_third_party, 'main', mock_main_for_install_third_party)
@@ -338,12 +276,12 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
             install_third_party_libs, 'PQ_CONFIGPARSER_FILEPATH',
             temp_pq_config_file)
 
-        with ensure_pip_install_swap, install_skulpt_swap, check_call_swap:
+        with ensure_pip_install_swap, check_call_swap:
             with install_third_party_main_swap, setup_main_swap:
                 with setup_gae_main_swap, pre_commit_hook_main_swap:
                     with pre_push_hook_main_swap, py_config_swap:
                         with pq_config_swap, tweak_yarn_executable_swap:
-                            install_third_party_libs.main(args=[])
+                            install_third_party_libs.main()
         self.assertEqual(check_function_calls, expected_check_function_calls)
         with python_utils.open_file(temp_py_config_file, 'r') as f:
             self.assertEqual(f.read(), py_expected_text)
@@ -354,7 +292,6 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
     def test_function_calls_on_windows(self):
         check_function_calls = {
             'ensure_pip_library_is_installed_is_called': False,
-            'install_skulpt_is_called': False,
             'install_third_party_main_is_called': False,
             'setup_main_is_called': False,
             'setup_gae_main_is_called': False,
@@ -364,7 +301,6 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         }
         expected_check_function_calls = {
             'ensure_pip_library_is_installed_is_called': True,
-            'install_skulpt_is_called': True,
             'install_third_party_main_is_called': True,
             'setup_main_is_called': True,
             'setup_gae_main_is_called': True,
@@ -376,8 +312,6 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
                 unused_package, unused_version, unused_path):
             check_function_calls[
                 'ensure_pip_library_is_installed_is_called'] = True
-        def mock_install_skulpt(unused_parsed_args):
-            check_function_calls['install_skulpt_is_called'] = True
         def mock_check_call(unused_cmd_tokens):
             pass
         # pylint: disable=unused-argument
@@ -398,8 +332,6 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         ensure_pip_install_swap = self.swap(
             install_third_party_libs, 'ensure_pip_library_is_installed',
             mock_ensure_pip_library_is_installed)
-        install_skulpt_swap = self.swap(
-            install_third_party_libs, 'install_skulpt', mock_install_skulpt)
         check_call_swap = self.swap(subprocess, 'check_call', mock_check_call)
         install_third_party_main_swap = self.swap(
             install_third_party, 'main', mock_main_for_install_third_party)
@@ -437,13 +369,13 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
             install_third_party_libs, 'PQ_CONFIGPARSER_FILEPATH',
             temp_pq_config_file)
 
-        with ensure_pip_install_swap, install_skulpt_swap, check_call_swap:
+        with ensure_pip_install_swap, check_call_swap:
             with install_third_party_main_swap, setup_main_swap:
                 with setup_gae_main_swap, pre_commit_hook_main_swap:
                     with pre_push_hook_main_swap, py_config_swap:
                         with pq_config_swap, tweak_yarn_executable_swap:
                             with os_name_swap:
-                                install_third_party_libs.main(args=[])
+                                install_third_party_libs.main()
         self.assertEqual(check_function_calls, expected_check_function_calls)
         with python_utils.open_file(temp_py_config_file, 'r') as f:
             self.assertEqual(f.read(), py_expected_text)

--- a/scripts/pre_commit_linter.py
+++ b/scripts/pre_commit_linter.py
@@ -64,7 +64,7 @@ import time
 
 # Install third party dependencies before proceeding.
 from . import install_third_party_libs
-install_third_party_libs.main(args=[])
+install_third_party_libs.main()
 
 # pylint: disable=wrong-import-position
 import python_utils  # isort:skip

--- a/scripts/release_scripts/deploy.py
+++ b/scripts/release_scripts/deploy.py
@@ -453,7 +453,7 @@ def execute_deployment():
     deploy_data_path = os.path.join(
         os.getcwd(), os.pardir, 'release-scripts', 'deploy_data', app_name)
 
-    install_third_party_libs.main(args=[])
+    install_third_party_libs.main()
 
     if not common.is_current_branch_a_release_branch():
         raise Exception(

--- a/scripts/release_scripts/deploy_test.py
+++ b/scripts/release_scripts/deploy_test.py
@@ -69,7 +69,7 @@ class DeployTests(test_utils.GenericTestBase):
     def setUp(self):
         super(DeployTests, self).setUp()
         # pylint: disable=unused-argument
-        def mock_main(args):
+        def mock_main():
             pass
         def mock_copytree(unused_dir1, unused_dir2, ignore):
             pass

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -29,7 +29,7 @@ import time
 
 # Install third party libraries before importing other files.
 from . import install_third_party_libs
-install_third_party_libs.main(args=[])
+install_third_party_libs.main()
 
 # pylint: disable=wrong-import-position
 import python_utils  # isort:skip


### PR DESCRIPTION
## Explanation
This PR fixes #7852 by updating skulpt to 1.1.0 and retrieving the built version directly from the bower distribution so that developers do not need to compile it locally.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.