### PR TITLE
Fix #9228 : Fixing subtopic card overflow

### DIFF
--- a/core/templates/pages/topic-editor-page/subtopics-list-tab/subtopics-list-tab.directive.html
+++ b/core/templates/pages/topic-editor-page/subtopics-list-tab/subtopics-list-tab.directive.html
@@ -105,7 +105,7 @@
   }
   subtopics-list-tab .subtopics-tab {
     display: flex;
-    height: 80vh;
+    height: auto;
     margin: 6vh 10vh 0 10vh;
   }
   subtopics-list-tab h4 {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #9228 .
2. This PR changes removes the height limitation of 80vh.
**Old:**
![image](https://user-images.githubusercontent.com/30312043/80925889-25bb9680-8db1-11ea-9691-076890496bd6.png)
**New:**
![image](https://user-images.githubusercontent.com/30312043/80925906-3966fd00-8db1-11ea-92a2-e22c289666c9.png)
![image](https://user-images.githubusercontent.com/30312043/80925931-5dc2d980-8db1-11ea-99f5-cbf75edd1ebe.png)


## Essential Checklist

- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The linter/Karma presubmit checks have passed locally on your machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [X] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
