### PR TITLE
Fix part of #7176: Refactor dicts in frontend to have only camelCase keys for FeedbackMessageSummaryObjectFactory

### DIFF
--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -1870,13 +1870,13 @@ class FetchIssuesPlaythroughHandlerTests(test_utils.GenericTestBase):
                 }
             },
             [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
         self.playthrough_id2 = stats_models.PlaythroughModel.create(
             self.EXP_ID, 1, 'MultipleIncorrectSubmissions',
@@ -1889,13 +1889,13 @@ class FetchIssuesPlaythroughHandlerTests(test_utils.GenericTestBase):
                 }
             },
             [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
                     'state_name': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
         stats_models.ExplorationIssuesModel.create(
             self.EXP_ID, 1,
@@ -1983,13 +1983,13 @@ class FetchIssuesPlaythroughHandlerTests(test_utils.GenericTestBase):
             })
         self.assertEqual(
             response['actions'], [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
 
 
@@ -2024,13 +2024,13 @@ class ResolveIssueHandlerTests(test_utils.GenericTestBase):
                 }
             },
             [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
         self.playthrough_id2 = stats_models.PlaythroughModel.create(
             self.EXP_ID, 1, 'EarlyQuit',
@@ -2043,13 +2043,13 @@ class ResolveIssueHandlerTests(test_utils.GenericTestBase):
                 }
             },
             [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
                     'state_name': {
                         'value': 'state_name2'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
 
         stats_models.ExplorationIssuesModel.create(

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -1872,7 +1872,7 @@ class FetchIssuesPlaythroughHandlerTests(test_utils.GenericTestBase):
             [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -1985,7 +1985,7 @@ class FetchIssuesPlaythroughHandlerTests(test_utils.GenericTestBase):
             response['actions'], [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -2026,7 +2026,7 @@ class ResolveIssueHandlerTests(test_utils.GenericTestBase):
             [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },

--- a/core/controllers/learner_dashboard.py
+++ b/core/controllers/learner_dashboard.py
@@ -170,13 +170,13 @@ class LearnerDashboardFeedbackThreadHandler(base.BaseHandler):
                 exploration.states[
                     suggestion.change.state_name].content.html)
             suggestion_summary = {
-                'suggestion_html': suggestion.change.new_value['html'],
-                'current_content_html': current_content_html,
+                'suggestionHtml': suggestion.change.new_value['html'],
+                'currentContentHtml': current_content_html,
                 'description': suggestion_thread.subject,
-                'author_username': authors_settings[0].username,
-                'author_picture_data_url': (
+                'authorUsername': authors_settings[0].username,
+                'authorPictureDataUrl': (
                     authors_settings[0].profile_picture_data_url),
-                'created_on_msecs': utils.get_time_in_millisecs(
+                'createdOnMsecs': utils.get_time_in_millisecs(
                     messages[0].created_on)
             }
             message_summary_list.append(suggestion_summary)
@@ -194,12 +194,12 @@ class LearnerDashboardFeedbackThreadHandler(base.BaseHandler):
                     author_settings.profile_picture_data_url)
 
             message_summary = {
-                'message_id': m.message_id,
+                'messageId': m.message_id,
                 'text': m.text,
-                'updated_status': m.updated_status,
-                'author_username': author_username,
-                'author_picture_data_url': author_picture_data_url,
-                'created_on_msecs': utils.get_time_in_millisecs(m.created_on)
+                'updatedStatus': m.updated_status,
+                'authorUsername': author_username,
+                'authorPictureDataUrl': author_picture_data_url,
+                'createdOnMsecs': utils.get_time_in_millisecs(m.created_on)
             }
             message_summary_list.append(message_summary)
 

--- a/core/controllers/learner_dashboard_test.py
+++ b/core/controllers/learner_dashboard_test.py
@@ -331,7 +331,7 @@ class LearnerDashboardFeedbackThreadHandlerTests(test_utils.GenericTestBase):
 
         self.assertDictContainsSubset({
             'text': 'a sample message',
-            'author_username': 'editor'
+            'authorUsername': 'editor'
         }, first_message)
 
         # Add another message.
@@ -355,7 +355,7 @@ class LearnerDashboardFeedbackThreadHandlerTests(test_utils.GenericTestBase):
         second_message = messages_summary[1]
         self.assertDictContainsSubset({
             'text': 'Message 1',
-            'author_username': 'editor'
+            'authorUsername': 'editor'
         }, second_message)
 
         self.logout()
@@ -381,8 +381,8 @@ class LearnerDashboardFeedbackThreadHandlerTests(test_utils.GenericTestBase):
         response_dict = self.get_json(thread_url)
         messages_summary = response_dict['message_summary_list'][0]
 
-        self.assertEqual(messages_summary['author_username'], None)
-        self.assertEqual(messages_summary['author_picture_data_url'], None)
+        self.assertEqual(messages_summary['authorUsername'], None)
+        self.assertEqual(messages_summary['authorPictureDataUrl'], None)
 
     def test_get_suggestions_after_updating_suggestion_summary(self):
         self.login(self.EDITOR_EMAIL)
@@ -398,12 +398,12 @@ class LearnerDashboardFeedbackThreadHandlerTests(test_utils.GenericTestBase):
         messages_summary = response_dict['message_summary_list'][0]
 
         self.assertEqual(
-            messages_summary['author_username'], self.EDITOR_USERNAME)
+            messages_summary['authorUsername'], self.EDITOR_USERNAME)
         self.assertTrue(
-            messages_summary['author_picture_data_url'].startswith(
+            messages_summary['authorPictureDataUrl'].startswith(
                 'data:image/png;'))
-        self.assertFalse(messages_summary.get('suggestion_html'))
-        self.assertFalse(messages_summary.get('current_content_html'))
+        self.assertFalse(messages_summary.get('suggestionHtml'))
+        self.assertFalse(messages_summary.get('currentContentHtml'))
         self.assertFalse(messages_summary.get('description'))
 
         new_content = state_domain.SubtitledHtml(
@@ -432,17 +432,17 @@ class LearnerDashboardFeedbackThreadHandlerTests(test_utils.GenericTestBase):
         first_suggestion = feedback_services.get_messages(thread_id)[0]
 
         self.assertEqual(
-            messages_summary['author_username'], self.EDITOR_USERNAME)
+            messages_summary['authorUsername'], self.EDITOR_USERNAME)
         self.assertTrue(
-            messages_summary['author_picture_data_url'].startswith(
+            messages_summary['authorPictureDataUrl'].startswith(
                 'data:image/png;'))
         self.assertEqual(
             utils.get_time_in_millisecs(first_suggestion.created_on),
-            messages_summary['created_on_msecs'])
+            messages_summary['createdOnMsecs'])
         self.assertEqual(
-            messages_summary['suggestion_html'], '<p>new content html</p>')
+            messages_summary['suggestionHtml'], '<p>new content html</p>')
         self.assertEqual(
-            messages_summary['current_content_html'], current_content_html)
+            messages_summary['currentContentHtml'], current_content_html)
         self.assertEqual(
             messages_summary['description'], suggestion_thread.subject)
         self.logout()

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -1480,13 +1480,13 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 }
             },
             [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
         stats_models.ExplorationIssuesModel.create(
             self.exp_id, 1, [{
@@ -1517,13 +1517,13 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 }
             },
             'actions': [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }]
         }
 
@@ -1579,13 +1579,13 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 },
             },
             [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
 
         model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
@@ -1612,13 +1612,13 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 },
             },
             'actions': [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }],
         }
 
