### PR TITLE
[WIP] Navigation test migration to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,13 +17,16 @@ workflows:
             - setup
       - e2e_classroom_page:
           requires:
-            - typescript_tests
+            - e2e_navigation
       - e2e_file_upload_features:
+          requires:
+            - e2e_navigation
+      - e2e_navigation:
           requires:
             - typescript_tests
       - e2e_topic_and_story_editor:
           requires:
-            - typescript_tests
+            - e2e_navigation
 
 var_for_docker_image: &docker_image circleci/python:2.7.17-browsers
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
       - run:
           name: Run e2e classroom page test
           command: |
-            python -m scripts.run_e2e_tests --suite="classroomPageFileUploadFeatures"
+            python -m scripts.run_e2e_tests --skip_install --suite="classroomPageFileUploadFeatures"
 
   e2e_file_upload_features:
     <<: *job_defaults
@@ -142,7 +142,7 @@ jobs:
       - run:
           name: Run e2e file upload features test
           command: |
-            python -m scripts.run_e2e_tests --suite="fileUploadFeatures"
+            python -m scripts.run_e2e_tests --skip_install --suite="fileUploadFeatures"
 
   e2e_navigation:
     <<: *job_defaults
@@ -155,7 +155,7 @@ jobs:
       - run:
           name: Run e2e file upload features test
           command: |
-            python -m scripts.run_e2e_tests --suite="navigation"
+            python -m scripts.run_e2e_tests --skip_install --suite="navigation"
 
   e2e_topic_and_story_editor:
     <<: *job_defaults
@@ -168,7 +168,7 @@ jobs:
       - run:
           name: Run e2e topic and story editor test
           command: |
-            python -m scripts.run_e2e_tests --suite="topicAndStoryEditorFileUploadFeatures"
+            python -m scripts.run_e2e_tests --skip_install --suite="topicAndStoryEditorFileUploadFeatures"
 notify:
   webhooks:
     # A list of hook hashes, containing the url field

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,19 @@ jobs:
           command: |
             python -m scripts.run_e2e_tests --suite="fileUploadFeatures"
 
+  e2e_navigation:
+    <<: *job_defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /home/circleci/
+      - run:
+          <<: *install_dependencies
+      - run:
+          name: Run e2e file upload features test
+          command: |
+            python -m scripts.run_e2e_tests --suite="navigation"
+
   e2e_topic_and_story_editor:
     <<: *job_defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
       - run:
           name: Run e2e classroom page test
           command: |
-            python -m scripts.run_e2e_tests --skip_install --suite="classroomPageFileUploadFeatures"
+            python -m scripts.run_e2e_tests --skip_install --skip-build --suite="classroomPageFileUploadFeatures" --prod_env
 
   e2e_file_upload_features:
     <<: *job_defaults
@@ -142,7 +142,7 @@ jobs:
       - run:
           name: Run e2e file upload features test
           command: |
-            python -m scripts.run_e2e_tests --skip_install --suite="fileUploadFeatures"
+            python -m scripts.run_e2e_tests --skip_install --skip-build --suite="fileUploadFeatures" --prod_env
 
   e2e_navigation:
     <<: *job_defaults
@@ -155,7 +155,13 @@ jobs:
       - run:
           name: Run e2e file upload features test
           command: |
-            python -m scripts.run_e2e_tests --skip_install --suite="navigation"
+            python -m scripts.run_e2e_tests --prod_env --skip_install --suite="navigation"
+      - persist_to_workspace:
+          root: /home/circleci/
+          paths:
+            - oppia/third_party/
+            - oppia/build/
+            - oppia/backend_prod_files/
 
   e2e_topic_and_story_editor:
     <<: *job_defaults
@@ -168,7 +174,7 @@ jobs:
       - run:
           name: Run e2e topic and story editor test
           command: |
-            python -m scripts.run_e2e_tests --skip_install --suite="topicAndStoryEditorFileUploadFeatures"
+            python -m scripts.run_e2e_tests --skip_install --skip-build --suite="topicAndStoryEditorFileUploadFeatures" --prod_env
 notify:
   webhooks:
     # A list of hook hashes, containing the url field

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ env:
     - RUN_E2E_TESTS_LEARNER_DASHBOARD=true
     - RUN_E2E_TESTS_LEARNER=true
     - RUN_E2E_TESTS_LIBRARY=true
-    - RUN_E2E_TESTS_NAVIGATION=true
     - RUN_E2E_TESTS_PREFERENCES=true
     - RUN_E2E_TESTS_PROFILE_FEATURES=true
     - RUN_E2E_TESTS_PROFILE_MENU=true
@@ -102,7 +101,6 @@ script:
 - if [ "$RUN_E2E_TESTS_LEARNER_DASHBOARD" == 'true' ]; then travis_retry python -m scripts.run_e2e_tests --suite="learnerDashboard" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_LEARNER" == 'true' ]; then travis_retry python -m scripts.run_e2e_tests --suite="learner" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_LIBRARY" == 'true' ]; then travis_retry python -m scripts.run_e2e_tests --suite="library" --prod_env; fi
-- if [ "$RUN_E2E_TESTS_NAVIGATION" == 'true' ]; then travis_retry python -m scripts.run_e2e_tests --suite="navigation" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_PREFERENCES" == 'true' ]; then travis_retry python -m scripts.run_e2e_tests --suite="preferences" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_PROFILE_FEATURES" == 'true' ]; then travis_retry python -m scripts.run_e2e_tests --suite="profileFeatures" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_PROFILE_MENU" == 'true' ]; then travis_retry python -m scripts.run_e2e_tests --suite="profileMenu" --prod_env; fi

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -96,6 +96,10 @@ _PARSER.add_argument(
     help='If true, skips installing dependencies. The default value is false.',
     action='store_true')
 _PARSER.add_argument(
+    '--skip-build',
+    help='If true, skips building files. The default value is false.',
+    action='store_true')
+_PARSER.add_argument(
     '--sharding-instances', type=int, default=3,
     help='Sets the number of parallel browsers to open while sharding.'
          'Sharding must be disabled (either by passing in false to --sharding'
@@ -446,7 +450,8 @@ def main(args=None):
     dev_mode = not parsed_args.prod_env
     update_community_dashboard_status_in_feconf_file(
         FECONF_FILE_PATH, parsed_args.community_dashboard_enabled)
-    build_js_files(dev_mode)
+    if not parsed_args.skip_build:
+        build_js_files(dev_mode)
     start_webdriver_manager()
 
     start_google_app_engine_server(dev_mode)


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes #N/A
2. This PR does the following: 
  - Moves the navigation test from TravisCI to CircleCI.
  - Makes the other e2e tests block on the navigation test (ie. if the navigation test fails, other e2e tests will not run)
  - Add the build skip option to the e2e test runner which is intended for tests other than the navigation tests to use.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
