### PR TITLE
Fix part of #4057: Added a test file for  exploration-param-changes.service.ts

### DIFF
--- a/core/templates/pages/exploration-editor-page/services/exploration-param-changes.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-param-changes.service.spec.ts
@@ -1,0 +1,47 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for the ExplorationParamChangesService.
+ */
+
+// TODO(#7222): Remove the following block of unnnecessary imports once
+// the code corresponding to the spec is upgraded to Angular 8.
+import { UpgradedServices } from 'services/UpgradedServices';
+// ^^^ This block is to be removed.
+
+require('pages/exploration-editor-page/' +
+  'services/exploration-param-changes.service.spec.ts');
+
+fdescribe('Exploration Param Changes Service', function() {
+  var epcs = null;
+
+  beforeEach(function() {
+    angular.mock.module('oppia');
+    angular.mock.module(function($provide) {
+      var ugs = new UpgradedServices();
+      for (let [key, value] of Object.entries(ugs.getUpgradedServices())) {
+        $provide.value(key, value);
+      }
+    });
+
+    angular.mock.inject(function($injector) {
+      epcs = $injector.get('ExplorationParamChangesService');
+    });
+  });
+
+  it('should test the child object properties', function() {
+    expect(epcs.propertyName).toBe('param_changes')
+  });
+});

--- a/core/templates/pages/exploration-editor-page/services/exploration-param-changes.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-param-changes.service.spec.ts
@@ -24,7 +24,7 @@ import { UpgradedServices } from 'services/UpgradedServices';
 require('pages/exploration-editor-page/' +
   'services/exploration-param-changes.service.spec.ts');
 
-fdescribe('Exploration Param Changes Service', function() {
+describe('Exploration Param Changes Service', function() {
   var epcs = null;
 
   beforeEach(function() {

--- a/core/templates/pages/exploration-editor-page/services/exploration-param-changes.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-param-changes.service.spec.ts
@@ -22,7 +22,7 @@ import { UpgradedServices } from 'services/UpgradedServices';
 // ^^^ This block is to be removed.
 
 require('pages/exploration-editor-page/' +
-  'services/exploration-param-changes.service.spec.ts');
+  'services/exploration-param-changes.service.ts');
 
 describe('Exploration Param Changes Service', function() {
   var epcs = null;

--- a/core/templates/pages/exploration-editor-page/services/exploration-param-changes.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-param-changes.service.spec.ts
@@ -42,6 +42,6 @@ fdescribe('Exploration Param Changes Service', function() {
   });
 
   it('should test the child object properties', function() {
-    expect(epcs.propertyName).toBe('param_changes')
+    expect(epcs.propertyName).toBe('param_changes');
   });
 });


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #4057.
2. This PR does the following: Added a test file(exploration-param-changes.service.spec.ts) for exploration-param-changes.service.ts

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
