### PR TITLE
Fix part of #4057: Add test file for AnswerGroupObjectFactory.ts

### DIFF
--- a/core/templates/dev/head/domain/exploration/AnswerGroupObjectFactorySpec.ts
+++ b/core/templates/dev/head/domain/exploration/AnswerGroupObjectFactorySpec.ts
@@ -1,0 +1,83 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview unit tests for answer group object factory.
+ */
+
+import { TestBed } from '@angular/core/testing';
+
+import { AnswerGroupObjectFactory } from
+  'domain/exploration/AnswerGroupObjectFactory';
+import { OutcomeObjectFactory } from 'domain/exploration/OutcomeObjectFactory';
+import { RuleObjectFactory } from 'domain/exploration/RuleObjectFactory';
+
+describe('Answer Group Object Factory', () => {
+  let agof = null;
+  let oof = null;
+  let rof = null;
+  let testAnswerGroup = null;
+  let ruleList = null;
+  let backendDict = null;
+  let backendList = null;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AnswerGroupObjectFactory]
+    });
+    agof = TestBed.get(AnswerGroupObjectFactory);
+    oof = TestBed.get(OutcomeObjectFactory);
+    rof = TestBed.get(RuleObjectFactory);
+    testAnswerGroup = agof.createNew([], oof.createNew('dest_1',
+      'outcome_1', '', []), ['training_data'], 'skill_id-1');
+    ruleList = [
+      rof.createNew('ruleType1', 'input1'),
+      rof.createNew('ruleType2', 'input2')
+    ];
+    backendDict = {
+      rule_specs: [],
+      outcome: {
+        dest: 'dest_1',
+        feedback: {
+          content_id: 'outcome_1',
+          html: ''
+        },
+        labelled_as_correct: false,
+        param_changes: [],
+        refresher_exploration_id: null,
+        missing_prerequisite_skill_id: null
+      },
+      training_data: ['training_data'],
+      tagged_skill_misconception_id: 'skill_id-1'
+    };
+    backendList = [{
+      rule_type: 'ruleType1',
+      inputs: 'input1'
+    },
+    {
+      rule_type: 'ruleType2',
+      inputs: 'input2'
+    }];
+  });
+
+  it('should create an answer group from dict and convert an answer ' +
+  'group object to backend dict correctly', () => {
+    expect(testAnswerGroup.toBackendDict()).toEqual(backendDict);
+    expect(agof.createFromBackendDict(backendDict)).toEqual(testAnswerGroup);
+  });
+
+  it('should create rules from an array of dictionaries ', () => {
+    expect(agof.generateRulesFromBackend(backendList)).toEqual(ruleList);
+  });
+});


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes part of #4057 by adding the test file of AnswerGroupObjectFactory.ts.

## Checklist
- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [X] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PR CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [X] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
