### PR TITLE
Fix #8487: Fixing wrong placement of checkbox

### DIFF
--- a/core/templates/components/state-editor/state-responses-editor/state-responses.directive.html
+++ b/core/templates/components/state-editor/state-responses-editor/state-responses.directive.html
@@ -1,10 +1,20 @@
 <div>
   <div class="oppia-editor-header">
-    <strong>Learner's Answers and Oppia's Responses</strong>
-    <span style="margin-left: 150px;" ng-if="!isCurrentInteractionTrivial()" ng-hide="!enableSolicitAnswerDetailsFeature">
-      <input type="checkbox" class="protractor-test-solicit-answer-details-checkbox" ng-change="onChangeSolicitAnswerDetails()" ng-model="stateSolicitAnswerDetailsService.displayed">
-      Solicit Answer Details
-    </span>
+    <table class="container-fluid">
+      <tr class="row">
+        <td class="col-md-7">
+          <strong>
+            Learner's Answers and Oppia's Responses
+          </strong>
+        </td>
+        <td class="col-md-5">
+          <span ng-if="!isCurrentInteractionTrivial()" ng-hide="!enableSolicitAnswerDetailsFeature" class="solicit-answer-details-span">
+            <input type="checkbox" class="protractor-test-solicit-answer-details-checkbox" ng-change="onChangeSolicitAnswerDetails()" ng-model="stateSolicitAnswerDetailsService.displayed">
+            Solicit Answer Details
+          </span>
+        </td>
+      </tr>
+    </table>
   </div>
 
   <md-card class="oppia-editor-card-with-avatar">


### PR DESCRIPTION
## Explanation
This PR attempts to fix #8487 by adding some CSS to directive.
![image](https://user-images.githubusercontent.com/32016324/73125958-ea037a80-3fd2-11ea-8a88-8159b67b82a6.png)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
