### PR TITLE
fix #8603: fixing the invalid date in suggestion thread

### DIFF
--- a/core/controllers/learner_dashboard.py
+++ b/core/controllers/learner_dashboard.py
@@ -175,7 +175,9 @@ class LearnerDashboardFeedbackThreadHandler(base.BaseHandler):
                 'description': suggestion_thread.subject,
                 'author_username': authors_settings[0].username,
                 'author_picture_data_url': (
-                    authors_settings[0].profile_picture_data_url)
+                    authors_settings[0].profile_picture_data_url),
+                'created_on': utils.get_time_in_millisecs(
+                    messages[0].created_on)
             }
             message_summary_list.append(suggestion_summary)
             messages.pop(0)

--- a/core/controllers/learner_dashboard_test.py
+++ b/core/controllers/learner_dashboard_test.py
@@ -401,6 +401,7 @@ class LearnerDashboardFeedbackThreadHandlerTests(test_utils.GenericTestBase):
         self.assertTrue(
             messages_summary['author_picture_data_url'].startswith(
                 'data:image/png;'))
+        self.assertTrue(messages_summary.get('created_on'))
         self.assertFalse(messages_summary.get('suggestion_html'))
         self.assertFalse(messages_summary.get('current_content_html'))
         self.assertFalse(messages_summary.get('description'))

--- a/core/controllers/learner_dashboard_test.py
+++ b/core/controllers/learner_dashboard_test.py
@@ -28,6 +28,7 @@ from core.domain import suggestion_services
 from core.platform import models
 from core.tests import test_utils
 import feconf
+import utils
 
 (suggestion_models, feedback_models) = models.Registry.import_models([
     models.NAMES.suggestion, models.NAMES.feedback])
@@ -401,7 +402,6 @@ class LearnerDashboardFeedbackThreadHandlerTests(test_utils.GenericTestBase):
         self.assertTrue(
             messages_summary['author_picture_data_url'].startswith(
                 'data:image/png;'))
-        self.assertTrue(messages_summary.get('created_on'))
         self.assertFalse(messages_summary.get('suggestion_html'))
         self.assertFalse(messages_summary.get('current_content_html'))
         self.assertFalse(messages_summary.get('description'))
@@ -429,12 +429,16 @@ class LearnerDashboardFeedbackThreadHandlerTests(test_utils.GenericTestBase):
                 suggestion.change.state_name].content.html)
         response_dict = self.get_json(thread_url)
         messages_summary = response_dict['message_summary_list'][0]
+        first_suggestion = feedback_services.get_messages(thread_id)[0]
 
         self.assertEqual(
             messages_summary['author_username'], self.EDITOR_USERNAME)
         self.assertTrue(
             messages_summary['author_picture_data_url'].startswith(
                 'data:image/png;'))
+        self.assertEqual(
+            utils.get_time_in_millisecs(first_suggestion.created_on),
+            messages_summary['created_on'])
         self.assertEqual(
             messages_summary['suggestion_html'], '<p>new content html</p>')
         self.assertEqual(


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #8603 The **created_on** field was not being sent from the backend for the original suggestion.
## Checklist
- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [X] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [X] The PR is made from a branch that's **not** called "develop".
- [X] The PR has an appropriate "PR CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
