### PR TITLE
Fix part of #7450 use update exploration instead of save_exploration

### DIFF
--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -553,13 +553,12 @@ written_translations:
                 'The title for ZIP download handler test!.yaml').read())
 
         # Check download to JSON.
-        exploration.update_objective('Test JSON download')
         exp_services.update_exploration(
             owner_id, exploration.id, [
                 exp_domain.ExplorationChange({
                     'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                     'property_name': 'objective',
-                    'new_value': 'the objective',
+                    'new_value': 'Test JSON download',
                 })], '')
 
         # Download to JSON string using download handler.

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -518,7 +518,6 @@ written_translations:
                     'cmd': exp_domain.CMD_DELETE_STATE,
                     'state_name': 'State 3',
                 })], 'changes')
-        exploration = exp_fetchers.get_exploration_by_id(exp_id)
         response = self.get_html_response('/create/%s' % exp_id)
 
         # Check download to zip file.

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -554,7 +554,7 @@ written_translations:
 
         # Check download to JSON.
         exploration.update_objective('Test JSON download')
-        exp_services._save_exploration(  # pylint: disable=protected-access
+        exp_services.update_exploration(
             owner_id, exploration, '', [])
 
         # Download to JSON string using download handler.

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -558,7 +558,7 @@ written_translations:
                     'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                     'property_name': 'objective',
                     'new_value': 'Test JSON download',
-                })], '')
+                })], 'Updates exploration objective')
 
         # Download to JSON string using download handler.
         self.maxDiff = None

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -554,8 +554,8 @@ written_translations:
 
         # Check download to JSON.
         exploration.update_objective('Test JSON download')
-        exp_services._save_exploration(  # pylint: disable=protected-access
-            owner_id, exploration, '', [])
+        exp_services.update_exploration(
+            owner_id, exploration.id, [], '')
 
         # Download to JSON string using download handler.
         self.maxDiff = None

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -555,7 +555,12 @@ written_translations:
         # Check download to JSON.
         exploration.update_objective('Test JSON download')
         exp_services.update_exploration(
-            owner_id, exploration.id, [], '')
+            owner_id, exploration.id, [
+                exp_domain.ExplorationChange({
+                    'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
+                    'property_name': 'objective',
+                    'new_value': 'the objective',
+                })], '')
 
         # Download to JSON string using download handler.
         self.maxDiff = None

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -554,7 +554,7 @@ written_translations:
 
         # Check download to JSON.
         exp_services.update_exploration(
-            owner_id, exploration.id, [
+            owner_id, exp_id, [
                 exp_domain.ExplorationChange({
                     'cmd': exp_domain.CMD_EDIT_EXPLORATION_PROPERTY,
                     'property_name': 'objective',


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

Fixes part of #7450
Used update_exploration instead of save_exploration function

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
