### PR TITLE
Fix part of #7450: Calling _save_exploration via update_exploration in tests

### DIFF
--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -556,8 +556,8 @@ written_translations:
 
         # Check download to JSON.
         exploration.update_objective('Test JSON download')
-        exp_services._save_exploration(  # pylint: disable=protected-access
-            owner_id, exploration, '', [])
+        exp_services.update_exploration(
+            owner_id, exploration.id, None, 'Test commit')
 
         # Download to JSON string using download handler.
         self.maxDiff = None

--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -145,8 +145,8 @@ class LibraryPageTests(test_utils.GenericTestBase):
         exploration = self.save_new_valid_exploration(
             'A', self.admin_id, title='Title A', category='Category A',
             objective='Objective A')
-        exp_services._save_exploration(  # pylint: disable=protected-access
-            self.admin_id, exploration, 'Exploration A', [])
+        exp_services.update_exploration(
+            self.admin_id, exploration.id, None, 'Exploration A')
 
         # Test that the private exploration isn't displayed.
         response_dict = self.get_json(feconf.LIBRARY_SEARCH_DATA_URL)
@@ -156,8 +156,8 @@ class LibraryPageTests(test_utils.GenericTestBase):
         exploration = self.save_new_valid_exploration(
             'B', self.admin_id, title='Title B', category='Category B',
             objective='Objective B')
-        exp_services._save_exploration(  # pylint: disable=protected-access
-            self.admin_id, exploration, 'Exploration B', [])
+        exp_services.update_exploration(
+            self.admin_id, exploration.id, None, 'Exploration B')
         rights_manager.publish_exploration(self.admin, 'B')
 
         # Publish exploration A.

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -84,7 +84,8 @@ class SuggestionUnitTests(test_utils.GenericTestBase):
             state_domain.SubtitledHtml.from_dict(self.old_content))
         exploration.states['State 3'].update_content(
             state_domain.SubtitledHtml.from_dict(self.old_content))
-        exp_services._save_exploration(self.editor_id, exploration, '', [])  # pylint: disable=protected-access
+        exp_services.update_exploration(
+            self.editor_id, exploration.id, None, 'Test commit')
 
         rights_manager.publish_exploration(self.editor, self.EXP_ID)
         rights_manager.assign_role_for_exploration(

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -4171,7 +4171,7 @@ class ApplyDraftUnitTests(test_utils.GenericTestBase):
             'to_version': '1'
         })]
         exp_services.update_exploration(
-            self.USER_ID, exploration.id, migration_change_list,
+            self.USER_ID, exploration.id, migration_change_list, 
             'Migrate state schema.')
 
     def test_get_exp_with_draft_applied_after_draft_upgrade(self):

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -2126,8 +2126,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services.update_exploration(
-            self.owner_id, exploration.id, None, 'Test commit')
+        exp_services._save_exploration(self.owner_id, exploration, '', [])
         exp_services.update_exploration(
             self.owner_id, self.EXP_ID, _get_change_list(
                 self.init_state_name, 'param_changes', self.param_changes), '')
