### PR TITLE
Fix #6271: Changing interaction_solution method to accept solution object instead of dict

### DIFF
--- a/core/controllers/admin.py
+++ b/core/controllers/admin.py
@@ -293,17 +293,16 @@ class AdminHandler(base.BaseHandler):
 
         state.update_recorded_voiceovers(recorded_voiceovers)
         state.update_written_translations(written_translations)
-        solution_dict = (
-            state_domain.Solution(
-                'TextInput', False, 'Solution', state_domain.SubtitledHtml(
-                    'solution', '<p>This is a solution.</p>')).to_dict())
+        solution = state_domain.Solution(
+            'TextInput', False, 'Solution', state_domain.SubtitledHtml(
+                'solution', '<p>This is a solution.</p>'))
         hints_list = [
             state_domain.Hint(
                 state_domain.SubtitledHtml('hint_1', '<p>This is a hint.</p>')
             )
         ]
 
-        state.update_interaction_solution(solution_dict)
+        state.update_interaction_solution(solution)
         state.update_interaction_hints(hints_list)
         state.update_interaction_customization_args({
             'placeholder': 'Enter text here',

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -716,15 +716,17 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         init_state.update_interaction_answer_groups(answer_groups_list)
         init_state.update_interaction_default_outcome(default_outcome)
         exploration.validate()
-
-        init_state.update_interaction_solution({
+        solution_dict = {
             'answer_is_exclusive': True,
             'correct_answer': 'hello_world!',
             'explanation': {
                 'content_id': 'solution',
                 'html': 'hello_world is a string'
                 }
-        })
+        }
+        solution = state_domain.Solution.from_dict(
+            init_state.interaction.id, solution_dict)
+        init_state.update_interaction_solution(solution)
         self._assert_validation_error(
             exploration,
             re.escape('Hint(s) must be specified if solution is specified'))
@@ -1210,7 +1212,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         ]
         init_state.update_interaction_hints(hints_list)
 
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': False,
             'correct_answer': 'helloworld!',
             'explanation': {
@@ -1218,6 +1220,8 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             },
         }
+        solution = state_domain.Solution.from_dict(
+            init_state.interaction.id, solution_dict)
         init_state.update_interaction_solution(solution)
 
         self.assertEqual(exploration.get_content_count(), 7)
@@ -8338,7 +8342,9 @@ class HtmlCollectionTests(test_utils.GenericTestBase):
             }
         }
 
