### PR TITLE
Introduce ClearExplorationIssuesOneOffJob for deleting all playthroughs in storage

### DIFF
--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -216,7 +216,7 @@ class ClearExplorationIssuesOneOffJob(jobs.BaseMapReduceOneOffJobManager):
         """
         if model.deleted:
             return
-        if isinstance(model, stats_models.ExplorationIssuesModel):
+        elif isinstance(model, stats_models.ExplorationIssuesModel):
             for exp_issue in model.unresolved_issues:
                 for playthrough_id in exp_issue['playthrough_ids']:
                     yield (

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -193,9 +193,10 @@ class ClearExplorationIssuesOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
     @staticmethod
     def map(model):
-        """For ExplorationIssuesModel will clear the list and yield each of its
-        tracked playthrough_ids, otherwise for PlaythroughModel will yield its
-        existence for the reduce key to handle.
+        """For ExplorationIssuesModel, clear out its list of unresolved issues
+        and yield the playthrough ids it had managed so that it can be deleted
+        by the reduce function. Otherwise, for PlaythroughModel, will yield its
+        ID for the reduce function to delete just in case it is an orphan.
 
         Args:
             model: ExplorationIssuesModel or PlaythroughModel.

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -214,6 +214,8 @@ class ClearExplorationIssuesOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                         item_key: str. Either ITEM_KEY_ALL or ITEM_KEY_TRACKED.
                         playthrough_id: str. ID of a PlaythroughModel.
         """
+        if model.deleted:
+            return
         if isinstance(model, stats_models.ExplorationIssuesModel):
             for exp_issue in model.unresolved_issues:
                 for playthrough_id in exp_issue['playthrough_ids']:

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -240,13 +240,11 @@ class ClearExplorationIssuesOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                     RESULT_UNTRACKED_DELETES.
                 count: int. The number of deletions corresponding to the result.
         """
-        if (reduce_key ==
-                ClearExplorationIssuesOneOffJob.REDUCE_KEY_CLEARED):
+        if reduce_key == ClearExplorationIssuesOneOffJob.REDUCE_KEY_CLEARED:
             yield (
                 ClearExplorationIssuesOneOffJob.RESULT_CLEARED,
                 len(stringified_values))
-        elif (reduce_key ==
-                ClearExplorationIssuesOneOffJob.REDUCE_KEY_TO_DELETE):
+        elif reduce_key == ClearExplorationIssuesOneOffJob.REDUCE_KEY_TO_DELETE:
             map_results = [ast.literal_eval(v) for v in stringified_values]
             tracked_playthrough_ids_to_delete = set()
             all_playthrough_ids = set()

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -218,7 +218,7 @@ class ClearExplorationIssuesOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                         ClearExplorationIssuesOneOffJob.REDUCE_KEY_TO_DELETE, (
                             ClearExplorationIssuesOneOffJob.ITEM_KEY_TRACKED,
                             playthrough_id))
-                exp_issue['playthrough_ids'] = []
+            model.unresolved_issues = []
             model.put()
             yield (ClearExplorationIssuesOneOffJob.REDUCE_KEY_CLEARED, model.id)
 

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -237,12 +237,10 @@ class ClearExplorationIssuesOneOffJob(jobs.BaseMapReduceOneOffJobManager):
         Args:
             reduce_key: str. Either REDUCE_KEY_CLEARED or REDUCE_KEY_DELETE.
             stringified_values: list(str).
-
                 When reduce_key is REDUCE_KEY_CLEARED, then each item is:
                     exp_issues_id: str. the ID of the corresponding
                         ExplorationIssuesModel which was cleared of
                         playthroughs.
-
                 Otherwise, when reduce_key is REDUCE_KEY_DELETE, then each item
                 is a stringified tuple with the following values:
                     item_key: str. Either ITEM_KEY_ALL or ITEM_KEY_TRACKED.
@@ -250,8 +248,8 @@ class ClearExplorationIssuesOneOffJob(jobs.BaseMapReduceOneOffJobManager):
 
         Yields:
             tuple. Contains the following 2 values:
-                result_key: str. Either RESULT_TRACKED_DELETES,
-                    RESULT_UNTRACKED_DELETES, or RESULT_CLEARED.
+                result_key: str. Either RESULT_CLEARED, RESULT_TRACKED_DELETES,
+                    or RESULT_UNTRACKED_DELETES.
                 count: int. The number of operations corresponding to the
                     result key.
         """

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -173,7 +173,7 @@ class PlaythroughAudit(jobs.BaseMapReduceOneOffJobManager):
 
 class ClearExplorationIssuesOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     """Iterates through ExplorationIssuesModel and PlaythroughModel to ensure
-    each of them are completely deleted from storage.
+    each of them are completely cleared out/deleted from storage, respectively.
     """
 
     REDUCE_KEY_DELETE = 'DELETE'

--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -204,7 +204,7 @@ class ClearExplorationIssuesOneOffJob(jobs.BaseMapReduceOneOffJobManager):
         Yields:
             tuple. Contains the following two items:
                 reduce_key: str. Either REDUCE_KEY_CLEARED or REDUCE_KEY_DELETE.
-                reduce_value: tuple or str.
+                reduce_value: str or tuple.
                     When reduce_key is REDUCE_KEY_CLEARED, then each item is:
                         exp_issues_id: str. the ID of the corresponding
                             ExplorationIssuesModel which was cleared of
