### PR TITLE
Added a pre-publish validation for topics

### DIFF
--- a/core/controllers/acl_decorators_test.py
+++ b/core/controllers/acl_decorators_test.py
@@ -2121,7 +2121,7 @@ class StoryViewerTests(test_utils.GenericTestBase):
             self.topic_id)
         self.save_new_topic(
             self.topic_id, self.admin_id, name='Name',
-            abbreviated_name='abbrev', thumbnail_filename=None,
+            abbreviated_name='abbrev', thumbnail_filename='Image.png',
             description='Description', canonical_story_ids=[self.story_id],
             additional_story_ids=[], uncategorized_skill_ids=[],
             subtopics=[], next_subtopic_id=1)

--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -441,7 +441,6 @@ class AdminHandler(base.BaseHandler):
             )
 
             topic_services.publish_story(topic_id_1, story_id, self.user_id)
-            topic_services.publish_topic(topic_id_1, self.user_id)
         else:
             raise Exception('Cannot load new structures data in production.')
 

--- a/core/controllers/classroom_test.py
+++ b/core/controllers/classroom_test.py
@@ -71,6 +71,7 @@ class ClassroomDataHandlerTests(BaseClassroomControllerTests):
         topic_services.save_new_topic(admin_id, private_topic)
         public_topic = topic_domain.Topic.create_default_topic(
             topic_id_2, 'public_topic_name', 'abbrev')
+        public_topic.thumbnail_filename = 'Topic.png'
         topic_services.save_new_topic(admin_id, public_topic)
         topic_services.publish_topic(topic_id_2, admin_id)
 

--- a/core/controllers/practice_sessions_test.py
+++ b/core/controllers/practice_sessions_test.py
@@ -51,10 +51,12 @@ class BasePracticeSessionsControllerTests(test_utils.GenericTestBase):
         self.topic.subtopics.append(topic_domain.Subtopic(
             1, 'subtopic_name', [self.skill_id2]))
         self.topic.next_subtopic_id = 2
+        self.topic.thumbnail_filename = 'Topic.png'
         topic_services.save_new_topic(self.admin_id, self.topic)
 
         self.topic = topic_domain.Topic.create_default_topic(
             self.topic_id_1, 'private_topic_name', 'abbrev')
+        self.topic.thumbnail_filename = 'Topic.png'
         topic_services.save_new_topic(self.admin_id, self.topic)
 
         topic_services.publish_topic(self.topic_id, self.admin_id)
@@ -109,6 +111,7 @@ class PracticeSessionsPageDataHandlerTests(BasePracticeSessionsControllerTests):
         topic = topic_domain.Topic.create_default_topic(
             'topic_id_3', 'topic_without_skills', 'abbrev')
         topic.uncategorized_skill_ids.append('non_existent_skill')
+        topic.thumbnail_filename = 'Topic.png'
         topic_services.save_new_topic(self.admin_id, topic)
         topic_services.publish_topic('topic_id_3', self.admin_id)
         with self.swap(constants, 'ENABLE_NEW_STRUCTURE_PLAYERS', True):

