### PR TITLE
Remove mathjs from manifest.json

### DIFF
--- a/extensions/objects/templates/drag-and-drop-html-string-editor.directive.ts
+++ b/extensions/objects/templates/drag-and-drop-html-string-editor.directive.ts
@@ -33,7 +33,7 @@ angular.module('oppia').directive('dragAndDropHtmlStringEditor', [
           ctrl.value = selectedItem;
         };
         ctrl.$onInit = function() {
-          ctrl.name = math.random().toString(36).substring(7);
+          ctrl.name = Math.random().toString(36).substring(7);
           ctrl.initArgs = ctrl.getInitArgs();
           ctrl.choices = ctrl.initArgs.choices;
 

--- a/extensions/objects/templates/list-of-sets-of-html-strings-editor.directive.ts
+++ b/extensions/objects/templates/list-of-sets-of-html-strings-editor.directive.ts
@@ -32,7 +32,7 @@ angular.module('oppia').directive('listOfSetsOfHtmlStringsEditor', [
         var errorMessage = '';
         ctrl.allowedChoices = function() {
           var allowedList = [];
-          for (var i = 0; i <= math.min(
+          for (var i = 0; i <= Math.min(
             ctrl.maxPrevIndex, ctrl.choices.length - 1); i++) {
             allowedList.push(i + 1);
           }
@@ -49,8 +49,7 @@ angular.module('oppia').directive('listOfSetsOfHtmlStringsEditor', [
           // ctrl.choices.splice(selectedRank, 0, ctrl.choices.splice(
           // choiceListIndex, 1)[0]);
           var choiceHtmlHasBeenAdded = false;
-          ctrl.maxPrevIndex = math.max(selectedRank + 1,
-            ctrl.maxPrevIndex);
+          ctrl.maxPrevIndex = Math.max(selectedRank + 1, ctrl.maxPrevIndex);
 
           for (var i = 0; i < ctrl.value.length; i++) {
             choiceHtmlHasBeenAdded = false;
@@ -117,7 +116,7 @@ angular.module('oppia').directive('listOfSetsOfHtmlStringsEditor', [
               for (var j = 0; j < ctrl.value.length; j++) {
                 if (ctrl.value[j].indexOf(choice) !== -1) {
                   ctrl.initValues.push(j + 1);
-                  ctrl.maxPrevIndex = math.max(ctrl.maxPrevIndex, j + 1);
+                  ctrl.maxPrevIndex = Math.max(ctrl.maxPrevIndex, j + 1);
                   break;
                 }
               }

--- a/manifest.json
+++ b/manifest.json
@@ -386,17 +386,6 @@
         "rootDirPrefix": "MathJax-",
         "targetDirPrefix": "MathJax-"
       },
-      "mathJs": {
-        "version": "5.10.3",
-        "downloadFormat": "files",
-        "url": "https://cdnjs.cloudflare.com/ajax/libs/mathjs/5.10.3",
-        "rootDirPrefix": "math-js-",
-        "targetDirPrefix": "math-js-",
-        "files": ["math.js", "math.min.js", "math.min.map"],
-        "bundle": {
-          "js": ["math.js"]
-        }
-      },
       "midiJs": {
         "version": "a8a84257afa70721ae462448048a87301fc1554a",
         "downloadFormat": "zip",


### PR DESCRIPTION
## Overview

~1. This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following: Removed mathjs from `manifest.json`. The reason is that the library is already imported by `package.json` and webpack imports. Also removed the references to mathjs from `extensions` since these can be done by JS native `Math`.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
