### PR TITLE
Fix UI issues in community dashboard page

### DIFF
--- a/core/templates/pages/community-dashboard-page/contributions-and-review/contributions-and-review.directive.ts
+++ b/core/templates/pages/community-dashboard-page/contributions-and-review/contributions-and-review.directive.ts
@@ -343,9 +343,9 @@ angular.module('oppia').directive('contributionsAndReview', [
             ctrl.contributionsDataLoading = true;
             ctrl.contributionSummaries = [];
             if (suggestionType === ctrl.SUGGESTION_TYPE_QUESTION) {
+              ctrl.activeContributionTab = ctrl.SUGGESTION_TYPE_QUESTION;
               ContributionAndReviewService.getUserCreatedQuestionSuggestions(
                 function(suggestionIdToSuggestions) {
-                  ctrl.activeContributionTab = ctrl.SUGGESTION_TYPE_QUESTION;
                   ctrl.contributions = suggestionIdToSuggestions;
                   ctrl.contributionSummaries = (
                     getQuestionContributionsSummary());
@@ -353,10 +353,10 @@ angular.module('oppia').directive('contributionsAndReview', [
                 });
             }
             if (suggestionType === ctrl.SUGGESTION_TYPE_TRANSLATE) {
+              ctrl.activeContributionTab = ctrl.SUGGESTION_TYPE_TRANSLATE;
               ContributionAndReviewService
                 .getUserCreatedTranslationSuggestions(
                   function(suggestionIdToSuggestions) {
-                    ctrl.activeContributionTab = ctrl.SUGGESTION_TYPE_TRANSLATE;
                     ctrl.contributions = suggestionIdToSuggestions;
                     ctrl.contributionSummaries = (
                       getTranslationContributionsSummary());
@@ -371,9 +371,9 @@ angular.module('oppia').directive('contributionsAndReview', [
             ctrl.contributionSummaries = [];
 
             if (suggestionType === ctrl.SUGGESTION_TYPE_QUESTION) {
+              ctrl.activeReviewTab = ctrl.SUGGESTION_TYPE_QUESTION;
               ContributionAndReviewService.getReviewableQuestionSuggestions(
                 function(suggestionIdToSuggestions) {
-                  ctrl.activeReviewTab = ctrl.SUGGESTION_TYPE_QUESTION;
                   ctrl.contributions = suggestionIdToSuggestions;
                   ctrl.contributionSummaries = (
                     getQuestionContributionsSummary());
@@ -382,10 +382,10 @@ angular.module('oppia').directive('contributionsAndReview', [
               );
             }
             if (suggestionType === ctrl.SUGGESTION_TYPE_TRANSLATE) {
+              ctrl.activeReviewTab = ctrl.SUGGESTION_TYPE_TRANSLATE;
               ContributionAndReviewService
                 .getReviewableTranslationSuggestions(
                   function(suggestionIdToSuggestions) {
-                    ctrl.activeReviewTab = ctrl.SUGGESTION_TYPE_TRANSLATE;
                     ctrl.contributions = suggestionIdToSuggestions;
                     ctrl.contributionSummaries = (
                       getTranslationContributionsSummary());

--- a/core/templates/pages/community-dashboard-page/modal-templates/question-suggestion-review.directive.html
+++ b/core/templates/pages/community-dashboard-page/modal-templates/question-suggestion-review.directive.html
@@ -9,9 +9,16 @@
   <section class="oppia-suggestion-review-container">
     <div class="oppia-question-suggestion">
       <div>
-        Skill Difficulty: <strong><[skillDifficultyLabel]></strong>
-        <br>
-        Skill Difficulty Explanation: <[skillRubricExplanation]>
+        <div class="oppia-question-suggestion-rubric">
+          <span>
+            <strong>Skill Difficulty: </strong><[skillDifficultyLabel]>
+          </span>
+        </div>
+        <div>
+          <strong>Skill Difficulty Explanation:</strong>
+          <angular-html-bind html-data="skillRubricExplanation">
+          </angular-html-bind>
+        </div>
       </div>
       <question-editor question-id="questionId"
                        misconceptions-by-skill="misconceptionsBySkill"
@@ -43,6 +50,10 @@
 <style>
   .author-header {
     margin-top: -12px;
+  }
+  .oppia-question-suggestion-rubric {
+    display: flex;
+    flex-direction: column;
   }
   .oppia-question-suggestion {
     height: 100%;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR fixes the following issues:
   - Issues in presenting skill difficulty explanation (Reported by @Vinit-Dantkale )
![image](https://user-images.githubusercontent.com/16653571/78284074-6e76fa00-753c-11ea-930d-197ddc4a1b18.png)

    - While switching tab the active tab color changes after http request completes.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
