### PR TITLE
Fix part of #5296: Added an audit job to find explorations with MathExpressionInput

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -96,7 +96,7 @@ class MathExpressionInputInteractionOneOffJob(jobs.BaseMapReduceOneOffJobManager
                             if any(sep in rule for sep in SEPARATORS):
                                 yield (
                                     item.id,
-                                    '%s: %s' % ( 
+                                    '%s: %s' % (
                                         state_name.encode('utf-8'),
                                         rule.encode('utf-8')))
 

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -40,7 +40,7 @@ import utils
     models.NAMES.exploration])
 gae_image_services = models.Registry.import_gae_image_services()
 
-
+SEPARATORS = ['<', '>', '=']
 ADDED_THREE_VERSIONS_TO_GCS = 'Added the three versions'
 _COMMIT_TYPE_REVERT = 'revert'
 ALL_IMAGES_VERIFIED = 'Images verified'
@@ -72,6 +72,37 @@ GCS_EXTERNAL_IMAGE_ID_REGEX = re.compile(
     r'^/([^/]+)/exploration/([^/]+)/assets/image/(([^/]+)\.(' + '|'.join(
         ALLOWED_IMAGE_EXTENSIONS) + '))$')
 SUCCESSFUL_EXPLORATION_MIGRATION = 'Successfully migrated exploration'
+
+
+class MathExpressionInputInteractionOneOffJob(jobs.BaseMapReduceOneOffJobManager):  # pylint: disable=line-too-long
+    """Job that produces a list of (exploration, state) pairs that use the Math
+    Expression Interaction and that have rules that contain [<, >, =] to
+    identify and prevent usage of equation/inequalities.
+    """
+
+    @classmethod
+    def entity_classes_to_map_over(cls):
+        return [exp_models.ExplorationModel]
+
+    @staticmethod
+    def map(item):
+        if not item.deleted:
+            exploration = exp_fetchers.get_exploration_from_model(item)
+            for state_name, state in exploration.states.items():
+                if state.interaction.id == 'MathExpressionInput':
+                    for group in state.interaction.answer_groups:
+                        for rule_spec in group.rule_specs:
+                            rule = rule_spec.inputs['x']
+                            if any(sep in rule for sep in SEPARATORS):
+                                yield (
+                                    item.id,
+                                    '%s: %s' % ( 
+                                        state_name.encode('utf-8'),
+                                        rule.encode('utf-8')))
+
+    @staticmethod
+    def reduce(key, values):
+        yield (key, values)
 
 
 class ExpSummariesCreationOneOffJob(jobs.BaseMapReduceOneOffJobManager):

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -87,7 +87,8 @@ ONE_OFF_JOB_MANAGERS = [
     user_jobs_one_off.UserFirstContributionMsecOneOffJob,
     user_jobs_one_off.UserLastExplorationActivityOneOffJob,
     user_jobs_one_off.UserProfilePictureOneOffJob,
-    user_jobs_one_off.UsernameLengthDistributionOneOffJob
+    user_jobs_one_off.UsernameLengthDistributionOneOffJob,
+    exp_jobs_one_off.MathExpressionInputInteractionOneOffJob
 ]
 
 # List of all manager classes for prod validation one-off batch jobs for which


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes part of #5296. 
This audit job aims to find all explorations that use the MathExpressionInput and have an equation/inequality in the ruleset.
#8573 aims to add validators to disallow the usage of equations/inequalities in MathExpressionInput, so the explorations surfaced via this PR will have to be altered accordingly.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PR CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