@@ -1648,13 +1648,13 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 },
             },
             [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
 
         model = stats_models.ExplorationIssuesModel.get_model(self.exp_id, 1)
@@ -1681,13 +1681,13 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 },
             },
             'actions': [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }]
         }
 
@@ -1871,13 +1871,13 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
                 }
             },
             [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
 
         stats_models.ExplorationIssuesModel.create(

--- a/core/controllers/reader_test.py
+++ b/core/controllers/reader_test.py
@@ -1482,7 +1482,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -1519,7 +1519,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             'actions': [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -1581,7 +1581,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -1614,7 +1614,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             'actions': [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -1650,7 +1650,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -1683,7 +1683,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             'actions': [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -1873,7 +1873,7 @@ class StorePlaythroughHandlerTest(test_utils.GenericTestBase):
             [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },

--- a/core/domain/stats_domain.py
+++ b/core/domain/stats_domain.py
@@ -780,13 +780,13 @@ class LearnerAction(python_utils.OBJECT):
             dict. A dict mapping of all fields of LearnerAction object.
         """
         return {
-            'action_type': self.action_type,
-            'action_customization_args': (
+            'actionType': self.action_type,
+            'actionCustomizationArgs': (
                 customization_args_util.get_full_customization_args(
                     self.action_customization_args,
                     action_registry.Registry.get_action_by_type(
                         self.action_type).customization_arg_specs)),
-            'schema_version': self.schema_version
+            'schemaVersion': self.schema_version
         }
 
     @classmethod
@@ -801,9 +801,9 @@ class LearnerAction(python_utils.OBJECT):
             LearnerAction. The corresponding LearnerAction domain object.
         """
         return cls(
-            action_dict['action_type'],
-            action_dict['action_customization_args'],
-            action_dict['schema_version'])
+            action_dict['actionType'],
+            action_dict['actionCustomizationArgs'],
+            action_dict['schemaVersion'])
 
     @classmethod
     def update_learner_action_from_model(cls, action_dict):
@@ -814,8 +814,8 @@ class LearnerAction(python_utils.OBJECT):
         Args:
             action_dict: dict. Dict representing the LearnerAction object.
         """
-        current_action_schema_version = action_dict['schema_version']
-        action_dict['schema_version'] += 1
+        current_action_schema_version = action_dict['schemaVersion']
+        action_dict['schemaVersion'] += 1
 
         conversion_fn = getattr(cls, '_convert_action_v%s_dict_to_v%s_dict' % (
             current_action_schema_version, current_action_schema_version + 1))

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -474,7 +474,7 @@ class PlaythroughTests(test_utils.GenericTestBase):
             }, [stats_domain.LearnerAction.from_dict({
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -495,7 +495,7 @@ class PlaythroughTests(test_utils.GenericTestBase):
             }, [stats_domain.LearnerAction.from_dict({
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -521,7 +521,7 @@ class PlaythroughTests(test_utils.GenericTestBase):
                 {
                     'actionType': 'ExplorationStart',
                     'actionCustomizationArgs': {
-                        'stateName': {
+                        'state_name': {
                             'value': 'state_name1'
                         }
                     },
@@ -545,7 +545,7 @@ class PlaythroughTests(test_utils.GenericTestBase):
             'actions': [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -572,7 +572,7 @@ class PlaythroughTests(test_utils.GenericTestBase):
             {
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -611,7 +611,7 @@ class PlaythroughTests(test_utils.GenericTestBase):
                 'actionType': 'InvalidActionType',
                 'schemaVersion': 1,
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'state_name1'
                     }
                 },
@@ -1012,13 +1012,13 @@ class LearnerActionTests(test_utils.GenericTestBase):
         self.learner_action.validate()
 
     def test_validate_with_int_action_type(self):
-        self.learner_action.actionType = 5
+        self.learner_action.action_type = 5
         with self.assertRaisesRegexp(utils.ValidationError, (
             'Expected actionType to be a string, received %s' % (type(5)))):
             self.learner_action.validate()
 
     def test_validate_with_string_schema_version(self):
-        self.learner_action.schemaVersion = '1'
+        self.learner_action.schema_version = '1'
         with self.assertRaisesRegexp(utils.ValidationError, (
             'Expected schemaVersion to be an int, received %s' % (type('1')))):
             self.learner_action.validate()

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -1014,13 +1014,13 @@ class LearnerActionTests(test_utils.GenericTestBase):
     def test_validate_with_int_action_type(self):
         self.learner_action.action_type = 5
         with self.assertRaisesRegexp(utils.ValidationError, (
-            'Expected actionType to be a string, received %s' % (type(5)))):
+            'Expected action_type to be a string, received %s' % (type(5)))):
             self.learner_action.validate()
 
     def test_validate_with_string_schema_version(self):
         self.learner_action.schema_version = '1'
         with self.assertRaisesRegexp(utils.ValidationError, (
-            'Expected schemaVersion to be an int, received %s' % (type('1')))):
+            'Expected schema_version to be an int, received %s' % (type('1')))):
             self.learner_action.validate()
 
 

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -920,9 +920,9 @@ class LearnerActionTests(test_utils.GenericTestBase):
                 playthrough_model)
 
         self.assertEqual(
-            playthrough.actions[0].actionType, 'ExplorationStart1')
+            playthrough.actions[0].action_type, 'ExplorationStart1')
         self.assertEqual(
-            playthrough.actions[0].actionCustomizationArgs['new_key'], 5)
+            playthrough.actions[0].action_customization_args['new_key'], 5)
 
         # For other action types, no changes happen during migration.
         learner_action1 = stats_domain.LearnerAction('ExplorationQuit', {}, 1)
@@ -953,7 +953,7 @@ class LearnerActionTests(test_utils.GenericTestBase):
                 playthrough_model_1)
 
         self.assertEqual(
-            playthrough1.actions[0].actionType, 'ExplorationQuit')
+            playthrough1.actions[0].action_type, 'ExplorationQuit')
 
     def test_cannot_update_learner_action_from_invalid_schema_version_model(
             self):

--- a/core/domain/stats_domain_test.py
+++ b/core/domain/stats_domain_test.py
@@ -472,13 +472,13 @@ class PlaythroughTests(test_utils.GenericTestBase):
                     'value': 200
                 }
             }, [stats_domain.LearnerAction.from_dict({
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             })])
         playthrough.validate()
         return playthrough
@@ -493,13 +493,13 @@ class PlaythroughTests(test_utils.GenericTestBase):
                     'value': 200
                 }
             }, [stats_domain.LearnerAction.from_dict({
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             })])
 
         playthrough_dict = playthrough.to_dict()
@@ -519,13 +519,13 @@ class PlaythroughTests(test_utils.GenericTestBase):
         self.assertEqual(
             playthrough_dict['actions'], [
                 {
-                    'action_type': 'ExplorationStart',
-                    'action_customization_args': {
-                        'state_name': {
+                    'actionType': 'ExplorationStart',
+                    'actionCustomizationArgs': {
+                        'stateName': {
                             'value': 'state_name1'
                         }
                     },
-                    'schema_version': 1
+                    'schemaVersion': 1
                 }])
 
     def test_from_dict(self):
@@ -543,13 +543,13 @@ class PlaythroughTests(test_utils.GenericTestBase):
                 }
             },
             'actions': [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }],
         }
 
@@ -570,13 +570,13 @@ class PlaythroughTests(test_utils.GenericTestBase):
         self.assertEqual(
             playthrough.actions[0].to_dict(),
             {
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             })
 
     def test_from_dict_raises_exception_when_miss_exp_id(self):
@@ -608,10 +608,10 @@ class PlaythroughTests(test_utils.GenericTestBase):
     def test_validate_with_invalid_action_type(self):
         self.playthrough.actions = [
             stats_domain.LearnerAction.from_dict({
-                'action_type': 'InvalidActionType',
-                'schema_version': 1,
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'InvalidActionType',
+                'schemaVersion': 1,
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'state_name1'
                     }
                 },
@@ -869,10 +869,10 @@ class LearnerActionTests(test_utils.GenericTestBase):
 
     def _dummy_convert_action_v1_dict_to_v2_dict(self, action_dict):
         """A test implementation of schema conversion function."""
-        action_dict['schema_version'] = 2
-        if action_dict['action_type'] == 'ExplorationStart':
-            action_dict['action_type'] = 'ExplorationStart1'
-            action_dict['action_customization_args']['new_key'] = 5
+        action_dict['schemaVersion'] = 2
+        if action_dict['actionType'] == 'ExplorationStart':
+            action_dict['actionType'] = 'ExplorationStart1'
+            action_dict['actionCustomizationArgs']['new_key'] = 5
 
         return action_dict
 
@@ -886,9 +886,9 @@ class LearnerActionTests(test_utils.GenericTestBase):
         }
         self.assertEqual(
             learner_action_dict, {
-                'action_type': 'ExplorationStart',
-                'action_customization_args': expected_customization_args,
-                'schema_version': 1
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': expected_customization_args,
+                'schemaVersion': 1
             })
 
     def test_update_learner_action_from_model(self):
@@ -920,9 +920,9 @@ class LearnerActionTests(test_utils.GenericTestBase):
                 playthrough_model)
 
         self.assertEqual(
-            playthrough.actions[0].action_type, 'ExplorationStart1')
+            playthrough.actions[0].actionType, 'ExplorationStart1')
         self.assertEqual(
-            playthrough.actions[0].action_customization_args['new_key'], 5)
+            playthrough.actions[0].actionCustomizationArgs['new_key'], 5)
 
         # For other action types, no changes happen during migration.
         learner_action1 = stats_domain.LearnerAction('ExplorationQuit', {}, 1)
@@ -953,7 +953,7 @@ class LearnerActionTests(test_utils.GenericTestBase):
                 playthrough_model_1)
 
         self.assertEqual(
-            playthrough1.actions[0].action_type, 'ExplorationQuit')
+            playthrough1.actions[0].actionType, 'ExplorationQuit')
 
     def test_cannot_update_learner_action_from_invalid_schema_version_model(
             self):
@@ -1012,15 +1012,15 @@ class LearnerActionTests(test_utils.GenericTestBase):
         self.learner_action.validate()
 
     def test_validate_with_int_action_type(self):
-        self.learner_action.action_type = 5
+        self.learner_action.actionType = 5
         with self.assertRaisesRegexp(utils.ValidationError, (
-            'Expected action_type to be a string, received %s' % (type(5)))):
+            'Expected actionType to be a string, received %s' % (type(5)))):
             self.learner_action.validate()
 
     def test_validate_with_string_schema_version(self):
-        self.learner_action.schema_version = '1'
+        self.learner_action.schemaVersion = '1'
         with self.assertRaisesRegexp(utils.ValidationError, (
-            'Expected schema_version to be an int, received %s' % (type('1')))):
+            'Expected schemaVersion to be an int, received %s' % (type('1')))):
             self.learner_action.validate()
 
 

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -406,10 +406,10 @@ def update_exp_issues_for_new_exp_version(
                 playthrough.issue_customization_args['state_name']['value'] = (
                     new_state_name)
             for a_idx, action in enumerate(playthrough.actions):
-                if action.action_customization_args['stateName']['value'] == (
+                if action.action_customization_args['state_name']['value'] == (
                         old_state_name):
                     playthroughs[p_idx].actions[
-                        a_idx].action_customization_args['stateName'][
+                        a_idx].action_customization_args['state_name'][
                             'value'] = new_state_name
 
         all_playthrough_ids.extend(playthrough_ids)

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -406,10 +406,10 @@ def update_exp_issues_for_new_exp_version(
                 playthrough.issue_customization_args['state_name']['value'] = (
                     new_state_name)
             for a_idx, action in enumerate(playthrough.actions):
-                if action.actionCustomizationArgs['stateName']['value'] == (
+                if action.action_customization_args['stateName']['value'] == (
                         old_state_name):
                     playthroughs[p_idx].actions[
-                        a_idx].actionCustomizationArgs['stateName'][
+                        a_idx].action_customization_args['stateName'][
                             'value'] = new_state_name
 
         all_playthrough_ids.extend(playthrough_ids)

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -83,7 +83,7 @@ def _migrate_to_latest_action_schema(learner_action_dict):
     Raises:
         Exception. The action_schema_version is invalid.
     """
-    action_schema_version = learner_action_dict['schema_version']
+    action_schema_version = learner_action_dict['schemaVersion']
     if action_schema_version is None or action_schema_version < 1:
         action_schema_version = 0
 

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -406,10 +406,10 @@ def update_exp_issues_for_new_exp_version(
                 playthrough.issue_customization_args['state_name']['value'] = (
                     new_state_name)
             for a_idx, action in enumerate(playthrough.actions):
-                if action.action_customization_args['state_name']['value'] == (
+                if action.actionCustomizationArgs['stateName']['value'] == (
                         old_state_name):
                     playthroughs[p_idx].actions[
-                        a_idx].action_customization_args['state_name'][
+                        a_idx].actionCustomizationArgs['stateName'][
                             'value'] = new_state_name
 
         all_playthrough_ids.extend(playthrough_ids)

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -212,7 +212,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             }, [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'New state'
                     }
                 },
@@ -632,7 +632,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             }, [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'Home'
                     }
                 },
@@ -649,7 +649,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             }, [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'End'
                     }
                 },
