### PR TITLE
Fix #8758: add waitFor statement before accessing response tab element

### DIFF
--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -23,7 +23,6 @@ var forms = require('../protractor_utils/forms.js');
 var general = require('../protractor_utils/general.js');
 var users = require('../protractor_utils/users.js');
 var workflow = require('../protractor_utils/workflow.js');
-var waitFor = require('../protractor_utils/waitFor.js');
 
 var CreatorDashboardPage =
   require('../protractor_utils/CreatorDashboardPage.js');
@@ -110,7 +109,6 @@ describe('Enable correctness feedback and set correctness', function() {
     // Go back to mark the solution as correct.
     explorationEditorPage.navigateToMainTab();
     explorationEditorMainTab.moveToState('First');
-    waitFor.visibilityOf(element(by.css('.protractor-test-response-tab')));
     responseEditor = explorationEditorMainTab.getResponseEditor(0);
     responseEditor.markAsCorrect();
     explorationEditorMainTab.expectTickMarkIsDisplayed();

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -110,7 +110,7 @@ describe('Enable correctness feedback and set correctness', function() {
     // Go back to mark the solution as correct.
     explorationEditorPage.navigateToMainTab();
     explorationEditorMainTab.moveToState('First');
-    waitFor.visibibilityOf(element(by.css('.protractor-test-response-tab')));
+    waitFor.visibilityOf(element(by.css('.protractor-test-response-tab')));
     responseEditor = explorationEditorMainTab.getResponseEditor(0);
     responseEditor.markAsCorrect();
     explorationEditorMainTab.expectTickMarkIsDisplayed();

--- a/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
+++ b/core/tests/protractor_desktop/coreEditorAndPlayerFeatures.js
@@ -23,7 +23,7 @@ var forms = require('../protractor_utils/forms.js');
 var general = require('../protractor_utils/general.js');
 var users = require('../protractor_utils/users.js');
 var workflow = require('../protractor_utils/workflow.js');
-
+var waitFor = require('../protractor_utils/waitFor.js');
 
 var CreatorDashboardPage =
   require('../protractor_utils/CreatorDashboardPage.js');
@@ -110,6 +110,7 @@ describe('Enable correctness feedback and set correctness', function() {
     // Go back to mark the solution as correct.
     explorationEditorPage.navigateToMainTab();
     explorationEditorMainTab.moveToState('First');
+    waitFor.visibibilityOf(element(by.css('.protractor-test-response-tab')));
     responseEditor = explorationEditorMainTab.getResponseEditor(0);
     responseEditor.markAsCorrect();
     explorationEditorMainTab.expectTickMarkIsDisplayed();


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes or fixes part of #8758.
2. This PR does the following: adds a waitFor statement before accessing the response tab element to wait for the element to fully load and reduce flakiness

## Essential Checklist

- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The linter/Karma presubmit checks have passed locally on your machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [X] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
