### PR TITLE
Fix issues with release wrap up

### DIFF
--- a/scripts/release_scripts/wrap_up_release.py
+++ b/scripts/release_scripts/wrap_up_release.py
@@ -53,15 +53,26 @@ def remove_release_labels(repo):
             repo.get_issues(
                 state='open', labels=[released_label]))
 
-    if current_release_prs:
-        raise Exception(
-            'Following PRs are not released: %s.' % (
-                [pr.number for pr in current_release_prs]))
-
     released_prs = repo.get_issues(state='closed', labels=[released_label])
+
+    current_release_pr_numbers = [pr.number for pr in current_release_prs]
+    released_pr_numbers = [pr.number for pr in released_prs]
+
+    unreleased_pr_numbers = [
+        pr_num for pr_num in current_release_pr_numbers if pr_num not in (
+            released_pr_numbers)]
+    if unreleased_pr_numbers:
+        raise Exception(
+            'Following PRs are not released: %s.' % unreleased_pr_numbers)
+
+    for pr in current_release_prs:
+        pr.remove_from_labels(release_constants.LABEL_FOR_CURRENT_RELEASE_PRS)
+        python_utils.PRINT('%s label removed from PR: #%s' % (
+            release_constants.LABEL_FOR_CURRENT_RELEASE_PRS, pr.number))
     for pr in released_prs:
         pr.remove_from_labels(release_constants.LABEL_FOR_RELEASED_PRS)
-        python_utils.PRINT('Label removed from PR: #%s' % pr.number)
+        python_utils.PRINT('%s label removed from PR: #%s' % (
+            release_constants.LABEL_FOR_RELEASED_PRS, pr.number))
 
 
 def remove_blocking_bugs_milestone_from_issues(repo):


### PR DESCRIPTION
1. This PR fixes or fixes part of N/A
2. This PR does the following: Updates `wrap_up_release` script to remove `PR: for current release` label automatically if `PR: released` label is also present.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
