### PR TITLE
Move fileUploadFeatures and topicAndStoryEditor E2E tests to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ workflows:
       - backend_tests:
           requires:
             - setup
+      - e2e_tests:
+          requires:
+            - setup
 
 var_for_docker_image: &docker_image circleci/python:2.7.17-browsers
 
@@ -133,6 +136,22 @@ jobs:
             ./cc-test-reporter upload-coverage
           when: on_success
 
+  e2e_tests:
+    <<: *job_defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          <<: *install_dependencies
+      - run:
+          name: RUN_E2E_TESTS_FILE_UPLOAD_FEATURES
+          command: |
+            bash scripts/run_e2e_tests.sh --suite="fileUploadFeatures"
+      - run:
+          name: RUN_E2E_TESTS_TOPIC_AND_STORY_EDITOR
+          command: |
+            bash scripts/run_e2e_tests.sh --suite="topicAndStoryEditor"
 notify:
   webhooks:
     # A list of hook hashes, containing the url field

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - run:
           <<: *install_dependencies
       - run:
-          name: RUN_E2E_TESTS_FILE_UPLOAD_FEATURES
+          name: Run e2e file upload features test
           command: |
             bash scripts/run_e2e_tests.sh --suite="fileUploadFeatures"
   
@@ -161,7 +161,7 @@ jobs:
       - run:
           <<: *install_dependencies
       - run:
-          name: RUN_E2E_TESTS_TOPIC_AND_STORY_EDITOR
+          name: Run e2e topic and story editor test
           command: |
             bash scripts/run_e2e_tests.sh --suite="topicAndStoryEditor"
 notify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,10 @@ workflows:
       - backend_tests:
           requires:
             - setup
-      - e2e_tests:
+      - e2e_file_upload_features:
+          requires:
+            - setup
+      - e2e_topic_and_story_editory:
           requires:
             - setup
 
@@ -136,7 +139,7 @@ jobs:
             ./cc-test-reporter upload-coverage
           when: on_success
 
-  e2e_tests:
+  e2e_file_upload_features:
     <<: *job_defaults
     steps:
       - checkout
@@ -148,6 +151,15 @@ jobs:
           name: RUN_E2E_TESTS_FILE_UPLOAD_FEATURES
           command: |
             bash scripts/run_e2e_tests.sh --suite="fileUploadFeatures"
+  
+  e2e_topic_and_story_editory:
+    <<: *job_defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          <<: *install_dependencies
       - run:
           name: RUN_E2E_TESTS_TOPIC_AND_STORY_EDITOR
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ workflows:
       - e2e_file_upload_features:
           requires:
             - setup
-      - e2e_topic_and_story_editory:
+      - e2e_topic_and_story_editor:
           requires:
             - setup
 
@@ -152,7 +152,7 @@ jobs:
           command: |
             bash scripts/run_e2e_tests.sh --suite="fileUploadFeatures"
   
-  e2e_topic_and_story_editory:
+  e2e_topic_and_story_editor:
     <<: *job_defaults
     steps:
       - checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ env:
     - RUN_E2E_TESTS_EXPLORATION_STATISTICS_TAB=true
     - RUN_E2E_TESTS_EXPLORATION_TRANSLATION_TAB=true
     - RUN_E2E_TESTS_EXTENSIONS=true
-    - RUN_E2E_TESTS_FILE_UPLOAD_FEATURES=true
     - RUN_E2E_TESTS_LEARNER_DASHBOARD=true
     - RUN_E2E_TESTS_LEARNER=true
     - RUN_E2E_TESTS_LIBRARY=true
@@ -50,7 +49,6 @@ env:
     - RUN_E2E_TESTS_SKILL_EDITOR=true
     - RUN_E2E_TESTS_SUBSCRIPTIONS=true
     - RUN_E2E_TESTS_TOPICS_AND_SKILLS_DASHBOARD=true
-    - RUN_E2E_TESTS_TOPIC_AND_STORY_EDITOR=true
     - RUN_E2E_TESTS_USERS=true
 
 jobs:
@@ -115,7 +113,6 @@ script:
 - if [ "$RUN_E2E_TESTS_EXPLORATION_STATISTICS_TAB" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="explorationStatisticsTab" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_EXPLORATION_TRANSLATION_TAB" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="explorationTranslationTab" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_EXTENSIONS" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="extensions" --prod_env; fi
-- if [ "$RUN_E2E_TESTS_FILE_UPLOAD_FEATURES" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="fileUploadFeatures"; fi
 - if [ "$RUN_E2E_TESTS_LEARNER_DASHBOARD" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="learnerDashboard" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_LEARNER" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="learner" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_LIBRARY" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="library" --prod_env; fi
@@ -127,7 +124,6 @@ script:
 - if [ "$RUN_E2E_TESTS_SKILL_EDITOR" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="skillEditor" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_SUBSCRIPTIONS" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="subscriptions" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_TOPICS_AND_SKILLS_DASHBOARD" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="topicsAndSkillsDashboard" --prod_env; fi
-- if [ "$RUN_E2E_TESTS_TOPIC_AND_STORY_EDITOR" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="topicAndStoryEditor"; fi
 - if [ "$RUN_E2E_TESTS_USERS" == 'true' ]; then travis_retry bash scripts/run_e2e_tests.sh --suite="users" --prod_env; fi
 # These lines are commented out because these checks are being run on CircleCI
 # here: https://circleci.com/gh/oppia/oppia


### PR DESCRIPTION
This PR moves `fileUploadFeatures` and `topicAndStoryEditor` End-to-End tests to CricleCI. These [tests fail](https://github.com/oppia/oppia/pull/8268#issuecomment-569472090) on Travis when GCS is used in DEV mode. This is not the case with CircleCI.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
