### PR TITLE
Fix part of #8746: Story editor, viewer, practice session bug fixes

### DIFF
--- a/core/controllers/topic_viewer.py
+++ b/core/controllers/topic_viewer.py
@@ -23,6 +23,7 @@ from constants import constants
 from core.controllers import acl_decorators
 from core.controllers import base
 from core.domain import email_manager
+from core.domain import question_services
 from core.domain import skill_services
 from core.domain import story_fetchers
 from core.domain import topic_fetchers
@@ -106,6 +107,13 @@ class TopicPageDataHandler(base.BaseHandler):
             for skill_id in assigned_skill_ids:
                 degrees_of_mastery[skill_id] = None
 
+        show_train_tab = False
+        if len(assigned_skill_ids) > 0:
+            questions = question_services.get_questions_by_skill_ids(
+                5, assigned_skill_ids, False)
+            if len(questions) == 5:
+                show_train_tab = True
+
         self.values.update({
             'topic_id': topic.id,
             'topic_name': topic.name,
@@ -114,6 +122,7 @@ class TopicPageDataHandler(base.BaseHandler):
             'uncategorized_skill_ids': uncategorized_skill_ids,
             'subtopics': subtopics,
             'degrees_of_mastery': degrees_of_mastery,
-            'skill_descriptions': skill_descriptions
+            'skill_descriptions': skill_descriptions,
+            'show_train_tab': show_train_tab
         })
         self.render_json(self.values)

--- a/core/controllers/topic_viewer.py
+++ b/core/controllers/topic_viewer.py
@@ -107,12 +107,12 @@ class TopicPageDataHandler(base.BaseHandler):
             for skill_id in assigned_skill_ids:
                 degrees_of_mastery[skill_id] = None
 
-        show_train_tab = False
-        if len(assigned_skill_ids) > 0:
+        train_tab_should_be_displayed = False
+        if assigned_skill_ids:
             questions = question_services.get_questions_by_skill_ids(
                 5, assigned_skill_ids, False)
             if len(questions) == 5:
-                show_train_tab = True
+                train_tab_should_be_displayed = True
 
         self.values.update({
             'topic_id': topic.id,
@@ -123,6 +123,6 @@ class TopicPageDataHandler(base.BaseHandler):
             'subtopics': subtopics,
             'degrees_of_mastery': degrees_of_mastery,
             'skill_descriptions': skill_descriptions,
-            'show_train_tab': show_train_tab
+            'train_tab_should_be_displayed': train_tab_should_be_displayed
         })
         self.render_json(self.values)

--- a/core/controllers/topic_viewer_test.py
+++ b/core/controllers/topic_viewer_test.py
@@ -138,7 +138,7 @@ class TopicPageDataHandlerTests(BaseTopicViewerControllerTests):
                     self.skill_id_1: 'Skill Description 1',
                     self.skill_id_2: 'Skill Description 2'
                 },
-                'show_train_tab': False
+                'train_tab_should_be_displayed': False
             }
             self.assertDictContainsSubset(expected_dict, json_response)
 
@@ -184,7 +184,7 @@ class TopicPageDataHandlerTests(BaseTopicViewerControllerTests):
                         self.skill_id_1: None,
                         self.skill_id_2: 'Skill Description 2'
                     },
-                    'show_train_tab': False
+                    'train_tab_should_be_displayed': False
                 }
                 self.assertDictContainsSubset(expected_dict, json_response)
 
@@ -213,7 +213,7 @@ class TopicPageDataHandlerTests(BaseTopicViewerControllerTests):
                 'subtopics': [],
                 'degrees_of_mastery': {},
                 'skill_descriptions': {},
-                'show_train_tab': False
+                'train_tab_should_be_displayed': False
             }
             self.assertDictContainsSubset(expected_dict, json_response)
 
@@ -251,7 +251,7 @@ class TopicPageDataHandlerTests(BaseTopicViewerControllerTests):
                 'skill_descriptions': {
                     self.skill_id_1: 'Skill Description 1'
                 },
