### PR TITLE
Add QA Team Codeowner for all E2E Files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -420,10 +420,14 @@
 
 # QA team.
 /core/tests/ @nithusha21
-/core/tests/protractor_utils @U8NWXD
-/core/tests/protractor_desktop @U8NWXD
-/core/tests/protractor @U8NWXD
-/extensions/**/protractor.js @U8NWXD
+/core/tests/protractor_utils/ @U8NWXD
+/core/tests/protractor_desktop/ @U8NWXD
+/core/tests/protractor/ @U8NWXD
+/extensions/interactions/*/protractor.js @U8NWXD
+/extensions/interactions/protractor.js @U8NWXD
+/extensions/rich_text_components/*/protractor.js @U8NWXD
+/extensions/rich_text_components/protractor.js @U8NWXD
+/extensions/objects/protractor.js @U8NWXD
 /assets/ @nithusha21
 /data/ @nithusha21
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -423,7 +423,12 @@
 /core/tests/protractor_utils/ @U8NWXD
 /core/tests/protractor_desktop/ @U8NWXD
 /core/tests/protractor/ @U8NWXD
-protractor*.js @U8NWXD
+/core/tests/protractor.conf.js @U8NWXD
+/extensions/interactions/*/protractor.js @U8NWXD
+/extensions/interactions/protractor.js @U8NWXD
+/extensions/rich_text_components/*/protractor.js @U8NWXD
+/extensions/rich_text_components/protractor.js @U8NWXD
+/extensions/objects/protractor.js @U8NWXD
 /assets/ @nithusha21
 /data/ @nithusha21
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -423,11 +423,7 @@
 /core/tests/protractor_utils/ @U8NWXD
 /core/tests/protractor_desktop/ @U8NWXD
 /core/tests/protractor/ @U8NWXD
-/extensions/interactions/*/protractor.js @U8NWXD
-/extensions/interactions/protractor.js @U8NWXD
-/extensions/rich_text_components/*/protractor.js @U8NWXD
-/extensions/rich_text_components/protractor.js @U8NWXD
-/extensions/objects/protractor.js @U8NWXD
+protractor*.js @U8NWXD
 /assets/ @nithusha21
 /data/ @nithusha21
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -422,6 +422,8 @@
 /core/tests/ @nithusha21
 /core/tests/protractor_utils @U8NWXD
 /core/tests/protractor_desktop @U8NWXD
+/core/tests/protractor @U8NWXD
+/extensions/**/protractor.js @U8NWXD
 /assets/ @nithusha21
 /data/ @nithusha21
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of n/a.
2. This PR does the following: Consolidates codeownership of all end-to-end test files. Previously many e2e-test-related files, such as the `protractor.js` files for the various interactions or rich text editors, were not owned by the QA team.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
