### PR TITLE
Fix #8423: Check that functions with test_only in their names are only used in _test.py files.

### DIFF
--- a/scripts/linters/python_linter.py
+++ b/scripts/linters/python_linter.py
@@ -159,7 +159,7 @@ class PythonLintChecksManager(python_utils.OBJECT):
 
             python_utils.PRINT(summary_message)
             summary_messages.append(summary_message)
-        return summary_messages    
+        return summary_messages
 
     def _check_that_all_jobs_are_listed_in_the_job_registry_file(self):
         """This function is used to check that all the one-off and audit jobs
@@ -290,7 +290,10 @@ class PythonLintChecksManager(python_utils.OBJECT):
         import_order_check_message = self._check_import_order()
         job_registry_check_message = (
             self._check_that_all_jobs_are_listed_in_the_job_registry_file())
-        return import_order_check_message + job_registry_check_message
+        test_function_check_message = self._check_non_test_files()
+        all_messages = import_order_check_message + job_registry_check_message
+        all_messages = all_messages + test_function_check_message
+        return all_messages
 
 
 class ThirdPartyPythonLintChecksManager(python_utils.OBJECT):

--- a/scripts/linters/python_linter.py
+++ b/scripts/linters/python_linter.py
@@ -117,6 +117,50 @@ class PythonLintChecksManager(python_utils.OBJECT):
                 summary_messages.append(summary_message)
         return summary_messages
 
+    def _check_non_test_files(self):
+        """This function is used to check that function
+           with test_only in their names are in test files.
+        """
+        if self.verbose_mode_enabled:
+            python_utils.PRINT('Starting function defintion checks')
+            python_utils.PRINT('----------------------------------------')
+        summary_messages = []
+        files_to_check = self.py_filepaths
+        with linter_utils.redirect_stdout(sys.stdout):
+            failed = False
+            for filepath in files_to_check:
+                if filepath.endswith('_test.py'):
+                    continue
+                for line_num, line in enumerate(FILE_CACHE.readlines(
+                        filepath)):
+                    line = line.strip()
+                    words = line.split()
+                    if len(words) < 2:
+                        continue
+                    ind1 = words[0].startswith('def')
+                    ind2 = words[1].startswith('test_only')
+                    if ind1 and ind2:
+                        summary_message = (
+                            '%s --> Line %s: Please do not use \'test_only\' '
+                            'in the non-test file.' % (filepath, line_num + 1))
+                        python_utils.PRINT(summary_message)
+                        summary_messages.append(summary_message)
+                        failed = True
+
+            if failed:
+                summary_message = (
+                    '%s Function defintion checks failed,'
+                    'see affect files above.'
+                    % (linter_utils.MESSAGE_TYPE_FAILED))
+            else:
+                summary_message = (
+                    '%s Function definition checks passed'
+                    % (linter_utils.MESSAGE_TYPE_SUCCESS))
+
+            python_utils.PRINT(summary_message)
+            summary_messages.append(summary_message)
+        return summary_messages    
+
     def _check_that_all_jobs_are_listed_in_the_job_registry_file(self):
         """This function is used to check that all the one-off and audit jobs
         are registered in jobs_registry.py file.


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #8423 .
2. This PR does the following: Check that functions with test_only in their names are only used in _test.py files.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
