### PR TITLE
Fixes part of #7450: fix tests that refer to private functions in jobs_test.BaseContinuousComputationManagerTests

### DIFF
--- a/core/jobs_test.py
+++ b/core/jobs_test.py
@@ -837,7 +837,7 @@ class BaseMapReduceJobManagerForContinuousComputationsTests(
 
 
 class BaseContinuousComputationManagerTests(test_utils.GenericTestBase):
-    
+
     EXP_ID = 'exp_id'
 
     def test_raise_error_with_get_event_types_listened_to(self):

--- a/core/jobs_test.py
+++ b/core/jobs_test.py
@@ -857,8 +857,7 @@ class BaseContinuousComputationManagerTests(test_utils.GenericTestBase):
                 'Subclasses of BaseContinuousComputationManager must implement '
                 '_get_realtime_datastore_class(). This method should return '
                 'the datastore class to be used by the realtime layer.')):
-          jobs.BaseContinuousComputationManager.
-          get_active_realtime_layer_id(self.EXP_ID)
+            jobs.BaseContinuousComputationManager.get_active_realtime_layer_id(self.EXP_ID)
 
     def test_raise_error_with_get_multi_active_realtime_layer_ids(self):
         with self.assertRaisesRegexp(
@@ -867,8 +866,7 @@ class BaseContinuousComputationManagerTests(test_utils.GenericTestBase):
                 'Subclasses of BaseContinuousComputationManager must implement '
                 '_get_realtime_datastore_class(). This method should return '
                 'the datastore class to be used by the realtime layer.')):
-	jobs.BaseContinuousComputationManager.
-        get_active_realtime_layer_id([self.EXP_ID])
+	    jobs.BaseContinuousComputationManager.get_active_realtime_layer_id([self.EXP_ID])
 
     def test_raise_error_with_get_batch_job_manager_class(self):
         with self.assertRaisesRegexp(
@@ -877,8 +875,7 @@ class BaseContinuousComputationManagerTests(test_utils.GenericTestBase):
                 'Subclasses of BaseContinuousComputationManager must implement '
                 '_get_batch_job_manager_class(). This method should return the'
                 'manager class for the continuously-running batch job.')):
-            jobs.BaseContinuousComputationManager.
-            stop_computation('admin_user_id')
+            jobs.BaseContinuousComputationManager.stop_computation('admin_user_id')
 
     def test_raise_error_with_handle_incoming_event(self):
         with self.assertRaisesRegexp(
@@ -888,8 +885,7 @@ class BaseContinuousComputationManagerTests(test_utils.GenericTestBase):
                 '_handle_incoming_event(...). Please check the docstring of '
                 'this method in jobs.BaseContinuousComputationManager for '
                 'important developer information.')):
-            jobs.BaseContinuousComputationManager.
-            on_incoming_event(1, 'event_type')
+            jobs.BaseContinuousComputationManager.on_incoming_event(1, 'event_type')
 
 
 class JobQueriesTests(test_utils.GenericTestBase):

--- a/core/jobs_test.py
+++ b/core/jobs_test.py
@@ -837,6 +837,8 @@ class BaseMapReduceJobManagerForContinuousComputationsTests(
 
 
 class BaseContinuousComputationManagerTests(test_utils.GenericTestBase):
+    
+    EXP_ID = 'exp_id'
 
     def test_raise_error_with_get_event_types_listened_to(self):
         with self.assertRaisesRegexp(
@@ -848,15 +850,25 @@ class BaseContinuousComputationManagerTests(test_utils.GenericTestBase):
                 'class subscribes to.')):
             jobs.BaseContinuousComputationManager.get_event_types_listened_to()
 
-    def test_raise_error_with_get_realtime_datastore_class(self):
+    def test_raise_error_with_get_active_realtime_layer_id(self):
         with self.assertRaisesRegexp(
             NotImplementedError,
             re.escape(
                 'Subclasses of BaseContinuousComputationManager must implement '
                 '_get_realtime_datastore_class(). This method should return '
                 'the datastore class to be used by the realtime layer.')):
-            jobs.BaseContinuousComputationManager._get_realtime_datastore_class(  # pylint: disable=protected-access
-                )
+          jobs.BaseContinuousComputationManager.
+          get_active_realtime_layer_id(self.EXP_ID)
+
+    def test_raise_error_with_get_multi_active_realtime_layer_ids(self):
+        with self.assertRaisesRegexp(
+            NotImplementedError,
+            re.escape(
+                'Subclasses of BaseContinuousComputationManager must implement '
+                '_get_realtime_datastore_class(). This method should return '
+                'the datastore class to be used by the realtime layer.')):
+	jobs.BaseContinuousComputationManager.
+        get_active_realtime_layer_id([self.EXP_ID])
 
     def test_raise_error_with_get_batch_job_manager_class(self):
         with self.assertRaisesRegexp(
@@ -865,7 +877,8 @@ class BaseContinuousComputationManagerTests(test_utils.GenericTestBase):
                 'Subclasses of BaseContinuousComputationManager must implement '
                 '_get_batch_job_manager_class(). This method should return the'
                 'manager class for the continuously-running batch job.')):
-            jobs.BaseContinuousComputationManager._get_batch_job_manager_class()  # pylint: disable=protected-access
+            jobs.BaseContinuousComputationManager.
+            stop_computation('admin_user_id')
 
     def test_raise_error_with_handle_incoming_event(self):
         with self.assertRaisesRegexp(
@@ -875,8 +888,8 @@ class BaseContinuousComputationManagerTests(test_utils.GenericTestBase):
                 '_handle_incoming_event(...). Please check the docstring of '
                 'this method in jobs.BaseContinuousComputationManager for '
                 'important developer information.')):
-            jobs.BaseContinuousComputationManager._handle_incoming_event(  # pylint: disable=protected-access
-                1, 'event_type')
+            jobs.BaseContinuousComputationManager.
+            on_incoming_event(1, 'event_type')
 
 
 class JobQueriesTests(test_utils.GenericTestBase):


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #7450 .
2. This PR does the following: test_raise_error_with_get_realtime_datastore_class
test_raise_error_with_get_batch_job_manager_class
test_raise_error_with_handle_incoming_event
the above tests previously depending on private methods are rewritten so as to replace them with public methods which call the aforementioned private methods.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
