### PR TITLE
Fix frontend test timeout

### DIFF
--- a/core/tests/karma.conf.ts
+++ b/core/tests/karma.conf.ts
@@ -93,7 +93,8 @@ module.exports = function(config) {
     // Kill the browser if it does not capture in the given timeout [ms].
     captureTimeout: 60000,
     browserNoActivityTimeout: 120000,
-    browserDisconnectTimeout: 10000,
+    browserDisconnectTimeout: 20000,
+    browserDisconnectTolerance: 3,
     browserConsoleLogOptions: {
       level: 'log',
       format: '%b %T: %m',

--- a/core/tests/karma.conf.ts
+++ b/core/tests/karma.conf.ts
@@ -92,12 +92,13 @@ module.exports = function(config) {
     browsers: ['CI_Chrome'],
     // Kill the browser if it does not capture in the given timeout [ms].
     captureTimeout: 60000,
+    browserNoActivityTimeout: 120000,
+    browserDisconnectTimeout: 10000,
     browserConsoleLogOptions: {
       level: 'log',
       format: '%b %T: %m',
       terminal: true
     },
-    browserNoActivityTimeout: 120000,
     // Continue running in the background after running tests.
     singleRun: true,
     customLaunchers: {

--- a/core/tests/karma.conf.ts
+++ b/core/tests/karma.conf.ts
@@ -109,7 +109,8 @@ module.exports = function(config) {
         // https://github.com/karma-runner/karma-chrome-launcher/issues/180
         flags: [
           '--no-sandbox',
-          '--disable-gpu'
+          '--disable-gpu',
+          '--js-flags=--max-old-space-size=4096'
         ]
       }
     },


### PR DESCRIPTION
## Explanation
Increase the timeout for reconnecting to browser and garbage memory size.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
