### PR TITLE
Fix part of #7462: Add url validation for Link component

### DIFF
--- a/core/templates/components/forms/schema-based-editors/schema-based-unicode-editor.directive.ts
+++ b/core/templates/components/forms/schema-based-editors/schema-based-unicode-editor.directive.ts
@@ -20,7 +20,8 @@ require('interactions/codemirrorRequires.ts');
 
 require(
   'components/forms/custom-forms-directives/apply-validation.directive.ts');
-
+require('components/forms/validators/is-nonempty.filter.ts');
+require('components/forms/validators/is-valid-url.filter.ts');
 require('filters/convert-unicode-with-params-to-html.filter.ts');
 require('services/contextual/device-info.service.ts');
 

--- a/core/templates/components/forms/validators/is-valid-url.filter.spec.ts
+++ b/core/templates/components/forms/validators/is-valid-url.filter.spec.ts
@@ -1,0 +1,47 @@
+// Copyright 2019 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Tests for Validator to check if input is nonempty.
+ */
+
+// TODO(#7222): Remove the following block of unnnecessary imports once
+// the code corresponding to the spec is upgraded to Angular 8.
+import { UpgradedServices } from 'services/UpgradedServices';
+// ^^^ This block is to be removed.
+
+require('components/forms/validators/is-valid-url.filter.ts');
+
+describe('Normalizer tests', function() {
+  var filterName = 'isValidUrl';
+
+  beforeEach(angular.mock.module('oppia'));
+
+  beforeEach(angular.mock.module('oppia', function($provide) {
+    var ugs = new UpgradedServices();
+    for (let [key, value] of Object.entries(ugs.getUpgradedServices())) {
+      $provide.value(key, value);
+    }
+  }));
+
+  it('should have the relevant filters', angular.mock.inject(function($filter) {
+    expect($filter(filterName)).not.toEqual(null);
+  }));
+
+  it('should validate non-emptiness', angular.mock.inject(function($filter) {
+    var filter = $filter('isValidUrl');
+    expect(filter('https://www.example.com')).toBe(true);
+    expect(filter('mailto:example@example.com')).toBe(false);
+  }));
+});

--- a/core/templates/components/forms/validators/is-valid-url.filter.ts
+++ b/core/templates/components/forms/validators/is-valid-url.filter.ts
@@ -17,9 +17,8 @@
  */
 
 angular.module('oppia').filter('isValidUrl', [function() {
-    var IS_VALID_URL_REGEXP = /^((?!(mailto:)).)*$/;
-    return function(input) {
-      return IS_VALID_URL_REGEXP.test(input);
-    };
-  }]);
-  
+  var IS_VALID_URL_REGEXP = /^((?!(mailto:)).)*$/;
+  return function(input) {
+    return IS_VALID_URL_REGEXP.test(input);
+  };
+}]);

--- a/core/templates/components/forms/validators/is-valid-url.filter.ts
+++ b/core/templates/components/forms/validators/is-valid-url.filter.ts
@@ -1,0 +1,25 @@
+// Copyright 2019 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Validator to check if input is nonempty.
+ */
+
+angular.module('oppia').filter('isValidUrl', [function() {
+    var IS_VALID_URL_REGEXP = /^((?!(mailto:)).)*$/;
+    return function(input) {
+      return IS_VALID_URL_REGEXP.test(input);
+    };
+  }]);
+  

--- a/extensions/objects/models/objects.py
+++ b/extensions/objects/models/objects.py
@@ -326,6 +326,8 @@ class SanitizedUrl(BaseObject):
         'type': 'unicode',
         'validators': [{
             'id': 'is_nonempty'
+        }, {
+            'id': 'is_valid_url'
         }],
         'ui_config': {
             'placeholder': 'https://www.example.com'

--- a/extensions/objects/templates/sanitized-url-editor.directive.ts
+++ b/extensions/objects/templates/sanitized-url-editor.directive.ts
@@ -34,6 +34,8 @@ angular.module('oppia').directive('sanitizedUrlEditor', [
             type: 'unicode',
             validators: [{
               id: 'is_nonempty'
+            }, {
+              id: 'is_valid_url'
             }],
             ui_config: {
               placeholder: 'https://www.example.com'

--- a/extensions/rich_text_components/components.py
+++ b/extensions/rich_text_components/components.py
@@ -122,6 +122,15 @@ class Image(BaseRteComponent):
 class Link(BaseRteComponent):
     """Class for Link component."""
 
+    @classmethod
+    def validate(cls, value_dict):
+        """Validates Link component."""
+        super(Link, cls).validate(value_dict)
+        regex_pattern = r'.*mailto:.*'
+        url_with_value = value_dict['url-with-value']
+        if re.match(regex_pattern, url_with_value):
+            raise Exception('Invalid URL')
+
 
 class Math(BaseRteComponent):
     """Class for Math component."""

--- a/extensions/rich_text_components/components_test.py
+++ b/extensions/rich_text_components/components_test.py
@@ -110,6 +110,9 @@ class ComponentValidationUnitTests(test_utils.GenericTestBase):
         }, {
             'url-with-value': 'http://link.com',
             'text-with-value': 1234
+        }, {
+            'url-with-value': 'https://mailto:abc@link.com',
+            'text-with-value': 'abc@link.com'
         }]
 
         self.check_validation(

--- a/schema_utils.py
+++ b/schema_utils.py
@@ -339,6 +339,18 @@ class _Validators(python_utils.OBJECT):
         return bool(obj)
 
     @staticmethod
+    def is_valid_url(obj):
+        """Ensures that `obj` (a string) is a valid URL.
+
+        Args:
+            obj: str. A string.
+
+        Returns:
+            bool. Whether the given object is a valif URL.
+        """
+        return bool(re.search(r'^((?!(mailto:)).)*$', obj))
+
+    @staticmethod
     def is_uniquified(obj):
         """Returns True iff the given object (a list) has no duplicates.
 

--- a/schema_utils_test.py
+++ b/schema_utils_test.py
@@ -449,6 +449,15 @@ class SchemaValidationUnitTests(test_utils.GenericTestBase):
         self.assertTrue(is_nonempty('    '))
         self.assertFalse(is_nonempty(''))
 
+    def test_is_valid_url_validator(self):
+        """Tests if static method is_valid_url returns true iff obj
+        is not a valid url.
+        """
+        is_valid_url = schema_utils.get_validator('is_valid_url')
+        self.assertTrue(is_valid_url('https://www.example.com'))
+        self.assertFalse(is_valid_url('mailto:abc@xyz.com'))
+        self.assertFalse(is_valid_url('mailto:abc@xyz.com,asd@qwerty.com'))
+
     def test_is_at_most_validator(self):
         """Tests if static method is_at_most returns true iff obj
         is at most a value.

--- a/scripts/create_expression_parser.py
+++ b/scripts/create_expression_parser.py
@@ -18,9 +18,7 @@ from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import argparse
-import fileinput
 import os
-import re
 import subprocess
 
 import python_utils


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes part of #7462 .
2. This PR does the following: This PR adds frontend and backend validation for Link component so that URLs containing "mailto:" are not accepted.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
