### PR TITLE
Fix #9632: Forgive missing state stats when performing updates

### DIFF
--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -139,11 +139,9 @@ def update_stats(exp_id, exp_version, aggregated_stats):
     for state_name, aggregated_state_stats in (
             aggregated_stats['state_stats_mapping'].items()):
         if state_name not in exploration_stats.state_stats_mapping:
-            state_stats = (
+            exploration_stats.state_stats_mapping[state_name] = (
                 stats_domain.StateStats.create_default())
-            exploration_stats.state_stats_mapping[state_name] = state_stats
-        else:
-            state_stats = exploration_stats.state_stats_mapping[state_name]
+        state_stats = exploration_stats.state_stats_mapping[state_name]
         state_stats.total_answers_count_v2 += (
             aggregated_state_stats['total_answers_count'])
         state_stats.useful_feedback_count_v2 += (

--- a/core/domain/stats_services.py
+++ b/core/domain/stats_services.py
@@ -136,25 +136,26 @@ def update_stats(exp_id, exp_version, aggregated_stats):
     exploration_stats.num_actual_starts_v2 += aggregated_stats[
         'num_actual_starts']
 
-    for state_name in aggregated_stats['state_stats_mapping']:
-        exploration_stats.state_stats_mapping[
-            state_name].total_answers_count_v2 += aggregated_stats[
-                'state_stats_mapping'][state_name]['total_answers_count']
-        exploration_stats.state_stats_mapping[
-            state_name].useful_feedback_count_v2 += aggregated_stats[
-                'state_stats_mapping'][state_name]['useful_feedback_count']
-        exploration_stats.state_stats_mapping[
-            state_name].total_hit_count_v2 += aggregated_stats[
-                'state_stats_mapping'][state_name]['total_hit_count']
-        exploration_stats.state_stats_mapping[
-            state_name].first_hit_count_v2 += aggregated_stats[
-                'state_stats_mapping'][state_name]['first_hit_count']
-        exploration_stats.state_stats_mapping[
-            state_name].num_times_solution_viewed_v2 += aggregated_stats[
-                'state_stats_mapping'][state_name]['num_times_solution_viewed']
-        exploration_stats.state_stats_mapping[
-            state_name].num_completions_v2 += aggregated_stats[
-                'state_stats_mapping'][state_name]['num_completions']
+    for state_name, aggregated_state_stats in (
+            aggregated_stats['state_stats_mapping'].items()):
+        if state_name not in exploration_stats.state_stats_mapping:
+            state_stats = (
+                stats_domain.StateStats.create_default())
+            exploration_stats.state_stats_mapping[state_name] = state_stats
+        else:
+            state_stats = exploration_stats.state_stats_mapping[state_name]
+        state_stats.total_answers_count_v2 += (
+            aggregated_state_stats['total_answers_count'])
+        state_stats.useful_feedback_count_v2 += (
+            aggregated_state_stats['useful_feedback_count'])
+        state_stats.total_hit_count_v2 += (
+            aggregated_state_stats['total_hit_count'])
+        state_stats.first_hit_count_v2 += (
+            aggregated_state_stats['first_hit_count'])
+        state_stats.num_times_solution_viewed_v2 += (
+            aggregated_state_stats['num_times_solution_viewed'])
+        state_stats.num_completions_v2 += (
+            aggregated_state_stats['num_completions'])
 
     save_stats_model_transactional(exploration_stats)
 

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -94,6 +94,56 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             }
         }
 
+        stats_services.update_stats('exp_id1', 1, aggregated_stats)
+        exploration_stats = (
+            stats_services.get_exploration_stats_by_id('exp_id1', 1))
+        self.assertEqual(exploration_stats.num_starts_v2, 1)
+        self.assertEqual(exploration_stats.num_actual_starts_v2, 1)
+        self.assertEqual(exploration_stats.num_completions_v2, 1)
+        self.assertEqual(
+            exploration_stats.state_stats_mapping[
+                'Home'].total_hit_count_v2, 1)
+        self.assertEqual(
+            exploration_stats.state_stats_mapping[
+                'Home'].first_hit_count_v2, 1)
+        self.assertEqual(
+            exploration_stats.state_stats_mapping[
+                'Home'].total_answers_count_v2, 1)
+        self.assertEqual(
+            exploration_stats.state_stats_mapping[
+                'Home'].useful_feedback_count_v2, 1)
+        self.assertEqual(
+            exploration_stats.state_stats_mapping[
+                'Home'].num_completions_v2, 1)
+        self.assertEqual(
+            exploration_stats.state_stats_mapping[
+                'Home'].num_times_solution_viewed_v2, 1)
+
+    def test_update_stats_method_when_state_stats_are_missing(self):
+        """Test the update_stats method."""
+        exploration_stats = stats_services.get_exploration_stats_by_id(
+            'exp_id1', 1)
+        exploration_stats.state_stats_mapping = {}
+        stats_services.save_stats_model_transactional(exploration_stats)
+
+        # Pass in exploration start event to stats model created in setup
+        # function.
+        aggregated_stats = {
+            'num_starts': 1,
+            'num_actual_starts': 1,
+            'num_completions': 1,
+            'state_stats_mapping': {
+                'Home': {
+                    'total_hit_count': 1,
+                    'first_hit_count': 1,
+                    'total_answers_count': 1,
+                    'useful_feedback_count': 1,
+                    'num_times_solution_viewed': 1,
+                    'num_completions': 1
+                }
+            }
+        }
+
         stats_services.update_stats(
             'exp_id1', 1, aggregated_stats)
         exploration_stats = stats_services.get_exploration_stats_by_id(

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -120,15 +120,13 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                 'Home'].num_times_solution_viewed_v2, 1)
 
     def test_update_stats_method_when_state_stats_are_missing(self):
