### PR TITLE
Remove any from angular in all modules

### DIFF
--- a/core/templates/pages/about-page/about-page.module.ts
+++ b/core/templates/pages/about-page/about-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/admin-page/admin-page.module.ts
+++ b/core/templates/pages/admin-page/admin-page.module.ts
@@ -73,7 +73,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/classroom-page/classroom-page.module.ts
+++ b/core/templates/pages/classroom-page/classroom-page.module.ts
@@ -66,7 +66,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/collection-editor-page/collection-editor-page.module.ts
+++ b/core/templates/pages/collection-editor-page/collection-editor-page.module.ts
@@ -80,7 +80,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/collection-player-page/collection-player-page.module.ts
+++ b/core/templates/pages/collection-player-page/collection-player-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/community-dashboard-page/community-dashboard-page.module.ts
+++ b/core/templates/pages/community-dashboard-page/community-dashboard-page.module.ts
@@ -66,7 +66,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/contact-page/contact-page.module.ts
+++ b/core/templates/pages/contact-page/contact-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/creator-dashboard-page/creator-dashboard-page.module.ts
+++ b/core/templates/pages/creator-dashboard-page/creator-dashboard-page.module.ts
@@ -80,7 +80,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/delete-account-page/delete-account-page.module.ts
+++ b/core/templates/pages/delete-account-page/delete-account-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/donate-page/donate-page.module.ts
+++ b/core/templates/pages/donate-page/donate-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-page.module.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-page.module.ts
@@ -77,7 +77,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-result.module.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-result.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/error-pages/error-page.module.ts
+++ b/core/templates/pages/error-pages/error-page.module.ts
@@ -70,7 +70,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.module.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.module.ts
@@ -92,7 +92,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/exploration-player-page/exploration-player-page.module.ts
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.module.ts
@@ -85,7 +85,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/get-started-page/get-started-page.module.ts
+++ b/core/templates/pages/get-started-page/get-started-page.module.ts
@@ -64,7 +64,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/landing-pages/stewards-landing-page/stewards-landing-page.module.ts
+++ b/core/templates/pages/landing-pages/stewards-landing-page/stewards-landing-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/landing-pages/topic-landing-page/topic-landing-page.module.ts
+++ b/core/templates/pages/landing-pages/topic-landing-page/topic-landing-page.module.ts
@@ -74,7 +74,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.module.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.module.ts
@@ -77,7 +77,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/library-page/library-page.module.ts
+++ b/core/templates/pages/library-page/library-page.module.ts
@@ -77,7 +77,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/maintenance-page/maintenance-page.module.ts
+++ b/core/templates/pages/maintenance-page/maintenance-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/moderator-page/moderator-page.module.ts
+++ b/core/templates/pages/moderator-page/moderator-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/notifications-dashboard-page/notifications-dashboard-page.module.ts
+++ b/core/templates/pages/notifications-dashboard-page/notifications-dashboard-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/pending-account-deletion-page/pending-account-deletion-page.module.ts
+++ b/core/templates/pages/pending-account-deletion-page/pending-account-deletion-page.module.ts
@@ -63,7 +63,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   require('angular-cookies'), 'pascalprecht.translate', 'toastr',

--- a/core/templates/pages/practice-session-page/practice-session-page.module.ts
+++ b/core/templates/pages/practice-session-page/practice-session-page.module.ts
@@ -83,7 +83,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/preferences-page/preferences-page.module.ts
+++ b/core/templates/pages/preferences-page/preferences-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/privacy-page/privacy-page.module.ts
+++ b/core/templates/pages/privacy-page/privacy-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/profile-page/profile-page.module.ts
+++ b/core/templates/pages/profile-page/profile-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/review-test-page/review-test-page.module.ts
+++ b/core/templates/pages/review-test-page/review-test-page.module.ts
@@ -77,7 +77,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/signup-page/signup-page.module.ts
+++ b/core/templates/pages/signup-page/signup-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/skill-editor-page/skill-editor-page.module.ts
+++ b/core/templates/pages/skill-editor-page/skill-editor-page.module.ts
@@ -85,7 +85,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/splash-page/splash-page.module.ts
+++ b/core/templates/pages/splash-page/splash-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/story-editor-page/story-editor-page.module.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.module.ts
@@ -81,7 +81,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/story-viewer-page/story-viewer-page.module.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.module.ts
@@ -72,7 +72,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.module.ts
+++ b/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.module.ts
@@ -64,7 +64,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/teach-page/teach-page.module.ts
+++ b/core/templates/pages/teach-page/teach-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/terms-page/terms-page.module.ts
+++ b/core/templates/pages/terms-page/terms-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/thanks-page/thanks-page.module.ts
+++ b/core/templates/pages/thanks-page/thanks-page.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/topic-editor-page/topic-editor-page.module.ts
+++ b/core/templates/pages/topic-editor-page/topic-editor-page.module.ts
@@ -87,7 +87,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/topic-viewer-page/topic-viewer-page.module.ts
+++ b/core/templates/pages/topic-viewer-page/topic-viewer-page.module.ts
@@ -72,7 +72,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.module.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.module.ts
@@ -83,7 +83,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',

--- a/core/templates/tests/console_errors.module.ts
+++ b/core/templates/tests/console_errors.module.ts
@@ -69,7 +69,7 @@ const bootstrapFn = (extraProviders: StaticProvider[]) => {
 };
 const downgradedModule = downgradeModule(bootstrapFn);
 
-declare var angular: any;
+declare var angular: ng.IAngularStatic;
 
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',


### PR DESCRIPTION
## Explanation

This PR does the following: In all the modules `angular` is defined as `any`. This PR aims to assign the type of that `angular` variable. The type of this variable was found by seeing the type of `angular` in other controllers and directives i.e. `ng.IAngularStatic`.

## Essential Checklist

- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