-                'show_train_tab': True
+                'train_tab_should_be_displayed': True
             }
             self.assertDictContainsSubset(expected_dict, json_response)
         self.logout()

--- a/core/controllers/topic_viewer_test.py
+++ b/core/controllers/topic_viewer_test.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 from constants import constants
+from core.domain import question_services
 from core.domain import skill_services
 from core.domain import story_domain
 from core.domain import story_services
@@ -26,6 +27,7 @@ from core.domain import topic_services
 from core.domain import user_services
 from core.tests import test_utils
 import feconf
+import python_utils
 
 
 class BaseTopicViewerControllerTests(test_utils.GenericTestBase):
@@ -135,7 +137,8 @@ class TopicPageDataHandlerTests(BaseTopicViewerControllerTests):
                 'skill_descriptions': {
                     self.skill_id_1: 'Skill Description 1',
                     self.skill_id_2: 'Skill Description 2'
-                }
+                },
+                'show_train_tab': False
             }
             self.assertDictContainsSubset(expected_dict, json_response)
 
@@ -180,7 +183,8 @@ class TopicPageDataHandlerTests(BaseTopicViewerControllerTests):
                     'skill_descriptions': {
                         self.skill_id_1: None,
                         self.skill_id_2: 'Skill Description 2'
-                    }
+                    },
+                    'show_train_tab': False
                 }
                 self.assertDictContainsSubset(expected_dict, json_response)
 
@@ -191,3 +195,63 @@ class TopicPageDataHandlerTests(BaseTopicViewerControllerTests):
             self.get_json(
                 '%s/%s' % (feconf.TOPIC_DATA_HANDLER, 'public_topic_name'),
                 expected_status_int=404)
+
+    def test_get_with_no_skills_ids(self):
+        self.topic = topic_domain.Topic.create_default_topic(
+            self.topic_id, 'topic_with_no_skills', 'abbrev')
+        topic_services.save_new_topic(self.admin_id, self.topic)
+        topic_services.publish_topic(self.topic_id, self.admin_id)
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', True):
+            json_response = self.get_json(
+                '%s/%s' % (feconf.TOPIC_DATA_HANDLER, 'topic_with_no_skills'))
+            expected_dict = {
+                'topic_name': 'topic_with_no_skills',
+                'topic_id': self.topic_id,
+                'canonical_story_dicts': [],
+                'additional_story_dicts': [],
+                'uncategorized_skill_ids': [],
+                'subtopics': [],
+                'degrees_of_mastery': {},
+                'skill_descriptions': {},
+                'show_train_tab': False
+            }
+            self.assertDictContainsSubset(expected_dict, json_response)
+
+    def test_get_with_five_or_more_questions(self):
+        number_of_questions = 6
+        self.topic_id = 'new_topic'
+        self.skill_id_1 = skill_services.get_new_skill_id()
+        self.topic = topic_domain.Topic.create_default_topic(
+            self.topic_id, 'new_topic', 'abbrev')
+        self.topic.uncategorized_skill_ids.append(self.skill_id_1)
+        topic_services.save_new_topic(self.admin_id, self.topic)
+        topic_services.publish_topic(self.topic_id, self.admin_id)
+        self.save_new_skill(
+            self.skill_id_1, self.admin_id, description='Skill Description 1')
+        for index in python_utils.RANGE(number_of_questions):
+            self.question_id = question_services.get_new_question_id()
+            self.question = self.save_new_question(
+                self.question_id, self.admin_id,
+                self._create_valid_question_data(index), [self.skill_id_1])
+            question_services.create_new_question_skill_link(
+                self.admin_id, self.question_id, self.skill_id_1, 0.5)
+        with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', True):
+            json_response = self.get_json(
+                '%s/%s' % (feconf.TOPIC_DATA_HANDLER, 'new_topic'))
+            expected_dict = {
+                'topic_name': 'new_topic',
+                'topic_id': self.topic_id,
+                'canonical_story_dicts': [],
+                'additional_story_dicts': [],
+                'uncategorized_skill_ids': [self.skill_id_1],
+                'subtopics': [],
+                'degrees_of_mastery': {
+                    self.skill_id_1: None
+                },
+                'skill_descriptions': {
+                    self.skill_id_1: 'Skill Description 1'
+                },
+                'show_train_tab': True
+            }
+            self.assertDictContainsSubset(expected_dict, json_response)
+        self.logout()

