### PR TITLE
Fix signup issues in e2e tests

### DIFF
--- a/core/tests/protractor_utils/users.js
+++ b/core/tests/protractor_utils/users.js
@@ -54,8 +54,8 @@ var logout = function() {
 // that this will fail if the user already has a username.
 var _completeSignup = function(username) {
   // This is required since there is a redirect which can be considered
-  // as a client side navigation and the tests fail since Angular cannot
-  // be find in this case.
+  // as a client side navigation and the tests fail since Angular is
+  // not found due to the navigation interfering with protractor.
   browser.waitForAngularEnabled(false);
   browser.get('/signup?return_url=http%3A%2F%2Flocalhost%3A9001%2F');
   browser.waitForAngularEnabled(true);

--- a/core/tests/protractor_utils/users.js
+++ b/core/tests/protractor_utils/users.js
@@ -53,7 +53,12 @@ var logout = function() {
 // The user needs to log in immediately before this method is called. Note
 // that this will fail if the user already has a username.
 var _completeSignup = function(username) {
+  // This is required since there is a redirect which can be considered
+  // as a client side navigation and the tests fail since Angular cannot
+  // be find in this case.
+  browser.waitForAngularEnabled(false);
   browser.get('/signup?return_url=http%3A%2F%2Flocalhost%3A9001%2F');
+  browser.waitForAngularEnabled(true);
   var usernameInput = element(by.css('.protractor-test-username-input'));
   var agreeToTermsCheckbox = element(
     by.css('.protractor-test-agree-to-terms-checkbox'));

--- a/core/tests/protractor_utils/users.js
+++ b/core/tests/protractor_utils/users.js
@@ -55,7 +55,8 @@ var logout = function() {
 var _completeSignup = function(username) {
   // This is required since there is a redirect which can be considered
   // as a client side navigation and the tests fail since Angular is
-  // not found due to the navigation interfering with protractor.
+  // not found due to the navigation interfering with protractor's
+  // bootstrapping.
   browser.waitForAngularEnabled(false);
   browser.get('/signup?return_url=http%3A%2F%2Flocalhost%3A9001%2F');
   browser.waitForAngularEnabled(true);


### PR DESCRIPTION
## Explanation
Tries to fix signup issues in e2e tests.

One of the common failures in circleci e2e tests is:
```
Failed: Error while waiting for Protractor to sync with the page: "both angularJS testability and angular testability are undefined.  This could be either because this is a non-angular page or because your test involves client-side navigation, which can interfere with Protractor's bootstrapping.  See http://git.io/v4gXM for details"
      - Expected $.length = 1 to equal 0.
      Expected $[0] = Entry({ level: SEVERE, message: 'http://localhost:9001/signup?return_url=http%3A%2F%2Flocalhost%3A9001%2F - Failed to load resource: the server responded with a status of 500 (Internal Server Error)', timestamp: 1580884870359, type: '' }) to equal undefined.
```

I think this might be due to the redirect happening in our signup procedure which can be considered as a client-side navigation as mentioned in the error message. This PR tries to fix that failure.

If the e2e tests pass or fail with a different error atleast thrice, we can merge this one in.

## Checklist
- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PR CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
