### PR TITLE
Fix part of #4057: Add tests for ParamChangesObjectFactory.ts

### DIFF
--- a/core/templates/dev/head/domain/exploration/ParamChangesObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/exploration/ParamChangesObjectFactorySpec.ts
@@ -1,0 +1,68 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview unit tests for ParamChangesObjectFactory.
+ */
+
+import { TestBed } from '@angular/core/testing';
+
+import { ParamChange } from
+  'domain/exploration/ParamChangeObjectFactory';
+import { ParamChangesObjectFactory } from
+  'domain/exploration/ParamChangesObjectFactory';
+
+describe('ParamChanges Object Factory', () => {
+  let pcsof: ParamChangesObjectFactory;
+  const cArgs = {
+    parse_with_jinja: true,
+    value: ''
+  };
+  const gId = 'Copier';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ParamChangesObjectFactory]
+    });
+
+    pcsof = TestBed.get(ParamChangesObjectFactory);
+  });
+
+  it('should create a ParamChange array from a list of dictionaries',
+    () => {
+      let paramName = 'param_1';
+      let paramName2 = 'param_2';
+      let backendList = [{
+        customization_args: cArgs,
+        generator_id: gId,
+        name: paramName
+      },
+      {
+        customization_args: cArgs,
+        generator_id: gId,
+        name: paramName2
+      }];
+
+      let testOutcome: ParamChange[] = pcsof.createFromBackendList(backendList);
+
+      expect(testOutcome.length).toBe(2);
+      expect(testOutcome[0].customizationArgs).toEqual(cArgs);
+      expect(testOutcome[0].generatorId).toBe(gId);
+      expect(testOutcome[0].name).toBe(paramName);
+      expect(testOutcome[1].customizationArgs).toEqual(cArgs);
+      expect(testOutcome[1].generatorId).toBe(gId);
+      expect(testOutcome[1].name).toBe(paramName2);
+    }
+  );
+});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix part of #4057 : add ParamChangesObjectFactorySpec.ts which includes tests for ParamChangesObjectFactory class.
## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
