### PR TITLE
Turn improvements tab off by default

### DIFF
--- a/core/controllers/admin_test.py
+++ b/core/controllers/admin_test.py
@@ -105,7 +105,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
         response_dict = self.get_json('/adminhandler')
         response_config_properties = response_dict['config_properties']
         self.assertDictContainsSubset({
-            'value': True,
+            'value': False,
         }, response_config_properties[
             config_domain.IS_IMPROVEMENTS_TAB_ENABLED.name])
 

--- a/core/domain/config_domain.py
+++ b/core/domain/config_domain.py
@@ -335,7 +335,7 @@ RECORD_PLAYTHROUGH_PROBABILITY = ConfigProperty(
 IS_IMPROVEMENTS_TAB_ENABLED = ConfigProperty(
     'is_improvements_tab_enabled', BOOL_SCHEMA,
     'Exposes the Improvements Tab for creators in the exploration editor.',
-    True)
+    False)
 
 ALWAYS_ASK_LEARNERS_FOR_ANSWER_DETAILS = ConfigProperty(
     'always_ask_learners_for_answer_details', BOOL_SCHEMA,


### PR DESCRIPTION
## Explanation
Fixes #8812

This PR does the following: Changes default state of exploration editor to match production behavior. In prod, we use the feedback tab and not the improvements tab, hence the change of default value from ON to OFF.
