### PR TITLE
Fix #9010: Add script import MathJax HTML

### DIFF
--- a/core/templates/pages/exploration-player-page/exploration-player-page.mainpage.html
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.mainpage.html
@@ -39,7 +39,7 @@
     @load('pages/footer_js_libs.html')
     <script src="/third_party/static/ckeditor-4.12.1/ckeditor.js"></script>
     <script src="/third_party/static/MathJax-2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-    <script async src="/third_party/static/MathJax-2.7.5/jax/output/HTML-CSS/jax.js?V=2.7.5"></script>
+    <script defer src="/third_party/static/MathJax-2.7.5/jax/output/HTML-CSS/jax.js?V=2.7.5"></script>
     @loadExtensions('interactions/dependency_html.html')
   </body>
 </html>

--- a/core/templates/pages/exploration-player-page/exploration-player-page.mainpage.html
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.mainpage.html
@@ -14,6 +14,13 @@
         }
       }
     </style>
+    <!-- Prefetch files to enable the MathExpressionInput interaction to work
+         even in offline mode. -->
+    <link rel="prefetch" href="/third_party/static/MathJax-2.7.5/jax/output/HTML-CSS/jax.js?V=2.7.5">
+    <link rel="prefetch" href="/third_party/static/MathJax-2.7.5/jax/output/HTML-CSS/fonts/TeX/fontdata.js?V=2.7.5">
+    <link rel="prefetch" href="/third_party/static/MathJax-2.7.5/fonts/HTML-CSS/TeX/woff/MathJax_Main-Regular.woff?V=2.7.5">
+    <link rel="prefetch" href="/third_party/static/MathJax-2.7.5/fonts/HTML-CSS/TeX/woff/MathJax_Math-Italic.woff?V=2.7.5">
+    <link rel="prefetch" href="/third_party/static/MathJax-2.7.5/fonts/HTML-CSS/TeX/woff/MathJax_Size1-Regular.woff?V=2.7.5">
   </head>
   <body>
     <service-bootstrap></service-bootstrap>
@@ -39,7 +46,6 @@
     @load('pages/footer_js_libs.html')
     <script src="/third_party/static/ckeditor-4.12.1/ckeditor.js"></script>
     <script src="/third_party/static/MathJax-2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-    <script defer src="/third_party/static/MathJax-2.7.5/jax/output/HTML-CSS/jax.js?V=2.7.5"></script>
     @loadExtensions('interactions/dependency_html.html')
   </body>
 </html>

--- a/core/templates/pages/exploration-player-page/exploration-player-page.mainpage.html
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.mainpage.html
@@ -39,6 +39,7 @@
     @load('pages/footer_js_libs.html')
     <script src="/third_party/static/ckeditor-4.12.1/ckeditor.js"></script>
     <script src="/third_party/static/MathJax-2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script async src="/third_party/static/MathJax-2.7.5/jax/output/HTML-CSS/jax.js?V=2.7.5"></script>
     @loadExtensions('interactions/dependency_html.html')
   </body>
 </html>


### PR DESCRIPTION
## Overview

1. This PR fixes #9010.
2. This PR does the following: Add script import for part of MAthJax that is needed to render it in dialogs to enable smooth work of the explorations in the offline mode.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