--- a/core/controllers/topic_viewer_test.py
+++ b/core/controllers/topic_viewer_test.py
@@ -229,12 +229,12 @@ class TopicPageDataHandlerTests(BaseTopicViewerControllerTests):
         self.save_new_skill(
             self.skill_id_1, self.admin_id, description='Skill Description 1')
         for index in python_utils.RANGE(number_of_questions):
-            self.question_id = question_services.get_new_question_id()
-            self.question = self.save_new_question(
-                self.question_id, self.admin_id,
+            question_id = question_services.get_new_question_id()
+            self.save_new_question(
+                question_id, self.admin_id,
                 self._create_valid_question_data(index), [self.skill_id_1])
             question_services.create_new_question_skill_link(
-                self.admin_id, self.question_id, self.skill_id_1, 0.5)
+                self.admin_id, question_id, self.skill_id_1, 0.5)
         with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', True):
             json_response = self.get_json(
                 '%s/%s' % (feconf.TOPIC_DATA_HANDLER, 'new_topic'))

--- a/core/templates/components/question-directives/questions-list/questions-list.directive.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.directive.ts
@@ -627,8 +627,8 @@ angular.module('oppia').directive('questionsList', [
                       });
                     }, function() {
                       // Note to developers:
-                      // This callback is triggered when the Cancel button is clicked.
-                      // No further action is needed.
+                      // This callback is triggered when the Cancel button is
+                      // clicked. No further action is needed.
                     });
                   };
 

--- a/core/templates/components/question-directives/questions-list/questions-list.directive.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.directive.ts
@@ -311,6 +311,10 @@ angular.module('oppia').directive('questionsList', [
                 ctrl.initializeNewQuestionCreation(
                   ctrl.newQuestionSkillIds);
               }
+            }, function() {
+              // Note to developers:
+              // This callback is triggered when the Cancel button is clicked.
+              // No further action is needed.
             });
           };
 
@@ -621,6 +625,10 @@ angular.module('oppia').directive('questionsList', [
                         id: summary.id,
                         task: 'add'
                       });
+                    }, function() {
+                      // Note to developers:
+                      // This callback is triggered when the Cancel button is clicked.
+                      // No further action is needed.
                     });
                   };
 

--- a/core/templates/components/skill-selector/select-skill-modal.template.html
+++ b/core/templates/components/skill-selector/select-skill-modal.template.html
@@ -10,6 +10,6 @@
   </select-skill>
 </div>
 <div class="modal-footer">
-  <button class="btn btn-success protractor-test-confirm-skill-selection-button" ng-click="save()">Done</button>
+  <button class="btn btn-success protractor-test-confirm-skill-selection-button" ng-click="save()" ng-disabled="!selectedSkillId">Done</button>
   <button class="btn btn-secondary" ng-click="cancel()">Cancel</button>
 </div>

--- a/core/templates/components/summary-tile/story-summary-tile.directive.html
+++ b/core/templates/components/summary-tile/story-summary-tile.directive.html
@@ -1,4 +1,4 @@
-<a ng-href="<[$ctrl.getStoryLink()]>">
+<a title="<[$ctrl.getStoryTitle()]>" ng-href="<[$ctrl.getStoryLink()]>">
   <div class="oppia-story-image">
     <img ng-src="<[$ctrl.getStaticImageUrl('/subjects/Lightbulb.svg')]>" alt="">
   </div>