@@ -234,7 +234,7 @@ class ClearExplorationIssuesOneOffJob(jobs.BaseMapReduceOneOffJobManager):
     @staticmethod
     def reduce(reduce_key, stringified_values):
         """Yields details about the actions taken onto ExplorationIssuesModel
-        and PlaPlaythroughModel instances.
+        and PlaythroughModel instances.
 
         Args:
             reduce_key: str. Either REDUCE_KEY_CLEARED or REDUCE_KEY_DELETE.

--- a/core/domain/stats_jobs_one_off_test.py
+++ b/core/domain/stats_jobs_one_off_test.py
@@ -235,6 +235,24 @@ class ClearExplorationIssuesOneOffJobTests(OneOffJobTestBase):
     def test_job_reports_nothing_when_there_are_no_models(self):
         self.assertItemsEqual(self.run_one_off_job(), [])
 
+    def test_job_reports_nothing_when_items_are_already_deleted(self):
+        all_playthrough_ids = [
+            self.create_playthrough() for _ in python_utils.RANGE(2)
+        ]
+        exp_issues_id = self.create_exp_issues_with_playthroughs(
+            [all_playthrough_ids[0:1]])
+        exp_issues = (
+            stats_models.ExplorationIssuesModel.get_by_id(exp_issues_id))
+        exp_issues.deleted = True
+        exp_issues.put()
+        for playthrough_id in all_playthrough_ids:
+            playthrough = (
+                stats_models.PlaythroughModel.get_by_id(playthrough_id))
+            playthrough.deleted = True
+            playthrough.put()
+
+        self.assertItemsEqual(self.run_one_off_job(), [])
+
     def test_job_reports_cleared_exp_issues_without_any_playthroughs(self):
         exp_issues_id = self.create_exp_issues_with_playthroughs([
             [], [], [], # 3 exploration issues each referring to 0 playthroughs.

--- a/core/domain/stats_jobs_one_off_test.py
+++ b/core/domain/stats_jobs_one_off_test.py
@@ -246,9 +246,7 @@ class ClearExplorationIssuesOneOffJobTests(OneOffJobTestBase):
 
         exp_issues = (
             stats_models.ExplorationIssuesModel.get_by_id(exp_issues_id))
-        self.assertEqual(exp_issues.unresolved_issues[0]['playthrough_ids'], [])
-        self.assertEqual(exp_issues.unresolved_issues[1]['playthrough_ids'], [])
-        self.assertEqual(exp_issues.unresolved_issues[2]['playthrough_ids'], [])
+        self.assertEqual(exp_issues.unresolved_issues, [])
 
     def test_job_reports_deleted_untracked_playthroughs(self):
         playthrough_id = self.create_playthrough()
@@ -277,9 +275,7 @@ class ClearExplorationIssuesOneOffJobTests(OneOffJobTestBase):
 
         exp_issues = (
             stats_models.ExplorationIssuesModel.get_by_id(exp_issues_id))
-        self.assertEqual(exp_issues.unresolved_issues[0]['playthrough_ids'], [])
-        self.assertEqual(exp_issues.unresolved_issues[1]['playthrough_ids'], [])
-        self.assertEqual(exp_issues.unresolved_issues[2]['playthrough_ids'], [])
+        self.assertEqual(exp_issues.unresolved_issues, [])
         for playthrough_id in all_playthrough_ids:
             self.assertIsNone(
                 stats_models.PlaythroughModel.get_by_id(playthrough_id))
@@ -303,9 +299,7 @@ class ClearExplorationIssuesOneOffJobTests(OneOffJobTestBase):
 
         exp_issues = (
             stats_models.ExplorationIssuesModel.get_by_id(exp_issues_id))
-        self.assertEqual(exp_issues.unresolved_issues[0]['playthrough_ids'], [])
-        self.assertEqual(exp_issues.unresolved_issues[1]['playthrough_ids'], [])
-        self.assertEqual(exp_issues.unresolved_issues[2]['playthrough_ids'], [])
+        self.assertEqual(exp_issues.unresolved_issues, [])
         for playthrough_id in all_playthrough_ids:
             self.assertIsNone(
                 stats_models.PlaythroughModel.get_by_id(playthrough_id))

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -62,6 +62,7 @@ ONE_OFF_JOB_MANAGERS = [
     question_jobs_one_off.QuestionMigrationOneOffJob,
     recommendations_jobs_one_off.ExplorationRecommendationsOneOffJob,
     skill_jobs_one_off.SkillMigrationOneOffJob,
+    stats_jobs_one_off.ClearExplorationIssuesOneOffJob,
     stats_jobs_one_off.ExplorationMissingStatsAudit,
     stats_jobs_one_off.PlaythroughAudit,
     stats_jobs_one_off.RecomputeStatisticsOneOffJob,


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. ~~This PR fixes or fixes part of #N/A.~~
2. This PR does the following: Introduces a one off job for clearing all playthroughs from the storage, even if they aren't being tracked by an `ExplorationIssuesModel`. For those that are tracked, however, the corresponding tracking lists are cleared out as well. After this job, every `ExplorationIssuesModel` instance will have an empty list of `unresolved_issues`.

## Essential Checklist

- [x] ~~The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)~~
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
