### PR TITLE
Fix backend tests

### DIFF
--- a/core/domain/collection_services_test.py
+++ b/core/domain/collection_services_test.py
@@ -888,6 +888,10 @@ class CollectionCreateAndDeleteUnitTests(CollectionServicesUnitTests):
             collection_models.CollectionRightsSnapshotContentModel.get_by_id(
                 collection_rights_snapshot_id))
 
+    def test_deletion_of_multiple_collections_empty(self):
+        """Test that delete_collections with empty list works correctly."""
+        collection_services.delete_collections(self.owner_id, [])
+
     def test_soft_deletion_of_multiple_collections(self):
         """Test that soft deletion of multiple collections works correctly."""
         # TODO(sll): Add tests for deletion of states and version snapshots.

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -723,14 +723,16 @@ def delete_explorations_from_subscribed_users(exploration_ids):
     Args:
         exploration_ids: list(str). The ids of the explorations to delete.
     """
-    if exploration_ids:
-        subscription_models = user_models.UserSubscriptionsModel.query(
-            user_models.UserSubscriptionsModel.activity_ids.IN(exploration_ids)
-        ).fetch()
-        for model in subscription_models:
-            model.activity_ids = [
-                id_ for id_ in model.activity_ids if id_ not in exploration_ids]
-        user_models.UserSubscriptionsModel.put_multi(subscription_models)
+    if not exploration_ids:
+        return
+
+    subscription_models = user_models.UserSubscriptionsModel.query(
+        user_models.UserSubscriptionsModel.activity_ids.IN(exploration_ids)
+    ).fetch()
+    for model in subscription_models:
+        model.activity_ids = [
+            id_ for id_ in model.activity_ids if id_ not in exploration_ids]
+    user_models.UserSubscriptionsModel.put_multi(subscription_models)
 
 
 # Operations on exploration snapshots.

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -723,13 +723,14 @@ def delete_explorations_from_subscribed_users(exploration_ids):
     Args:
         exploration_ids: list(str). The ids of the explorations to delete.
     """
-    subscription_models = user_models.UserSubscriptionsModel.query(
-        user_models.UserSubscriptionsModel.activity_ids.IN(exploration_ids)
-    ).fetch()
-    for model in subscription_models:
-        model.activity_ids = [
-            id_ for id_ in model.activity_ids if id_ not in exploration_ids]
-    user_models.UserSubscriptionsModel.put_multi(subscription_models)
+    if exploration_ids:
+        subscription_models = user_models.UserSubscriptionsModel.query(
+            user_models.UserSubscriptionsModel.activity_ids.IN(exploration_ids)
+        ).fetch()
+        for model in subscription_models:
+            model.activity_ids = [
+                id_ for id_ in model.activity_ids if id_ not in exploration_ids]
+        user_models.UserSubscriptionsModel.put_multi(subscription_models)
 
 
 # Operations on exploration snapshots.

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -559,6 +559,11 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
             exp_models.ExplorationRightsSnapshotContentModel.get_by_id(
                 exp_rights_snapshot_id))
 
+    def test_deletion_of_multiple_explorations_empty(self):
+        """Test that delete_explorations with empty list works correctly."""
+        exp_services.delete_explorations(self.owner_id, [])
+        self.process_and_flush_pending_tasks()
+
     def test_soft_deletion_of_multiple_explorations(self):
         """Test that soft deletion of explorations works correctly."""
         # TODO(sll): Add tests for deletion of states and version snapshots.

--- a/core/domain/wipeout_jobs_one_off_test.py
+++ b/core/domain/wipeout_jobs_one_off_test.py
@@ -62,6 +62,7 @@ class UserDeletionOneOffJobTests(test_utils.GenericTestBase):
             id=self.user_1_id, exploration_ids=[], collection_ids=[]
         ).put()
         wipeout_service.pre_delete_user(self.user_1_id)
+        self.process_and_flush_pending_tasks()
 
     def test_repeated_migration(self):
         output = self._run_one_off_job()
@@ -123,6 +124,7 @@ class VerifyUserDeletionOneOffJobTests(test_utils.GenericTestBase):
             id=self.user_1_id, exploration_ids=[], collection_ids=[]
         ).put()
         wipeout_service.pre_delete_user(self.user_1_id)
+        self.process_and_flush_pending_tasks()
 
     def test_not_deleted(self):
         output = self._run_one_off_job()


### PR DESCRIPTION
## Explanation
Delete multi introduced deferred job for deleting explorations form subscribed users, that needs to be flushed in the tests for wipeout one-off jobs. Also, the  
`delete_explorations_from_subscribed_users` function failed with empty list.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
