### PR TITLE
Suppress 40k lines of ENOSPC output in frontend tests. Build GitHub Actions only on pushes/PRs to develop or release branches.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - develop
+      - release-*
   pull_request:
     branches:
       - develop
+      - release-*
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,11 @@
 name: Lint Checks
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,4 +36,8 @@ jobs:
       - name: Install third party
         run: python -m scripts.install_third_party_libs
       - name: Run frontend tests
-        run: python -m scripts.run_frontend_tests --run_minified_tests --skip_install --check_coverage
+        run: |
+          # Suppresses ENOSPC error from chokidar file watcher: see https://stackoverflow.com/a/32600959.
+          # Probably due to GitHub Actions machines having low capacity.
+          echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+          python -m scripts.run_frontend_tests --run_minified_tests --skip_install --check_coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,11 @@
 name: CI Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
 
 jobs:
   backend:
@@ -35,9 +41,7 @@ jobs:
           architecture: 'x64'
       - name: Install third party
         run: python -m scripts.install_third_party_libs
+      - name: Suppress ENOSPC error from chokidar file watcher. See https://stackoverflow.com/a/32600959.
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - name: Run frontend tests
-        run: |
-          # Suppresses ENOSPC error from chokidar file watcher: see https://stackoverflow.com/a/32600959.
-          # Probably due to GitHub Actions machines having low capacity.
-          echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-          python -m scripts.run_frontend_tests --run_minified_tests --skip_install --check_coverage
+        run: python -m scripts.run_frontend_tests --run_minified_tests --skip_install --check_coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - develop
+      - release-*
   pull_request:
     branches:
       - develop
+      - release-*
 
 jobs:
   backend:


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of n/a
2. This PR does the following: Attempts to prevent 40k lines of ENOSPC output in frontend tests as shown in e.g. this GitHub Actions log: https://github.com/oppia/oppia/pull/9672/checks?check_run_id=813620007. Also builds only on pushes/PRs to develop or release branches.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
