### PR TITLE
Fixes issue #3369: Resize editor to avoid overflowing when creator uses longer responses

### DIFF
--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.directive.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.directive.ts
@@ -54,7 +54,6 @@ angular.module('oppia').directive('ckEditor4Rte', [
         function resize() {
           var modal_width = parseInt($('.modal-header').width()) - 15;
           modal_width = modal_width.toString();
-
           $('.oppia-rte-resizer').css({
             'width': (modal_width + 'px')
            });
@@ -213,8 +212,6 @@ angular.module('oppia').directive('ckEditor4Rte', [
             .css('height', '24px')
             .css('width', '24px');
           ck.setData(wrapComponents(ngModel.$viewValue));
-
-
         });
 
         // Angular rendering of components confuses CKEditor's undo system, so

--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.directive.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.directive.ts
@@ -54,7 +54,7 @@ angular.module('oppia').directive('ckEditor4Rte', [
         var resize = function() {
           var modalWidth = $('.modal-header').width() - 15;
           $('.oppia-rte-resizer').css({
-            'width': (modalWidth.toString() + 'px')
+            width: (modalWidth.toString() + 'px')
           });
         };
         for (var i in editable) {

--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.directive.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.directive.ts
@@ -29,7 +29,8 @@ angular.module('oppia').directive('ckEditor4Rte', [
         uiConfig: '&'
       },
       template: '<div><div></div>' +
-                '<div contenteditable="true" class="oppia-rte-resizer oppia-rte">' +
+                '<div contenteditable="true" ' +
+                'class="oppia-rte-resizer oppia-rte">' +
                 '</div></div>',
       require: '?ngModel',
 
@@ -49,20 +50,18 @@ angular.module('oppia').directive('ckEditor4Rte', [
           }
         });
 
-        // Resize editor textbox to prevent responses from overflowing
-        var editable = document.getElementsByClassName('oppia-rte-resizer');
-        function resize() {
-          var modal_width = parseInt($('.modal-header').width()) - 15;
-          modal_width = modal_width.toString();
+        var editable = document.querySelectorAll('.oppia-rte-resizer');
+        var resize = function() {
+          var modalWidth = $('.modal-header').width() - 15;
           $('.oppia-rte-resizer').css({
-            'width': (modal_width + 'px')
-           });
-        }
+            'width': (modalWidth.toString() + 'px')
+          });
+        };
         for (var i in editable) {
-          editable[i].onchange = function() {
+          (<HTMLElement>editable[i]).onchange = function() {
             resize();
           };
-          editable[i].onclick = function() {
+          (<HTMLElement>editable[i]).onclick = function() {
             resize();
           };
         }

--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.directive.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.directive.ts
@@ -29,7 +29,7 @@ angular.module('oppia').directive('ckEditor4Rte', [
         uiConfig: '&'
       },
       template: '<div><div></div>' +
-                '<div contenteditable="true" class="oppia-rte">' +
+                '<div contenteditable="true" class="oppia-rte-resizer oppia-rte">' +
                 '</div></div>',
       require: '?ngModel',
 
@@ -48,6 +48,25 @@ angular.module('oppia').directive('ckEditor4Rte', [
             icons.push(componentDefn.iconDataUrl);
           }
         });
+
+        // Resize editor textbox to prevent responses from overflowing
+        var editable = document.getElementsByClassName('oppia-rte-resizer');
+        function resize() {
+          var modal_width = parseInt($('.modal-header').width()) - 15;
+          modal_width = modal_width.toString();
+
+          $('.oppia-rte-resizer').css({
+            'width': (modal_width + 'px')
+           });
+        }
+        for (var i in editable) {
+          editable[i].onchange = function() {
+            resize();
+          };
+          editable[i].onclick = function() {
+            resize();
+          };
+        }
 
         /**
          * Create rules to whitelist all the rich text components and
@@ -194,6 +213,8 @@ angular.module('oppia').directive('ckEditor4Rte', [
             .css('height', '24px')
             .css('width', '24px');
           ck.setData(wrapComponents(ngModel.$viewValue));
+
+
         });
 
         // Angular rendering of components confuses CKEditor's undo system, so


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #3369 .
2. This PR does the following: To fix the problem of long responses overflowing the creator's textbox as shown in the issue #3369 , I modified the ck-editor directive file so that the width of the "contenteditable" box always dynamically matches that of the "modal-header" class above it. I also adjusted this to be slightly smaller than the "modal-header" width by subtracting 15px to ensure the "x" closing sign at the top right does not overflow and remains visible. After manually testing with lengthy math latex equations, written responses, and varying window sizes, the box now appears to be able to resize appropriately. There were no error messages from the presubmit checks in the command line when I pushed these changes.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
