### PR TITLE
Fix pylint linter decoding error.

### DIFF
--- a/core/controllers/acl_decorators_test.py
+++ b/core/controllers/acl_decorators_test.py
@@ -1859,8 +1859,11 @@ class EditTopicDecoratorTests(test_utils.GenericTestBase):
             debug=feconf.DEBUG,
         ))
         self.save_new_topic(
-            self.topic_id, self.viewer_id, 'Name', 'abbrev', None,
-            'Description', [], [], [], [], 1)
+            self.topic_id, self.viewer_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=1)
         topic_services.create_new_topic_rights(self.topic_id, self.admin_id)
         topic_services.assign_role(
             self.admin, self.manager, topic_domain.ROLE_MANAGER, self.topic_id)
@@ -1926,8 +1929,11 @@ class EditStoryDecoratorTests(test_utils.GenericTestBase):
             self.story_id, self.admin_id, 'Title', 'Description', 'Notes',
             self.topic_id)
         self.save_new_topic(
-            self.topic_id, self.admin_id, 'Name', 'abbrev', None,
-            'Description', [self.story_id], [], [], [], 1)
+            self.topic_id, self.admin_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[self.story_id],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=1)
         topic_services.create_new_topic_rights(self.topic_id, self.admin_id)
 
     def test_can_not_edit_story_with_invalid_story_id(self):
@@ -2015,8 +2021,11 @@ class AddStoryToTopicTests(test_utils.GenericTestBase):
             debug=feconf.DEBUG,
         ))
         self.save_new_topic(
-            self.topic_id, self.viewer_id, 'Name', 'abbrev', None,
-            'Description', [], [], [], [], 1)
+            self.topic_id, self.viewer_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=1)
         topic_services.create_new_topic_rights(self.topic_id, self.admin_id)
         topic_services.assign_role(
             self.admin, self.manager, topic_domain.ROLE_MANAGER, self.topic_id)
@@ -2099,8 +2108,11 @@ class StoryViewerTests(test_utils.GenericTestBase):
             self.story_id, self.admin_id, 'Title', 'Description', 'Notes',
             self.topic_id)
         self.save_new_topic(
-            self.topic_id, self.admin_id, 'Name', 'abbrev', None,
-            'Description', [self.story_id], [], [], [], 1)
+            self.topic_id, self.admin_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[self.story_id],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=1)
 
     def test_cannot_access_non_existent_story(self):
         with self.swap(self, 'testapp', self.mock_testapp):
@@ -2807,8 +2819,11 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
         self.login(self.ADMIN_EMAIL)
         topic_id = topic_services.get_new_topic_id()
         self.save_new_topic(
-            topic_id, self.admin_id, 'Name', 'abbrev', None,
-            'Description', [], [], [], [], 1)
+            topic_id, self.admin_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=1)
         with self.swap(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_TOPIC, topic_id))
@@ -2819,7 +2834,7 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
     def test_can_edit_skill(self):
         self.login(self.ADMIN_EMAIL)
         skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id, self.admin_id, 'Description')
+        self.save_new_skill(skill_id, self.admin_id, description='Description')
         with self.swap(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_SKILL, skill_id))
@@ -2835,8 +2850,11 @@ class EditEntityDecoratorTests(test_utils.GenericTestBase):
             story_id, self.admin_id, 'Title', 'Description', 'Notes',
             topic_id)
         self.save_new_topic(
-            topic_id, self.admin_id, 'Name', 'abbrev', None,
-            'Description', [story_id], [], [], [], 1)
+            topic_id, self.admin_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[story_id],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=1)
         with self.swap(self, 'testapp', self.mock_testapp):
             response = self.get_json('/mock_edit_entity/%s/%s' % (
                 feconf.ENTITY_TYPE_STORY, story_id))

--- a/core/controllers/admin_test.py
+++ b/core/controllers/admin_test.py
@@ -872,8 +872,11 @@ class AdminRoleHandlerTest(test_utils.GenericTestBase):
 
         topic_id = topic_services.get_new_topic_id()
         self.save_new_topic(
-            topic_id, user_id, 'Name', 'abbrev', None,
-            'Description', [], [], [], [], 1)
+            topic_id, user_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=1)
 
         self.login(self.ADMIN_EMAIL, is_super_admin=True)
 

--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -160,7 +160,7 @@ class BaseHandler(webapp2.RequestHandler):
             if user_settings.deleted:
                 self.user_is_scheduled_for_deletion = user_settings.deleted
             elif (self.REDIRECT_UNFINISHED_SIGNUPS and not
-                    user_services.has_fully_registered(user_settings.user_id)):
+                  user_services.has_fully_registered(user_settings.user_id)):
                 self.partially_logged_in = True
             else:
                 self.username = user_settings.username

--- a/core/controllers/community_dashboard_test.py
+++ b/core/controllers/community_dashboard_test.py
@@ -18,7 +18,6 @@ from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 from core.domain import exp_domain
 from core.domain import exp_services
-from core.domain import skill_services
 from core.domain import story_domain
 from core.domain import story_services
 from core.domain import topic_domain
@@ -73,7 +72,8 @@ class ContributionOpportunitiesHandlerTest(test_utils.GenericTestBase):
         self.skill_id_1 = 'skill_id_1'
         self.skill_ids = [self.skill_id_0, self.skill_id_1]
         for skill_id in self.skill_ids:
-            self.save_new_skill(skill_id, self.admin_id, 'skill_description')
+            self.save_new_skill(
+                skill_id, self.admin_id, description='skill_description')
             topic_services.add_uncategorized_skill(
                 self.admin_id, '0', skill_id)
 

--- a/core/controllers/concept_card_viewer_test.py
+++ b/core/controllers/concept_card_viewer_test.py
@@ -60,11 +60,11 @@ class ConceptCardDataHandlerTest(test_utils.GenericTestBase):
         self.admin = user_services.UserActionsInfo(self.admin_id)
         self.skill_id = skill_services.get_new_skill_id()
         self.save_new_skill(
-            self.skill_id, self.admin_id, 'Description',
+            self.skill_id, self.admin_id, description='Description',
             skill_contents=self.skill_contents)
         self.skill_id_1 = skill_services.get_new_skill_id()
         self.save_new_skill(
-            self.skill_id_1, self.admin_id, 'Description',
+            self.skill_id_1, self.admin_id, description='Description',
             skill_contents=self.skill_contents_1)
         self.skill_id_2 = skill_services.get_new_skill_id()
 

--- a/core/controllers/feedback_test.py
+++ b/core/controllers/feedback_test.py
@@ -629,8 +629,11 @@ class ThreadListHandlerForTopicsHandlerTests(test_utils.GenericTestBase):
 
         self.topic_id = topic_services.get_new_topic_id()
         self.save_new_topic(
-            self.topic_id, self.owner_id, 'Name', 'abbrev', None,
-            'Description', [], [], [], [], 1)
+            self.topic_id, self.owner_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=1)
 
     def test_get_feedback_threads_linked_to_topics(self):
         self.login(self.OWNER_EMAIL)

--- a/core/controllers/practice_sessions_test.py
+++ b/core/controllers/practice_sessions_test.py
@@ -39,8 +39,10 @@ class BasePracticeSessionsControllerTests(test_utils.GenericTestBase):
         self.skill_id1 = 'skill_id_1'
         self.skill_id2 = 'skill_id_2'
 
-        self.save_new_skill(self.skill_id1, self.admin_id, 'Skill 1')
-        self.save_new_skill(self.skill_id2, self.admin_id, 'Skill 2')
+        self.save_new_skill(
+            self.skill_id1, self.admin_id, description='Skill 1')
+        self.save_new_skill(
+            self.skill_id2, self.admin_id, description='Skill 2')
 
         self.topic = topic_domain.Topic.create_default_topic(
             self.topic_id, 'public_topic_name', 'abbrev')

--- a/core/controllers/question_editor_test.py
+++ b/core/controllers/question_editor_test.py
@@ -55,7 +55,8 @@ class BaseQuestionEditorControllerTests(test_utils.GenericTestBase):
         self.editor = user_services.UserActionsInfo(self.editor_id)
 
         self.skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(self.skill_id, self.admin_id, 'Skill Description')