-        state1.update_interaction_solution(solution_dict1)
+        solution = state_domain.Solution.from_dict(
+            state1.interaction.id, solution_dict1)
+        state1.update_interaction_solution(solution)
 
         answer_group_list2 = [{
             'rule_specs': [{

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -403,7 +403,11 @@ def apply_change_list(exploration_id, change_list):
                 elif (
                         change.property_name ==
                         exp_domain.STATE_PROPERTY_INTERACTION_SOLUTION):
-                    state.update_interaction_solution(change.new_value)
+                    new_solution = None
+                    if change.new_value is not None:
+                        new_solution = state_domain.Solution.from_dict(
+                            state.interaction.id, change.new_value)
+                    state.update_interaction_solution(new_solution)
                 elif (
                         change.property_name ==
                         exp_domain.STATE_PROPERTY_SOLICIT_ANSWER_DETAILS):

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -4088,6 +4088,19 @@ title: Old Title
             exploration.init_state.interaction.solution.to_dict(),
             solution)
 
+        solution = None
+        exp_services.update_exploration(
+            self.albert_id, self.NEW_EXP_ID, [exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'property_name': exp_domain.STATE_PROPERTY_INTERACTION_SOLUTION,
+                'state_name': exploration.init_state_name,
+                'new_value': solution
+            })], 'Changed interaction_solutions.')
+        exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
+        self.assertEqual(
+            exploration.init_state.interaction.solution,
+            None)
+
     def test_cannot_update_recorded_voiceovers_with_invalid_type(self):
         exploration = exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
 

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -1910,15 +1910,14 @@ class State(python_utils.OBJECT):
         self._update_content_ids_in_assets(
             old_content_id_list, new_content_id_list)
 
-    def update_interaction_solution(self, solution_dict):
+    def update_interaction_solution(self, solution):
         """Update the solution of interaction.
 
         Args:
-            solution_dict: dict or None. The dict representation of
-                Solution object.
+            solution: Solution. Object of class Solution.
 
         Raises:
-            Exception: 'solution_dict' is not a dict.
+            Exception: 'solution' is not a domain object.
         """
         old_content_id_list = []
         new_content_id_list = []
@@ -1926,13 +1925,12 @@ class State(python_utils.OBJECT):
             old_content_id_list.append(
                 self.interaction.solution.explanation.content_id)
 
-        if solution_dict is not None:
-            if not isinstance(solution_dict, dict):
+        if solution is not None:
+            if not isinstance(solution, Solution):
                 raise Exception(
-                    'Expected solution to be a dict, received %s'
-                    % solution_dict)
-            self.interaction.solution = Solution.from_dict(
-                self.interaction.id, solution_dict)
+                    'Expected solution to be a Solution object,recieved %s'
+                    % solution)
+            self.interaction.solution = solution
             new_content_id_list.append(
                 self.interaction.solution.explanation.content_id)
         else:

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -210,11 +210,15 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                     '</oppia-noninteractive-math></p>')
             },
         }
-
-        init_state.update_interaction_solution(solution_dict)
+        solution = state_domain.Solution.from_dict(
+            init_state.interaction.id, solution_dict
+        )
+        init_state.update_interaction_solution(solution)
         self.assertFalse(init_state.is_rte_content_supported_on_android())
         solution_dict['explanation']['html'] = ''
-        init_state.update_interaction_solution(solution_dict)
+        init_state.update_interaction_solution(
+            state_domain.Solution.from_dict(
+                init_state.interaction.id, solution_dict))
         self.assertTrue(init_state.is_rte_content_supported_on_android())
 
         hints_list = []
@@ -440,8 +444,9 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             },
         }
-
-        init_state.update_interaction_solution(solution_dict)
+        solution = state_domain.Solution.from_dict(
+            init_state.interaction.id, solution_dict)
+        init_state.update_interaction_solution(solution)
 
         written_translations_dict = {
             'translations_mapping': {
@@ -868,8 +873,10 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             },
         }
-
-        init_state.update_interaction_solution(solution_dict)
+        solution = state_domain.Solution.from_dict(
+            init_state.interaction.id, solution_dict
+        )
+        init_state.update_interaction_solution(solution)
         exploration.validate()
 
         hints_list.append(
@@ -913,7 +920,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             )
         ]
         init_state.update_interaction_hints(hints_list)
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': False,
             'correct_answer': [0, 0],
             'explanation': {
@@ -926,9 +933,9 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaises(AssertionError):
             init_state.interaction.solution = (
                 state_domain.Solution.from_dict(
-                    init_state.interaction.id, solution))
+                    init_state.interaction.id, solution_dict))
 
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': False,
             'correct_answer': 'hello_world!',
             'explanation': {
@@ -936,7 +943,9 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             }
         }
-        init_state.update_interaction_solution(solution)
+        init_state.update_interaction_solution(
+            state_domain.Solution.from_dict(
+                init_state.interaction.id, solution_dict))
         exploration.validate()
 
     def test_validate_state_solicit_answer_details(self):
@@ -974,7 +983,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         # Solution should be set to None as default.
         self.assertEqual(exploration.init_state.interaction.solution, None)
 
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': False,
             'correct_answer': 'hello_world!',
             'explanation': {
@@ -987,12 +996,13 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 state_domain.SubtitledHtml('hint_1', '')
             )
         ]
