### PR TITLE
Fix part of #6271: Refactor solution update method to accept domain object instead of dict.

### DIFF
--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -288,17 +288,16 @@ class AdminHandler(base.BaseHandler):
 
         state.update_recorded_voiceovers(recorded_voiceovers)
         state.update_written_translations(written_translations)
-        solution_dict = (
-            state_domain.Solution(
-                'TextInput', False, 'Solution', state_domain.SubtitledHtml(
-                    'solution', '<p>This is a solution.</p>')).to_dict())
+        solution = state_domain.Solution(
+            'TextInput', False, 'Solution', state_domain.SubtitledHtml(
+                'solution', '<p>This is a solution.</p>'))
         hints_list = [
             state_domain.Hint(
                 state_domain.SubtitledHtml(
                     'hint_1', '<p>This is a hint.</p>')).to_dict()
         ]
 
-        state.update_interaction_solution(solution_dict)
+        state.update_interaction_solution(solution)
         state.update_interaction_hints(hints_list)
         state.update_interaction_customization_args({
             'placeholder': 'Enter text here',

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -717,14 +717,18 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         init_state.update_interaction_default_outcome(default_outcome.to_dict())
         exploration.validate()
 
-        init_state.update_interaction_solution({
+        solution_dict = {
             'answer_is_exclusive': True,
             'correct_answer': 'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': 'hello_world is a string'
-                }
-        })
+            }
+        }
+        solution = state_domain.Solution.from_dict(
+            init_state.interaction.id, solution_dict
+        )
+        init_state.update_interaction_solution(solution)
         self._assert_validation_error(
             exploration,
             re.escape('Hint(s) must be specified if solution is specified'))
@@ -1212,7 +1216,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         })
         init_state.update_interaction_hints(hints_list)
 
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': False,
             'correct_answer': 'helloworld!',
             'explanation': {
@@ -1220,6 +1224,9 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             },
         }
+        solution = state_domain.Solution.from_dict(
+            init_state.interaction.id, solution_dict
+        )
         init_state.update_interaction_solution(solution)
 
         self.assertEqual(exploration.get_content_count(), 7)
@@ -7589,7 +7596,7 @@ class HtmlCollectionTests(test_utils.GenericTestBase):
         }]
         state2.update_interaction_hints(hint_list2)
 
-        solution_dict1 = {
+        solution_dict = {
             'interaction_id': '',
             'answer_is_exclusive': True,
             'correct_answer': 'Answer1',
@@ -7598,8 +7605,10 @@ class HtmlCollectionTests(test_utils.GenericTestBase):
                 'html': '<p>This is solution for state1</p>'
             }
         }
-
-        state1.update_interaction_solution(solution_dict1)
+        solution = state_domain.Solution.from_dict(
+            state1.interaction.id, solution_dict
+        )
+        state1.update_interaction_solution(solution)
 
         answer_group_list2 = [{
             'rule_specs': [{

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -373,7 +373,10 @@ def apply_change_list(exploration_id, change_list):
                 elif (
                         change.property_name ==
                         exp_domain.STATE_PROPERTY_INTERACTION_SOLUTION):
-                    state.update_interaction_solution(change.new_value)
+                    solution = state_domain.Solution.from_dict(
+                        state.interaction.id, change.new_value
+                    )
+                    state.update_interaction_solution(solution)
                 elif (
                         change.property_name ==
                         exp_domain.STATE_PROPERTY_SOLICIT_ANSWER_DETAILS):

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -4058,6 +4058,7 @@ title: Old Title
             })], 'Changed interaction_solutions.')
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
+
         self.assertEqual(
             exploration.init_state.interaction.solution.to_dict(),
             solution)

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -1796,15 +1796,11 @@ class State(python_utils.OBJECT):
         self._update_content_ids_in_assets(
             old_content_id_list, new_content_id_list)
 
-    def update_interaction_solution(self, solution_dict):
+    def update_interaction_solution(self, solution):
         """Update the solution of interaction.
 
         Args:
-            solution_dict: dict or None. The dict representation of
-                Solution object.
-
-        Raises:
-            Exception: 'solution_dict' is not a dict.
+            solution: object or None. The Solution object.
         """
         old_content_id_list = []
         new_content_id_list = []
@@ -1812,13 +1808,8 @@ class State(python_utils.OBJECT):
             old_content_id_list.append(
                 self.interaction.solution.explanation.content_id)
 
-        if solution_dict is not None:
-            if not isinstance(solution_dict, dict):
-                raise Exception(
-                    'Expected solution to be a dict, received %s'
-                    % solution_dict)
-            self.interaction.solution = Solution.from_dict(
-                self.interaction.id, solution_dict)
+        if solution is not None:
+            self.interaction.solution = solution
             new_content_id_list.append(
                 self.interaction.solution.explanation.content_id)
         else:

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -224,7 +224,8 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'content_id': 'content',
                 'html': '<p>This is content</p>'
             }))
-        init_state.update_interaction_id('TextInput')
+        interaction_id = 'TextInput'
+        init_state.update_interaction_id(interaction_id)
         default_outcome_dict = {
             'dest': 'Introduction',
             'feedback': {
@@ -279,8 +280,11 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             },
         }
