### PR TITLE
Fix #8993: Linter now catchs custom js/ts lint errors

### DIFF
--- a/core/templates/third-party-imports/wave-surfer.import.ts
+++ b/core/templates/third-party-imports/wave-surfer.import.ts
@@ -1,2 +1,20 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview This file imports the wavesurfer library.
+ */
+
 module.exports = require(
   'static/wave-surfer-js-2.2.1/wavesurfer.min.js');

--- a/scripts/linters/pre_commit_linter.py
+++ b/scripts/linters/pre_commit_linter.py
@@ -230,13 +230,15 @@ def _lint_all_files(
     css_file_extension_type = 'css' in file_extensions_to_lint
     other_file_extension_type = 'other' in file_extensions_to_lint
 
-    if not other_file_extension_type:
-        general_files_to_lint = '.' + file_extensions_to_lint
+    if js_ts_file_extension_type:
+        general_files_to_lint = _FILES['.js'] + _FILES['.ts']
+    if other_file_extension_type:
+        general_files_to_lint = _FILES['other']
     else:
-        general_files_to_lint = file_extensions_to_lint
+        general_files_to_lint = _FILES['.%s' % file_extensions_to_lint]
 
     custom_linter, third_party_linter = general_purpose_linter.get_linters(
-        _FILES[general_files_to_lint],
+        general_files_to_lint,
         verbose_mode_enabled=verbose_mode_enabled)
     custom_linters.append(custom_linter)
 

--- a/scripts/linters/pre_commit_linter.py
+++ b/scripts/linters/pre_commit_linter.py
@@ -196,20 +196,13 @@ class FileCache(python_utils.OBJECT):
         return self._CACHE_DATA_DICT[key]
 
 
-def _lint_all_files(
-        js_filepaths, ts_filepaths, py_filepaths, html_filepaths,
-        css_filepaths, file_extensions_to_lint, verbose_mode_enabled=False):
+def _lint_all_files(file_extensions_to_lint, verbose_mode_enabled=False):
     """Run all lint checks.
 
     Args:
-        js_filepaths: list(str). The list of js filepaths to be linted.
-        ts_filepaths: list(str). The list of ts filepaths to be linted.
-        py_filepaths: list(str). The list of python filepaths to be linted.
-        html_filepaths: list(str). The list of HTML filepaths to be linted.
-        css_filepaths: list(str). The list of CSS filepaths to be linted.
-        verbose_mode_enabled: bool. True if verbose mode is enabled.
         file_extensions_to_lint: list(str). The list of file extensions to be
             linted.
+        verbose_mode_enabled: bool. True if verbose mode is enabled.
 
     Returns:
         custom_linter: list. Custom lint checks.
@@ -231,11 +224,9 @@ def _lint_all_files(
     other_file_extension_type = 'other' in file_extensions_to_lint
 
     if js_ts_file_extension_type:
-        general_files_to_lint = _FILES['.js'] + _FILES['.ts']
-    if other_file_extension_type:
-        general_files_to_lint = _FILES['other']
+        general_files_to_lint = _FILES['js'] + _FILES['ts']
     else:
-        general_files_to_lint = _FILES['.%s' % file_extensions_to_lint]
+        general_files_to_lint = _FILES[file_extensions_to_lint]
 
     custom_linter, third_party_linter = general_purpose_linter.get_linters(
         general_files_to_lint,
@@ -244,31 +235,31 @@ def _lint_all_files(
 
     if js_ts_file_extension_type:
         custom_linter, third_party_linter = js_ts_linter.get_linters(
-            js_filepaths, ts_filepaths,
+            _FILES['js'], _FILES['ts'],
             verbose_mode_enabled=verbose_mode_enabled)
         custom_linters.append(custom_linter)
         third_party_linters.append(third_party_linter)
 
     if html_file_extension_type:
         custom_linter, third_party_linter = html_linter.get_linters(
-            html_filepaths, verbose_mode_enabled=verbose_mode_enabled)
+            _FILES['html'], verbose_mode_enabled=verbose_mode_enabled)
         custom_linters.append(custom_linter)
         third_party_linters.append(third_party_linter)
 
         custom_linter, third_party_linter = css_linter.get_linters(
-            config_path_for_css_in_html, html_filepaths,
+            config_path_for_css_in_html, _FILES['html'],
             verbose_mode_enabled=verbose_mode_enabled)
         third_party_linters.append(third_party_linter)
 
     if css_file_extension_type:
         custom_linter, third_party_linter = css_linter.get_linters(
-            config_path_for_oppia_css, css_filepaths,
+            config_path_for_oppia_css, _FILES['css'],
             verbose_mode_enabled=verbose_mode_enabled)
         third_party_linters.append(third_party_linter)
 
     if py_file_extension_type:
         custom_linter, third_party_linter = python_linter.get_linters(
-            py_filepaths, verbose_mode_enabled=verbose_mode_enabled)
+            _FILES['py'], verbose_mode_enabled=verbose_mode_enabled)
         custom_linters.append(custom_linter)
         third_party_linters.append(third_party_linter)
 
@@ -413,7 +404,7 @@ def read_files(file_paths):
 def categorize_files(file_paths):
     """Categorize all the files and store them in shared variable _FILES."""
     all_filepaths_dict = {
-        '.py': [], '.html': [], '.ts': [], '.js': [], 'other': [], '.css': []
+        'py': [], 'html': [], 'ts': [], 'js': [], 'other': [], 'css': []
     }
     for file_path in file_paths:
         _, extension = os.path.splitext(file_path)
@@ -474,9 +465,7 @@ def main(args=None):
     third_party_linters = []
     for file_extension_type in file_extension_types:
         custom_linter, third_party_linter = _lint_all_files(
-            _FILES['.js'], _FILES['.ts'], _FILES['.py'], _FILES['.html'],
-            _FILES['.css'], file_extension_type,
-            verbose_mode_enabled=verbose_mode_enabled)
+            file_extension_type, verbose_mode_enabled=verbose_mode_enabled)
         custom_linters += custom_linter
         third_party_linters += third_party_linter
 

--- a/scripts/linters/pre_commit_linter.py
+++ b/scripts/linters/pre_commit_linter.py
@@ -209,10 +209,6 @@ def _lint_all_files(file_extensions_to_lint, verbose_mode_enabled=False):
         third_party_linter: list. Third party lint checks.
     """
     parent_dir = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
-    config_path_for_css_in_html = os.path.join(
-        parent_dir, 'oppia', '.stylelintrc')
-    config_path_for_oppia_css = os.path.join(
-        parent_dir, 'oppia', 'core', 'templates', 'css', '.stylelintrc')
     custom_linters = []
     third_party_linters = []
 
@@ -246,12 +242,16 @@ def _lint_all_files(file_extensions_to_lint, verbose_mode_enabled=False):
         custom_linters.append(custom_linter)
         third_party_linters.append(third_party_linter)
 
+        config_path_for_css_in_html = os.path.join(
+            parent_dir, 'oppia', '.stylelintrc')
         custom_linter, third_party_linter = css_linter.get_linters(
             config_path_for_css_in_html, _FILES['html'],
             verbose_mode_enabled=verbose_mode_enabled)
         third_party_linters.append(third_party_linter)
 
     if css_file_extension_type:
+        config_path_for_oppia_css = os.path.join(
+            parent_dir, 'oppia', 'core', 'templates', 'css', '.stylelintrc')
         custom_linter, third_party_linter = css_linter.get_linters(
             config_path_for_oppia_css, _FILES['css'],
             verbose_mode_enabled=verbose_mode_enabled)

--- a/scripts/linters/pre_commit_linter.py
+++ b/scripts/linters/pre_commit_linter.py
@@ -197,11 +197,11 @@ class FileCache(python_utils.OBJECT):
         return self._CACHE_DATA_DICT[key]
 
 
-def _lint_all_files(file_extensions_to_lint, verbose_mode_enabled=False):
+def _lint_all_files(file_extension_to_lint, verbose_mode_enabled=False):
     """Run all lint checks.
 
     Args:
-        file_extension_to_lint: str. The file extensions to be linted.
+        file_extension_to_lint: str. The file extension to be linted.
         verbose_mode_enabled: bool. True if verbose mode is enabled.
 
     Returns:
@@ -212,19 +212,19 @@ def _lint_all_files(file_extensions_to_lint, verbose_mode_enabled=False):
     custom_linters = []
     third_party_linters = []
 
-    js_ts_file_extension_type = '.js' == file_extensions_to_lint or (
-        '.ts' == file_extensions_to_lint)
-    py_file_extension_type = '.py' == file_extensions_to_lint
-    html_file_extension_type = '.html' == file_extensions_to_lint
-    css_file_extension_type = '.css' == file_extensions_to_lint
-    other_file_extension_type = 'other' == file_extensions_to_lint
+    js_ts_file_extension_type = '.js' == file_extension_to_lint or (
+        '.ts' == file_extension_to_lint)
+    py_file_extension_type = '.py' == file_extension_to_lint
+    html_file_extension_type = '.html' == file_extension_to_lint
+    css_file_extension_type = '.css' == file_extension_to_lint
+    other_file_extension_type = 'other' == file_extension_to_lint
 
     if js_ts_file_extension_type:
         general_files_to_lint = _FILES['.js'] + _FILES['.ts']
     elif other_file_extension_type:
         general_files_to_lint = _FILES['other']
     else:
-        general_files_to_lint = _FILES['.%s' % file_extensions_to_lint]
+        general_files_to_lint = _FILES['.%s' % file_extension_to_lint]
 
     custom_linter, third_party_linter = general_purpose_linter.get_linters(
         general_files_to_lint,

--- a/scripts/linters/pre_commit_linter.py
+++ b/scripts/linters/pre_commit_linter.py
@@ -92,7 +92,7 @@ _EXCLUSIVE_GROUP.add_argument(
     nargs='+',
     choices=['html', 'css', 'js', 'ts', 'py', 'other'],
     help='specific file extensions to be linted. Space separated list. '
-        'If either of js or ts used then both js and ts files will be linted.',
+    'If either of js or ts used then both js and ts files will be linted.',
     action='store')
 
 if not os.getcwd().endswith('oppia'):
@@ -213,8 +213,8 @@ def _get_linters_for_file_extension(
     custom_linters = []
     third_party_linters = []
 
-    file_extension_type_js_ts = '.js' == file_extension_to_lint or (
-        '.ts' == file_extension_to_lint)
+    file_extension_type_js_ts = file_extension_to_lint == 'js' or (
+        file_extension_to_lint == 'ts')
 
     if file_extension_type_js_ts:
         general_files_to_lint = _FILES['.js'] + _FILES['.ts']
@@ -235,7 +235,7 @@ def _get_linters_for_file_extension(
         custom_linters.append(custom_linter)
         third_party_linters.append(third_party_linter)
 
-    elif file_extension_to_lint == '.html':
+    elif file_extension_to_lint == 'html':
         custom_linter, third_party_linter = html_linter.get_linters(
             _FILES['.html'], verbose_mode_enabled=verbose_mode_enabled)
         custom_linters.append(custom_linter)
@@ -248,7 +248,7 @@ def _get_linters_for_file_extension(
             verbose_mode_enabled=verbose_mode_enabled)
         third_party_linters.append(third_party_linter)
 
-    elif file_extension_to_lint == '.css':
+    elif file_extension_to_lint == 'css':
         config_path_for_oppia_css = os.path.join(
             parent_dir, 'oppia', 'core', 'templates', 'css', '.stylelintrc')
         custom_linter, third_party_linter = css_linter.get_linters(
@@ -256,7 +256,7 @@ def _get_linters_for_file_extension(
             verbose_mode_enabled=verbose_mode_enabled)
         third_party_linters.append(third_party_linter)
 
-    elif file_extension_to_lint == '.py':
+    elif file_extension_to_lint == 'py':
         custom_linter, third_party_linter = python_linter.get_linters(
             _FILES['.py'], verbose_mode_enabled=verbose_mode_enabled)
         custom_linters.append(custom_linter)

--- a/scripts/linters/pre_commit_linter.py
+++ b/scripts/linters/pre_commit_linter.py
@@ -197,8 +197,9 @@ class FileCache(python_utils.OBJECT):
         return self._CACHE_DATA_DICT[key]
 
 
-def _lint_all_files(file_extension_to_lint, verbose_mode_enabled=False):
-    """Run all lint checks.
+def _get_linters_for_file_extension(
+        file_extension_to_lint, verbose_mode_enabled=False):
+    """Return linters for the file extension type.
 
     Args:
         file_extension_to_lint: str. The file extension to be linted.
@@ -212,16 +213,12 @@ def _lint_all_files(file_extension_to_lint, verbose_mode_enabled=False):
     custom_linters = []
     third_party_linters = []
 
-    js_ts_file_extension_type = '.js' == file_extension_to_lint or (
+    file_extension_type_js_ts = '.js' == file_extension_to_lint or (
         '.ts' == file_extension_to_lint)
-    py_file_extension_type = '.py' == file_extension_to_lint
-    html_file_extension_type = '.html' == file_extension_to_lint
-    css_file_extension_type = '.css' == file_extension_to_lint
-    other_file_extension_type = 'other' == file_extension_to_lint
 
-    if js_ts_file_extension_type:
+    if file_extension_type_js_ts:
         general_files_to_lint = _FILES['.js'] + _FILES['.ts']
-    elif other_file_extension_type:
+    elif file_extension_to_lint == 'other':
         general_files_to_lint = _FILES['other']
     else:
         general_files_to_lint = _FILES['.%s' % file_extension_to_lint]
@@ -231,14 +228,14 @@ def _lint_all_files(file_extension_to_lint, verbose_mode_enabled=False):
         verbose_mode_enabled=verbose_mode_enabled)
     custom_linters.append(custom_linter)
 
-    if js_ts_file_extension_type:
+    if file_extension_type_js_ts:
         custom_linter, third_party_linter = js_ts_linter.get_linters(
             _FILES['.js'], _FILES['.ts'],
             verbose_mode_enabled=verbose_mode_enabled)
         custom_linters.append(custom_linter)
         third_party_linters.append(third_party_linter)
 
-    if html_file_extension_type:
+    elif file_extension_to_lint == '.html':
         custom_linter, third_party_linter = html_linter.get_linters(
             _FILES['.html'], verbose_mode_enabled=verbose_mode_enabled)
         custom_linters.append(custom_linter)
@@ -251,7 +248,7 @@ def _lint_all_files(file_extension_to_lint, verbose_mode_enabled=False):
             verbose_mode_enabled=verbose_mode_enabled)
         third_party_linters.append(third_party_linter)
 
-    if css_file_extension_type:
+    elif file_extension_to_lint == '.css':
         config_path_for_oppia_css = os.path.join(
             parent_dir, 'oppia', 'core', 'templates', 'css', '.stylelintrc')
         custom_linter, third_party_linter = css_linter.get_linters(
@@ -259,7 +256,7 @@ def _lint_all_files(file_extension_to_lint, verbose_mode_enabled=False):
             verbose_mode_enabled=verbose_mode_enabled)
         third_party_linters.append(third_party_linter)
 
-    if py_file_extension_type:
+    elif file_extension_to_lint == '.py':
         custom_linter, third_party_linter = python_linter.get_linters(
             _FILES['.py'], verbose_mode_enabled=verbose_mode_enabled)
         custom_linters.append(custom_linter)
@@ -466,7 +463,7 @@ def main(args=None):
     custom_linters = []
     third_party_linters = []
     for file_extension_type in file_extension_types:
-        custom_linter, third_party_linter = _lint_all_files(
+        custom_linter, third_party_linter = _get_linters_for_file_extension(
             file_extension_type, verbose_mode_enabled=verbose_mode_enabled)
         custom_linters += custom_linter
         third_party_linters += third_party_linter


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST: Please answer *both* questions below and check off every point from the essential checklist!
-->

1. This PR fixes or fixes part of #8993.
2. This PR does the following: This PR solves the problem of not catching custom ts lint errors.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
