### PR TITLE
Reconfigure circleci cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,9 @@ anchor_for_installing_cc_test_reporter: &install_cc
     chmod +x ./cc-test-reporter
     ./cc-test-reporter before-build
 
-anchor_for_restoring_cache: &restore_cache
-  keys:
-    - setup-files-cache-{{ checksum "date" }}-{{ .Branch }}
-    - third-party-cache-{{ checksum "date" }}-{{ .Branch }}
+anchor_for_attaching_setup_files: &attaching_files
+  attach_workspace:
+    at: /home/circleci/oppia
 
 version: 2
 jobs:
@@ -53,13 +52,10 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - run: date +%F > date
-      - restore_cache:
-          <<: *restore_cache
       - run:
           <<: *install_dependencies
-      - save_cache:
-          key: setup-files-cache-{{ checksum "date" }}
+      - persist_to_workspace:
+          root: /home/circleci/oppia
           paths:
             - node_modules/
             - ../oppia_tools/
@@ -68,8 +64,8 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - restore_cache:
-          <<: *restore_cache
+      - run:
+          <<: *attaching_files
       - run:
           <<: *install_dependencies
       - run:
@@ -85,8 +81,8 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - restore_cache:
-          <<: *restore_cache
+      - run:
+        <<: *attaching_files
       - run:
           <<: *install_dependencies
       - run:
@@ -98,8 +94,8 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - restore_cache:
-          <<: *restore_cache
+      - run:
+        <<: *attaching_files
       - run:
           <<: *install_dependencies
       - run:
@@ -117,8 +113,8 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - restore_cache:
-          <<: *restore_cache
+      - run:
+        <<: *attaching_files
       - run:
           <<: *install_dependencies
       - run: sudo pip install webtest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ anchor_for_installing_cc_test_reporter: &install_cc
 
 anchor_for_attaching_setup_files: &attaching_files
   attach_workspace:
-    at: /home/circleci/oppia
+    at: /home/circleci/
 
 version: 2
 jobs:
@@ -55,10 +55,11 @@ jobs:
       - run:
           <<: *install_dependencies
       - persist_to_workspace:
-          root: /home/circleci/oppia
+          root: /home/circleci/
           paths:
-            - node_modules/
-            - ../oppia_tools/
+            - oppia/node_modules/
+            - oppia/third_party/
+            - oppia_tools/
 
   lint_tests:
     <<: *job_defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,8 @@ anchor_for_installing_cc_test_reporter: &install_cc
 
 anchor_for_restoring_cache: &restore_cache
   keys:
-    - setup-files-cache-{{ checksum "date" }}
-    - third-party-cache-{{ checksum "date" }}
+    - setup-files-cache-{{ checksum "date" }}-{{ .Branch }}
+    - third-party-cache-{{ checksum "date" }}-{{ .Branch }}
 
 version: 2
 jobs:
@@ -68,6 +68,8 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
+      - restore_cache:
+          <<: *restore_cache
       - run:
           <<: *install_dependencies
       - run:
@@ -83,11 +85,10 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - run:
-          <<: *install_dependencies
-      - run: date +%F > date
       - restore_cache:
           <<: *restore_cache
+      - run:
+          <<: *install_dependencies
       - run:
           name: Run typescript tests
           command: |
@@ -97,9 +98,6 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - run:
-          <<: *install_dependencies
-      - run: date +%F > date
       - restore_cache:
           <<: *restore_cache
       - run:
@@ -117,9 +115,6 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - run:
-          <<: *install_dependencies
-      - run: date +%F > date
       - restore_cache:
           <<: *restore_cache
       - run: sudo pip install webtest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,6 @@ anchor_for_installing_cc_test_reporter: &install_cc
     chmod +x ./cc-test-reporter
     ./cc-test-reporter before-build
 
-anchor_for_attaching_setup_files: &attaching_files
-  attach_workspace:
-    at: /home/circleci/
 
 version: 2
 jobs:
@@ -65,8 +62,8 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - run:
-          <<: *attaching_files
+      - attach_workspace:
+          at: /home/circleci/
       - run:
           <<: *install_dependencies
       - run:
@@ -82,8 +79,8 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - run:
-        <<: *attaching_files
+      - attach_workspace:
+          at: /home/circleci/
       - run:
           <<: *install_dependencies
       - run:
@@ -95,8 +92,8 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - run:
-        <<: *attaching_files
+      - attach_workspace:
+          at: /home/circleci/
       - run:
           <<: *install_dependencies
       - run:
@@ -114,8 +111,8 @@ jobs:
     <<: *job_defaults
     steps:
       - checkout
-      - run:
-        <<: *attaching_files
+      - attach_workspace:
+          at: /home/circleci/
       - run:
           <<: *install_dependencies
       - run: sudo pip install webtest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,8 @@ jobs:
       - restore_cache:
           <<: *restore_cache
       - run:
+          <<: *install_dependencies
+      - run:
           name: Run frontend tests
           command: |
             python -m scripts.run_frontend_tests --run_minified_tests --skip_install
@@ -117,6 +119,8 @@ jobs:
       - checkout
       - restore_cache:
           <<: *restore_cache
+      - run:
+          <<: *install_dependencies
       - run: sudo pip install webtest
       - run: sudo pip install coverage
       - run:


### PR DESCRIPTION
## Explanation
Reconfiguring the caches for CircleCI so that we can utilize it more efficiently. 

Note: There was an purposeful decision to not use caches but rather to persist setup files across workflows. The reason is that our dependencies are defined in various places to keep track. We were previously using date to track cache versions.  

Impact: Typescript test went from 1:59 to 0:56.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
