### PR TITLE
Change codeownership from Mariana to Nithesh

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,7 +117,7 @@
 /tox.ini @kevinlee12
 /scripts/*.py @DubeySandeep
 /scripts/check_e2e_tests_are_captured_in_ci*.py @Showtim3 @DubeySandeep
-/scripts/check_frontend_coverage*.py @marianazangrossi @DubeySandeep
+/scripts/check_frontend_coverage*.py @nithusha21 @DubeySandeep
 /scripts/create_topological_sort_of_all_services*.py @bansalnitish @DubeySandeep
 /scripts/install_prerequisites.sh @DubeySandeep
 /scripts/typescript_checks*.py @ankita240796 @DubeySandeep
@@ -535,10 +535,10 @@
 /core/templates/services/services.constants.ts @vojtechjelinek
 
 # Frontend unit tests
-/core/templates/**/*.spec.ts @marianazangrossi
-/core/templates/**/*Spec.ts @marianazangrossi
-/extensions/**/*.spec.ts @marianazangrossi
-/extensions/**/*Spec.ts @marianazangrossi
+/core/templates/**/*.spec.ts @nithusha21
+/core/templates/**/*Spec.ts @nithusha21
+/extensions/**/*.spec.ts @nithusha21
+/extensions/**/*Spec.ts @nithusha21
 
 # Draft version upgrade.
 /core/domain/draft_upgrade_services*.py @DubeySandeep


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of - 
2. This PR does the following: Change codeowner for spec files in order to reduce review load on Mariana

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
