### PR TITLE
Fix #9006 and #9009: Disallowed same chapter titles in stories and fixed empty names for downloaded yaml files

### DIFF
--- a/core/controllers/editor.py
+++ b/core/controllers/editor.py
@@ -388,9 +388,12 @@ class ExplorationFileDownloader(EditorHandler):
             version = exploration.version
 
         # If the title of the exploration has changed, we use the new title.
-        filename = utils.to_ascii(
-            'oppia-%s-v%s.zip'
-            % (exploration.title.replace(' ', ''), version)).decode('utf-8')
+        if not exploration.title:
+            init_filename = 'oppia-unpublished_exploration-v%s.zip' % version
+        else:
+            init_filename = 'oppia-%s-v%s.zip' % (
+                exploration.title.replace(' ', ''), version)
+        filename = utils.to_ascii(init_filename).decode('utf-8')
 
         if output_format == feconf.OUTPUT_FORMAT_ZIP:
             self.render_downloadable_file(

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -616,6 +616,34 @@ written_translations:
 
         self.logout()
 
+    def test_exploration_download_handler_with_no_title(self):
+        # This is the case for most unpublished explorations.
+        self.login(self.EDITOR_EMAIL)
+        owner_id = self.get_user_id_from_email(self.EDITOR_EMAIL)
+
+        # Create a simple exploration.
+        exp_id = 'eid'
+        self.save_new_valid_exploration(
+            exp_id, owner_id,
+            title='',
+            category='This is just a test category',
+            objective='')
+
+        # Download to zip file using download handler.
+        download_url = '/createhandler/download/%s' % exp_id
+        response = self.get_custom_response(download_url, 'text/plain')
+
+        # Check downloaded zip file.
+        filename = 'oppia-unpublished_exploration-v1.zip'
+        self.assertEqual(response.headers['Content-Disposition'],
+                         'attachment; filename=%s' % filename)
+
+        zf_saved = zipfile.ZipFile(
+            python_utils.string_io(buffer_value=response.body))
+        self.assertEqual(zf_saved.namelist(), ['Unpublished_exploration.yaml'])
+
+        self.logout()
+
     def test_state_yaml_handler(self):
         self.login(self.EDITOR_EMAIL)
         owner_id = self.get_user_id_from_email(self.EDITOR_EMAIL)

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -273,8 +273,10 @@ def export_to_zip_file(exploration_id, version=None):
     memfile = python_utils.string_io()
     with zipfile.ZipFile(
         memfile, mode='w', compression=zipfile.ZIP_DEFLATED) as zfile:
-
-        zfile.writestr('%s.yaml' % exploration.title, yaml_repr)
+        if not exploration.title:
+            zfile.writestr('Unpublished_exploration.yaml', yaml_repr)
+        else:
+            zfile.writestr('%s.yaml' % exploration.title, yaml_repr)
 
         fs = fs_domain.AbstractFileSystem(
             fs_domain.GcsFileSystem(

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1825,6 +1825,17 @@ title: A title
         self.assertEqual(
             zf.open('A title.yaml').read(), self.SAMPLE_YAML_CONTENT)
 
+    def test_export_to_zip_file_with_unpublished_exploration(self):
+        """Test the export_to_zip_file() method."""
+        self.save_new_default_exploration(
+            self.EXP_0_ID, self.owner_id, title='')
+
+        zip_file_output = exp_services.export_to_zip_file(self.EXP_0_ID)
+        zf = zipfile.ZipFile(python_utils.string_io(
+            buffer_value=zip_file_output))
+
+        self.assertEqual(zf.namelist(), ['Unpublished_exploration.yaml'])
+
     def test_export_to_zip_file_with_assets(self):
         """Test exporting an exploration with assets to a zip file."""
         exploration = self.save_new_valid_exploration(

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.directive.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.directive.ts
@@ -123,9 +123,20 @@ angular.module('oppia').directive('storyNodeEditor', [
             if (newTitle === $scope.currentTitle) {
               return;
             }
-            StoryUpdateService.setStoryNodeTitle(
-              $scope.story, $scope.getId(), newTitle);
-            $scope.currentTitle = newTitle;
+            var titleIsValid = true;
+            for (var idx in $scope.story.getStoryContents().getNodes()) {
+              var node = $scope.story.getStoryContents().getNodes()[idx];
+              if (node.getTitle() === newTitle) {
+                titleIsValid = false;
+                AlertsService.addInfoMessage(
+                  'A chapter already exists with given title.', 5000);
+              }
+            }
+            if (titleIsValid) {
+              StoryUpdateService.setStoryNodeTitle(
+                $scope.story, $scope.getId(), newTitle);
+              $scope.currentTitle = newTitle;
+            }
           };
 
           $scope.viewNodeEditor = function(nodeId) {


### PR DESCRIPTION
## Overview

1. This PR fixes #9006 and fixes #9009.
2. This PR does the following:

- For #9006, added a check so that same chapter titles cannot be saved and added an alert message for the same:
![image](https://user-images.githubusercontent.com/22347970/79123605-25cf0480-7db8-11ea-9484-297fb672a687.png)

- For #9009, gave a placeholder title 'Unpublished_exploration' in case an unpublished exploration with no title is downloaded.
![image](https://user-images.githubusercontent.com/22347970/79123644-3ed7b580-7db8-11ea-9a02-d69412d1ab09.png)

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