+        self.save_new_skill(
+            self.skill_id, self.admin_id, description='Skill Description')
 
         self.question_id = question_services.get_new_question_id()
         self.question = self.save_new_question(
@@ -271,10 +272,11 @@ class QuestionSkillLinkHandlerTest(BaseQuestionEditorControllerTests):
         """Completes the setup for QuestionSkillLinkHandlerTest."""
         super(QuestionSkillLinkHandlerTest, self).setUp()
         self.skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(self.skill_id, self.admin_id, 'Skill Description')
+        self.save_new_skill(
+            self.skill_id, self.admin_id, description='Skill Description')
         self.skill_id_2 = skill_services.get_new_skill_id()
         self.save_new_skill(
-            self.skill_id_2, self.admin_id, 'Skill Description 2')
+            self.skill_id_2, self.admin_id, description='Skill Description 2')
         self.question_id_2 = question_services.get_new_question_id()
         self.save_new_question(
             self.question_id_2, self.editor_id,

--- a/core/controllers/questions_list_test.py
+++ b/core/controllers/questions_list_test.py
@@ -39,14 +39,19 @@ class BaseQuestionsListControllerTests(test_utils.GenericTestBase):
 
         self.admin = user_services.UserActionsInfo(self.admin_id)
         self.skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(self.skill_id, self.admin_id, 'Skill Description')
+        self.save_new_skill(
+            self.skill_id, self.admin_id, description='Skill Description')
         self.skill_id_2 = skill_services.get_new_skill_id()
         self.save_new_skill(
-            self.skill_id_2, self.admin_id, 'Skill Description 2')
+            self.skill_id_2, self.admin_id, description='Skill Description 2')
         self.topic_id = topic_services.get_new_topic_id()
         self.save_new_topic(
-            self.topic_id, self.admin_id, 'Name', 'abbrev', None,
-            'Description', [], [], [self.skill_id, self.skill_id_2], [], 1)
+            self.topic_id, self.admin_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.skill_id, self.skill_id_2],
+            subtopics=[], next_subtopic_id=1)
         self.skill_id_3 = skill_services.get_new_skill_id()
         changelist = [topic_domain.TopicChange({
             'cmd': topic_domain.CMD_ADD_SUBTOPIC,

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -253,15 +253,18 @@ class ExplorationPretestsUnitTest(test_utils.GenericTestBase):
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
         self.skill_id = skill_services.get_new_skill_id()
         self.save_new_skill(
-            self.skill_id, 'user', 'Description')
+            self.skill_id, 'user', description='Description')
 
     def test_get_exploration_pretests(self):
         super(ExplorationPretestsUnitTest, self).setUp()
         story_id = story_services.get_new_story_id()
         topic_id = topic_services.get_new_topic_id()
         self.save_new_topic(
-            topic_id, 'user', 'Topic', 'abbrev', None, 'A new topic',
-            [], [], [], [], 0)
+            topic_id, 'user', name='Topic',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='A new topic', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=0)
         self.save_new_story(
             story_id, 'user', 'Title', 'Description', 'Notes', topic_id
         )
@@ -349,7 +352,7 @@ class QuestionsUnitTest(test_utils.GenericTestBase):
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
 
         self.skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(self.skill_id, 'user', 'Description')
+        self.save_new_skill(self.skill_id, 'user', description='Description')
 
         self.question_id = question_services.get_new_question_id()
         self.save_new_question(
@@ -381,7 +384,7 @@ class QuestionsUnitTest(test_utils.GenericTestBase):
 
     def test_multiple_skill_id_returns_questions(self):
         skill_id_2 = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id_2, 'user', 'Description')
+        self.save_new_skill(skill_id_2, 'user', description='Description')
 
         question_id_3 = question_services.get_new_question_id()
         self.save_new_question(

--- a/core/controllers/resources_test.py
+++ b/core/controllers/resources_test.py
@@ -149,9 +149,12 @@ class AssetDevHandlerImageTests(test_utils.GenericTestBase):
             story_id, admin_id, 'Title', 'Description', 'Notes',
             topic_id)
         self.save_new_topic(
-            topic_id, admin_id, 'Name', 'abbrev', None,
-            'Description', [story_id], [], [], [subtopic], 2)
-        self.save_new_skill(skill_id, admin_id, 'Description')
+            topic_id, admin_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[story_id],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[subtopic], next_subtopic_id=2)
+        self.save_new_skill(skill_id, admin_id, description='Description')
 
         # Page context: Exploration.
         self.login(self.EDITOR_EMAIL)

--- a/core/controllers/review_tests_test.py
+++ b/core/controllers/review_tests_test.py
@@ -67,8 +67,8 @@ class BaseReviewTestsControllerTests(test_utils.GenericTestBase):
             'exploration_id': self.exp_id
         }
 
-        self.save_new_skill('skill_id_1', self.admin_id, 'Skill 1')
-        self.save_new_skill('skill_id_2', self.admin_id, 'Skill 2')
+        self.save_new_skill('skill_id_1', self.admin_id, description='Skill 1')
+        self.save_new_skill('skill_id_2', self.admin_id, description='Skill 2')
 
         self.story = story_domain.Story.create_default_story(
             self.story_id_1, 'Public Story Title', self.topic_id)
@@ -83,9 +83,12 @@ class BaseReviewTestsControllerTests(test_utils.GenericTestBase):
             self.story_id_2, 'Private Story Title', self.topic_id)
         story_services.save_new_story(self.admin_id, self.story_2)
         self.save_new_topic(
-            self.topic_id, 'user', 'Topic', 'abbrev', None,
-            'A new topic', [self.story_id_1, self.story_id_3],
-            [], [], [], 0)
+            self.topic_id, 'user', name='Topic',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='A new topic',
+            canonical_story_ids=[self.story_id_1, self.story_id_3],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=0)
         topic_services.publish_topic(self.topic_id, self.admin_id)
         topic_services.publish_story(
             self.topic_id, self.story_id_1, self.admin_id)

--- a/core/controllers/skill_editor_test.py
+++ b/core/controllers/skill_editor_test.py
@@ -44,13 +44,18 @@ class BaseSkillEditorControllerTests(test_utils.GenericTestBase):
 
         self.admin = user_services.UserActionsInfo(self.admin_id)
         self.skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(self.skill_id, self.admin_id, 'Description')
+        self.save_new_skill(
+            self.skill_id, self.admin_id, description='Description')
         self.skill_id_2 = skill_services.get_new_skill_id()
