### PR TITLE
Stop indexing the cached last_nonempty_message_text

### DIFF
--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -78,7 +78,7 @@ class GeneralFeedbackThreadModel(base_models.BaseModel):
     message_count = ndb.IntegerProperty(indexed=True, default=0)
     # Cached text of the last message in the thread with non-empty content, or
     # None if there is no such message.
-    last_nonempty_message_text = ndb.StringProperty(indexed=True)
+    last_nonempty_message_text = ndb.StringProperty(indexed=False)
     # Cached ID for the user of the last message in the thread with non-empty
     # content, or None if the message was made anonymously or if there is no
     # such message.

--- a/core/storage/feedback/gae_models.py
+++ b/core/storage/feedback/gae_models.py
@@ -78,7 +78,7 @@ class GeneralFeedbackThreadModel(base_models.BaseModel):
     message_count = ndb.IntegerProperty(indexed=True, default=0)
     # Cached text of the last message in the thread with non-empty content, or
     # None if there is no such message.
-    last_nonempty_message_text = ndb.StringProperty(indexed=False)
+    last_nonempty_message_text = ndb.TextProperty(indexed=False)
     # Cached ID for the user of the last message in the thread with non-empty
     # content, or None if the message was made anonymously or if there is no
     # such message.
@@ -228,6 +228,9 @@ class GeneralFeedbackMessageModel(base_models.BaseModel):
     # rest of the thread, should exist only when the subject changes.
     updated_subject = ndb.StringProperty(indexed=False)
     # Message text. Allowed not to exist (e.g. post only to update the status).
+    # TODO(#8368): String properties have a size limit of 1500 bytes according
+    # to the GAE API. We should investigate the effort required to use
+    # ndb.TextProperty instead.
     text = ndb.StringProperty(indexed=False)
     # Whether the incoming message is received by email (as opposed to via
     # the web).

--- a/core/storage/feedback/gae_models_test.py
+++ b/core/storage/feedback/gae_models_test.py
@@ -147,6 +147,11 @@ class FeedbackThreadModelTest(test_utils.GenericTestBase):
         }
         self.assertEqual(user_data, test_data)
 
+    def test_message_cache_supports_huge_text(self):
+        self.feedback_thread_model.last_nonempty_message_text = 'X' * 2000
+        # Storing the model should not throw.
+        self.feedback_thread_model.put()
+
 
 class GeneralFeedbackMessageModelTests(test_utils.GenericTestBase):
     """Tests for the GeneralFeedbackMessageModel class."""


### PR DESCRIPTION
Indexed properties need to be <= 1500 bytes in size, but some messages on Oppia exceed this. To allow the cache to remain part of the Thread class, we stop indexing on the text and add a unit test (this is its' output before this PR: https://pastebin.com/rFHv48Ub) to ensure that such large sizes are permitted.