### PR TITLE
Move all wrap up steps to script

### DIFF
--- a/release_constants.py
+++ b/release_constants.py
@@ -51,10 +51,7 @@ RELEASE_ROTA_URL = (
     'https://github.com/oppia/oppia/wiki/Release-Schedule#'
     'release-coordinators-and-qa-coordinators-for-upcoming-releases')
 
-REPEATABLE_JOBS_SPREADSHEETS_URL = (
-    'https://docs.google.com/spreadsheets/d/'
-    '1cSoVEwFyT-Q6d7yonbB0N-ElYGCFz5feMWXZXsv16_Y/edit#gid=1262496785')
-ONE_TIME_JOBS_SPREADSHEET_URL = (
+JOBS_SPREADSHEETS_URL = (
     'https://docs.google.com/spreadsheets/d/'
     '1Wegd0rZhVOm3Q3VCIw0xMbLC7IWtRyrEahiPn61Fhoo/edit#gid=948463314')
 

--- a/scripts/release_scripts/initial_release_prep.py
+++ b/scripts/release_scripts/initial_release_prep.py
@@ -163,9 +163,7 @@ def main():
             'run them after deployment:\n%s' % '\n'.join(extra_jobs_to_run))
 
     common.open_new_tab_in_browser_if_possible(
-        release_constants.REPEATABLE_JOBS_SPREADSHEETS_URL)
-    common.open_new_tab_in_browser_if_possible(
-        release_constants.ONE_TIME_JOBS_SPREADSHEET_URL)
+        release_constants.JOBS_SPREADSHEETS_URL)
     common.ask_user_to_confirm(
         'Please copy the names of the jobs to be run for this release along '
         'with author names, author mail ids & instruction docs.\n'

--- a/scripts/release_scripts/wrap_up_release.py
+++ b/scripts/release_scripts/wrap_up_release.py
@@ -99,6 +99,37 @@ def remove_blocking_bugs_milestone_from_issues(repo):
         issue.edit(milestone=None)
 
 
+def remove_protection_rule():
+    """Asks the release co-ordinator to perform the steps for deletion of
+    github protection rule for release branch.
+    """
+    common.ask_user_to_confirm(
+        'Ask Sean to delete '
+        'the github protection rule by:\n'
+        '1. Going to this page: '
+        'https://github.com/oppia/oppia/settings/branches. '
+        '(Note, this link will give a 404 since access is limited to Sean.)\n'
+        '2. Delete the github protection rule for %s branch but leave the '
+        'existing release-* rule as-is. This will cause the branch to fall '
+        'under the general protection rule for release branches\n' % (
+            common.get_current_branch_name()))
+
+
+def update_jobs_tracker():
+    """Asks the release co-ordinator to update the status of jobs run
+    in the release.
+    """
+    common.open_new_tab_in_browser_if_possible(
+        release_constants.JOBS_SPREADSHEETS_URL)
+    common.ask_user_to_confirm(
+        'Move all the jobs which are run (both successful & failed ones) to '
+        'the past jobs tab in the jobs tracker.\n')
+    common.ask_user_to_confirm(
+        'Send updates regarding each job to the job author '
+        '(just the success/failure status, don\'t include any data or '
+        'job output).\n')
+
+
 def main():
     """Performs task to wrap up the release."""
     if not common.is_current_branch_a_release_branch():
@@ -114,6 +145,8 @@ def main():
     g = github.Github(personal_access_token)
     repo = g.get_organization('oppia').get_repo('oppia')
 
+    remove_protection_rule()
+    update_jobs_tracker()
     remove_blocking_bugs_milestone_from_issues(repo)
     remove_release_labels(repo)
 

--- a/scripts/release_scripts/wrap_up_release.py
+++ b/scripts/release_scripts/wrap_up_release.py
@@ -99,7 +99,7 @@ def remove_blocking_bugs_milestone_from_issues(repo):
         issue.edit(milestone=None)
 
 
-def remove_protection_rule():
+def ask_user_to_remove_protection_rule():
     """Asks the release co-ordinator to perform the steps for deletion of
     github protection rule for release branch.
     """
@@ -115,7 +115,7 @@ def remove_protection_rule():
             common.get_current_branch_name()))
 
 
-def update_jobs_tracker():
+def ask_user_to_update_jobs_tracker():
     """Asks the release co-ordinator to update the status of jobs run
     in the release.
     """
@@ -145,8 +145,8 @@ def main():
     g = github.Github(personal_access_token)
     repo = g.get_organization('oppia').get_repo('oppia')
 
-    remove_protection_rule()
-    update_jobs_tracker()
+    ask_user_to_remove_protection_rule()
+    ask_user_to_update_jobs_tracker()
     remove_blocking_bugs_milestone_from_issues(repo)
     remove_release_labels(repo)
 

