### PR TITLE
Modify release info generation for release summary to be generated independently 

### DIFF
--- a/scripts/release_scripts/generate_release_info.py
+++ b/scripts/release_scripts/generate_release_info.py
@@ -296,9 +296,6 @@ def main(personal_access_token):
     g = github.Github(personal_access_token)
     repo = g.get_organization('oppia').get_repo('oppia')
 
-    common.check_blocking_bug_issue_count(repo)
-    common.check_prs_for_current_release_are_released(repo)
-
     current_release = get_current_version_tag(repo)
     current_release_tag = current_release.name
     base_commit = current_release.commit.sha
@@ -403,3 +400,10 @@ def main(personal_access_token):
 
     python_utils.PRINT('Done. Summary file generated in %s' % (
         release_constants.RELEASE_SUMMARY_FILEPATH))
+
+
+# The 'no coverage' pragma is used as this line is un-testable. This is because
+# it will only be called when generate_release_info.py is used as
+# a script.
+if __name__ == '__main__': # pragma: no cover
+    main(common.get_personal_access_token())

--- a/scripts/release_scripts/generate_release_info_test.py
+++ b/scripts/release_scripts/generate_release_info_test.py
@@ -315,10 +315,6 @@ class GenerateReleaseInfoTests(test_utils.GenericTestBase):
         self.assertEqual(actual_storgae_models, expected_storage_models)
 
     def test_release_summary_content(self):
-        def mock_check_blocking_bug_issue_count(unused_repo):
-            pass
-        def mock_check_prs_for_current_release_are_released(unused_repo):
-            pass
         def mock_get_current_version_tag(unused_repo):
             return github.Tag.Tag(
                 requester='', headers='',
@@ -363,12 +359,6 @@ class GenerateReleaseInfoTests(test_utils.GenericTestBase):
         def mock_get_changelog_categories(unused_pulls):
             return {'category': ['pr1', 'pr2']}
 
-        blocking_bug_swap = self.swap(
-            common, 'check_blocking_bug_issue_count',
-            mock_check_blocking_bug_issue_count)
-        check_prs_swap = self.swap(
-            common, 'check_prs_for_current_release_are_released',
-            mock_check_prs_for_current_release_are_released)
         version_tag_swap = self.swap(
             generate_release_info, 'get_current_version_tag',
             mock_get_current_version_tag)
@@ -403,8 +393,8 @@ class GenerateReleaseInfoTests(test_utils.GenericTestBase):
 
         with self.branch_name_swap, self.open_browser_swap:
             with self.get_organization_swap, self.get_repo_swap:
-                with self.getpass_swap, blocking_bug_swap, check_prs_swap:
-                    with version_tag_swap, extra_commits_swap, get_prs_swap:
+                with self.getpass_swap, version_tag_swap:
+                    with extra_commits_swap, get_prs_swap:
                         with gather_logs_swap, extract_issues_swap:
                             with check_versions_swap, setup_scripts_swap:
                                 with storage_models_swap, release_summary_swap:

--- a/scripts/release_scripts/update_changelog_and_credits.py
+++ b/scripts/release_scripts/update_changelog_and_credits.py
@@ -464,6 +464,13 @@ def main():
 
     personal_access_token = common.get_personal_access_token()
 
+    g = github.Github(personal_access_token)
+    repo = g.get_organization('oppia').get_repo('oppia')
+    repo_fork = g.get_repo('%s/oppia' % github_username)
+
+    common.check_blocking_bug_issue_count(repo)
+    common.check_prs_for_current_release_are_released(repo)
+
     python_utils.PRINT('Generating release summary...')
     generate_release_info.main(personal_access_token)
 
@@ -471,9 +478,6 @@ def main():
         raise Exception(
             'Release summary file %s is missing. Please re-run '
             'this script.' % release_constants.RELEASE_SUMMARY_FILEPATH)
-
-    g = github.Github(personal_access_token)
-    repo_fork = g.get_repo('%s/oppia' % github_username)
 
     current_release_version_number = common.get_current_release_version_number(
         branch_name)


### PR DESCRIPTION
## Explanation
Modifies `generate_release_info` script so that release summary can be generated irrespective of checks like whether all blocking bugs are resolved or not.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
