### PR TITLE
Fix part of #6271: Refactored add_misconception() to accept object instead of dictionary

### DIFF
--- a/core/domain/prod_validation_jobs_one_off_test.py
+++ b/core/domain/prod_validation_jobs_one_off_test.py
@@ -6937,11 +6937,12 @@ class SkillModelValidatorTests(test_utils.GenericTestBase):
             'id': 0, 'name': 'name', 'notes': '<p>notes</p>',
             'feedback': '<p>default_feedback</p>',
             'must_be_addressed': True}
+        misconception = skill_domain.Misconception.from_dict(misconception_dict)
 
         for index, skill in enumerate(skills):
             skill.language_code = language_codes[index]
             skill.skill_contents = skill_contents
-            skill.add_misconception(misconception_dict)
+            skill.add_misconception(misconception, misconception_dict['id'])
             if index < 2:
                 skill.superseding_skill_id = '%s' % (index + 3)
                 skill.all_questions_merged = True
@@ -7159,11 +7160,12 @@ class SkillSnapshotMetadataModelValidatorTests(
             'id': 0, 'name': 'name', 'notes': '<p>notes</p>',
             'feedback': '<p>default_feedback</p>',
             'must_be_addressed': True}
+        misconception = skill_domain.Misconception.from_dict(misconception_dict)
 
         for index, skill in enumerate(skills):
             skill.language_code = language_codes[index]
             skill.skill_contents = skill_contents
-            skill.add_misconception(misconception_dict)
+            skill.add_misconception(misconception, misconception_dict['id'])
             if index == 0:
                 skill_services.save_new_skill(self.user_id, skill)
             else:
@@ -7357,11 +7359,12 @@ class SkillSnapshotContentModelValidatorTests(test_utils.GenericTestBase):
             'id': 0, 'name': 'name', 'notes': '<p>notes</p>',
             'feedback': '<p>default_feedback</p>',
             'must_be_addressed': True}
+        misconception = skill_domain.Misconception.from_dict(misconception_dict)
 
         for index, skill in enumerate(skills):
             skill.language_code = language_codes[index]
             skill.skill_contents = skill_contents
-            skill.add_misconception(misconception_dict)
+            skill.add_misconception(misconception, misconception_dict['id'])
             skill_services.save_new_skill(self.owner_id, skill)
 
         self.model_instance_0 = (
@@ -7505,11 +7508,12 @@ class SkillCommitLogEntryModelValidatorTests(test_utils.GenericTestBase):
             'id': 0, 'name': 'name', 'notes': '<p>notes</p>',
             'feedback': '<p>default_feedback</p>',
             'must_be_addressed': True}
+        misconception = skill_domain.Misconception.from_dict(misconception_dict)
 
         for index, skill in enumerate(skills):
             skill.language_code = language_codes[index]
             skill.skill_contents = skill_contents
-            skill.add_misconception(misconception_dict)
+            skill.add_misconception(misconception, misconception_dict['id'])
             skill_services.save_new_skill(self.owner_id, skill)
 
         self.model_instance_0 = (
@@ -7741,11 +7745,12 @@ class SkillSummaryModelValidatorTests(test_utils.GenericTestBase):
             'id': 0, 'name': 'name', 'notes': '<p>notes</p>',
             'feedback': '<p>default_feedback</p>',
             'must_be_addressed': True}
+        misconception = skill_domain.Misconception.from_dict(misconception_dict)
 
         for index, skill in enumerate(skills):
             skill.language_code = language_codes[index]
             skill.skill_contents = skill_contents
-            skill.add_misconception(misconception_dict)
+            skill.add_misconception(misconception, misconception_dict['id'])
             skill_services.save_new_skill(self.owner_id, skill)
 
         self.model_instance_0 = skill_models.SkillSummaryModel.get_by_id('0')

--- a/core/domain/skill_domain.py
+++ b/core/domain/skill_domain.py
@@ -113,7 +113,7 @@ class SkillChange(change_domain.BaseChange):
         'optional_attribute_names': []
     }, {
         'name': CMD_ADD_SKILL_MISCONCEPTION,
-        'required_attribute_names': ['new_misconception_dict'],
+        'required_attribute_names': ['misconception', 'misconception_id'],
         'optional_attribute_names': []
     }, {
         'name': CMD_DELETE_SKILL_MISCONCEPTION,
@@ -982,21 +982,16 @@ class Skill(python_utils.OBJECT):
                 return ind
         return None
 
-    def add_misconception(self, misconception_dict):
+    def add_misconception(self, misconception, misconception_id):
         """Adds a new misconception to the skill.
 
         Args:
-            misconception_dict: dict. The misconception to be added.
+            misconception: misconception. The misconception to be added.
+            misconception_id: int. The id of the misconception.
         """
-        misconception = Misconception(
-            misconception_dict['id'],
-            misconception_dict['name'],
-            misconception_dict['notes'],
-            misconception_dict['feedback'],
-            misconception_dict['must_be_addressed'])
         self.misconceptions.append(misconception)
         self.next_misconception_id = self.get_incremented_misconception_id(
-            misconception_dict['id'])
+            misconception_id)
 
     def _find_prerequisite_skill_id_index(self, skill_id_to_find):
         """Returns the index of the skill_id in the prerequisite_skill_ids

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -509,7 +509,10 @@ def apply_change_list(skill_id, change_list, committer_id):
                         for worked_example in change.new_value]
                     skill.update_worked_examples(worked_examples_list)
             elif change.cmd == skill_domain.CMD_ADD_SKILL_MISCONCEPTION:
-                skill.add_misconception(change.new_misconception_dict)
+                misconception = skill_domain.Misconception.from_dict(
+                    change.new_misconception_dict)
+                misconception_id = change.new_misconception_dict['id']
+                skill.add_misconception(misconception, misconception_id)
             elif change.cmd == skill_domain.CMD_DELETE_SKILL_MISCONCEPTION:
                 skill.delete_misconception(change.misconception_id)
             elif change.cmd == skill_domain.CMD_ADD_PREREQUISITE_SKILL:


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes or fixes part of #6271 .
2. This PR does the following: Refactored add_misconception() to accept misconception object instead of dictionary. Changed all caller functions and test files of add_misconception() to convert dictionary into misconception object.

## Essential Checklist

- [X ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X ] The linter/Karma presubmit checks have passed locally on your machine.
- [X ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [X ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
