### PR TITLE
Fix #9709: Show question images in question player

### DIFF
--- a/core/templates/pages/exploration-player-page/services/question-player-engine.service.ts
+++ b/core/templates/pages/exploration-player-page/services/question-player-engine.service.ts
@@ -37,15 +37,15 @@ angular.module('oppia').factory('QuestionPlayerEngineService', [
   'ContextService', 'ExplorationHtmlFormatterService',
   'ExpressionInterpolationService', 'FocusManagerService',
   'QuestionObjectFactory', 'ReadOnlyExplorationBackendApiService',
-  'StateCardObjectFactory', 'UrlService', 'INTERACTION_DISPLAY_MODE_INLINE',
-  'INTERACTION_SPECS',
+  'StateCardObjectFactory', 'UrlService', 'ENTITY_TYPE',
+  'INTERACTION_DISPLAY_MODE_INLINE', 'INTERACTION_SPECS',
   function(
       AlertsService, AnswerClassificationService,
       ContextService, ExplorationHtmlFormatterService,
       ExpressionInterpolationService, FocusManagerService,
       QuestionObjectFactory, ReadOnlyExplorationBackendApiService,
-      StateCardObjectFactory, UrlService, INTERACTION_DISPLAY_MODE_INLINE,
-      INTERACTION_SPECS) {
+      StateCardObjectFactory, UrlService, ENTITY_TYPE,
+      INTERACTION_DISPLAY_MODE_INLINE, INTERACTION_SPECS) {
     ContextService.setQuestionPlayerIsOpen();
     var _explorationId = ContextService.getExplorationId();
     var _questionPlayerMode = ContextService.isInQuestionPlayerMode();
@@ -102,6 +102,8 @@ angular.module('oppia').factory('QuestionPlayerEngineService', [
         AlertsService.addWarning('No questions available.');
         return;
       }
+      ContextService.setCustomEntityContext(
+        ENTITY_TYPE.QUESTION, questions[0].getId());
       var initialState = questions[0].getStateData();
 
       var questionHtml = makeQuestion(initialState, []);
@@ -274,13 +276,18 @@ angular.module('oppia').factory('QuestionPlayerEngineService', [
 
           questionHtml = questionHtml + _getRandomSuffix();
           nextInteractionHtml = nextInteractionHtml + _getRandomSuffix();
-
+          if (!onSameCard) {
+            ContextService.setCustomEntityContext(
+              ENTITY_TYPE.QUESTION, questions[nextIndex].getId());
+          }
           nextCard = StateCardObjectFactory.createNewCard(
             true, questionHtml, nextInteractionHtml,
             _getNextStateData().interaction,
             _getNextStateData().recordedVoiceovers,
             _getNextStateData().content.getContentId()
           );
+        } else if (!onSameCard) {
+          ContextService.removeCustomEntityContext();
         }
         successCallback(
           nextCard, refreshInteraction, feedbackHtml,

--- a/core/templates/services/context.service.ts
+++ b/core/templates/services/context.service.ts
@@ -105,7 +105,7 @@ export class ContextService {
         } else if (pathnameArray[i] === 'collection_editor') {
           this.pageContext = ServicesConstants.PAGE_CONTEXT.COLLECTION_EDITOR;
           return ServicesConstants.PAGE_CONTEXT.COLLECTION_EDITOR;
-        } else if (pathnameArray[i] === 'topics_and_skills_dashboard') {
+        } else if (pathnameArray[i] === 'topics-and-skills-dashboard') {
           this.pageContext = (
             ServicesConstants.PAGE_CONTEXT.TOPICS_AND_SKILLS_DASHBOARD);
           return ServicesConstants.PAGE_CONTEXT.TOPICS_AND_SKILLS_DASHBOARD;


### PR DESCRIPTION
## Overview

1. This PR fixes #9709
2. This PR does the following: Fixes the images issue in question player and allow them to be displayed.
![image](https://user-images.githubusercontent.com/22347970/86398079-a835d900-bcc2-11ea-8cec-fe042b6f62a6.png)


## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
