### PR TITLE
Fix #9372: Mocked datetime to fix admin test flakyness.

### DIFF
--- a/core/controllers/admin_test.py
+++ b/core/controllers/admin_test.py
@@ -17,9 +17,9 @@
 from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
+import datetime
 import logging
 import math
-import time
 
 from constants import constants
 from core import jobs
@@ -1248,14 +1248,18 @@ class UpdateUsernameHandlerTest(test_utils.GenericTestBase):
     def test_update_username_creates_audit_model(self):
         user_id = self.get_user_id_from_email(self.ADMIN_EMAIL)
         csrf_token = self.get_new_csrf_token()
-        time_of_query = time.time()
 
-        self.put_json(
-            '/updateusernamehandler',
-            payload={
-                'old_username': self.OLD_USERNAME,
-                'new_username': self.NEW_USERNAME},
-            csrf_token=csrf_token)
+        current_datetime = datetime.datetime.utcnow()
+        with self.mock_datetime_utcnow(current_datetime):
+            # To get the current time in seconds.
+            time_of_query = (datetime.datetime.utcnow() - datetime.datetime(
+                1970, 1, 1)).total_seconds()
+            self.put_json(
+                '/updateusernamehandler',
+                payload={
+                    'old_username': self.OLD_USERNAME,
+                    'new_username': self.NEW_USERNAME},
+                csrf_token=csrf_token)
 
         self.assertTrue(
             audit_models.UsernameChangeAuditModel.has_reference_to_user_id(


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #9372.
2. This PR does the following: Mocks the datetime in the username change test function to fix the flakiness introduced by these tests

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
