### PR TITLE
Fix #9137: Changed google app engine path to be absolute path

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -46,9 +46,10 @@ COVERAGE_VERSION = '4.5.4'
 RELEASE_BRANCH_NAME_PREFIX = 'release-'
 CURR_DIR = os.path.abspath(os.getcwd())
 OPPIA_TOOLS_DIR = os.path.join(CURR_DIR, os.pardir, 'oppia_tools')
+OPPIA_TOOLS_DIR_ABS_PATH = os.path.abspath(OPPIA_TOOLS_DIR)
 THIRD_PARTY_DIR = os.path.join(CURR_DIR, 'third_party')
 GOOGLE_APP_ENGINE_HOME = os.path.join(
-    OPPIA_TOOLS_DIR, 'google_appengine_1.9.67', 'google_appengine')
+    OPPIA_TOOLS_DIR_ABS_PATH, 'google_appengine_1.9.67', 'google_appengine')
 GOOGLE_CLOUD_SDK_HOME = os.path.join(
     OPPIA_TOOLS_DIR, 'google-cloud-sdk-251.0.0', 'google-cloud-sdk')
 NODE_PATH = os.path.join(OPPIA_TOOLS_DIR, 'node-%s' % NODE_VERSION)

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -150,13 +150,13 @@ def ensure_screenshots_dir_is_removed():
 
 def cleanup():
     """Kill the running subprocesses and server fired in this program."""
-    dev_appserver_path = '%s/' % common.GOOGLE_APP_ENGINE_HOME
+    google_app_engine_path = '%s/' % common.GOOGLE_APP_ENGINE_HOME
     webdriver_download_path = '%s/downloads' % WEBDRIVER_HOME_PATH
     if common.is_windows_os():
         # In windows system, the java command line will use absolute path.
         webdriver_download_path = os.path.abspath(webdriver_download_path)
     processes_to_kill = [
-        '.*%s.*' % re.escape(dev_appserver_path),
+        '.*%s.*' % re.escape(google_app_engine_path),
         '.*%s.*' % re.escape(webdriver_download_path)
     ]
     for p in SUBPROCESSES:

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -150,7 +150,7 @@ def ensure_screenshots_dir_is_removed():
 
 def cleanup():
     """Kill the running subprocesses and server fired in this program."""
-    dev_appserver_path = '%s/dev_appserver.py' % common.GOOGLE_APP_ENGINE_HOME
+    dev_appserver_path = '%s/' % common.GOOGLE_APP_ENGINE_HOME
     webdriver_download_path = '%s/downloads' % WEBDRIVER_HOME_PATH
     if common.is_windows_os():
         # In windows system, the java command line will use absolute path.

--- a/scripts/run_e2e_tests_test.py
+++ b/scripts/run_e2e_tests_test.py
@@ -143,7 +143,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         subprocess_swap = self.swap(run_e2e_tests, 'SUBPROCESSES', [])
 
 
-        dev_appserver_path = '%s/dev_appserver.py' % (
+        dev_appserver_path = '%s/' % (
             common.GOOGLE_APP_ENGINE_HOME)
         webdriver_download_path = '%s/downloads' % (
             run_e2e_tests.WEBDRIVER_HOME_PATH)
@@ -187,7 +187,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
 
         subprocess_swap = self.swap(run_e2e_tests, 'SUBPROCESSES', [])
 
-        dev_appserver_path = '%s/dev_appserver.py' % (
+        dev_appserver_path = '%s/' % (
             common.GOOGLE_APP_ENGINE_HOME)
         webdriver_download_path = '%s/downloads' % (
             run_e2e_tests.WEBDRIVER_HOME_PATH)

--- a/scripts/run_e2e_tests_test.py
+++ b/scripts/run_e2e_tests_test.py
@@ -143,12 +143,12 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         subprocess_swap = self.swap(run_e2e_tests, 'SUBPROCESSES', [])
 
 
-        dev_appserver_path = '%s/' % (
+        google_app_engine_path = '%s/' % (
             common.GOOGLE_APP_ENGINE_HOME)
         webdriver_download_path = '%s/downloads' % (
             run_e2e_tests.WEBDRIVER_HOME_PATH)
         process_pattern = [
-            ('.*%s.*' % re.escape(dev_appserver_path),),
+            ('.*%s.*' % re.escape(google_app_engine_path),),
             ('.*%s.*' % re.escape(webdriver_download_path),)
         ]
         def mock_kill_process_based_on_regex(unused_regex):
@@ -187,12 +187,12 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
 
         subprocess_swap = self.swap(run_e2e_tests, 'SUBPROCESSES', [])
 
-        dev_appserver_path = '%s/' % (
+        google_app_engine_path = '%s/' % (
             common.GOOGLE_APP_ENGINE_HOME)
         webdriver_download_path = '%s/downloads' % (
             run_e2e_tests.WEBDRIVER_HOME_PATH)
         process_pattern = [
-            ('.*%s.*' % re.escape(dev_appserver_path),),
+            ('.*%s.*' % re.escape(google_app_engine_path),),
             ('.*%s.*' % re.escape(webdriver_download_path),)
         ]
         expected_pattern = process_pattern[:]


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #9137 
2. This PR does the following: The problem was that we match the processes to close using regex and the process had name like
`... /oppia_tools/google_app_engine.....`
and the process we were matching was something like
`... /oppia/../oppia_tools/google_app_engine ....`

So these didn't match and the process didn't close.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
