### PR TITLE
Fix pylint linter errors

### DIFF
--- a/scripts/check_e2e_tests_are_captured_in_ci.py
+++ b/scripts/check_e2e_tests_are_captured_in_ci.py
@@ -70,7 +70,7 @@ def get_e2e_suite_names_from_script_travis_yml_file():
     travis_file_content = read_and_parse_travis_yml_file()
     script_str = python_utils.convert_to_bytes(travis_file_content['script'])
     # The following line extracts the test suites from patterns like
-    # python -m scripts.run_e2e_tests --suite="accessibility"
+    # python -m scripts.run_e2e_tests --suite="accessibility".
     e2e_test_suite_regex = re.compile(
         r'python -m scripts.run_e2e_tests --suite="([a-zA-Z_-]*)"')
     suites_list = e2e_test_suite_regex.findall(script_str)

--- a/scripts/create_expression_parser.py
+++ b/scripts/create_expression_parser.py
@@ -18,9 +18,7 @@ from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import argparse
-import fileinput
 import os
-import re
 import subprocess
 
 import python_utils

--- a/scripts/pylint_extensions.py
+++ b/scripts/pylint_extensions.py
@@ -1448,20 +1448,21 @@ class BlankLineBelowFileOverviewChecker(checkers.BaseChecker):
                 closing_line_index_of_fileoverview = line_num
                 break
 
-        empty_line_check_index = closing_line_index_of_fileoverview
-        if empty_line_check_index < file_length - 1:
-            while file_content[empty_line_check_index + 1] == b'\n':
-                empty_line_counter += 1
-                empty_line_check_index += 1
+        if triple_quote_counter == 2:
+            empty_line_check_index = closing_line_index_of_fileoverview
+            if empty_line_check_index < file_length - 1:
+                while file_content[empty_line_check_index + 1] == b'\n':
+                    empty_line_counter += 1
+                    empty_line_check_index += 1
 
-        if empty_line_counter > 1:
-            self.add_message(
-                'only-a-single-empty-line-should-be-provided',
-                line=closing_line_index_of_fileoverview + 1)
-        elif empty_line_counter == 0:
-            self.add_message(
-                'no-empty-line-provided-below-fileoverview',
-                line=closing_line_index_of_fileoverview + 1)
+            if empty_line_counter > 1:
+                self.add_message(
+                    'only-a-single-empty-line-should-be-provided',
+                    line=closing_line_index_of_fileoverview + 1)
+            elif empty_line_counter == 0:
+                self.add_message(
+                    'no-empty-line-provided-below-fileoverview',
+                    line=closing_line_index_of_fileoverview + 1)
 
 
 def register(linter):

--- a/scripts/pylint_extensions_test.py
+++ b/scripts/pylint_extensions_test.py
@@ -2120,6 +2120,28 @@ class BlankLineBelowFileOverviewCheckerTests(unittest.TestCase):
         with self.checker_test_object.assertNoMessages():
             temp_file.close()
 
+    def test_file_with_no_file_overview(self):
+        node_file_with_no_file_overview = astroid.scoped_nodes.Module(
+            name='test',
+            doc='Custom test')
+        temp_file = tempfile.NamedTemporaryFile()
+        filename = temp_file.name
+
+        with python_utils.open_file(filename, 'w') as tmp:
+            tmp.write(
+                u"""
+                    import something
+                    import random
+                """)
+        node_file_with_no_file_overview.file = filename
+        node_file_with_no_file_overview.path = filename
+
+        self.checker_test_object.checker.process_module(
+            node_file_with_no_file_overview)
+
+        with self.checker_test_object.assertNoMessages():
+            temp_file.close()
+
     def test_file_overview_at_end_of_file(self):
         node_file_overview_at_end_of_file = astroid.scoped_nodes.Module(
             name='test',


### PR DESCRIPTION
## Explanation
PR #8409  introduced an error that resulted in 'local variable referenced before initialization'. Because of this, no link checks were being run. The linter falsely reported success, despite there being lint errors in the codebase. This PR aims to fix that error

## Essential Checklist

- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
