### PR TITLE
Fix part of #7176: Refactor dicts in frontend to have only camelCase keys for TopicObjectFactory

### DIFF
--- a/core/controllers/topic_editor.py
+++ b/core/controllers/topic_editor.py
@@ -67,11 +67,11 @@ class TopicEditorStoryHandler(base.BaseHandler):
             summary.to_dict() for summary in additional_story_summaries]
 
         for summary in canonical_story_summary_dicts:
-            summary['story_is_published'] = (
+            summary['storyIsPublished'] = (
                 story_id_to_publication_status_map[summary['id']])
 
         for summary in additional_story_summary_dicts:
-            summary['story_is_published'] = (
+            summary['storyIsPublished'] = (
                 story_id_to_publication_status_map[summary['id']])
 
         self.values.update({

--- a/core/controllers/topic_editor_test.py
+++ b/core/controllers/topic_editor_test.py
@@ -121,7 +121,7 @@ class TopicEditorStoryHandlerTests(BaseTopicEditorControllerTests):
         self.assertEqual(
             canonical_story_summary_dict['id'], canonical_story_id)
         self.assertEqual(
-            canonical_story_summary_dict['story_is_published'], True)
+            canonical_story_summary_dict['storyIsPublished'], True)
 
         self.assertEqual(
             additional_story_summary_dict['description'],
@@ -131,7 +131,7 @@ class TopicEditorStoryHandlerTests(BaseTopicEditorControllerTests):
         self.assertEqual(
             additional_story_summary_dict['id'], additional_story_id)
         self.assertEqual(
-            additional_story_summary_dict['story_is_published'], False)
+            additional_story_summary_dict['storyIsPublished'], False)
 
         self.logout()
 

--- a/core/domain/prod_validation_jobs_one_off.py
+++ b/core/domain/prod_validation_jobs_one_off.py
@@ -3175,10 +3175,10 @@ class TopicModelValidator(BaseModelValidator):
             skill_ids = skill_ids + subtopic['skill_ids']
         skill_ids = list(set(skill_ids))
         canonical_story_ids = [
-            reference['story_id']
+            reference['storyId']
             for reference in item.canonical_story_references]
         additional_story_ids = [
-            reference['story_id']
+            reference['storyId']
             for reference in item.additional_story_references]
         return {
             'topic_commit_log_entry_ids': (
@@ -3439,9 +3439,9 @@ class TopicSummaryModelValidator(BaseSummaryModelValidator):
             if topic_model is None or topic_model.deleted:
                 continue
             pubished_canonical_story_ids = [
-                reference['story_id']
+                reference['storyId']
                 for reference in topic_model.canonical_story_references
-                if reference['story_is_published']]
+                if reference['storyIsPublished']]
             if item.canonical_story_count != len(pubished_canonical_story_ids):
                 cls.errors['canonical story count check'].append((
                     'Entity id %s: Canonical story count: %s does not '
@@ -3469,9 +3469,9 @@ class TopicSummaryModelValidator(BaseSummaryModelValidator):
             if topic_model is None or topic_model.deleted:
                 continue
             published_additional_story_ids = [
-                reference['story_id']
+                reference['storyId']
                 for reference in topic_model.additional_story_references
-                if reference['story_is_published']]
+                if reference['storyIsPublished']]
             if (
                     item.additional_story_count !=
                     len(published_additional_story_ids)):
@@ -4502,8 +4502,8 @@ class StoryProgressModelValidator(BaseUserModelValidator):
                     topic.additional_story_references)
                 story_is_published = False
                 for reference in all_story_references:
-                    if reference['story_id'] == story_model.id:
-                        story_is_published = reference['story_is_published']
+                    if reference['storyId'] == story_model.id:
+                        story_is_published = reference['storyIsPublished']
                 if not story_is_published:
                     cls.errors['public story check'].append(
                         'Entity id %s: Story with id %s corresponding to '

--- a/core/domain/topic_domain.py
+++ b/core/domain/topic_domain.py
@@ -48,7 +48,7 @@ TOPIC_PROPERTY_THUMBNAIL_FILENAME = 'thumbnailFilename'
 TOPIC_PROPERTY_DESCRIPTION = 'description'
 TOPIC_PROPERTY_CANONICAL_STORY_REFERENCES = 'canonicalStoryReferences'
 TOPIC_PROPERTY_ADDITIONAL_STORY_REFERENCES = 'additionalStoryReferences'
-TOPIC_PROPERTY_LANGUAGE_CODE = 'languageCode'
+TOPIC_PROPERTY_LANGUAGE_CODE = 'language_code'
 
 SUBTOPIC_PROPERTY_TITLE = 'title'
 
@@ -459,7 +459,7 @@ class Topic(python_utils.OBJECT):
             ],
             'subtopicSchemaVersion': self.subtopic_schema_version,
             'nextSubtopicId': self.next_subtopic_id,
-            'languageCode': self.language_code,
+            'language_code': self.language_code,
             'version': self.version,
             'storyReferenceSchemaVersion': (
                 self.story_reference_schema_version)

--- a/core/domain/topic_domain.py
+++ b/core/domain/topic_domain.py
@@ -43,12 +43,12 @@ ROLE_NONE = 'none'
 # Do not modify the values of these constants. This is to preserve backwards
 # compatibility with previous change dicts.
 TOPIC_PROPERTY_NAME = 'name'
-TOPIC_PROPERTY_ABBREVIATED_NAME = 'abbreviated_name'
-TOPIC_PROPERTY_THUMBNAIL_FILENAME = 'thumbnail_filename'
+TOPIC_PROPERTY_ABBREVIATED_NAME = 'abbreviatedName'
+TOPIC_PROPERTY_THUMBNAIL_FILENAME = 'thumbnailFilename'
 TOPIC_PROPERTY_DESCRIPTION = 'description'
-TOPIC_PROPERTY_CANONICAL_STORY_REFERENCES = 'canonical_story_references'
-TOPIC_PROPERTY_ADDITIONAL_STORY_REFERENCES = 'additional_story_references'
-TOPIC_PROPERTY_LANGUAGE_CODE = 'language_code'
+TOPIC_PROPERTY_CANONICAL_STORY_REFERENCES = 'canonicalStoryReferences'
+TOPIC_PROPERTY_ADDITIONAL_STORY_REFERENCES = 'additionalStoryReferences'
+TOPIC_PROPERTY_LANGUAGE_CODE = 'languageCode'
 
 SUBTOPIC_PROPERTY_TITLE = 'title'
 
@@ -236,8 +236,8 @@ class StoryReference(python_utils.OBJECT):
             A dict, mapping all fields of StoryReference instance.
         """
         return {
-            'story_id': self.story_id,
-            'story_is_published': self.story_is_published
+            'storyId': self.story_id,
+            'storyIsPublished': self.story_is_published
         }
 
     @classmethod
@@ -252,8 +252,8 @@ class StoryReference(python_utils.OBJECT):
             StoryReference. The corresponding StoryReference domain object.
         """
         story_reference = cls(
-            story_reference_dict['story_id'],
-            story_reference_dict['story_is_published'])
+            story_reference_dict['storyId'],
+            story_reference_dict['storyIsPublished'])
         return story_reference
 
     @classmethod
@@ -442,26 +442,26 @@ class Topic(python_utils.OBJECT):
         return {
             'id': self.id,
             'name': self.name,
-            'abbreviated_name': self.abbreviated_name,
-            'thumbnail_filename': self.thumbnail_filename,
+            'abbreviatedName': self.abbreviated_name,
+            'thumbnailFilename': self.thumbnail_filename,
             'description': self.description,
-            'canonical_story_references': [
+            'canonicalStoryReferences': [
                 reference.to_dict()
                 for reference in self.canonical_story_references
             ],
-            'additional_story_references': [
+            'additionalStoryReferences': [
                 reference.to_dict()
                 for reference in self.additional_story_references
             ],
-            'uncategorized_skill_ids': self.uncategorized_skill_ids,
+            'uncategorizedSkillIds': self.uncategorized_skill_ids,
             'subtopics': [
                 subtopic.to_dict() for subtopic in self.subtopics
             ],
-            'subtopic_schema_version': self.subtopic_schema_version,
-            'next_subtopic_id': self.next_subtopic_id,
-            'language_code': self.language_code,
+            'subtopicSchemaVersion': self.subtopic_schema_version,
+            'nextSubtopicId': self.next_subtopic_id,
+            'languageCode': self.language_code,
             'version': self.version,
-            'story_reference_schema_version': (
+            'storyReferenceSchemaVersion': (
                 self.story_reference_schema_version)
         }
 

--- a/core/domain/topic_domain_test.py
+++ b/core/domain/topic_domain_test.py
@@ -56,17 +56,17 @@ class TopicDomainUnitTests(test_utils.GenericTestBase):
         expected_topic_dict = {
             'id': self.topic_id,
             'name': 'Name',
-            'abbreviated_name': 'abbrev',
-            'thumbnail_filename': None,
+            'abbreviatedName': 'abbrev',
+            'thumbnailFilename': None,
             'description': feconf.DEFAULT_TOPIC_DESCRIPTION,
-            'canonical_story_references': [],
-            'additional_story_references': [],
-            'uncategorized_skill_ids': [],
+            'canonicalStoryReferences': [],
+            'additionalStoryReferences': [],
+            'uncategorizedSkillIds': [],
             'subtopics': [],
-            'next_subtopic_id': 1,
-            'language_code': constants.DEFAULT_LANGUAGE_CODE,
-            'subtopic_schema_version': feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION,
-            'story_reference_schema_version': (
+            'nextSubtopicId': 1,
+            'languageCode': constants.DEFAULT_LANGUAGE_CODE,
+            'subtopicSchemaVersion': feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION,
+            'storyReferenceSchemaVersion': (
                 feconf.CURRENT_STORY_REFERENCE_SCHEMA_VERSION),
             'version': 0
         }

--- a/core/domain/topic_domain_test.py
+++ b/core/domain/topic_domain_test.py
@@ -64,7 +64,7 @@ class TopicDomainUnitTests(test_utils.GenericTestBase):
             'uncategorizedSkillIds': [],
             'subtopics': [],
             'nextSubtopicId': 1,
-            'languageCode': constants.DEFAULT_LANGUAGE_CODE,
+            'language_code': constants.DEFAULT_LANGUAGE_CODE,
             'subtopicSchemaVersion': feconf.CURRENT_SUBTOPIC_SCHEMA_VERSION,
             'storyReferenceSchemaVersion': (
                 feconf.CURRENT_STORY_REFERENCE_SCHEMA_VERSION),

--- a/core/domain/topic_services_test.py
+++ b/core/domain/topic_services_test.py
@@ -1304,8 +1304,8 @@ class StoryReferenceMigrationTests(test_utils.GenericTestBase):
             'name': 'name'
         })
         story_reference_dict = {
-            'story_id': 'story_id',
-            'story_is_published': False
+            'storyId': 'story_id',
+            'storyIsPublished': False
         }
         model = topic_models.TopicModel(
             id='topic_id',

--- a/core/templates/domain/topic/StoryReferenceObjectFactory.ts
+++ b/core/templates/domain/topic/StoryReferenceObjectFactory.ts
@@ -50,8 +50,8 @@ export class StoryReferenceObjectFactory {
       // camelCasing.
       storyReferenceBackendDict: any): StoryReference {
     return new StoryReference(
-      storyReferenceBackendDict.story_id,
-      storyReferenceBackendDict.story_is_published);
+      storyReferenceBackendDict.storyId,
+      storyReferenceBackendDict.storyIsPublished);
   }
 
   createFromStoryId(storyId: string): StoryReference {

--- a/core/templates/domain/topic/StoryReferenceObjectFactorySpec.ts
+++ b/core/templates/domain/topic/StoryReferenceObjectFactorySpec.ts
@@ -33,8 +33,8 @@ describe('Story reference object factory', () => {
     storyReferenceObjectFactory = TestBed.get(StoryReferenceObjectFactory);
 
     var sampleStoryReferenceBackendObject = {
-      story_id: 'story_id',
-      story_is_published: true
+      storyId: 'story_id',
+      storyIsPublished: true
     };
 
     _sampleStoryReference = storyReferenceObjectFactory.createFromBackendDict(

--- a/core/templates/domain/topic/TopicObjectFactory.ts
+++ b/core/templates/domain/topic/TopicObjectFactory.ts
@@ -441,25 +441,25 @@ export class TopicObjectFactory {
         subtopic, skillIdToDescriptionDict);
     });
     let canonicalStoryReferences =
-        topicBackendDict.canonical_story_references.map(
+        topicBackendDict.canonicalStoryReferences.map(
           (reference: StoryReference) => {
             return this.storyReferenceObjectFactory.createFromBackendDict(
               reference);
           });
     let additionalStoryReferences =
-        topicBackendDict.additional_story_references.map(
+        topicBackendDict.additionalStoryReferences.map(
           (reference: StoryReference) => {
             return this.storyReferenceObjectFactory.createFromBackendDict(
               reference);
           });
     return new Topic(
       topicBackendDict.id, topicBackendDict.name,
-      topicBackendDict.abbreviated_name,
-      topicBackendDict.description, topicBackendDict.language_code,
+      topicBackendDict.abbreviatedName,
+      topicBackendDict.description, topicBackendDict.languageCode,
       canonicalStoryReferences, additionalStoryReferences,
-      topicBackendDict.uncategorized_skill_ids,
-      topicBackendDict.next_subtopic_id, topicBackendDict.version,
-      subtopics, topicBackendDict.thumbnail_filename,
+      topicBackendDict.uncategorizedSkillIds,
+      topicBackendDict.nextSubtopicId, topicBackendDict.version,
+      subtopics, topicBackendDict.thumbnailFilename,
       skillIdToDescriptionDict, this.skillSummaryObjectFactory,
       this.subtopicObjectFactory, this.storyReferenceObjectFactory
     );

--- a/core/templates/domain/topic/TopicObjectFactory.ts
+++ b/core/templates/domain/topic/TopicObjectFactory.ts
@@ -455,7 +455,7 @@ export class TopicObjectFactory {
     return new Topic(
       topicBackendDict.id, topicBackendDict.name,
       topicBackendDict.abbreviatedName,
-      topicBackendDict.description, topicBackendDict.languageCode,
+      topicBackendDict.description, topicBackendDict.language_code,
       canonicalStoryReferences, additionalStoryReferences,
       topicBackendDict.uncategorizedSkillIds,
       topicBackendDict.nextSubtopicId, topicBackendDict.version,

--- a/core/templates/domain/topic/TopicObjectFactorySpec.ts
+++ b/core/templates/domain/topic/TopicObjectFactorySpec.ts
@@ -55,7 +55,7 @@ describe('Topic object factory', () => {
         skill_ids: ['skill_3']
       }],
       nextSubtopicId: 1,
-      languageCode: 'en'
+      language_code: 'en'
     };
     let skillIdToDescriptionDict = {
       skill_1: 'Description 1',
@@ -117,7 +117,7 @@ describe('Topic object factory', () => {
       id: 'topic_id_2',
       name: 'Another name',
       description: 'Another description',
-      languageCode: 'en',
+      language_code: 'en',
       version: '15',
       canonicalStoryReferences: [{
         storyId: 'story_10',

--- a/core/templates/domain/topic/TopicObjectFactorySpec.ts
+++ b/core/templates/domain/topic/TopicObjectFactorySpec.ts
@@ -30,32 +30,32 @@ describe('Topic object factory', () => {
     let sampleTopicBackendObject = {
       id: 'sample_topic_id',
       name: 'Topic name',
-      abbreviated_name: 'abbrev',
-      thumbnail_filename: 'img.png',
+      abbreviatedName: 'abbrev',
+      thumbnailFilename: 'img.png',
       description: 'Topic description',
       version: 1,
-      uncategorized_skill_ids: ['skill_1', 'skill_2'],
-      canonical_story_references: [{
-        story_id: 'story_1',
-        story_is_published: true
+      uncategorizedSkillIds: ['skill_1', 'skill_2'],
+      canonicalStoryReferences: [{
+        storyId: 'story_1',
+        storyIsPublished: true
       }, {
-        story_id: 'story_4',
-        story_is_published: false
+        storyId: 'story_4',
+        storyIsPublished: false
       }],
-      additional_story_references: [{
-        story_id: 'story_2',
-        story_is_published: true
+      additionalStoryReferences: [{
+        storyId: 'story_2',
+        storyIsPublished: true
       }, {
-        story_id: 'story_3',
-        story_is_published: false
+        storyId: 'story_3',
+        storyIsPublished: false
       }],
       subtopics: [{
         id: 1,
         title: 'Title',
         skill_ids: ['skill_3']
       }],
-      next_subtopic_id: 1,
-      language_code: 'en'
+      nextSubtopicId: 1,
+      languageCode: 'en'
     };
     let skillIdToDescriptionDict = {
       skill_1: 'Description 1',
@@ -117,18 +117,18 @@ describe('Topic object factory', () => {
       id: 'topic_id_2',
       name: 'Another name',
       description: 'Another description',
-      language_code: 'en',
+      languageCode: 'en',
       version: '15',
-      canonical_story_references: [{
-        story_id: 'story_10',
-        story_is_published: true
+      canonicalStoryReferences: [{
+        storyId: 'story_10',
+        storyIsPublished: true
       }],
-      additional_story_references: [{
-        story_id: 'story_5',
-        story_is_published: true
+      additionalStoryReferences: [{
+        storyId: 'story_5',
+        storyIsPublished: true
       }],
-      uncategorized_skill_ids: ['skill_2', 'skill_3'],
-      next_subtopic_id: 2,
+      uncategorizedSkillIds: ['skill_2', 'skill_3'],
+      nextSubtopicId: 2,
       subtopics: [{
         id: 1,
         title: 'Title',

--- a/core/templates/domain/topic/editable-topic-backend-api.service.spec.ts
+++ b/core/templates/domain/topic/editable-topic-backend-api.service.spec.ts
@@ -61,9 +61,9 @@ describe('Editable topic backend API service', function() {
         name: 'Topic Name',
         description: 'Topic Description',
         version: '1',
-        canonical_story_references: [{
-          story_id: 'story_1',
-          story_is_published: true
+        canonicalStoryReferences: [{
+          storyId: 'story_1',
+          storyIsPublished: true
         }],
         canonical_story_summary_dicts: [{
           id: '0',
@@ -71,11 +71,11 @@ describe('Editable topic backend API service', function() {
           node_count: 1,
           story_is_published: false
         }],
-        additional_story_references: [{
-          story_id: 'story_2',
-          story_is_published: true
+        additionalStoryReferences: [{
+          storyId: 'story_2',
+          storyIsPublished: true
         }],
-        uncategorized_skill_ids: ['skill_id_1'],
+        uncategorizedSkillIds: ['skill_id_1'],
         subtopics: [],
         language_code: 'en'
       },

--- a/core/templates/domain/topic/topic-domain.constants.ts
+++ b/core/templates/domain/topic/topic-domain.constants.ts
@@ -47,10 +47,10 @@ export class TopicDomainConstants {
     CMD_UPDATE_SUBTOPIC_PAGE_PROPERTY = 'update_subtopic_page_property';
 
   public static TOPIC_PROPERTY_NAME = 'name';
-  public static TOPIC_PROPERTY_ABBREVIATED_NAME = 'abbreviated_name';
-  public static TOPIC_PROPERTY_THUMBNAIL_FILENAME = 'thumbnail_filename';
+  public static TOPIC_PROPERTY_ABBREVIATED_NAME = 'abbreviatedName';
+  public static TOPIC_PROPERTY_THUMBNAIL_FILENAME = 'thumbnailFilename';
   public static TOPIC_PROPERTY_DESCRIPTION = 'description';
-  public static TOPIC_PROPERTY_LANGUAGE_CODE = 'language_code';
+  public static TOPIC_PROPERTY_LANGUAGE_CODE = 'languageCode';
 
   public static SUBTOPIC_PROPERTY_TITLE = 'title';
 

--- a/core/templates/domain/topic/topic-domain.constants.ts
+++ b/core/templates/domain/topic/topic-domain.constants.ts
@@ -50,7 +50,7 @@ export class TopicDomainConstants {
   public static TOPIC_PROPERTY_ABBREVIATED_NAME = 'abbreviatedName';
   public static TOPIC_PROPERTY_THUMBNAIL_FILENAME = 'thumbnailFilename';
   public static TOPIC_PROPERTY_DESCRIPTION = 'description';
-  public static TOPIC_PROPERTY_LANGUAGE_CODE = 'languageCode';
+  public static TOPIC_PROPERTY_LANGUAGE_CODE = 'language_code';
 
   public static SUBTOPIC_PROPERTY_TITLE = 'title';
 

--- a/core/templates/domain/topic/topic-update.service.spec.ts
+++ b/core/templates/domain/topic/topic-update.service.spec.ts
@@ -118,21 +118,21 @@ describe('Topic update service', function() {
         name: 'Topic name',
         description: 'Topic description',
         version: 1,
-        uncategorized_skill_ids: ['skill_1'],
-        canonical_story_references: [{
-          story_id: 'story_1',
-          story_is_published: true
+        uncategorizedSkillIds: ['skill_1'],
+        canonicalStoryReferences: [{
+          storyId: 'story_1',
+          storyIsPublished: true
         }],
-        additional_story_references: [{
-          story_id: 'story_2',
-          story_is_published: true
+        additionalStoryReferences: [{
+          storyId: 'story_2',
+          storyIsPublished: true
         }],
         subtopics: [{
           id: 1,
           title: 'Title',
           skill_ids: ['skill_2']
         }],
-        next_subtopic_id: 2,
+        nextSubtopicId: 2,
         language_code: 'en'
       },
       skillIdToDescriptionDict: {

--- a/core/templates/pages/topic-editor-page/services/topic-editor-state.service.spec.ts
+++ b/core/templates/pages/topic-editor-page/services/topic-editor-state.service.spec.ts
@@ -218,19 +218,19 @@ describe('Topic editor state service', function() {
         id: '0',
         name: 'Topic Name',
         description: 'Topic Description',
-        canonical_story_references: [{
-          story_id: 'story_1',
-          story_is_published: true
+        canonicalStoryReferences: [{
+          storyId: 'story_1',
+          storyIsPublished: true
         }],
-        additional_story_references: [{
-          story_id: 'story_2',
-          story_is_published: true
+        additionalStoryReferences: [{
+          storyId: 'story_2',
+          storyIsPublished: true
         }],
-        uncategorized_skill_ids: ['skill_1'],
+        uncategorizedSkillIds: ['skill_1'],
         subtopics: [],
-        language_code: 'en',
-        next_subtopic_id: 1,
-        subtopic_schema_version: '1',
+        languageCode: 'en',
+        nextSubtopicId: 1,
+        subtopicSchemaVersion: '1',
         version: '1'
       },
       groupedSkillSummaries: {},
@@ -256,15 +256,15 @@ describe('Topic editor state service', function() {
         id: '0',
         name: 'Topic Name 2',
         description: 'Topic Description 2',
-        canonical_story_references: [{
-          story_id: 'story_3',
-          story_is_published: true
+        canonicalStoryReferences: [{
+          storyId: 'story_3',
+          storyIsPublished: true
         }],
-        additional_story_references: [{
-          story_id: 'story_4',
-          story_is_published: true
+        additionalStoryReferences: [{
+          storyId: 'story_4',
+          storyIsPublished: true
         }],
-        uncategorized_skill_ids: ['skill_5'],
+        uncategorizedSkillIds: ['skill_5'],
         subtopics: [
           {
             id: 1,
@@ -276,9 +276,9 @@ describe('Topic editor state service', function() {
             skill_ids: ['skill_3']
           }
         ],
-        language_code: 'en',
-        next_subtopic_id: 3,
-        subtopic_schema_version: '1',
+        languageCode: 'en',
+        nextSubtopicId: 3,
+        subtopicSchemaVersion: '1',
         version: '1'
       },
       groupedSkillSummaries: {},

--- a/core/templates/pages/topic-editor-page/services/topic-editor-state.service.spec.ts
+++ b/core/templates/pages/topic-editor-page/services/topic-editor-state.service.spec.ts
@@ -228,7 +228,7 @@ describe('Topic editor state service', function() {
         }],
         uncategorizedSkillIds: ['skill_1'],
         subtopics: [],
-        languageCode: 'en',
+        language_code: 'en',
         nextSubtopicId: 1,
         subtopicSchemaVersion: '1',
         version: '1'
@@ -276,7 +276,7 @@ describe('Topic editor state service', function() {
             skill_ids: ['skill_3']
           }
         ],
-        languageCode: 'en',
+        language_code: 'en',
         nextSubtopicId: 3,
         subtopicSchemaVersion: '1',
         version: '1'


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes or fixes part of #7176 .
2. This PR does the following: Refactor dicts in frontend to have only camelCase keys for `core/templates/domain/topic/TopicObjectFactory.ts` and `core/templates/domain/topic/StoryReferenceObjectFactory.ts`

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
