### PR TITLE
Update release scripts to address concerns around clarity of instructions

### DIFF
--- a/scripts/release_scripts/generate_release_updates.py
+++ b/scripts/release_scripts/generate_release_updates.py
@@ -126,6 +126,8 @@ def prompt_user_to_send_announcement_email():
     """
     new_contributors_mail_ids = (', ').join(
         get_new_authors_and_contributors_mail_ids())
+    release_version = common.get_current_release_version_number(
+        common.get_current_branch_name())
     common.open_new_tab_in_browser_if_possible(
         'https://www.gmail.com')
     common.ask_user_to_confirm(
@@ -133,9 +135,11 @@ def prompt_user_to_send_announcement_email():
         '   TO: oppia-dev@googlegroups.com\n'
         '   BCC: oppia@googlegroups.com, '
         'oppia-announce@googlegroups.com, %s\n'
+        'with the following subject: "Announcing release v%s of Oppia!"'
         'Please make sure to check that the mail ids of new authors '
         'and contributors are correct.\n' % (
-            RELEASE_MAIL_MESSAGE_FILEPATH, new_contributors_mail_ids))
+            RELEASE_MAIL_MESSAGE_FILEPATH, new_contributors_mail_ids,
+            release_version))
     common.open_new_tab_in_browser_if_possible(
         'https://groups.google.com/forum/#!categories/oppia/announcements')
     common.ask_user_to_confirm('Add announcements label to the email sent.\n')
@@ -171,14 +175,16 @@ def prepare_for_next_release():
         'Send the following message to oppia-dev:\n\n'
         'Hi all, This is an update for the next month\'s release. '
         'The next month release cut is [Add release cut date for next month]. '
-        'Make sure you plan your tasks accordingly. Thanks!\n')
+        'Make sure you plan your tasks accordingly. Thanks!\n'
+        'The subject for the message: Updates for next release\n')
     common.ask_user_to_confirm(
         'Send the following message to oppia-dev:\n\n'
         'Hi all, This is a reminder to fill in the job requests '
         'here: %s if you are planning to run your job in the next release. '
         'Please fill in the requests by [Add a deadline which is at least 7 '
-        'days before the next release cut]. Thanks!\n' % (
-            release_constants.JOBS_FORM_URL))
+        'days before the next release cut]. Thanks!\n'
+        'The subject for the message: Deadline for job requests for '
+        'next release\n' % release_constants.JOBS_FORM_URL)
 
 
 def main():

--- a/scripts/release_scripts/generate_release_updates.py
+++ b/scripts/release_scripts/generate_release_updates.py
@@ -184,7 +184,7 @@ def prepare_for_next_release():
         'Please fill in the requests by [Add a deadline which is at least 7 '
         'days before the next release cut]. Thanks!\n'
         'The subject for the message: Deadline for job requests for '
-        'next release\n' % release_constants.JOBS_FORM_URL)
+        'the next release\n' % release_constants.JOBS_FORM_URL)
 
 
 def main():

--- a/scripts/release_scripts/generate_release_updates_test.py
+++ b/scripts/release_scripts/generate_release_updates_test.py
@@ -112,7 +112,7 @@ class GenerateReleaseUpdatesTests(test_utils.GenericTestBase):
             generate_release_updates,
             'get_new_authors_and_contributors_mail_ids',
             mock_get_new_authors_and_contributors_mail_ids)
-        with self.input_swap, open_tab_swap:
+        with self.branch_name_swap, self.input_swap, open_tab_swap:
             with get_new_authors_and_contributors_mail_ids_swap:
                 (
                     generate_release_updates

--- a/scripts/release_scripts/update_configs.py
+++ b/scripts/release_scripts/update_configs.py
@@ -199,7 +199,7 @@ def main(personal_access_token):
         raise Exception(e)
 
     common.ask_user_to_confirm(
-        'Done! Please check feconf.py and assetes/constants.ts to ensure that '
+        'Done! Please check feconf.py and assets/constants.ts to ensure that '
         'the changes made are correct. Specifically verify that the '
         'MAILGUN_API_KEY is updated correctly and other config changes '
         'are corresponding to %s and %s.\n' % (

--- a/scripts/release_scripts/update_configs.py
+++ b/scripts/release_scripts/update_configs.py
@@ -199,7 +199,7 @@ def main(personal_access_token):
         raise Exception(e)
 
     common.ask_user_to_confirm(
-        'Done! Please check feconf.py and constants.ts to ensure that '
+        'Done! Please check feconf.py and assetes/constants.ts to ensure that '
         'the changes made are correct. Specifically verify that the '
         'MAILGUN_API_KEY is updated correctly and other config changes '
         'are corresponding to %s and %s.\n' % (

--- a/scripts/release_scripts/update_configs.py
+++ b/scripts/release_scripts/update_configs.py
@@ -199,4 +199,8 @@ def main(personal_access_token):
         raise Exception(e)
 
     common.ask_user_to_confirm(
-        'Done! Please check manually to ensure all the changes are correct.')
+        'Done! Please check feconf.py and constants.ts to ensure that '
+        'the changes made are correct. Specifically verify that the '
+        'MAILGUN_API_KEY is updated correctly and other config changes '
+        'are corresponding to %s and %s.\n' % (
+            FECONF_CONFIG_PATH, CONSTANTS_CONFIG_PATH))


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of N/A.
2. This PR does the following:

   - Updates mail messages in all scripts to have a subject.
   - Updates instructions in `update_configs` script to clarify the behaviour which user needs to check.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
