### PR TITLE
Fix #8375: Add check for _submitAnswerFn

### DIFF
--- a/core/templates/dev/head/pages/exploration-player-page/services/current-interaction.service.spec.ts
+++ b/core/templates/dev/head/pages/exploration-player-page/services/current-interaction.service.spec.ts
@@ -101,15 +101,28 @@ describe('Current Interaction Service', function() {
     var dummyValidityCheckFn = function() {
       return false;
     };
+    var dummySubmitAnswerFn = function() {
+      return false;
+    };
     CurrentInteractionService.registerCurrentInteraction(
-      null, dummyValidityCheckFn);
+      dummySubmitAnswerFn, dummyValidityCheckFn);
     expect(CurrentInteractionService.isSubmitButtonDisabled()).toBe(
       !dummyValidityCheckFn());
   });
 
   it('should handle case where validityCheckFn is null', function() {
-    CurrentInteractionService.registerCurrentInteraction(null, null);
+    var dummySubmitAnswerFn = function() {
+      return false;
+    };
+    CurrentInteractionService.registerCurrentInteraction(
+      dummySubmitAnswerFn, null);
     expect(CurrentInteractionService.isSubmitButtonDisabled()).toBe(false);
+  });
+
+  it('should handle case where submitAnswerFn is null', function() {
+    CurrentInteractionService.registerCurrentInteraction(
+      null, null);
+    expect(CurrentInteractionService.isSubmitButtonDisabled()).toBe(true);
   });
 
   it('should properly register and clear presubmit hooks', function() {

--- a/core/templates/dev/head/pages/exploration-player-page/services/current-interaction.service.ts
+++ b/core/templates/dev/head/pages/exploration-player-page/services/current-interaction.service.ts
@@ -108,6 +108,14 @@ angular.module('oppia').factory('CurrentInteractionService', [
         }
       },
       isSubmitButtonDisabled: function() {
+        /* The submit button should be disabled if the current interaction
+         * did not register a _submitAnswerFn. This could occur in
+         * low-bandwidth scenarios where the interaction has not finished
+         * loading.
+         */
+        if (_submitAnswerFn === null) {
+          return true;
+        }
         /* Returns whether or not the Submit button should be disabled based on
          * the validity of the current answer. If the interaction does not pass
          * in a _validityCheckFn, then _validityCheckFn will be null and by


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #8375: A check for _submitAnswerFn ensures that the submit button is disabled if the interaction has not yet loaded.

This should also fix #6921.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
