### PR TITLE
Fix part of #8015: search-explorations-backend-api now returns an ExplorationMetadata object instead of a dictionary

### DIFF
--- a/core/templates/domain/collection/search-explorations-backend-api.service.spec.ts
+++ b/core/templates/domain/collection/search-explorations-backend-api.service.spec.ts
@@ -88,8 +88,9 @@ describe('Exploration search backend API service', () => {
         }]
       };
 
-      var explorationMetadataObject =
-      ExplorationMetadataObjectFactory.createFromBackendDict(searchResults);
+      var explorationMetadataObject = (
+        ExplorationMetadataObjectFactory.createFromBackendDict(
+          searchResults));
 
       SearchExplorationsService.fetchExplorations('count')
         .then(successHandler, failHandler);

--- a/core/templates/domain/collection/search-explorations-backend-api.service.spec.ts
+++ b/core/templates/domain/collection/search-explorations-backend-api.service.spec.ts
@@ -23,6 +23,9 @@ import { TestBed, fakeAsync, flushMicrotasks } from '@angular/core/testing';
 import { SearchExplorationsBackendApiService } from
   'domain/collection/search-explorations-backend-api.service';
 
+import { ExplorationMetadataObjectFactory } from
+  'domain/exploration/ExplorationMetadataObjectFactory';
+
 describe('Exploration search backend API service', () => {
   let SearchExplorationsService: SearchExplorationsBackendApiService = null;
   let httpTestingController: HttpTestingController;
@@ -46,6 +49,11 @@ describe('Exploration search backend API service', () => {
       let successHandler = jasmine.createSpy('success');
       let failHandler = jasmine.createSpy('fail');
       let query = escape(btoa('three'));
+
+      var explorationMetadataObject =
+        ExplorationMetadataObjectFactory.createFromBackendDict(
+          {collection_node_metadata_list: []}
+        );
 
       SearchExplorationsService.fetchExplorations('three')
         .then(successHandler, failHandler);
@@ -81,6 +89,9 @@ describe('Exploration search backend API service', () => {
         }]
       };
 
+      var explorationMetadataObject =
+      ExplorationMetadataObjectFactory.createFromBackendDict(searchResults);
+
       SearchExplorationsService.fetchExplorations('count')
         .then(successHandler, failHandler);
       let req = httpTestingController.expectOne(
@@ -89,7 +100,7 @@ describe('Exploration search backend API service', () => {
 
       flushMicrotasks();
 
-      expect(successHandler).toHaveBeenCalledWith(searchResults);
+      expect(successHandler).toHaveBeenCalledWith(explorationMetadataObject);
       expect(failHandler).not.toHaveBeenCalled();
     })
   );

--- a/core/templates/domain/collection/search-explorations-backend-api.service.spec.ts
+++ b/core/templates/domain/collection/search-explorations-backend-api.service.spec.ts
@@ -50,10 +50,9 @@ describe('Exploration search backend API service', () => {
       let failHandler = jasmine.createSpy('fail');
       let query = escape(btoa('three'));
 
-      var explorationMetadataObject =
+      var explorationMetadataObject = (
         ExplorationMetadataObjectFactory.createFromBackendDict(
-          {collection_node_metadata_list: []}
-        );
+          {collection_node_metadata_list: []}));
 
       SearchExplorationsService.fetchExplorations('three')
         .then(successHandler, failHandler);
@@ -89,8 +88,8 @@ describe('Exploration search backend API service', () => {
         }]
       };
 
-      var explorationMetadataObject =
-      ExplorationMetadataObjectFactory.createFromBackendDict(searchResults);
+      var explorationMetadataObject = (
+        ExplorationMetadataObjectFactory.createFromBackendDict(searchResults));
 
       SearchExplorationsService.fetchExplorations('count')
         .then(successHandler, failHandler);

--- a/core/templates/domain/collection/search-explorations-backend-api.service.spec.ts
+++ b/core/templates/domain/collection/search-explorations-backend-api.service.spec.ts
@@ -50,10 +50,9 @@ describe('Exploration search backend API service', () => {
       let failHandler = jasmine.createSpy('fail');
       let query = escape(btoa('three'));
 
-      var explorationMetadataObject =
+      var explorationMetadataObject = (
         ExplorationMetadataObjectFactory.createFromBackendDict(
-          {collection_node_metadata_list: []}
-        );
+          {collection_node_metadata_list: []}));
 
       SearchExplorationsService.fetchExplorations('three')
         .then(successHandler, failHandler);

--- a/core/templates/domain/collection/search-explorations-backend-api.service.ts
+++ b/core/templates/domain/collection/search-explorations-backend-api.service.ts
@@ -47,10 +47,9 @@ export class SearchExplorationsBackendApiService {
       }
     );
     this.http.get(queryUrl).toPromise().then((response) => {
-      explorationMetadataObject =
-      ExplorationMetadataObjectFactory.createFromBackendDict(
-        angular.copy(response)
-      );
+      explorationMetadataObject = (
+        ExplorationMetadataObjectFactory.createFromBackendDict(
+          angular.copy(response)));
       successCallback(explorationMetadataObject);
     }, (errorResponse) => {
       errorCallback(errorResponse);

--- a/core/templates/domain/collection/search-explorations-backend-api.service.ts
+++ b/core/templates/domain/collection/search-explorations-backend-api.service.ts
@@ -24,6 +24,8 @@ import { LibraryPageConstants } from
   'pages/library-page/library-page.constants';
 import { UrlInterpolationService } from
   'domain/utilities/url-interpolation.service';
+import { ExplorationMetadataObjectFactory } from
+  'domain/exploration/ExplorationMetadataObjectFactory';
 
 @Injectable({
   providedIn: 'root'
@@ -38,13 +40,18 @@ export class SearchExplorationsBackendApiService {
       searchQuery: string, successCallback: (
       value?: Object | PromiseLike<Object>) => void,
       errorCallback: (reason?: any) => void): void {
+    var explorationMetadataObject = null;
     var queryUrl = this.urlInterpolationService.interpolateUrl(
       LibraryPageConstants.SEARCH_EXPLORATION_URL_TEMPLATE, {
         query: btoa(searchQuery)
       }
     );
     this.http.get(queryUrl).toPromise().then((response) => {
-      successCallback(response);
+      explorationMetadataObject =
+      ExplorationMetadataObjectFactory.createFromBackendDict(
+        angular.copy(response)
+      );
+      successCallback(explorationMetadataObject);
     }, (errorResponse) => {
       errorCallback(errorResponse);
     });

--- a/core/templates/domain/exploration/ExplorationMetadataObjectFactory.ts
+++ b/core/templates/domain/exploration/ExplorationMetadataObjectFactory.ts
@@ -14,7 +14,7 @@
 
 /**
  * @fileoverview Factory for creating instances of frontend
- * subtopic data domain objects.
+ * exploration metadata domain objects.
  */
 
 import { downgradeInjectable } from '@angular/upgrade/static';

--- a/core/templates/domain/exploration/ExplorationMetadataObjectFactory.ts
+++ b/core/templates/domain/exploration/ExplorationMetadataObjectFactory.ts
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 /**
- * @fileoverview Factory for creating instances of frontend
- * subtopic data domain objects.
+ * @fileoverview Factory for creating instances of Exploration
+ * MetaData as a search exploration http request returnable.
  */
 
 import { downgradeInjectable } from '@angular/upgrade/static';

--- a/core/templates/domain/exploration/ExplorationMetadataObjectFactory.ts
+++ b/core/templates/domain/exploration/ExplorationMetadataObjectFactory.ts
@@ -1,0 +1,48 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Factory for creating instances of frontend
+ * subtopic data domain objects.
+ */
+
+import { downgradeInjectable } from '@angular/upgrade/static';
+import { Injectable } from '@angular/core';
+
+export class ExplorationMetadata {
+  metadataList;
+
+  constructor(metadataList) {
+    this.metadataList = angular.copy(metadataList);
+  }
+
+  getMetadataList() {
+    return this.metadataList;
+  }
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ExplorationMetadataObjectFactory {
+  static createFromBackendDict(explorationMetadataBackendDict: any) {
+    return new ExplorationMetadata(
+      explorationMetadataBackendDict.collection_node_metadata_list
+    );
+  }
+}
+
+angular.module('oppia').factory(
+  'ExplorationMetadataObjectFactory',
+  downgradeInjectable(ExplorationMetadataObjectFactory));

--- a/core/templates/domain/exploration/ExplorationMetadataObjectFactorySpec.ts
+++ b/core/templates/domain/exploration/ExplorationMetadataObjectFactorySpec.ts
@@ -41,7 +41,9 @@ describe('Exploration Metadata object factory', () => {
     };
 
 
-    sampleExplorationMetadata = ExplorationMetadataObjectFactory.
+    sampleExplorationMetadata = (
+      ExplorationMetadataObjectFactory.createFromBackendDict(
+        sampleExplorationMetadataBackendDict));
       createFromBackendDict(sampleExplorationMetadataBackendDict);
   });
 
@@ -60,4 +62,3 @@ describe('Exploration Metadata object factory', () => {
     );
   });
 });
-

--- a/core/templates/domain/exploration/ExplorationMetadataObjectFactorySpec.ts
+++ b/core/templates/domain/exploration/ExplorationMetadataObjectFactorySpec.ts
@@ -44,7 +44,6 @@ describe('Exploration Metadata object factory', () => {
     sampleExplorationMetadata = (
       ExplorationMetadataObjectFactory.createFromBackendDict(
         sampleExplorationMetadataBackendDict));
-      createFromBackendDict(sampleExplorationMetadataBackendDict);
   });
 
   it('should be able to get all the values', function() {

--- a/core/templates/domain/exploration/ExplorationMetadataObjectFactorySpec.ts
+++ b/core/templates/domain/exploration/ExplorationMetadataObjectFactorySpec.ts
@@ -23,10 +23,10 @@ import { ExplorationMetadataObjectFactory } from
 
 
 describe('Exploration Metadata object factory', () => {
-  var _sampleExplorationMetadata = null;
+  let sampleExplorationMetadata = null;
 
   beforeEach(() => {
-    var sampleExplorationMetadataBackendDict = {
+    let sampleExplorationMetadataBackendDict = {
       collection_node_metadata_list: [{
         id: '12',
         objective:
@@ -41,12 +41,12 @@ describe('Exploration Metadata object factory', () => {
     };
 
 
-    _sampleExplorationMetadata = ExplorationMetadataObjectFactory.
+    sampleExplorationMetadata = ExplorationMetadataObjectFactory.
       createFromBackendDict(sampleExplorationMetadataBackendDict);
   });
 
   it('should be able to get all the values', function() {
-    expect(_sampleExplorationMetadata.getMetadataList()).toEqual([{
+    expect(sampleExplorationMetadata.getMetadataList()).toEqual([{
       id: '12',
       objective:
       'learn how to count permutations accurately and systematically',

--- a/core/templates/domain/exploration/ExplorationMetadataObjectFactorySpec.ts
+++ b/core/templates/domain/exploration/ExplorationMetadataObjectFactorySpec.ts
@@ -1,0 +1,63 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Tests for ExplorationMetadataObjectFactory.
+ */
+
+import { TestBed } from '@angular/core/testing';
+
+import { ExplorationMetadataObjectFactory } from
+  'domain/exploration/ExplorationMetadataObjectFactory';
+
+
+describe('Exploration Metadata object factory', () => {
+  var _sampleExplorationMetadata = null;
+
+  beforeEach(() => {
+    var sampleExplorationMetadataBackendDict = {
+      collection_node_metadata_list: [{
+        id: '12',
+        objective:
+        'learn how to count permutations accurately and systematically',
+        title: 'Protractor Test'
+      }, {
+        id: '4',
+        objective:
+        'learn how to count permutations accurately and systematically',
+        title: 'Three Balls'
+      }]
+    };
+
+
+    _sampleExplorationMetadata = ExplorationMetadataObjectFactory.
+      createFromBackendDict(sampleExplorationMetadataBackendDict);
+  });
+
+  it('should be able to get all the values', function() {
+    expect(_sampleExplorationMetadata.getMetadataList()).toEqual([{
+      id: '12',
+      objective:
+      'learn how to count permutations accurately and systematically',
+      title: 'Protractor Test'
+    }, {
+      id: '4',
+      objective:
+      'learn how to count permutations accurately and systematically',
+      title: 'Three Balls'
+    }]
+    );
+  });
+});
+

--- a/core/templates/domain/exploration/ExplorationMetadataObjectFactorySpec.ts
+++ b/core/templates/domain/exploration/ExplorationMetadataObjectFactorySpec.ts
@@ -23,7 +23,7 @@ import { ExplorationMetadataObjectFactory } from
 
 
 describe('Exploration Metadata object factory', () => {
-  var _sampleExplorationMetadata = null;
+  var sampleExplorationMetadata = null;
 
   beforeEach(() => {
     var sampleExplorationMetadataBackendDict = {
@@ -41,12 +41,13 @@ describe('Exploration Metadata object factory', () => {
     };
 
 
-    _sampleExplorationMetadata = ExplorationMetadataObjectFactory.
-      createFromBackendDict(sampleExplorationMetadataBackendDict);
+    sampleExplorationMetadata = (
+      ExplorationMetadataObjectFactory.
+        createFromBackendDict(sampleExplorationMetadataBackendDict));
   });
 
   it('should be able to get all the values', function() {
-    expect(_sampleExplorationMetadata.getMetadataList()).toEqual([{
+    expect(sampleExplorationMetadata.getMetadataList()).toEqual([{
       id: '12',
       objective:
       'learn how to count permutations accurately and systematically',

--- a/core/templates/pages/collection-editor-page/editor-tab/collection-node-creator.directive.ts
+++ b/core/templates/pages/collection-editor-page/editor-tab/collection-node-creator.directive.ts
@@ -65,9 +65,9 @@ angular.module('oppia').directive('collectionNodeCreator', [
               ctrl.searchQueryHasError = false;
               return SearchExplorationsBackendApiService.fetchExplorations(
                 searchQuery
-              ).then(function(explorationMetadataBackendDict) {
+              ).then(function(explorationMetadata) {
                 var options = [];
-                explorationMetadataBackendDict.collection_node_metadata_list.
+                explorationMetadata.getMetadataList().
                   map(function(item) {
                     if (!ctrl.collection.containsCollectionNode(item.id)) {
                       options.push(item.title + ' (' + item.id + ')');

--- a/scripts/check_frontend_coverage.py
+++ b/scripts/check_frontend_coverage.py
@@ -136,6 +136,7 @@ FULLY_COVERED_FILENAMES = [
     'exploration-title.service.ts',
     'exploration-warnings.service.ts',
     'ExplorationDraftObjectFactory.ts',
+    'ExplorationMetadataObjectFactory.ts',
     'ExplorationObjectFactory.ts',
     'ExplorationOpportunitySummaryObjectFactory.ts',
     'expression-parser.service.ts',


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes or fixes part of #8015.
2. This PR does the following: 
Previously, search-explorations-backend-api returned a dictionary directly from its http query response.

To accommodate change, we created a new domain object (ExplorationMetadata), its factory, and their unit tests. Modified existing tests to take into account new return type.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
