### PR TITLE
Add check for invalid emails

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,7 +21,7 @@ Abhimanyu Thakre <abhimanyuthakre@gmail.com>
 Abhishek Arya <abhishekarya286@gmail.com>
 Abhishek Kumar <anonims.ak@gmail.com>
 Abhishek Uniyal <abhishekuniyal09@gmail.com>
-acash mkj <31628272+acashmkj@users.noreply.github.com>
+Acash Mkj <acash.mkj@gmail.com>
 Adarsh Kumar <kumar.adarshluv99@gmail.com>
 Aditya Jain <adityajain.783@gmail.com>
 Ajo John <ajojohn555@gmail.com>
@@ -224,7 +224,7 @@ Rudra Sadhu <rdrsadhu@gmail.com>
 Sachin Gopal <sachin.gopal2015@vit.ac.in>
 Saeed Jassani <saeedjassani@gmail.com>
 Safwan Mansuri <safwanmansuri.ict17@gmail.com>
-Sagar Manohar <code247@users.noreply.github.com>
+Sagar Manohar <sagarmanohar24@gmail.com>
 Samara Trilling <samara.trilling@gmail.com>
 Samriddhi Mishra <samriddhi2958@gmail.com>
 Sandeep Dubey <dubeysandeep.in@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,7 +34,7 @@ Abhishek Arya <abhishekarya286@gmail.com>
 Abhishek Kumar <anonims.ak@gmail.com>
 Abhishek Uniyal <abhishekuniyal09@gmail.com>
 Abraham Mgowano <mgowano@google.com>
-acash mkj <31628272+acashmkj@users.noreply.github.com>
+Acash Mkj <acash.mkj@gmail.com>
 Adarsh Kumar <kumar.adarshluv99@gmail.com>
 Aditya Jain <adityajain.783@gmail.com>
 Ajay Sharma <ayejay.nsit@gmail.com>
@@ -255,7 +255,7 @@ Sachin Gopal <sachin.gopal2015@vit.ac.in>
 Saeed Jassani <saeedjassani@gmail.com>
 Safwan Mansuri <safwanmansuri.ict17@gmail.com>
 Sagang Wee <sagangwee@gmail.com>
-Sagar Manohar <code247@users.noreply.github.com>
+Sagar Manohar <sagarmanohar24@gmail.com>
 Samara Trilling <samara.trilling@gmail.com>
 Samriddhi Mishra <samriddhi2958@gmail.com>
 Sandeep Dubey <dubeysandeep.in@gmail.com>

--- a/core/templates/pages/about-page/about-page.directive.html
+++ b/core/templates/pages/about-page/about-page.directive.html
@@ -118,7 +118,7 @@
                 <li>Abhishek Kumar</li>
                 <li>Abhishek Uniyal</li>
                 <li>Abraham Mgowano</li>
-                <li>acash mkj</li>
+                <li>Acash Mkj</li>
                 <li>Adarsh Kumar</li>
                 <li>Aditya Jain</li>
                 <li>Ajay Sharma</li>

--- a/core/tests/release_sources/release_summary.md
+++ b/core/tests/release_sources/release_summary.md
@@ -38,7 +38,7 @@ This indicates that a migration may be needed
 
 ### Existing Authors:
 * Akshay Anand <akshayanand681@gmail.com>
-* Amey <43315144+amey-kudari@users.noreply.github.com>
+* Amey <amey-kudari@gmail.com>
 * Ankita Saxena <ankitasonu24@gmail.com>
 * Anubhav Sinha <anubhavsinha98@gmail.com>
 * Apurv Bajaj <apurvabajaj007@gmail.com>

