### PR TITLE
Fix part of #6271: Refactor Outcome update method to accept domain object instead of dict.

### DIFF
--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -308,7 +308,8 @@ class AdminHandler(base.BaseHandler):
             state_domain.Outcome(
                 None, state_domain.SubtitledHtml(
                     'feedback_id', '<p>Dummy Feedback</p>'),
-                True, [], None, None).to_dict()
+                True, [], None, None
+            )
         )
         question = question_domain.Question(
             question_id, state,

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -493,9 +493,9 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
 
         # Restore a valid exploration.
         init_state = exploration.states[exploration.init_state_name]
-        default_outcome_dict = init_state.interaction.default_outcome.to_dict()
-        default_outcome_dict['dest'] = exploration.init_state_name
-        init_state.update_interaction_default_outcome(default_outcome_dict)
+        default_outcome = init_state.interaction.default_outcome
+        default_outcome.dest = exploration.init_state_name
+        init_state.update_interaction_default_outcome(default_outcome)
         exploration.validate()
 
         # Ensure an invalid destination can also be detected for answer groups.
@@ -714,7 +714,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         answer_groups_list = [
             answer_group.to_dict() for answer_group in answer_groups]
         init_state.update_interaction_answer_groups(answer_groups_list)
-        init_state.update_interaction_default_outcome(default_outcome.to_dict())
+        init_state.update_interaction_default_outcome(default_outcome)
         exploration.validate()
 
         init_state.update_interaction_solution({
@@ -1529,19 +1529,14 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
 
         exploration.add_states(['DEF'])
 
-        default_outcome_dict = {
-            'dest': 'DEF',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': '<p>Default outcome for state1</p>'
-            },
-            'param_changes': [],
-            'labelled_as_correct': False,
-            'refresher_exploration_id': 'refresher_exploration_id',
-            'missing_prerequisite_skill_id': None
-        }
+        default_outcome = state_domain.Outcome(
+            'DEF', state_domain.SubtitledHtml(
+                'default_outcome', '<p>Default outcome for state1</p>'),
+            False, [], 'refresher_exploration_id', None,
+        )
         exploration.init_state.update_interaction_default_outcome(
-            default_outcome_dict)
+            default_outcome
+        )
 
         with self.assertRaisesRegexp(
             Exception,
@@ -7563,18 +7558,12 @@ class HtmlCollectionTests(test_utils.GenericTestBase):
         state3.update_interaction_customization_args(customization_args_dict3)
         state4.update_interaction_customization_args(customization_args_dict4)
 
-        default_outcome_dict1 = {
-            'dest': 'state2',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': '<p>Default outcome for state1</p>'
-            },
-            'param_changes': [],
-            'labelled_as_correct': False,
-            'refresher_exploration_id': None,
-            'missing_prerequisite_skill_id': None
-        }
-        state1.update_interaction_default_outcome(default_outcome_dict1)
+        default_outcome = state_domain.Outcome(
+            'state2', state_domain.SubtitledHtml(
+                'default_outcome', '<p>Default outcome for state1</p>'),
+            False, [], None, None
+        )
+        state1.update_interaction_default_outcome(default_outcome)
 
         hint_list2 = [{
             'hint_content': {

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -779,19 +779,12 @@ class ExplorationValidityJobManagerTests(test_utils.GenericTestBase):
         intro_state.update_interaction_id('TextInput')
         end_state.update_interaction_id('EndExploration')
 
-        default_outcome_dict = {
-            'dest': 'End',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': '<p>Introduction</p>'
-            },
-            'labelled_as_correct': False,
-            'param_changes': [],
-            'refresher_exploration_id': None,
-            'missing_prerequisite_skill_id': None
-        }
-
-        intro_state.update_interaction_default_outcome(default_outcome_dict)
+        default_outcome = state_domain.Outcome(
+            'End', state_domain.SubtitledHtml(
+                'default_outcome', '<p>Introduction</p>'
+            ), False, [], None, None
+        )
+        intro_state.update_interaction_default_outcome(default_outcome)
         end_state.update_interaction_default_outcome(None)
 
         exp_services.save_new_exploration(self.albert_id, exploration)
@@ -1757,36 +1750,24 @@ class ExplorationContentValidationJobForCKEditorTests(
             )
         }
 
-        default_outcome_dict1 = {
-            'dest': 'State2',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': (
-                    '<ol><ol><li>Item1</li></ol><li>Item2</li></ol>'
-                )
-            },
-            'labelled_as_correct': False,
-            'param_changes': [],
-            'refresher_exploration_id': None,
-            'missing_prerequisite_skill_id': None
-        }
-        default_outcome_dict2 = {
-            'dest': 'State1',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': (
+        default_outcome1 = state_domain.Outcome(
+            'State2', state_domain.SubtitledHtml(
+                'default_outcome',
+                '<ol><ol><li>Item1</li></ol><li>Item2</li></ol>'
+            ), False, [], None, None
+        )
+        default_outcome2 = state_domain.Outcome(
+            'State1',
+            state_domain.SubtitledHtml(
+                'default_outcome',
+                (
                     '<pre>Hello this is <b> testing '
                     '<oppia-noninteractive-image filepath-with-value="amp;quot;'
                     'random.png&amp;quot;"></oppia-noninteractive-image> in '
                     '</b>progress</pre>'
-
                 )
-            },
-            'labelled_as_correct': False,
-            'param_changes': [],
-            'refresher_exploration_id': None,
-            'missing_prerequisite_skill_id': None
-        }
+            ), False, [], None, None,
+        )
 
         mock_validate_context = self.swap(
             state_domain.SubtitledHtml, 'validate', mock_validate)