-        self.save_new_skill(self.skill_id_2, self.admin_id, 'Description')
+        self.save_new_skill(
+            self.skill_id_2, self.admin_id, description='Description')
         self.topic_id = topic_services.get_new_topic_id()
         self.save_new_topic(
-            self.topic_id, self.admin_id, 'Name', 'abbrev', None,
-            'Description', [], [], [self.skill_id], [], 1)
+            self.topic_id, self.admin_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[self.skill_id],
+            subtopics=[], next_subtopic_id=1)
 
     def delete_skill_model_and_memcache(self, user_id, skill_id):
         """Deletes skill model and memcache corresponding to the given skill

--- a/core/controllers/skill_mastery_test.py
+++ b/core/controllers/skill_mastery_test.py
@@ -32,10 +32,10 @@ class SkillMasteryDataHandlerTest(test_utils.GenericTestBase):
 
         self.skill_id_1 = skill_services.get_new_skill_id()
         self.save_new_skill(
-            self.skill_id_1, self.user_id, 'Skill Description 1')
+            self.skill_id_1, self.user_id, description='Skill Description 1')
         self.skill_id_2 = skill_services.get_new_skill_id()
         self.save_new_skill(
-            self.skill_id_2, self.user_id, 'Skill Description 2')
+            self.skill_id_2, self.user_id, description='Skill Description 2')
 
         self.degree_of_mastery_1 = 0.3
         self.degree_of_mastery_2 = 0.5

--- a/core/controllers/story_editor_test.py
+++ b/core/controllers/story_editor_test.py
@@ -44,8 +44,11 @@ class BaseStoryEditorControllerTests(test_utils.GenericTestBase):
             self.story_id, self.admin_id, 'Title', 'Description', 'Notes',
             self.topic_id)
         self.save_new_topic(
-            self.topic_id, self.admin_id, 'Name', 'abbrev', None,
-            'Description', [self.story_id], [], [], [], 1)
+            self.topic_id, self.admin_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[self.story_id],
+            additional_story_ids=[], uncategorized_skill_ids=[], subtopics=[],
+            next_subtopic_id=1)
 
 
 class StoryPublicationTests(BaseStoryEditorControllerTests):
@@ -186,8 +189,11 @@ class StoryEditorTests(BaseStoryEditorControllerTests):
             expected_status_int=404)
 
         self.save_new_topic(
-            'topic_id_new', self.admin_id, 'Name 2', 'abbrev', None,
-            'Description', [], [], [], [], 1)
+            'topic_id_new', self.admin_id, name='Name 2',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[], subtopics=[],
+            next_subtopic_id=1)
 
         # An error would be raised here also as the story is not in the given
         # topic.
@@ -260,8 +266,11 @@ class StoryEditorTests(BaseStoryEditorControllerTests):
         # Raises error 404 even when topic is saved as the story id is not
         # associated with the new topic.
         self.save_new_topic(
-            'topic_id_new', self.admin_id, 'Name 2', 'abbrev', None,
-            'Description', [], [], [], [], 1)
+            'topic_id_new', self.admin_id, name='Name 2',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[], subtopics=[],
+            next_subtopic_id=1)
         csrf_token = self.get_new_csrf_token()
 
         self.put_json(

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -111,7 +111,7 @@ class BaseStoryViewerControllerTests(test_utils.GenericTestBase):
             self.TOPIC_ID, 'user', name='Topic',
             abbreviated_name='abbrev', thumbnail_filename=None,
             description='A new topic', canonical_story_ids=[story.id],
-            additional_story_ids=[], uncategorized_skill_ids=[self.skill_id],
+            additional_story_ids=[], uncategorized_skill_ids=[],
             subtopics=[], next_subtopic_id=0)
         topic_services.publish_topic(self.TOPIC_ID, self.admin_id)
         topic_services.publish_story(

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -108,8 +108,11 @@ class BaseStoryViewerControllerTests(test_utils.GenericTestBase):
         story.story_contents.next_node_id = 'node_4'
         story_services.save_new_story(self.admin_id, story)
         self.save_new_topic(
-            self.TOPIC_ID, 'user', 'Topic', 'abbrev', None,
-            'A new topic', [story.id], [], [], [], 0)
+            self.TOPIC_ID, 'user', name='Topic',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='A new topic', canonical_story_ids=[story.id],
+            additional_story_ids=[], uncategorized_skill_ids=[self.skill_id],
+            subtopics=[], next_subtopic_id=0)
         topic_services.publish_topic(self.TOPIC_ID, self.admin_id)
         topic_services.publish_story(
             self.TOPIC_ID, self.STORY_ID, self.admin_id)
@@ -171,8 +174,11 @@ class StoryPageDataHandlerTests(BaseStoryViewerControllerTests):
     def test_can_not_access_story_viewer_page_with_unpublished_topic(self):
         new_story_id = 'new_story_id'
         self.save_new_topic(
-            'topic_id_1', 'user', 'Topic 2', 'abbrev', None,
-            'A new topic', [new_story_id], [], [], [], 0)
+            'topic_id_1', 'user', name='Topic 2',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='A new topic', canonical_story_ids=[new_story_id],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=0)
         story = story_domain.Story.create_default_story(
             new_story_id, 'Title', 'topic_id_1')
         story_services.save_new_story(self.admin_id, story)

--- a/core/controllers/subtopic_viewer_test.py
+++ b/core/controllers/subtopic_viewer_test.py
@@ -62,12 +62,19 @@ class BaseSubtopicViewerControllerTests(test_utils.GenericTestBase):
         subtopic = topic_domain.Subtopic.create_default_subtopic(
             1, 'Subtopic Title')
         self.save_new_topic(
-            self.topic_id, self.admin_id, 'Name', 'abbrev', None,
-            'Description', [], [], [], [subtopic], 2)
+            self.topic_id, self.admin_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[subtopic], next_subtopic_id=2)
         topic_services.publish_topic(self.topic_id, self.admin_id)
         self.save_new_topic(
-            'topic_id_2', self.admin_id, 'Private_Name', 'abbrev', None,
-            'Description', [], [], [], [subtopic], 2)
+            'topic_id_2', self.admin_id, name='Private_Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[],
+            subtopics=[subtopic], next_subtopic_id=2)
         self.recorded_voiceovers_dict = {
             'voiceovers_mapping': {
                 'content': {

--- a/core/controllers/suggestion_test.py
+++ b/core/controllers/suggestion_test.py
@@ -617,7 +617,7 @@ class QuestionSuggestionTests(test_utils.GenericTestBase):
         self.author_id = self.get_user_id_from_email(self.AUTHOR_EMAIL)
         self.set_admins([self.ADMIN_USERNAME])
         self.save_new_skill(
-            self.SKILL_ID, self.admin_id, self.SKILL_DESCRIPTION)
+            self.SKILL_ID, self.admin_id, description=self.SKILL_DESCRIPTION)
         self.question_dict = {
             'question_state_data': self._create_valid_question_data(
                 'default_state').to_dict(),
@@ -727,7 +727,8 @@ class SkillSuggestionTests(test_utils.GenericTestBase):
         self.set_admins([self.ADMIN_USERNAME])
 
         self.skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(self.skill_id, self.admin_id, 'Description')
+        self.save_new_skill(
+            self.skill_id, self.admin_id, description='Description')
 
         self.question_dict = {
             'question_state_data': self._create_valid_question_data(
@@ -996,7 +997,7 @@ class UserSubmittedSuggestionsHandlerTest(test_utils.GenericTestBase):
             })], 'Changes.')
 
         self.save_new_skill(
-            self.SKILL_ID, self.owner_id, self.SKILL_DESCRIPTION)
+            self.SKILL_ID, self.owner_id, description=self.SKILL_DESCRIPTION)
 
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
@@ -1168,7 +1169,7 @@ class ReviewableSuggestionsHandlerTest(test_utils.GenericTestBase):
             })], 'Changes.')
 
         self.save_new_skill(
-            self.SKILL_ID, self.owner_id, self.SKILL_DESCRIPTION)
+            self.SKILL_ID, self.owner_id, description=self.SKILL_DESCRIPTION)
 
         self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
         self.editor_id = self.get_user_id_from_email(self.EDITOR_EMAIL)

--- a/core/controllers/topic_editor_test.py
+++ b/core/controllers/topic_editor_test.py
@@ -49,14 +49,19 @@ class BaseTopicEditorControllerTests(test_utils.GenericTestBase):
         self.admin = user_services.UserActionsInfo(self.admin_id)
         self.new_user = user_services.UserActionsInfo(self.new_user_id)
         self.skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(self.skill_id, self.admin_id, 'Skill Description')
+        self.save_new_skill(
+            self.skill_id, self.admin_id, description='Skill Description')
         self.skill_id_2 = skill_services.get_new_skill_id()
         self.save_new_skill(
-            self.skill_id_2, self.admin_id, 'Skill Description 2')
+            self.skill_id_2, self.admin_id, description='Skill Description 2')
         self.topic_id = topic_services.get_new_topic_id()
         self.save_new_topic(
-            self.topic_id, self.admin_id, 'Name', 'abbrev', None,
-            'Description', [], [], [self.skill_id, self.skill_id_2], [], 1)
+            self.topic_id, self.admin_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.skill_id, self.skill_id_2],
+            subtopics=[], next_subtopic_id=1)
         changelist = [topic_domain.TopicChange({
             'cmd': topic_domain.CMD_ADD_SUBTOPIC,
             'title': 'Title',
@@ -84,10 +89,13 @@ class TopicEditorStoryHandlerTests(BaseTopicEditorControllerTests):
         self.assertEqual(response['additional_story_summary_dicts'], [])
 
         self.save_new_topic(
-            topic_id, self.admin_id, 'New name', 'abbrev', None,
-            'New description', [canonical_story_id],
-            [additional_story_id], [self.skill_id],
-            [], 1)
+            topic_id, self.admin_id, name='New name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='New description',
+            canonical_story_ids=[canonical_story_id],
+            additional_story_ids=[additional_story_id],
+            uncategorized_skill_ids=[self.skill_id],
+            subtopics=[], next_subtopic_id=1)
 
         self.save_new_story(
             canonical_story_id, self.admin_id, 'title', 'description',
@@ -520,8 +528,12 @@ class TopicEditorTests(BaseTopicEditorControllerTests):
 
         topic_id_1 = topic_services.get_new_topic_id()
         self.save_new_topic(
-            topic_id_1, self.admin_id, 'Name 1', 'abbrev', None,
-            'Description 1', [], [], [self.skill_id], [], 1)
+            topic_id_1, self.admin_id, name='Name 1',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description 1', canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.skill_id],
+            subtopics=[], next_subtopic_id=1)
 
         json_response = self.put_json(
             '%s/%s' % (

--- a/core/controllers/topic_viewer_test.py
+++ b/core/controllers/topic_viewer_test.py
@@ -70,9 +70,9 @@ class BaseTopicViewerControllerTests(test_utils.GenericTestBase):
             self.topic_id, self.story_id, self.admin_id)
 
         self.save_new_skill(
-            self.skill_id_1, self.user_id, 'Skill Description 1')
+            self.skill_id_1, self.user_id, description='Skill Description 1')
         self.save_new_skill(
-            self.skill_id_2, self.user_id, 'Skill Description 2')
+            self.skill_id_2, self.user_id, description='Skill Description 2')
         skill_services.create_user_skill_mastery(
             self.user_id, self.skill_id_1, 0.3)
         skill_services.create_user_skill_mastery(

--- a/core/controllers/topics_and_skills_dashboard_test.py
+++ b/core/controllers/topics_and_skills_dashboard_test.py
@@ -45,10 +45,14 @@ class BaseTopicsAndSkillsDashboardTests(test_utils.GenericTestBase):
         self.topic_id = topic_services.get_new_topic_id()
         self.linked_skill_id = skill_services.get_new_skill_id()
         self.save_new_skill(
-            self.linked_skill_id, self.admin_id, 'Description 3')
+            self.linked_skill_id, self.admin_id, description='Description 3')
         self.save_new_topic(
-            self.topic_id, self.admin_id, 'Name', 'abbrev', None,
-            'Description', [], [], [self.linked_skill_id], [], 1)
+            self.topic_id, self.admin_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description', canonical_story_ids=[self.story_id],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.linked_skill_id],
+            subtopics=[], next_subtopic_id=1)
 
 
 class TopicsAndSkillsDashboardPageDataHandlerTests(
@@ -58,7 +62,7 @@ class TopicsAndSkillsDashboardPageDataHandlerTests(
         # Check that non-admins or non-topic managers cannot access the
         # topics and skills dashboard data.
         skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id, self.admin_id, 'Description')
+        self.save_new_skill(skill_id, self.admin_id, description='Description')
         self.login(self.NEW_USER_EMAIL)
         self.get_json(
             feconf.TOPICS_AND_SKILLS_DASHBOARD_DATA_URL,
@@ -304,7 +308,8 @@ class MergeSkillHandlerTests(BaseTopicsAndSkillsDashboardTests):
 
         old_skill_id = self.linked_skill_id
         new_skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(new_skill_id, self.admin_id, 'Skill Description')
+        self.save_new_skill(
+            new_skill_id, self.admin_id, description='Skill Description')
         old_links = question_services.get_question_skill_links_of_skill(
             old_skill_id, 'Old Description')
         new_links = question_services.get_question_skill_links_of_skill(
@@ -351,7 +356,8 @@ class MergeSkillHandlerTests(BaseTopicsAndSkillsDashboardTests):
     def test_merge_skill_fails_when_old_skill_id_is_invalid(self):
         self.login(self.ADMIN_EMAIL)
         new_skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(new_skill_id, self.admin_id, 'Skill Description')
+        self.save_new_skill(
+            new_skill_id, self.admin_id, description='Skill Description')
         payload = {
             'old_skill_id': 'invalid_old_skill_id',
             'new_skill_id': new_skill_id

--- a/core/controllers/topics_and_skills_dashboard_test.py
+++ b/core/controllers/topics_and_skills_dashboard_test.py
@@ -49,7 +49,7 @@ class BaseTopicsAndSkillsDashboardTests(test_utils.GenericTestBase):
         self.save_new_topic(
             self.topic_id, self.admin_id, name='Name',
             abbreviated_name='abbrev', thumbnail_filename=None,
-            description='Description', canonical_story_ids=[self.story_id],
+            description='Description', canonical_story_ids=[],
             additional_story_ids=[],
             uncategorized_skill_ids=[self.linked_skill_id],
             subtopics=[], next_subtopic_id=1)

--- a/core/domain/collection_services.py
+++ b/core/domain/collection_services.py
@@ -546,6 +546,7 @@ def get_collection_summaries_subscribed_to(user_id):
         ) if summary is not None
     ]
 
+
 # TODO(bhenning): Update this function to support also matching the query to
 # explorations contained within this collection. Introduce tests to verify this
 # behavior.

--- a/core/domain/collection_services_test.py
+++ b/core/domain/collection_services_test.py
@@ -1099,7 +1099,7 @@ class CollectionCreateAndDeleteUnitTests(CollectionServicesUnitTests):
     def test_save_and_retrieve_collection(self):
         collection = self.save_new_valid_collection(
             self.COLLECTION_0_ID, self.owner_id)
-        collection_services._save_collection(
+        collection_services._save_collection(  # pylint: disable=protected-access
             self.owner_id, collection, '',
             _get_collection_change_list('title', ''))
 
@@ -1112,7 +1112,7 @@ class CollectionCreateAndDeleteUnitTests(CollectionServicesUnitTests):
     def test_save_and_retrieve_collection_summary(self):
         collection = self.save_new_valid_collection(
             self.COLLECTION_0_ID, self.owner_id)
-        collection_services._save_collection(
+        collection_services._save_collection(  # pylint: disable=protected-access
             self.owner_id, collection, '',
             _get_collection_change_list('title', ''))
 
@@ -1485,9 +1485,10 @@ class CommitMessageHandlingTests(CollectionServicesUnitTests):
             'received none.'
             ):
             collection_services.update_collection(
-                self.owner_id, self.COLLECTION_0_ID, _get_collection_change_list(
-                    collection_domain.COLLECTION_PROPERTY_TITLE,
-                    'New Title'), '')
+                self.owner_id, self.COLLECTION_0_ID,
+                _get_collection_change_list(
+                    collection_domain.COLLECTION_PROPERTY_TITLE, 'New Title'),
+                '')
 
     def test_unpublished_collections_can_accept_commit_message(self):
         """Test unpublished collections can accept optional commit messages."""
@@ -1602,7 +1603,7 @@ class CollectionSnapshotUnitTests(CollectionServicesUnitTests):
 
         # Using the old version of the collection should raise an error.
         with self.assertRaisesRegexp(Exception, 'version 1, which is too old'):
-            collection_services._save_collection(
+            collection_services._save_collection(  # pylint: disable=protected-access
                 second_committer_id, v1_collection, '',
                 _get_collection_change_list('title', ''))
 
@@ -1655,7 +1656,7 @@ class CollectionSnapshotUnitTests(CollectionServicesUnitTests):
             self.COLLECTION_0_ID, self.owner_id)
 
         collection.title = 'First title'
-        collection_services._save_collection(
+        collection_services._save_collection(  # pylint: disable=protected-access
             self.owner_id, collection, 'Changed title.',
             _get_collection_change_list('title', 'First title'))
         commit_dict_2 = {
@@ -1673,7 +1674,7 @@ class CollectionSnapshotUnitTests(CollectionServicesUnitTests):
         collection.add_node(
             self.save_new_valid_exploration(
                 'new_exploration_id', self.owner_id).id)
-        collection_services._save_collection(
+        collection_services._save_collection(  # pylint: disable=protected-access
             'committer_id_2', collection, 'Added new exploration',
             _get_added_exploration_change_list('new_exploration_id'))
 
@@ -1703,7 +1704,7 @@ class CollectionSnapshotUnitTests(CollectionServicesUnitTests):
 
         # Now delete the newly added exploration.
         collection.delete_node('new_exploration_id')
-        collection_services._save_collection(
+        collection_services._save_collection(  # pylint: disable=protected-access
             'committer_id_3', collection, 'Deleted exploration',
             _get_deleted_exploration_change_list('new_exploration_id'))
 

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -2658,11 +2658,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v12_dict_to_v13_dict(cls, exploration_dict):
         """Converts a v12 exploration dict into a v13 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v12.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v13.
