### PR TITLE
Replace ui-utils with ui-validate since only this part of utils is used

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -508,14 +508,14 @@
           "js": ["dist/angular-ui-tree.js"]
         }
       },
-      "uiUtils": {
-        "version": "0.1.1",
+      "uiValidate": {
+        "version": "1.2.3",
         "downloadFormat": "zip",
-        "url": "https://github.com/angular-ui/ui-utils/archive/v0.1.1.zip",
-        "rootDirPrefix": "ui-utils-",
-        "targetDirPrefix": "ui-utils-",
+        "url": "https://github.com/angular-ui/ui-validate/archive/1.2.3.zip",
+        "rootDirPrefix": "ui-validate-",
+        "targetDirPrefix": "ui-validate-",
         "bundle": {
-          "js": ["ui-utils.js"]
+          "js": ["src/validate.js"]
         }
       },
       "waveSurferJs": {


### PR DESCRIPTION
## Overview
~1. This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following: Replaces the ui-utils with ui-validate, since only ui-validate is used from the ui-utils.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
