### PR TITLE
Fix #9722: Fixing skill modal opening twice bug, Adding reordering functionality and Unassigned topic filter

### DIFF
--- a/core/domain/topic_domain.py
+++ b/core/domain/topic_domain.py
@@ -59,6 +59,7 @@ CMD_ADD_SUBTOPIC = 'add_subtopic'
 CMD_DELETE_SUBTOPIC = 'delete_subtopic'
 CMD_ADD_CANONICAL_STORY = 'add_canonical_story'
 CMD_DELETE_CANONICAL_STORY = 'delete_canonical_story'
+CMD_REARRANGE_CANONICAL_STORY = 'rearrange_canonical_story'
 CMD_ADD_ADDITIONAL_STORY = 'add_additional_story'
 CMD_DELETE_ADDITIONAL_STORY = 'delete_additional_story'
 CMD_PUBLISH_STORY = 'publish_story'
@@ -134,6 +135,10 @@ class TopicChange(change_domain.BaseChange):
     }, {
         'name': CMD_DELETE_CANONICAL_STORY,
         'required_attribute_names': ['story_id'],
+        'optional_attribute_names': []
+    }, {
+        'name': CMD_REARRANGE_CANONICAL_STORY,
+        'required_attribute_names': ['from_index', 'to_index'],
         'optional_attribute_names': []
     }, {
         'name': CMD_ADD_ADDITIONAL_STORY,
@@ -707,6 +712,35 @@ class Topic(python_utils.OBJECT):
             raise Exception(
                 'The story_id %s is not present in the canonical '
                 'story references list of the topic.' % story_id)
+
+    def rearrange_canonical_story(self, from_index, to_index):
+        """Rearranges or moves a canonical story to another position and
+
+        Args:
+            from_index: int. The index of canonical story index to move.
+            to_index: int. The index at which to insert the moved canonical
+                story.
+
+        Raises:
+            Exception. Invalid input.
+        """
+        if not isinstance(from_index, int):
+            raise Exception('Expected from_index value to be a number, '
+                            'received %s' % from_index)
+
+        if not isinstance(to_index, int):
+            raise Exception('Expected to_index value to be a number, '
+                            'received %s' % to_index)
+
+        if from_index == to_index:
+            raise Exception('Expected from_index and to_index values '
+                            'to be different.')
+
+        canonical_story_reference_to_move = copy.deepcopy(
+            self.canonical_story_references[from_index])
+        del self.canonical_story_references[from_index]
+        self.canonical_story_references.insert(
+            to_index, canonical_story_reference_to_move)
 
     def add_canonical_story(self, story_id):
         """Adds a story to the canonical_story_references list.

--- a/core/domain/topic_domain.py
+++ b/core/domain/topic_domain.py
@@ -714,10 +714,10 @@ class Topic(python_utils.OBJECT):
                 'story references list of the topic.' % story_id)
 
     def rearrange_canonical_story(self, from_index, to_index):
-        """Rearranges or moves a canonical story to another position and
+        """Rearranges or moves a canonical story to another position.
 
         Args:
-            from_index: int. The index of canonical story index to move.
+            from_index: int. The index of canonical story to move.
             to_index: int. The index at which to insert the moved canonical
                 story.
 
@@ -735,6 +735,11 @@ class Topic(python_utils.OBJECT):
         if from_index == to_index:
             raise Exception('Expected from_index and to_index values '
                             'to be different.')
+
+        if (from_index >= len(self.canonical_story_references) or
+                to_index >= len(self.canonical_story_references) or
+                from_index < 0 or to_index < 0):
+            raise Exception('Expected index values to be with-in bounds.')
 
         canonical_story_reference_to_move = copy.deepcopy(
             self.canonical_story_references[from_index])

--- a/core/domain/topic_domain_test.py
+++ b/core/domain/topic_domain_test.py
@@ -140,6 +140,23 @@ class TopicDomainUnitTests(test_utils.GenericTestBase):
                        'received a'):
             self.topic.rearrange_canonical_story(1, 'a')
 
+    def test_rearrange_canonical_story_fail_with_out_of_bound_indexes(self):
+        with self.assertRaisesRegexp(
+            Exception, 'Expected index values to be with-in bounds.'):
+            self.topic.rearrange_canonical_story(1, 10)
+
+        with self.assertRaisesRegexp(
+            Exception, 'Expected index values to be with-in bounds.'):
+            self.topic.rearrange_canonical_story(-1, 0)
+
+        with self.assertRaisesRegexp(
+            Exception, 'Expected index values to be with-in bounds.'):
+            self.topic.rearrange_canonical_story(10, 0)
+
+        with self.assertRaisesRegexp(
+            Exception, 'Expected index values to be with-in bounds.'):
+            self.topic.rearrange_canonical_story(-1, -10)
+
     def test_rearrange_canonical_story_fail_with_identical_index_values(self):
         with self.assertRaisesRegexp(
             Exception, 'Expected from_index and to_index values to be '

--- a/core/domain/topic_domain_test.py
+++ b/core/domain/topic_domain_test.py
@@ -118,6 +118,67 @@ class TopicDomainUnitTests(test_utils.GenericTestBase):
             ' story references list of the topic.'):
             self.topic.delete_canonical_story('story_id_5')
 
+    def test_rearrange_canonical_story_fail_with_invalid_from_index_value(self):
+        with self.assertRaisesRegexp(
+            Exception, 'Expected from_index value to be a number, '
+                       'received None'):
+            self.topic.rearrange_canonical_story(None, 2)
+
+        with self.assertRaisesRegexp(
+            Exception, 'Expected from_index value to be a number, '
+                       'received a'):
+            self.topic.rearrange_canonical_story('a', 2)
+
+    def test_rearrange_canonical_story_fail_with_invalid_to_index_value(self):
+        with self.assertRaisesRegexp(
+            Exception, 'Expected to_index value to be a number, '
+                       'received None'):
+            self.topic.rearrange_canonical_story(1, None)
+
+        with self.assertRaisesRegexp(
+            Exception, 'Expected to_index value to be a number, '
+                       'received a'):
+            self.topic.rearrange_canonical_story(1, 'a')
+
+    def test_rearrange_canonical_story_fail_with_identical_index_values(self):
+        with self.assertRaisesRegexp(
+            Exception, 'Expected from_index and to_index values to be '
+                       'different.'):
+            self.topic.rearrange_canonical_story(1, 1)
+
+    def test_rearrange_canonical_story(self):
+        self.topic.canonical_story_references = [
+            topic_domain.StoryReference.create_default_story_reference(
+                'story_id_1'),
+            topic_domain.StoryReference.create_default_story_reference(
+                'story_id_2'),
+            topic_domain.StoryReference.create_default_story_reference(
+                'story_id_3')
+        ]
+        canonical_story_ids = self.topic.get_canonical_story_ids()
+
+        self.assertEqual(canonical_story_ids[0], 'story_id_1')
+        self.assertEqual(canonical_story_ids[1], 'story_id_2')
+        self.assertEqual(canonical_story_ids[2], 'story_id_3')
+
+        self.topic.rearrange_canonical_story(1, 0)
+        canonical_story_ids = self.topic.get_canonical_story_ids()
+        self.assertEqual(canonical_story_ids[0], 'story_id_2')
+        self.assertEqual(canonical_story_ids[1], 'story_id_1')
+        self.assertEqual(canonical_story_ids[2], 'story_id_3')
+
+        self.topic.rearrange_canonical_story(2, 1)
+        canonical_story_ids = self.topic.get_canonical_story_ids()
+        self.assertEqual(canonical_story_ids[0], 'story_id_2')
+        self.assertEqual(canonical_story_ids[1], 'story_id_3')
+        self.assertEqual(canonical_story_ids[2], 'story_id_1')
+
+        self.topic.rearrange_canonical_story(2, 0)
+        canonical_story_ids = self.topic.get_canonical_story_ids()
+        self.assertEqual(canonical_story_ids[0], 'story_id_1')
+        self.assertEqual(canonical_story_ids[1], 'story_id_2')
+        self.assertEqual(canonical_story_ids[2], 'story_id_3')
+
     def test_get_all_story_references(self):
         self.topic.canonical_story_references = [
             topic_domain.StoryReference.create_default_story_reference(

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -282,6 +282,9 @@ def apply_change_list(topic_id, change_list):
                 topic.add_canonical_story(change.story_id)
             elif change.cmd == topic_domain.CMD_DELETE_CANONICAL_STORY:
                 topic.delete_canonical_story(change.story_id)
+            elif change.cmd == topic_domain.CMD_REARRANGE_CANONICAL_STORY:
+                topic.rearrange_canonical_story(
+                    change.from_index, change.to_index)
             elif change.cmd == topic_domain.CMD_ADD_ADDITIONAL_STORY:
                 topic.add_additional_story(change.story_id)
             elif change.cmd == topic_domain.CMD_DELETE_ADDITIONAL_STORY:

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -704,26 +704,6 @@ def add_additional_story(user_id, topic_id, story_id):
         'Added %s to additional story ids' % story_id)
 
 
-def rearrange_canonical_story(user_id, topic_id, from_index, to_index):
-    """Adds a story to the additional story reference list of a topic.
-
-    Args:
-        user_id: str. The id of the user who is performing the action.
-        topic_id: str. The id of the topic to which the story is to be added.
-        from_index: int. The index of canonical story index to move.
-        to_index: int. The index at which to insert the moved canonical story.
-    """
-    change_list = [topic_domain.TopicChange({
-        'cmd': topic_domain.CMD_REARRANGE_CANONICAL_STORY,
-        'from_index': from_index,
-        'to_index': to_index
-    })]
-    update_topic_and_subtopic_pages(
-        user_id, topic_id, change_list,
-        'Rearranged canonical story on index %s to index %s' % (
-            from_index, to_index))
-
-
 def delete_topic(committer_id, topic_id, force_deletion=False):
     """Deletes the topic with the given topic_id.
 

--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -704,6 +704,26 @@ def add_additional_story(user_id, topic_id, story_id):
         'Added %s to additional story ids' % story_id)
 
 
