### PR TITLE
Fix #9691: Increase build time for nav-and-misc e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,8 @@ jobs:
           name: Run e2e navigation test
           command: |
             python -m scripts.run_e2e_tests --prod_env --deparallelize_terser --skip-install --suite="navigation"
+          # Provide a longer time period for the first test, since the webpack build process can take up to 10 minutes.
+          no_output_timeout: 20m
       - run:
           name: Run e2e admin page test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,7 +110,10 @@ jobs:
           name: Run e2e navigation test
           command: |
             python -m scripts.run_e2e_tests --prod_env --deparallelize_terser --skip-install --suite="navigation"
-          # Provide a longer time period for the first test, since the webpack build process can take up to 10 minutes.
+          # Provide a longer time period for this first test (which omits the
+          # --skip-build flag), since the webpack build process itself can take
+          # up to 10 minutes. If this is not done, then the test may stall due
+          # to lack of test output during this time.
           no_output_timeout: 20m
       - run:
           name: Run e2e admin page test


### PR DESCRIPTION
## Overview

1. This PR fixes #9691.
2. This PR does the following: Extends build time without output for e2e_navigation_and_misc test. This particular e2e test may take longer because it is the only one which runs webpack build, which can run for at least 10 min on CircleCI without output, resulting in a stalled test.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
