### PR TITLE
New path of chromium on Unix

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -214,9 +214,6 @@ def main(args=None):
     elif os.path.isfile('/usr/bin/chromium-browser'):
         # Unix.
         chrome_bin = '/usr/bin/chromium-browser'
-    elif os.path.isfile('/usr/bin/google-chrome-beta'):
-        # Unix.
-        chrome_bin = '/usr/bin/google-chrome-beta'
     elif os.path.isfile('/usr/bin/chromium'):
         # Unix.
         chrome_bin = '/usr/bin/chromium'

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -214,6 +214,12 @@ def main(args=None):
     elif os.path.isfile('/usr/bin/chromium-browser'):
         # Unix.
         chrome_bin = '/usr/bin/chromium-browser'
+    elif os.path.isfile('/usr/bin/google-chrome-beta'):
+        # Unix.
+        chrome_bin = '/usr/bin/google-chrome-beta'
+    elif os.path.isfile('/usr/bin/chromium'):
+        # Unix.
+        chrome_bin = '/usr/bin/chromium'
     elif os.path.isfile(
             '/c/Program Files (x86)/Google/Chrome/Application/chrome.exe'):
         # Windows.


### PR DESCRIPTION
The Latest Chromium has changed the application name on bin.
From "chromium-browser" to only "chromium" (Found on Arch Linux)
 Also the chrome browser beta version path is added.