@@ -2680,11 +2680,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v13_dict_to_v14_dict(cls, exploration_dict):
         """Converts a v13 exploration dict into a v14 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v13.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v14.
@@ -2702,11 +2702,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v14_dict_to_v15_dict(cls, exploration_dict):
         """Converts a v14 exploration dict into a v15 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v14.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v15.
@@ -2724,11 +2724,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v15_dict_to_v16_dict(cls, exploration_dict):
         """Converts a v15 exploration dict into a v16 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v15.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v16.
@@ -2746,11 +2746,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v16_dict_to_v17_dict(cls, exploration_dict):
         """Converts a v16 exploration dict into a v17 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v16.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v17.
@@ -2768,11 +2768,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v17_dict_to_v18_dict(cls, exploration_dict):
         """Converts a v17 exploration dict into a v18 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v17.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v18.
@@ -2792,11 +2792,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v18_dict_to_v19_dict(cls, exploration_dict):
         """Converts a v18 exploration dict into a v19 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v18.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v19.
@@ -2815,11 +2815,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v19_dict_to_v20_dict(cls, exploration_dict):
         """Converts a v19 exploration dict into a v20 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v19.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v20.
@@ -2841,11 +2841,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v20_dict_to_v21_dict(cls, exploration_dict):
         """Converts a v20 exploration dict into a v21 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v20.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v21.
@@ -2865,11 +2865,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v21_dict_to_v22_dict(cls, exploration_dict):
         """Converts a v21 exploration dict into a v22 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v21.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v22.
@@ -2890,11 +2890,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v22_dict_to_v23_dict(cls, exploration_dict):
         """Converts a v22 exploration dict into a v23 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v22.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v23.
@@ -2914,11 +2914,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v23_dict_to_v24_dict(cls, exploration_dict):
         """Converts a v23 exploration dict into a v24 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v23.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v24.
@@ -2938,11 +2938,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v24_dict_to_v25_dict(cls, exploration_dict):
         """Converts a v24 exploration dict into a v25 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v24.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v25.
@@ -2963,11 +2963,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v25_dict_to_v26_dict(cls, exploration_dict):
         """Converts a v25 exploration dict into a v26 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v25.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v26.
@@ -2986,11 +2986,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v26_dict_to_v27_dict(cls, exploration_dict):
         """Converts a v26 exploration dict into a v27 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v26.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v27.
@@ -3010,11 +3010,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v27_dict_to_v28_dict(cls, exploration_dict):
         """Converts a v27 exploration dict into a v28 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v27.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v28.
@@ -3033,11 +3033,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v28_dict_to_v29_dict(cls, exploration_dict):
         """Converts a v28 exploration dict into a v29 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v28.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v29.
