### PR TITLE
Changed username length limit to 36 from 50.

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -491,7 +491,7 @@
     "I18N_SIGNUP_EMAIL_PREFERENCES_EXPLAIN": "You can change this setting at any time from your Preferences page.",
     "I18N_SIGNUP_ERROR_MUST_AGREE_TO_TERMS": "In order to edit explorations on this site, you will need to agree to the site terms.",
     "I18N_SIGNUP_ERROR_NO_USERNAME": "Please enter a username.",
-    "I18N_SIGNUP_ERROR_USERNAME_MORE_35_CHARS": "A username can have at most 35 characters.",
+    "I18N_SIGNUP_ERROR_USERNAME_MORE_36_CHARS": "A username can have at most 36 characters.",
     "I18N_SIGNUP_ERROR_USERNAME_NOT_AVAILABLE": "This user name is not available.",
     "I18N_SIGNUP_ERROR_USERNAME_ONLY_ALPHANUM": "Usernames can only have alphanumeric characters.",
     "I18N_SIGNUP_ERROR_USERNAME_TAKEN": "Sorry, this username is already taken.",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -491,7 +491,7 @@
     "I18N_SIGNUP_EMAIL_PREFERENCES_EXPLAIN": "You can change this setting at any time from your Preferences page.",
     "I18N_SIGNUP_ERROR_MUST_AGREE_TO_TERMS": "In order to edit explorations on this site, you will need to agree to the site terms.",
     "I18N_SIGNUP_ERROR_NO_USERNAME": "Please enter a username.",
-    "I18N_SIGNUP_ERROR_USERNAME_MORE_50_CHARS": "A username can have at most 50 characters.",
+    "I18N_SIGNUP_ERROR_USERNAME_MORE_35_CHARS": "A username can have at most 35 characters.",
     "I18N_SIGNUP_ERROR_USERNAME_NOT_AVAILABLE": "This user name is not available.",
     "I18N_SIGNUP_ERROR_USERNAME_ONLY_ALPHANUM": "Usernames can only have alphanumeric characters.",
     "I18N_SIGNUP_ERROR_USERNAME_TAKEN": "Sorry, this username is already taken.",

--- a/assets/i18n/qqq.json
+++ b/assets/i18n/qqq.json
@@ -491,7 +491,7 @@
 	"I18N_SIGNUP_EMAIL_PREFERENCES_EXPLAIN": "Text displayed in the signup page. - It's shown in the bottom of the email preferences section and explains that the selection the user does during the registration process can be changed in the future from the preferences page. See I18N_SIGNUP_EMAIL_PREFERENCES.",
 	"I18N_SIGNUP_ERROR_MUST_AGREE_TO_TERMS": "Text displayed in an error warning in the signup page. - It's shown when the user tries to finish the registration without checking the box that agrees to term of services.",
 	"I18N_SIGNUP_ERROR_NO_USERNAME": "Text displayed in an error warning in the signup page. - It's shown when the user tries to finish the registration without introducing a username.",
-	"I18N_SIGNUP_ERROR_USERNAME_MORE_35_CHARS": "Text displayed in an error warning in the signup page. - It's shown when the user chooses a username that has more than 35 characters.",
+	"I18N_SIGNUP_ERROR_USERNAME_MORE_36_CHARS": "Text displayed in an error warning in the signup page. - It's shown when the user chooses a username that has more than 36 characters.",
 	"I18N_SIGNUP_ERROR_USERNAME_NOT_AVAILABLE": "Text displayed in an error warning in the signup page. - It's shown when the user chooses a username that already exists in the site.",
 	"I18N_SIGNUP_ERROR_USERNAME_ONLY_ALPHANUM": "Text displayed in an error warning in the signup page. - It's shown when the user chooses a username that contains characters that are not letters or numbers.",
 	"I18N_SIGNUP_ERROR_USERNAME_TAKEN": "Text displayed in an error warning in the signup page. - It's shown when the user chooses a username that another user has already chosen.",

--- a/assets/i18n/qqq.json
+++ b/assets/i18n/qqq.json
@@ -491,7 +491,7 @@
 	"I18N_SIGNUP_EMAIL_PREFERENCES_EXPLAIN": "Text displayed in the signup page. - It's shown in the bottom of the email preferences section and explains that the selection the user does during the registration process can be changed in the future from the preferences page. See I18N_SIGNUP_EMAIL_PREFERENCES.",
 	"I18N_SIGNUP_ERROR_MUST_AGREE_TO_TERMS": "Text displayed in an error warning in the signup page. - It's shown when the user tries to finish the registration without checking the box that agrees to term of services.",
 	"I18N_SIGNUP_ERROR_NO_USERNAME": "Text displayed in an error warning in the signup page. - It's shown when the user tries to finish the registration without introducing a username.",
