### PR TITLE
Fix #6271 Develop all update_interaction_solution methods in core/domain files, accepting object instead of dict.

### DIFF
--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -1929,10 +1929,6 @@ class YamlCreationUnitTests(test_utils.GenericTestBase):
         self.assertEqual(len(exploration2.states), 2)
         yaml_content_2 = exploration2.to_yaml()
         self.assertEqual(yaml_content_2, yaml_content)
-
-        # Verify SAMPLE_UNTITLED_YAML_CONTENT can be converted to an exploration
-        # without error.
-        
         exp_domain.Exploration.from_untitled_yaml(
             'exp4', 'Title', 'Category', self.SAMPLE_UNTITLED_YAML_CONTENT)
 

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -1217,7 +1217,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             },
-        } 
+        }
         init_state.update_interaction_solution([solution])
 
         self.assertEqual(exploration.get_content_count(), 7)
@@ -1932,6 +1932,7 @@ class YamlCreationUnitTests(test_utils.GenericTestBase):
 
         # Verify SAMPLE_UNTITLED_YAML_CONTENT can be converted to an exploration
         # without error.
+        
         exp_domain.Exploration.from_untitled_yaml(
             'exp4', 'Title', 'Category', self.SAMPLE_UNTITLED_YAML_CONTENT)
 

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -1929,6 +1929,9 @@ class YamlCreationUnitTests(test_utils.GenericTestBase):
         self.assertEqual(len(exploration2.states), 2)
         yaml_content_2 = exploration2.to_yaml()
         self.assertEqual(yaml_content_2, yaml_content)
+
+        # Verify SAMPLE_UNTITLED_YAML_CONTENT can be converted to an exploration
+        # without error.
         exp_domain.Exploration.from_untitled_yaml(
             'exp4', 'Title', 'Category', self.SAMPLE_UNTITLED_YAML_CONTENT)
 

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -716,15 +716,15 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         init_state.update_interaction_answer_groups(answer_groups_list)
         init_state.update_interaction_default_outcome(default_outcome)
         exploration.validate()
-
-        init_state.update_interaction_solution({
+        sol ={
             'answer_is_exclusive': True,
             'correct_answer': 'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': 'hello_world is a string'
                 }
-        })
+        }
+        init_state.update_interaction_solution([sol])
         self._assert_validation_error(
             exploration,
             re.escape('Hint(s) must be specified if solution is specified'))
@@ -1217,8 +1217,8 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             },
-        }
-        init_state.update_interaction_solution(solution)
+        } 
+        init_state.update_interaction_solution([solution])
 
         self.assertEqual(exploration.get_content_count(), 7)
 
@@ -8338,7 +8338,7 @@ class HtmlCollectionTests(test_utils.GenericTestBase):
             }
         }
 