@@ -3057,12 +3057,12 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v29_dict_to_v30_dict(cls, exp_id, exploration_dict):
         """Converts a v29 exploration dict into a v30 exploration dict.
-        
+
         Args:
             exp_id: str. ID of the exploration.
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v29.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v30.
@@ -3081,11 +3081,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v30_dict_to_v31_dict(cls, exploration_dict):
         """Converts a v30 exploration dict into a v31 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v30.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v31.
@@ -3105,11 +3105,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v31_dict_to_v32_dict(cls, exploration_dict):
         """Converts a v31 exploration dict into a v32 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v31.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v32.
@@ -3128,11 +3128,11 @@ class Exploration(python_utils.OBJECT):
     @classmethod
     def _convert_v32_dict_to_v33_dict(cls, exploration_dict):
         """Converts a v32 exploration dict into a v33 exploration dict.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v32.
-                
+
         Returns:
             dict. The dict representation of the Exploration domain object,
             following schema version v33.
@@ -3140,7 +3140,7 @@ class Exploration(python_utils.OBJECT):
         Replaces content_ids_to_audio_translations with recorded_voiceovers in
         each state of the exploration.
         """
-        
+
         exploration_dict['schema_version'] = 33
 
         exploration_dict['states'] = cls._convert_states_v27_dict_to_v28_dict(
@@ -3155,7 +3155,7 @@ class Exploration(python_utils.OBJECT):
 
         Adds solicit_answer_details in state to ask learners for the
         answer details.
-        
+
         Args:
             exploration_dict: dict. The dict representation of an exploration
                 with schema version v33.
@@ -3814,4 +3814,3 @@ class ExplorationSummary(python_utils.OBJECT):
             bool. Whether the exploration is solely owned by the user.
         """
         return user_id in self.owner_ids and len(self.owner_ids) == 1
-

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -768,7 +768,8 @@ class ExplorationCreateAndDeleteUnitTests(ExplorationServicesUnitTests):
             })],
             '')
 
-        retrieved_exploration = exp_fetchers.get_exploration_by_id(self.EXP_0_ID)
+        retrieved_exploration = exp_fetchers.get_exploration_by_id(
+            self.EXP_0_ID)
         self.assertEqual(retrieved_exploration.title, 'A title')
         self.assertEqual(retrieved_exploration.category, 'A category')
         self.assertEqual(len(retrieved_exploration.states), 1)
@@ -2083,7 +2084,8 @@ written_translations:
                     'new_value': 'TextInput'
                 })], 'Add state name')
 
-        dict_output = exp_services.export_states_to_yaml(self.EXP_0_ID, width=50)
+        dict_output = exp_services.export_states_to_yaml(
+            self.EXP_0_ID, width=50)
 
         self.assertEqual(dict_output, self.SAMPLE_EXPORTED_DICT)
 

--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -18,7 +18,6 @@ from __future__ import unicode_literals # pylint: disable=import-only-modules
 
 from core import jobs
 from core.domain import feedback_services
-from core.domain import user_services
 from core.platform import models
 
 (feedback_models,) = models.Registry.import_models([models.NAMES.feedback])

--- a/core/domain/fs_domain_test.py
+++ b/core/domain/fs_domain_test.py
@@ -18,7 +18,6 @@
 from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
-from constants import constants
 from core.domain import fs_domain
 from core.platform import models
 from core.tests import test_utils

--- a/core/domain/fs_services_test.py
+++ b/core/domain/fs_services_test.py
@@ -183,9 +183,10 @@ class SaveOriginalAndCompressedVersionsOfImageTests(test_utils.GenericTestBase):
                     micro_image_content),
                 (22, 22))
 
+
 class FileSystemClassifierDataTests(test_utils.GenericTestBase):
     """Unit tests for storing, reading and deleting classifier data."""
-    
+
     def setUp(self):
         super(FileSystemClassifierDataTests, self).setUp()
         self.fs = fs_domain.AbstractFileSystem(
@@ -205,7 +206,7 @@ class FileSystemClassifierDataTests(test_utils.GenericTestBase):
             'exp_id', 'job_id', self.classifier_data)
         classifier_data = fs_services.read_classifier_data('exp_id', 'job_id')
         self.assertEqual(classifier_data, self.classifier_data)
-    
+
     def test_remove_classifier_data(self):
         """Test that classifier data is removed upon deletion."""
         fs_services.save_classifier_data(

--- a/core/domain/html_validation_service_test.py
+++ b/core/domain/html_validation_service_test.py
@@ -1344,7 +1344,6 @@ class ContentMigrationTests(test_utils.GenericTestBase):
         }]
 
         exp_id = 'eid'
-        owner_id = 'Admin'
 
         with python_utils.open_file(
             os.path.join(feconf.TESTS_DATA_DIR, 'img.png'), 'rb',
@@ -1382,7 +1381,6 @@ class ContentMigrationTests(test_utils.GenericTestBase):
         )
 
         exp_id = 'exp_id'
-        owner_id = 'Admin'
 
         with python_utils.open_file(
             os.path.join(feconf.TESTS_DATA_DIR, 'img.png'), 'rb',
@@ -1449,7 +1447,6 @@ class ContentMigrationTests(test_utils.GenericTestBase):
         }]
 
         exp_id = 'eid'
-        owner_id = 'Admin'
 
         with python_utils.open_file(
             os.path.join(feconf.TESTS_DATA_DIR, 'img.png'), 'rb',

--- a/core/domain/opportunity_jobs_one_off_test.py
+++ b/core/domain/opportunity_jobs_one_off_test.py
@@ -373,8 +373,10 @@ class SkillOpportunityModelRegenerationJobTest(test_utils.GenericTestBase):
         self.skill_id_2 = 'skill_2'
         self.skill_desc_2 = 'skill 2'
 
-        self.save_new_skill(self.skill_id_1, self.admin_id, self.skill_desc_1)
-        self.save_new_skill(self.skill_id_2, self.admin_id, self.skill_desc_2)
+        self.save_new_skill(
+            self.skill_id_1, self.admin_id, description=self.skill_desc_1)
+        self.save_new_skill(
+            self.skill_id_2, self.admin_id, description=self.skill_desc_2)
 
     def test_regeneration_job_returns_the_initial_opportunity(self):
         skill_opp_model_regen_job_class = (

--- a/core/domain/opportunity_services_test.py
+++ b/core/domain/opportunity_services_test.py
@@ -385,7 +385,8 @@ class OpportunityServicesIntegrationTest(test_utils.GenericTestBase):
             opportunity_services.get_skill_opportunities(None))
         self.assertEqual(len(skill_opportunities), 0)
 
-        self.save_new_skill(self.SKILL_ID, self.USER_ID, 'skill_description')
+        self.save_new_skill(
+            self.SKILL_ID, self.USER_ID, description='skill_description')
 
         skill_opportunities, _, _ = (
             opportunity_services.get_skill_opportunities(None))
@@ -424,7 +425,8 @@ class OpportunityServicesIntegrationTest(test_utils.GenericTestBase):
                 self.SKILL_ID, 'description')
 
     def test_update_skill_description_updates_skill_opportunity(self):