--- a/core/templates/pages/exploration-player-page/services/question-player-engine.service.ts
+++ b/core/templates/pages/exploration-player-page/services/question-player-engine.service.ts
@@ -97,6 +97,10 @@ angular.module('oppia').factory('QuestionPlayerEngineService', [
 
     // This should only be called when 'exploration' is non-null.
     var _loadInitialQuestion = function(successCallback) {
+      if (!questions || questions.length === 0) {
+        AlertsService.addWarning('No questions available.');
+        return;
+      }
       var initialState = questions[0].getStateData();
 
       var questionHtml = makeQuestion(initialState, []);

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-prerequisite-skills-editor/skill-prerequisite-skills-editor.directive.ts
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-prerequisite-skills-editor/skill-prerequisite-skills-editor.directive.ts
@@ -95,6 +95,10 @@ angular.module('oppia').directive('skillPrerequisiteSkillsEditor', [
                 }
               }
               SkillUpdateService.addPrerequisiteSkill($scope.skill, skillId);
+            }, function() {
+              // Note to developers:
+              // This callback is triggered when the Cancel button is clicked.
+              // No further action is needed.
             });
           };
 

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.directive.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.directive.ts
@@ -172,6 +172,10 @@ angular.module('oppia').directive('storyNodeEditor', [
                 AlertsService.addInfoMessage(
                   'Given skill is already a prerequisite skill', 5000);
               }
+            }, function() {
+              // Note to developers:
+              // This callback is triggered when the Cancel button is clicked.
+              // No further action is needed.
             });
           };
 
@@ -206,6 +210,10 @@ angular.module('oppia').directive('storyNodeEditor', [
                 AlertsService.addInfoMessage(
                   'Given skill is already an acquired skill', 5000);
               }
+            }, function() {
+              // Note to developers:
+              // This callback is triggered when the Cancel button is clicked.
+              // No further action is needed.
             });
           };
 

--- a/core/templates/pages/story-viewer-page/story-viewer-page.directive.html
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.directive.html
@@ -47,7 +47,8 @@
           <img ng-src="<[$ctrl.getStaticImageUrl('/general/collection_mascot.svg')]>" class="story-mascot">
           <a ng-repeat="node in $ctrl.storyPlaythroughObject.getStoryNodes()"
              ng-href="<[$ctrl.getExplorationUrl(node)]>"
-             ng-style="{position: 'absolute', left: '<[$ctrl.pathIconParameters[$index].left]>', top: '<[$ctrl.pathIconParameters[$index].top]>'}">
+             ng-style="{position: 'absolute', left: '<[$ctrl.pathIconParameters[$index].left]>', top: '<[$ctrl.pathIconParameters[$index].top]>'}"
+             ng-class="{'oppia-story-node-default-cursor': !$ctrl.isSummaryTileVisible(node)}">
             <div ng-style="{width: '160px',position: 'absolute',left: '<[$ctrl.getExplorationTitlePosition($index)]>',color: '#006553','font-family': 'Capriola, Roboto, Arial,sans-serif','font-size': '18px',bottom: '65%'}">
               <span ng-if="node.isCompleted()" aria-live="assertive" translate="I18N_STORY_VIEWER_COMPLETED_CHAPTER" translate-values="{title: node.getTitle()}">
               </span>
@@ -91,7 +92,8 @@
                  ng-mouseover="$ctrl.updateExplorationPreview(node);
                                $ctrl.setIconHighlight(node, $index);"
                  ng-mouseleave="$ctrl.togglePreviewCard(node);
-                                $ctrl.unsetIconHighlight();">
+                                $ctrl.unsetIconHighlight();"
+                 ng-class="{'oppia-story-node-default-cursor': !$ctrl.isSummaryTileVisible(node)}">
                 <circle ng-show="$ctrl.node.getExplorationId() === $ctrl.nextExplorationId &&
                   $index !== $ctrl.activeHighlightedIconIndex"
                         cx="50"
@@ -272,5 +274,8 @@
     text-align: center;
     top: -30px;
     width: 220px;
+  }
+  .oppia-story-node-default-cursor {
+    cursor: default;
   }
 </style>

