### PR TITLE
Fix part of #8746: Centralized the story view icons

### DIFF
--- a/core/templates/pages/story-viewer-page/story-viewer-page.directive.html
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.directive.html
@@ -49,7 +49,7 @@
              ng-href="<[$ctrl.getExplorationUrl(node)]>"
              ng-style="{position: 'absolute', left: '<[$ctrl.pathIconParameters[$index].left]>', top: '<[$ctrl.pathIconParameters[$index].top]>'}"
              ng-class="{'oppia-story-node-default-cursor': !$ctrl.isSummaryTileVisible(node)}">
-            <div ng-style="{width: '160px',position: 'absolute',left: '<[$ctrl.getExplorationTitlePosition($index)]>',color: '#006553','font-family': 'Capriola, Roboto, Arial,sans-serif','font-size': '18px',bottom: '65%'}">
+            <div ng-style="{width: '120px',position: 'absolute',left: '<[$ctrl.getExplorationTitlePosition($index)]>',color: '#006553','font-family': 'Capriola, Roboto, Arial,sans-serif','font-size': '18px',bottom: '82%'}">
               <span ng-if="node.isCompleted()" aria-live="assertive" translate="I18N_STORY_VIEWER_COMPLETED_CHAPTER" translate-values="{title: node.getTitle()}">
               </span>
               <span ng-if="!node.isCompleted()" aria-live="assertive">
@@ -62,7 +62,7 @@
                  xmlns="http://www.w3.org/2000/svg"
                  xmlns:xlink="http://www.w3.org/1999/xlink"
                  version="1.1"
-                 style="position:relative;top:20px">
+                 style="position:relative">
               <defs>
                 <pattern id="image<[$index]>" patternUnits="userSpaceOnUse" height="150" width="100">
                   <circle cx="50"
@@ -261,7 +261,7 @@
     left: 50%;
     position: absolute;
     text-align: center;
-    transform: translate(-50%, 195px);
+    transform: translate(-50%, 170px);
     z-index: 1;
   }
   .oppia-story-node-small-screen::before {


### PR DESCRIPTION
## Explanation

This PR fixes part of #8746

This PR does the following:
Realigned the icons in the story viewer path.

## Essential Checklist

- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
