### PR TITLE
Fix part of #9740: Remove <any> from spec files and replace it by @ts-ignore

### DIFF
--- a/core/templates/components/button-directives/exploration-embed-button-modal.controller.spec.ts
+++ b/core/templates/components/button-directives/exploration-embed-button-modal.controller.spec.ts
@@ -52,7 +52,9 @@ describe('Exploration Embed Button Modal Controller', function() {
   it('should add range from a click event', function() {
     var removeAllRanges = jasmine.createSpy('removeAllRanges');
     var addRange = jasmine.createSpy('addRange');
-    spyOn(window, 'getSelection').and.returnValue(<any>{
+    // @ts-ignore window getSelection method return more properties than
+    // removeAllRanges and addRange.
+    spyOn(window, 'getSelection').and.returnValue({
       removeAllRanges: removeAllRanges,
       addRange: addRange
     });

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
@@ -562,8 +562,12 @@ describe('Exploration editor page component', function() {
           // should be declared.
           spyOn(window, '$').and.returnValue(element);
           var animateSpy = spyOn(element, 'animate').and.callThrough();
+          // @ts-ignore Angular element method doesn't expect to receive
+          // 1 argument in the lints.
           spyOn(angular, 'element').withArgs('#tutorialStateContent').and
-            .returnValue(<any>{
+            .returnValue({
+              // @ts-ignore Angular element should have more properties than
+              // just offset in the lint settings.
               offset: () => ({
                 top: 5
               })
@@ -584,8 +588,12 @@ describe('Exploration editor page component', function() {
           // should be declared.
           spyOn(window, '$').and.returnValue(element);
           var animateSpy = spyOn(element, 'animate').and.callThrough();
+          // @ts-ignore Angular element method doesn't expect to receive
+          // 1 argument in the lints.
           spyOn(angular, 'element').withArgs('#tutorialStateInteraction').and
-            .returnValue(<any>{
+            .returnValue({
+              // @ts-ignore Angular element should have more properties than
+              // just offset in the lint settings.
               offset: () => ({
                 top: 20
               })
@@ -606,8 +614,12 @@ describe('Exploration editor page component', function() {
           // should be declared.
           spyOn(window, '$').and.returnValue(element);
           var animateSpy = spyOn(element, 'animate').and.callThrough();
+          // @ts-ignore Angular element method doesn't expect to receive
+          // 1 argument in the lints.
           spyOn(angular, 'element').withArgs('#tutorialPreviewTab').and
-            .returnValue(<any>{
+            .returnValue({
+              // @ts-ignore Angular element should have more properties than
+              // just offset in the lint settings.
               offset: () => ({
                 top: 5
               })
@@ -628,8 +640,12 @@ describe('Exploration editor page component', function() {
           // should be declared.
           spyOn(window, '$').and.returnValue(element);
           var animateSpy = spyOn(element, 'animate').and.callThrough();
+          // @ts-ignore Angular element method doesn't expect to receive
+          // 1 argument in the lints.
           spyOn(angular, 'element').withArgs('#tutorialStateInteraction').and
-            .returnValue(<any>{
+            .returnValue({
+              // @ts-ignore Angular element should have more properties than
+              // just offset in the lint settings.
               offset: () => ({
                 top: 20
               })
@@ -650,8 +666,12 @@ describe('Exploration editor page component', function() {
           // should be declared.
           spyOn(window, '$').and.returnValue(element);
           var animateSpy = spyOn(element, 'animate').and.callThrough();
+          // @ts-ignore Angular element method doesn't expect to receive
+          // 1 argument in the lints.
           spyOn(angular, 'element').withArgs('#tutorialPreviewTab').and
-            .returnValue(<any>{
+            .returnValue({
+              // @ts-ignore Angular element should have more properties than
+              // just offset in the lint settings.
               offset: () => ({
                 top: 5
               })
@@ -672,8 +692,12 @@ describe('Exploration editor page component', function() {
           // should be declared.
           spyOn(window, '$').and.returnValue(element);
           var animateSpy = spyOn(element, 'animate').and.callThrough();
+          // @ts-ignore Angular element method doesn't expect to receive
+          // 1 argument in the lints.
           spyOn(angular, 'element').withArgs('#tutorialStateInteraction').and
-            .returnValue(<any>{
+            .returnValue({
+              // @ts-ignore Angular element should have more properties than
+              // just offset in the lint settings.
               offset: () => ({
                 top: 20
               })

--- a/core/templates/pages/exploration-player-page/exploration-player-page.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.component.spec.ts
@@ -72,21 +72,29 @@ describe('Exploration player page', function() {
 
     var elementNameItemProp = $('<div>');
     angularElementSpy.withArgs(
-      'meta[itemprop="name"]').and.returnValue(<any>elementNameItemProp);
+      // @ts-ignore Angular element method doesn't expect to receive 1 argument
+      // in the lints.
+      'meta[itemprop="name"]').and.returnValue(elementNameItemProp);
 
     var elementDescriptionItemProp = $('<div>');
     angularElementSpy.withArgs(
+      // @ts-ignore Angular element method doesn't expect to receive 1 argument
+      // in the lints.
       'meta[itemprop="description"]').and.returnValue(
-        <any>elementDescriptionItemProp);
+      elementDescriptionItemProp);
 
     var elementTitleProperty = $('<div>');
     angularElementSpy.withArgs(
-      'meta[property="og:title"]').and.returnValue(<any>elementTitleProperty);
+      // @ts-ignore Angular element method doesn't expect to receive 1 argument
+      // in the lints.
+      'meta[property="og:title"]').and.returnValue(elementTitleProperty);
 
     var elementDescriptionProperty = $('<div>');
     angularElementSpy.withArgs(
+      // @ts-ignore Angular element method doesn't expect to receive 1 argument
+      // in the lints.
       'meta[property="og:description"]').and.returnValue(
-        <any>elementDescriptionProperty);
+      elementDescriptionProperty);
 
     ctrl.$onInit();
     $scope.$apply();

--- a/core/templates/pages/preferences-page/modal-templates/edit-profile-picture-modal.controller.spec.ts
+++ b/core/templates/pages/preferences-page/modal-templates/edit-profile-picture-modal.controller.spec.ts
@@ -88,7 +88,9 @@ describe('EditProfilePictureModalController', function() {
         'data:application/octet-stream;base64,' + dataBase64Mock);
 
       var mockUrl = 'mock-url';
-      spyOn(Cropper.prototype, 'getCroppedCanvas').and.returnValue(<any>{
+      // @ts-ignore Cropper getCroppedCanvas method should return more
+      // properties than toDataURL according with lint settings.
+      spyOn(Cropper.prototype, 'getCroppedCanvas').and.returnValue({
         toDataURL: () => mockUrl
       });
       $scope.confirm();

--- a/extensions/interactions/LogicProof/static/js/tools/logic-demo-test.controller.spec.ts
+++ b/extensions/interactions/LogicProof/static/js/tools/logic-demo-test.controller.spec.ts
@@ -476,7 +476,9 @@ describe('Logic demo test', function() {
 
   it('should submit mistakes', function() {
     const MISTAKE_STRINGS_LENGTH = 40;
-    spyOn(logicProofTeacher2, 'buildMistakeSection').and.returnValue(<any>[{
+    // @ts-ignore logicProofTeacher2 buildMistakeSection method should return
+    // ore properties than entries according with lint settings.
+    spyOn(logicProofTeacher2, 'buildMistakeSection').and.returnValue([{
       entries: []
     }]);
     var sectionNumber = 0;
@@ -500,8 +502,9 @@ describe('Logic demo test', function() {
   });
 
   it('should submit control functions', function() {
-    spyOn(logicProofTeacher2, 'buildControlFunctionTable').and.returnValue(
-      <any>{});
+    // @ts-ignore logicProofTeacher2 buildControlFunctionTable method should
+    // return more properties than {} according with lint settings.
+    spyOn(logicProofTeacher2, 'buildControlFunctionTable').and.returnValue({});
     $scope.submitControlFunctions();
 
     expect($scope.controlFunctionSuccess).toBe(true);
@@ -536,11 +539,14 @@ describe('Logic demo test', function() {
   });
 
   it('should request javascript', function() {
-    spyOn(logicProofTeacher2, 'buildMistakeSection').and.returnValue(<any>[{
+    // @ts-ignore logicProofTeacher2 buildMistakeSection method should return
+    // ore properties than entries according with lint settings.
+    spyOn(logicProofTeacher2, 'buildMistakeSection').and.returnValue([{
       entries: []
     }]);
-    spyOn(logicProofTeacher2, 'buildControlFunctionTable').and.returnValue(
-      <any>{});
+    // @ts-ignore logicProofTeacher2 buildControlFunctionTable method should
+    // return more properties than {} according with lint settings.
+    spyOn(logicProofTeacher2, 'buildControlFunctionTable').and.returnValue({});
 
     $scope.submitMistakes(0);
     $scope.submitMistakes(1);


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. ~~This PR fixes or fixes part of #[fill_in_number_here].~~
2. This PR does the following: It removes `<any>` usage of spec files when spying with `angular.element` and JQuery methods and instead the `@ts-ignore` comment is being used. The `@ts-ignore` is more error-proof and it may avoid future lint errors.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
