### PR TITLE
Fix #9018: Capitalizes the tab name in comunity dashboard page

### DIFF
--- a/core/templates/pages/community-dashboard-page/community-dashboard-page.constants.ts
+++ b/core/templates/pages/community-dashboard-page/community-dashboard-page.constants.ts
@@ -20,7 +20,7 @@ export class CommunityDashboardConstants {
   public static COMMUNITY_DASHBOARD_TABS_DETAILS = {
     myContributionTab: {
       ariaLabel: 'Check your contributions.',
-      tabName: 'My contribution',
+      tabName: 'My Contribution',
       description: '',
       customizationOptions: []
     },

--- a/core/templates/pages/community-dashboard-page/community-dashboard-page.constants.ts
+++ b/core/templates/pages/community-dashboard-page/community-dashboard-page.constants.ts
@@ -20,7 +20,7 @@ export class CommunityDashboardConstants {
   public static COMMUNITY_DASHBOARD_TABS_DETAILS = {
     myContributionTab: {
       ariaLabel: 'Check your contributions.',
-      tabName: 'My Contribution',
+      tabName: 'My Contributions',
       description: '',
       customizationOptions: []
     },

--- a/core/templates/pages/community-dashboard-page/modal-templates/question-suggestion-editor-modal.directive.html
+++ b/core/templates/pages/community-dashboard-page/modal-templates/question-suggestion-editor-modal.directive.html
@@ -3,7 +3,7 @@
     <h3><[skill.getDescription()]></h3>
   </div>
 
-  <div class="modal-body"">
+  <div class="modal-body">
     <div class="oppia-question-editor-section">
       <h3>Question Editor</h3>
       <question-editor question-id="questionId"


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes #9018 
2. This PR does the following: Capitalizes the tab name in comunity dashboard page
## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