--- a/core/templates/pages/topic-viewer-page/topic-viewer-page.controller.ts
+++ b/core/templates/pages/topic-viewer-page/topic-viewer-page.controller.ts
@@ -73,7 +73,8 @@ angular.module('oppia').directive('topicViewerPage', [
                 ctrl.subtopics = topicDataDict.subtopics;
                 $rootScope.loadingMessage = '';
                 ctrl.topicId = topicDataDict.id;
-                ctrl.showTrainTab = topicDataDict.show_train_tab;
+                ctrl.trainTabShouldBeDisplayed = (
+                  topicDataDict.train_tab_should_be_displayed);
                 // TODO(#8521): Remove the use of $rootScope.$apply()
                 // once the controller is migrated to angular.
                 $rootScope.$apply();

--- a/core/templates/pages/topic-viewer-page/topic-viewer-page.controller.ts
+++ b/core/templates/pages/topic-viewer-page/topic-viewer-page.controller.ts
@@ -73,6 +73,7 @@ angular.module('oppia').directive('topicViewerPage', [
                 ctrl.subtopics = topicDataDict.subtopics;
                 $rootScope.loadingMessage = '';
                 ctrl.topicId = topicDataDict.id;
+                ctrl.showTrainTab = topicDataDict.show_train_tab;
                 // TODO(#8521): Remove the use of $rootScope.$apply()
                 // once the controller is migrated to angular.
                 $rootScope.$apply();

--- a/core/templates/pages/topic-viewer-page/topic-viewer-page.directive.html
+++ b/core/templates/pages/topic-viewer-page/topic-viewer-page.directive.html
@@ -11,7 +11,7 @@
            translate="I18N_TOPIC_VIEWER_PLAY">
         </a>
       </li>
-      <li ng-class="{'topic-viewer-tabs-active': $ctrl.activeTab === 'practice'}" ng-hide="!$ctrl.showTrainTab">
+      <li ng-class="{'topic-viewer-tabs-active': $ctrl.activeTab === 'practice'}" ng-show="$ctrl.trainTabShouldBeDisplayed">
         <a class="topic-viewer-tabs-text"
            ng-click="$ctrl.setActiveTab('practice')"
            translate="I18N_TOPIC_VIEWER_TRAIN">

--- a/core/templates/pages/topic-viewer-page/topic-viewer-page.directive.html
+++ b/core/templates/pages/topic-viewer-page/topic-viewer-page.directive.html
@@ -11,7 +11,7 @@
            translate="I18N_TOPIC_VIEWER_PLAY">
         </a>
       </li>
-      <li ng-class="{'topic-viewer-tabs-active': $ctrl.activeTab === 'practice'}">
+      <li ng-class="{'topic-viewer-tabs-active': $ctrl.activeTab === 'practice'}" ng-hide="!$ctrl.showTrainTab">
         <a class="topic-viewer-tabs-text"
            ng-click="$ctrl.setActiveTab('practice')"
            translate="I18N_TOPIC_VIEWER_TRAIN">
@@ -39,7 +39,7 @@
 <style>
   .oppia-topic-viewer-tabs-container {
     margin: 0 auto;
-    width: 70%;
+    width: 60%;
   }
 
   .oppia-topic-viewer-tabs-container .topic-viewer-tabs {
@@ -47,7 +47,6 @@
     display: flex;
     flex-wrap: wrap;
     margin-bottom: 0;
-    margin-left: 12.5%;
     padding-left: 0;
     padding-top: 7vh;
     text-align: center;
@@ -58,6 +57,7 @@
     display: flex;
     margin-bottom: 0;
     width: 250px;
+    flex: 1;
   }
 
   .oppia-topic-viewer-tabs-container .topic-viewer-tabs .topic-viewer-tabs-text {

--- a/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.directive.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/skills-list/skills-list.directive.ts
@@ -197,6 +197,10 @@ angular.module('oppia').directive('skillsList', [
                   $rootScope.$broadcast(
                     EVENT_TOPICS_AND_SKILLS_DASHBOARD_REINITIALIZED);
                 }, 100);
+              }, function() {
+                // Note to developers:
+                // This callback is triggered when the Cancel button is clicked.
+                // No further action is needed.
               });
             }, function() {
               // Note to developers:

--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.directive.html
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.directive.html
@@ -14,7 +14,7 @@
     </div>
   </div>
   <div ng-if="$ctrl.topicSummaries.length > 0 || $ctrl.untriagedSkillSummaries.length > 0">
-    <ul class="dashboard-tabs">
+    <ul class="dashboard-tabs protractor-test-topics-tab">
       <li ng-class="{'dashboard-tabs-active': $ctrl.activeTab === $ctrl.TAB_NAME_TOPICS}">
         <a class="dashboard-tabs-text"
            ng-click="$ctrl.setActiveTab($ctrl.TAB_NAME_TOPICS)">

--- a/core/tests/protractor_utils/TopicsAndSkillsDashboardPage.js
+++ b/core/tests/protractor_utils/TopicsAndSkillsDashboardPage.js
@@ -75,6 +75,9 @@ var TopicsAndSkillsDashboardPage = function() {
     by.css('.protractor-test-topic-name-in-topic-select-modal'));
   var abbreviatedTopicNameField = element(
     by.css('.protractor-test-new-abbreviated-topic-name-field'));
+  var topicsTabButton = element(
+    by.css('.protractor-test-topics-tab')
+  );
 
   // Returns a promise of all topics with the given name.
   var _getTopicElements = function(topicName) {
@@ -231,6 +234,8 @@ var TopicsAndSkillsDashboardPage = function() {
   };
 
   this.editTopic = function(topicName) {
+    waitFor.elementToBeClickable(
+      topicsTabButton, 'Unable to click on topics tab.');
     _getTopicElements(topicName).then(function(topicElements) {
       if (topicElements.length === 0) {
         throw 'Could not find topic tile with name ' + topicName;


### PR DESCRIPTION
<!--
  - Thanks for submitting code to Oppia! Please fill out the following as part of
  - your pull request so we can review your code more easily.
  -->
## Explanation
<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->
Fixes part of #8746: Contains bug fixes for the following issues.

- [x] Fix tooltip in topic viewer.
screenshot:
![tooltip](https://user-images.githubusercontent.com/11008603/76088191-9aef3300-5fdd-11ea-9bb2-54d318095f0b.gif)

- [x] Remove hand pointer in story viewer
screenshot:
![no_hand_pointer](https://user-images.githubusercontent.com/11008603/76088221-a7738b80-5fdd-11ea-9a47-11b7e7e78fb4.png)

- [x] Fix practice session when no questions (angular.js:15570 TypeError: Cannot read property 'getStateData' of undefined)
screenshot:
![no_train_tab](https://user-images.githubusercontent.com/11008603/76088293-bfe3a600-5fdd-11ea-9e1e-88c0fcfc680d.png)
No 'TRAIN' tab is present when the number of questions is < 5.
![with_train_tab_selected](https://user-images.githubusercontent.com/11008603/76088287-bd814c00-5fdd-11ea-9bcf-b4198f3f08de.png)
'TRAIN' tab is present when questions >= 5.

- [x] Empty prerequisite and acquired skills shouldn’t be allowed
![disable_done_acquiredskills](https://user-images.githubusercontent.com/11008603/76088315-c7a34a80-5fdd-11ea-85de-2afc3efa9694.png)
'Done' button is disabled when no skill is selected.

## Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR explanation includes the words "Fixes #bugnum: ..." (or "Fixes part of #bugnum" if the PR only partially fixes an issue).
- [x] The linter/Karma presubmit checks have passed.
  - These should run automatically, but if not, you can manually trigger them locally using `python -m scripts.pre_commit_linter` and `python -m scripts.run_frontend_tests`.
- [x] The PR is made from a branch that's **not** called "develop".
- [x] The PR has an appropriate "PR CHANGELOG: ..." label (If you are unsure of which label to add, ask the reviewers for guidance).
- [x] The PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] The PR addresses the points mentioned in the codeowner checks for the files/folders changed. (See the [codeowner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).)
- [x] The PR is **assigned** to an appropriate reviewer.
  - If you're a new contributor, please ask on [Gitter](https://gitter.im/oppia/oppia-chat) for someone to assign a reviewer and don't tick this checkbox.
  - If you're not sure who the appropriate reviewer is, please assign to the issue's "owner" -- see the "talk-to" label on the issue. Do not only request the review but also add the reviewer as an assignee.
