### PR TITLE
Install third-party libs before running backend tests.

### DIFF
--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -59,8 +59,6 @@ import python_utils
 from . import common
 from . import concurrent_task_utils
 from . import install_third_party_libs
-from . import setup
-from . import setup_gae
 
 DIRS_TO_ADD_TO_SYS_PATH = [
     os.path.join(common.OPPIA_TOOLS_DIR, 'pylint-1.9.4'),
@@ -245,9 +243,6 @@ def main(args=None):
     # Make sure that third-party libraries are up-to-date before running tests,
     # otherwise import errors may result.
     install_third_party_libs.main()
-
-    setup.main(args=[])
-    setup_gae.main(args=[])
 
     for directory in DIRS_TO_ADD_TO_SYS_PATH:
         if not os.path.exists(os.path.dirname(directory)):

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -58,9 +58,9 @@ import python_utils
 
 from . import common
 from . import concurrent_task_utils
+from . import install_third_party_libs
 from . import setup
 from . import setup_gae
-
 
 DIRS_TO_ADD_TO_SYS_PATH = [
     os.path.join(common.OPPIA_TOOLS_DIR, 'pylint-1.9.4'),
@@ -241,6 +241,10 @@ def _get_all_test_targets(test_path=None, include_load_tests=True):
 def main(args=None):
     """Run the tests."""
     parsed_args = _PARSER.parse_args(args=args)
+
+    # Make sure that third-party libraries are up-to-date before running tests,
+    # otherwise import errors may result.
+    install_third_party_libs.main()
 
     setup.main(args=[])
     setup_gae.main(args=[])


### PR DESCRIPTION
1. This PR fixes or fixes part of N/A
2. This PR does the following: Installs third-party libs (or makes sure they're up to date) before running the backend tests. Otherwise, we keep seeing errors when contributors pull from develop and find that the backend tests can't run "because of an import error", due to new versions of libraries being updated.

/cc @vojtechjelinek @varun-tandon 

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
