### PR TITLE
Remove lint checks and backend tests from circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,16 +19,10 @@ workflows:
 
     jobs:
       - setup
-      - lint_tests:
-          requires:
-            - setup
       - frontend_tests:
           requires:
             - setup
       - typescript_tests:
-          requires:
-            - frontend_tests
-      - backend_tests:
           requires:
             - frontend_tests
       - e2e_non_prod_tests:
@@ -104,22 +98,6 @@ jobs:
             - oppia/third_party/
             - oppia_tools/
 
-  lint_tests:
-    <<: *job_defaults
-    steps:
-      - checkout
-      - merge_target_branch
-      - attach_workspace:
-          at: /home/circleci/
-      - run:
-          name: Run lint tests
-          # All the python scripts should behave as modules. Files like the
-          # pre_commit_linter and third_party_size_check need to import other
-          # Python files and that is only possible if we treat it as a module.
-          command: |
-            python -m scripts.third_party_size_check
-            python -m scripts.linters.pre_commit_linter --path=. --verbose
-
   typescript_tests:
     <<: *job_defaults
     steps:
@@ -149,18 +127,6 @@ jobs:
             sudo pip install codecov
             codecov --file ../karma_coverage_reports/lcov.info -F frontend
           when: on_success
-
-  backend_tests:
-    <<: *job_defaults
-    steps:
-      - checkout
-      - merge_target_branch
-      - attach_workspace:
-          at: /home/circleci/
-      - run:
-          name: Run backend tests
-          command: |
-            python -m scripts.run_backend_tests --generate_coverage_report --exclude_load_tests
 
   # Production environment e2e tests
   # The following e2e tests are run in the production environment. Tests that require uploading files


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: In an attempt to reduce the pressure on the CircleCI queue, we have moved these tests to Github Actions.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
