### PR TITLE
Fix #9249: Add error message instead of warning modal in skill editor

### DIFF
--- a/core/templates/domain/skill/SkillObjectFactory.ts
+++ b/core/templates/domain/skill/SkillObjectFactory.ts
@@ -255,9 +255,8 @@ export class SkillObjectFactory {
 
   hasValidDescription(description: string) {
     var allowDescriptionToBeBlank = false;
-    var showWarnings = true;
     return this.validatorService.isValidEntityName(
-      description, showWarnings, allowDescriptionToBeBlank);
+      description, false, allowDescriptionToBeBlank);
   }
 
   createFromBackendDict(skillBackendDict: ISkillBackendDict): Skill {

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-description-editor/skill-description-editor.directive.html
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-description-editor/skill-description-editor.directive.html
@@ -7,11 +7,16 @@
       </div>
       <p ng-class="{'has-error': !tmpSkillDescription.length > 0}">
         <input type="text" class="form-control protractor-test-skill-description-field" ng-if="canEditSkillDescription()"
-               ng-model="tmpSkillDescription" ng-blur="saveSkillDescription(tmpSkillDescription)"
+               ng-model="tmpSkillDescription" ng-change="resetErrorMsg()" ng-blur="saveSkillDescription(tmpSkillDescription)"
                maxlength="<[MAX_CHARS_IN_SKILL_DESCRIPTION]>" ng-trim="false">
         <span class="oppia-input-box-subtitle">
           <i>
             Skill description should be at most <[MAX_CHARS_IN_SKILL_DESCRIPTION]> characters.
+          </i>
+        </span>
+        <span ng-if="errorMsg" class="skill-description-error-message">
+          <i>
+            <[errorMsg]>
           </i>
         </span>
         <span ng-if="!canEditSkillDescription()"><[tmpSkillDescription]></span>
@@ -25,5 +30,11 @@
     color: #595959;
     font-size: 0.8em;
     font-style: italic;
+  }
+
+  skill-description-editor .skill-description-error-message {
+    color: red;
+    display: block;
+    font-size: 0.8em;
   }
 </style>

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-description-editor/skill-description-editor.directive.ts
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-description-editor/skill-description-editor.directive.ts
@@ -39,10 +39,14 @@ angular.module('oppia').directive('skillDescriptionEditor', [
         '$scope', 'EVENT_SKILL_REINITIALIZED',
         function($scope, EVENT_SKILL_REINITIALIZED) {
           var ctrl = this;
-          $scope.MAX_CHARS_IN_SKILL_DESCRIPTION =
-            MAX_CHARS_IN_SKILL_DESCRIPTION;
+          $scope.MAX_CHARS_IN_SKILL_DESCRIPTION = (
+            MAX_CHARS_IN_SKILL_DESCRIPTION);
           $scope.canEditSkillDescription = function() {
             return $scope.skillRights.canEditSkillDescription();
+          };
+
+          $scope.resetErrorMsg = function() {
+            $scope.errorMsg = '';
           };
 
           $scope.saveSkillDescription = function(newSkillDescription) {
@@ -55,6 +59,10 @@ angular.module('oppia').directive('skillDescriptionEditor', [
               SkillUpdateService.setSkillDescription(
                 $scope.skill,
                 newSkillDescription);
+            } else {
+              $scope.errorMsg = (
+                'Please use a non-empty description consisting of ' +
+                'alphanumeric characters, spaces and/or hyphens.');
             }
           };
 
@@ -62,6 +70,7 @@ angular.module('oppia').directive('skillDescriptionEditor', [
             $scope.skill = SkillEditorStateService.getSkill();
             $scope.tmpSkillDescription = $scope.skill.getDescription();
             $scope.skillRights = SkillEditorStateService.getSkillRights();
+            $scope.errorMsg = '';
             $scope.$on(EVENT_SKILL_REINITIALIZED, function() {
               $scope.tmpSkillDescription = $scope.skill.getDescription();
             });

--- a/core/templates/pages/topics-and-skills-dashboard-page/navbar/topics-and-skills-dashboard-navbar.directive.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/navbar/topics-and-skills-dashboard-navbar.directive.ts
@@ -21,6 +21,7 @@ require('components/entity-creation-services/topic-creation.service.ts');
 require(
   'components/review-material-editor/review-material-editor.directive.ts');
 require('domain/skill/RubricObjectFactory.ts');
+require('domain/skill/SkillObjectFactory.ts');
 require('domain/topic/editable-topic-backend-api.service.ts');
 require('domain/utilities/url-interpolation.service.ts');
 
@@ -37,7 +38,7 @@ angular.module('oppia').directive('topicsAndSkillsDashboardNavbar', [
         'topics-and-skills-dashboard-navbar.directive.html'),
       controller: [
         '$scope', '$rootScope', '$uibModal', 'TopicCreationService',
-        'RubricObjectFactory', 'SkillCreationService',
+        'RubricObjectFactory', 'SkillCreationService', 'SkillObjectFactory',
         'EVENT_TYPE_TOPIC_CREATION_ENABLED',
         'EVENT_TYPE_SKILL_CREATION_ENABLED', 'EditableTopicBackendApiService',
         'EVENT_TOPICS_AND_SKILLS_DASHBOARD_REINITIALIZED',
@@ -45,7 +46,7 @@ angular.module('oppia').directive('topicsAndSkillsDashboardNavbar', [
         'SKILL_DESCRIPTION_STATUS_VALUES',
         function(
             $scope, $rootScope, $uibModal, TopicCreationService,
-            RubricObjectFactory, SkillCreationService,
+            RubricObjectFactory, SkillCreationService, SkillObjectFactory,
             EVENT_TYPE_TOPIC_CREATION_ENABLED,
             EVENT_TYPE_SKILL_CREATION_ENABLED, EditableTopicBackendApiService,
             EVENT_TOPICS_AND_SKILLS_DASHBOARD_REINITIALIZED,
@@ -72,6 +73,7 @@ angular.module('oppia').directive('topicsAndSkillsDashboardNavbar', [
                     MAX_CHARS_IN_SKILL_DESCRIPTION);
                   $scope.newSkillDescription = '';
                   $scope.rubrics = rubrics;
+                  $scope.errorMsg = '';
                   $scope.bindableDict = {
                     displayedConceptCardExplanation: ''
                   };
@@ -106,7 +108,19 @@ angular.module('oppia').directive('topicsAndSkillsDashboardNavbar', [
                     }
                   };
 
+                  $scope.resetErrorMsg = function() {
+                    $scope.errorMsg = '';
+                  };
+
                   $scope.createNewSkill = function() {
+                    if (
+                      !SkillObjectFactory.hasValidDescription(
+                        $scope.newSkillDescription)) {
+                      $scope.errorMsg = (
+                        'Please use a non-empty description consisting of ' +
+                        'alphanumeric characters, spaces and/or hyphens.');
+                      return;
+                    }
                     $uibModalInstance.close({
                       description: $scope.newSkillDescription,
                       rubrics: $scope.rubrics,

--- a/core/templates/pages/topics-and-skills-dashboard-page/templates/create-new-skill-modal.template.html
+++ b/core/templates/pages/topics-and-skills-dashboard-page/templates/create-new-skill-modal.template.html
@@ -8,11 +8,16 @@
       <strong>New Skill Description</strong>
     </div>
     <input type="text" class="form-control protractor-test-new-skill-description-field"
-           placeholder="eg: Adding Fractions" ng-model="newSkillDescription"
+           placeholder="eg: Adding Fractions" ng-change="resetErrorMsg()" ng-model="newSkillDescription"
            autofocus maxlength="<[MAX_CHARS_IN_SKILL_DESCRIPTION]>">
     <span class="oppia-input-box-subtitle">
       <i>
         Skill description should be at most <[MAX_CHARS_IN_SKILL_DESCRIPTION]> characters.
+      </i>
+    </span>
+    <span ng-if="errorMsg" class="skill-description-error-message">
+      <i>
+        <[errorMsg]>
       </i>
     </span>
     <div class="oppia-rule-details-header" style="margin-bottom: 0.5em; margin-top: 1em;">
@@ -39,3 +44,10 @@
     </button>
   </div>
 </form>
+<style>
+  .skill-description-error-message {
+    color: red;
+    display: block;
+    font-size: 0.8em;
+  }
+</style>

--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.controller.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.controller.ts
@@ -32,6 +32,7 @@ require('components/entity-creation-services/topic-creation.service.ts');
 require('components/rubrics-editor/rubrics-editor.directive.ts');
 
 require('domain/skill/RubricObjectFactory.ts');
+require('domain/skill/SkillObjectFactory.ts');
 require(
   'domain/topics_and_skills_dashboard/' +
   'topics-and-skills-dashboard-backend-api.service.ts'
@@ -57,8 +58,8 @@ angular.module('oppia').directive('topicsAndSkillsDashboardPage', [
       controller: [
         '$http', '$rootScope', '$scope', '$uibModal', '$window',
         'AlertsService', 'RubricObjectFactory', 'SkillCreationService',
-        'TopicCreationService', 'TopicsAndSkillsDashboardBackendApiService',
-        'UrlInterpolationService',
+        'SkillObjectFactory', 'TopicCreationService',
+        'TopicsAndSkillsDashboardBackendApiService', 'UrlInterpolationService',
         'EVENT_TOPICS_AND_SKILLS_DASHBOARD_REINITIALIZED',
         'EVENT_TYPE_SKILL_CREATION_ENABLED',
         'EVENT_TYPE_TOPIC_CREATION_ENABLED',
@@ -67,8 +68,8 @@ angular.module('oppia').directive('topicsAndSkillsDashboardPage', [
         function(
             $http, $rootScope, $scope, $uibModal, $window,
             AlertsService, RubricObjectFactory, SkillCreationService,
-            TopicCreationService, TopicsAndSkillsDashboardBackendApiService,
-            UrlInterpolationService,
+            SkillObjectFactory, TopicCreationService,
+            TopicsAndSkillsDashboardBackendApiService, UrlInterpolationService,
             EVENT_TOPICS_AND_SKILLS_DASHBOARD_REINITIALIZED,
             EVENT_TYPE_SKILL_CREATION_ENABLED,
             EVENT_TYPE_TOPIC_CREATION_ENABLED,
@@ -146,6 +147,7 @@ angular.module('oppia').directive('topicsAndSkillsDashboardPage', [
                 function($scope, $uibModalInstance) {
                   $scope.newSkillDescription = '';
                   $scope.rubrics = rubrics;
+                  $scope.errorMsg = '';
                   $scope.bindableDict = {
                     displayedConceptCardExplanation: ''
                   };
@@ -182,7 +184,19 @@ angular.module('oppia').directive('topicsAndSkillsDashboardPage', [
                     }
                   };
 
+                  $scope.resetErrorMsg = function() {
+                    $scope.errorMsg = '';
+                  };
+
                   $scope.createNewSkill = function() {
+                    if (
+                      !SkillObjectFactory.hasValidDescription(
+                        $scope.newSkillDescription)) {
+                      $scope.errorMsg = (
+                        'Please use a non-empty description consisting of ' +
+                        'alphanumeric characters, spaces and/or hyphens.');
+                      return;
+                    }
                     $uibModalInstance.close({
                       description: $scope.newSkillDescription,
                       rubrics: $scope.rubrics,


### PR DESCRIPTION
## Overview

1. This PR fixes #9249 
2. This PR does the following: Adds an error message below the input box if the skill description is invalid instead of error modals.

Screenshot:

![image](https://user-images.githubusercontent.com/22347970/81210846-1ece9700-8ff0-11ea-9110-c09accb66c25.png)


## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
