### PR TITLE
Fixed whitespace in the rte in chapter outline

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -547,6 +547,10 @@ p:last-child {
   margin-bottom: 18px;
 }
 
+.oppia-rte p:last-child {
+  margin: 0px;
+}
+
 .oppia-rte ol, .oppia-rte ul, .oppia-rte-editor ol, .oppia-rte-editor ul {
   line-height: 1.846;
   margin-bottom: 18px;

--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -547,10 +547,6 @@ p:last-child {
   margin-bottom: 18px;
 }
 
-.oppia-rte p:last-child {
-  margin: 0px;
-}
-
 .oppia-rte ol, .oppia-rte ul, .oppia-rte-editor ol, .oppia-rte-editor ul {
   line-height: 1.846;
   margin-bottom: 18px;
@@ -1867,6 +1863,10 @@ pre.oppia-pre-wrapped-text {
 }
 .oppia-rte-viewer > p:last-child {
   margin-bottom: 0;
+}
+
+.oppia-rte p:last-child {
+  margin: 0px;
 }
 
 .oppia-shadow-preview-card .oppia-rte-viewer > p:first-child {

--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -541,6 +541,12 @@ p:last-child {
   font-size: 1em !important;
 }
 
+.oppia-rte p {
+  line-height: 1.2;
+  margin-top: 0px;
+  margin-bottom: 18px;
+}
+
 .oppia-rte ol, .oppia-rte ul, .oppia-rte-editor ol, .oppia-rte-editor ul {
   line-height: 1.846;
   margin-bottom: 18px;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

~1. This PR fixes or fixes part of #[fill_in_number_here].~
This PR does the following: Fix the weird whitespace in the rte in chapter outline. This was caused due to the css 
```css
.oppia-long-text p {
  line-height: 1.4;
  /* The following should be the same as the line-height (1.4). */
  margin: 1.4em 0;
}
```
Because the story editor in a card with class `oppia-long-text` and the text in rte in wrapped in \<p\> tags.

So, I've written css for overriding these values to the default one's.

#### Before
![before](https://user-images.githubusercontent.com/36989112/80647995-052bcd80-8a8d-11ea-9907-9c67ba2044f9.png)

#### After
![after](https://user-images.githubusercontent.com/36989112/80648012-0e1c9f00-8a8d-11ea-908b-37cca1413b07.png)


## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