@@ -1799,8 +1780,8 @@ class ExplorationContentValidationJobForCKEditorTests(
             state3.update_content(
                 state_domain.SubtitledHtml.from_dict(content3_dict))
 
-            state1.update_interaction_default_outcome(default_outcome_dict1)
-            state2.update_interaction_default_outcome(default_outcome_dict2)
+            state1.update_interaction_default_outcome(default_outcome1)
+            state2.update_interaction_default_outcome(default_outcome2)
             exp_services.save_new_exploration(self.albert_id, exploration)
             job_id = (
                 exp_jobs_one_off
@@ -1939,22 +1920,18 @@ class InteractionCustomizationArgsValidationJobTests(
                 '</oppia-noninteractive-tabs>'
             )
         }
-        default_outcome_dict2 = {
-            'dest': 'State1',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': (
+        default_outcome2 = state_domain.Outcome(
+            'State1',
+            state_domain.SubtitledHtml(
+                'default_outcome',
+                (
                     '<p><oppia-noninteractive-link text-with-value="'
                     '&amp;quot;What is a link?&amp;quot;" url-with-'
                     'value="&amp;quot;htt://link.com&amp'
                     ';quot;"></oppia-noninteractive-link></p>'
                 )
-            },
-            'labelled_as_correct': False,
-            'param_changes': [],
-            'refresher_exploration_id': None,
-            'missing_prerequisite_skill_id': None
-        }
+            ), False, [], None, None
+        )
         content3_dict = {
             'content_id': 'content',
             'html': (
@@ -1969,7 +1946,7 @@ class InteractionCustomizationArgsValidationJobTests(
         with self.swap(state_domain.SubtitledHtml, 'validate', mock_validate):
             state1.update_content(
                 state_domain.SubtitledHtml.from_dict(content1_dict))
-            state2.update_interaction_default_outcome(default_outcome_dict2)
+            state2.update_interaction_default_outcome(default_outcome2)
             state3.update_content(
                 state_domain.SubtitledHtml.from_dict(content3_dict))
             exp_services.save_new_exploration(self.albert_id, exploration)

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -360,7 +360,10 @@ def apply_change_list(exploration_id, change_list):
                 elif (
                         change.property_name ==
                         exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME):
-                    state.update_interaction_default_outcome(change.new_value)
+                    new_outcome = state_domain.Outcome.from_dict(
+                        change.new_value
+                    )
+                    state.update_interaction_default_outcome(new_outcome)
                 elif (
                         change.property_name ==
                         exp_domain.STATE_PROPERTY_UNCLASSIFIED_ANSWERS):

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -360,9 +360,11 @@ def apply_change_list(exploration_id, change_list):
                 elif (
                         change.property_name ==
                         exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME):
-                    new_outcome = state_domain.Outcome.from_dict(
-                        change.new_value
-                    )
+                    new_outcome = None
+                    if change.new_value:
+                        new_outcome = state_domain.Outcome.from_dict(
+                            change.new_value
+                        )
                     state.update_interaction_default_outcome(new_outcome)
                 elif (
                         change.property_name ==

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1477,18 +1477,12 @@ class GetImageFilenamesFromExplorationTests(ExplorationServicesUnitTests):
         state2.update_interaction_customization_args(customization_args_dict2)
         state3.update_interaction_customization_args(customization_args_dict3)
 
-        default_outcome_dict1 = {
-            'dest': 'state2',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': '<p>Default outcome for state1</p>'
-            },
-            'param_changes': [],
-            'labelled_as_correct': False,
-            'refresher_exploration_id': None,
-            'missing_prerequisite_skill_id': None
-        }
-        state1.update_interaction_default_outcome(default_outcome_dict1)
+        default_outcome1 = state_domain.Outcome(
+            'state2', state_domain.SubtitledHtml(
+                'default_outcome', '<p>Default outcome for state1</p>'),
+            False, [], None, None
+        )
+        state1.update_interaction_default_outcome(default_outcome1)
 
         hint_list2 = [{
             'hint_content': {

--- a/core/domain/prod_validation_jobs_one_off_test.py
+++ b/core/domain/prod_validation_jobs_one_off_test.py
@@ -11604,18 +11604,12 @@ class CompletedActivitiesModelValidatorTests(test_utils.GenericTestBase):
         intro_state.update_interaction_id('TextInput')
         end_state.update_interaction_id('EndExploration')
 
-        default_outcome_dict = {
-            'dest': 'End',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': '<p>Introduction</p>'
-            },
-            'labelled_as_correct': False,
-            'param_changes': [],
-            'refresher_exploration_id': None,
-            'missing_prerequisite_skill_id': None
-        }
-        intro_state.update_interaction_default_outcome(default_outcome_dict)
+        default_outcome = state_domain.Outcome(
+            'End', state_domain.SubtitledHtml(
+                'default_outcome', '<p>Introduction</p>'),
+            False, [], None, None
+        )
+        intro_state.update_interaction_default_outcome(default_outcome)
         end_state.update_interaction_default_outcome(None)
 
         for exp in explorations:
@@ -11796,18 +11790,12 @@ class IncompleteActivitiesModelValidatorTests(test_utils.GenericTestBase):
             intro_state.update_interaction_id('TextInput')
             end_state.update_interaction_id('EndExploration')
 
-            default_outcome_dict = {
-                'dest': 'End',
-                'feedback': {
-                    'content_id': 'default_outcome',
-                    'html': '<p>Introduction</p>'
-                },
-                'labelled_as_correct': False,
-                'param_changes': [],
-                'refresher_exploration_id': None,
-                'missing_prerequisite_skill_id': None
-            }
-            intro_state.update_interaction_default_outcome(default_outcome_dict)
+            default_outcome = state_domain.Outcome(
+                'End', state_domain.SubtitledHtml(
+                    'default_outcome', '<p>Introduction</p>'),
+                False, [], None, None
+            )
+            intro_state.update_interaction_default_outcome(default_outcome)
             end_state.update_interaction_default_outcome(None)
 
         for exp in explorations:
@@ -11989,18 +11977,12 @@ class ExpUserLastPlaythroughModelValidatorTests(
         intro_state.update_interaction_id('TextInput')
         end_state.update_interaction_id('EndExploration')
 
-        default_outcome_dict = {
-            'dest': 'End',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': '<p>Introduction</p>'
-            },
-            'labelled_as_correct': False,
-            'param_changes': [],
-            'refresher_exploration_id': None,
-            'missing_prerequisite_skill_id': None
-        }
-        intro_state.update_interaction_default_outcome(default_outcome_dict)
+        default_outcome = state_domain.Outcome(
+            'End', state_domain.SubtitledHtml(
+                'default_outcome', '<p>Introduction</p>'),
+            False, [], None, None
+        )
+        intro_state.update_interaction_default_outcome(default_outcome)
         end_state.update_interaction_default_outcome(None)
 
         for exp in explorations:
@@ -12152,18 +12134,12 @@ class LearnerPlaylistModelValidatorTests(test_utils.GenericTestBase):
         intro_state.update_interaction_id('TextInput')
         end_state.update_interaction_id('EndExploration')
 
-        default_outcome_dict = {
-            'dest': 'End',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': '<p>Introduction</p>'
-            },
-            'labelled_as_correct': False,
-            'param_changes': [],
-            'refresher_exploration_id': None,
-            'missing_prerequisite_skill_id': None
-        }
-        intro_state.update_interaction_default_outcome(default_outcome_dict)
+        default_outcome = state_domain.Outcome(
+            'End', state_domain.SubtitledHtml(
+                'default_outcome', '<p>Introduction</p>'),
+            False, [], None, None
+        )
+        intro_state.update_interaction_default_outcome(default_outcome)
         end_state.update_interaction_default_outcome(None)
 
         for exp in explorations:

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -1723,12 +1723,11 @@ class State(python_utils.OBJECT):
         self._update_content_ids_in_assets(
             old_content_id_list, new_content_id_list)
 
-    def update_interaction_default_outcome(self, default_outcome_dict):
+    def update_interaction_default_outcome(self, default_outcome):
         """Update the default_outcome of InteractionInstance domain object.
 
         Args:
-            default_outcome_dict: dict. Dict that represents Outcome domain
-                object.
+            default_outcome: Outcome object representing the Outcome.
         """
         old_content_id_list = []
         new_content_id_list = []
@@ -1736,13 +1735,8 @@ class State(python_utils.OBJECT):
             old_content_id_list.append(
                 self.interaction.default_outcome.feedback.content_id)
 
-        if default_outcome_dict:
-            if not isinstance(default_outcome_dict, dict):
-                raise Exception(
-                    'Expected default_outcome_dict to be a dict, received %s'
-                    % default_outcome_dict)
-            self.interaction.default_outcome = Outcome.from_dict(
-                default_outcome_dict)
+        if default_outcome:
+            self.interaction.default_outcome = default_outcome
             new_content_id_list.append(
                 self.interaction.default_outcome.feedback.content_id)
         else:

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -1727,7 +1727,7 @@ class State(python_utils.OBJECT):
         """Update the default_outcome of InteractionInstance domain object.
 
         Args:
-            default_outcome: Outcome object representing the Outcome.
+            default_outcome: Outcome. Object representing the new Outcome.
         """
         old_content_id_list = []
         new_content_id_list = []

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -225,18 +225,13 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>This is content</p>'
             }))
         init_state.update_interaction_id('TextInput')
-        default_outcome_dict = {
-            'dest': 'Introduction',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': '<p>The default outcome.</p>'},
-            'labelled_as_correct': False,
-            'missing_prerequisite_skill_id': None,
-            'param_changes': [],
-            'refresher_exploration_id': None
-        }
+        default_outcome = state_domain.Outcome(
+            'Introduction', state_domain.SubtitledHtml(
+                'default_outcome', '<p>The default outcome.</p>'),
+            False, [], None, None
+        )
 
-        init_state.update_interaction_default_outcome(default_outcome_dict)
+        init_state.update_interaction_default_outcome(default_outcome)
 
         answer_group_dict = {
             'outcome': {
@@ -1233,14 +1228,6 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             exploration.init_state.interaction.confirmed_unclassified_answers,
             answer_groups_list)
-
-    def test_cannot_update_non_dict_interaction_default_outcome(self):
-        exploration = self.save_new_valid_exploration('exp_id', 'owner_id')
-
-        with self.assertRaisesRegexp(
-            Exception, 'Expected default_outcome_dict to be a dict'):
-            exploration.init_state.update_interaction_default_outcome(
-                'invalid_default_outcome')
 
     def test_cannot_update_non_list_interaction_answer_groups(self):
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -684,7 +684,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         })
         init_state.update_interaction_hints(hints_list)
 
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': False,
             'correct_answer': 'helloworld!',
             'explanation': {
@@ -693,7 +693,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             },
         }
 
