### PR TITLE
Fix part of #8015: editable.question.backend.api.service.ts now returns a domain object …

### DIFF
--- a/core/templates/components/question-directives/questions-list/questions-list.directive.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.directive.ts
@@ -345,21 +345,21 @@ angular.module('oppia').directive('questionsList', [
             EditableQuestionBackendApiService.fetchQuestion(
               questionSummaryForOneSkill.getQuestionId()).then(
               function(response) {
-                if (response.associated_skill_dicts) {
-                  response.associated_skill_dicts.forEach(function(skillDict) {
-                    ctrl.misconceptionsBySkill[skillDict.id] =
-                      skillDict.misconceptions.map(function(misconception) {
-                        return MisconceptionObjectFactory.createFromBackendDict(
-                          misconception);
-                      });
-                    ctrl.associatedSkillSummaries.push(
-                      SkillSummaryObjectFactory.create(
-                        skillDict.id, skillDict.description));
-                  });
+                if (response.associatedSkillObjects) {
+                  response.associatedSkillObjects
+                    .forEach(function(skillObject) {
+                      ctrl.misconceptionsBySkill[skillObject.getId()] =
+                        skillObject.getMisconceptions()
+                          .map(function(misconception) {
+                            return MisconceptionObjectFactory
+                              .createFromBackendDict(misconception);
+                          });
+                      ctrl.associatedSkillSummaries.push(
+                        SkillSummaryObjectFactory.create(
+                          skillObject.getId(), skillObject.getDescription()));
+                    });
                 }
-                ctrl.question =
-                  QuestionObjectFactory.createFromBackendDict(
-                    response.question_dict);
+                ctrl.question = angular.copy(response.questionObject);
                 ctrl.questionId = ctrl.question.getId();
                 ctrl.questionStateData = ctrl.question.getStateData();
                 ctrl.questionIsBeingUpdated = true;

--- a/core/templates/components/question-directives/questions-list/questions-list.directive.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.directive.ts
@@ -345,19 +345,17 @@ angular.module('oppia').directive('questionsList', [
             EditableQuestionBackendApiService.fetchQuestion(
               questionSummaryForOneSkill.getQuestionId()).then(
               function(response) {
-                if (response.associatedSkillObjects) {
-                  response.associatedSkillObjects
-                    .forEach(function(skillObject) {
-                      ctrl.misconceptionsBySkill[skillObject.getId()] =
-                        skillObject.getMisconceptions()
-                          .map(function(misconception) {
-                            return MisconceptionObjectFactory
-                              .createFromBackendDict(misconception);
-                          });
-                      ctrl.associatedSkillSummaries.push(
-                        SkillSummaryObjectFactory.create(
-                          skillObject.getId(), skillObject.getDescription()));
-                    });
+                if (response.associated_skill_dicts) {
+                  response.associated_skill_dicts.forEach(function(skillDict) {
+                    ctrl.misconceptionsBySkill[skillDict.id] =
+                      skillDict.misconceptions.map(function(misconception) {
+                        return MisconceptionObjectFactory.createFromBackendDict(
+                          misconception);
+                      });
+                    ctrl.associatedSkillSummaries.push(
+                      SkillSummaryObjectFactory.create(
+                        skillDict.id, skillDict.description));
+                  });
                 }
                 ctrl.question = angular.copy(response.questionObject);
                 ctrl.questionId = ctrl.question.getId();

--- a/core/templates/domain/question/editable-question-backend-api.service.spec.ts
+++ b/core/templates/domain/question/editable-question-backend-api.service.spec.ts
@@ -31,6 +31,7 @@ describe('Editable question backend API service', function() {
   var EditableQuestionBackendApiService = null;
   var QuestionObjectFactory;
   var sampleDataResults = null;
+  var sampleDataResultsObjects = null;
   var $rootScope = null;
   var $scope = null;
   var $httpBackend = null;
@@ -112,6 +113,13 @@ describe('Editable question backend API service', function() {
       },
       associated_skill_dicts: []
     };
+
+    sampleDataResultsObjects = {
+      questionObject:
+        QuestionObjectFactory.createFromBackendDict(
+          sampleDataResults.question_dict),
+      associatedSkillObjects: []
+    };
   }));
 
   afterEach(function() {
@@ -125,13 +133,12 @@ describe('Editable question backend API service', function() {
 
     var skillsId = ['0', '01', '02'];
     var skillDifficulties = [1, 1, 2];
-    var questionDict = QuestionObjectFactory.createFromBackendDict(
-      sampleDataResults.question_dict);
+    var questionObject = sampleDataResultsObjects.questionObject;
 
     $httpBackend.expectPOST('/question_editor_handler/create_new').respond(
       200, {question_id: '0'});
     EditableQuestionBackendApiService.createQuestion(
-      skillsId, skillDifficulties, questionDict).then(
+      skillsId, skillDifficulties, questionObject).then(
       successHandler, failHandler);
     $httpBackend.flush();
 
@@ -146,13 +153,12 @@ describe('Editable question backend API service', function() {
 
       var skillsId = ['0', '01', '02'];
       var skillDifficulties = [1, 1, 2];
-      var questionDict = QuestionObjectFactory.createFromBackendDict(
-        sampleDataResults.question_dict);
+      var questionObject = sampleDataResultsObjects.questionObject;
 
       $httpBackend.expectPOST('/question_editor_handler/create_new').respond(
         500, 'Error creating a new question.');
       EditableQuestionBackendApiService.createQuestion(
-        skillsId, skillDifficulties, questionDict).then(
+        skillsId, skillDifficulties, questionObject).then(
         successHandler, failHandler);
       $httpBackend.flush();
 
@@ -173,7 +179,7 @@ describe('Editable question backend API service', function() {
       $httpBackend.flush();
 
       expect(successHandler).toHaveBeenCalledWith(
-        sampleDataResults);
+        sampleDataResultsObjects);
       expect(failHandler).not.toHaveBeenCalled();
     }
   );
@@ -206,7 +212,7 @@ describe('Editable question backend API service', function() {
 
       EditableQuestionBackendApiService.fetchQuestion('0').then(
         function(data) {
-          question = data.question_dict;
+          question = data.questionObject.toBackendDict(false);
         });
       $httpBackend.flush();
       question.question_state_data.content.html = 'New Question Content';

--- a/core/templates/domain/question/editable-question-backend-api.service.spec.ts
+++ b/core/templates/domain/question/editable-question-backend-api.service.spec.ts
@@ -118,7 +118,7 @@ describe('Editable question backend API service', function() {
       questionObject:
         QuestionObjectFactory.createFromBackendDict(
           sampleDataResults.question_dict),
-      associatedSkillObjects: []
+      associated_skill_dicts: []
     };
   }));
 

--- a/core/templates/domain/question/editable-question-backend-api.service.ts
+++ b/core/templates/domain/question/editable-question-backend-api.service.ts
@@ -22,6 +22,8 @@ require('domain/exploration/AnswerGroupObjectFactory.ts');
 require('domain/exploration/HintObjectFactory.ts');
 require('domain/exploration/OutcomeObjectFactory.ts');
 require('domain/exploration/ParamSpecObjectFactory.ts');
+require('domain/question/QuestionObjectFactory.ts');
+require('domain/skill/SkillObjectFactory.ts');
 require('domain/exploration/WrittenTranslationObjectFactory.ts');
 require('domain/objects/FractionObjectFactory.ts');
 require('domain/utilities/url-interpolation.service.ts');
@@ -29,11 +31,13 @@ require('domain/utilities/url-interpolation.service.ts');
 require('domain/question/question-domain.constants.ajs.ts');
 
 angular.module('oppia').factory('EditableQuestionBackendApiService', [
-  '$http', '$q', 'UrlInterpolationService',
+  '$http', '$q', 'QuestionObjectFactory',
+  'SkillObjectFactory', 'UrlInterpolationService',
   'EDITABLE_QUESTION_DATA_URL_TEMPLATE', 'QUESTION_CREATION_URL',
   'QUESTION_SKILL_LINK_URL_TEMPLATE',
   function(
-      $http, $q, UrlInterpolationService,
+      $http, $q, QuestionObjectFactory,
+      SkillObjectFactory, UrlInterpolationService,
       EDITABLE_QUESTION_DATA_URL_TEMPLATE, QUESTION_CREATION_URL,
       QUESTION_SKILL_LINK_URL_TEMPLATE) {
     var _createQuestion = function(
@@ -63,11 +67,20 @@ angular.module('oppia').factory('EditableQuestionBackendApiService', [
         });
 
       $http.get(questionDataUrl).then(function(response) {
-        var data = angular.copy(response.data);
+        var questionObject =
+          QuestionObjectFactory.createFromBackendDict(
+            response.data.question_dict);
+        var associatedSkillObjects =
+          response.data.associated_skill_dicts.map(
+            (skillDict) => {
+              return SkillObjectFactory
+                .createFromBackendDict(skillDict);
+            }
+          );
         if (successCallback) {
           successCallback({
-            question_dict: data.question_dict,
-            associated_skill_dicts: data.associated_skill_dicts
+            questionObject: questionObject,
+            associatedSkillObjects: associatedSkillObjects
           });
         }
       }, function(errorResponse) {

--- a/core/templates/domain/question/editable-question-backend-api.service.ts
+++ b/core/templates/domain/question/editable-question-backend-api.service.ts
@@ -23,7 +23,6 @@ require('domain/exploration/HintObjectFactory.ts');
 require('domain/exploration/OutcomeObjectFactory.ts');
 require('domain/exploration/ParamSpecObjectFactory.ts');
 require('domain/question/QuestionObjectFactory.ts');
-require('domain/skill/SkillObjectFactory.ts');
 require('domain/exploration/WrittenTranslationObjectFactory.ts');
 require('domain/objects/FractionObjectFactory.ts');
 require('domain/utilities/url-interpolation.service.ts');
@@ -32,12 +31,12 @@ require('domain/question/question-domain.constants.ajs.ts');
 
 angular.module('oppia').factory('EditableQuestionBackendApiService', [
   '$http', '$q', 'QuestionObjectFactory',
-  'SkillObjectFactory', 'UrlInterpolationService',
+  'UrlInterpolationService',
   'EDITABLE_QUESTION_DATA_URL_TEMPLATE', 'QUESTION_CREATION_URL',
   'QUESTION_SKILL_LINK_URL_TEMPLATE',
   function(
       $http, $q, QuestionObjectFactory,
-      SkillObjectFactory, UrlInterpolationService,
+      UrlInterpolationService,
       EDITABLE_QUESTION_DATA_URL_TEMPLATE, QUESTION_CREATION_URL,
       QUESTION_SKILL_LINK_URL_TEMPLATE) {
     var _createQuestion = function(
@@ -70,17 +69,12 @@ angular.module('oppia').factory('EditableQuestionBackendApiService', [
         var questionObject =
           QuestionObjectFactory.createFromBackendDict(
             response.data.question_dict);
-        var associatedSkillObjects =
-          response.data.associated_skill_dicts.map(
-            (skillDict) => {
-              return SkillObjectFactory
-                .createFromBackendDict(skillDict);
-            }
-          );
+        var skillDicts = angular.copy(
+          response.data.associated_skill_dicts);
         if (successCallback) {
           successCallback({
             questionObject: questionObject,
-            associatedSkillObjects: associatedSkillObjects
+            associated_skill_dicts: skillDicts
           });
         }
       }, function(errorResponse) {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes or fixes part of #8015.
2. This PR does the following: editable-question-backend-api now returns a question object instead of question dict and associated skills objects instead of associated skills dicts. questions-list.directive is modified to directly use objects returned from the service. 
modified the tests spec to expect domain object.

## Essential Checklist

- [ X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ X] The linter/Karma presubmit checks have passed locally on your machine.
- [ X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ X] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
