### PR TITLE
Fix #857 : Update answer group rules when choices in multiple choice input interaction are deleted

### DIFF
--- a/core/templates/components/forms/schema-based-editors/schema-based-editor.directive.html
+++ b/core/templates/components/forms/schema-based-editors/schema-based-editor.directive.html
@@ -42,7 +42,7 @@
                           local-value="$ctrl.localValue" is-disabled="$ctrl.isDisabled()"
                           item-schema="$ctrl.schema().items" len="$ctrl.schema().len"
                           ui-config="$ctrl.schema().ui_config" validators="$ctrl.schema().validators"
-                          label-for-focus-target="$ctrl.labelForFocusTarget()">
+                          label-for-focus-target="$ctrl.labelForFocusTarget()" old-to-new-list-mapping="$ctrl.oldToNewListMapping">
 </schema-based-list-editor>
 
 <schema-based-dict-editor ng-if="$ctrl.schema().type === 'dict' && !$ctrl.schema().choices"

--- a/core/templates/components/forms/schema-based-editors/schema-based-editor.directive.ts
+++ b/core/templates/components/forms/schema-based-editors/schema-based-editor.directive.ts
@@ -54,7 +54,8 @@ angular.module('oppia').directive('schemaBasedEditor', [
         localValue: '=',
         labelForFocusTarget: '&',
         onInputBlur: '=',
-        onInputFocus: '='
+        onInputFocus: '=',
+        oldToNewListMapping: '='
       },
       template: require('./schema-based-editor.directive.html'),
       controllerAs: '$ctrl',

--- a/core/templates/components/forms/schema-based-editors/schema-based-list-editor.directive.html
+++ b/core/templates/components/forms/schema-based-editors/schema-based-list-editor.directive.html
@@ -21,7 +21,7 @@
         <schema-based-editor schema="itemSchema()" is-disabled="isDisabled()" local-value="localValue[$index]"
                              label-for-focus-target="getFocusLabel($index)"
                              on-input-blur="($last ? lastElementOnBlur : showAddItemButton)"
-                             on-input-focus="($last ? hideAddItemButton : showAddItemButton)">
+                             on-input-focus="($last ? hideAddItemButton : showAddItemButton)" old-to-new-list-mapping="oldToNewListMapping">
         </schema-based-editor>
       </td>
       <td ng-if="!len && (!minListLength || localValue.length > minListLength) && localValue.length > 0" style="vertical-align: top;">

--- a/core/templates/components/forms/schema-based-editors/schema-based-list-editor.directive.ts
+++ b/core/templates/components/forms/schema-based-editors/schema-based-list-editor.directive.ts
@@ -45,7 +45,10 @@ angular.module('oppia').directive('schemaBasedListEditor', [
         // UI configuration. May be undefined.
         uiConfig: '&',
         validators: '&',
-        labelForFocusTarget: '&'
+        labelForFocusTarget: '&',
+        // Variable to keep track of the changes in the list-editor on
+        // addition and deletion of elements.
+        oldToNewListMapping: '='
       },
       template: require('./schema-based-list-editor.directive.html'),
       restrict: 'E',
@@ -81,6 +84,29 @@ angular.module('oppia').directive('schemaBasedListEditor', [
           return false;
         };
 
+        var initializeOldToNewListMapping = function() {
+          if ($scope.oldToNewListMapping !== undefined) {
+            for (var i = 0; i < $scope.localValue.length; i++) {
+              $scope.oldToNewListMapping.
+                newToOldListPosition.push(i);
+            }
+          }
+        };
+        var updateOldToNewListMappingOnDeleteItem = function(index) {
+          if ($scope.oldToNewListMapping !== undefined) {
+            var deletedIndex = $scope.oldToNewListMapping.
+              newToOldListPosition[index];
+            if (deletedIndex !== -1) {
+              $scope.oldToNewListMapping.deletedIndexes.push(deletedIndex);
+            }
+            $scope.oldToNewListMapping.newToOldListPosition.splice(index, 1);
+          }
+        };
+        var updateOldToNewListMappingOnAddItem = function() {
+          if ($scope.oldToNewListMapping !== undefined) {
+            $scope.oldToNewListMapping.newToOldListPosition.push(-1);
+          }
+        };
         var validate = function() {
           if ($scope.showDuplicatesWarning) {
             $scope.listEditorForm.$setValidity(
@@ -142,6 +168,7 @@ angular.module('oppia').directive('schemaBasedListEditor', [
                 SchemaDefaultValueService.getDefaultValue($scope.itemSchema()));
               FocusManagerService.setFocus(
                 $scope.getFocusLabel($scope.localValue.length - 1));
+              updateOldToNewListMappingOnAddItem();
             };
 
             var _deleteLastElementIfUndefined = function() {
@@ -212,8 +239,10 @@ angular.module('oppia').directive('schemaBasedListEditor', [
               'submittedSchemaBasedFloatForm', $scope._onChildFormSubmit);
             $scope.$on(
               'submittedSchemaBasedUnicodeForm', $scope._onChildFormSubmit);
+            initializeOldToNewListMapping();
 
             $scope.deleteElement = function(index) {
+              updateOldToNewListMappingOnDeleteItem(index);
               // Need to let the RTE know that HtmlContent has been changed.
               $scope.$broadcast('externalHtmlContentChange');
               $scope.localValue.splice(index, 1);

--- a/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.directive.ts
+++ b/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.directive.ts
@@ -120,7 +120,8 @@ angular.module('oppia').directive('stateInteractionEditor', [
               interactionCustomizationArgs, false);
           };
 
-          var _updateInteractionPreviewAndAnswerChoices = function() {
+          var _updateInteractionPreviewAndAnswerChoices = function(
+              oldToNewListMapping = {}) {
             $scope.interactionId = StateInteractionIdService.savedMemento;
 
             var currentCustomizationArgs =
@@ -131,7 +132,8 @@ angular.module('oppia').directive('stateInteractionEditor', [
             $rootScope.$broadcast(
               'updateAnswerChoices',
               StateEditorService.getAnswerChoices(
-                $scope.interactionId, currentCustomizationArgs));
+                $scope.interactionId, currentCustomizationArgs),
+              oldToNewListMapping);
           };
 
           // If a terminal interaction is selected for a state with no content,
@@ -151,7 +153,8 @@ angular.module('oppia').directive('stateInteractionEditor', [
             $scope.onSaveStateContent(StateContentService.displayed);
           };
 
-          $scope.onCustomizationModalSavePostHook = function() {
+          $scope.onCustomizationModalSavePostHook = function(
+              oldToNewListMapping) {
             var hasInteractionIdChanged = (
               StateInteractionIdService.displayed !==
               StateInteractionIdService.savedMemento);
@@ -182,7 +185,8 @@ angular.module('oppia').directive('stateInteractionEditor', [
             }
 
             $scope.recomputeGraph();
-            _updateInteractionPreviewAndAnswerChoices();
+            _updateInteractionPreviewAndAnswerChoices(
+              oldToNewListMapping);
           };
 
           $scope.openInteractionCustomizerModal = function() {
@@ -229,7 +233,12 @@ angular.module('oppia').directive('stateInteractionEditor', [
                         UrlInterpolationService.getInteractionThumbnailImageUrl(
                           interactionId));
                     };
-
+                    $scope.oldToNewListMappingObject = {
+                      oldToNewListMapping: {
+                        newToOldListPosition: [],
+                        deletedIndexes: []
+                      }
+                    };
                     $scope.INTERACTION_SPECS = INTERACTION_SPECS;
 
                     if (StateEditorService.isInQuestionMode()) {
@@ -369,7 +378,9 @@ angular.module('oppia').directive('stateInteractionEditor', [
                     $scope.save = function() {
                       EditorFirstTimeEventsService
                         .registerFirstSaveInteractionEvent();
-                      $uibModalInstance.close();
+                      $uibModalInstance.close(
+                        $scope.oldToNewListMappingObject.
+                          oldToNewListMapping);
                     };
 
                     $scope.okay = function() {

--- a/core/templates/components/state-editor/state-responses-editor/state-responses.directive.ts
+++ b/core/templates/components/state-editor/state-responses-editor/state-responses.directive.ts
@@ -635,9 +635,11 @@ angular.module('oppia').directive('stateResponses', [
                 ResponsesService.getActiveAnswerGroupIndex());
             });
 
-            $scope.$on('updateAnswerChoices', function(evt, newAnswerChoices) {
+            $scope.$on('updateAnswerChoices', function(
+                evt, newAnswerChoices, oldToNewListMapping) {
               ResponsesService.updateAnswerChoices(
-                newAnswerChoices, function(newAnswerGroups) {
+                newAnswerChoices, oldToNewListMapping, function(
+                    newAnswerGroups) {
                   $scope.onSaveInteractionAnswerGroups(newAnswerGroups);
                   $scope.refreshWarnings()();
                 });

--- a/core/templates/pages/exploration-editor-page/editor-tab/services/responses.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/services/responses.service.spec.ts
@@ -30,7 +30,7 @@ describe('Responses Service', function() {
   var interactionData = null;
   var interactionDataWithRules = null;
   var LoggerService = null;
-
+  var oldToNewListMapping = null;
   beforeEach(angular.mock.module('oppia'));
   beforeEach(angular.mock.module('oppia', function($provide) {
     var ugs = new UpgradedServices();
@@ -321,13 +321,17 @@ describe('Responses Service', function() {
     StateInteractionIdService.init('stateName', 'ItemSelectionInput');
 
     // Set _answerChoices variable
+    oldToNewListMapping = {
+      newToOldListPosition: [0, 1, 2],
+      deletedIndexes: []
+    };
     ResponsesService.updateAnswerChoices([{
       val: 'a'
     }, {
       val: 'b'
     }, {
       val: 'c'
-    }], function() {});
+    }], oldToNewListMapping, function() {});
     ResponsesService.changeActiveAnswerGroupIndex(0);
 
     var newAnswerChoices = [{
@@ -338,7 +342,8 @@ describe('Responses Service', function() {
       val: 'a'
     }];
     var callbackSpy = jasmine.createSpy('callback');
-    ResponsesService.updateAnswerChoices(newAnswerChoices, callbackSpy);
+    ResponsesService.updateAnswerChoices(
+      newAnswerChoices, oldToNewListMapping, callbackSpy);
 
     var expectedRules = ['c'];
     var expectedAnswerGroup = interactionDataWithRules.answerGroups;
@@ -356,13 +361,17 @@ describe('Responses Service', function() {
     StateEditorService.setInteraction(interactionDataWithRules);
     StateInteractionIdService.init('stateName', 'ItemSelectionInput');
 
+    oldToNewListMapping = {
+      newToOldListPosition: [0, 1, 2],
+      deletedIndexes: []
+    };
     ResponsesService.updateAnswerChoices([{
       val: 'a'
     }, {
       val: 'b'
     }, {
       val: 'c'
-    }], function() {});
+    }], oldToNewListMapping, function() {});
 
     var newAnswerChoices = [{
       val: 'd'
@@ -372,11 +381,76 @@ describe('Responses Service', function() {
       val: 'f'
     }];
     var callbackSpy = jasmine.createSpy('callback');
-    ResponsesService.updateAnswerChoices(newAnswerChoices, callbackSpy);
+    ResponsesService.updateAnswerChoices(
+      newAnswerChoices, oldToNewListMapping, callbackSpy);
 
     var expectedAnswerGroup = interactionDataWithRules.answerGroups;
     expectedAnswerGroup[0].rules[0].inputs.x = ['f', 'd', 'e'];
     expectedAnswerGroup[0].rules[0].inputs.y = ['d', 'e', 'f'];
+
+    expect(callbackSpy).toHaveBeenCalledWith(expectedAnswerGroup);
+    expect(ResponsesService.getAnswerGroup(0)).toEqual(
+      expectedAnswerGroup[0]);
+    expect(ResponsesService.getAnswerChoices()).toEqual(newAnswerChoices);
+  });
+
+  it('should update answer choices when savedMemento is MultipleChoiceInput' +
+    ' and choices are deleted', function() {
+    interactionDataWithRules.answerGroups = [{
+      outcome: {
+        dest: '',
+        feedback: {
+          content_id: 'feedback_1',
+          html: ''
+        },
+      },
+      rules: [{
+        type: 'Equals',
+        inputs: {
+          x: 0
+        }
+      }, {
+        type: 'Equals',
+        inputs: {
+          x: 2
+        }
+      }],
+    }];
+    ResponsesService.init(interactionDataWithRules);
+    StateEditorService.setInteraction(interactionDataWithRules);
+    StateInteractionIdService.init('stateName', 'MultipleChoiceInput');
+
+    ResponsesService.updateAnswerChoices([{
+      val: 'a'
+    }, {
+      val: 'b'
+    }, {
+      val: 'c'
+    }, {
+      val: 'd'
+    }, {
+      val: 'e'
+    }], oldToNewListMapping, function() {});
+
+    oldToNewListMapping = {
+      newToOldListPosition: [1, 3, 4],
+      deletedIndexes: [0, 2]
+    };
+    var newAnswerChoices = [{
+      val: 'b'
+    }, {
+      val: 'd'
+    }, {
+      val: 'e'
+    }];
+
+    var callbackSpy = jasmine.createSpy('callback');
+    ResponsesService.updateAnswerChoices(
+      newAnswerChoices, oldToNewListMapping, callbackSpy);
+
+    var expectedAnswerGroup = interactionDataWithRules.answerGroups;
+    expectedAnswerGroup[0].rules[0].inputs.x = Number.MAX_SAFE_INTEGER;
+    expectedAnswerGroup[0].rules[1].inputs.x = Number.MAX_SAFE_INTEGER;
 
     expect(callbackSpy).toHaveBeenCalledWith(expectedAnswerGroup);
     expect(ResponsesService.getAnswerGroup(0)).toEqual(
@@ -396,21 +470,30 @@ describe('Responses Service', function() {
     StateEditorService.setInteraction(interactionDataWithRules);
     StateInteractionIdService.init('stateName', 'DragAndDropSortInput');
 
+    oldToNewListMapping = {
+      newToOldListPosition: [0, 1, 2],
+      deletedIndexes: []
+    };
     ResponsesService.updateAnswerChoices([{
       val: 'a'
     }, {
       val: 'b'
     }, {
       val: 'c'
-    }], function() {});
+    }], oldToNewListMapping, function() {});
 
+    oldToNewListMapping = {
+      newToOldListPosition: [1, 2],
+      deletedIndexes: [0]
+    };
     var newAnswerChoices = [{
       val: 'c'
     }, {
       val: 'b'
     }];
     var callbackSpy = jasmine.createSpy('callback');
-    ResponsesService.updateAnswerChoices(newAnswerChoices, callbackSpy);
+    ResponsesService.updateAnswerChoices(
+      newAnswerChoices, oldToNewListMapping, callbackSpy);
 
     var expectedAnswerGroup = interactionDataWithRules.answerGroups;
     expectedAnswerGroup[0].rules[0].inputs.x = '';
@@ -432,13 +515,17 @@ describe('Responses Service', function() {
 
     StateInteractionIdService.init('stateName', 'DragAndDropSortInput');
 
+    oldToNewListMapping = {
+      newToOldListPosition: [0, 1, 2],
+      deletedIndexes: []
+    };
     ResponsesService.updateAnswerChoices([{
       val: 'a'
     }, {
       val: 'b'
     }, {
       val: 'c'
-    }], function() {});
+    }], oldToNewListMapping, function() {});
 
     var newAnswerChoices = [{
       val: 'd'
@@ -448,8 +535,13 @@ describe('Responses Service', function() {
       val: 'f'
     }];
     var callbackSpy = jasmine.createSpy('callback');
-    ResponsesService.updateAnswerChoices(newAnswerChoices, callbackSpy);
+    ResponsesService.updateAnswerChoices(
+      newAnswerChoices, oldToNewListMapping, callbackSpy);
 
+    oldToNewListMapping = {
+      newToOldListPosition: [0, 1, 2],
+      deletedIndexes: []
+    };
     var expectedAnswerGroup = interactionDataWithRules.answerGroups;
     expectedAnswerGroup[0].rules[0].inputs.x = '';
     expectedAnswerGroup[0].rules[0].inputs.y = '';
@@ -469,13 +561,17 @@ describe('Responses Service', function() {
     StateEditorService.setInteraction(interactionDataWithRules);
     StateInteractionIdService.init('stateName', 'DragAndDropSortInput');
 
+    oldToNewListMapping = {
+      newToOldListPosition: [0, 1, 2],
+      deletedIndexes: []
+    };
     ResponsesService.updateAnswerChoices([{
       val: 'a'
     }, {
       val: 'b'
     }, {
       val: 'c'
-    }], function() {});
+    }], oldToNewListMapping, function() {});
 
     var newAnswerChoices = [{
       val: 'd'
@@ -485,7 +581,8 @@ describe('Responses Service', function() {
       val: 'f'
     }];
     var callbackSpy = jasmine.createSpy('callback');
-    ResponsesService.updateAnswerChoices(newAnswerChoices, callbackSpy);
+    ResponsesService.updateAnswerChoices(
+      newAnswerChoices, oldToNewListMapping, callbackSpy);
 
     var expectedAnswerGroup = interactionDataWithRules.answerGroups;
     expectedAnswerGroup[0].rules[0].inputs.x = [];
@@ -501,13 +598,17 @@ describe('Responses Service', function() {
     StateEditorService.setInteraction(interactionDataWithRules);
     StateInteractionIdService.init('stateName', 'DragAndDropSortInput');
 
+    oldToNewListMapping = {
+      newToOldListPosition: [0, 1, 2],
+      deletedIndexes: []
+    };
     ResponsesService.updateAnswerChoices([{
       val: 'a'
     }, {
       val: 'b'
     }, {
       val: 'c'
-    }], function() {});
+    }], oldToNewListMapping, function() {});
 
     var newAnswerChoices = [{
       val: 'c'
@@ -517,7 +618,8 @@ describe('Responses Service', function() {
       val: 'a'
     }];
     var callbackSpy = jasmine.createSpy('callback');
-    ResponsesService.updateAnswerChoices(newAnswerChoices, callbackSpy);
+    ResponsesService.updateAnswerChoices(
+      newAnswerChoices, oldToNewListMapping, callbackSpy);
 
     expect(callbackSpy).not.toHaveBeenCalled();
     expect(ResponsesService.getAnswerGroup(0)).toEqual(

--- a/core/templates/pages/exploration-editor-page/editor-tab/services/responses.service.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/services/responses.service.ts
@@ -323,9 +323,63 @@ angular.module('oppia').factory('ResponsesService', [
       // Updates answer choices when the interaction requires it -- for
       // example, the rules for multiple choice need to refer to the multiple
       // choice interaction's customization arguments.
-      updateAnswerChoices: function(newAnswerChoices, callback) {
+      updateAnswerChoices: function(
+          newAnswerChoices, oldToNewListMapping, callback) {
         var oldAnswerChoices = angular.copy(_answerChoices);
         _answerChoices = newAnswerChoices;
+
+        // If the interaction is MultipleChoiceInput, update the answer groups
+        // to refer to the new answer options.
+        if (StateInteractionIdService.savedMemento === 'MultipleChoiceInput') {
+          // Save and update the answer groups for MultipleChoiceInput
+          // based on the information about the modification of answer choices
+          // from the schema-based-list editor.
+          // The information regarding the modifications of answer choices is
+          // present in oldToNewListMapping.
+
+          if (
+            oldToNewListMapping !== undefined &&
+               oldToNewListMapping !== null &&
+               oldToNewListMapping.hasOwnProperty('deletedIndexes')) {
+            var deletedIndexes = oldToNewListMapping.deletedIndexes;
+            // We need to make copy of _answerGroups because we make decisions
+            // based on the original value of inputs.x since the value of
+            // inputs.x in _answerGroups gets modified over the course of the
+            // algorithm.
+            var answerGroupsBeforeUpdating = angular.copy(_answerGroups);
+            deletedIndexes.forEach(function(deletedIndex) {
+              for (var i = 0; i < answerGroupsBeforeUpdating.length; i++) {
+                var rules = answerGroupsBeforeUpdating[i].rules;
+                for (var j = 0; j < rules.length; j++) {
+                  if (deletedIndex < rules[j].inputs.x) {
+                    // If the deletedIndex is lesser than a rule index
+                    // we need to reduce the rule index by one because
+                    // length the of answer choices reduce by one after the
+                    // after the choice corresponding to deletedIndex is
+                    // deleted.
+                    _answerGroups[i].rules[j].inputs.x--;
+                  } else if (deletedIndex === rules[j].inputs.x) {
+                    // If deletedIndex corresponds to a rule index we make the
+                    // corresponding rule invalid. For an answer group to be
+                    // invalid a rule index in that answer group should be
+                    // greater than the number of choices.
+                    // We make the rule invalid by assigning the rule a value
+                    // which is much higher than length of the answer choices.
+                    _answerGroups[i].rules[j].inputs.x = (
+                      Number.MAX_SAFE_INTEGER);
+                  }
+                }
+              }
+            });
+          }
+          _answerGroups.forEach(function(answerGroup, answerGroupIndex) {
+            var newRules = angular.copy(answerGroup.rules);
+            _updateAnswerGroup(
+              answerGroupIndex, {
+                rules: newRules
+              }, callback);
+          });
+        }
 
         // If the interaction is ItemSelectionInput, update the answer groups
         // to refer to the new answer options.

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/customize-interaction-modal.template.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/customize-interaction-modal.template.html
@@ -33,7 +33,7 @@
       <h5 ng-if="StateInteractionIdService.displayed == 'DragAndDropSortInput'">
         <b>Note:</b> Please enter at least two choices.
       </h5>
-      <schema-based-editor ng-class="{'boolean-checkbox': customizationArgSpec.schema.type === 'bool'}" local-value="StateCustomizationArgsService.displayed[customizationArgSpec.name].value" schema="customizationArgSpec.schema">
+      <schema-based-editor ng-class="{'boolean-checkbox': customizationArgSpec.schema.type === 'bool'}" local-value="StateCustomizationArgsService.displayed[customizationArgSpec.name].value" schema="customizationArgSpec.schema" old-to-new-list-mapping="oldToNewListMappingObject.oldToNewListMapping">
       </schema-based-editor>
       <div ng-if="customizationArgSpec.schema.type === 'bool'" class="oppia-interaction-customization-label"><[customizationArgSpec.description]></div>
       <div style="margin-bottom: 15px;"></div>

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -264,6 +264,8 @@ describe('Core exploration functionality', function() {
   var explorationEditorMainTab = null;
   var explorationEditorSettingsTab = null;
   var userNumber = 1;
+  var openInteractionCustomizationModal =
+     element(by.css('.protractor-test-interaction'));
 
   beforeEach(function() {
     explorationEditorPage = new ExplorationEditorPage.ExplorationEditorPage();
@@ -310,9 +312,73 @@ describe('Core exploration functionality', function() {
     });
     explorationEditorMainTab.setInteraction(
       'MultipleChoiceInput',
-      [forms.toRichText('option A'), forms.toRichText('option B')]);
+      [forms.toRichText('option A'), forms.toRichText('option B'),
+        forms.toRichText('option C'), forms.toRichText('option D'),
+        forms.toRichText('option E'), forms.toRichText('option F')]);
+    explorationEditorMainTab.addResponse('MultipleChoiceInput',
+      function(richTextEditor) {
+        richTextEditor.appendBoldText('correct');
+      }, 'final card', true, 'Equals', 'option A');
+    explorationEditorMainTab.getResponseEditor(0)
+      .addRule('MultipleChoiceInput', 'Equals', 'option C');
+    explorationEditorMainTab.getResponseEditor(0)
+      .addRule('MultipleChoiceInput', 'Equals', 'option F');
+    explorationEditorMainTab.getResponseEditor(0)
+      .expectFeedbackInstructionToBe('correct');
+
+    explorationEditorMainTab.getResponseEditor(0).expectRuleToBe(
+      'MultipleChoiceInput', 'Equals', 0, ['option A']);
+    explorationEditorMainTab.getResponseEditor(0).expectRuleToBe(
+      'MultipleChoiceInput', 'Equals', 1, ['option C']);
+    explorationEditorMainTab.getResponseEditor(0).expectRuleToBe(
+      'MultipleChoiceInput', 'Equals', 2, ['option F']);
+
+    // Delete the options corresponding to answer rules.
+    openInteractionCustomizationModal.click();
+    explorationEditorMainTab.editInteraction(
+      'MultipleChoiceInput', null, 'delete', 0);
+    openInteractionCustomizationModal.click();
+    explorationEditorMainTab.editInteraction(
+      'MultipleChoiceInput', null, 'delete', 1);
+    openInteractionCustomizationModal.click();
+    explorationEditorMainTab.editInteraction(
+      'MultipleChoiceInput', null, 'delete', 3);
+
+    // Add 3 more options to make sure that the answer rules still remain
+    // invalid even when an index corresponding to the invalid rule is added
+    // back.
+    openInteractionCustomizationModal.click();
+    explorationEditorMainTab.editInteraction(
+      'MultipleChoiceInput', [forms.toRichText('option X ')], 'add');
+    openInteractionCustomizationModal.click();
+    explorationEditorMainTab.editInteraction(
+      'MultipleChoiceInput', [forms.toRichText('option Y ')], 'add');
+    openInteractionCustomizationModal.click();
+    explorationEditorMainTab.editInteraction(
+      'MultipleChoiceInput', [forms.toRichText('option Z ')], 'add');
+    openInteractionCustomizationModal.click();
+    explorationEditorMainTab.editInteraction(
+      'MultipleChoiceInput', [forms.toRichText('option new')], 'edit', 1);
+
+    // Validates that the answer rules are invalid if the corresponding option
+    // is deleted.
+    explorationEditorMainTab.getResponseEditor(0).expectRuleToBe(
+      'MultipleChoiceInput', 'Equals', 0, ['[INVALID]']);
+    explorationEditorMainTab.getResponseEditor(0).expectRuleToBe(
+      'MultipleChoiceInput', 'Equals', 1, ['[INVALID]']);
+    explorationEditorMainTab.getResponseEditor(0).expectRuleToBe(
+      'MultipleChoiceInput', 'Equals', 2, ['[INVALID]']);
+
+    // Delete the the invalid response and add a new response.
+    explorationEditorMainTab.getResponseEditor(0).deleteResponse();
+    explorationEditorMainTab.addResponse('MultipleChoiceInput',
+      function(richTextEditor) {
+        richTextEditor.appendBoldText('correct');
+      }, 'final card', false, 'Equals', 'option X');
+    explorationEditorMainTab.getResponseEditor('default').
+      setFeedback(forms.toRichText('try again'));
     explorationEditorMainTab.getResponseEditor('default').setDestination(
-      'final card', true, null);
+      '(try again)', false, null);
 
     // Setup a terminating state.
     explorationEditorMainTab.moveToState('final card');
@@ -323,8 +389,16 @@ describe('Core exploration functionality', function() {
     explorationPlayerPage.expectExplorationToNotBeOver();
     explorationPlayerPage.expectInteractionToMatch(
       'MultipleChoiceInput',
-      [forms.toRichText('option A'), forms.toRichText('option B')]);
+      [forms.toRichText('option B'), forms.toRichText('option new'),
+        forms.toRichText('option E'), forms.toRichText('option X'),
+        forms.toRichText('option Y'), forms.toRichText('option Z')]);
+    // First, we enter a wrong answer to check the default response.
     explorationPlayerPage.submitAnswer('MultipleChoiceInput', 'option B');
+    explorationPlayerPage.expectLatestFeedbackToMatch(
+      forms.toRichText('try again'));
+    // Enter the correct answer.
+    explorationPlayerPage.submitAnswer('MultipleChoiceInput', 'option X');
+    explorationPlayerPage.clickThroughToNextCard();
     explorationPlayerPage.expectExplorationToBeOver();
   });
 
@@ -336,7 +410,7 @@ describe('Core exploration functionality', function() {
         richTextEditor.appendBoldText('correct');
       }, 'final card', true, 'IsInclusivelyBetween', -1, 3);
     explorationEditorMainTab.getResponseEditor(0).expectRuleToBe(
-      'NumericInput', 'IsInclusivelyBetween', [-1, 3]);
+      'NumericInput', 'IsInclusivelyBetween', 0, [-1, 3]);
     explorationEditorMainTab.getResponseEditor(0)
       .expectFeedbackInstructionToBe('correct');
     explorationEditorMainTab.getResponseEditor('default').setFeedback(
@@ -391,7 +465,7 @@ describe('Core exploration functionality', function() {
     // does not have any customization options. To dismiss this modal, user
     // clicks 'Okay' implying that he/she has got the message.
     explorationEditorMainTab.setInteraction('NumericInput');
-    element(by.css('.protractor-test-interaction')).click();
+    openInteractionCustomizationModal.click();
     var okayBtn = element(
       by.css('.protractor-test-close-no-customization-modal'));
     expect(okayBtn.isPresent()).toBe(true);
@@ -403,7 +477,7 @@ describe('Core exploration functionality', function() {
     // button.
     explorationEditorMainTab.deleteInteraction();
     explorationEditorMainTab.setInteraction('Continue');
-    element(by.css('.protractor-test-interaction')).click();
+    openInteractionCustomizationModal.click();
     var saveInteractionBtn = element(
       by.css('.protractor-test-save-interaction'));
     expect(saveInteractionBtn.isPresent()).toBe(true);
@@ -426,7 +500,7 @@ describe('Core exploration functionality', function() {
       'TextInput', forms.toRichText('You must be happy!'),
       'I am happy', true, 'FuzzyEquals', 'happy');
     explorationEditorMainTab.getResponseEditor(0).expectRuleToBe(
-      'TextInput', 'FuzzyEquals', ['"happy"']);
+      'TextInput', 'FuzzyEquals', 0, ['"happy"']);
     explorationEditorMainTab.getResponseEditor(0)
       .expectFeedbackInstructionToBe('You must be happy!');
     // Verify newly created state.
@@ -438,7 +512,7 @@ describe('Core exploration functionality', function() {
       'TextInput', forms.toRichText('You cannot be sad!'),
       '(try again)', false, 'FuzzyEquals', 'sad');
     explorationEditorMainTab.getResponseEditor(1).expectRuleToBe(
-      'TextInput', 'FuzzyEquals', ['"sad"']);
+      'TextInput', 'FuzzyEquals', 0, ['"sad"']);
     explorationEditorPage.saveChanges();
   });
 

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -264,7 +264,7 @@ describe('Core exploration functionality', function() {
   var explorationEditorMainTab = null;
   var explorationEditorSettingsTab = null;
   var userNumber = 1;
-  var openInteractionCustomizationModal =
+  var interactionCustomizationModal =
      element(by.css('.protractor-test-interaction'));
 
   beforeEach(function() {
@@ -334,29 +334,29 @@ describe('Core exploration functionality', function() {
       'MultipleChoiceInput', 'Equals', 2, ['option F']);
 
     // Delete the options corresponding to answer rules.
-    openInteractionCustomizationModal.click();
+    interactionCustomizationModal.click();
     explorationEditorMainTab.editInteraction(
       'MultipleChoiceInput', null, 'delete', 0);
-    openInteractionCustomizationModal.click();
+    interactionCustomizationModal.click();
     explorationEditorMainTab.editInteraction(
       'MultipleChoiceInput', null, 'delete', 1);
-    openInteractionCustomizationModal.click();
+    interactionCustomizationModal.click();
     explorationEditorMainTab.editInteraction(
       'MultipleChoiceInput', null, 'delete', 3);
 
     // Add 3 more options to make sure that the answer rules still remain
     // invalid even when an index corresponding to the invalid rule is added
     // back.
-    openInteractionCustomizationModal.click();
+    interactionCustomizationModal.click();
     explorationEditorMainTab.editInteraction(
       'MultipleChoiceInput', [forms.toRichText('option X ')], 'add');
-    openInteractionCustomizationModal.click();
+    interactionCustomizationModal.click();
     explorationEditorMainTab.editInteraction(
       'MultipleChoiceInput', [forms.toRichText('option Y ')], 'add');
-    openInteractionCustomizationModal.click();
+    interactionCustomizationModal.click();
     explorationEditorMainTab.editInteraction(
       'MultipleChoiceInput', [forms.toRichText('option Z ')], 'add');
-    openInteractionCustomizationModal.click();
+    interactionCustomizationModal.click();
     explorationEditorMainTab.editInteraction(
       'MultipleChoiceInput', [forms.toRichText('option new')], 'edit', 1);
 
@@ -465,7 +465,7 @@ describe('Core exploration functionality', function() {
     // does not have any customization options. To dismiss this modal, user
     // clicks 'Okay' implying that he/she has got the message.
     explorationEditorMainTab.setInteraction('NumericInput');
-    openInteractionCustomizationModal.click();
+    interactionCustomizationModal.click();
     var okayBtn = element(
       by.css('.protractor-test-close-no-customization-modal'));
     expect(okayBtn.isPresent()).toBe(true);
@@ -477,7 +477,7 @@ describe('Core exploration functionality', function() {
     // button.
     explorationEditorMainTab.deleteInteraction();
     explorationEditorMainTab.setInteraction('Continue');
-    openInteractionCustomizationModal.click();
+    interactionCustomizationModal.click();
     var saveInteractionBtn = element(
       by.css('.protractor-test-save-interaction'));
     expect(saveInteractionBtn.isPresent()).toBe(true);

--- a/core/tests/protractor_utils/ExplorationEditorMainTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorMainTab.js
@@ -35,6 +35,7 @@ var ExplorationEditorMainTab = function() {
     by.css('.protractor-test-add-response-details'));
   var addResponseHeader = element(
     by.css('.protractor-test-add-response-modal-header'));
+  var answerTabs = element.all(by.css('.protractor-test-answer-tab'));
   var multipleChoiceAnswerOptions = function(optionNum) {
     return element(
       by.cssContainingText('.protractor-test-html-select-option', optionNum));
@@ -330,17 +331,28 @@ var ExplorationEditorMainTab = function() {
        * Check for correct rule parameters.
        * @param {string} [interactionId] - Interaction type.
        * @param {string} [ruleName] - Appropriate rule of provided interaction.
+       * @param {integer} [ruleIndex] - The index of the rule to check.
        * @param {string[]} [feedbackTextArray] - Exact feedback text to match.
        */
-      expectRuleToBe: function(interactionId, ruleName, feedbackTextArray) {
-        var ruleDescription = _getRuleDescription(interactionId, ruleName);
-        // Replace selectors with feedbackTextArray's elements.
-        ruleDescription = _replaceRuleInputPlaceholders(
-          ruleDescription, feedbackTextArray);
-        ruleDescription += '...';
-        // Adding "..." to end of string.
-        var answerTab = element(by.css('.protractor-test-answer-tab'));
-        expect(answerTab.getText()).toEqual(ruleDescription);
+      expectRuleToBe: function(
+          interactionId, ruleName, ruleIndex, feedbackTextArray) {
+        answerTabs.then(
+          function(answerTabs) {
+            var ruleDescription = _getRuleDescription(interactionId, ruleName);
+            // Replace selectors with feedbackTextArray's elements.
+            if (ruleIndex > 0) {
+            // From second rule onwards, we need add an "or" before the
+            // rule description.
+              ruleDescription = 'or ' + _replaceRuleInputPlaceholders(
+                ruleDescription, feedbackTextArray, interactionId);
+            } else {
+              ruleDescription = _replaceRuleInputPlaceholders(
+                ruleDescription, feedbackTextArray, interactionId);
+            }
+            // Adding "..." to end of string.
+            ruleDescription += '...';
+            expect(answerTabs[ruleIndex].getText()).toEqual(ruleDescription);
+          });
       },
       /**
        * Check for correct learner's feedback.
@@ -640,7 +652,12 @@ var ExplorationEditorMainTab = function() {
     waitFor.visibilityOf(
       interaction, 'interaction takes too long to appear');
   };
-
+  // This function will be used as the standard way to modify an interaction
+  // after it has been created. Additional arguments may be sent to this
+  // function, and they will be passed on to the relevant interaction editor.
+  this.editInteraction = function(interactionId) {
+    customizeInteraction.apply(null, arguments);
+  };
   this.setInteractionWithoutCloseAddResponse = function(interactionId) {
     createNewInteraction(interactionId);
     customizeInteraction.apply(null, arguments);
@@ -901,7 +918,8 @@ var ExplorationEditorMainTab = function() {
    * @param {string} [ruleDescription] - Interaction type.
    * @param {string[]} [providedText] - Feedback text to replace with.
    */
-  var _replaceRuleInputPlaceholders = function(ruleDescription, providedText) {
+  var _replaceRuleInputPlaceholders = function(
+      ruleDescription, providedText, interactionId) {
     // An example of rule description:
     // "is equal to {{a|NonnegativeInt}} and {{b|NonnegativeInt}}"
     // (from NumericInput).
@@ -921,8 +939,22 @@ var ExplorationEditorMainTab = function() {
             ') is expected to match # of placeholders(' +
             (placeholders.length) + ')');
           }
-          ruleDescription = ruleDescription.replace(
-            placeholderElement, providedText[index].toString());
+          // In the case of MultipleChoiceInput, the rule description is
+          // a little different than other interactions. The placeholderElement
+          // is enclosed in a single quote.
+          // An example: " is equal to 'option C' ".
+          // Hence, we need to enclose the providedText in single
+          // quotes before adding it to the rule description. Also in the case
+          // of INVALID rule, we don't need to enclose it in single quotes.
+
+          if (interactionId === 'MultipleChoiceInput' &&
+               providedText[index].toString() !== '[INVALID]') {
+            ruleDescription = ruleDescription.replace(
+              placeholderElement, '\'' + providedText[index].toString() + '\'');
+          } else {
+            ruleDescription = ruleDescription.replace(
+              placeholderElement, providedText[index].toString());
+          }
         }
       });
     }
@@ -934,7 +966,8 @@ var ExplorationEditorMainTab = function() {
   var _selectRule = function(ruleElem, interactionId, ruleName) {
     var ruleDescription = _getRuleDescription(interactionId, ruleName);
     // Replace selectors with "...".
-    ruleDescription = _replaceRuleInputPlaceholders(ruleDescription, ['...']);
+    ruleDescription = _replaceRuleInputPlaceholders(
+      ruleDescription, ['...'], interactionId);
     var ruleDescriptionInDropdown = ruleDescription;
     var answerDescription = element(
       by.css('.protractor-test-answer-description'));

--- a/extensions/interactions/MultipleChoiceInput/protractor.js
+++ b/extensions/interactions/MultipleChoiceInput/protractor.js
@@ -22,13 +22,69 @@ var forms = require(process.cwd() + '/core/tests/protractor_utils/forms.js');
 // The members of richTextInstructionsArray are functions, one for each option,
 // which will each be passed a 'handler' that they can use to edit the
 // rich-text area of the option, for example by
-//   handler.appendUnderlineText('emphasised');
-var customizeInteraction = function(elem, richTextInstructionsArray) {
-  forms.ListEditor(elem).setLength(richTextInstructionsArray.length);
-  for (var i = 0; i < richTextInstructionsArray.length; i++) {
-    var richTextEditor = forms.ListEditor(elem).editItem(i, 'RichText');
-    richTextEditor.clear();
-    richTextInstructionsArray[i](richTextEditor);
+// handler.appendUnderlineText('emphasised');
+// The third and fourth arguments are optional and can be used to edit the
+// interaction after its creation. , The third argument editCommand is a
+// string('edit', 'delete', 'add') and the fourth argument
+// itemIndex is the index of the object to be edited or deleted. In the case of
+// 'add' command, the fourth argument itemIndex is not required.
+var customizeInteraction = function(
+    elem, richTextInstructionsArray, editCommand, itemIndex) {
+  if (editCommand === undefined) {
+    forms.ListEditor(elem).setLength(richTextInstructionsArray.length);
+    for (var i = 0; i < richTextInstructionsArray.length; i++) {
+      var richTextEditor = forms.ListEditor(elem).editItem(i, 'RichText');
+      richTextEditor.clear();
+      richTextInstructionsArray[i](richTextEditor);
+    }
+  } else {
+    if (editCommand === 'delete') {
+      if (richTextInstructionsArray === null) {
+        elem.all(by.repeater('item in localValue track by $index')).count().
+          then(
+            function(length) {
+              if (itemIndex < length) {
+                forms.ListEditor(elem).deleteItem(itemIndex);
+              } else {
+                throw Error('The given index is invalid.');
+              }
+            });
+      } else {
+        throw Error('richTextInstructionsArray should be null.');
+      }
+    } else if (editCommand === 'add') {
+      if (richTextInstructionsArray !== null &&
+            richTextInstructionsArray.length === 1) {
+        var richTextEditor = forms.ListEditor(elem).addItem('RichText');
+        richTextEditor.clear();
+        richTextInstructionsArray[0](richTextEditor);
+      } else {
+        throw Error(
+          'richTextInstructionsArray should be non-null and have exactly one' +
+          ' element.');
+      }
+    } else if (editCommand === 'edit') {
+      if (
+        richTextInstructionsArray !== null &&
+          richTextInstructionsArray.length === 1) {
+        elem.all(by.repeater('item in localValue track by $index')).count().
+          then(
+            function(length) {
+              if (itemIndex < length) {
+                var richTextEditor = forms.ListEditor(elem).editItem(
+                  itemIndex, 'RichText');
+                richTextEditor.clear();
+                richTextInstructionsArray[0](richTextEditor);
+              } else {
+                throw Error('The given index is invalid.');
+              }
+            });
+      } else {
+        throw Error(
+          'richTextInstructionsArray should be non-null and have exactly one' +
+          ' element.');
+      }
+    }
   }
 };
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes or fixes part of #857 
2. This PR does the following: Update answer group rules when choices in multiple-choice input interactions are deleted. Previously if the choices were deleted in multiple-choice interaction, the answer groups
were not updated in order to match with the new choices.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