--- a/core/controllers/review_tests_test.py
+++ b/core/controllers/review_tests_test.py
@@ -85,7 +85,7 @@ class BaseReviewTestsControllerTests(test_utils.GenericTestBase):
         story_services.save_new_story(self.admin_id, self.story_2)
         self.save_new_topic(
             self.topic_id, 'user', name='Topic',
-            abbreviated_name='abbrev', thumbnail_filename=None,
+            abbreviated_name='abbrev', thumbnail_filename='Topic.png',
             description='A new topic',
             canonical_story_ids=[self.story_id_1, self.story_id_3],
             additional_story_ids=[], uncategorized_skill_ids=[],

--- a/core/controllers/story_viewer_test.py
+++ b/core/controllers/story_viewer_test.py
@@ -110,7 +110,7 @@ class BaseStoryViewerControllerTests(test_utils.GenericTestBase):
         story_services.save_new_story(self.admin_id, story)
         self.save_new_topic(
             self.TOPIC_ID, 'user', name='Topic',
-            abbreviated_name='abbrev', thumbnail_filename=None,
+            abbreviated_name='abbrev', thumbnail_filename='Topic.png',
             description='A new topic', canonical_story_ids=[story.id],
             additional_story_ids=[], uncategorized_skill_ids=[],
             subtopics=[], next_subtopic_id=0)

--- a/core/controllers/subtopic_viewer_test.py
+++ b/core/controllers/subtopic_viewer_test.py
@@ -62,9 +62,10 @@ class BaseSubtopicViewerControllerTests(test_utils.GenericTestBase):
         )
         subtopic = topic_domain.Subtopic.create_default_subtopic(
             1, 'Subtopic Title')
+        subtopic.skill_ids = ['skill_id_1']
         self.save_new_topic(
             self.topic_id, self.admin_id, name='Name',
-            abbreviated_name='abbrev', thumbnail_filename=None,
+            abbreviated_name='abbrev', thumbnail_filename='Topic.png',
             description='Description', canonical_story_ids=[],
             additional_story_ids=[], uncategorized_skill_ids=[],
             subtopics=[subtopic], next_subtopic_id=2)

--- a/core/controllers/topic_editor_test.py
+++ b/core/controllers/topic_editor_test.py
@@ -58,7 +58,7 @@ class BaseTopicEditorControllerTests(test_utils.GenericTestBase):
         self.topic_id = topic_services.get_new_topic_id()
         self.save_new_topic(
             self.topic_id, self.admin_id, name='Name',
-            abbreviated_name='abbrev', thumbnail_filename=None,
+            abbreviated_name='abbrev', thumbnail_filename='topic.png',
             description='Description', canonical_story_ids=[],
             additional_story_ids=[],
             uncategorized_skill_ids=[self.skill_id, self.skill_id_2],
@@ -67,6 +67,11 @@ class BaseTopicEditorControllerTests(test_utils.GenericTestBase):
             'cmd': topic_domain.CMD_ADD_SUBTOPIC,
             'title': 'Title',
             'subtopic_id': 1
+        }), topic_domain.TopicChange({
+            'cmd': topic_domain.CMD_MOVE_SKILL_ID_TO_SUBTOPIC,
+            'old_subtopic_id': None,
+            'new_subtopic_id': 1,
+            'skill_id': self.skill_id
         })]
         topic_services.update_topic_and_subtopic_pages(
             self.admin_id, self.topic_id, changelist, 'Added subtopic.')

--- a/core/controllers/topic_viewer_test.py
+++ b/core/controllers/topic_viewer_test.py
@@ -58,6 +58,7 @@ class BaseTopicViewerControllerTests(test_utils.GenericTestBase):
         self.topic.subtopics.append(topic_domain.Subtopic(
             1, 'subtopic_name', [self.skill_id_2]))
         self.topic.next_subtopic_id = 2
+        self.topic.thumbnail_filename = 'Image.png'
         self.topic.canonical_story_references.append(
             topic_domain.StoryReference.create_default_story_reference(
                 self.story_id))
@@ -66,6 +67,7 @@ class BaseTopicViewerControllerTests(test_utils.GenericTestBase):
 
         self.topic = topic_domain.Topic.create_default_topic(
             self.topic_id_1, 'private_topic_name', 'abbrev')
+        self.topic.thumbnail_filename = 'Image.png'
         topic_services.save_new_topic(self.admin_id, self.topic)
 
         topic_services.publish_topic(self.topic_id, self.admin_id)
@@ -224,6 +226,7 @@ class TopicPageDataHandlerTests(BaseTopicViewerControllerTests):
         self.topic = topic_domain.Topic.create_default_topic(
             self.topic_id, 'new_topic', 'abbrev')
         self.topic.uncategorized_skill_ids.append(self.skill_id_1)
