### PR TITLE
Update title reference in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Overview
 <!--
-Directions: Please answer *both* questions below and check off every point from the essential checklist!.
+READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!.
 -->
 
 1. This PR fixes #[fill_in_number_here].

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@ This PR does the following: [Explain what your PR does and why]
 
 ## Essential Checklist
 
+- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
 - [ ] The linter/Karma presubmit checks have passed locally on your machine.
 - [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
   - This lets reviewers restart your CircleCI tests for you.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,10 @@
-## Explanation
+## Overview
+<!--
+Directions: Please answer *both* questions below and check off every point from the essential checklist!.
+-->
 
-This PR fixes #[fill_in_number_here].
-
-This PR does the following: [Explain what your PR does and why]
+1. This PR fixes #[fill_in_number_here].
+2. This PR does the following: [Explain here what your PR does and why]
 
 ## Essential Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Overview
 <!--
-READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!.
+READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
 -->
 
 1. This PR fixes #[fill_in_number_here].


### PR DESCRIPTION
## Explanation

This PR fixes N/A

This PR does the following: [Explain what your PR does and why]
Adds the PR title in the checklist.

## Essential Checklist

- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
