### PR TITLE
Decrease parallelization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,13 @@ workflows:
             - setup
       - e2e_classroom_page:
           requires:
-            - setup
+            - typescript_tests
       - e2e_file_upload_features:
           requires:
-            - setup
+            - typescript_tests
       - e2e_topic_and_story_editor:
           requires:
-            - setup
+            - typescript_tests
 
 var_for_docker_image: &docker_image circleci/python:2.7.17-browsers
 

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -104,7 +104,7 @@ ALL_ERRORS = []
 LOG_LINE_PREFIX = 'LOG_INFO_TEST: '
 _LOAD_TESTS_DIR = os.path.join(os.getcwd(), 'core', 'tests', 'load_tests')
 
-MAX_CONCURRENT_RUNS = 30
+MAX_CONCURRENT_RUNS = 25
 
 _PARSER = argparse.ArgumentParser(description="""
 Run this script from the oppia root folder:
@@ -527,9 +527,6 @@ def main(args=None):
 
         report_stdout, _ = process.communicate()
         python_utils.PRINT(report_stdout)
-
-        python_utils.PRINT('Generating xml coverage report...')
-        subprocess.check_call([sys.executable, COVERAGE_MODULE_PATH, 'xml'])
 
         coverage_result = re.search(
             r'TOTAL\s+(\d+)\s+(\d+)\s+(?P<total>\d+)%\s+', report_stdout)


### PR DESCRIPTION
## Explanation
Decrease test parallelization since one test is constantly failing. Also made the e2e tests rely on the typescript test to pass before running.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
