### PR TITLE
Wipeout 3.9: Add contributors audit job

### DIFF
--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -42,7 +42,7 @@ import python_utils
 # List of all manager classes for one-off batch jobs for which to show controls
 # on the admin dashboard.
 ONE_OFF_JOB_MANAGERS = [
-    activity_jobs_one_off.AuditContributorsOneOffJobTests,
+    activity_jobs_one_off.AuditContributorsOneOffJob,
     activity_jobs_one_off.IndexAllActivitiesJobManager,
     activity_jobs_one_off.ReplaceAdminIdOneOffJob,
     collection_jobs_one_off.CollectionMigrationOneOffJob,

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -42,6 +42,7 @@ import python_utils
 # List of all manager classes for one-off batch jobs for which to show controls
 # on the admin dashboard.
 ONE_OFF_JOB_MANAGERS = [
+    activity_jobs_one_off.AuditContributorsOneOffJobTests,
     activity_jobs_one_off.IndexAllActivitiesJobManager,
     activity_jobs_one_off.ReplaceAdminIdOneOffJob,
     collection_jobs_one_off.CollectionMigrationOneOffJob,


### PR DESCRIPTION
## Overview

~1. This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following: Add audit jobs for checking the integrity of `contributor_ids` and `contributors_summary` fields in `ExpSummaryModel` and `ColelctionSummaryModel`. Apparently, not all the ids that are in `contributor_ids` are also present in `contributors_summary` and we need to check why.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