@@ -2173,8 +2172,7 @@ class UpdateStateTests(ExplorationServicesUnitTests):
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services.update_exploration(
-            self.owner_id, exploration.id, None, 'Test commit')
+        exp_services._save_exploration(self.owner_id, exploration, '', [])
 
         self.param_changes[0]['generator_id'] = 'fake'
         with self.assertRaisesRegexp(
@@ -2645,8 +2643,8 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
 
         # Using the old version of the exploration should raise an error.
         with self.assertRaisesRegexp(Exception, 'version 1, which is too old'):
-            exp_services.update_exploration(
-                second_committer_id, v1_exploration.id, None, 'Test commit')
+            exp_services._save_exploration(
+                second_committer_id, v1_exploration, '', [])
 
         # Another person modifies the exploration.
         new_change_list = [exp_domain.ExplorationChange({
@@ -2699,8 +2697,8 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
             self.EXP_ID, self.owner_id)
 
         exploration.title = 'First title'
-        exp_services.update_exploration(
-            self.owner_id, exploration.id, None, 'Changed title.')
+        exp_services._save_exploration(
+            self.owner_id, exploration, 'Changed title.', [])
         commit_dict_2 = {
             'committer_id': self.owner_id,
             'commit_message': 'Changed title.',
@@ -2781,8 +2779,8 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
         # In version 1, the title was 'A title'.
         # In version 2, the title becomes 'V2 title'.
         exploration.title = 'V2 title'
-        exp_services.update_exploration(
-            self.owner_id, exploration.id, None, 'Changed title.')
+        exp_services._save_exploration(
+            self.owner_id, exploration, 'Changed title.', [])
 
         # In version 3, a new state is added.
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
@@ -2962,21 +2960,20 @@ class ExplorationCommitLogUnitTests(ExplorationServicesUnitTests):
                 self.EXP_ID_1, self.albert_id)
 
             exploration_1.title = 'Exploration 1 title'
-            exp_services.update_exploration(
-                self.bob_id, exploration_1.id, None, 'Changed title.')
+            exp_services._save_exploration(
+                self.bob_id, exploration_1, 'Changed title.', [])
 
             exploration_2 = self.save_new_valid_exploration(
                 self.EXP_ID_2, self.albert_id)
 
             exploration_1.title = 'Exploration 1 Albert title'
-            exp_services.update_exploration(
-                self.albert_id, exploration_1.id, None,
-                'Changed title to Albert1 title.')
+            exp_services._save_exploration(
+                self.albert_id, exploration_1,
+                'Changed title to Albert1 title.', [])
 
             exploration_2.title = 'Exploration 2 Albert title'
-            exp_services.update_exploration(
-                self.albert_id, exploration_2.id, None,
-                    'Changed title to Albert2.')
+            exp_services._save_exploration(
+                self.albert_id, exploration_2, 'Changed title to Albert2.', [])
 
             exp_services.revert_exploration(self.bob_id, self.EXP_ID_1, 3, 2)
 
@@ -3734,8 +3731,7 @@ title: Old Title
 
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services.update_exploration(
-            self.albert_id, exploration.id, None, 'Test commit')
+        exp_services._save_exploration(self.albert_id, exploration, '', [])
 
         param_changes = [{
             'customization_args': {
@@ -3962,8 +3958,7 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
             self.EXP_ID1, self.USER_ID)
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services.update_exploration(
-            self.USER_ID, exploration.id, None, 'Test commit')
+        exp_services._save_exploration(self.USER_ID, exploration, '', [])
         self.save_new_valid_exploration(self.EXP_ID2, self.USER_ID)
         self.save_new_valid_exploration(self.EXP_ID3, self.USER_ID)
         self.init_state_name = exploration.init_state_name
@@ -4170,9 +4165,9 @@ class ApplyDraftUnitTests(test_utils.GenericTestBase):
             'from_version': '0',
             'to_version': '1'
         })]
-        exp_services.update_exploration(
-            self.USER_ID, exploration.id, migration_change_list, 
-            'Migrate state schema.')
+        exp_services._save_exploration(
+            self.USER_ID, exploration, 'Migrate state schema.',
+            migration_change_list)
 
     def test_get_exp_with_draft_applied_after_draft_upgrade(self):
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID1)

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -4171,7 +4171,7 @@ class ApplyDraftUnitTests(test_utils.GenericTestBase):
             'to_version': '1'
         })]
         exp_services.update_exploration(
-            self.USER_ID, exploration.id, migration_change_list, 
+            self.USER_ID, exploration.id, migration_change_list,
             'Migrate state schema.')
 
     def test_get_exp_with_draft_applied_after_draft_upgrade(self):

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -2124,9 +2124,11 @@ class UpdateStateTests(ExplorationServicesUnitTests):
     def test_update_param_changes(self):
         """Test updating of param_changes."""
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
-        exploration.param_specs = {
-            'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services._save_exploration(self.owner_id, exploration, '', [])
+        exp_services.update_exploration(
+            self.owner_id, self.EXP_ID, _get_change_list(
+                self.init_state_name, 'param_specs',
+                {'myParam': param_domain.ParamSpec('UnicodeString')}), '')
+        
         exp_services.update_exploration(
             self.owner_id, self.EXP_ID, _get_change_list(
                 self.init_state_name, 'param_changes', self.param_changes), '')

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -2126,7 +2126,8 @@ class UpdateStateTests(ExplorationServicesUnitTests):
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services._save_exploration(self.owner_id, exploration, '', [])
+        exp_services.update_exploration(
+            self.owner_id, exploration.id, None, 'Test commit')
         exp_services.update_exploration(
             self.owner_id, self.EXP_ID, _get_change_list(
                 self.init_state_name, 'param_changes', self.param_changes), '')
@@ -2172,7 +2173,8 @@ class UpdateStateTests(ExplorationServicesUnitTests):
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services._save_exploration(self.owner_id, exploration, '', [])
+        exp_services.update_exploration(
+            self.owner_id, exploration.id, None, 'Test commit')
 
         self.param_changes[0]['generator_id'] = 'fake'
         with self.assertRaisesRegexp(
@@ -2643,8 +2645,8 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
 
         # Using the old version of the exploration should raise an error.
         with self.assertRaisesRegexp(Exception, 'version 1, which is too old'):
-            exp_services._save_exploration(
-                second_committer_id, v1_exploration, '', [])
+            exp_services.update_exploration(
+                second_committer_id, v1_exploration.id, None, 'Test commit')
 
         # Another person modifies the exploration.
         new_change_list = [exp_domain.ExplorationChange({
@@ -2697,8 +2699,8 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
             self.EXP_ID, self.owner_id)
 
         exploration.title = 'First title'
-        exp_services._save_exploration(
-            self.owner_id, exploration, 'Changed title.', [])
+        exp_services.update_exploration(
+            self.owner_id, exploration.id, None, 'Changed title.')
         commit_dict_2 = {
             'committer_id': self.owner_id,
             'commit_message': 'Changed title.',
@@ -2779,8 +2781,8 @@ class ExplorationSnapshotUnitTests(ExplorationServicesUnitTests):
         # In version 1, the title was 'A title'.
         # In version 2, the title becomes 'V2 title'.
         exploration.title = 'V2 title'
-        exp_services._save_exploration(
-            self.owner_id, exploration, 'Changed title.', [])
+        exp_services.update_exploration(
+            self.owner_id, exploration.id, None, 'Changed title.')
 
         # In version 3, a new state is added.
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
@@ -2960,20 +2962,21 @@ class ExplorationCommitLogUnitTests(ExplorationServicesUnitTests):
                 self.EXP_ID_1, self.albert_id)
 
             exploration_1.title = 'Exploration 1 title'
-            exp_services._save_exploration(
-                self.bob_id, exploration_1, 'Changed title.', [])
+            exp_services.update_exploration(
+                self.bob_id, exploration_1.id, None, 'Changed title.')
 
             exploration_2 = self.save_new_valid_exploration(
                 self.EXP_ID_2, self.albert_id)
 
             exploration_1.title = 'Exploration 1 Albert title'
-            exp_services._save_exploration(
-                self.albert_id, exploration_1,
-                'Changed title to Albert1 title.', [])
+            exp_services.update_exploration(
+                self.albert_id, exploration_1.id, None,
+                'Changed title to Albert1 title.')
 
             exploration_2.title = 'Exploration 2 Albert title'
-            exp_services._save_exploration(
-                self.albert_id, exploration_2, 'Changed title to Albert2.', [])
+            exp_services.update_exploration(
+                self.albert_id, exploration_2.id, None,
+                    'Changed title to Albert2.')
 
             exp_services.revert_exploration(self.bob_id, self.EXP_ID_1, 3, 2)
 
@@ -3731,7 +3734,8 @@ title: Old Title
 
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services._save_exploration(self.albert_id, exploration, '', [])
+        exp_services.update_exploration(
+            self.albert_id, exploration.id, None, 'Test commit')
 
         param_changes = [{
             'customization_args': {
@@ -3958,7 +3962,8 @@ class EditorAutoSavingUnitTests(test_utils.GenericTestBase):
             self.EXP_ID1, self.USER_ID)
         exploration.param_specs = {
             'myParam': param_domain.ParamSpec('UnicodeString')}
-        exp_services._save_exploration(self.USER_ID, exploration, '', [])
+        exp_services.update_exploration(
+            self.USER_ID, exploration.id, None, 'Test commit')
         self.save_new_valid_exploration(self.EXP_ID2, self.USER_ID)
         self.save_new_valid_exploration(self.EXP_ID3, self.USER_ID)
         self.init_state_name = exploration.init_state_name
@@ -4165,9 +4170,9 @@ class ApplyDraftUnitTests(test_utils.GenericTestBase):
             'from_version': '0',
             'to_version': '1'
         })]
-        exp_services._save_exploration(
-            self.USER_ID, exploration, 'Migrate state schema.',
-            migration_change_list)
+        exp_services.update_exploration(
+            self.USER_ID, exploration.id, migration_change_list, 
+            'Migrate state schema.')
 
     def test_get_exp_with_draft_applied_after_draft_upgrade(self):
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID1)

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -2124,11 +2124,9 @@ class UpdateStateTests(ExplorationServicesUnitTests):
     def test_update_param_changes(self):
         """Test updating of param_changes."""
         exploration = exp_fetchers.get_exploration_by_id(self.EXP_ID)
-        exp_services.update_exploration(
-            self.owner_id, self.EXP_ID, _get_change_list(
-                self.init_state_name, 'param_specs',
-                {'myParam': param_domain.ParamSpec('UnicodeString')}), '')
-        
+        exploration.param_specs = {
+            'myParam': param_domain.ParamSpec('UnicodeString')}
+        exp_services._save_exploration(self.owner_id, exploration, '', [])
         exp_services.update_exploration(
             self.owner_id, self.EXP_ID, _get_change_list(
                 self.init_state_name, 'param_changes', self.param_changes), '')


### PR DESCRIPTION
## Explanation
* Fixes part of #7450  
* Fixes the parts:
   * `editor_test.ExplorationEditorLogoutTest`

   * `library_test.LibraryPageTests`

   * `suggestion_test.SuggestionUnitTests` 
<!--   * `suggestion_services_test.SuggestionIntegrationTests` -->

* Calling `_save_exploration()` via `update_exploration()` in tests. 
* Passing `None` as `change_list`.
* Passing a non-empty commit message to avoid value error that would be raised by `update_exploration()` since the exploration is public.


## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
