### PR TITLE
Fix #8911:  Fix issues with exploration state graph

### DIFF
--- a/core/templates/pages/exploration-editor-page/editor-tab/graph-directives/state-graph-visualization.directive.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/graph-directives/state-graph-visualization.directive.ts
@@ -160,7 +160,7 @@ angular.module('oppia').directive('stateGraphVisualization', [
           };
 
           var centerGraph = function() {
-            if ($scope.graphLoaded && $scope.centerAtCurrentState) {
+            if ($scope.graphData() && $scope.centerAtCurrentState) {
               if ($scope.allowPanning) {
                 makeGraphPannable();
               }


### PR DESCRIPTION
## Overview
1. This PR fixes #8911.
2. This PR does the following: Fixes the issues in centring & panning of exploration graph.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