--- a/scripts/release_scripts/wrap_up_release_test.py
+++ b/scripts/release_scripts/wrap_up_release_test.py
@@ -88,6 +88,46 @@ class WrapReleaseTests(test_utils.GenericTestBase):
                     'tokens and re-run the script')):
                 wrap_up_release.main()
 
+    def test_remove_protection_rule(self):
+        check_function_calls = {
+            'ask_user_to_confirm_gets_called': False
+        }
+        def mock_get_current_branch_name():
+            return 'release-1.2.3'
+        def mock_ask_user_to_confirm(unused_msg):
+            check_function_calls['ask_user_to_confirm_gets_called'] = True
+        branch_name_swap = self.swap(
+            common, 'get_current_branch_name', mock_get_current_branch_name)
+        ask_user_swap = self.swap(
+            common, 'ask_user_to_confirm', mock_ask_user_to_confirm)
+        with branch_name_swap, ask_user_swap:
+            wrap_up_release.remove_protection_rule()
+        self.assertTrue(check_function_calls['ask_user_to_confirm_gets_called'])
+
+    def test_update_jobs_tracker(self):
+        check_function_calls = {
+            'ask_user_to_confirm_gets_called': False,
+            'open_new_tab_in_browser_if_possible_gets_called': False
+        }
+        expected_check_function_calls = {
+            'ask_user_to_confirm_gets_called': True,
+            'open_new_tab_in_browser_if_possible_gets_called': True
+        }
+        def mock_open_new_tab_in_browser_if_possible(unused_url):
+            check_function_calls[
+                'open_new_tab_in_browser_if_possible_gets_called'] = True
+        def mock_ask_user_to_confirm(unused_msg):
+            check_function_calls['ask_user_to_confirm_gets_called'] = True
+
+        open_tab_swap = self.swap(
+            common, 'open_new_tab_in_browser_if_possible',
+            mock_open_new_tab_in_browser_if_possible)
+        ask_user_swap = self.swap(
+            common, 'ask_user_to_confirm', mock_ask_user_to_confirm)
+        with open_tab_swap, ask_user_swap:
+            wrap_up_release.update_jobs_tracker()
+        self.assertEqual(check_function_calls, expected_check_function_calls)
+
     def test_closed_blocking_bugs_milestone_results_in_exception(self):
         # pylint: disable=unused-argument
         def mock_get_milestone(unused_self, number):
@@ -267,16 +307,24 @@ class WrapReleaseTests(test_utils.GenericTestBase):
         check_function_calls = {
             'remove_blocking_bugs_milestone_from_issues_gets_called': False,
             'remove_release_labels_gets_called': False,
+            'remove_protection_rule_gets_called': False,
+            'update_jobs_tracker_gets_called': False
         }
         expected_check_function_calls = {
             'remove_blocking_bugs_milestone_from_issues_gets_called': True,
             'remove_release_labels_gets_called': True,
+            'remove_protection_rule_gets_called': True,
+            'update_jobs_tracker_gets_called': True
         }
         def mock_remove_blocking_bugs_milestone_from_issues(unused_repo):
             check_function_calls[
                 'remove_blocking_bugs_milestone_from_issues_gets_called'] = True
         def mock_remove_release_labels(unused_repo):
             check_function_calls['remove_release_labels_gets_called'] = True
+        def mock_remove_protection_rule():
+            check_function_calls['remove_protection_rule_gets_called'] = True
+        def mock_update_jobs_tracker():
+            check_function_calls['update_jobs_tracker_gets_called'] = True
         def mock_get_organization(unused_self, unused_name):
             return github.Organization.Organization(
                 requester='', headers='', attributes={}, completed='')
@@ -293,6 +341,11 @@ class WrapReleaseTests(test_utils.GenericTestBase):
         remove_release_labels_swap = self.swap(
             wrap_up_release, 'remove_release_labels',
             mock_remove_release_labels)
+        remove_protection_swap = self.swap(
+            wrap_up_release, 'remove_protection_rule',
+            mock_remove_protection_rule)
+        update_jobs_swap = self.swap(
+            wrap_up_release, 'update_jobs_tracker', mock_update_jobs_tracker)
         get_org_swap = self.swap(
             github.Github, 'get_organization', mock_get_organization)
         get_repo_swap = self.swap(
@@ -302,6 +355,7 @@ class WrapReleaseTests(test_utils.GenericTestBase):
         with self.branch_name_swap, self.exists_swap, get_org_swap:
             with get_repo_swap, getpass_swap, remove_release_labels_swap:
                 with remove_blocking_bugs_milestone_from_issues_swap:
-                    wrap_up_release.main()
+                    with remove_protection_swap, update_jobs_swap:
+                        wrap_up_release.main()
 
         self.assertEqual(check_function_calls, expected_check_function_calls)

--- a/scripts/release_scripts/wrap_up_release_test.py
+++ b/scripts/release_scripts/wrap_up_release_test.py
@@ -88,7 +88,7 @@ class WrapReleaseTests(test_utils.GenericTestBase):
                     'tokens and re-run the script')):
                 wrap_up_release.main()
 
