### PR TITLE
Fix #8827, #8904 and #8903: Fixed highlight reset of feedback icon, visibility of dest state name in outcome editor and behavior of dropdown in 'Add Answer Group' modal

### DIFF
--- a/core/templates/components/state-directives/outcome-editor/outcome-editor.directive.html
+++ b/core/templates/components/state-directives/outcome-editor/outcome-editor.directive.html
@@ -87,7 +87,7 @@
         to...</strong>
         <strong ng-if="!$ctrl.displayFeedback">Oppia directs the learner to...</strong>
         <span ng-if="!$ctrl.isSelfLoop($ctrl.outcome)" style="position: relative;">
-          <[outcome.dest]>
+          <[$ctrl.outcome.dest]>
         </span>
         <span ng-if="$ctrl.isSelfLoop($ctrl.outcome)" style="position: relative;">
           <span ng-if="!$ctrl.outcome.refresherExplorationId">(try again)</span>

--- a/core/templates/components/state-directives/rule-editor/rule-type-selector.directive.ts
+++ b/core/templates/components/state-directives/rule-editor/rule-type-selector.directive.ts
@@ -74,7 +74,7 @@ angular.module('oppia').directive('ruleTypeSelector', [function() {
             // Suppress the search box.
             minimumResultsForSearch: -1,
             width: '350px',
-            dropdownParent: $('.rule-parent'),
+            dropdownParent: $(select2Node).parent(),
             templateSelection: function(object) {
               return $filter('truncateAtFirstEllipsis')(object.text);
             }

--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -903,8 +903,10 @@ textarea {
   color: white;
   text-align: center;
 }
-.navbar-light .navbar-nav .nav-link:hover,
 .navbar-light .navbar-nav .nav-link:focus {
+  color: white;
+}
+.navbar-light .navbar-nav .nav-link:hover {
   background-color: white;
   color: #06b9ac;
 }


### PR DESCRIPTION
## Overview

1. This PR fixes #8827, fixes #8904 and fixes #8903
2. Screenshots/GIFs:

#8827
Here, the `:focus` css style was split from `:hover` css style and given appropriate styling so that the highlight reset correctly.

![ezgif-5-4a6365745871](https://user-images.githubusercontent.com/22347970/77430005-80e88980-6e00-11ea-9e3a-434e3036fb89.gif)

#8904 
The only reason this issue was occurring was due to a missing `$ctrl` before the variable name, which was added.

![Annotation 2020-03-24 175924](https://user-images.githubusercontent.com/22347970/77430628-7d093700-6e01-11ea-9f82-718548fc9924.jpg)

#8903
This issue seems to be a more general issue with select2 dropdowns for which the fix online is to add a dropdownParent attribute, which although already existed wasn't the right one, hence that was fixed.

![ezgif-5-38fa4acb2767](https://user-images.githubusercontent.com/22347970/77430353-0f5d0b00-6e01-11ea-9886-4e0bf49a667b.gif)

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