-        self.save_new_skill(self.SKILL_ID, self.USER_ID, 'skill_description')
+        self.save_new_skill(
+            self.SKILL_ID, self.USER_ID, description='skill_description')
         changelist = [
             skill_domain.SkillChange({
                 'cmd': skill_domain.CMD_UPDATE_SKILL_PROPERTY,
@@ -454,7 +456,8 @@ class OpportunityServicesIntegrationTest(test_utils.GenericTestBase):
         self.assertEqual(len(skill_opportunities), 0)
 
     def test_delete_skill_deletes_skill_opportunity(self):
-        self.save_new_skill(self.SKILL_ID, self.USER_ID, 'skill_description')
+        self.save_new_skill(
+            self.SKILL_ID, self.USER_ID, description='skill_description')
         skill_opportunities, _, _ = (
             opportunity_services.get_skill_opportunities(None))
         self.assertEqual(len(skill_opportunities), 1)

--- a/core/domain/question_fetchers_test.py
+++ b/core/domain/question_fetchers_test.py
@@ -47,9 +47,9 @@ class QuestionFetchersUnitTests(test_utils.GenericTestBase):
         self.editor = user_services.UserActionsInfo(self.editor_id)
 
         self.save_new_skill(
-            'skill_1', self.admin_id, 'Skill Description 1')
+            'skill_1', self.admin_id, description='Skill Description 1')
         self.save_new_skill(
-            'skill_2', self.admin_id, 'Skill Description 2')
+            'skill_2', self.admin_id, description='Skill Description 2')
 
         self.question_id = question_services.get_new_question_id()
         self.question = self.save_new_question(

--- a/core/domain/question_jobs_one_off_test.py
+++ b/core/domain/question_jobs_one_off_test.py
@@ -45,7 +45,8 @@ class QuestionMigrationOneOffJobTests(test_utils.GenericTestBase):
         self.albert_id = self.get_user_id_from_email(self.ALBERT_EMAIL)
         self.process_and_flush_pending_tasks()
         self.skill_id = 'skill_id'
-        self.save_new_skill(self.skill_id, self.albert_id, 'Skill Description')
+        self.save_new_skill(
+            self.skill_id, self.albert_id, description='Skill Description')
 
         self.question = self.save_new_question(
             self.QUESTION_ID, self.albert_id,

--- a/core/domain/question_services_test.py
+++ b/core/domain/question_services_test.py
@@ -60,11 +60,11 @@ class QuestionServicesUnitTest(test_utils.GenericTestBase):
         self.editor = user_services.UserActionsInfo(self.editor_id)
 
         self.save_new_skill(
-            'skill_1', self.admin_id, 'Skill Description 1')
+            'skill_1', self.admin_id, description='Skill Description 1')
         self.save_new_skill(
-            'skill_2', self.admin_id, 'Skill Description 2')
+            'skill_2', self.admin_id, description='Skill Description 2')
         self.save_new_skill(
-            'skill_3', self.admin_id, 'Skill Description 3')
+            'skill_3', self.admin_id, description='Skill Description 3')
 
         self.question_id = question_services.get_new_question_id()
         self.question = self.save_new_question(

--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -63,6 +63,7 @@ CMD_MIGRATE_MISCONCEPTIONS_SCHEMA_TO_LATEST_VERSION = (
 CMD_MIGRATE_RUBRICS_SCHEMA_TO_LATEST_VERSION = (
     'migrate_rubrics_schema_to_latest_version')
 
+
 class SkillChange(change_domain.BaseChange):
     """Domain object for changes made to skill object.
 

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -66,7 +66,7 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
         self.user_admin_2 = user_services.UserActionsInfo(self.user_id_admin_2)
 
         self.skill = self.save_new_skill(
-            self.SKILL_ID, self.USER_ID, 'Description',
+            self.SKILL_ID, self.USER_ID, description='Description',
             misconceptions=misconceptions,
             skill_contents=skill_contents,
             prerequisite_skill_ids=['skill_id_1', 'skill_id_2'])
@@ -101,7 +101,7 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
 
     def test_get_descriptions_of_skills(self):
         self.save_new_skill(
-            'skill_id_1', self.user_id_admin, 'Description 1',
+            'skill_id_1', self.user_id_admin, description='Description 1',
             misconceptions=[],
             skill_contents=skill_domain.SkillContents(
                 state_domain.SubtitledHtml('1', '<p>Explanation</p>'), [
@@ -111,7 +111,7 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
                 state_domain.WrittenTranslations.from_dict(
                     {'translations_mapping': {'1': {}, '2': {}}})))
         self.save_new_skill(
-            'skill_id_2', self.user_id_admin, 'Description 2',
+            'skill_id_2', self.user_id_admin, description='Description 2',
             misconceptions=[],
             skill_contents=skill_domain.SkillContents(
                 state_domain.SubtitledHtml('1', '<p>Explanation</p>'), [
@@ -135,7 +135,7 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
 
     def test_get_rubrics_of_linked_skills(self):
         self.save_new_skill(
-            'skill_id_1', self.user_id_admin, 'Description 1',
+            'skill_id_1', self.user_id_admin, description='Description 1',
             misconceptions=[],
             skill_contents=skill_domain.SkillContents(
                 state_domain.SubtitledHtml('1', '<p>Explanation</p>'), [
@@ -145,7 +145,7 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
                 state_domain.WrittenTranslations.from_dict(
                     {'translations_mapping': {'1': {}, '2': {}}})))
         self.save_new_skill(
-            'skill_id_2', self.user_id_admin, 'Description 2',
+            'skill_id_2', self.user_id_admin, description='Description 2',
             misconceptions=[],
             skill_contents=skill_domain.SkillContents(
                 state_domain.SubtitledHtml('1', '<p>Explanation</p>'), [
@@ -364,7 +364,8 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
 
     def test_get_multi_skills(self):
         self.save_new_skill(
-            'skill_a', self.user_id_admin, 'Description A', misconceptions=[],
+            'skill_a', self.user_id_admin, description='Description A',
+            misconceptions=[],
             skill_contents=skill_domain.SkillContents(
                 state_domain.SubtitledHtml('1', '<p>Explanation</p>'), [
                     state_domain.SubtitledHtml('2', '<p>Example 1</p>')],
@@ -373,7 +374,8 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
                 state_domain.WrittenTranslations.from_dict(
                     {'translations_mapping': {'1': {}, '2': {}}})))
         self.save_new_skill(
-            'skill_b', self.user_id_admin, 'Description B', misconceptions=[],
+            'skill_b', self.user_id_admin, description='Description B',
+            misconceptions=[],
             skill_contents=skill_domain.SkillContents(
                 state_domain.SubtitledHtml('1', '<p>Explanation</p>'), [
                     state_domain.SubtitledHtml('2', '<p>Example 1</p>')],

--- a/core/domain/story_fetchers_test.py
+++ b/core/domain/story_fetchers_test.py
@@ -42,8 +42,11 @@ class StoryFetchersUnitTests(test_utils.GenericTestBase):
         self.STORY_ID = story_services.get_new_story_id()
         self.TOPIC_ID = topic_services.get_new_topic_id()
         self.save_new_topic(
-            self.TOPIC_ID, self.USER_ID, 'Topic', 'abbrev', None,
-            'A new topic', [], [], [], [], 0)
+            self.TOPIC_ID, self.USER_ID, name='Topic',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='A new topic', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=0)
         self.save_new_story(
             self.STORY_ID, self.USER_ID, 'Title', 'Description', 'Notes',
             self.TOPIC_ID)

--- a/core/domain/story_jobs_one_off_test.py
+++ b/core/domain/story_jobs_one_off_test.py
@@ -52,11 +52,13 @@ class StoryMigrationOneOffJobTests(test_utils.GenericTestBase):
         self.skill_id_1 = 'skill_id_1'
         self.skill_id_2 = 'skill_id_2'
         self.save_new_topic(
-            self.TOPIC_ID, self.albert_id, 'Name', 'abbrev', None,
-            'Description', [self.story_id_1, self.story_id_2],
-            [self.story_id_3], [self.skill_id_1, self.skill_id_2],
-            [], 1
-        )
+            self.TOPIC_ID, self.albert_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description',
+            canonical_story_ids=[self.story_id_1, self.story_id_2],
+            additional_story_ids=[self.story_id_3],
+            uncategorized_skill_ids=[self.skill_id_1, self.skill_id_2],
+            subtopics=[], next_subtopic_id=1)
         self.process_and_flush_pending_tasks()
 
     def test_migration_job_does_not_convert_up_to_date_story(self):

--- a/core/domain/story_services_test.py
+++ b/core/domain/story_services_test.py
@@ -46,8 +46,11 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
         self.STORY_ID = story_services.get_new_story_id()
         self.TOPIC_ID = topic_services.get_new_topic_id()
         self.save_new_topic(
-            self.TOPIC_ID, self.USER_ID, 'Topic', 'abbrev', None,
-            'A new topic', [], [], [], [], 0)
+            self.TOPIC_ID, self.USER_ID, name='Topic',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='A new topic', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=0)
         self.save_new_story(
             self.STORY_ID, self.USER_ID, 'Title', 'Description', 'Notes',
             self.TOPIC_ID)
@@ -226,10 +229,13 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
 
     def test_update_story_which_not_corresponding_topic_id(self):
         topic_id = topic_services.get_new_topic_id()
-        self.save_new_topic(
-            topic_id, self.USER_ID, 'A New Topic', 'abbrev', None,
-            'A new topic description.', [], [], [], [], 0)
         story_id = story_services.get_new_story_id()
+        self.save_new_topic(
+            topic_id, self.USER_ID, name='A New Topic',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='A new topic description.', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=0)
         self.save_new_story(
             story_id, self.USER_ID, 'Title', 'Description', 'Notes', topic_id)
 
@@ -478,8 +484,11 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
         topic_id = topic_services.get_new_topic_id()
         story_id = story_services.get_new_story_id()
         self.save_new_topic(
-            topic_id, self.USER_ID, 'A different topic', 'abbrev', None,
-            'A new topic', [], [], [], [], 0)
+            topic_id, self.USER_ID, name='A different topic',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='A new topic', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=0)
         self.save_new_story(
             story_id, self.USER_ID, 'new title', 'Description', 'Notes',
             topic_id)
@@ -748,8 +757,11 @@ class StoryProgressUnitTests(StoryServicesUnitTests):
         self.owner_id = 'owner'
         self.TOPIC_ID = topic_services.get_new_topic_id()
         self.save_new_topic(
-            self.TOPIC_ID, self.USER_ID, 'New Topic', 'abbrev', None,
-            'A new topic', [], [], [], [], 0)
+            self.TOPIC_ID, self.USER_ID, name='New Topic',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='A new topic', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=0)
         story = story_domain.Story.create_default_story(
             self.STORY_1_ID, 'Title', self.TOPIC_ID)
         story.description = ('Description')
@@ -978,8 +990,11 @@ class StoryContentsMigrationTests(test_utils.GenericTestBase):
         topic_id = topic_services.get_new_topic_id()
         user_id = 'user_id'
         self.save_new_topic(
-            topic_id, user_id, 'Topic', 'abbrev', None,
-            'A new topic', [], [], [], [], 0)
+            topic_id, user_id, name='Topic',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='A new topic', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=0)
         self.save_new_story(
             story_id, user_id, 'Title', 'Description', 'Notes',
             topic_id)

--- a/core/domain/suggestion_registry_test.py
+++ b/core/domain/suggestion_registry_test.py
@@ -1254,7 +1254,7 @@ class SuggestionAddQuestionTest(test_utils.GenericTestBase):
             expected_suggestion_dict['score_category'], self.fake_date)
 
         skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id, self.author_id, 'description')
+        self.save_new_skill(skill_id, self.author_id, description='description')
         suggestion.change.skill_id = skill_id
 
         suggestion.pre_accept_validate()
@@ -1278,7 +1278,7 @@ class SuggestionAddQuestionTest(test_utils.GenericTestBase):
             expected_suggestion_dict['score_category'], self.fake_date)
 
         skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id, self.author_id, 'description')
+        self.save_new_skill(skill_id, self.author_id, description='description')
         suggestion.change.skill_id = skill_id
 
         suggestion.pre_accept_validate()
@@ -1307,7 +1307,7 @@ class SuggestionAddQuestionTest(test_utils.GenericTestBase):
             expected_suggestion_dict['score_category'], self.fake_date)
 
         skill_id = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id, self.author_id, 'description')
+        self.save_new_skill(skill_id, self.author_id, description='description')
         suggestion.change.skill_id = skill_id
 
         suggestion.pre_accept_validate()

--- a/core/domain/topic_fetchers_test.py
+++ b/core/domain/topic_fetchers_test.py
@@ -49,11 +49,13 @@ class TopicFetchersUnitTests(test_utils.GenericTestBase):
             'subtopic_id': 1
         })]
         self.save_new_topic(
-            self.TOPIC_ID, self.user_id, 'Name', 'abbrev',
-            'img.png', 'Description',
-            [self.story_id_1, self.story_id_2], [self.story_id_3],
-            [self.skill_id_1, self.skill_id_2], [], 1
-        )
+            self.TOPIC_ID, self.user_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename='img.png',
+            description='Description',
+            canonical_story_ids=[self.story_id_1, self.story_id_2],
+            additional_story_ids=[self.story_id_3],
+            uncategorized_skill_ids=[self.skill_id_1, self.skill_id_2],
+            subtopics=[], next_subtopic_id=1)
         self.save_new_story(
             self.story_id_1, self.user_id, 'Title', 'Description', 'Notes',
             self.TOPIC_ID)
@@ -149,8 +151,11 @@ class TopicFetchersUnitTests(test_utils.GenericTestBase):
     def test_get_topic_by_version(self):
         topic_id = topic_services.get_new_topic_id()
         self.save_new_topic(
-            topic_id, self.user_id, 'topic name',
-            'abbrev', 'img.png', 'Description', [], [], [], [], 1)
+            topic_id, self.user_id, name='topic name',
+            abbreviated_name='abbrev', thumbnail_filename='img.png',
+            description='Description', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=1)
 
         changelist = [topic_domain.TopicChange({
             'cmd': topic_domain.CMD_UPDATE_TOPIC_PROPERTY,

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -25,7 +25,6 @@ from core.domain import exp_fetchers
 from core.domain import opportunity_services
 from core.domain import rights_manager
 from core.domain import role_services
-from core.domain import skill_services
 from core.domain import state_domain
 from core.domain import story_fetchers
 from core.domain import subtopic_page_domain

--- a/core/domain/topic_services_test.py
+++ b/core/domain/topic_services_test.py
@@ -54,10 +54,13 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
             'subtopic_id': 1
         })]
         self.save_new_topic(
-            self.TOPIC_ID, self.user_id, 'Name', 'abbrev', None, 'Description',
-            [self.story_id_1, self.story_id_2], [self.story_id_3],
-            [self.skill_id_1, self.skill_id_2], [], 1
-        )
+            self.TOPIC_ID, self.user_id, name='Name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description',
+            canonical_story_ids=[self.story_id_1, self.story_id_2],
+            additional_story_ids=[self.story_id_3],
+            uncategorized_skill_ids=[self.skill_id_1, self.skill_id_2],
+            subtopics=[], next_subtopic_id=1)
         self.save_new_story(
             self.story_id_1, self.user_id, 'Title', 'Description', 'Notes',
             self.TOPIC_ID)
@@ -226,9 +229,13 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
             'Moved skill to subtopic.')
         topic_id = topic_services.get_new_topic_id()
         self.save_new_topic(
-            topic_id, self.user_id, 'Name 2', 'abbrev', None, 'Description',
-            [], [], [self.skill_id_1, 'skill_3'], [], 1
-        )
+            topic_id, self.user_id, name='Name 2',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description',
+            canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.skill_id_1, 'skill_3'],
+            subtopics=[], next_subtopic_id=1)
         self.assertEqual(
             topic_services.get_all_skill_ids_assigned_to_some_topic(),
             set([self.skill_id_1, self.skill_id_2, 'skill_3']))
@@ -1042,8 +1049,11 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(
             Exception, 'Topic with name \'Name\' already exists'):
             self.save_new_topic(
-                'topic_2', self.user_id, 'Name', 'abbrev', None,
-                'Description 2', [], [], [], [], 1)
+                'topic_2', self.user_id, name='Name',
+                abbreviated_name='abbrev', thumbnail_filename=None,
+                description='Description 2', canonical_story_ids=[],
+                additional_story_ids=[], uncategorized_skill_ids=[],
+                subtopics=[], next_subtopic_id=1)
 
     def test_update_topic_language_code(self):
         topic = topic_fetchers.get_topic_by_id(self.TOPIC_ID)
@@ -1148,11 +1158,17 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
 
     def test_deassign_user_from_all_topics(self):
         self.save_new_topic(
-            'topic_2', self.user_id, 'Name 2', 'abbrev', None, 'Description 2',
-            [], [], [], [], 1)
+            'topic_2', self.user_id, name='Name 2',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description 2', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=1)
         self.save_new_topic(
-            'topic_3', self.user_id, 'Name 3', 'abbrev', None, 'Description 3',
-            [], [], [], [], 1)
+            'topic_3', self.user_id, name='Name 3',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='Description 3', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=1)
 
         topic_services.assign_role(
             self.user_admin, self.user_a,

--- a/core/domain/user_id_migration.py
+++ b/core/domain/user_id_migration.py
@@ -18,7 +18,6 @@ from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import inspect
 
-from constants import constants
 from core import jobs
 from core.platform import models
 import feconf
@@ -434,7 +433,7 @@ class ModelsUserIdsHaveUserSettingsVerificationJob(
             if user_id is None:
                 yield ('SUCCESS_NONE - %s' % model_class.__name__, model.id)
             elif (ModelsUserIdsHaveUserSettingsVerificationJob
-                    ._check_id_and_user_id_exist(model.id, user_id)):
+                  ._check_id_and_user_id_exist(model.id, user_id)):
                 yield ('SUCCESS - %s' % model_class.__name__, model.id)
             else:
                 yield ('FAILURE - %s' % model_class.__name__, model.id)
@@ -450,7 +449,7 @@ class ModelsUserIdsHaveUserSettingsVerificationJob(
             if user_id is None:
                 yield ('SUCCESS_NONE - %s' % model_class.__name__, model.id)
             elif (ModelsUserIdsHaveUserSettingsVerificationJob
-                    ._does_user_settings_model_exist(user_id)):
+                  ._does_user_settings_model_exist(user_id)):
                 yield ('SUCCESS - %s' % model_class.__name__, model.id)
             else:
                 yield ('FAILURE - %s' % model_class.__name__, model.id)

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -218,7 +218,9 @@ class ContinuousComputationEventDispatcher(python_utils.OBJECT):
         classes which listen to events of that type.
 
         Args:
-             event_type: str. The type of the event.
+            event_type: str. The type of the event.
+            args: *. Positional arguments to pass to on_incoming_event().
+            kwargs: *. Keyword arguments to pass to on_incoming_event().
         """
         for klass in ALL_CONTINUOUS_COMPUTATION_MANAGERS:
             if event_type in klass.get_event_types_listened_to():

--- a/core/platform/app_identity/gae_app_identity_services_test.py
+++ b/core/platform/app_identity/gae_app_identity_services_test.py
@@ -24,6 +24,7 @@ from core.tests import test_utils
 
 from google.appengine.api import app_identity
 
+
 class GaeAppIdentityServicesTests(test_utils.GenericTestBase):
 
     def setUp(self):

--- a/core/storage/base_model/gae_models.py
+++ b/core/storage/base_model/gae_models.py
@@ -729,8 +729,9 @@ class VersionedModel(BaseModel):
                 commit_cmds)
 
     @classmethod
-    def delete_multi(cls, entity_ids, committer_id,
-                     commit_message, force_deletion=False):
+    def delete_multi(
+            cls, entity_ids, committer_id, commit_message,
+            force_deletion=False):
         """Deletes the given cls instancies with the given entity_ids.
 
         Args:
@@ -1097,8 +1098,9 @@ class BaseSnapshotMetadataModel(BaseModel):
             keys_only=True) is not None
 
     @classmethod
-    def create(cls, snapshot_id, committer_id, commit_type,
-               commit_message, commit_cmds):
+    def create(
+            cls, snapshot_id, committer_id, commit_type, commit_message,
+            commit_cmds):
         """This method returns an instance of the BaseSnapshotMetadataModel for
         a construct with the common fields filled.
 

--- a/core/storage/collection/gae_models.py
+++ b/core/storage/collection/gae_models.py
@@ -140,8 +140,9 @@ class CollectionModel(base_models.VersionedModel):
         collection_commit_log.put()
 
     @classmethod
-    def delete_multi(cls, entity_ids, committer_id,
-                     commit_message, force_deletion=False):
+    def delete_multi(
+            cls, entity_ids, committer_id, commit_message,
+            force_deletion=False):
         """Deletes the given cls instances with the given entity_ids.
 
         Note that this extends the superclass method.

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -169,8 +169,9 @@ class ExplorationModel(base_models.VersionedModel):
         exploration_commit_log.put()
 
     @classmethod
-    def delete_multi(cls, entity_ids, committer_id,
-                     commit_message, force_deletion=False):
+    def delete_multi(
+            cls, entity_ids, committer_id, commit_message,
+            force_deletion=False):
         """Deletes the given cls instances with the given entity_ids.
 
         Note that this extends the superclass method.
@@ -198,8 +199,10 @@ class ExplorationModel(base_models.VersionedModel):
             exp_rights_models = ExplorationRightsModel.get_multi(
                 entity_ids, include_deleted=True)
             versioned_models = cls.get_multi(entity_ids, include_deleted=True)
-            for model, rights_model in python_utils.ZIP(versioned_models,
-                                                        exp_rights_models):
+
+            versioned_and_exp_rights_models = python_utils.ZIP(
+                versioned_models, exp_rights_models)
+            for model, rights_model in versioned_and_exp_rights_models:
                 exploration_commit_log = ExplorationCommitLogEntryModel.create(
                     model.id, model.version, committer_id, committer_username,
                     cls._COMMIT_TYPE_DELETE,

--- a/core/storage/question/gae_models.py
+++ b/core/storage/question/gae_models.py
@@ -473,7 +473,7 @@ class QuestionSkillLinkModel(base_models.BaseModel):
         """
         question_skill_link_models = cls.query().filter(
             cls.skill_id == skill_id,
-            cls.deleted == False)
+            cls.deleted == False) #pylint: disable=singleton-comparison
         question_ids = [
             model.question_id for model in question_skill_link_models
         ]
@@ -601,12 +601,13 @@ class QuestionSummaryModel(base_models.BaseModel):
         return base_models.DELETION_POLICY.LOCALLY_PSEUDONYMIZE
 
     @classmethod
-    def has_reference_to_user_id(cls, user_id):
+    def has_reference_to_user_id(cls, unused_user_id):
         """Check whether any existing QuestionSummaryModel refers to the given
         user_id.
 
         Args:
-            user_id: str. The ID of the user whose data should be checked.
+            unused_user_id: str. The ID of the user whose data should be
+                checked.
 
         Returns:
             bool. Whether any models refer to the given user_id.

--- a/core/storage/question/gae_models_test.py
+++ b/core/storage/question/gae_models_test.py
@@ -20,8 +20,6 @@ import datetime
 import types
 
 from constants import constants
-from core.domain import question_domain
-from core.domain import question_services
 from core.domain import skill_services
 from core.domain import state_domain
 from core.platform import models
@@ -269,9 +267,9 @@ class QuestionSkillLinkModelUnitTests(test_utils.GenericTestBase):
 
     def test_get_question_skill_links_by_skill_ids(self):
         skill_id_1 = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id_1, 'user', 'Description 1')
+        self.save_new_skill(skill_id_1, 'user', description='Description 1')
         skill_id_2 = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id_2, 'user', 'Description 2')
