### PR TITLE
Fix #8888: Await Visible Confirmation Message on Role Update

### DIFF
--- a/core/tests/protractor_utils/AdminPage.js
+++ b/core/tests/protractor_utils/AdminPage.js
@@ -223,6 +223,7 @@ var AdminPage = function() {
     waitFor.textToBePresentInElement(
       statusMessage, 'successfully updated to',
       'Could not set role successfully');
+    waitFor.visibilityOf(statusMessage, 'Confirmation message not visible');
   };
 
   this.getUsersAsssignedToRole = function(role) {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes #8888.
2. This PR does the following:

When an E2E test updates a role (e.g. in the
topicAndStoryEditorFileUploadFeatures suite), we do not wait for the
confirmation message to be visible. This can lead the test to proceed
even though the role update has not completed, yielding a 401 error that
breaks the test. This commit waits for the confirmation to be visible to
resolve this issue.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
