### PR TITLE
Remove extra spaces in changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,7 +51,7 @@ Data handling
 * Fix part of #5914: Complete Takeout Frontend (#9424)
 * Fix part of #5914: Add JSON rendering testing to Takeout (#9301)
 * Fixed user updates. (#9252)
-*  Added update username functionality in the admin tab. (#9191)
+* Added update username functionality in the admin tab. (#9191)
 * Wipeout 3.10: Add new field to rights models (#8505)
 
 QA Team
@@ -87,7 +87,7 @@ Angular Migration
 * Milestone 1.4.3: Add type definitions for __fixtures__ (#9307)
 * Fix #8472: Collection creation service upgrade (#9303)
 * Fix part of #8472: Upgrades StatsReportingService and MessengerService to Angular (#9299)
-*  Milestone 1.4.2: Split ICustomScope to respective directives (#9298)
+* Milestone 1.4.2: Split ICustomScope to respective directives (#9298)
 * Fix part of #8472: Upgrades PlaythroughService to Angular (#9290)
 * Fix part of #8472: Upgrades PredictionAlgorithmRegistryService to Angular 8 (#9289)
 * Migrates donate-page directive to angular component (#9202)


### PR DESCRIPTION
## Overview
~~1. This PR fixes or fixes part of N/A.~~
2. This PR does the following: Removes extra spaces from changelog

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
