### PR TITLE
Fix incorrect escaping in backend.

### DIFF
--- a/core/domain/html_cleaner.py
+++ b/core/domain/html_cleaner.py
@@ -165,10 +165,8 @@ def get_rte_components(html_string):
             for attr in oppia_custom_tag_attrs[tag_name]:
                 # Unescape special HTML characters such as '&quot;'.
                 attr_val = parser.unescape(component_tag[attr])
-                # Adds escapes so that things like '\frac' aren't
-                # interpreted as special characters.
-                attr_val = attr_val.encode('unicode_escape')
                 customization_args[attr] = json.loads(attr_val)
+
             component['customization_args'] = customization_args
             components.append(component)
     return components

--- a/core/domain/html_cleaner_test.py
+++ b/core/domain/html_cleaner_test.py
@@ -158,10 +158,12 @@ class RteComponentExtractorUnitTests(test_utils.GenericTestBase):
         test_data = (
             '<p>Test text&nbsp;'
             '<oppia-noninteractive-math '
-            'raw_latex-with-value="&amp;quot;\\frac{x}{y}&amp;quot;">'
+            'raw_latex-with-value="&amp;quot;\\\\frac{x}{y}&amp;quot;">'
             '</oppia-noninteractive-math></p><p>&nbsp;'
             '<oppia-noninteractive-link '
-            'text-with-value="&amp;quot;Link&amp;quot;" '
+            'text-with-value='
+            '"&amp;quot;Link\\&amp;quot;quoted text\\&amp;quot;'
+            '&amp;#39;singlequotes&amp;#39;&amp;quot;" '
             'url-with-value="&amp;quot;https://www.example.com&amp;quot;">'
             '</oppia-noninteractive-link>.</p>'
             '<p>Video</p>'
@@ -175,7 +177,7 @@ class RteComponentExtractorUnitTests(test_utils.GenericTestBase):
         expected_components = [
             {
                 'customization_args': {
-                    'text-with-value': u'Link',
+                    'text-with-value': u'Link"quoted text"\'singlequotes\'',
                     'url-with-value': u'https://www.example.com'},
                 'id': 'oppia-noninteractive-link'
             },


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of N/A.
2. This PR does the following: Fixes escaping behaviour to handle double quotes. A backend test was incorrect and this has been fixed. More test cases have also been added for double and single quotes.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
