### PR TITLE
Add an audit job to find all explorations using multichoice input interaction having invalid rules.

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -74,6 +74,42 @@ GCS_EXTERNAL_IMAGE_ID_REGEX = re.compile(
 SUCCESSFUL_EXPLORATION_MIGRATION = 'Successfully migrated exploration'
 
 
+class MultipleChoiceInteractionOneOffJob(jobs.BaseMapReduceOneOffJobManager):
+    """Job that produces a list of all (exploration, state) pairs that use the
+    Multiple selection interaction and have rules that do not correspond to any
+    answer choices.
+    """
+
+    @classmethod
+    def entity_classes_to_map_over(cls):
+        return [exp_models.ExplorationModel]
+
+    @staticmethod
+    def map(item):
+        if item.deleted:
+            return
+
+        exploration = exp_fetchers.get_exploration_from_model(item)
+        for state_name, state in exploration.states.items():
+            if state.interaction.id == 'MultipleChoiceInput':
+                choices_length = len(
+                    state.interaction.customization_args['choices']['value'])
+                for anwer_group_index, answer_group in enumerate(
+                        state.interaction.answer_groups):
+                    for rule_index, rule_spec in enumerate(
+                            answer_group.rule_specs):
+                        if rule_spec.inputs['x'] > choices_length:
+                            yield (
+                                item.id,
+                                'State name:%s, AnswerGroup:%s, Rule:%s' % (
+                                    state_name.encode('utf-8'),
+                                    anwer_group_index, rule_index))
+
+    @staticmethod
+    def reduce(key, values):
+        yield (key, values)
+
+
 class MathExpressionInputInteractionOneOffJob(jobs.BaseMapReduceOneOffJobManager):  # pylint: disable=line-too-long
     """Job that produces a list of (exploration, state) pairs that use the Math
     Expression Interaction and that have rules that contain [<, >, =] to

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -104,12 +104,15 @@ class MultipleChoiceInteractionOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                         state.interaction.answer_groups):
                     for rule_index, rule_spec in enumerate(
                             answer_group.rule_specs):
-                        if rule_spec.inputs['x'] > choices_length:
+                        if rule_spec.inputs['x'] >= choices_length:
                             yield (
                                 item.id,
-                                'State name:%s, AnswerGroup:%s, Rule:%s' % (
+                                'State name: %s, AnswerGroup: %s,' % (
                                     state_name.encode('utf-8'),
-                                    anwer_group_index, rule_index))
+                                    anwer_group_index) +
+                                ' Rule: %s is invalid.' % (rule_index) +
+                                '(Indices here are 0-indexed.)')
+
 
     @staticmethod
     def reduce(key, values):

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -215,7 +215,8 @@ class MultipleChoiceInteractionOneOffJobTests(test_utils.GenericTestBase):
                 job_id))
         expected_output = [(
             u'[u\'exp_id0\', '
-            u'[u\'State name:State2, AnswerGroup:0, Rule:1\']]'
+            u'[u\'State name: State2, AnswerGroup: 0, Rule: 1 is invalid.' +
+            '(Indices here are 0-indexed.)\']]'
         )]
         self.assertEqual(actual_output, expected_output)
 

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -151,7 +151,7 @@ class MultipleChoiceInteractionOneOffJobTests(test_utils.GenericTestBase):
         state1.update_interaction_answer_groups(answer_group_list1)
         exp_services.save_new_exploration(self.albert_id, exploration)
 
-        # Start ItemSelectionInteractionOneOff job on sample exploration.
+        # Start MultipleChoiceInteractionOneOffJob job on sample exploration.
         job_id = exp_jobs_one_off.MultipleChoiceInteractionOneOffJob.create_new(
         )
         exp_jobs_one_off.MultipleChoiceInteractionOneOffJob.enqueue(job_id)
@@ -199,7 +199,7 @@ class MultipleChoiceInteractionOneOffJobTests(test_utils.GenericTestBase):
 
         exp_services.save_new_exploration(self.albert_id, exploration)
 
-        # Start ItemSelectionInteractionOneOff job on sample exploration.
+        # Start MultipleChoiceInteractionOneOffJob job on sample exploration.
         job_id = exp_jobs_one_off.MultipleChoiceInteractionOneOffJob.create_new(
         )
         exp_jobs_one_off.MultipleChoiceInteractionOneOffJob.enqueue(job_id)

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -88,6 +88,186 @@ def run_job_for_deleted_exp(
         self.assertEqual(job_class.get_output(job_id), [])
 
 
+class MultipleChoiceInteractionOneOffJobTests(test_utils.GenericTestBase):
+
+    ALBERT_EMAIL = 'albert@example.com'
+    ALBERT_NAME = 'albert'
+
+    VALID_EXP_ID = 'exp_id0'
+    NEW_EXP_ID = 'exp_id1'
+    EXP_TITLE = 'title'
+
+    def setUp(self):
+        super(MultipleChoiceInteractionOneOffJobTests, self).setUp()
+
+        # Setup user who will own the test explorations.
+        self.signup(self.ALBERT_EMAIL, self.ALBERT_NAME)
+        self.albert_id = self.get_user_id_from_email(self.ALBERT_EMAIL)
+        self.process_and_flush_pending_tasks()
+
+    def test_exp_state_pairs_are_produced_only_for_desired_interactions(self):
+        """Checks output pairs are produced only for
+        desired interactions.
+        """
+        exploration = exp_domain.Exploration.create_default_exploration(
+            self.VALID_EXP_ID, title='title', category='category')
+
+        exploration.add_states(['State1', 'State2'])
+
+        state1 = exploration.states['State1']
+        state2 = exploration.states['State2']
+
+        state1.update_interaction_id('MultipleChoiceInput')
+        state2.update_interaction_id('MultipleChoiceInput')
+
+        customization_args_dict1 = {
+            'choices': {'value': [
+                '<p>This is value1 for MultipleChoiceInput</p>',
+                '<p>This is value2 for MultipleChoiceInput</p>',
+            ]}
+        }
+
+        answer_group_list1 = [{
+            'rule_specs': [{
+                'rule_type': 'Equals',
+                'inputs': {'x': '1'}
+            }],
+            'outcome': {
+                'dest': 'Introduction',
+                'feedback': {
+                    'content_id': 'feedback',
+                    'html': '<p>Outcome for state1</p>'
+                },
+                'param_changes': [],
+                'labelled_as_correct': False,
+                'refresher_exploration_id': None,
+                'missing_prerequisite_skill_id': None
+            },
+            'training_data': [],
+            'tagged_skill_misconception_id': None
+        }]
+
+        state1.update_interaction_customization_args(customization_args_dict1)
+        state1.update_interaction_answer_groups(answer_group_list1)
+        exp_services.save_new_exploration(self.albert_id, exploration)
+
+        # Start ItemSelectionInteractionOneOff job on sample exploration.
+        job_id = exp_jobs_one_off.MultipleChoiceInteractionOneOffJob.create_new(
+        )
+        exp_jobs_one_off.MultipleChoiceInteractionOneOffJob.enqueue(job_id)
+        self.process_and_flush_pending_tasks()
+
+        actual_output = (
+            exp_jobs_one_off.MultipleChoiceInteractionOneOffJob.get_output(
+                job_id))
+        self.assertEqual(actual_output, [])
+
+        customization_args_dict2 = {
+            'choices': {'value': [
+                '<p>This is value1 for MultipleChoiceInput</p>',
+                '<p>This is value2 for MultipleChoiceInput</p>',
+                '<p>This is value3 for MultipleChoiceInput</p>',
+                '<p>This is value4 for MultipleChoiceInput</p>',
+            ]}
+        }
+
+        answer_group_list2 = [{
+            'rule_specs': [{
+                'rule_type': 'Equals',
+                'inputs': {'x': '0'}
+            }, {
+                'rule_type': 'Equals',
+                'inputs': {'x': '9007199254740991'}
+            }],
+            'outcome': {
+                'dest': 'State1',
+                'feedback': {
+                    'content_id': 'feedback',
+                    'html': '<p>Outcome for state2</p>'
+                },
+                'param_changes': [],
+                'labelled_as_correct': False,
+                'refresher_exploration_id': None,
+                'missing_prerequisite_skill_id': None
+            },
+            'training_data': [],
+            'tagged_skill_misconception_id': None
+        }]
+
+        state2.update_interaction_customization_args(customization_args_dict2)
+        state2.update_interaction_answer_groups(answer_group_list2)
+
+        exp_services.save_new_exploration(self.albert_id, exploration)
+
+        # Start ItemSelectionInteractionOneOff job on sample exploration.
+        job_id = exp_jobs_one_off.MultipleChoiceInteractionOneOffJob.create_new(
+        )
+        exp_jobs_one_off.MultipleChoiceInteractionOneOffJob.enqueue(job_id)
+        self.process_and_flush_pending_tasks()
+
+        actual_output = (
+            exp_jobs_one_off.MultipleChoiceInteractionOneOffJob.get_output(
+                job_id))
+        expected_output = [(
+            u'[u\'exp_id0\', '
+            u'[u\'State name:State2, AnswerGroup:0, Rule:1\']]'
+        )]
+        self.assertEqual(actual_output, expected_output)
+
+    def test_no_action_is_performed_for_deleted_exploration(self):
+        """Test that no action is performed on deleted explorations."""
+
+        exploration = exp_domain.Exploration.create_default_exploration(
+            self.VALID_EXP_ID, title='title', category='category')
+
+        exploration.add_states(['State1'])
+
+        state1 = exploration.states['State1']
+
+        state1.update_interaction_id('MultipleChoiceInput')
+
+        customization_args_dict = {
+            'choices': {'value': [
+                '<p>This is value1 for MultipleChoiceInput</p>',
+                '<p>This is value2 for MultipleChoiceInput</p>',
+            ]}
+        }
+
+        answer_group_list = [{
+            'rule_specs': [{
+                'rule_type': 'Equals',
+                'inputs': {'x': '0'}
+            }, {
+                'rule_type': 'Equals',
+                'inputs': {'x': '9007199254740991'}
+            }],
+            'outcome': {
+                'dest': 'State1',
+                'feedback': {
+                    'content_id': 'feedback',
+                    'html': '<p>Outcome for state2</p>'
+                },
+                'param_changes': [],
+                'labelled_as_correct': False,
+                'refresher_exploration_id': None,
+                'missing_prerequisite_skill_id': None
+            },
+            'training_data': [],
+            'tagged_skill_misconception_id': None
+        }]
+
+        state1.update_interaction_customization_args(customization_args_dict)
+        state1.update_interaction_answer_groups(answer_group_list)
+
+        exp_services.save_new_exploration(self.albert_id, exploration)
+
+        exp_services.delete_exploration(self.albert_id, self.VALID_EXP_ID)
+
+        run_job_for_deleted_exp(
+            self, exp_jobs_one_off.MultipleChoiceInteractionOneOffJob)
+
+
+
 class MathExpressionInputInteractionOneOffJobTests(test_utils.GenericTestBase):
 
     ALBERT_EMAIL = 'albert@example.com'

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -89,7 +89,8 @@ ONE_OFF_JOB_MANAGERS = [
     user_jobs_one_off.UserLastExplorationActivityOneOffJob,
     user_jobs_one_off.UserProfilePictureOneOffJob,
     user_jobs_one_off.UsernameLengthDistributionOneOffJob,
-    exp_jobs_one_off.MathExpressionInputInteractionOneOffJob
+    exp_jobs_one_off.MathExpressionInputInteractionOneOffJob,
+    exp_jobs_one_off.MultipleChoiceInteractionOneOffJob
 ]
 
 # List of all manager classes for prod validation one-off batch jobs for which


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR does the following: Add an audit job to find all explorations using multichoice input interaction having invalid rules. In multichoice input interactions, Some rules may correspond to answer choices that may no longer exist. This audit job finds such rules.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
