### PR TITLE
Fix #9014, #9016: Add empty callback function when modal is cancelled

### DIFF
--- a/core/templates/components/question-directives/questions-list/questions-list.directive.ts
+++ b/core/templates/components/question-directives/questions-list/questions-list.directive.ts
@@ -496,6 +496,10 @@ angular.module('oppia').directive('questionsList', [
                     });
                 }
               }
+            }, function() {
+              // Note to developers:
+              // This callback is triggered when the Cancel button is clicked.
+              // No further action is needed.
             });
           };
 
@@ -673,6 +677,10 @@ angular.module('oppia').directive('questionsList', [
                       modalInstance.result.then(function(commitMessage) {
                         returnModalObject.commitMessage = commitMessage;
                         $uibModalInstance.close(returnModalObject);
+                      }, function() {
+                        // Note to developers:
+                        // This callback is triggered when the Cancel button is
+                        // clicked. No further action is needed.
                       });
                     } else {
                       $uibModalInstance.close(returnModalObject);

--- a/core/templates/pages/community-dashboard-page/question-opportunities/question-opportunities.directive.ts
+++ b/core/templates/pages/community-dashboard-page/question-opportunities/question-opportunities.directive.ts
@@ -170,6 +170,10 @@ angular.module('oppia').directive('questionOpportunities', [
               if (AlertsService.warnings.length === 0) {
                 ctrl.createQuestion(result.skill, result.skillDifficulty);
               }
+            }, function() {
+              // Note to developers:
+              // This callback is triggered when the Cancel button is clicked.
+              // No further action is needed.
             });
           };
 

--- a/core/templates/pages/story-editor-page/editor-tab/story-editor.directive.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-editor.directive.ts
@@ -134,10 +134,14 @@ angular.module('oppia').directive('storyEditor', [
               ]
             });
 
-            modalInstance.result.then(function(title) {
+            modalInstance.result.then(function() {
               StoryUpdateService.deleteStoryNode($scope.story, nodeId);
               _initEditor();
               $scope.$broadcast('recalculateAvailableNodes');
+            }, function() {
+              // Note to developers:
+              // This callback is triggered when the Cancel button is clicked.
+              // No further action is needed.
             });
           };
 

--- a/core/templates/pages/story-editor-page/editor-tab/story-node-editor.directive.ts
+++ b/core/templates/pages/story-editor-page/editor-tab/story-node-editor.directive.ts
@@ -302,6 +302,10 @@ angular.module('oppia').directive('storyNodeEditor', [
               _recalculateAvailableNodes();
               $rootScope.$broadcast(
                 'storyGraphUpdated', $scope.story.getStoryContents());
+            }, function() {
+              // Note to developers:
+              // This callback is triggered when the Cancel button is clicked.
+              // No further action is needed.
             });
           };
 


### PR DESCRIPTION
## Overview
1. This PR fixes #9016 and fixes #9014.
2. This PR does the following: Adds empty callback methods for modals.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
