### PR TITLE
Fix last_updated for commit log models

### DIFF
--- a/core/domain/activity_jobs_one_off_test.py
+++ b/core/domain/activity_jobs_one_off_test.py
@@ -648,6 +648,9 @@ class FixCommitLastUpdatedOneOffJobTests(test_utils.GenericTestBase):
             .get_output(job_id))
         eval_output = [ast.literal_eval(stringified_item) for
                        stringified_item in stringified_output]
+        for output in eval_output:
+            if output[0] == 'SUCCESS_INCORRECT':
+                output[1] = ast.literal_eval(output[1])
         return eval_output
 
     def test_one_commit_model_last_updated_before(self):
@@ -673,8 +676,7 @@ class FixCommitLastUpdatedOneOffJobTests(test_utils.GenericTestBase):
 
         output = self._run_one_off_job()
         self.assertItemsEqual(
-            [['SUCCESS_ALREADY_CORRECT - CollectionCommitLogEntryModel', 1]],
-            output)
+            [['SUCCESS_CORRECT - CollectionCommitLogEntryModel', 1]], output)
 
         migrated_commit_model = (
             collection_models.CollectionCommitLogEntryModel.get_by_id('id'))
@@ -708,8 +710,7 @@ class FixCommitLastUpdatedOneOffJobTests(test_utils.GenericTestBase):
 
         output = self._run_one_off_job()
         self.assertItemsEqual(
-            [['SUCCESS_FIXED - CollectionCommitLogEntryModel', 1]],
-            output)
+            [['SUCCESS_FIXED - CollectionCommitLogEntryModel', 1]], output)
 
         migrated_commit_model = (
             collection_models.CollectionCommitLogEntryModel.get_by_id('id'))
@@ -746,8 +747,7 @@ class FixCommitLastUpdatedOneOffJobTests(test_utils.GenericTestBase):
 
         output = self._run_one_off_job()
         self.assertItemsEqual(
-            [['SUCCESS_ALREADY_CORRECT - CollectionCommitLogEntryModel', 1]],
-            output)
+            [['SUCCESS_CORRECT - CollectionCommitLogEntryModel', 1]], output)
 
         migrated_commit_model = (
             collection_models.CollectionCommitLogEntryModel.get_by_id('id'))
@@ -757,3 +757,67 @@ class FixCommitLastUpdatedOneOffJobTests(test_utils.GenericTestBase):
         self.assertEqual(
             original_commit_model.last_updated,
             migrated_commit_model.last_updated)
+
+    def test_multiple_commit_models_last_updated_wrong(self):
+        original_commit_model_1 = (
+            collection_models.CollectionCommitLogEntryModel(
+                id='id1',
+                user_id='committer_id',
+                collection_id='col_id',
+                commit_type='create',
+                commit_message='Message',
+                commit_cmds=[],
+                version=1,
+                post_commit_status='public',
+                post_commit_community_owned=False,
+                post_commit_is_private=False,
+                created_on=datetime.datetime.strptime(
+                    '2020-07-01T09:59:59Z', '%Y-%m-%dT%H:%M:%SZ'),
+                last_updated=datetime.datetime.strptime(
+                    '2020-07-01T09:00:00Z', '%Y-%m-%dT%H:%M:%SZ')
+            )
+        )
+        original_commit_model_1.put(update_last_updated_time=False)
+        original_commit_model_2 = (
+            collection_models.CollectionCommitLogEntryModel(
+                id='id2',
+                user_id='committer_id',
+                collection_id='col_id',
+                commit_type='create',
+                commit_message='Message',
+                commit_cmds=[],
+                version=1,
+                post_commit_status='public',
+                post_commit_community_owned=False,
+                post_commit_is_private=False,
+                created_on=datetime.datetime.strptime(
+                    '2020-07-01T09:59:59Z', '%Y-%m-%dT%H:%M:%SZ'),
+                last_updated=datetime.datetime.strptime(
+                    '2020-07-20T09:00:00Z', '%Y-%m-%dT%H:%M:%SZ')
+            )
+        )
+        original_commit_model_2.put(update_last_updated_time=False)
+
+        output = self._run_one_off_job()
+        self.assertItemsEqual(
+            [['SUCCESS_INCORRECT - CollectionCommitLogEntryModel',
+              ['id1', 'id2']]],
+            output)
+
+        migrated_commit_model_1 = (
+            collection_models.CollectionCommitLogEntryModel.get_by_id('id1'))
+        self.assertEqual(
+            original_commit_model_1.created_on,
+            migrated_commit_model_1.created_on)
+        self.assertEqual(
+            original_commit_model_1.last_updated,
+            migrated_commit_model_1.last_updated)
+
+        migrated_commit_model_2 = (
+            collection_models.CollectionCommitLogEntryModel.get_by_id('id2'))
+        self.assertEqual(
+            original_commit_model_2.created_on,
+            migrated_commit_model_2.created_on)
+        self.assertEqual(
+            original_commit_model_2.last_updated,
+            migrated_commit_model_2.last_updated)

--- a/core/domain/activity_jobs_one_off_test.py
+++ b/core/domain/activity_jobs_one_off_test.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import ast
+import datetime
 
 from constants import constants
 from core.domain import activity_jobs_one_off
@@ -624,6 +625,135 @@ class RemoveCommitUsernamesOneOffJobTests(test_utils.GenericTestBase):
             collection_models.CollectionCommitLogEntryModel.get_by_id('id'))
         self.assertNotIn('username', migrated_commit_model._values)
         self.assertNotIn('username', migrated_commit_model._properties)