+        solution = state_domain.Solution.from_dict(
+            interaction_id, solution_dict
+        )
 
-        init_state.update_interaction_solution(solution_dict)
+        init_state.update_interaction_solution(solution)
 
         written_translations_dict = {
             'translations_mapping': {
@@ -684,7 +688,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         })
         init_state.update_interaction_hints(hints_list)
 
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': False,
             'correct_answer': 'helloworld!',
             'explanation': {
@@ -692,6 +696,9 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             },
         }
+        solution = state_domain.Solution.from_dict(
+            init_state.interaction.id, solution_dict
+        )
 
         init_state.update_interaction_solution(solution)
         exploration.validate()
@@ -727,7 +734,8 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         exploration = exp_domain.Exploration.create_default_exploration('eid')
         exploration.objective = 'Objective'
         init_state = exploration.states[exploration.init_state_name]
-        init_state.update_interaction_id('TextInput')
+        interaction_id = 'TextInput'
+        init_state.update_interaction_id(interaction_id)
         exploration.validate()
 
         # Solution should be set to None as default.
@@ -741,7 +749,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             },
         })
         init_state.update_interaction_hints(hints_list)
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': False,
             'correct_answer': [0, 0],
             'explanation': {
@@ -754,9 +762,9 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaises(AssertionError):
             init_state.interaction.solution = (
                 state_domain.Solution.from_dict(
-                    init_state.interaction.id, solution))
+                    init_state.interaction.id, solution_dict))
 
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': False,
             'correct_answer': 'hello_world!',
             'explanation': {
@@ -764,6 +772,9 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             }
         }
+        solution = state_domain.Solution.from_dict(
+            interaction_id, solution_dict
+        )
         init_state.update_interaction_solution(solution)
         exploration.validate()
 
@@ -803,7 +814,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         self.assertEqual(exploration.init_state.interaction.solution, None)
 
         hints_list = []
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': False,
             'correct_answer': 'hello_world!',
             'explanation': {
@@ -811,6 +822,9 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             }
         }
+        solution = state_domain.Solution.from_dict(
+            exploration.init_state.interaction.id, solution_dict
+        )
         hints_list.append({
             'hint_content': {
                 'content_id': 'hint_1',
@@ -821,7 +835,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         exploration.init_state.update_interaction_solution(solution)
         exploration.validate()
 
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': 1,
             'correct_answer': 'hello_world!',
             'explanation': {
@@ -829,6 +843,9 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             }
         }
+        solution = state_domain.Solution.from_dict(
+            exploration.init_state.interaction.id, solution_dict
+        )
 
         exploration.init_state.update_interaction_solution(solution)
         with self.assertRaisesRegexp(
@@ -931,7 +948,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         hints_list = [state_domain.Hint(subtitled_html)]
 
         exploration.init_state.interaction.hints = hints_list
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': True,
             'correct_answer': 'hello_world!',
             'explanation': {
@@ -939,6 +956,9 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             }
         }
+        solution = state_domain.Solution.from_dict(
+            exploration.init_state.interaction.id, solution_dict
+        )
 
         exploration.init_state.update_interaction_solution(solution)
         exploration.init_state.update_content(
@@ -1143,33 +1163,6 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             Exception,
             'The content_id hint_2 already exists in recorded_voiceovers'):
             exploration.init_state.update_interaction_hints(new_hints_list)
-
-    def test_cannot_update_interaction_solution_with_non_dict_solution(self):
-        exploration = self.save_new_valid_exploration('exp_id', 'owner_id')
-        hints_list = [{
-            'hint_content': {
-                'content_id': 'hint_1',
-                'html': '<p>Hello, this is html1 for state2</p>'
-            }
-        }]
-        solution = {
-            'answer_is_exclusive': True,
-            'correct_answer': u'hello_world!',
-            'explanation': {
-                'content_id': 'solution',
-                'html': u'<p>hello_world is a string</p>'
-            }
-        }
-
-        exploration.init_state.update_interaction_hints(hints_list)
-        exploration.init_state.update_interaction_solution(solution)
-
-        self.assertEqual(
-            exploration.init_state.interaction.solution.to_dict(), solution)
-
-        with self.assertRaisesRegexp(
-            Exception, 'Expected solution to be a dict'):
-            exploration.init_state.update_interaction_solution([])
 
     def test_update_interaction_solution_with_no_solution(self):
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -2061,13 +2061,16 @@ class AppEngineTestBase(TestBase):
                 'html': '<p>This is a solution.</p>'
             }
         }
+        solution = state_domain.Solution.from_dict(
+            state.interaction.id, solution_dict
+        )
         hints_list = [{
             'hint_content': {
                 'content_id': 'hint_1',
                 'html': '<p>This is a hint.</p>'
             }
         }]
-        state.update_interaction_solution(solution_dict)
+        state.update_interaction_solution(solution)
         state.update_interaction_hints(hints_list)
         state.interaction.customization_args = {
             'placeholder': 'Enter text here',


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
#6271 wants to remove the usage of dicts from the updates of "domain" objects.
This part addresses the _update_interaction_solution_ method, from the Solution domain class.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PR CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