--- a/release_constants.py
+++ b/release_constants.py
@@ -68,3 +68,5 @@ RELEASE_NOTES_EXAMPLE_URL = (
 JOBS_FORM_URL = 'https://goo.gl/forms/XIj00RJ2h5L55XzU2'
 
 OPPIA_DEV_GROUP_URL = 'https://groups.google.com/forum/#!forum/oppia-dev'
+
+INVALID_EMAIL_SUFFIX = 'users.noreply.github.com'

--- a/release_constants.py
+++ b/release_constants.py
@@ -70,3 +70,11 @@ JOBS_FORM_URL = 'https://goo.gl/forms/XIj00RJ2h5L55XzU2'
 OPPIA_DEV_GROUP_URL = 'https://groups.google.com/forum/#!forum/oppia-dev'
 
 INVALID_EMAIL_SUFFIX = 'users.noreply.github.com'
+
+NEW_AUTHORS_HEADER = '### New Authors:\n'
+EXISTING_AUTHORS_HEADER = '### Existing Authors:\n'
+NEW_CONTRIBUTORS_HEADER = '### New Contributors:\n'
+EMAIL_HEADER = '### Email C&P Blurbs about authors:\n'
+CHANGELOG_HEADER = '### Changelog:\n'
+COMMIT_HISTORY_HEADER = '### Commit History:\n'
+ISSUES_HEADER = '### Issues mentioned in commits:\n'

--- a/scripts/release_scripts/generate_release_info.py
+++ b/scripts/release_scripts/generate_release_info.py
@@ -354,20 +354,20 @@ def main(personal_access_token):
         existing_author_names = [name for name, _ in existing_authors]
 
         # TODO(apb7): duplicate author handling due to email changes.
-        out.write('\n### New Authors:\n')
+        out.write('\n%s' % release_constants.NEW_AUTHORS_HEADER)
         for name, email in new_authors:
             out.write('* %s <%s>\n' % (name, email))
 
-        out.write('\n### Existing Authors:\n')
+        out.write('\n%s' % release_constants.EXISTING_AUTHORS_HEADER)
         for name, email in existing_authors:
             out.write('* %s <%s>\n' % (name, email))
 
-        out.write('\n### New Contributors:\n')
+        out.write('\n%s' % release_constants.NEW_CONTRIBUTORS_HEADER)
         for name, email in new_authors:
             out.write('* %s <%s>\n' % (name, email))
 
         # Generate the author sections of the email.
-        out.write('\n### Email C&P Blurbs about authors:\n')
+        out.write('\n%s' % release_constants.EMAIL_HEADER)
         new_author_comma_list = (
             '%s, and %s' % (', '.join(
                 new_author_names[:-1]), new_author_names[-1]))
@@ -382,20 +382,20 @@ def main(personal_access_token):
             'possible.``\n' % existing_author_comma_list)
 
         if personal_access_token:
-            out.write('\n### Changelog:\n')
+            out.write('\n%s' % release_constants.CHANGELOG_HEADER)
             for category in categorized_pr_titles:
                 out.write('%s\n' % category)
                 for pr_title in categorized_pr_titles[category]:
                     out.write('* %s\n' % pr_title)
                 out.write('\n')
 
-        out.write('\n### Commit History:\n')
+        out.write('\n%s' % release_constants.COMMIT_HISTORY_HEADER)
         for name, title in [(log.author, log.message.split('\n\n')[0])
                             for log in new_release_logs]:
             out.write('* %s\n' % title)
 
         if issue_links:
-            out.write('\n### Issues mentioned in commits:\n')
+            out.write('\n%s' % release_constants.ISSUES_HEADER)
             for link in issue_links:
                 out.write('* [%s](%s)\n' % (link, link))
 

--- a/scripts/release_scripts/generate_release_info_test.py
+++ b/scripts/release_scripts/generate_release_info_test.py
@@ -405,5 +405,5 @@ class GenerateReleaseInfoTests(test_utils.GenericTestBase):
             expected_lines = f.readlines()
         with python_utils.open_file(tmp_file.name, 'r') as f:
             actual_lines = f.readlines()
-        update_changelog_and_credits.check_ordering_of_sections(actual_lines)
+        update_changelog_and_credits.is_order_of_sections_valid(actual_lines)
         self.assertEqual(actual_lines, expected_lines)

--- a/scripts/release_scripts/generate_release_updates.py
+++ b/scripts/release_scripts/generate_release_updates.py
@@ -102,7 +102,9 @@ def get_new_authors_and_contributors_mail_ids():
         release_summary_lines = f.readlines()
 
     new_authors_and_contributors_mail_ids = []