-    def test_remove_protection_rule(self):
+    def test_ask_user_to_remove_protection_rule(self):
         check_function_calls = {
             'ask_user_to_confirm_gets_called': False
         }
@@ -101,10 +101,10 @@ class WrapReleaseTests(test_utils.GenericTestBase):
         ask_user_swap = self.swap(
             common, 'ask_user_to_confirm', mock_ask_user_to_confirm)
         with branch_name_swap, ask_user_swap:
-            wrap_up_release.remove_protection_rule()
+            wrap_up_release.ask_user_to_remove_protection_rule()
         self.assertTrue(check_function_calls['ask_user_to_confirm_gets_called'])
 
-    def test_update_jobs_tracker(self):
+    def test_ask_user_to_update_jobs_tracker(self):
         check_function_calls = {
             'ask_user_to_confirm_gets_called': False,
             'open_new_tab_in_browser_if_possible_gets_called': False
@@ -125,7 +125,7 @@ class WrapReleaseTests(test_utils.GenericTestBase):
         ask_user_swap = self.swap(
             common, 'ask_user_to_confirm', mock_ask_user_to_confirm)
         with open_tab_swap, ask_user_swap:
-            wrap_up_release.update_jobs_tracker()
+            wrap_up_release.ask_user_to_update_jobs_tracker()
         self.assertEqual(check_function_calls, expected_check_function_calls)
 
     def test_closed_blocking_bugs_milestone_results_in_exception(self):
@@ -307,24 +307,26 @@ class WrapReleaseTests(test_utils.GenericTestBase):
         check_function_calls = {
             'remove_blocking_bugs_milestone_from_issues_gets_called': False,
             'remove_release_labels_gets_called': False,
-            'remove_protection_rule_gets_called': False,
-            'update_jobs_tracker_gets_called': False
+            'ask_user_to_remove_protection_rule_gets_called': False,
+            'ask_user_to_update_jobs_tracker_gets_called': False
         }
         expected_check_function_calls = {
             'remove_blocking_bugs_milestone_from_issues_gets_called': True,
             'remove_release_labels_gets_called': True,
-            'remove_protection_rule_gets_called': True,
-            'update_jobs_tracker_gets_called': True
+            'ask_user_to_remove_protection_rule_gets_called': True,
+            'ask_user_to_update_jobs_tracker_gets_called': True
         }
         def mock_remove_blocking_bugs_milestone_from_issues(unused_repo):
             check_function_calls[
                 'remove_blocking_bugs_milestone_from_issues_gets_called'] = True
         def mock_remove_release_labels(unused_repo):
             check_function_calls['remove_release_labels_gets_called'] = True
-        def mock_remove_protection_rule():
-            check_function_calls['remove_protection_rule_gets_called'] = True
-        def mock_update_jobs_tracker():
-            check_function_calls['update_jobs_tracker_gets_called'] = True
+        def mock_ask_user_to_remove_protection_rule():
+            check_function_calls[
+                'ask_user_to_remove_protection_rule_gets_called'] = True
+        def mock_ask_user_to_update_jobs_tracker():
+            check_function_calls[
+                'ask_user_to_update_jobs_tracker_gets_called'] = True
         def mock_get_organization(unused_self, unused_name):
             return github.Organization.Organization(
                 requester='', headers='', attributes={}, completed='')
@@ -342,10 +344,11 @@ class WrapReleaseTests(test_utils.GenericTestBase):
             wrap_up_release, 'remove_release_labels',
             mock_remove_release_labels)
         remove_protection_swap = self.swap(
-            wrap_up_release, 'remove_protection_rule',
-            mock_remove_protection_rule)
+            wrap_up_release, 'ask_user_to_remove_protection_rule',
+            mock_ask_user_to_remove_protection_rule)
         update_jobs_swap = self.swap(
-            wrap_up_release, 'update_jobs_tracker', mock_update_jobs_tracker)
+            wrap_up_release, 'ask_user_to_update_jobs_tracker',
+            mock_ask_user_to_update_jobs_tracker)
         get_org_swap = self.swap(
             github.Github, 'get_organization', mock_get_organization)
         get_repo_swap = self.swap(


### PR DESCRIPTION
1. This PR fixes or fixes part of N/A.
2. This PR does the following: Automates wrap up of release by moving all steps to wrap_up_release script.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
