### PR TITLE
Fix InteractionAnswerSummariesMRJobManager handling of utf-8 strings

### DIFF
--- a/core/domain/stats_jobs_continuous.py
+++ b/core/domain/stats_jobs_continuous.py
@@ -125,13 +125,8 @@ class InteractionAnswerSummariesMRJobManager(
                     Occurs when the key to reduce cannot be split into
                     components.
         """
-        try:
-            exploration_id, exploration_version, state_name = (
-                key.decode('utf-8').split(':'))
-        except Exception as e:
-            yield (key, 'ERROR: Expected valid exploration id, version, and '
-                        'state name triple, actual: %r' % e)
-            return
+        exploration_id, exploration_version, state_name = (
+            key.decode('utf-8').split(':'))
 
         value_dicts = [
             ast.literal_eval(stringified_value)

--- a/core/domain/stats_jobs_continuous.py
+++ b/core/domain/stats_jobs_continuous.py
@@ -75,8 +75,8 @@ class InteractionAnswerSummariesMRJobManager(
         Yields:
             dict(str, str). The submitted answer in dict format.
         """
-        if InteractionAnswerSummariesMRJobManager.entity_created_before_job_queued( # pylint: disable=line-too-long
-                item):
+        if (InteractionAnswerSummariesMRJobManager
+                .entity_created_before_job_queued(item)):
             # Output answers submitted to the exploration for this exp version.
             versioned_key = u'%s:%s:%s' % (
                 item.exploration_id, item.exploration_version, item.state_name)
@@ -126,7 +126,8 @@ class InteractionAnswerSummariesMRJobManager(
                     components.
         """
         try:
-            exploration_id, exploration_version, state_name = key.split(':')
+            exploration_id, exploration_version, state_name = (
+                key.decode('utf-8').split(':'))
         except Exception as e:
             yield (key, 'ERROR: Expected valid exploration id, version, and '
                         'state name triple, actual: %r' % e)

--- a/core/domain/stats_jobs_continuous_test.py
+++ b/core/domain/stats_jobs_continuous_test.py
@@ -75,7 +75,7 @@ class InteractionAnswerSummariesAggregatorTests(test_utils.GenericTestBase):
             stats_jobs_continuous, 'InteractionAnswerSummariesAggregator',
             NonContinuousInteractionAnswerSummariesAggregator)
 
-    def test_answer_for_state_with_unicode_name(self):
+    def test_answers_for_states_with_unicode_names(self):
         exp_id = 'eid'
         exp = self.save_new_valid_exploration(exp_id, 'author@website.com')
         # State names used by our test server to confirm unicode support.

--- a/core/domain/stats_jobs_continuous_test.py
+++ b/core/domain/stats_jobs_continuous_test.py
@@ -19,8 +19,6 @@
 from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
-import ast
-
 from core.domain import event_services
 from core.domain import exp_domain
 from core.domain import exp_fetchers


### PR DESCRIPTION
1. This PR fixes or fixes part of ~~#[fill_in_number_here]~~.
2. This PR does the following: Decodes the `utf-8`-encoded key before splitting it.