@@ -715,7 +715,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                 'value'], 'Renamed state')
         self.assertEqual(
             playthrough1_instance.actions[0]['actionCustomizationArgs'][
-                'stateName']['value'],
+                'state_name']['value'],
             'Renamed state')
         playthrough2_instance = stats_models.PlaythroughModel.get(
             playthrough_id2)
@@ -724,7 +724,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                 'value'], 'End')
         self.assertEqual(
             playthrough2_instance.actions[0]['actionCustomizationArgs'][
-                'stateName']['value'],
+                'state_name']['value'],
             'End')
 
         # Test deletion of states.
@@ -757,7 +757,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                 'value'], 'Renamed state')
         self.assertEqual(
             playthrough1_instance.actions[0]['actionCustomizationArgs'][
-                'stateName']['value'],
+                'state_name']['value'],
             'Renamed state')
         playthrough2_instance = stats_models.PlaythroughModel.get(
             playthrough_id2)
@@ -766,7 +766,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                 'value'], 'End')
         self.assertEqual(
             playthrough2_instance.actions[0]['actionCustomizationArgs'][
-                'stateName']['value'],
+                'state_name']['value'],
             'End')
 
     def test_get_playthroughs_multi(self):
@@ -1029,7 +1029,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             [{
                 'actionType': 'ExplorationStart',
                 'actionCustomizationArgs': {
-                    'stateName': {
+                    'state_name': {
                         'value': 'Home'
                     }
                 },
@@ -1063,7 +1063,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                 'value'], ['Home', 'End', 'Home'])
         self.assertEqual(
             playthrough_instance.actions[0]['actionCustomizationArgs'][
-                'stateName']['value'], 'Home')
+                'state_name']['value'], 'Home')
 
         # Test renaming of states.
         exploration.rename_state('Home', 'Renamed state')