-
+        solution = state_domain.Solution.from_dict(
+            exploration.init_state.interaction.id, solution_dict)
         exploration.init_state.update_interaction_hints(hints_list)
         exploration.init_state.update_interaction_solution(solution)
         exploration.validate()
 
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': 1,
             'correct_answer': 'hello_world!',
             'explanation': {
@@ -1000,7 +1010,8 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             }
         }
-
+        solution = state_domain.Solution.from_dict(
+            exploration.init_state.interaction.id, solution_dict)
         exploration.init_state.update_interaction_solution(solution)
         with self.assertRaisesRegexp(
             Exception, 'Expected answer_is_exclusive to be bool, received 1'):
@@ -1095,7 +1106,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         hints_list = [state_domain.Hint(subtitled_html)]
 
         exploration.init_state.interaction.hints = hints_list
-        solution = {
+        solution_dict = {
             'answer_is_exclusive': True,
             'correct_answer': 'hello_world!',
             'explanation': {
@@ -1103,7 +1114,8 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
                 'html': '<p>hello_world is a string</p>'
             }
         }
-
+        solution = state_domain.Solution.from_dict(
+            exploration.init_state.interaction.id, solution_dict)
         exploration.init_state.update_interaction_solution(solution)
         exploration.init_state.update_content(
             state_domain.SubtitledHtml.from_dict({
@@ -1329,14 +1341,17 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         }
 
         exploration.init_state.update_interaction_hints(hints_list)
-        exploration.init_state.update_interaction_solution(solution)
+        exploration.init_state.update_interaction_solution(
+            state_domain.Solution.from_dict(
+                exploration.init_state.interaction.id, solution))
 
         self.assertEqual(
             exploration.init_state.interaction.solution.to_dict(), solution)
 
         with self.assertRaisesRegexp(
-            Exception, 'Expected solution to be a dict'):
-            exploration.init_state.update_interaction_solution([])
+            Exception, 'Expected solution to be a Solution object,'
+            'recieved test string'):
+            exploration.init_state.update_interaction_solution('test string')
 
     def test_update_interaction_solution_with_no_solution(self):
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -1547,7 +1547,7 @@ tags: []
             name: str. The name of the topic.
             abbreviated_name: str. The abbreviated name of the topic.
             canonical_name: str. The canonical name (lowercase) of the topic.
-            description: str. The desscription of the topic.
+            description: str. The description of the topic.
             thumbnail_filename: str. The thumbnail file name of the topic.
             thumbnail_bg_color: str. The thumbnail background color of the
                 topic.

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -205,8 +205,6 @@ class TestBase(unittest.TestCase):
     # A test unicode string.
     UNICODE_TEST_STRING = u'unicode ¡马!'
 
-    SUPER_ADMIN_EMAIL = 'tmpsuperadmin@example.com'
-
     # Dummy strings representing user attributes. Note that it is up to the
     # individual test to actually register these users as editors, admins, etc.
     ADMIN_EMAIL = 'admin@example.com'
@@ -593,7 +591,7 @@ tags: []
         """Signs up a superadmin user. Should be called at the end of
         setUp().
         """
-        self.signup(self.SUPER_ADMIN_EMAIL, 'tmpsuperadm1n')
+        self.signup('tmpsuperadmin@example.com', 'tmpsuperadm1n')
 
     def log_line(self, line):
         """Print the line with a prefix that can be identified by the
@@ -970,7 +968,8 @@ tags: []
         """Sets a given configuration object's value to the new value specified
         using a POST request.
         """
-        with self.login_context(self.SUPER_ADMIN_EMAIL, is_super_admin=True):
+        with self.login_context('tmpsuperadmin@example.com',
+                                is_super_admin=True):
             csrf_token = self.get_new_csrf_token()
             self.post_json(
                 '/adminhandler', {
@@ -987,7 +986,8 @@ tags: []
             username: str. Username of the given user.
             user_role: str. Role of the given user.
         """
-        with self.login_context(self.SUPER_ADMIN_EMAIL, is_super_admin=True):
+        with self.login_context('tmpsuperadmin@example.com',
+                                is_super_admin=True):
             csrf_token = self.get_new_csrf_token()
             self.post_json(
                 '/adminrolehandler', {
@@ -1485,7 +1485,7 @@ tags: []
             thumbnail_filename: str|None. The thumbnail filename of the topic.
             thumbnail_bg_color: str|None. The thumbnail background color of the
                 topic.
-            description: str. The description of the topic.
+            description: str. The desscription of the topic.
             canonical_story_ids: list(str). The list of ids of canonical stories
                 that are part of the topic.
             additional_story_ids: list(str). The list of ids of additional
@@ -1547,7 +1547,7 @@ tags: []
             name: str. The name of the topic.
             abbreviated_name: str. The abbreviated name of the topic.
             canonical_name: str. The canonical name (lowercase) of the topic.
-            description: str. The description of the topic.
+            description: str. The desscription of the topic.
             thumbnail_filename: str. The thumbnail file name of the topic.
             thumbnail_bg_color: str. The thumbnail background color of the
                 topic.
@@ -2202,7 +2202,9 @@ class AppEngineTestBase(TestBase):
                 state_domain.SubtitledHtml('hint_1', '<p>This is a hint.</p>')
             )
         ]
-        state.update_interaction_solution(solution_dict)
+        state.update_interaction_solution(
+            state_domain.Solution.from_dict(
+                state.interaction.id, solution_dict))
         state.update_interaction_hints(hints_list)
         state.interaction.customization_args = {
             'placeholder': 'Enter text here',

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -205,6 +205,8 @@ class TestBase(unittest.TestCase):
     # A test unicode string.
     UNICODE_TEST_STRING = u'unicode ¡马!'
 
+    SUPER_ADMIN_EMAIL = 'tmpsuperadmin@example.com'
+
     # Dummy strings representing user attributes. Note that it is up to the
     # individual test to actually register these users as editors, admins, etc.
     ADMIN_EMAIL = 'admin@example.com'
@@ -591,7 +593,7 @@ tags: []
         """Signs up a superadmin user. Should be called at the end of
         setUp().
         """
-        self.signup('tmpsuperadmin@example.com', 'tmpsuperadm1n')
+        self.signup(self.SUPER_ADMIN_EMAIL, 'tmpsuperadm1n')
 
     def log_line(self, line):
         """Print the line with a prefix that can be identified by the
@@ -968,8 +970,7 @@ tags: []
         """Sets a given configuration object's value to the new value specified
         using a POST request.
         """
-        with self.login_context('tmpsuperadmin@example.com',
-                                is_super_admin=True):
+        with self.login_context(self.SUPER_ADMIN_EMAIL, is_super_admin=True):
             csrf_token = self.get_new_csrf_token()
             self.post_json(
                 '/adminhandler', {
@@ -986,8 +987,7 @@ tags: []
             username: str. Username of the given user.
             user_role: str. Role of the given user.
         """
-        with self.login_context('tmpsuperadmin@example.com',
-                                is_super_admin=True):
+        with self.login_context(self.SUPER_ADMIN_EMAIL, is_super_admin=True):
             csrf_token = self.get_new_csrf_token()
             self.post_json(
                 '/adminrolehandler', {
@@ -1485,7 +1485,7 @@ tags: []
             thumbnail_filename: str|None. The thumbnail filename of the topic.
             thumbnail_bg_color: str|None. The thumbnail background color of the
                 topic.
-            description: str. The desscription of the topic.
+            description: str. The description of the topic.
             canonical_story_ids: list(str). The list of ids of canonical stories
                 that are part of the topic.
             additional_story_ids: list(str). The list of ids of additional


### PR DESCRIPTION
…
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #6271 
2. This PR does the following: Changing interaction_solution method to accept solution object instead of dict

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
