### PR TITLE
Fix #6893: Make the suggestion validation less stringent to match validation of exploration categories

### DIFF
--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -283,11 +283,6 @@ class SuggestionEditStateContent(BaseSuggestion):
                     suggestion_models.SCORE_TYPE_CONTENT,
                     self.get_score_type()))
 
-        if self.get_score_sub_type() not in constants.ALL_CATEGORIES:
-            raise utils.ValidationError(
-                'Expected the second part of score_category to be a valid'
-                ' category, received %s' % self.get_score_sub_type())
-
         if self.change.cmd != exp_domain.CMD_EDIT_STATE_PROPERTY:
             raise utils.ValidationError(
                 'Expected cmd to be %s, received %s' % (
@@ -424,11 +419,6 @@ class SuggestionTranslateContent(BaseSuggestion):
                 ', received %s' % (
                     suggestion_models.SCORE_TYPE_TRANSLATION,
                     self.get_score_type()))
-
-        if self.get_score_sub_type() not in constants.ALL_CATEGORIES:
-            raise utils.ValidationError(
-                'Expected the second part of score_category to be a valid'
-                ' category, received %s' % self.get_score_sub_type())
 
         if self.change.cmd != exp_domain.CMD_ADD_TRANSLATION:
             raise utils.ValidationError(

--- a/core/domain/suggestion_registry_test.py
+++ b/core/domain/suggestion_registry_test.py
@@ -382,25 +382,6 @@ class SuggestionEditStateContentUnitTests(test_utils.GenericTestBase):
             'Expected the first part of score_category to be content'):
             suggestion.validate()
 
-    def test_validate_score_sub_type(self):
-        expected_suggestion_dict = self.suggestion_dict
-        suggestion = suggestion_registry.SuggestionEditStateContent(
-            expected_suggestion_dict['suggestion_id'],
-            expected_suggestion_dict['target_id'],
-            expected_suggestion_dict['target_version_at_submission'],
-            expected_suggestion_dict['status'], self.author_id,
-            self.reviewer_id, expected_suggestion_dict['change'],
-            expected_suggestion_dict['score_category'], self.fake_date)
-
-        suggestion.validate()
-
-        suggestion.score_category = 'content.invalid_score_sub_type'
-        with self.assertRaisesRegexp(
-            Exception,
-            'Expected the second part of score_category to be a valid'
-            ' category'):
-            suggestion.validate()
-
     def test_validate_change_cmd(self):
         expected_suggestion_dict = self.suggestion_dict
         suggestion = suggestion_registry.SuggestionEditStateContent(
@@ -410,7 +391,6 @@ class SuggestionEditStateContentUnitTests(test_utils.GenericTestBase):
             expected_suggestion_dict['status'], self.author_id,
             self.reviewer_id, expected_suggestion_dict['change'],
             expected_suggestion_dict['score_category'], self.fake_date)
-
         suggestion.validate()
 
         suggestion.change.cmd = 'invalid_cmd'
@@ -883,25 +863,6 @@ class SuggestionTranslateContentUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(
             Exception,
             'Expected the first part of score_category to be translation'):
-            suggestion.validate()
-
-    def test_validate_score_sub_type(self):
-        expected_suggestion_dict = self.suggestion_dict
-        suggestion = suggestion_registry.SuggestionTranslateContent(
-            expected_suggestion_dict['suggestion_id'],
-            expected_suggestion_dict['target_id'],
-            expected_suggestion_dict['target_version_at_submission'],
-            expected_suggestion_dict['status'], self.author_id,
-            self.reviewer_id, expected_suggestion_dict['change'],
-            expected_suggestion_dict['score_category'], self.fake_date)
-
-        suggestion.validate()
-
-        suggestion.score_category = 'translation.invalid_score_sub_type'
-        with self.assertRaisesRegexp(
-            Exception,
-            'Expected the second part of score_category to be a valid'
-            ' category'):
             suggestion.validate()
 
     def test_validate_change_cmd(self):


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #6893.
2. This PR does the following: Makes the validation of the score category less stringent as we noticed that the exploration category can be any string and it isn't restricted to the categories set in the constants.ALL_CATEGORIES. In light of this, we are removing the validation from suggestions.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
