### PR TITLE
Fix #9264: Fix node reference in typescript checks

### DIFF
--- a/scripts/typescript_checks.py
+++ b/scripts/typescript_checks.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 
 import python_utils
+from . import common
 
 COMPILED_JS_DIR = os.path.join('local_compiled_js_for_test', '')
 TSCONFIG_FILEPATH = 'tsconfig.json'
@@ -42,7 +43,7 @@ def validate_compiled_js_dir():
 
 def compile_and_check_typescript():
     """Compiles typescript files and checks the compilation errors."""
-    node_path = os.path.join(os.pardir, 'oppia_tools/node-10.18.0')
+    node_path = common.NODE_PATH
     os.environ['PATH'] = '%s/bin:' % node_path + os.environ['PATH']
 
     validate_compiled_js_dir()


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #9264.
2. This PR does the following: [Explain here what your PR does and why]
Fixes the node path reference in the typescript test file.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
