### PR TITLE
Fix #8694: Places CSS for the loading message in the correct place.

### DIFF
--- a/core/templates/dev/head/pages/exploration-player-page/exploration-player-page.directive.html
+++ b/core/templates/dev/head/pages/exploration-player-page/exploration-player-page.directive.html
@@ -3,18 +3,3 @@
   <conversation-skin></conversation-skin>
   <attribution-guide></attribution-guide>
 </div>
-<style>
-  .oppia-exploration-h1 {
-    color: #ffffff;
-    display: inline;
-    font-size: 1em;
-    font-weight: normal;
-  }
-  .oppia-exploration-info-icon:hover {
-    background: #fff;
-    color: #009688;
-    margin-top: -13px;
-    height: 56px;
-    padding-top: 12px;
-  }
-</style>

--- a/core/templates/dev/head/pages/exploration-player-page/layout-directives/learner-view-info.directive.html
+++ b/core/templates/dev/head/pages/exploration-player-page/layout-directives/learner-view-info.directive.html
@@ -8,3 +8,19 @@
     <span class="oppia-icon-accessibility-label"><['I18N_PLAYER_INFO_TOOLTIP' | translate]></span>
   </li>
 </ul>
+
+<style>
+  .oppia-exploration-h1 {
+    color: #fff;
+    display: inline;
+    font-size: 1em;
+    font-weight: normal;
+  }
+  .oppia-exploration-info-icon:hover {
+    background: #fff;
+    color: #009688;
+    height: 56px;
+    margin-top: -13px;
+    padding-top: 12px;
+  }
+</style>


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
Fixes #8694, Places CSS for the loading message in the correct place.

On investigating this issue I found that we have two loading messages in the exploration player page:
1. On the navbar, which shows exploration title is loading.
2. In the middle of the exploration player page, which shows the exploration player is loading. 
![cccc](https://user-images.githubusercontent.com/16653571/75079509-f4ac2380-552e-11ea-8aba-5118d6284a70.png)

Issue #8694 was happening because of the 1st loading message i.e, on the navbar. I found that the CSS required for the nav-bar loading message was placed in the exploration player page which loads after the navbar. So I moved the required CSS in the correct place.



<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [ ] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [ ] The PR is made from a branch that's **not** called "develop".
- [ ] The PR has an appropriate "PR CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [ ] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [ ] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
