### PR TITLE
Remove ngResource from manifest as it is not used anywhere

### DIFF
--- a/core/templates/pages/about-page/about-page.module.ts
+++ b/core/templates/pages/about-page/about-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/admin-page/admin-page.module.ts
+++ b/core/templates/pages/admin-page/admin-page.module.ts
@@ -85,7 +85,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/classroom-page/classroom-page.module.ts
+++ b/core/templates/pages/classroom-page/classroom-page.module.ts
@@ -78,7 +78,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/collection-editor-page/collection-editor-page.module.ts
+++ b/core/templates/pages/collection-editor-page/collection-editor-page.module.ts
@@ -92,7 +92,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/collection-player-page/collection-player-page.module.ts
+++ b/core/templates/pages/collection-player-page/collection-player-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/community-dashboard-page/community-dashboard-page.module.ts
+++ b/core/templates/pages/community-dashboard-page/community-dashboard-page.module.ts
@@ -78,7 +78,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/contact-page/contact-page.module.ts
+++ b/core/templates/pages/contact-page/contact-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/creator-dashboard-page/creator-dashboard-page.module.ts
+++ b/core/templates/pages/creator-dashboard-page/creator-dashboard-page.module.ts
@@ -92,7 +92,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/delete-account-page/delete-account-page.module.ts
+++ b/core/templates/pages/delete-account-page/delete-account-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/donate-page/donate-page.module.ts
+++ b/core/templates/pages/donate-page/donate-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-page.module.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-page.module.ts
@@ -82,7 +82,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-result.module.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-result.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/error-pages/error-page.module.ts
+++ b/core/templates/pages/error-pages/error-page.module.ts
@@ -82,7 +82,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.module.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.module.ts
@@ -104,7 +104,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.codemirror', 'ui.sortable', 'ui.tree',
   'ui.validate', 'ui-leaflet', downgradedModule
 ])

--- a/core/templates/pages/exploration-player-page/exploration-player-page.module.ts
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.module.ts
@@ -97,7 +97,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.codemirror', 'ui.sortable', 'ui.tree',
   'ui.validate', 'ui-leaflet', downgradedModule
 ])

--- a/core/templates/pages/get-started-page/get-started-page.module.ts
+++ b/core/templates/pages/get-started-page/get-started-page.module.ts
@@ -76,7 +76,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/landing-pages/stewards-landing-page/stewards-landing-page.module.ts
+++ b/core/templates/pages/landing-pages/stewards-landing-page/stewards-landing-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/landing-pages/topic-landing-page/topic-landing-page.module.ts
+++ b/core/templates/pages/landing-pages/topic-landing-page/topic-landing-page.module.ts
@@ -86,7 +86,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.module.ts
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.module.ts
@@ -89,7 +89,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/library-page/library-page.module.ts
+++ b/core/templates/pages/library-page/library-page.module.ts
@@ -89,7 +89,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/maintenance-page/maintenance-page.module.ts
+++ b/core/templates/pages/maintenance-page/maintenance-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/moderator-page/moderator-page.module.ts
+++ b/core/templates/pages/moderator-page/moderator-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/notifications-dashboard-page/notifications-dashboard-page.module.ts
+++ b/core/templates/pages/notifications-dashboard-page/notifications-dashboard-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/practice-session-page/practice-session-page.module.ts
+++ b/core/templates/pages/practice-session-page/practice-session-page.module.ts
@@ -88,7 +88,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/preferences-page/preferences-page.module.ts
+++ b/core/templates/pages/preferences-page/preferences-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/privacy-page/privacy-page.module.ts
+++ b/core/templates/pages/privacy-page/privacy-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/profile-page/profile-page.module.ts
+++ b/core/templates/pages/profile-page/profile-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/review-test-page/review-test-page.module.ts
+++ b/core/templates/pages/review-test-page/review-test-page.module.ts
@@ -89,7 +89,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/signup-page/signup-page.module.ts
+++ b/core/templates/pages/signup-page/signup-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/skill-editor-page/skill-editor-page.module.ts
+++ b/core/templates/pages/skill-editor-page/skill-editor-page.module.ts
@@ -97,7 +97,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.codemirror', 'ui.sortable', 'ui.tree',
   'ui.validate', downgradedModule
 ])

--- a/core/templates/pages/splash-page/splash-page.module.ts
+++ b/core/templates/pages/splash-page/splash-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/story-editor-page/story-editor-page.module.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.module.ts
@@ -93,7 +93,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.codemirror', 'ui.sortable', 'ui.tree',
   'ui.validate', downgradedModule
 ])

--- a/core/templates/pages/story-viewer-page/story-viewer-page.module.ts
+++ b/core/templates/pages/story-viewer-page/story-viewer-page.module.ts
@@ -84,7 +84,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.module.ts
+++ b/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.module.ts
@@ -76,7 +76,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/teach-page/teach-page.module.ts
+++ b/core/templates/pages/teach-page/teach-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/terms-page/terms-page.module.ts
+++ b/core/templates/pages/terms-page/terms-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/thanks-page/thanks-page.module.ts
+++ b/core/templates/pages/thanks-page/thanks-page.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/topic-editor-page/topic-editor-page.module.ts
+++ b/core/templates/pages/topic-editor-page/topic-editor-page.module.ts
@@ -99,7 +99,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.codemirror', 'ui.sortable', 'ui.tree',
   'ui.validate', downgradedModule
 ])

--- a/core/templates/pages/topic-viewer-page/topic-viewer-page.module.ts
+++ b/core/templates/pages/topic-viewer-page/topic-viewer-page.module.ts
@@ -84,7 +84,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.module.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.module.ts
@@ -94,7 +94,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/core/templates/tests/console_errors.module.ts
+++ b/core/templates/tests/console_errors.module.ts
@@ -81,7 +81,7 @@ declare var angular: ng.IAngularStatic;
 angular.module('oppia', [
   'dndLists', 'headroom', 'infinite-scroll', 'ngAnimate',
   'ngAudio', require('angular-cookies'), 'ngImgCrop', 'ngJoyRide', 'ngMaterial',
-  'ngResource', 'ngSanitize', 'ngTouch', 'pascalprecht.translate',
+  'ngSanitize', 'ngTouch', 'pascalprecht.translate',
   'toastr', 'ui.bootstrap', 'ui.sortable', 'ui.tree', 'ui.validate',
   downgradedModule
 ])

--- a/manifest.json
+++ b/manifest.json
@@ -129,7 +129,7 @@
         ],
         "bundle": {
           "js": [
-            "angular-animate.js", "angular-resource.js", "angular-sanitize.js",
+            "angular-animate.js", "angular-sanitize.js",
             "angular-touch.js", "angular-aria.js"
           ]
         }


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

~~1. This PR fixes or fixes part of #[fill_in_number_here].~~
2. This PR does the following: I think ngResource library is not used anywhere. So, it can be removed from the bundle.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