-        """Test the update_stats method."""
+        """Test the update_stats method when a state does not have stats."""
         exploration_stats = stats_services.get_exploration_stats_by_id(
             'exp_id1', 1)
         exploration_stats.state_stats_mapping = {}
         stats_services.save_stats_model_transactional(exploration_stats)
 
-        # Pass in exploration start event to stats model created in setup
-        # function.
-        aggregated_stats = {
+        stats_services.update_stats('exp_id1', 1, {
             'num_starts': 1,
             'num_actual_starts': 1,
             'num_completions': 1,
@@ -142,21 +140,16 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
                     'num_completions': 1
                 }
             }
-        }
-
-        stats_services.update_stats(
-            'exp_id1', 1, aggregated_stats)
-        exploration_stats = stats_services.get_exploration_stats_by_id(
-            'exp_id1', 1)
+        })
+        exploration_stats = (
+            stats_services.get_exploration_stats_by_id('exp_id1', 1))
         self.assertEqual(exploration_stats.num_starts_v2, 1)
         self.assertEqual(exploration_stats.num_actual_starts_v2, 1)
         self.assertEqual(exploration_stats.num_completions_v2, 1)
         self.assertEqual(
-            exploration_stats.state_stats_mapping[
-                'Home'].total_hit_count_v2, 1)
+            exploration_stats.state_stats_mapping['Home'].total_hit_count_v2, 1)
         self.assertEqual(
-            exploration_stats.state_stats_mapping[
-                'Home'].first_hit_count_v2, 1)
+            exploration_stats.state_stats_mapping['Home'].first_hit_count_v2, 1)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
                 'Home'].total_answers_count_v2, 1)
@@ -164,8 +157,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             exploration_stats.state_stats_mapping[
                 'Home'].useful_feedback_count_v2, 1)
         self.assertEqual(
-            exploration_stats.state_stats_mapping[
-                'Home'].num_completions_v2, 1)
+            exploration_stats.state_stats_mapping['Home'].num_completions_v2, 1)
         self.assertEqual(
             exploration_stats.state_stats_mapping[
                 'Home'].num_times_solution_viewed_v2, 1)

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -121,26 +121,27 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
 
     def test_update_stats_method_when_state_stats_are_missing(self):
         """Test the update_stats method when a state does not have stats."""
-        exploration_stats = stats_services.get_exploration_stats_by_id(
-            'exp_id1', 1)
+        exploration_stats = (
+            stats_services.get_exploration_stats_by_id('exp_id1', 1))
         exploration_stats.state_stats_mapping = {}
         stats_services.save_stats_model_transactional(exploration_stats)
 
-        stats_services.update_stats('exp_id1', 1, {
-            'num_starts': 1,
-            'num_actual_starts': 1,
-            'num_completions': 1,
-            'state_stats_mapping': {
-                'Home': {
-                    'total_hit_count': 1,
-                    'first_hit_count': 1,
-                    'total_answers_count': 1,
-                    'useful_feedback_count': 1,
-                    'num_times_solution_viewed': 1,
-                    'num_completions': 1
+        stats_services.update_stats(
+            'exp_id1', 1, {
+                'num_starts': 1,
+                'num_actual_starts': 1,
+                'num_completions': 1,
+                'state_stats_mapping': {
+                    'Home': {
+                        'total_hit_count': 1,
+                        'first_hit_count': 1,
+                        'total_answers_count': 1,
+                        'useful_feedback_count': 1,
+                        'num_times_solution_viewed': 1,
+                        'num_completions': 1
+                    }
                 }
-            }
-        })
+            })
         exploration_stats = (
             stats_services.get_exploration_stats_by_id('exp_id1', 1))
         self.assertEqual(exploration_stats.num_starts_v2, 1)


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #9632.
2. This PR does the following: Missing state-stats are causing 500 error logs from "/_ah/queue/deferred". This PR forgives missing states, and gives them a default value of "zero" so that we can prevent more errors.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
