### PR TITLE
Fix Travis email notifications to always notify on failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ notifications:
       # travis encrypt -r oppia/oppia "oppia-ci-notifications@googlegroups.com"
       secure: uMMzsG4ZAB9ofJR/m+KUlTmsYj7oahtCIzUVCZl9BX0qxgMgiwHDTEzHqvyAcyFOaYsKpFyWFKRBfakOizPXP8DZw8/yXi9YtieSUUzxXFZxsGahcVatJBRVKGPw1L4C+V59N9+DdeMLpAd/knQ88uEffOHCCLuoWrsfC/Tz/35yD7zCrLmsnFjcjkufaXh9qCEUjkzq/SgpsvqJRHHP8hrKh3QetmCWhzTD/ZoPxKgpkd5LiFN0AYjRmUN538NAP9Us8WLeQigcM2UyX7WJakmGHgLMm9ieAQRJwcd1bX3Nf+WQNymidGrZnoWSrFiyLmbO8+fiMDZHVRgVC7jeGXGt0hHP9FiNWCjyW4B66ll4RT8iN/IfYJ1RF7fcgzs6cU6jZFUUZBeIdf1Wiv1zNproEAKJKFZVrxlImJeg9Js9vC+TB/Talxj9mnvm/yWZVnSCW6FN/Q/n8dkuIR/VmVkoUwmL/8A0hsZzi31JpZCqv+/8K2hEv9b3zl3lKr6h/o1WHPhU6K5i/XzIV5LhjiM6O6AwEn97bjsEnZqNeZ8O/W7Q+aifG1yX+bfN3qflFE1A/xiruhRFxxSdYfbrF1PvX92IwAwvhBEjDm9Cw/a0QNRY7S92SBNgUaQqEb0MrgbmFyEapf4pzo9Sp9UyQwisLCpL9xZr0cC4vhWTE5A=
     on_success: change
-    on_failure: change
+    on_failure: always
   webhooks:
     urls:
     # This URL can be obtained by going to the Gitter chat room


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of n/a
2. This PR does the following: Updates Travis to send an email on every failure, rather than only on a status change from success to failed.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
