### PR TITLE
Fix #9382: fix for bug default language on Oppia is not accurate on reload

### DIFF
--- a/core/templates/I18nFooter.ts
+++ b/core/templates/I18nFooter.ts
@@ -50,7 +50,8 @@ angular.module('oppia').directive('i18nFooter', [
           };
           ctrl.$onInit = function() {
             ctrl.supportedSiteLanguages = SUPPORTED_SITE_LANGUAGES;
-            ctrl.currentLanguageCode = $translate.proposedLanguage();
+            ctrl.currentLanguageCode = (
+              $translate.proposedLanguage() || $translate.use());
           };
         }
       ]

--- a/core/templates/I18nFooter.ts
+++ b/core/templates/I18nFooter.ts
@@ -50,18 +50,7 @@ angular.module('oppia').directive('i18nFooter', [
           };
           ctrl.$onInit = function() {
             ctrl.supportedSiteLanguages = SUPPORTED_SITE_LANGUAGES;
-
-            // The $timeout seems to be necessary for the dropdown
-            // to show anything at the outset, if the default language
-            // is not English.
-            $timeout(function() {
-              // $translate.use() returns undefined until the language
-              // file is fully loaded, which causes a blank field
-              // in the dropdown, hence we use $translate.proposedLanguage()
-              // as suggested in http://stackoverflow.com/a/28903658
-              ctrl.currentLanguageCode = $translate.use() ||
-                $translate.proposedLanguage();
-            }, 50);
+            ctrl.currentLanguageCode = $translate.proposedLanguage();
           };
         }
       ]


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #9382
2. This PR does the following: 
* Properly queries for the set/upcoming language on reload

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
