### PR TITLE
Fix #8202: Wipeout 3.7: Delete GeneralFeedbackThreadUserModel that have user_id equal to None

### DIFF
--- a/core/controllers/feedback.py
+++ b/core/controllers/feedback.py
@@ -89,8 +89,9 @@ class ThreadHandler(base.BaseHandler):
         messages = [m.to_dict() for m in feedback_services.get_messages(
             thread_id)]
         message_ids = [message['message_id'] for message in messages]
-        feedback_services.update_messages_read_by_the_user(
-            self.user_id, thread_id, message_ids)
+        if self.user_id:
+            feedback_services.update_messages_read_by_the_user(
+                self.user_id, thread_id, message_ids)
         self.values.update({
             'messages': messages,
             'suggestion': suggestion.to_dict() if suggestion else None

--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -114,12 +114,18 @@ class GeneralFeedbackThreadUserOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     @staticmethod
     def map(model_instance):
         """Implements the map function for this job."""
-        if model_instance.user_id == 'None' or model_instance.user_id is None:
+        if model_instance.user_id is None:
             model_instance.delete()
-            yield ('SUCCESS - DELETED', model_instance.id)
+            yield ('SUCCESS-DELETED-NONE', model_instance.id)
+        elif model_instance.user_id == 'None':
+            model_instance.delete()
+            yield ('SUCCESS-DELETED-STRING', model_instance.id)
         else:
-            yield ('SUCCESS - NOT DELETED', model_instance.id)
+            yield ('SUCCESS-NOT_DELETED', model_instance.id)
 
     @staticmethod
     def reduce(key, values):
-        yield (key, len(values))
+        if key == 'SUCCESS-NOT_DELETED':
+            yield (key, len(values))
+        else:
+            yield (key, values)

--- a/core/domain/feedback_jobs_one_off.py
+++ b/core/domain/feedback_jobs_one_off.py
@@ -99,3 +99,27 @@ class FeedbackThreadCacheOneOffJob(jobs.BaseMapReduceOneOffJobManager):
             thread_model.last_nonempty_message_author_id = message_author_id
             return True
         return False
+
+
+class GeneralFeedbackThreadUserOneOffJob(jobs.BaseMapReduceOneOffJobManager):
+    """One-off job for deleting GeneralFeedbackThreadUserModels with user_id
+    equal to None or 'None'.
+    """
+
+    @classmethod
+    def entity_classes_to_map_over(cls):
+        """Return a list of datastore class references to map over."""
+        return [feedback_models.GeneralFeedbackThreadUserModel]
+
+    @staticmethod
+    def map(model_instance):
+        """Implements the map function for this job."""
+        if model_instance.user_id == 'None' or model_instance.user_id is None:
+            model_instance.delete()
+            yield ('SUCCESS - DELETED', model_instance.id)
+        else:
+            yield ('SUCCESS - NOT DELETED', model_instance.id)
+
+    @staticmethod
+    def reduce(key, values):
+        yield (key, len(values))

--- a/core/domain/feedback_jobs_one_off_test.py
+++ b/core/domain/feedback_jobs_one_off_test.py
@@ -373,7 +373,7 @@ class FeedbackThreadCacheOneOffJobTest(test_utils.GenericTestBase):
 
 
 class GeneralFeedbackThreadUserOneOffJobTest(test_utils.GenericTestBase):
-    """Tests for ExpSummary aggregations."""
+    """Tests for GeneralFeedbackThreadUserOneOffJob."""
 
     ONE_OFF_JOB_MANAGERS_FOR_TESTS = [
         feedback_jobs_one_off.GeneralFeedbackThreadUserOneOffJob]

--- a/core/domain/feedback_jobs_one_off_test.py
+++ b/core/domain/feedback_jobs_one_off_test.py
@@ -462,62 +462,6 @@ class GeneralFeedbackThreadUserOneOffJobTest(test_utils.GenericTestBase):
         self.assertEqual(output, [['SUCCESS-NOT_DELETED', 1]])
         self._check_model_validity(user_id, thread_id, user_feedback_model)
 
-    def test_successful_migration_deleted_none_multiple(self):
-        user_id1 = None
-        thread_id1 = 'exploration.exp_id.thread_id1'
-        instance_id1 = '%s.%s' % (user_id1, thread_id1)
-        user_feedback_model1 = feedback_models.GeneralFeedbackThreadUserModel(
-            id=instance_id1, user_id=user_id1, thread_id=thread_id1)
-        user_feedback_model1.put()
-
-        user_id2 = None
-        thread_id2 = 'exploration.exp_id.thread_id2'
-        instance_id2 = '%s.%s' % (user_id2, thread_id2)
-        user_feedback_model2 = feedback_models.GeneralFeedbackThreadUserModel(
-            id=instance_id2, user_id=user_id2, thread_id=thread_id2)
-        user_feedback_model2.put()
-
-        output = self._run_one_off_job()
-        self.assertEqual(
-            output,
-            [['SUCCESS-DELETED-NONE',
-              ['None.exploration.exp_id.thread_id1',
-               'None.exploration.exp_id.thread_id2']]])
-        self.assertIsNone(
-            feedback_models.GeneralFeedbackThreadUserModel.get_by_id(
-                instance_id1))
-        self.assertIsNone(
-            feedback_models.GeneralFeedbackThreadUserModel.get_by_id(
-                instance_id2))
-
-    def test_successful_migration_deleted_string_multiple(self):
-        user_id1 = 'None'
-        thread_id1 = 'exploration.exp_id.thread_id1'
-        instance_id1 = '%s.%s' % (user_id1, thread_id1)
-        user_feedback_model1 = feedback_models.GeneralFeedbackThreadUserModel(
-            id=instance_id1, user_id=user_id1, thread_id=thread_id1)
-        user_feedback_model1.put()
-
-        user_id2 = 'None'
-        thread_id2 = 'exploration.exp_id.thread_id2'
-        instance_id2 = '%s.%s' % (user_id2, thread_id2)
-        user_feedback_model2 = feedback_models.GeneralFeedbackThreadUserModel(
-            id=instance_id2, user_id=user_id2, thread_id=thread_id2)
-        user_feedback_model2.put()
-
-        output = self._run_one_off_job()
-        self.assertEqual(
-            output,
-            [['SUCCESS-DELETED-STRING',
-              ['None.exploration.exp_id.thread_id1',
-               'None.exploration.exp_id.thread_id2']]])
-        self.assertIsNone(
-            feedback_models.GeneralFeedbackThreadUserModel.get_by_id(
-                instance_id1))
-        self.assertIsNone(
-            feedback_models.GeneralFeedbackThreadUserModel.get_by_id(
-                instance_id2))
-
     def test_successful_migration_not_deleted_multiple(self):
         user_id1 = 'user1'
         thread_id1 = 'exploration.exp_id.thread_id1'

--- a/core/domain/feedback_jobs_one_off_test.py
+++ b/core/domain/feedback_jobs_one_off_test.py
@@ -429,7 +429,7 @@ class GeneralFeedbackThreadUserOneOffJobTest(test_utils.GenericTestBase):
         user_feedback_model.put()
 
         output = self._run_one_off_job()
-        self.assertEqual(output, [(u'SUCCESS - DELETED', 1)])
+        self.assertEqual(output, [('SUCCESS - DELETED', 1)])
         self.assertIsNone(
             feedback_models.GeneralFeedbackThreadUserModel.get_by_id(
                 instance_id))
@@ -443,7 +443,7 @@ class GeneralFeedbackThreadUserOneOffJobTest(test_utils.GenericTestBase):
         user_feedback_model.put()
 
         output = self._run_one_off_job()
-        self.assertEqual(output, [(u'SUCCESS - NOT DELETED', 1)])
+        self.assertEqual(output, [('SUCCESS - NOT DELETED', 1)])
         self._check_model_validity(user_id, thread_id, user_feedback_model)
 
     def test_successful_migration_deleted_multiple(self):
@@ -462,7 +462,7 @@ class GeneralFeedbackThreadUserOneOffJobTest(test_utils.GenericTestBase):
         user_feedback_model2.put()
 
         output = self._run_one_off_job()
-        self.assertEqual(output, [(u'SUCCESS - DELETED', 2)])
+        self.assertEqual(output, [('SUCCESS - DELETED', 2)])
         self.assertIsNone(
             feedback_models.GeneralFeedbackThreadUserModel.get_by_id(
                 instance_id1))
@@ -486,6 +486,48 @@ class GeneralFeedbackThreadUserOneOffJobTest(test_utils.GenericTestBase):
         user_feedback_model2.put()
 
         output = self._run_one_off_job()
-        self.assertEqual(output, [(u'SUCCESS - NOT DELETED', 2)])
+        self.assertEqual(output, [('SUCCESS - NOT DELETED', 2)])
         self._check_model_validity(user_id1, thread_id1, user_feedback_model1)
         self._check_model_validity(user_id2, thread_id2, user_feedback_model2)
+
+
+    def test_successful_migration_combined(self):
+        user_id1 = None
+        thread_id1 = 'exploration.exp_id.thread_id1'
+        instance_id1 = '%s.%s' % (user_id1, thread_id1)
+        user_feedback_model1 = feedback_models.GeneralFeedbackThreadUserModel(
+            id=instance_id1, user_id=user_id1, thread_id=thread_id1)
+        user_feedback_model1.put()
+
+        user_id2 = None
+        thread_id2 = 'exploration.exp_id.thread_id2'
+        instance_id2 = '%s.%s' % (user_id2, thread_id2)
+        user_feedback_model2 = feedback_models.GeneralFeedbackThreadUserModel(
+            id=instance_id2, user_id=user_id2, thread_id=thread_id2)
+        user_feedback_model2.put()
+
+        user_id3 = 'user1'
+        thread_id3 = 'exploration.exp_id.thread_id1'
+        instance_id3 = '%s.%s' % (user_id3, thread_id3)
+        user_feedback_model3 = feedback_models.GeneralFeedbackThreadUserModel(
+            id=instance_id3, user_id=user_id3, thread_id=thread_id3)
+        user_feedback_model3.put()
+
+        user_id4 = 'user4'
+        thread_id4 = 'exploration.exp_id.thread_id4'
+        instance_id4 = '%s.%s' % (user_id4, thread_id4)
+        user_feedback_model4 = feedback_models.GeneralFeedbackThreadUserModel(
+            id=instance_id4, user_id=user_id4, thread_id=thread_id4)
+        user_feedback_model4.put()
+
+        output = self._run_one_off_job()
+        self.assertIn(('SUCCESS - NOT DELETED', 2), output)
+        self.assertIn(('SUCCESS - DELETED', 2), output)
+        self.assertIsNone(
+            feedback_models.GeneralFeedbackThreadUserModel.get_by_id(
+                instance_id1))
+        self.assertIsNone(
+            feedback_models.GeneralFeedbackThreadUserModel.get_by_id(
+                instance_id2))
+        self._check_model_validity(user_id3, thread_id3, user_feedback_model3)
+        self._check_model_validity(user_id4, thread_id4, user_feedback_model4)

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -57,6 +57,7 @@ ONE_OFF_JOB_MANAGERS = [
     exp_jobs_one_off.InteractionCustomizationArgsValidationJob,
     exp_jobs_one_off.TranslatorToVoiceArtistOneOffJob,
     feedback_jobs_one_off.FeedbackThreadCacheOneOffJob,
+    feedback_jobs_one_off.GeneralFeedbackThreadUserOneOffJob,
     opportunity_jobs_one_off.ExplorationOpportunitySummaryModelRegenerationJob,
     opportunity_jobs_one_off.SkillOpportunityModelRegenerationJob,
     question_jobs_one_off.QuestionMigrationOneOffJob,


### PR DESCRIPTION
## Explanation
Fixes #8202: Delete `GeneralFeedbackThreadUserModel` that have `user_id` equal to `None` and enforce `user_id` to be equal to some id when creating new `GeneralFeedbackThreadUserModels`.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