-    for line_text in ['### New Authors:\n', '### New Contributors:\n']:
+    for line_text in [
+            release_constants.NEW_AUTHORS_HEADER,
+            release_constants.NEW_CONTRIBUTORS_HEADER]:
         start_index = release_summary_lines.index(line_text)
         end_index = start_index
         for index, line in enumerate(release_summary_lines[start_index + 1:]):

--- a/scripts/release_scripts/update_changelog_and_credits.py
+++ b/scripts/release_scripts/update_changelog_and_credits.py
@@ -96,7 +96,7 @@ def update_sorted_file(filepath, new_list):
             f.write(line)
 
 
-def check_ordering_of_sections(release_summary_lines):
+def is_order_of_sections_valid(release_summary_lines):
     """Checks that the ordering of sections in release_summary file
     matches the expected ordering.
 
@@ -455,26 +455,27 @@ def get_release_summary_lines():
     In either case, the user will be asked to update the release
     summary file and the lines will be re-read.
     """
-    is_invalid_email_present = True
-    is_ordering_invalid = True
-    while is_invalid_email_present or is_ordering_invalid:
+    invalid_email_is_present = True
+    ordering_is_invalid = True
+    while invalid_email_is_present or ordering_is_invalid:
         release_summary_file = python_utils.open_file(
             release_constants.RELEASE_SUMMARY_FILEPATH, 'r')
         release_summary_lines = release_summary_file.readlines()