+        self.topic.thumbnail_filename = 'Image.png'
         topic_services.save_new_topic(self.admin_id, self.topic)
         topic_services.publish_topic(self.topic_id, self.admin_id)
         self.save_new_skill(

--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -390,6 +390,7 @@ class StoryContents(python_utils.OBJECT):
 
         initial_node_is_present = False
         node_id_list = []
+        node_title_list = []
 
         for node in self.nodes:
             if not isinstance(node, StoryNode):
@@ -412,6 +413,7 @@ class StoryContents(python_utils.OBJECT):
                 raise utils.ValidationError(
                     'The node with id %s is out of bounds.' % node.id)
             node_id_list.append(node.id)
+            node_title_list.append(node.title)
 
         if len(self.nodes) > 0:
             if not initial_node_is_present:
@@ -420,6 +422,10 @@ class StoryContents(python_utils.OBJECT):
             if len(node_id_list) > len(set(node_id_list)):
                 raise utils.ValidationError(
                     'Expected all node ids to be distinct.')
+
+            if len(node_title_list) > len(set(node_title_list)):
+                raise utils.ValidationError(
+                    'Expected all chapter titles to be distinct.')
 
             # nodes_queue stores the pending nodes to visit in the story that
             # are unlocked, in a 'queue' form with a First In First Out

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -226,7 +226,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
             self.TOPIC_ID
         )
         self.story.add_node(self.NODE_ID_1, 'Node title')
-        self.story.add_node(self.NODE_ID_2, 'Node title')
+        self.story.add_node(self.NODE_ID_2, 'Node title 2')
         self.story.update_node_destination_node_ids(
             self.NODE_ID_1, [self.NODE_ID_2])
         self.signup('user@example.com', 'user')
@@ -787,8 +787,47 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         ]
         self._assert_validation_error('Expected all node ids to be distinct')
 