-	"I18N_SIGNUP_ERROR_USERNAME_MORE_50_CHARS": "Text displayed in an error warning in the signup page. - It's shown when the user chooses a username that has more than 50 characters.",
+	"I18N_SIGNUP_ERROR_USERNAME_MORE_35_CHARS": "Text displayed in an error warning in the signup page. - It's shown when the user chooses a username that has more than 35 characters.",
 	"I18N_SIGNUP_ERROR_USERNAME_NOT_AVAILABLE": "Text displayed in an error warning in the signup page. - It's shown when the user chooses a username that already exists in the site.",
 	"I18N_SIGNUP_ERROR_USERNAME_ONLY_ALPHANUM": "Text displayed in an error warning in the signup page. - It's shown when the user chooses a username that contains characters that are not letters or numbers.",
 	"I18N_SIGNUP_ERROR_USERNAME_TAKEN": "Text displayed in an error warning in the signup page. - It's shown when the user chooses a username that another user has already chosen.",

--- a/core/templates/pages/signup-page/signup-page.controller.spec.ts
+++ b/core/templates/pages/signup-page/signup-page.controller.spec.ts
@@ -114,9 +114,9 @@ describe('Signup controller', function() {
 
     it('should show warning if username is too long', function() {
       ctrl.updateWarningText(
-        'abcdefghijklmnopqrstuvwxyzyxwvutsrqponmlkjihgfedcba');
+        'abcdefghijklmnopqrstuvwxyzyxwvutsrqp');
       expect(ctrl.warningI18nCode).toEqual(
-        'I18N_SIGNUP_ERROR_USERNAME_MORE_50_CHARS');
+        'I18N_SIGNUP_ERROR_USERNAME_MORE_35_CHARS');
     });
 
     it('should show warning if username has non-alphanumeric characters',

--- a/core/templates/pages/signup-page/signup-page.controller.spec.ts
+++ b/core/templates/pages/signup-page/signup-page.controller.spec.ts
@@ -114,9 +114,9 @@ describe('Signup controller', function() {
 
     it('should show warning if username is too long', function() {
       ctrl.updateWarningText(
-        'abcdefghijklmnopqrstuvwxyzyxwvutsrqp');
+        'abcdefghijklmnopqrstuvwxyzyxwvutsrqpo');
       expect(ctrl.warningI18nCode).toEqual(
-        'I18N_SIGNUP_ERROR_USERNAME_MORE_35_CHARS');
+        'I18N_SIGNUP_ERROR_USERNAME_MORE_36_CHARS');
     });
 
     it('should show warning if username has non-alphanumeric characters',

--- a/core/templates/pages/signup-page/signup-page.controller.ts
+++ b/core/templates/pages/signup-page/signup-page.controller.ts
@@ -102,8 +102,8 @@ angular.module('oppia').directive('signupPage', [
               ctrl.warningI18nCode = 'I18N_SIGNUP_ERROR_NO_USERNAME';
             } else if (username.indexOf(' ') !== -1) {
               ctrl.warningI18nCode = 'I18N_SIGNUP_ERROR_USERNAME_WITH_SPACES';
-            } else if (username.length > 50) {
-              ctrl.warningI18nCode = 'I18N_SIGNUP_ERROR_USERNAME_MORE_50_CHARS';
+            } else if (username.length > 35) {
+              ctrl.warningI18nCode = 'I18N_SIGNUP_ERROR_USERNAME_MORE_35_CHARS';
             } else if (!alphanumeric.test(username)) {
               ctrl.warningI18nCode = 'I18N_SIGNUP_ERROR_USERNAME_ONLY_ALPHANUM';
             } else if (admin.test(username)) {

--- a/core/templates/pages/signup-page/signup-page.controller.ts
+++ b/core/templates/pages/signup-page/signup-page.controller.ts
@@ -102,8 +102,8 @@ angular.module('oppia').directive('signupPage', [
               ctrl.warningI18nCode = 'I18N_SIGNUP_ERROR_NO_USERNAME';
             } else if (username.indexOf(' ') !== -1) {
               ctrl.warningI18nCode = 'I18N_SIGNUP_ERROR_USERNAME_WITH_SPACES';
-            } else if (username.length > 35) {
-              ctrl.warningI18nCode = 'I18N_SIGNUP_ERROR_USERNAME_MORE_35_CHARS';
+            } else if (username.length > 36) {
+              ctrl.warningI18nCode = 'I18N_SIGNUP_ERROR_USERNAME_MORE_36_CHARS';
             } else if (!alphanumeric.test(username)) {
               ctrl.warningI18nCode = 'I18N_SIGNUP_ERROR_USERNAME_ONLY_ALPHANUM';
             } else if (admin.test(username)) {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

~~1. This PR fixes or fixes part of #[fill_in_number_here].~~
2. This PR does the following: 
Changes the username length limit to 36 from 50. Now, only those usernames with length <= 36 will be allowed. This change is recommended at the end of this [doc](https://docs.google.com/document/d/1o_FbyEwnj8G-8DnefXwjZMRh-0lqdLmDDFjVjsWH4u4/edit#heading=h.ujnb8erdcj2q).

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