-        init_state.update_interaction_solution(solution)
+        init_state.update_interaction_solution(solution_dict)
         exploration.validate()
 
         hints_list.append({
@@ -881,19 +881,13 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
 
     def test_validate_duplicate_content_id_with_default_outcome(self):
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')
-        default_outcome_dict = {
-            'dest': 'Introduction',
-            'feedback': {
-                'content_id': 'default_outcome',
-                'html': ''},
-            'labelled_as_correct': False,
-            'missing_prerequisite_skill_id': None,
-            'param_changes': [],
-            'refresher_exploration_id': None
-        }
-
+        default_outcome = state_domain.Outcome(
+            'Introduction', state_domain.SubtitledHtml('default_outcome', ''),
+            False, [], None, None
+        )
         exploration.init_state.update_interaction_default_outcome(
-            default_outcome_dict)
+            default_outcome
+        )
         exploration.init_state.update_content(
             state_domain.SubtitledHtml.from_dict({
                 'content_id': 'default_outcome',


### PR DESCRIPTION
#6271 wants to remove the usage of dicts from the updates of domain objects.
This part addresses the 'update_interaction_default_outcome' method, from the Solution domain class.
Cherry-pick from oppia/oppia#8579, without the first commit 
(that should have been part of a different branch).
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PR CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
