### PR TITLE
Fix instructions in changelog updation

### DIFF
--- a/scripts/release_scripts/update_changelog_and_credits.py
+++ b/scripts/release_scripts/update_changelog_and_credits.py
@@ -489,29 +489,35 @@ def main():
             release_constants.RELEASE_SUMMARY_FILEPATH))
 
     common.ask_user_to_confirm(
-        'Check emails and names for authors and contributors in the release '
-        'summary file and verify that the emails are '
+        'Check emails and names for new authors and new contributors in the '
+        'file: %s and verify that the emails are '
         'correct through welcome emails sent from welcome@oppia.org '
-        '(confirm with Sean in case of doubt).')
+        '(confirm with Sean in case of doubt).' % (
+            release_constants.RELEASE_SUMMARY_FILEPATH))
     common.open_new_tab_in_browser_if_possible(
         release_constants.CREDITS_FORM_URL)
     common.ask_user_to_confirm(
         'Check the credits form and add any additional contributors '
-        'to the contributor list in the release summary file.')
+        'to the contributor list in the file: %s.' % (
+            release_constants.RELEASE_SUMMARY_FILEPATH))
     common.ask_user_to_confirm(
         'Categorize the PR titles in the Uncategorized section of the '
-        'changelog in the release summary file, and arrange the changelog '
-        'to have user-facing categories on top.')
+        'changelog in the file: %s, and arrange the changelog '
+        'to have user-facing categories on top.' % (
+            release_constants.RELEASE_SUMMARY_FILEPATH))
     common.ask_user_to_confirm(
-        'Verify each item is in the correct section in the release summary '
-        'file and remove trivial changes like "Fix lint errors" '
-        'from the changelog.')
+        'Verify each item is in the correct section in the '
+        'file: %s and remove trivial changes like "Fix lint errors" '
+        'from the changelog.' % (
+            release_constants.RELEASE_SUMMARY_FILEPATH))
     common.ask_user_to_confirm(
-        'Ensure that all items in changelog in the release summary file '
-        'start with a verb in simple present tense.')
+        'Ensure that all items in changelog in the file: %s '
+        'start with a verb in simple present tense.' % (
+            release_constants.RELEASE_SUMMARY_FILEPATH))
     common.ask_user_to_confirm(
-        'Please save the release summary file with all the changes that '
-        'you have made.')
+        'Please save the file: %s with all the changes that '
+        'you have made.' % (
+            release_constants.RELEASE_SUMMARY_FILEPATH))
 
     release_summary_lines = []
     with python_utils.open_file(


### PR DESCRIPTION
## Explanation
Makes instructions clear in `update_changelog_and_credits` file

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