+def rearrange_canonical_story(user_id, topic_id, from_index, to_index):
+    """Adds a story to the additional story reference list of a topic.
+
+    Args:
+        user_id: str. The id of the user who is performing the action.
+        topic_id: str. The id of the topic to which the story is to be added.
+        from_index: int. The index of canonical story index to move.
+        to_index: int. The index at which to insert the moved canonical story.
+    """
+    change_list = [topic_domain.TopicChange({
+        'cmd': topic_domain.CMD_REARRANGE_CANONICAL_STORY,
+        'from_index': from_index,
+        'to_index': to_index
+    })]
+    update_topic_and_subtopic_pages(
+        user_id, topic_id, change_list,
+        'Rearranged canonical story on index %s to index %s' % (
+            from_index, to_index))
+
+
 def delete_topic(committer_id, topic_id, force_deletion=False):
     """Deletes the topic with the given topic_id.
 

--- a/core/domain/topic_services_test.py
+++ b/core/domain/topic_services_test.py
@@ -258,6 +258,32 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
                 'new_value': 'New Description'
             })
 
+    def test_cannot_rearrange_story_with_missing_index_values(self):
+        with self.assertRaisesRegexp(
+            Exception, ('The following required attributes are missing: '
+                        'from_index, to_index')):
+            topic_domain.TopicChange({
+                'cmd': topic_domain.CMD_REARRANGE_CANONICAL_STORY,
+            })
+
+    def test_cannot_rearrange_story_with_missing_from_index_value(self):
+        with self.assertRaisesRegexp(
+            Exception, ('The following required attributes are missing: '
+                        'from_index')):
+            topic_domain.TopicChange({
+                'cmd': topic_domain.CMD_REARRANGE_CANONICAL_STORY,
+                'to_index': 1
+            })
+
+    def test_cannot_rearrange_story_with_missing_to_index_value(self):
+        with self.assertRaisesRegexp(
+            Exception, ('The following required attributes are missing: '
+                        'to_index')):
+            topic_domain.TopicChange({
+                'cmd': topic_domain.CMD_REARRANGE_CANONICAL_STORY,
+                'from_index': 1
+            })
+
     def test_cannot_update_topic_property_with_invalid_changelist(self):
         with self.assertRaisesRegexp(
             Exception, (

--- a/core/domain/topic_services_test.py
+++ b/core/domain/topic_services_test.py
@@ -298,8 +298,15 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             topic.canonical_story_references[2].story_id, story_id_new)
 
-        topic_services.rearrange_canonical_story(
-            self.user_id_admin, self.TOPIC_ID, 2, 0)
+        changelist = [topic_domain.TopicChange({
+            'cmd': topic_domain.CMD_REARRANGE_CANONICAL_STORY,
+            'from_index': 2,
+            'to_index': 0
+        })]
+
+        topic_services.update_topic_and_subtopic_pages(
+            self.user_id_admin, self.TOPIC_ID, changelist,
+            'Rearranged canonical story on index 2 to index 0.')
 
         topic = topic_fetchers.get_topic_by_id(self.TOPIC_ID)
         self.assertEqual(len(topic.canonical_story_references), 3)
@@ -317,7 +324,7 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(topic_commit_log_entry.user_id, self.user_id_admin)
         self.assertEqual(
             topic_commit_log_entry.commit_message,
-            'Rearranged canonical story on index 2 to index 0')
+            'Rearranged canonical story on index 2 to index 0.')
 
     def test_cannot_update_topic_property_with_invalid_changelist(self):
         with self.assertRaisesRegexp(

--- a/core/templates/components/entity-creation-services/skill-creation.service.ts
+++ b/core/templates/components/entity-creation-services/skill-creation.service.ts
@@ -63,11 +63,11 @@ angular.module('oppia').factory('SkillCreationService', [
         skillDescriptionStatusMarker = (
           SKILL_DESCRIPTION_STATUS_VALUES.STATUS_UNCHANGED);
       },
-      createNewSkill: function() {
+      createNewSkill: function(topicIds) {
         $uibModal.open({
           templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
             '/pages/topics-and-skills-dashboard-page/templates/' +
-              'create-new-skill-modal.template.html'),
+            'create-new-skill-modal.template.html'),
           backdrop: 'static',
           controller: 'CreateNewSkillModalController'
         }).result.then(function(result) {
@@ -91,7 +91,7 @@ angular.module('oppia').factory('SkillCreationService', [
           var imagesData = ImageLocalStorageService.getStoredImagesData();
           SkillCreationBackendApiService.createSkill(
             result.description, rubrics, result.explanation,
-            [], imagesData).then(function(response) {
+            topicIds || [], imagesData).then(function(response) {
             $timeout(function() {
               $rootScope.$broadcast(
                 EVENT_TOPICS_AND_SKILLS_DASHBOARD_REINITIALIZED, true);

--- a/core/templates/domain/topic/TopicObjectFactory.ts
+++ b/core/templates/domain/topic/TopicObjectFactory.ts
@@ -346,6 +346,13 @@ export class Topic {
     this._canonicalStoryReferences.splice(index, 1);
   }
 
+  rearrangeCanonicalStory(fromIndex: number, toIndex: number): void {
+    const canonicalStoryToMove = cloneDeep(
+      this._canonicalStoryReferences[fromIndex]);
+    this._canonicalStoryReferences.splice(fromIndex, 1);
+    this._canonicalStoryReferences.splice(toIndex, 0, canonicalStoryToMove);
+  }
+
   clearCanonicalStoryReferences(): void {
     this._canonicalStoryReferences.length = 0;
   }

--- a/core/templates/domain/topic/topic-domain.constants.ajs.ts
+++ b/core/templates/domain/topic/topic-domain.constants.ajs.ts
@@ -44,6 +44,9 @@ angular.module('oppia').constant(
   'CMD_DELETE_CANONICAL_STORY',
   TopicDomainConstants.CMD_DELETE_CANONICAL_STORY);
 angular.module('oppia').constant(
+  'CMD_REARRANGE_CANONICAL_STORY',
+  TopicDomainConstants.CMD_REARRANGE_CANONICAL_STORY);
+angular.module('oppia').constant(
   'CMD_DELETE_SUBTOPIC', TopicDomainConstants.CMD_DELETE_SUBTOPIC);
 angular.module('oppia').constant(
   'CMD_REMOVE_UNCATEGORIZED_SKILL_ID',

--- a/core/templates/domain/topic/topic-domain.constants.ts
+++ b/core/templates/domain/topic/topic-domain.constants.ts
@@ -35,6 +35,7 @@ export class TopicDomainConstants {
   public static CMD_DELETE_ADDITIONAL_STORY = 'delete_additional_story';
   public static CMD_DELETE_CANONICAL_STORY = 'delete_canonical_story';
   public static CMD_DELETE_SUBTOPIC = 'delete_subtopic';
+  public static CMD_REARRANGE_CANONICAL_STORY = 'rearrange_canonical_story';
   public static
     CMD_REMOVE_UNCATEGORIZED_SKILL_ID = 'remove_uncategorized_skill_id';
   public static CMD_MOVE_SKILL_ID_TO_SUBTOPIC = 'move_skill_id_to_subtopic';

--- a/core/templates/domain/topic/topic-update.service.spec.ts
+++ b/core/templates/domain/topic/topic-update.service.spec.ts
@@ -122,6 +122,12 @@ describe('Topic update service', function() {
         canonical_story_references: [{
           story_id: 'story_1',
           story_is_published: true
+        }, {
+          story_id: 'story_2',
+          story_is_published: true
+        }, {
+          story_id: 'story_3',
+          story_is_published: true
         }],
         additional_story_references: [{
           story_id: 'story_2',
@@ -205,14 +211,18 @@ describe('Topic update service', function() {
   });
 
   it('should remove/add a canonical story id from/to a topic', function() {
-    expect(_sampleTopic.getCanonicalStoryIds()).toEqual(['story_1']);
+    let canonicalStoryIds = _sampleTopic.getCanonicalStoryIds();
+    expect(canonicalStoryIds).toEqual(
+      ['story_1', 'story_2', 'story_3']);
     TopicUpdateService.removeCanonicalStory(_sampleTopic, 'story_1');
-    expect(_sampleTopic.getCanonicalStoryIds()).toEqual([]);
+    canonicalStoryIds = _sampleTopic.getCanonicalStoryIds();
+    expect(canonicalStoryIds).toEqual(['story_2', 'story_3']);
 
     UndoRedoService.undoChange(_sampleTopic);
-    expect(_sampleTopic.getCanonicalStoryIds()).toEqual(['story_1']);
-  }
-  );
+    canonicalStoryIds = _sampleTopic.getCanonicalStoryIds();
+    expect(canonicalStoryIds).toEqual(
+      ['story_2', 'story_3', 'story_1']);
+  });
 
   it('should create a proper backend change dict for removing a canonical ' +
     'story id', function() {
@@ -516,6 +526,45 @@ describe('Topic update service', function() {
 
     UndoRedoService.undoChange(_sampleTopic);
     expect(_sampleTopic.getSubtopics().length).toEqual(1);
+  });
+
+  it('should rearrange a canonical story', function() {
+    let canonicalStoryIds = _sampleTopic.getCanonicalStoryIds();
+    expect(canonicalStoryIds.length).toEqual(3);
+    expect(canonicalStoryIds[0]).toEqual('story_1');
+    expect(canonicalStoryIds[1]).toEqual('story_2');
+    expect(canonicalStoryIds[2]).toEqual('story_3');
+
+    TopicUpdateService.rearrangeCanonicalStory(_sampleTopic, 1, 0);
+    canonicalStoryIds = _sampleTopic.getCanonicalStoryIds();
+    expect(canonicalStoryIds[0]).toEqual('story_2');
+    expect(canonicalStoryIds[1]).toEqual('story_1');
+    expect(canonicalStoryIds[2]).toEqual('story_3');
+
+    TopicUpdateService.rearrangeCanonicalStory(_sampleTopic, 2, 1);
+    canonicalStoryIds = _sampleTopic.getCanonicalStoryIds();
+    expect(canonicalStoryIds[0]).toEqual('story_2');
+    expect(canonicalStoryIds[1]).toEqual('story_3');
+    expect(canonicalStoryIds[2]).toEqual('story_1');
+
+    TopicUpdateService.rearrangeCanonicalStory(_sampleTopic, 2, 0);
+    canonicalStoryIds = _sampleTopic.getCanonicalStoryIds();
+    expect(canonicalStoryIds[0]).toEqual('story_1');
+    expect(canonicalStoryIds[1]).toEqual('story_2');
+    expect(canonicalStoryIds[2]).toEqual('story_3');
+
+    UndoRedoService.undoChange(_sampleTopic);
+    expect(_sampleTopic.getCanonicalStoryIds().length).toEqual(3);
+    canonicalStoryIds = _sampleTopic.getCanonicalStoryIds();
+    expect(canonicalStoryIds[0]).toEqual('story_2');
+    expect(canonicalStoryIds[1]).toEqual('story_3');
+    expect(canonicalStoryIds[2]).toEqual('story_1');
+
+    TopicUpdateService.rearrangeCanonicalStory(_sampleTopic, 2, 0);
+    canonicalStoryIds = _sampleTopic.getCanonicalStoryIds();
+    expect(canonicalStoryIds[0]).toEqual('story_1');
+    expect(canonicalStoryIds[1]).toEqual('story_2');
+    expect(canonicalStoryIds[2]).toEqual('story_3');
   });
 
   it('should create a proper backend change dict for adding a subtopic',

--- a/core/templates/domain/topic/topic-update.service.ts
+++ b/core/templates/domain/topic/topic-update.service.ts
@@ -31,7 +31,8 @@ angular.module('oppia').factory('TopicUpdateService', [
   'ChangeObjectFactory', 'UndoRedoService',
   'CMD_ADD_SUBTOPIC', 'CMD_DELETE_ADDITIONAL_STORY',
   'CMD_DELETE_CANONICAL_STORY', 'CMD_DELETE_SUBTOPIC',
-  'CMD_MOVE_SKILL_ID_TO_SUBTOPIC', 'CMD_REMOVE_SKILL_ID_FROM_SUBTOPIC',
+  'CMD_MOVE_SKILL_ID_TO_SUBTOPIC', 'CMD_REARRANGE_CANONICAL_STORY',
+  'CMD_REMOVE_SKILL_ID_FROM_SUBTOPIC',
   'CMD_REMOVE_UNCATEGORIZED_SKILL_ID', 'CMD_UPDATE_SUBTOPIC_PAGE_PROPERTY',
   'CMD_UPDATE_SUBTOPIC_PROPERTY', 'CMD_UPDATE_TOPIC_PROPERTY',
   'SUBTOPIC_PAGE_PROPERTY_PAGE_CONTENTS_AUDIO',
@@ -45,7 +46,8 @@ angular.module('oppia').factory('TopicUpdateService', [
       ChangeObjectFactory, UndoRedoService,
       CMD_ADD_SUBTOPIC, CMD_DELETE_ADDITIONAL_STORY,
       CMD_DELETE_CANONICAL_STORY, CMD_DELETE_SUBTOPIC,
-      CMD_MOVE_SKILL_ID_TO_SUBTOPIC, CMD_REMOVE_SKILL_ID_FROM_SUBTOPIC,
+      CMD_MOVE_SKILL_ID_TO_SUBTOPIC, CMD_REARRANGE_CANONICAL_STORY,
+      CMD_REMOVE_SKILL_ID_FROM_SUBTOPIC,
       CMD_REMOVE_UNCATEGORIZED_SKILL_ID, CMD_UPDATE_SUBTOPIC_PAGE_PROPERTY,
       CMD_UPDATE_SUBTOPIC_PROPERTY, CMD_UPDATE_TOPIC_PROPERTY,
       SUBTOPIC_PAGE_PROPERTY_PAGE_CONTENTS_AUDIO,
@@ -564,6 +566,23 @@ angular.module('oppia').factory('TopicUpdateService', [
         }, function(changeDict, topic) {
           // ---- Undo ----
           topic.addCanonicalStory(storyId);
+        });
+      },
+
+      /**
+       * Rearranges or moves a canonical story to another position and
+       * records the change in undo/redo service.
+       */
+      rearrangeCanonicalStory: function(topic, fromIndex, toIndex) {
+        _applyChange(topic, CMD_REARRANGE_CANONICAL_STORY, {
+          from_index: fromIndex,
+          to_index: toIndex
+        }, function(changeDict, topic) {
+          // ---- Apply ----
+          topic.rearrangeCanonicalStory(fromIndex, toIndex);
+        }, function(changeDict, topic) {
+          // ---- Undo ----
+          topic.rearrangeCanonicalStory(toIndex, fromIndex);
         });
       },
 

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-stories-list.directive.html
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-stories-list.directive.html
@@ -12,7 +12,11 @@
       <p ng-if="key === 'publication_status'" class="text-center">Published?</p>
     </th>
   </tr>
-  <tr ng-repeat="summary in storySummaries"
+  <tr ng-repeat="summary in storySummaries track by $index"
+      dnd-list="storySummaries"
+      dnd-dragstart="onMoveStoryStart($index)"
+      dnd-drop="onMoveStoryFinish($index)"
+      dnd-draggable="summary"
       class="list-item protractor-test-story-list-item">
     <td>
       <a ng-click="openStoryEditor(summary.getId())" class="list-summary text-left">

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-stories-list.directive.ts
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-stories-list.directive.ts
@@ -94,6 +94,23 @@ angular.module('oppia').directive('storiesList', [
             });
           };
 
+          $scope.onMoveStoryFinish = function(toIndex) {
+            $scope.toIndex = toIndex;
+            if ($scope.fromIndex === $scope.toIndex) {
+              return;
+            }
+            TopicUpdateService.rearrangeCanonicalStory(
+              $scope.getTopic(), $scope.fromIndex, $scope.toIndex);
+            var storySummary = (
+              angular.copy($scope.storySummaries[$scope.fromIndex]));
+            $scope.storySummaries.splice($scope.fromIndex, 1);
+            $scope.storySummaries.splice($scope.toIndex, 0, storySummary);
+          };
+
+          $scope.onMoveStoryStart = function(fromIndex) {
+            $scope.fromIndex = fromIndex;
+          };
+
           ctrl.$onInit = function() {
             $scope.STORY_TABLE_COLUMN_HEADINGS = [
               'title', 'node_count', 'publication_status'];

--- a/core/templates/pages/topic-editor-page/services/entity-creation.service.ts
+++ b/core/templates/pages/topic-editor-page/services/entity-creation.service.ts
@@ -39,20 +39,18 @@ require('services/context.service.ts');
 require('services/image-local-storage.service.ts');
 
 angular.module('oppia').factory('EntityCreationService', [
-  '$uibModal', 'ContextService',
-  'ImageLocalStorageService', 'RubricObjectFactory', 'SkillCreationService',
+  '$uibModal', 'SkillCreationService',
   'TopicEditorRoutingService', 'TopicEditorStateService',
-  'UrlInterpolationService', 'SKILL_DIFFICULTIES',
+  'UrlInterpolationService',
   function(
-      $uibModal, ContextService,
-      ImageLocalStorageService, RubricObjectFactory, SkillCreationService,
+      $uibModal, SkillCreationService,
       TopicEditorRoutingService, TopicEditorStateService,
-      UrlInterpolationService, SKILL_DIFFICULTIES) {
+      UrlInterpolationService) {
     var createSubtopic = function(topic) {
       $uibModal.open({
         templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
           '/pages/topic-editor-page/modal-templates/' +
-                'create-new-subtopic-modal.template.html'),
+          'create-new-subtopic-modal.template.html'),
         backdrop: true,
         resolve: {
           topic: () => topic
@@ -66,28 +64,7 @@ angular.module('oppia').factory('EntityCreationService', [
 
     var createSkill = function() {
       var topicId = TopicEditorStateService.getTopic().getId();
-      var rubrics = [
-        RubricObjectFactory.create(SKILL_DIFFICULTIES[0], []),
-        RubricObjectFactory.create(SKILL_DIFFICULTIES[1], ['']),
-        RubricObjectFactory.create(SKILL_DIFFICULTIES[2], [])];
-      ContextService.setImageSaveDestinationToLocalStorage();
-      $uibModal.open({
-        templateUrl: UrlInterpolationService.getDirectiveTemplateUrl(
-          '/pages/topics-and-skills-dashboard-page/templates/' +
-            'create-new-skill-modal.template.html'),
-        backdrop: 'static',
-        resolve: {
-          rubrics: () => rubrics
-        },
-        controller: 'CreateNewSkillModalController'
-      }).result.then(function(result) {
-        ContextService.resetImageSaveDestination();
-        SkillCreationService.createNewSkill(
-          result.description, result.rubrics, result.explanation, [topicId]);
-      }, function() {
-        ImageLocalStorageService.flushStoredImagesData();
-        SkillCreationService.resetSkillDescriptionStatusMarker();
-      });
+      SkillCreationService.createNewSkill([topicId]);
     };
 
     return {

--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.component.spec.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.component.spec.ts
@@ -119,7 +119,7 @@ describe('Topics and Skills Dashboard Page', function() {
       expect(ctrl.skillPageNumber).toEqual(0);
       expect(ctrl.selectedIndex).toEqual(null);
       expect(ctrl.itemsPerPageChoice).toEqual([10, 15, 20]);
-      expect(ctrl.classrooms).toEqual(['All', 'math']);
+      expect(ctrl.classrooms).toEqual(['All', 'Unassigned', 'math']);
       expect(ctrl.filterObject).toEqual(filterObject);
 
       expect(ctrl.sortOptions).toEqual([

--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.component.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.component.ts
@@ -86,6 +86,7 @@ angular.module('oppia').component('topicsAndSkillsDashboardPage', {
         SKILL_STATUS_OPTIONS, TOPIC_FILTER_CLASSROOM_ALL,
         TOPIC_SORT_OPTIONS, TOPIC_PUBLISHED_OPTIONS) {
       var ctrl = this;
+      var TOPIC_CLASSROOM_UNASSIGNED = 'Unassigned';
 
       /**
            * Calls the TopicsAndSkillsDashboardBackendApiService and fetches
@@ -133,11 +134,15 @@ angular.module('oppia').component('topicsAndSkillsDashboardPage', {
               ctrl.initSkillDashboard();
             }
             ctrl.classrooms = response.all_classroom_names;
-            // Adding this since karma tests adds
-            // TOPIC_FILTER_CLASSROOM_ALL for every it block.
+            // Adding the if checks since karma tests adds
+            // the values in the array for every it block.
+            if (!ctrl.classrooms.includes(TOPIC_CLASSROOM_UNASSIGNED)) {
+              ctrl.classrooms.unshift(TOPIC_CLASSROOM_UNASSIGNED);
+            }
             if (!ctrl.classrooms.includes(TOPIC_FILTER_CLASSROOM_ALL)) {
               ctrl.classrooms.unshift(TOPIC_FILTER_CLASSROOM_ALL);
             }
+
             $rootScope.$apply();
           },
           function(errorResponse) {

--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.service.spec.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.service.spec.ts
@@ -90,7 +90,7 @@ describe('Topic and Skill dashboard page service', () => {
       language_code: 'en',
       $$hashKey: 'object:63',
     };
-    const topicsArray = [topic1, topic2, topic3];
+    let topicsArray = [topic1, topic2, topic3];
     let filterOptions = dfof.createDefault();
     let filteredArray = tsds.getFilteredTopics(topicsArray, filterOptions);
     expect(filteredArray).toEqual(topicsArray);
@@ -129,6 +129,14 @@ describe('Topic and Skill dashboard page service', () => {
     filterOptions.classroom = 'Math';
     filteredArray = tsds.getFilteredTopics(topicsArray, filterOptions);
     expect(filteredArray).toEqual([topic2, topic1]);
+
+    filterOptions.classroom = 'Unassigned';
+    filteredArray = tsds.getFilteredTopics(topicsArray, filterOptions);
+    expect(filteredArray).toEqual([]);
+
+    topic3.classroom = null;
+    filteredArray = tsds.getFilteredTopics(topicsArray, filterOptions);
+    expect(filteredArray).toEqual([topic3]);
 
     // @ts-ignore
     // since sort is an ENUM, we can't assign any random value.

--- a/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.service.ts
+++ b/core/templates/pages/topics-and-skills-dashboard-page/topics-and-skills-dashboard-page.service.ts
@@ -64,6 +64,9 @@ export class TopicsAndSkillsDashboardPageService {
     if (filterObject.classroom !==
         TopicsAndSkillsDashboardPageConstants.TOPIC_FILTER_CLASSROOM_ALL) {
       filteredTopics = filteredTopics.filter((topic) => {
+        if (filterObject.classroom === 'Unassigned' && !topic.classroom) {
+          return true;
+        }
         return (
           topic.classroom && filterObject.classroom.toLowerCase() ===
             topic.classroom.toLowerCase());


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #9722
2. This PR adds the reordering functionality for stories and adds the "Unassigned" topic filter.

Reordering video [here](https://drive.google.com/file/d/10XwdgRUD4yg8FmmFiN2B_loHHozhFAuh/view?usp=sharing)
Dashboard filter video [here](https://drive.google.com/file/d/1leXFxY_o2XGhCrPC57JJDWOwVVk0GhE0/view?usp=sharing)
## Essential Checklist

- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The linter/Karma presubmit checks have passed locally on your machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [X] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