-        is_invalid_email_present = any(
+        invalid_email_is_present = any(
             release_constants.INVALID_EMAIL_SUFFIX in line
             for line in release_summary_lines)
-        if is_invalid_email_present:
+        if invalid_email_is_present:
             common.ask_user_to_confirm(
                 'The release summary file contains emails of the form: %s '
-                'Please replace them with correct emails.' % (
+                'Please replace them with the correct emails.' % (
                     release_constants.INVALID_EMAIL_SUFFIX))
-        is_ordering_invalid = not(
-            check_ordering_of_sections(release_summary_lines))
-        if is_ordering_invalid:
+        ordering_is_invalid = not(
+            is_order_of_sections_valid(release_summary_lines))
+        if ordering_is_invalid:
             common.ask_user_to_confirm(
-                'Please fix the ordering in release summary file.')
-        if is_invalid_email_present or is_ordering_invalid:
+                'Please fix the ordering in release summary file. '
+                '(See error messages above.)')
+        if invalid_email_is_present or ordering_is_invalid:
             common.ask_user_to_confirm(
                 'Please save the file: %s with all the changes that '
                 'you have made.' % (

--- a/scripts/release_scripts/update_changelog_and_credits.py
+++ b/scripts/release_scripts/update_changelog_and_credits.py
@@ -454,15 +454,15 @@ def create_branch(
 
 
 def is_invalid_email_present(release_summary_lines):
-    """Returns new contributors and authors from the release
-    summary lines.
+    """Checks if any invalid email is present in the list of
+    new authors and contributors.
 
     Args:
         release_summary_lines: list(str). List of lines in
             ../release_summary.md.
 
     Returns:
-        list(str). A list of new contributors and authors.
+        bool. Whether invalid email is present or not.
     """
     authors_start_index = release_summary_lines.index(
         release_constants.NEW_AUTHORS_HEADER) + 1
@@ -486,6 +486,9 @@ def get_release_summary_lines():
     incorrect email is present or ordering of sections is invalid.
     In either case, the user will be asked to update the release
     summary file and the lines will be re-read.
+
+    Returns:
+        list(str). List of lines in ../release_summary.md.
     """
     invalid_email_is_present = True
     ordering_is_invalid = True

--- a/scripts/release_scripts/update_changelog_and_credits.py
+++ b/scripts/release_scripts/update_changelog_and_credits.py
@@ -55,7 +55,7 @@ GIT_CMD_CHECKOUT = 'git checkout -- %s %s %s %s' % (
 # changelog and credits performed using this script will work
 # correctly only if the ordering of sections in release summary
 # file matches this expected ordering.
-EXPECTED_ORDERING = {
+EXPECTED_ORDERING_DICT = {
     release_constants.CHANGELOG_HEADER: release_constants.COMMIT_HISTORY_HEADER,
     release_constants.NEW_AUTHORS_HEADER: (
         release_constants.EXISTING_AUTHORS_HEADER),
@@ -115,7 +115,7 @@ def is_order_of_sections_valid(release_summary_lines):
     sections = [
         line for line in release_summary_lines if line.startswith('###')
     ]
-    for section, next_section in EXPECTED_ORDERING.items():
+    for section, next_section in EXPECTED_ORDERING_DICT.items():
         if section not in sections:
             python_utils.PRINT(
                 'Expected release_summary to have %s section to ensure '
@@ -476,9 +476,12 @@ def is_invalid_email_present(release_summary_lines):
     new_contributors = (
         release_summary_lines[contributors_start_index:contributors_end_index])
     new_email_ids = new_authors + new_contributors
-    return any(
-        release_constants.INVALID_EMAIL_SUFFIX in id
-        for id in new_email_ids)
+    invalid_email_ids = [
+        email_id for email_id in new_email_ids
+        if release_constants.INVALID_EMAIL_SUFFIX in email_id]
+    python_utils.PRINT(
+        'Following email ids are invalid: %s' % invalid_email_ids)
+    return bool(invalid_email_ids)
 
 
 def get_release_summary_lines():
@@ -501,7 +504,8 @@ def get_release_summary_lines():
         if invalid_email_is_present:
             common.ask_user_to_confirm(
                 'The release summary file contains emails of the form: %s '
-                'Please replace them with the correct emails.' % (
+                'Please replace them with the correct emails. '
+                '(See error messages above.)' % (
                     release_constants.INVALID_EMAIL_SUFFIX))
         ordering_is_invalid = not(
             is_order_of_sections_valid(release_summary_lines))

--- a/scripts/release_scripts/update_changelog_and_credits_test.py
+++ b/scripts/release_scripts/update_changelog_and_credits_test.py
@@ -289,7 +289,7 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
             invalid_ordering)
         with ordering_swap:
             self.assertFalse(
-                update_changelog_and_credits.check_ordering_of_sections(
+                update_changelog_and_credits.is_order_of_sections_valid(
                     release_summary_lines))
 
     def test_invalid_ordering_of_sections_in_release_summary(self):
@@ -302,7 +302,7 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
             invalid_ordering)
         with ordering_swap:
             self.assertFalse(
-                update_changelog_and_credits.check_ordering_of_sections(
+                update_changelog_and_credits.is_order_of_sections_valid(
                     release_summary_lines))
 
     def test_missing_span_in_about_page(self):
@@ -434,12 +434,12 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
         check_function_calls = {
             'readlines_gets_called': 0,
             'ask_user_to_confirm_gets_called': 0,
-            'check_ordering_of_sections_gets_called': 0
+            'is_order_of_sections_valid_gets_called': 0
         }
         expected_check_function_calls = {
             'readlines_gets_called': 2,
             'ask_user_to_confirm_gets_called': 3,
-            'check_ordering_of_sections_gets_called': 2
+            'is_order_of_sections_valid_gets_called': 2
         }
         class MockFile(python_utils.OBJECT):
             def readlines(self):
@@ -455,11 +455,11 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
             return MockFile()
         def mock_ask_user_to_confirm(unused_msg):
             check_function_calls['ask_user_to_confirm_gets_called'] += 1
-        def mock_check_ordering_of_sections(unused_release_summary_lines):
+        def mock_is_order_of_sections_valid(unused_release_summary_lines):
             check_function_calls[
-                'check_ordering_of_sections_gets_called'] += 1
+                'is_order_of_sections_valid_gets_called'] += 1
             if check_function_calls[
-                    'check_ordering_of_sections_gets_called'] == 1:
+                    'is_order_of_sections_valid_gets_called'] == 1:
                 return False
             return True
 
@@ -467,8 +467,8 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
         ask_user_swap = self.swap(
             common, 'ask_user_to_confirm', mock_ask_user_to_confirm)
         check_order_swap = self.swap(
-            update_changelog_and_credits, 'check_ordering_of_sections',
-            mock_check_ordering_of_sections)
+            update_changelog_and_credits, 'is_order_of_sections_valid',
+            mock_is_order_of_sections_valid)
         with open_file_swap, ask_user_swap, check_order_swap:
             self.assertEqual(
                 correct_lines,

--- a/scripts/release_scripts/update_changelog_and_credits_test.py
+++ b/scripts/release_scripts/update_changelog_and_credits_test.py
@@ -287,13 +287,10 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
         ordering_swap = self.swap(
             update_changelog_and_credits, 'EXPECTED_ORDERING',
             invalid_ordering)
-        with ordering_swap, self.assertRaisesRegexp(
-            Exception, (
-                'Expected release_summary to have ### section1: section to '
-                'ensure that automatic updates to changelog and credits are '
-                'correct.')):
-            update_changelog_and_credits.check_ordering_of_sections(
-                release_summary_lines)
+        with ordering_swap:
+            self.assertFalse(
+                update_changelog_and_credits.check_ordering_of_sections(
+                    release_summary_lines))
 
     def test_invalid_ordering_of_sections_in_release_summary(self):
         release_summary_lines = read_from_file(MOCK_RELEASE_SUMMARY_FILEPATH)
@@ -303,13 +300,10 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
         ordering_swap = self.swap(
             update_changelog_and_credits, 'EXPECTED_ORDERING',
             invalid_ordering)
-        with ordering_swap, self.assertRaisesRegexp(
-            Exception, (
-                'Expected ### New Authors: section to be followed by ### '
-                'section2: section in release_summary to ensure that automatic '
-                'updates to changelog and credits are correct.')):
-            update_changelog_and_credits.check_ordering_of_sections(
-                release_summary_lines)
+        with ordering_swap:
+            self.assertFalse(
+                update_changelog_and_credits.check_ordering_of_sections(
+                    release_summary_lines))
 
     def test_missing_span_in_about_page(self):
         about_page_lines = [
@@ -428,6 +422,59 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
                             'Please re-run this script.')):
                         update_changelog_and_credits.main()
 
+    def test_get_release_summary_lines(self):
+        with python_utils.open_file(MOCK_RELEASE_SUMMARY_FILEPATH, 'r') as f:
+            correct_lines = f.readlines()
+            wrong_lines = []
+            for line in correct_lines:
+                line = line.replace(
+                    'gmail.com', release_constants.INVALID_EMAIL_SUFFIX)
+                wrong_lines.append(line)
+
+        check_function_calls = {
+            'readlines_gets_called': 0,
+            'ask_user_to_confirm_gets_called': 0,
+            'check_ordering_of_sections_gets_called': 0
+        }
+        expected_check_function_calls = {
+            'readlines_gets_called': 2,
+            'ask_user_to_confirm_gets_called': 3,
+            'check_ordering_of_sections_gets_called': 2
+        }
+        class MockFile(python_utils.OBJECT):
+            def readlines(self):
+                """Read lines of the file object."""
+                return mock_readlines()
+        def mock_readlines():
+            check_function_calls['readlines_gets_called'] += 1
+            if check_function_calls['readlines_gets_called'] == 2:
+                return correct_lines
+            return wrong_lines
+
+        def mock_open_file(unused_path, unused_mode):
+            return MockFile()
+        def mock_ask_user_to_confirm(unused_msg):
+            check_function_calls['ask_user_to_confirm_gets_called'] += 1
+        def mock_check_ordering_of_sections(unused_release_summary_lines):
+            check_function_calls[
+                'check_ordering_of_sections_gets_called'] += 1
+            if check_function_calls[
+                    'check_ordering_of_sections_gets_called'] == 1:
+                return False
+            return True
+
+        open_file_swap = self.swap(python_utils, 'open_file', mock_open_file)
+        ask_user_swap = self.swap(
+            common, 'ask_user_to_confirm', mock_ask_user_to_confirm)
+        check_order_swap = self.swap(
+            update_changelog_and_credits, 'check_ordering_of_sections',
+            mock_check_ordering_of_sections)
+        with open_file_swap, ask_user_swap, check_order_swap:
+            self.assertEqual(
+                correct_lines,
+                update_changelog_and_credits.get_release_summary_lines())
+        self.assertEqual(check_function_calls, expected_check_function_calls)
+
     def test_create_branch(self):
         check_function_calls = {
             'get_branch_gets_called': False,
@@ -497,7 +544,7 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
             'update_authors_gets_called': False,
             'update_contributors_gets_called': False,
             'update_developer_names_gets_called': False,
-            'check_ordering_of_sections_gets_called': False,
+            'get_release_summary_lines_gets_called': False,
             'create_branch_gets_called': False,
             'open_new_tab_in_browser_if_possible_gets_called': False
         }
@@ -509,7 +556,7 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
             'update_authors_gets_called': True,
             'update_contributors_gets_called': True,
             'update_developer_names_gets_called': True,
-            'check_ordering_of_sections_gets_called': True,
+            'get_release_summary_lines_gets_called': True,
             'create_branch_gets_called': True,
             'open_new_tab_in_browser_if_possible_gets_called': True
         }
@@ -536,9 +583,8 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
             check_function_calls['update_contributors_gets_called'] = True
         def mock_update_developer_names(unused_release_summary_lines):
             check_function_calls['update_developer_names_gets_called'] = True
-        def mock_check_ordering_of_sections(unused_release_summary_lines):
-            check_function_calls[
-                'check_ordering_of_sections_gets_called'] = True
+        def mock_get_release_summary_lines():
+            check_function_calls['get_release_summary_lines_gets_called'] = True
         def mock_create_branch(
                 unused_repo_fork, unused_target_branch, unused_github_username,
                 unused_current_release_version_number):
@@ -574,9 +620,9 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
         update_developer_names_swap = self.swap(
             update_changelog_and_credits, 'update_developer_names',
             mock_update_developer_names)
-        check_order_swap = self.swap(
-            update_changelog_and_credits, 'check_ordering_of_sections',
-            mock_check_ordering_of_sections)
+        get_lines_swap = self.swap(
+            update_changelog_and_credits, 'get_release_summary_lines',
+            mock_get_release_summary_lines)
         create_branch_swap = self.swap(
             update_changelog_and_credits, 'create_branch', mock_create_branch)
         input_swap = self.swap(python_utils, 'INPUT', mock_input)
@@ -590,7 +636,7 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
             with self.main_swap, self.getpass_swap, input_swap, check_prs_swap:
                 with remove_updates_swap, update_authors_swap, open_tab_swap:
                     with update_changelog_swap, update_contributors_swap:
-                        with update_developer_names_swap, check_order_swap:
+                        with update_developer_names_swap, get_lines_swap:
                             with create_branch_swap, get_repo_swap:
                                 with blocking_bug_swap, get_org_swap:
                                     with get_org_repo_swap:

--- a/scripts/release_scripts/update_changelog_and_credits_test.py
+++ b/scripts/release_scripts/update_changelog_and_credits_test.py
@@ -285,7 +285,7 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
             '### section1:\n': '### section2: \n'
         }
         ordering_swap = self.swap(
-            update_changelog_and_credits, 'EXPECTED_ORDERING',
+            update_changelog_and_credits, 'EXPECTED_ORDERING_DICT',
             invalid_ordering)
         with ordering_swap:
             self.assertFalse(
@@ -298,7 +298,7 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
             release_constants.NEW_AUTHORS_HEADER: '### section2: \n'
         }
         ordering_swap = self.swap(
-            update_changelog_and_credits, 'EXPECTED_ORDERING',
+            update_changelog_and_credits, 'EXPECTED_ORDERING_DICT',
             invalid_ordering)
         with ordering_swap:
             self.assertFalse(

--- a/scripts/release_scripts/update_changelog_and_credits_test.py
+++ b/scripts/release_scripts/update_changelog_and_credits_test.py
@@ -295,7 +295,7 @@ class ChangelogAndCreditsUpdateTests(test_utils.GenericTestBase):
     def test_invalid_ordering_of_sections_in_release_summary(self):
         release_summary_lines = read_from_file(MOCK_RELEASE_SUMMARY_FILEPATH)
         invalid_ordering = {
-            '### New Authors:\n': '### section2: \n'
+            release_constants.NEW_AUTHORS_HEADER: '### section2: \n'
         }
         ordering_swap = self.swap(
             update_changelog_and_credits, 'EXPECTED_ORDERING',


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of N/A.
2. This PR does the following:
    - Adds a new check to ensure invalid emails are not present in release summary.
    - Updates the current checks to repeatedly ask user to fix the issues instead of exiting with an exception.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
