### PR TITLE
Fix #9777: Overriding guppy osk styles to fix tooltip position.

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -96,6 +96,14 @@ md-input-group.md-default-theme label {
   margin-bottom: 0;
 }
 
+/* The following classes' styles are overriden by Guppy's OSK stylesheet and
+they end up rotating the tooltips which are placed on the left or right. This is
+why they need to be overriden.  */
+.left, .right {
+  -webkit-transform: none !important;
+  transform: none !important;
+}
+
 .md-button {
   font-size: 16px;
   line-height: 22px;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #9777.
2. This PR does the following:
Overrides guppy osk styles that were causing unexpected rotation on tooltips placed left and right.

Before:
![before](https://user-images.githubusercontent.com/35144226/86514858-8b201800-be32-11ea-9f6f-a8f65fbc34f4.png)

After:
![after](https://user-images.githubusercontent.com/35144226/86514860-8f4c3580-be32-11ea-8536-153ad6159c57.png)


## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