-        state1.update_interaction_solution(solution_dict1)
+        state1.update_interaction_solution([solution_dict1])
 
         answer_group_list2 = [{
             'rule_specs': [{

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -716,7 +716,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         init_state.update_interaction_answer_groups(answer_groups_list)
         init_state.update_interaction_default_outcome(default_outcome)
         exploration.validate()
-        sol ={
+        sol = {
             'answer_is_exclusive': True,
             'correct_answer': 'hello_world!',
             'explanation': {

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -4057,14 +4057,14 @@ title: Old Title
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
         self.assertIsNone(exploration.init_state.interaction.solution)
 
-        solution = {
+        solution = [{
             'answer_is_exclusive': False,
             'correct_answer': 'helloworld!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             },
-        }
+        }]
 
         hint_list = [{
             'hint_content': {
@@ -4092,13 +4092,13 @@ title: Old Title
                 'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
                 'property_name': exp_domain.STATE_PROPERTY_INTERACTION_SOLUTION,
                 'state_name': exploration.init_state_name,
-                'new_value': solution
+                'new_value': solution[0]
             })], 'Changed interaction_solutions.')
 
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
         self.assertEqual(
             exploration.init_state.interaction.solution.to_dict(),
-            solution)
+            solution[0])
 
     def test_cannot_update_recorded_voiceovers_with_invalid_type(self):
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -1931,9 +1931,8 @@ class State(python_utils.OBJECT):
                 raise Exception(
                     'Expected solution to be a list, received %s'
                     % solution_list)
-            solution_dict = solution_list[0]  
             self.interaction.solution = Solution.from_dict(
-                self.interaction.id, solution_dict)
+                self.interaction.id, solution_list[0])
             new_content_id_list.append(
                 self.interaction.solution.explanation.content_id)
         else:

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -1931,7 +1931,7 @@ class State(python_utils.OBJECT):
                 raise Exception(
                     'Expected solution to be a list, received %s'
                     % solution_list)
-            solution_dict = solution_list[0]       
+            solution_dict = solution_list[0]  
             self.interaction.solution = Solution.from_dict(
                 self.interaction.id, solution_dict)
             new_content_id_list.append(

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -1910,15 +1910,15 @@ class State(python_utils.OBJECT):
         self._update_content_ids_in_assets(
             old_content_id_list, new_content_id_list)
 
-    def update_interaction_solution(self, solution_dict):
+    def update_interaction_solution(self, solution_list):
         """Update the solution of interaction.
 
         Args:
-            solution_dict: dict or None. The dict representation of
+            solution_dict: list or None. The list representation of
                 Solution object.
 
         Raises:
-            Exception: 'solution_dict' is not a dict.
+            Exception: 'solution_list' is not a list.
         """
         old_content_id_list = []
         new_content_id_list = []
@@ -1926,11 +1926,12 @@ class State(python_utils.OBJECT):
             old_content_id_list.append(
                 self.interaction.solution.explanation.content_id)
 
-        if solution_dict is not None:
-            if not isinstance(solution_dict, dict):
+        if solution_list is not None:
+            if not isinstance(solution_list, list):
                 raise Exception(
-                    'Expected solution to be a dict, received %s'
-                    % solution_dict)
+                    'Expected solution to be a list, received %s'
+                    % solution_list)
+            solution_dict=solution_list[0]       
             self.interaction.solution = Solution.from_dict(
                 self.interaction.id, solution_dict)
             new_content_id_list.append(

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -1914,7 +1914,7 @@ class State(python_utils.OBJECT):
         """Update the solution of interaction.
 
         Args:
-            solution_dict: list or None. The list representation of
+            solution_list: list or None. The list representation of
                 Solution object.
 
         Raises:
@@ -1931,7 +1931,7 @@ class State(python_utils.OBJECT):
                 raise Exception(
                     'Expected solution to be a list, received %s'
                     % solution_list)
-            solution_dict=solution_list[0]       
+            solution_dict = solution_list[0]       
             self.interaction.solution = Solution.from_dict(
                 self.interaction.id, solution_dict)
             new_content_id_list.append(

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -199,7 +199,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
 
         init_state = exploration.states[exploration.init_state_name]
         init_state.update_interaction_id('TextInput')
-        solution_dict = {
+        solution_list = [ {
             'answer_is_exclusive': False,
             'correct_answer': 'helloworld!',
             'explanation': {
@@ -209,12 +209,13 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                     'raw_latex-with-value="&amp;quot;\\frac{x}{y}&amp;quot;">'
                     '</oppia-noninteractive-math></p>')
             },
-        }
+        } ]
 
-        init_state.update_interaction_solution(solution_dict)
+        init_state.update_interaction_solution(solution_list)
         self.assertFalse(init_state.is_rte_content_supported_on_android())
+        solution_dict = solution_list[0]
         solution_dict['explanation']['html'] = ''
-        init_state.update_interaction_solution(solution_dict)
+        init_state.update_interaction_solution(solution_list)
         self.assertTrue(init_state.is_rte_content_supported_on_android())
 
         hints_list = []
@@ -432,16 +433,16 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         ]
         init_state.update_interaction_hints(hints_list)
 
-        solution_dict = {
+        solution_list = [ {
             'answer_is_exclusive': False,
             'correct_answer': 'helloworld!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             },
-        }
+        } ]
 
-        init_state.update_interaction_solution(solution_dict)
+        init_state.update_interaction_solution(solution_list)
 
         written_translations_dict = {
             'translations_mapping': {
@@ -860,16 +861,16 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         ]
         init_state.update_interaction_hints(hints_list)
 
-        solution_dict = {
+        solution_list = [ {
             'answer_is_exclusive': False,
             'correct_answer': 'helloworld!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             },
-        }
+        } ]
 
-        init_state.update_interaction_solution(solution_dict)
+        init_state.update_interaction_solution(solution_list)
         exploration.validate()
 
         hints_list.append(
@@ -928,15 +929,15 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 state_domain.Solution.from_dict(
                     init_state.interaction.id, solution))
 
-        solution = {
+        solution_list = [ {
             'answer_is_exclusive': False,
             'correct_answer': 'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             }
-        }
-        init_state.update_interaction_solution(solution)
+        } ]
+        init_state.update_interaction_solution(solution_list)
         exploration.validate()
 
     def test_validate_state_solicit_answer_details(self):
@@ -974,14 +975,14 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         # Solution should be set to None as default.
         self.assertEqual(exploration.init_state.interaction.solution, None)
 
-        solution = {
+        solution = [ {
             'answer_is_exclusive': False,
             'correct_answer': 'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             }
-        }
+        } ]
         hints_list = [
             state_domain.Hint(
                 state_domain.SubtitledHtml('hint_1', '')
@@ -992,16 +993,16 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         exploration.init_state.update_interaction_solution(solution)
         exploration.validate()
 
-        solution = {
+        solution_list = [ {
             'answer_is_exclusive': 1,
             'correct_answer': 'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             }
-        }
+        } ]
 
-        exploration.init_state.update_interaction_solution(solution)
+        exploration.init_state.update_interaction_solution(solution_list)
         with self.assertRaisesRegexp(
             Exception, 'Expected answer_is_exclusive to be bool, received 1'):
             exploration.validate()
@@ -1095,16 +1096,17 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         hints_list = [state_domain.Hint(subtitled_html)]
 
         exploration.init_state.interaction.hints = hints_list
-        solution = {
+        solution_list = [ {
             'answer_is_exclusive': True,
             'correct_answer': 'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             }
-        }
+        } ]
 
-        exploration.init_state.update_interaction_solution(solution)
+        exploration.init_state.update_interaction_solution(solution_list)
+        solution=solution_list[0]
         exploration.init_state.update_content(
             state_domain.SubtitledHtml.from_dict({
                 'content_id': 'solution',
@@ -1311,7 +1313,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             'The content_id hint_2 already exists in recorded_voiceovers'):
             exploration.init_state.update_interaction_hints(new_hints_list)
 
-    def test_cannot_update_interaction_solution_with_non_dict_solution(self):
+    def test_cannot_update_interaction_solution_with_non_list_solution(self):
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')
         hints_list = [
             state_domain.Hint(
@@ -1319,24 +1321,21 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                     'hint_1', '<p>Hello, this is html1 for state2</p>')
             )
         ]
-        solution = {
+        solution = [ {
             'answer_is_exclusive': True,
             'correct_answer': u'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': u'<p>hello_world is a string</p>'
             }
-        }
+        } ]
 
         exploration.init_state.update_interaction_hints(hints_list)
         exploration.init_state.update_interaction_solution(solution)
 
-        self.assertEqual(
-            exploration.init_state.interaction.solution.to_dict(), solution)
-
         with self.assertRaisesRegexp(
-            Exception, 'Expected solution to be a dict'):
-            exploration.init_state.update_interaction_solution([])
+            Exception, 'Expected solution to be a list'):
+            exploration.init_state.update_interaction_solution('invalid solution')
 
     def test_update_interaction_solution_with_no_solution(self):
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -199,7 +199,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
 
         init_state = exploration.states[exploration.init_state_name]
         init_state.update_interaction_id('TextInput')
-        solution_list = [ {
+        solution_list = [{
             'answer_is_exclusive': False,
             'correct_answer': 'helloworld!',
             'explanation': {
@@ -209,7 +209,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                     'raw_latex-with-value="&amp;quot;\\frac{x}{y}&amp;quot;">'
                     '</oppia-noninteractive-math></p>')
             },
-        } ]
+        }]
 
         init_state.update_interaction_solution(solution_list)
         self.assertFalse(init_state.is_rte_content_supported_on_android())
@@ -433,14 +433,14 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         ]
         init_state.update_interaction_hints(hints_list)
 
-        solution_list = [ {
+        solution_list = [{
             'answer_is_exclusive': False,
             'correct_answer': 'helloworld!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             },
-        } ]
+        }]
 
         init_state.update_interaction_solution(solution_list)
 
@@ -861,14 +861,14 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         ]
         init_state.update_interaction_hints(hints_list)
 
-        solution_list = [ {
+        solution_list = [{
             'answer_is_exclusive': False,
             'correct_answer': 'helloworld!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             },
-        } ]
+        }]
 
         init_state.update_interaction_solution(solution_list)
         exploration.validate()
@@ -929,14 +929,14 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 state_domain.Solution.from_dict(
                     init_state.interaction.id, solution))
 
-        solution_list = [ {
+        solution_list = [{
             'answer_is_exclusive': False,
             'correct_answer': 'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             }
-        } ]
+        }]
         init_state.update_interaction_solution(solution_list)
         exploration.validate()
 
@@ -975,14 +975,14 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         # Solution should be set to None as default.
         self.assertEqual(exploration.init_state.interaction.solution, None)
 
-        solution = [ {
+        solution = [{
             'answer_is_exclusive': False,
             'correct_answer': 'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             }
-        } ]
+        }]
         hints_list = [
             state_domain.Hint(
                 state_domain.SubtitledHtml('hint_1', '')
@@ -993,14 +993,14 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         exploration.init_state.update_interaction_solution(solution)
         exploration.validate()
 
-        solution_list = [ {
+        solution_list = [{
             'answer_is_exclusive': 1,
             'correct_answer': 'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             }
-        } ]
+        }]
 
         exploration.init_state.update_interaction_solution(solution_list)
         with self.assertRaisesRegexp(
@@ -1096,17 +1096,16 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         hints_list = [state_domain.Hint(subtitled_html)]
 
         exploration.init_state.interaction.hints = hints_list
-        solution_list = [ {
+        solution_list = [{
             'answer_is_exclusive': True,
             'correct_answer': 'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': '<p>hello_world is a string</p>'
             }
-        } ]
+        }]
 
         exploration.init_state.update_interaction_solution(solution_list)
-        solution=solution_list[0]
         exploration.init_state.update_content(
             state_domain.SubtitledHtml.from_dict({
                 'content_id': 'solution',
@@ -1321,21 +1320,22 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                     'hint_1', '<p>Hello, this is html1 for state2</p>')
             )
         ]
-        solution = [ {
+        solution = [{
             'answer_is_exclusive': True,
             'correct_answer': u'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': u'<p>hello_world is a string</p>'
             }
-        } ]
+        }]
 
         exploration.init_state.update_interaction_hints(hints_list)
         exploration.init_state.update_interaction_solution(solution)
 
         with self.assertRaisesRegexp(
             Exception, 'Expected solution to be a list'):
-            exploration.init_state.update_interaction_solution('invalid solution')
+            exploration.init_state.update_interaction_solution(
+                'invalid solution')
 
     def test_update_interaction_solution_with_no_solution(self):
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #6271 .
2. This PR does the following:This pr make changes in the respective places of codebase to accept object instead of dict in  method "update_interaction_solution".

## Essential Checklist

- [-] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [-] The linter/Karma presubmit checks have passed locally on your machine.
- [-] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [-] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