@@ -1092,7 +1092,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                 'value'], ['Renamed state', 'End', 'Renamed state'])
         self.assertEqual(
             playthrough_instance.actions[0]['actionCustomizationArgs'][
-                'stateName']['value'],
+                'state_name']['value'],
             'Renamed state')
 
     def test_get_multiple_exploration_stats_by_version_with_invalid_exp_id(

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -210,13 +210,13 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                     'value': 200
                 }
             }, [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'New state'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
         exp_issue1 = stats_domain.ExplorationIssue.from_dict({
             'issue_type': 'EarlyQuit',
@@ -630,13 +630,13 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                     'value': 200
                 }
             }, [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'Home'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
         playthrough_id2 = stats_models.PlaythroughModel.create(
             exploration.id, exploration.version, 'EarlyQuit', {
@@ -647,13 +647,13 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                     'value': 200
                 }
             }, [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'End'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
         exp_issue1 = stats_domain.ExplorationIssue.from_dict({
             'issue_type': 'EarlyQuit',
@@ -714,8 +714,8 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             playthrough1_instance.issue_customization_args['state_name'][
                 'value'], 'Renamed state')
         self.assertEqual(
-            playthrough1_instance.actions[0]['action_customization_args'][
-                'state_name']['value'],
+            playthrough1_instance.actions[0]['actionCustomizationArgs'][
+                'stateName']['value'],
             'Renamed state')
         playthrough2_instance = stats_models.PlaythroughModel.get(
             playthrough_id2)
@@ -723,8 +723,8 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             playthrough2_instance.issue_customization_args['state_name'][
                 'value'], 'End')
         self.assertEqual(
-            playthrough2_instance.actions[0]['action_customization_args'][
-                'state_name']['value'],
+            playthrough2_instance.actions[0]['actionCustomizationArgs'][
+                'stateName']['value'],
             'End')
 
         # Test deletion of states.
@@ -756,8 +756,8 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             playthrough1_instance.issue_customization_args['state_name'][
                 'value'], 'Renamed state')
         self.assertEqual(
-            playthrough1_instance.actions[0]['action_customization_args'][
-                'state_name']['value'],
+            playthrough1_instance.actions[0]['actionCustomizationArgs'][
+                'stateName']['value'],
             'Renamed state')
         playthrough2_instance = stats_models.PlaythroughModel.get(
             playthrough_id2)
@@ -765,8 +765,8 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             playthrough2_instance.issue_customization_args['state_name'][
                 'value'], 'End')
         self.assertEqual(
-            playthrough2_instance.actions[0]['action_customization_args'][
-                'state_name']['value'],
+            playthrough2_instance.actions[0]['actionCustomizationArgs'][
+                'stateName']['value'],
             'End')
 
     def test_get_playthroughs_multi(self):
@@ -1027,13 +1027,13 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                 },
             },
             [{
-                'action_type': 'ExplorationStart',
-                'action_customization_args': {
-                    'state_name': {
+                'actionType': 'ExplorationStart',
+                'actionCustomizationArgs': {
+                    'stateName': {
                         'value': 'Home'
                     }
                 },
-                'schema_version': 1
+                'schemaVersion': 1
             }])
 
         exp_issue = stats_domain.ExplorationIssue.from_dict({
@@ -1062,8 +1062,8 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             playthrough_instance.issue_customization_args['state_names'][
                 'value'], ['Home', 'End', 'Home'])
         self.assertEqual(
-            playthrough_instance.actions[0]['action_customization_args'][
-                'state_name']['value'], 'Home')
+            playthrough_instance.actions[0]['actionCustomizationArgs'][
+                'stateName']['value'], 'Home')
 
         # Test renaming of states.
         exploration.rename_state('Home', 'Renamed state')
@@ -1091,8 +1091,8 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             playthrough_instance.issue_customization_args['state_names'][
                 'value'], ['Renamed state', 'End', 'Renamed state'])
         self.assertEqual(
-            playthrough_instance.actions[0]['action_customization_args'][
-                'state_name']['value'],
+            playthrough_instance.actions[0]['actionCustomizationArgs'][
+                'stateName']['value'],
             'Renamed state')
 
     def test_get_multiple_exploration_stats_by_version_with_invalid_exp_id(

--- a/core/templates/domain/feedback_message/FeedbackMessageSummaryObjectFactory.ts
+++ b/core/templates/domain/feedback_message/FeedbackMessageSummaryObjectFactory.ts
@@ -62,8 +62,8 @@ export class FeedbackMessageSummaryObjectFactory {
       authorPictureDataUrl, createdOnMsecs);
   }
   // TODO(#7176): Replace 'any' with the exact type. This has been kept as
