### PR TITLE
Add check for version length

### DIFF
--- a/scripts/release_scripts/deploy.py
+++ b/scripts/release_scripts/deploy.py
@@ -480,7 +480,8 @@ def execute_deployment():
         raise Exception('Current release version has \'.\' character.')
 
     assert len(current_release_version) <= 25, (
-        'Length of version should be less than equal to 25 characters.')
+        'The length of the "version" arg should be less than or '
+        'equal to 25 characters.')
 
     # Do prerequisite checks.
     common.require_cwd_to_be_oppia()

--- a/scripts/release_scripts/deploy.py
+++ b/scripts/release_scripts/deploy.py
@@ -479,6 +479,9 @@ def execute_deployment():
     if '.' in current_release_version:
         raise Exception('Current release version has \'.\' character.')
 
+    assert len(current_release_version) <= 25, (
+        'Length of version should be less than equal to 25 characters.')
+
     # Do prerequisite checks.
     common.require_cwd_to_be_oppia()
     common.ensure_release_scripts_folder_exists_and_is_up_to_date()

--- a/scripts/release_scripts/deploy_test.py
+++ b/scripts/release_scripts/deploy_test.py
@@ -208,12 +208,12 @@ class DeployTests(test_utils.GenericTestBase):
         args_swap = self.swap(
             sys, 'argv', [
                 'deploy.py', '--app_name=oppiatestserver',
-                '--version=release-1.2.3-invalid-custom'])
+                '--version=release-1.2.3-invalid-too-long'])
         with self.get_branch_swap, args_swap, self.install_swap:
             with self.assertRaisesRegexp(
                 AssertionError,
-                'Length of version should be less than equal to 25 '
-                'characters.'):
+                'The length of the "version" arg should be less than or '
+                'equal to 25 characters.'):
                 deploy.execute_deployment()
 
     def test_invalid_last_commit_msg(self):

--- a/scripts/release_scripts/deploy_test.py
+++ b/scripts/release_scripts/deploy_test.py
@@ -204,6 +204,18 @@ class DeployTests(test_utils.GenericTestBase):
                 'Current release version has \'.\' character.'):
                 deploy.execute_deployment()
 
+    def test_invalid_release_version_length(self):
+        args_swap = self.swap(
+            sys, 'argv', [
+                'deploy.py', '--app_name=oppiatestserver',
+                '--version=release-1.2.3-invalid-custom'])
+        with self.get_branch_swap, args_swap, self.install_swap:
+            with self.assertRaisesRegexp(
+                AssertionError,
+                'Length of version should be less than equal to 25 '
+                'characters.'):
+                deploy.execute_deployment()
+
     def test_invalid_last_commit_msg(self):
         args_swap = self.swap(
             sys, 'argv', ['deploy.py', '--app_name=oppiaserver'])


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of N/A.
2. This PR does the following: Adds a check to ensure version used in deployment has length less than equal to 25.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
