### PR TITLE
Fix #8668: Document the service file with jsdoc and fix the unused-import bug.

### DIFF
--- a/core/templates/pages/exploration-editor-page/services/user-email-preferences.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/user-email-preferences.service.ts
@@ -34,24 +34,42 @@ angular.module('oppia').factory('UserEmailPreferencesService', [
         this.feedbackNotificationsMuted = feedbackNotificationsMuted;
         this.suggestionNotificationsMuted = suggestionNotificationsMuted;
       },
+      /**
+       * @return {boolean} Whether the feedback notification is muted.
+       */
       areFeedbackNotificationsMuted: function() {
         return this.feedbackNotificationsMuted;
       },
+      /**
+       * @return {boolean} Whether the suggestion notification is muted.
+       */
       areSuggestionNotificationsMuted: function() {
         return this.suggestionNotificationsMuted;
       },
+      /**
+       * Set the message type to feedback and mute to true or false.
+       * @param {boolean} mute - Whether the feedback notification is muted.
+       */
       setFeedbackNotificationPreferences: function(mute) {
         this.saveChangeToBackend({
           message_type: MESSAGE_TYPE_FEEDBACK,
           mute: mute
         });
       },
+      /**
+       * Set the message type to suggestion and mute to true or false.
+       * @param {boolean} mute - Whether the suggestion notification is muted. 
+       */
       setSuggestionNotificationPreferences: function(mute) {
         this.saveChangeToBackend({
           message_type: MESSAGE_TYPE_SUGGESTION,
           mute: mute
         });
       },
+      /**
+       * Save the change of message_type and mute to backend.
+       * @param {object} requestParams - Info about message_type and mute.
+       */
       saveChangeToBackend: function(requestParams) {
         var that = this;
         var emailPreferencesUrl = UrlInterpolationService.interpolateUrl(

--- a/core/templates/pages/exploration-editor-page/services/user-email-preferences.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/user-email-preferences.service.ts
@@ -58,7 +58,7 @@ angular.module('oppia').factory('UserEmailPreferencesService', [
       },
       /**
        * Set the message type to suggestion and mute to true or false.
-       * @param {boolean} mute - Whether the suggestion notification is muted. 
+       * @param {boolean} mute - Whether the suggestion notification is muted.
        */
       setSuggestionNotificationPreferences: function(mute) {
         this.saveChangeToBackend({

--- a/scripts/create_expression_parser.py
+++ b/scripts/create_expression_parser.py
@@ -18,9 +18,7 @@ from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import argparse
-import fileinput
 import os
-import re
 import subprocess
 
 import python_utils


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->

## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fix #8668: Document the service file [user-email-preferences.service.ts] with jsdoc and fix the unused-import bug showed below.

************* Module oppia.scripts.create_expression_parser
W: 21, 0: Unused import fileinput (unused-import)
W: 23, 0: Unused import re (unused-import)

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PR CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