-  // 'any' because 'feedbackMessageSummaryBackendDict' is a dict with	
-  // underscore_cased keys which give tslint errors against underscore_casing	
+  // 'any' because 'feedbackMessageSummaryBackendDict' is a dict with
+  // underscore_cased keys which give tslint errors against underscore_casing
   // in favor of camelCasing.
   createFromBackendDict(
       feedbackMessageSummaryBackendDict: any): FeedbackMessageSummary {

--- a/core/templates/domain/feedback_message/FeedbackMessageSummaryObjectFactory.ts
+++ b/core/templates/domain/feedback_message/FeedbackMessageSummaryObjectFactory.ts
@@ -61,22 +61,19 @@ export class FeedbackMessageSummaryObjectFactory {
       newMessageId, newMessageText, null, null, null, null, authorUsername,
       authorPictureDataUrl, createdOnMsecs);
   }
-  // TODO(#7176): Replace 'any' with the exact type. This has been kept as
-  // 'any' because 'feedbackMessageSummaryBackendDict' is a dict with
-  // underscore_cased keys which give tslint errors against underscore_casing
-  // in favor of camelCasing.
+
   createFromBackendDict(
       feedbackMessageSummaryBackendDict: any): FeedbackMessageSummary {
     return new FeedbackMessageSummary(
-      feedbackMessageSummaryBackendDict.message_id,
+      feedbackMessageSummaryBackendDict.messageId,
       feedbackMessageSummaryBackendDict.text,
-      feedbackMessageSummaryBackendDict.updated_status,
-      feedbackMessageSummaryBackendDict.suggestion_html,
-      feedbackMessageSummaryBackendDict.current_content_html,
+      feedbackMessageSummaryBackendDict.updatedStatus,
+      feedbackMessageSummaryBackendDict.suggestionHtml,
+      feedbackMessageSummaryBackendDict.currentContentHtml,
       feedbackMessageSummaryBackendDict.description,
-      feedbackMessageSummaryBackendDict.author_username,
-      feedbackMessageSummaryBackendDict.author_picture_data_url,
-      feedbackMessageSummaryBackendDict.created_on_msecs);
+      feedbackMessageSummaryBackendDict.authorUsername,
+      feedbackMessageSummaryBackendDict.authorPictureDataUrl,
+      feedbackMessageSummaryBackendDict.createdOnMsecs);
   }
 }
 