+        self.save_new_skill(skill_id_2, 'user', description='Description 2')
 
         questionskilllink_model1 = (
             question_models.QuestionSkillLinkModel.create(
@@ -312,13 +310,13 @@ class QuestionSkillLinkModelUnitTests(test_utils.GenericTestBase):
     def test_get_question_skill_links_by_skill_ids_many_skills(self):
         # Test the case when len(skill_ids) > constants.MAX_SKILLS_PER_QUESTION.
         skill_id_1 = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id_1, 'user', 'Description 1')
+        self.save_new_skill(skill_id_1, 'user', description='Description 1')
         skill_id_2 = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id_2, 'user', 'Description 2')
+        self.save_new_skill(skill_id_2, 'user', description='Description 2')
         skill_id_3 = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id_3, 'user', 'Description 3')
+        self.save_new_skill(skill_id_3, 'user', description='Description 3')
         skill_id_4 = skill_services.get_new_skill_id()
-        self.save_new_skill(skill_id_4, 'user', 'Description 4')
+        self.save_new_skill(skill_id_4, 'user', description='Description 4')
 
         questionskilllink_model1 = (
             question_models.QuestionSkillLinkModel.create(

--- a/core/storage/skill/gae_models_test.py
+++ b/core/storage/skill/gae_models_test.py
@@ -19,10 +19,8 @@ from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 from constants import constants
-from core.domain import rights_manager
 from core.platform import models
 from core.tests import test_utils
-import python_utils
 
 (base_models, skill_models) = models.Registry.import_models(
     [models.NAMES.base_model, models.NAMES.skill])
@@ -37,7 +35,7 @@ class SkillModelUnitTest(test_utils.GenericTestBase):
             base_models.DELETION_POLICY.KEEP_IF_PUBLIC)
 
     def test_has_reference_to_user_id(self):
-        self.save_new_skill('skill_id', 'owner_id', 'description')
+        self.save_new_skill('skill_id', 'owner_id', description='description')
         self.assertTrue(
             skill_models.SkillModel.has_reference_to_user_id('owner_id'))
         self.assertFalse(

--- a/core/storage/topic/gae_models_test.py
+++ b/core/storage/topic/gae_models_test.py
@@ -43,8 +43,11 @@ class TopicModelUnitTests(test_utils.GenericTestBase):
 
     def test_has_reference_to_user_id(self):
         self.save_new_topic(
-            'topic_id', 'owner_id', 'name', 'abbrev', None,
-            'description', [], [], [], [], 0)
+            'topic_id', 'owner_id', name='name',
+            abbreviated_name='abbrev', thumbnail_filename=None,
+            description='description', canonical_story_ids=[],
+            additional_story_ids=[], uncategorized_skill_ids=[],
+            subtopics=[], next_subtopic_id=0)
         self.assertTrue(
             topic_models.TopicModel.has_reference_to_user_id('owner_id'))
         self.assertFalse(

--- a/scripts/pylint_extensions.py
+++ b/scripts/pylint_extensions.py
@@ -58,7 +58,7 @@ def read_from_node(node):
     Returns:
         list(str). The data read from the ast node.
     """
-    return list(node.stream().readlines())
+    return list([line.decode('utf-8') for line in node.stream().readlines()])
 
 
 class ExplicitKeywordArgsChecker(checkers.BaseChecker):

--- a/scripts/release_scripts/generate_release_info_test.py
+++ b/scripts/release_scripts/generate_release_info_test.py
@@ -227,13 +227,13 @@ class GenerateReleaseInfoTests(test_utils.GenericTestBase):
             attributes={
                 'title': 'PR2', 'number': 2, 'labels': [
                     {'name': 'CHANGELOG: Test-changes-1 -- @owner1'}]},
-                    completed='')
+            completed='')
         pull3 = github.PullRequest.PullRequest(
             requester='', headers='',
             attributes={
                 'title': 'PR3', 'number': 3, 'labels': [
                     {'name': 'CHANGELOG: Test-changes-2 -- @owner2'}]},
-                    completed='')
+            completed='')
         pull4 = github.PullRequest.PullRequest(
             requester='', headers='',
             attributes={

--- a/utils_test.py
+++ b/utils_test.py
@@ -190,7 +190,7 @@ class UtilsTests(test_utils.GenericTestBase):
         self.assertEqual(p, '.')
         p = utils.vfs_normpath('//foo//bar//baz//')
         self.assertEqual(p, '//foo/bar/baz')
-    
+
     def test_capitalize_string(self):
         test_data = [
             [None, None],


### PR DESCRIPTION
## Explanation

This PR attempts to fix the linter error shown [here](https://circleci.com/gh/Showtim3/oppia/895), which is resulting in the lint checks passing when they should not be. It also fixes all the lint errors that have accumulated since the PR was introduced two months ago.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.