### PR TITLE
Fix part of #8746: Fixed topic viewer tab alignment

### DIFF
--- a/core/templates/pages/topic-viewer-page/topic-viewer-page.directive.html
+++ b/core/templates/pages/topic-viewer-page/topic-viewer-page.directive.html
@@ -48,7 +48,7 @@
     flex-wrap: wrap;
     margin-bottom: 0;
     padding-left: 0;
-    padding-top: 7vh;
+    padding-top: 50px;
     text-align: center;
   }
 


### PR DESCRIPTION
## Explanation

This PR fixes part of #8746

This PR does the following:
The topic viewer tabs were getting misaligned upon resizing the browser. This PR fixes that.

## Essential Checklist

- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
