### PR TITLE
Updates to automation scripts to resolve issues faced in previous releases

### DIFF
--- a/release_constants.py
+++ b/release_constants.py
@@ -47,6 +47,9 @@ RELEASE_DRIVE_URL = (
 RELEASE_NOTES_URL = (
     'https://docs.google.com/document/d/'
     '1pmcDNfM2KtmkZeYipuInC48RE5JfkSJWQYdIQAkD0hQ/edit#')
+RELEASE_ROTA_URL = (
+    'https://github.com/oppia/oppia/wiki/Release-Schedule#'
+    'release-coordinators-and-qa-coordinators-for-upcoming-releases')
 
 REPEATABLE_JOBS_SPREADSHEETS_URL = (
     'https://docs.google.com/spreadsheets/d/'

--- a/scripts/release_scripts/generate_release_updates.py
+++ b/scripts/release_scripts/generate_release_updates.py
@@ -146,21 +146,21 @@ def create_group_for_next_release():
     the next release.
     """
     common.open_new_tab_in_browser_if_possible(
-        'https://github.com/oppia/oppia/wiki/Release-Schedule#'
-        'release-coordinators-and-qa-coordinators-for-upcoming-releases')
+        release_constants.RELEASE_ROTA_URL)
     common.ask_user_to_confirm(
-        'Please check the Release co-ordinator & QA Lead for the next '
-        'release and create a new chat group for the next release. '
-        'Add the release co-ordinator, QA Lead, Sean, Ankita & Nithesh to '
-        'the group.')
-    common.ask_user_to_confirm(
-        'Please send the following message to the newly created group:\n\n'
+        'Please do the following two things:\n\n'
+        '1. Create a new chat group for the next release, '
+        'and add the release coordinator, QA lead, Ankita '
+        'and Nithesh to that group. You can find the release schedule '
+        'and coordinators here: %s\n\n'
+        '2. Please send the following message to the newly created group:\n\n'
         'Hi all, This is the group chat for the next release. '
         '[Release co-ordinator\'s name] and [QA Lead\'s name] will be '
         'the release co-ordinator & QA Lead for next release. '
         'Please follow the release process doc: '
         '[Add link to release process doc] to ensure the release '
-        'follows the schedule. Thanks!')
+        'follows the schedule. Thanks!\n' % (
+            release_constants.RELEASE_ROTA_URL))
 
 
 def main():

--- a/scripts/release_scripts/generate_release_updates.py
+++ b/scripts/release_scripts/generate_release_updates.py
@@ -35,6 +35,7 @@ SECTIONS_TO_ADD = [
     '[Add your name]']
 RELEASE_MAIL_MESSAGE_TEMPLATE = (
     'Hi all,\n\n'
+    '   We are happy to announce the release of v%s of Oppia.\n'
     '   The main changes in this release are %s.\n'
     '   %s.\n'
     '   %s\n'
@@ -42,7 +43,7 @@ RELEASE_MAIL_MESSAGE_TEMPLATE = (
     'testing, bug-fixing and QA, as well as %s for leading the QA team for '
     'this release.\n\n'
     'Thanks,\n'
-    '%s\n') % tuple(SECTIONS_TO_ADD)
+    '%s\n')
 
 PARENT_DIR = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
 RELEASE_MAIL_MESSAGE_FILEPATH = os.path.join(
@@ -51,8 +52,11 @@ RELEASE_MAIL_MESSAGE_FILEPATH = os.path.join(
 
 def create_new_file_with_release_message_template():
     """Adds the template message to release mail filepath."""
+    release_version = common.get_current_release_version_number(
+        common.get_current_branch_name())
     with python_utils.open_file(RELEASE_MAIL_MESSAGE_FILEPATH, 'w') as f:
-        f.write(RELEASE_MAIL_MESSAGE_TEMPLATE)
+        f.write(RELEASE_MAIL_MESSAGE_TEMPLATE % (
+            tuple([release_version] + SECTIONS_TO_ADD)))
 
     common.ask_user_to_confirm(
         'Please make updates to following file %s for generating the '
@@ -137,6 +141,28 @@ def prompt_user_to_send_announcement_email():
         'Ensure the email sent to oppia@ is in the Announcements category')
 
 
+def create_group_for_next_release():
+    """Asks the release co-ordinator to create a new chat group for
+    the next release.
+    """
+    common.open_new_tab_in_browser_if_possible(
+        'https://github.com/oppia/oppia/wiki/Release-Schedule#'
+        'release-coordinators-and-qa-coordinators-for-upcoming-releases')
+    common.ask_user_to_confirm(
+        'Please check the Release co-ordinator & QA Lead for the next '
+        'release and create a new chat group for the next release. '
+        'Add the release co-ordinator, QA Lead, Sean, Ankita & Nithesh to '
+        'the group.')
+    common.ask_user_to_confirm(
+        'Please send the following message to the newly created group:\n\n'
+        'Hi all, This is the group chat for the next release. '
+        '[Release co-ordinator\'s name] and [QA Lead\'s name] will be '
+        'the release co-ordinator & QA Lead for next release. '
+        'Please follow the release process doc: '
+        '[Add link to release process doc] to ensure the release '
+        'follows the schedule. Thanks!')
+
+
 def main():
     """Performs task to generate message for release announcement."""
     if not common.is_current_branch_a_release_branch():
@@ -157,6 +183,7 @@ def main():
     finally:
         if os.path.exists(RELEASE_MAIL_MESSAGE_FILEPATH):
             os.remove(RELEASE_MAIL_MESSAGE_FILEPATH)
+    create_group_for_next_release()
 
 
 # The 'no coverage' pragma is used as this line is un-testable. This is because

--- a/scripts/release_scripts/update_changelog_and_credits.py
+++ b/scripts/release_scripts/update_changelog_and_credits.py
@@ -489,8 +489,8 @@ def main():
             release_constants.RELEASE_SUMMARY_FILEPATH))
 
     common.ask_user_to_confirm(
-        'Check emails and names for authors and contributors and '
-        'verify that the emails are '
+        'Check emails and names for authors and contributors in release '
+        'summary file and verify that the emails are '
         'correct through welcome emails sent from welcome@oppia.org '
         '(confirm with Sean in case of doubt).')
     common.open_new_tab_in_browser_if_possible(
@@ -500,14 +500,18 @@ def main():
         'to the contributor list in release summary file.')
     common.ask_user_to_confirm(
         'Categorize the PR titles in the Uncategorized section of the '
-        'changelog, and arrange the changelog to have user-facing '
-        'categories on top.')
+        'changelog in release summary file, and arrange the changelog '
+        'to have user-facing categories on top.')
     common.ask_user_to_confirm(
-        'Verify each item is in the correct section and remove '
-        'trivial changes like "Fix lint errors" from the changelog.')
+        'Verify each item is in the correct section in release summary '
+        'file and remove trivial changes like "Fix lint errors" '
+        'from the changelog.')
     common.ask_user_to_confirm(
-        'Ensure that all items in changelog start with a '
-        'verb in simple present tense.')
+        'Ensure that all items in changelog in release summary file '
+        'start with a verb in simple present tense.')
+    common.ask_user_to_confirm(
+        'Please save the release summary file with all the changes that '
+        'you have made.')
 
     release_summary_lines = []
     with python_utils.open_file(

--- a/scripts/release_scripts/update_changelog_and_credits.py
+++ b/scripts/release_scripts/update_changelog_and_credits.py
@@ -489,7 +489,7 @@ def main():
             release_constants.RELEASE_SUMMARY_FILEPATH))
 
     common.ask_user_to_confirm(
-        'Check emails and names for authors and contributors in release '
+        'Check emails and names for authors and contributors in the release '
         'summary file and verify that the emails are '
         'correct through welcome emails sent from welcome@oppia.org '
         '(confirm with Sean in case of doubt).')
@@ -497,17 +497,17 @@ def main():
         release_constants.CREDITS_FORM_URL)
     common.ask_user_to_confirm(
         'Check the credits form and add any additional contributors '
-        'to the contributor list in release summary file.')
+        'to the contributor list in the release summary file.')
     common.ask_user_to_confirm(
         'Categorize the PR titles in the Uncategorized section of the '
-        'changelog in release summary file, and arrange the changelog '
+        'changelog in the release summary file, and arrange the changelog '
         'to have user-facing categories on top.')
     common.ask_user_to_confirm(
-        'Verify each item is in the correct section in release summary '
+        'Verify each item is in the correct section in the release summary '
         'file and remove trivial changes like "Fix lint errors" '
         'from the changelog.')
     common.ask_user_to_confirm(
-        'Ensure that all items in changelog in release summary file '
+        'Ensure that all items in changelog in the release summary file '
         'start with a verb in simple present tense.')
     common.ask_user_to_confirm(
         'Please save the release summary file with all the changes that '


### PR DESCRIPTION
## Explanation
- Updates the release update mail message
- Adds a new function to ensure that a new group is created for next release after wrapping up the release
- Makes the instructions to update release summary file clear

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
