### PR TITLE
Fix #7637: Set hoveredRegion inside onMouseMoveRegion if null

### DIFF
--- a/extensions/objects/templates/image-with-regions-editor.directive.html
+++ b/extensions/objects/templates/image-with-regions-editor.directive.html
@@ -34,7 +34,7 @@
           ng-attr-style="<[$ctrl.getRegionStyle($index)]>"
           ng-mouseover="$ctrl.onMouseoverRegion($index)"
           ng-mouseout="$ctrl.onMouseoutRegion($index)"
-          ng-mousemove="$ctrl.onMouseMoveRegion()"
+          ng-mousemove="$ctrl.onMouseMoveRegion($index)"
           ng-mousedown="$ctrl.onMousedownRegion($index)">
     </rect>
     <a ng-repeat="labeledRegion in $ctrl.value.labeledRegions" href

--- a/extensions/objects/templates/image-with-regions-editor.directive.ts
+++ b/extensions/objects/templates/image-with-regions-editor.directive.ts
@@ -382,11 +382,14 @@ angular.module('oppia').directive('imageWithRegionsEditor', [
             }
             ctrl.movedOutOfRegion = false;
           };
-          ctrl.onMouseMoveRegion = function() {
+          ctrl.onMouseMoveRegion = function(index) {
             if (
               ctrl.userIsCurrentlyDragging ||
               ctrl.userIsCurrentlyResizing) {
               return;
+            }
+            if (ctrl.hoveredRegion === null) {
+              ctrl.hoveredRegion = index;
             }
             var region = cornerAndDimensionsFromRegionArea(
               ctrl.value.labeledRegions[


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes #7637: Adds a null check and sets `hoveredRegion` index. It seems like `onMouseMoveRegion` is being triggered before `onMouseoverRegion` (where the `hoveredRegion` index is set) causing hoveredRegion to be null inside `onMouseMoveRegion`. This could be the case when moving the cursor outside a region in the image-with-region editor (which unsets `hoveredRegion`) and then quickly moving the cursor back into the same region again.

I was able to repro this on Chrome and Edge browsers on a windows machine.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PR CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