--- a/core/templates/domain/feedback_message/FeedbackMessageSummaryObjectFactory.ts
+++ b/core/templates/domain/feedback_message/FeedbackMessageSummaryObjectFactory.ts
@@ -61,7 +61,10 @@ export class FeedbackMessageSummaryObjectFactory {
       newMessageId, newMessageText, null, null, null, null, authorUsername,
       authorPictureDataUrl, createdOnMsecs);
   }
-
+  // TODO(#7176): Replace 'any' with the exact type. This has been kept as
+  // 'any' because 'feedbackMessageSummaryBackendDict' is a dict with	
+  // underscore_cased keys which give tslint errors against underscore_casing	
+  // in favor of camelCasing.
   createFromBackendDict(
       feedbackMessageSummaryBackendDict: any): FeedbackMessageSummary {
     return new FeedbackMessageSummary(

--- a/core/templates/domain/feedback_message/FeedbackMessageSummaryObjectFactorySpec.ts
+++ b/core/templates/domain/feedback_message/FeedbackMessageSummaryObjectFactorySpec.ts
@@ -45,9 +45,9 @@ describe('Feedback message object factory', () => {
       messageId: 0,
       text: 'Sample text',
       updatedStatus: null,
-      author_username: 'User 1',
-      author_picture_data_url: 'sample_picture_url_1',
-      created_on_msecs: 1000
+      authorUsername: 'User 1',
+      authorPictureDataUrl: 'sample_picture_url_1',
+      createdOnMsecs: 1000
     };
 
     var feedbackMessageSummary = (

--- a/core/templates/domain/statistics/LearnerActionObjectFactory.ts
+++ b/core/templates/domain/statistics/LearnerActionObjectFactory.ts
@@ -60,9 +60,9 @@ export class LearnerAction {
   // camelCasing.
   toBackendDict(): any {
     return {
-      action_type: this.actionType,
-      action_customization_args: this.actionCustomizationArgs,
-      schema_version: this.schemaVersion,
+      actionType: this.actionType,
+      actionCustomizationArgs: this.actionCustomizationArgs,
+      schemaVersion: this.schemaVersion,
     };
   }
 }
@@ -107,9 +107,9 @@ export class LearnerActionObjectFactory {
   // camelCasing.
   createFromBackendDict(learnerActionBackendDict: any): LearnerAction {
     return new LearnerAction(
-      learnerActionBackendDict.action_type,
-      learnerActionBackendDict.action_customization_args,
-      learnerActionBackendDict.schema_version);
+      learnerActionBackendDict.actionType,
+      learnerActionBackendDict.actionCustomizationArgs,
+      learnerActionBackendDict.schemaVersion);
   }
 }
 

--- a/core/templates/domain/statistics/LearnerActionObjectFactorySpec.ts
+++ b/core/templates/domain/statistics/LearnerActionObjectFactorySpec.ts
@@ -65,9 +65,9 @@ describe('Learner Action Object Factory', () => {
   it('should create a new learner action from a backend dict', () => {
     var learnerActionObject =
         this.LearnerActionObjectFactory.createFromBackendDict({
-          action_type: 'AnswerSubmit',
-          action_customization_args: {},
-          schema_version: 1
+          actionType: 'AnswerSubmit',
+          actionCustomizationArgs: {},
+          schemaVersion: 1
         });
 
     expect(learnerActionObject.actionType).toEqual('AnswerSubmit');
@@ -81,9 +81,9 @@ describe('Learner Action Object Factory', () => {
 
     var learnerActionDict = learnerActionObject.toBackendDict();
     expect(learnerActionDict).toEqual({
-      action_type: 'AnswerSubmit',
-      action_customization_args: {},
-      schema_version: 1
+      actionType: 'AnswerSubmit',
+      actionCustomizationArgs: {},
+      schemaVersion: 1
     });
   });
 });

--- a/core/templates/domain/statistics/PlaythroughObjectFactorySpec.ts
+++ b/core/templates/domain/statistics/PlaythroughObjectFactorySpec.ts
@@ -55,9 +55,9 @@ describe('Playthrough Object Factory', () => {
         issue_type: 'EarlyQuit',
         issue_customization_args: {},
         actions: [{
-          action_type: 'AnswerSubmit',
-          action_customization_args: {},
-          schema_version: 1
+          actionType: 'AnswerSubmit',
+          actionCustomizationArgs: {},
+          schemaVersion: 1
         }]
       }
     );
@@ -84,9 +84,9 @@ describe('Playthrough Object Factory', () => {
       issue_type: 'EarlyQuit',
       issue_customization_args: {},
       actions: [{
-        action_type: 'AnswerSubmit',
-        action_customization_args: {},
-        schema_version: 1
+        actionType: 'AnswerSubmit',
+        actionCustomizationArgs: {},
+        schemaVersion: 1
       }]
     });
   });

--- a/core/templates/services/playthrough-issues-backend-api.service.spec.ts
+++ b/core/templates/services/playthrough-issues-backend-api.service.spec.ts
@@ -137,13 +137,13 @@ describe('PlaythroughIssuesBackendApiService', function() {
           }
         },
         actions: [{
-          action_type: 'ExplorationStart',
-          action_customization_args: {
+          actionType: 'ExplorationStart',
+          actionCustomizationArgs: {
             state_name: {
               value: 'state_name1'
             }
           },
-          schema_version: 1
+          schemaVersion: 1
         }]
       };
 

--- a/core/templates/services/playthrough-issues.service.spec.ts
+++ b/core/templates/services/playthrough-issues.service.spec.ts
@@ -58,13 +58,13 @@ describe('Playthrough Issues Service', function() {
       }
     },
     actions: [{
-      action_type: 'ExplorationStart',
-      action_customization_args: {
+      actionType: 'ExplorationStart',
+      actionCustomizationArgs: {
         state_name: {
           value: 'state_name1'
         }
       },
-      schema_version: 1
+      schemaVersion: 1
     }]
   };
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1.This PR fixes or fixes part of #7176 .
2.This PR does the following: Refactor dicts in frontend to have only camelCase keys for `core/templates/dev/head/domain/feedback_message/FeedbackMessageSummaryObjectFactory.ts`
and `core/templates/dev/head/domain/statistics/LearnerActionObjectFactory.ts`

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