+        # Case 5: Graph with duplicate titles.
+        node_1 = {
+            'id': 'node_1',
+            'title': 'Title 1',
+            'destination_node_ids': ['node_2'],
+            'acquired_skill_ids': ['skill_2'],
+            'prerequisite_skill_ids': ['skill_1'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': None
+        }
+        node_2 = {
+            'id': 'node_2',
+            'title': 'Title 2',
+            'destination_node_ids': ['node_3'],
+            'acquired_skill_ids': ['skill_3'],
+            'prerequisite_skill_ids': ['skill_2'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': None
+        }
+        node_3 = {
+            'id': 'node_3',
+            'title': 'Title 2',
+            'destination_node_ids': [],
+            'acquired_skill_ids': ['skill_4'],
+            'prerequisite_skill_ids': ['skill_3'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': None
+        }
+        self.story.story_contents.nodes = [
+            story_domain.StoryNode.from_dict(node_1),
+            story_domain.StoryNode.from_dict(node_2),
+            story_domain.StoryNode.from_dict(node_3)
+        ]
+        self._assert_validation_error(
+            'Expected all chapter titles to be distinct.')
+
         self.story.story_contents.next_node_id = 'node_5'
-        # Case 5: A valid graph.
+        # Case 6: A valid graph.
         node_1 = {
             'id': 'node_1',
             'title': 'Title 1',

--- a/core/domain/topic_domain.py
+++ b/core/domain/topic_domain.py
@@ -687,6 +687,25 @@ class Topic(python_utils.OBJECT):
                 'The story_id %s is not present in the additional '
                 'story references list of the topic.' % story_id)
 
+    def prepublish_validate(self):
+        """Validates extra topic properties before publishing it.
+
+        Raises:
+            ValidationError: Thumbnail is not uploaded.
+            ValidationError: One or more subtopics does not have a skill ID
+                linked.
+        """
+        if not isinstance(self.thumbnail_filename, python_utils.BASESTRING):
+            raise utils.ValidationError(
+                'Expected thumbnail filename to be a string, received %s'
+                % self.thumbnail_filename)
+
+        for subtopic in self.subtopics:
+            if not subtopic.skill_ids:
+                raise utils.ValidationError(
+                    'Subtopic with title %s does not have any skills linked.'
+                    % subtopic.title)
+
     def validate(self):
         """Validates all properties of this topic and its constituents.
 

--- a/core/domain/topic_domain.py
+++ b/core/domain/topic_domain.py
@@ -687,27 +687,12 @@ class Topic(python_utils.OBJECT):
                 'The story_id %s is not present in the additional '
                 'story references list of the topic.' % story_id)
 
-    def prepublish_validate(self):
-        """Validates extra topic properties before publishing it.
-
-        Raises:
-            ValidationError: Thumbnail is not uploaded.
-            ValidationError: One or more subtopics does not have a skill ID
-                linked.
-        """
-        if not isinstance(self.thumbnail_filename, python_utils.BASESTRING):
-            raise utils.ValidationError(
-                'Expected thumbnail filename to be a string, received %s'
-                % self.thumbnail_filename)
-
-        for subtopic in self.subtopics:
-            if not subtopic.skill_ids:
-                raise utils.ValidationError(
-                    'Subtopic with title %s does not have any skills linked.'
-                    % subtopic.title)
-
-    def validate(self):
+    def validate(self, strict=False):
         """Validates all properties of this topic and its constituents.
+
+        Args:
+            strict: bool. Enable strict checks on the topic when the topic is
+                published or is going to be published.
 
         Raises:
             ValidationError: One or more attributes of the Topic are not
@@ -720,6 +705,13 @@ class Topic(python_utils.OBJECT):
             raise utils.ValidationError(
                 'Expected thumbnail filename to be a string, received %s'
                 % self.thumbnail_filename)
+
+        if strict:
+            if not isinstance(self.thumbnail_filename, python_utils.BASESTRING):
+                raise utils.ValidationError(
+                    'Expected thumbnail filename to be a string, received %s'
+                    % self.thumbnail_filename)
+
         if not isinstance(self.description, python_utils.BASESTRING):
             raise utils.ValidationError(
                 'Expected description to be a string, received %s'
@@ -770,6 +762,11 @@ class Topic(python_utils.OBJECT):
                     'The id for subtopic %s is greater than or equal to '
                     'next_subtopic_id %s'
                     % (subtopic.id, self.next_subtopic_id))
+            if strict:
+                if not subtopic.skill_ids:
+                    raise utils.ValidationError(
+                        'Subtopic with title %s does not have any skills '
+                        'linked.' % subtopic.title)
 
         if not isinstance(self.language_code, python_utils.BASESTRING):
             raise utils.ValidationError(

--- a/core/domain/topic_domain_test.py
+++ b/core/domain/topic_domain_test.py
@@ -192,6 +192,12 @@ class TopicDomainUnitTests(test_utils.GenericTestBase):
             utils.ValidationError, expected_error_substring):
             self.topic.validate()
 
+    def _assert_prepublish_validation_error(self, expected_error_substring):
+        """Checks that the topic passes prepublish validation."""
+        with self.assertRaisesRegexp(
+            utils.ValidationError, expected_error_substring):
+            self.topic.prepublish_validate()
+
     def _assert_valid_topic_id(self, expected_error_substring, topic_id):
         """Checks that the skill passes strict validation."""
         with self.assertRaisesRegexp(
@@ -222,6 +228,15 @@ class TopicDomainUnitTests(test_utils.GenericTestBase):
         self.topic.thumbnail_filename = 1
         self._assert_validation_error(
             'Expected thumbnail filename to be a string, received 1')
+        self.topic.thumbnail_filename = None
+        self._assert_prepublish_validation_error(
+            'Expected thumbnail filename to be a string, received None')
+
+    def test_subtopic_prepublish_validation(self):
+        self.topic.thumbnail_filename = 'filename'
+        self.topic.subtopics[0].skill_ids = []
+        self._assert_prepublish_validation_error(
+            'Subtopic with title Title does not have any skills linked')
 
     def test_subtopic_title_validation(self):
         self.topic.subtopics[0].title = 1

--- a/core/domain/topic_domain_test.py
+++ b/core/domain/topic_domain_test.py
@@ -192,11 +192,11 @@ class TopicDomainUnitTests(test_utils.GenericTestBase):
             utils.ValidationError, expected_error_substring):
             self.topic.validate()
 
-    def _assert_prepublish_validation_error(self, expected_error_substring):
+    def _assert_strict_validation_error(self, expected_error_substring):
         """Checks that the topic passes prepublish validation."""
         with self.assertRaisesRegexp(
             utils.ValidationError, expected_error_substring):
-            self.topic.prepublish_validate()
+            self.topic.validate(strict=True)
 
     def _assert_valid_topic_id(self, expected_error_substring, topic_id):
         """Checks that the skill passes strict validation."""
@@ -229,13 +229,13 @@ class TopicDomainUnitTests(test_utils.GenericTestBase):
         self._assert_validation_error(
             'Expected thumbnail filename to be a string, received 1')
         self.topic.thumbnail_filename = None
-        self._assert_prepublish_validation_error(
+        self._assert_strict_validation_error(
             'Expected thumbnail filename to be a string, received None')
 
-    def test_subtopic_prepublish_validation(self):
+    def test_subtopic_strict_validation(self):
         self.topic.thumbnail_filename = 'filename'
         self.topic.subtopics[0].skill_ids = []
-        self._assert_prepublish_validation_error(
+        self._assert_strict_validation_error(
             'Subtopic with title Title does not have any skills linked')
 
     def test_subtopic_title_validation(self):

--- a/core/domain/topic_jobs_one_off_test.py
+++ b/core/domain/topic_jobs_one_off_test.py
@@ -123,7 +123,7 @@ class TopicMigrationOneOffJobTests(test_utils.GenericTestBase):
         # Generate topic with old(v1) subtopic data.
         self.save_new_topic_with_subtopic_schema_v1(
             self.TOPIC_ID, self.albert_id, 'A name', 'abbrev',
-            'a name', '', [], [], [], 2)
+            'a name', '', 'Image.png', [], [], [], 2)
         topic = (
             topic_fetchers.get_topic_by_id(self.TOPIC_ID))
         self.assertEqual(topic.subtopic_schema_version, 1)
@@ -156,7 +156,8 @@ class TopicMigrationOneOffJobTests(test_utils.GenericTestBase):
         # The topic model created will be invalid due to invalid language code.
         self.save_new_topic_with_subtopic_schema_v1(
             self.TOPIC_ID, self.albert_id, 'A name', 'abbrev',
-            'a name', '', [], [], [], 2, language_code='invalid_language_code')
+            'a name', '', 'Image.png', [], [], [], 2,
+            language_code='invalid_language_code')
 
         job_id = (
             topic_jobs_one_off.TopicMigrationOneOffJob.create_new())

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -873,6 +873,8 @@ def publish_topic(topic_id, committer_id):
     if topic_rights.topic_is_published:
         raise Exception('The topic is already published.')
     topic_rights.topic_is_published = True
+    topic = topic_fetchers.get_topic_by_id(topic_id)
+    topic.prepublish_validate()
     commit_cmds = [topic_domain.TopicRightsChange({
         'cmd': topic_domain.CMD_PUBLISH_TOPIC
     })]

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -386,10 +386,7 @@ def _save_topic(committer_id, topic, commit_message, change_list):
             'Unexpected error: received an invalid change list when trying to '
             'save topic %s: %s' % (topic.id, change_list))
     topic_rights = get_topic_rights(topic.id, strict=False)
-    if topic_rights.topic_is_published:
-        topic.validate(strict=True)
-    else:
-        topic.validate()
+    topic.validate(strict=topic_rights.topic_is_published)
 
     topic_model = topic_models.TopicModel.get(topic.id, strict=False)
 

--- a/core/domain/topic_services_test.py
+++ b/core/domain/topic_services_test.py
@@ -57,7 +57,7 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
         })]
         self.save_new_topic(
             self.TOPIC_ID, self.user_id, name='Name',
-            abbreviated_name='abbrev', thumbnail_filename=None,
+            abbreviated_name='abbrev', thumbnail_filename='topic.png',
             description='Description',
             canonical_story_ids=[self.story_id_1, self.story_id_2],
             additional_story_ids=[self.story_id_3],
@@ -965,6 +965,15 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
         published_topic_ids = topic_services.filter_published_topic_ids([
             self.TOPIC_ID, 'invalid_id'])
         self.assertEqual(len(published_topic_ids), 0)
+        changelist = [topic_domain.TopicChange({
+            'cmd': topic_domain.CMD_MOVE_SKILL_ID_TO_SUBTOPIC,
+            'old_subtopic_id': None,
+            'new_subtopic_id': self.subtopic_id,
+            'skill_id': 'skill_1'
+        })]
+        topic_services.update_topic_and_subtopic_pages(
+            self.user_id_admin, self.TOPIC_ID, changelist,
+            'Updated subtopic skill ids.')
         topic_services.publish_topic(self.TOPIC_ID, self.user_id_admin)
         published_topic_ids = topic_services.filter_published_topic_ids([
             self.TOPIC_ID, 'invalid_id'])
@@ -974,6 +983,15 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
     def test_publish_and_unpublish_topic(self):
         topic_rights = topic_services.get_topic_rights(self.TOPIC_ID)
         self.assertFalse(topic_rights.topic_is_published)
+        changelist = [topic_domain.TopicChange({
+            'cmd': topic_domain.CMD_MOVE_SKILL_ID_TO_SUBTOPIC,
+            'old_subtopic_id': None,
+            'new_subtopic_id': self.subtopic_id,
+            'skill_id': 'skill_1'
+        })]
+        topic_services.update_topic_and_subtopic_pages(
+            self.user_id_admin, self.TOPIC_ID, changelist,
+            'Updated subtopic skill ids.')
         topic_services.publish_topic(self.TOPIC_ID, self.user_id_admin)
 
         with self.assertRaisesRegexp(
@@ -1134,7 +1152,15 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
     def test_cannot_publish_a_published_topic(self):
         topic_rights = topic_services.get_topic_rights(self.TOPIC_ID)
         self.assertFalse(topic_rights.topic_is_published)
-
+        changelist = [topic_domain.TopicChange({
+            'cmd': topic_domain.CMD_MOVE_SKILL_ID_TO_SUBTOPIC,
+            'old_subtopic_id': None,
+            'new_subtopic_id': self.subtopic_id,
+            'skill_id': 'skill_1'
+        })]
+        topic_services.update_topic_and_subtopic_pages(
+            self.user_id_admin, self.TOPIC_ID, changelist,
+            'Updated subtopic skill ids.')
         topic_services.publish_topic(self.TOPIC_ID, self.user_id_admin)
         topic_rights = topic_services.get_topic_rights(self.TOPIC_ID)
         self.assertTrue(topic_rights.topic_is_published)

--- a/core/templates/domain/topic/TopicObjectFactory.ts
+++ b/core/templates/domain/topic/TopicObjectFactory.ts
@@ -199,6 +199,13 @@ export class Topic {
     if (!this._thumbnailFilename) {
       issues.push('Topic should have a thumbnail.');
     }
+    for (let i = 0; i < this._subtopics.length; i++) {
+      if (this._subtopics[i].getSkillSummaries().length === 0) {
+        issues.push(
+          'Subtopic with title ' + this._subtopics[i].getTitle() +
+          ' does not have any skill IDs linked.');
+      }
+    }
     return issues;
   }
 

--- a/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.directive.ts
+++ b/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.directive.ts
@@ -146,6 +146,12 @@ angular.module('oppia').directive('topicEditorNavbar', [
           };
 
           $scope.isTopicSaveable = function() {
+            if ($scope.topicRights.isPublished()) {
+              return (
+                $scope.getChangeListLength() > 0 &&
+                $scope.getWarningsCount() === 0 &&
+                $scope.prepublishValidationIssues.length === 0);
+            }
             return (
               $scope.getChangeListLength() > 0 &&
               $scope.getWarningsCount() === 0);

--- a/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.directive.ts
+++ b/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.directive.ts
@@ -146,15 +146,13 @@ angular.module('oppia').directive('topicEditorNavbar', [
           };
 
           $scope.isTopicSaveable = function() {
-            if ($scope.topicRights.isPublished()) {
-              return (
-                $scope.getChangeListLength() > 0 &&
-                $scope.getWarningsCount() === 0 &&
-                $scope.prepublishValidationIssues.length === 0);
-            }
             return (
               $scope.getChangeListLength() > 0 &&
-              $scope.getWarningsCount() === 0);
+              $scope.getWarningsCount() === 0 && (
+                !$scope.topicRights.isPublished() ||
+                $scope.prepublishValidationIssues.length === 0
+              )
+            );
           };
 
           $scope.getWarningsCount = function() {

--- a/core/templates/pages/topic-editor-page/services/topic-editor-state.service.ts
+++ b/core/templates/pages/topic-editor-page/services/topic-editor-state.service.ts
@@ -327,8 +327,6 @@ angular.module('oppia').factory('TopicEditorStateService', [
         if (index === null) {
           if (newIndex === -1) {
             return;
-          } else {
-            throw Error('Invalid subtopic page.');
           }
         }
         _cachedSubtopicPages.splice(index, 1);

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -387,7 +387,7 @@ class TestBase(unittest.TestCase):
     }
 
     VERSION_1_SUBTOPIC_DICT = {
-        'skill_ids': [],
+        'skill_ids': ['skill_1'],
         'id': 1,
         'title': 'A subtitle'
     }
@@ -1481,7 +1481,7 @@ tags: []
 
     def save_new_topic_with_subtopic_schema_v1(
             self, topic_id, owner_id, name, abbreviated_name,
-            canonical_name, description,
+            canonical_name, description, thumbnail_filename,
             canonical_story_references, additional_story_references,
             uncategorized_skill_ids, next_subtopic_id,
             language_code=constants.DEFAULT_LANGUAGE_CODE):
@@ -1504,6 +1504,7 @@ tags: []
             abbreviated_name: str. The abbreviated name of the topic.
             canonical_name: str. The canonical name (lowercase) of the topic.
             description: str. The desscription of the topic.
+            thumbnail_filename: str. The thumbnail file name of the topic.
             canonical_story_references: list(StoryReference). A set of story
                 reference objects representing the canonical stories that are
                 part of this topic.
@@ -1525,6 +1526,7 @@ tags: []
             id=topic_id,
             name=name,
             abbreviated_name=abbreviated_name,
+            thumbnail_filename=thumbnail_filename,
             canonical_name=canonical_name,
             description=description,
             language_code=language_code,


### PR DESCRIPTION
## Overview

1. This PR does the following: Adds a validation for topics which checks whether every subtopic in a topic consists of a skill, before publishing a topic.

Screenshots:

Save Changes possible:
![image](https://user-images.githubusercontent.com/22347970/79053354-50a34680-7c5a-11ea-8acf-8a01eaa854be.png)

Publish button disabled after saving changes:
![image](https://user-images.githubusercontent.com/22347970/79053360-5f89f900-7c5a-11ea-86ed-5a998461aba0.png)


## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