+        self.assertEqual(
+            original_commit_model.last_updated,
+            migrated_commit_model.last_updated)
+
+
+class FixCommitLastUpdatedOneOffJobTests(test_utils.GenericTestBase):
+
+    USER_1_ID = 'user_1_id'
+
+    def _run_one_off_job(self):
+        """Runs the one-off MapReduce job."""
+        job_id = (
+            activity_jobs_one_off.FixCommitLastUpdatedOneOffJob.create_new())
+        activity_jobs_one_off.FixCommitLastUpdatedOneOffJob.enqueue(job_id)
+        self.assertEqual(
+            self.count_jobs_in_taskqueue(
+                taskqueue_services.QUEUE_NAME_ONE_OFF_JOBS), 1)
+        self.process_and_flush_pending_tasks()
+        stringified_output = (
+            activity_jobs_one_off.FixCommitLastUpdatedOneOffJob
+            .get_output(job_id))
+        eval_output = [ast.literal_eval(stringified_item) for
+                       stringified_item in stringified_output]
+        return eval_output
+
+    def test_one_commit_model_last_updated_before(self):
+        original_commit_model = (
+            collection_models.CollectionCommitLogEntryModel(
+                id='id',
+                user_id='committer_id',
+                collection_id='col_id',
+                commit_type='create',
+                commit_message='Message',
+                commit_cmds=[],
+                version=1,
+                post_commit_status='public',
+                post_commit_community_owned=False,
+                post_commit_is_private=False,
+                created_on=datetime.datetime.strptime(
+                    '2020-06-18T22:00:00Z', '%Y-%m-%dT%H:%M:%SZ'),
+                last_updated=datetime.datetime.strptime(
+                    '2020-06-20T22:00:00Z', '%Y-%m-%dT%H:%M:%SZ')
+            )
+        )
+        original_commit_model.put(update_last_updated_time=False)
+
+        output = self._run_one_off_job()
+        self.assertItemsEqual(
+            [['SUCCESS_ALREADY_CORRECT - CollectionCommitLogEntryModel', 1]],
+            output)
+
+        migrated_commit_model = (
+            collection_models.CollectionCommitLogEntryModel.get_by_id('id'))
+        self.assertEqual(
+            original_commit_model.created_on,
+            migrated_commit_model.created_on)
+        self.assertEqual(
+            original_commit_model.last_updated,
+            migrated_commit_model.last_updated)
+
+    def test_one_commit_model_last_updated_during(self):
+        original_commit_model = (
+            collection_models.CollectionCommitLogEntryModel(
+                id='id',
+                user_id='committer_id',
+                collection_id='col_id',
+                commit_type='create',
+                commit_message='Message',
+                commit_cmds=[],
+                version=1,
+                post_commit_status='public',
+                post_commit_community_owned=False,
+                post_commit_is_private=False,
+                created_on=datetime.datetime.strptime(
+                    '2019-06-29T01:00:00Z', '%Y-%m-%dT%H:%M:%SZ'),
+                last_updated=datetime.datetime.strptime(
+                    '2020-06-29T11:00:00Z', '%Y-%m-%dT%H:%M:%SZ')
+            )
+        )
+        original_commit_model.put(update_last_updated_time=False)
+
+        output = self._run_one_off_job()
+        self.assertItemsEqual(
+            [['SUCCESS_FIXED - CollectionCommitLogEntryModel', 1]],
+            output)
+
+        migrated_commit_model = (
+            collection_models.CollectionCommitLogEntryModel.get_by_id('id'))
+        self.assertEqual(
+            original_commit_model.created_on,
+            migrated_commit_model.created_on)
+        self.assertNotEqual(
+            original_commit_model.last_updated,
+            migrated_commit_model.last_updated)
+        self.assertEqual(
+            original_commit_model.created_on,
+            migrated_commit_model.last_updated)
+
+    def test_one_commit_model_last_updated_after(self):
+        original_commit_model = (
+            collection_models.CollectionCommitLogEntryModel(
+                id='id',
+                user_id='committer_id',
+                collection_id='col_id',
+                commit_type='create',
+                commit_message='Message',
+                commit_cmds=[],
+                version=1,
+                post_commit_status='public',
+                post_commit_community_owned=False,
+                post_commit_is_private=False,
+                created_on=datetime.datetime.strptime(
+                    '2020-07-01T08:59:59Z', '%Y-%m-%dT%H:%M:%SZ'),
+                last_updated=datetime.datetime.strptime(
+                    '2020-07-01T09:00:00Z', '%Y-%m-%dT%H:%M:%SZ')
+            )
+        )
+        original_commit_model.put(update_last_updated_time=False)
+
+        output = self._run_one_off_job()
+        self.assertItemsEqual(
+            [['SUCCESS_ALREADY_CORRECT - CollectionCommitLogEntryModel', 1]],
+            output)
+
+        migrated_commit_model = (
+            collection_models.CollectionCommitLogEntryModel.get_by_id('id'))
+        self.assertEqual(
+            original_commit_model.created_on,
+            migrated_commit_model.created_on)
         self.assertEqual(
             original_commit_model.last_updated,
             migrated_commit_model.last_updated)

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -45,6 +45,7 @@ import python_utils
 ONE_OFF_JOB_MANAGERS = [
     activity_jobs_one_off.ActivityContributorsSummaryOneOffJob,
     activity_jobs_one_off.AuditContributorsOneOffJob,
+    activity_jobs_one_off.FixCommitLastUpdatedOneOffJob,
     activity_jobs_one_off.IndexAllActivitiesJobManager,
     activity_jobs_one_off.RemoveCommitUsernamesOneOffJob,
     collection_jobs_one_off.CollectionMigrationOneOffJob,


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Add one-off job to fix the `last_updated` in commit log models, the field was wrongly updated during the user ID migration.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
