### PR TITLE
Disallow bundling of audio assets when downloading an exploration

### DIFF
--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -70,9 +70,6 @@ SEARCH_INDEX_EXPLORATIONS = 'explorations'
 # search query.
 MAX_ITERATIONS = 10
 
-# Asset directories that should not be bundled for download.
-DOWNLOAD_RESTRICTED_ASSET_DIRS = ['audio']
-
 
 def is_exp_summary_editable(exp_summary, user_id=None):
     """Checks if a given user has permissions to edit the exploration.
@@ -270,6 +267,7 @@ def export_to_zip_file(exploration_id, version=None):
         str. The contents of the ZIP archive of the exploration (which can be
         subsequently converted into a zip file via zipfile.ZipFile()).
     """
+    ASSET_DIRS_TO_INCLUDE_IN_DOWNLOADS = ('image',)
     exploration = exp_fetchers.get_exploration_by_id(
         exploration_id, version=version)
     yaml_repr = exploration.to_yaml()
@@ -287,7 +285,7 @@ def export_to_zip_file(exploration_id, version=None):
                 feconf.ENTITY_TYPE_EXPLORATION, exploration_id))
         dir_list = fs.listdir('')
         for filepath in dir_list:
-            if filepath.startswith(tuple(DOWNLOAD_RESTRICTED_ASSET_DIRS)):
+            if not filepath.startswith(ASSET_DIRS_TO_INCLUDE_IN_DOWNLOADS):
                 continue
             file_contents = fs.get(filepath)
 

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -70,6 +70,9 @@ SEARCH_INDEX_EXPLORATIONS = 'explorations'
 # search query.
 MAX_ITERATIONS = 10
 
+# Asset directories that should not be bundled for download.
+DOWNLOAD_RESTRICTED_ASSET_DIRS = ['audio']
+
 
 def is_exp_summary_editable(exp_summary, user_id=None):
     """Checks if a given user has permissions to edit the exploration.
@@ -284,6 +287,8 @@ def export_to_zip_file(exploration_id, version=None):
                 feconf.ENTITY_TYPE_EXPLORATION, exploration_id))
         dir_list = fs.listdir('')
         for filepath in dir_list:
+            if filepath.startswith(tuple(DOWNLOAD_RESTRICTED_ASSET_DIRS)):
+                continue
             file_contents = fs.get(filepath)
 
             str_filepath = 'assets/%s' % filepath

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -70,6 +70,9 @@ SEARCH_INDEX_EXPLORATIONS = 'explorations'
 # search query.
 MAX_ITERATIONS = 10
 
+# Asset directories that need to be included in exploration download.
+ASSET_DIRS_TO_INCLUDE_IN_DOWNLOADS = ('image',)
+
 
 def is_exp_summary_editable(exp_summary, user_id=None):
     """Checks if a given user has permissions to edit the exploration.
@@ -267,7 +270,6 @@ def export_to_zip_file(exploration_id, version=None):
         str. The contents of the ZIP archive of the exploration (which can be
         subsequently converted into a zip file via zipfile.ZipFile()).
     """
-    ASSET_DIRS_TO_INCLUDE_IN_DOWNLOADS = ('image',)
     exploration = exp_fetchers.get_exploration_by_id(
         exploration_id, version=version)
     yaml_repr = exploration.to_yaml()

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -70,9 +70,6 @@ SEARCH_INDEX_EXPLORATIONS = 'explorations'
 # search query.
 MAX_ITERATIONS = 10
 
-# Asset directories that need to be included in exploration download.
-ASSET_DIRS_TO_INCLUDE_IN_DOWNLOADS = ('image',)
-
 
 def is_exp_summary_editable(exp_summary, user_id=None):
     """Checks if a given user has permissions to edit the exploration.
@@ -270,6 +267,8 @@ def export_to_zip_file(exploration_id, version=None):
         str. The contents of the ZIP archive of the exploration (which can be
         subsequently converted into a zip file via zipfile.ZipFile()).
     """
+    # Asset directories that need to be included in exploration download.
+    asset_dirs_to_include_in_downloads = ('image',)
     exploration = exp_fetchers.get_exploration_by_id(
         exploration_id, version=version)
     yaml_repr = exploration.to_yaml()
@@ -287,7 +286,7 @@ def export_to_zip_file(exploration_id, version=None):
                 feconf.ENTITY_TYPE_EXPLORATION, exploration_id))
         dir_list = fs.listdir('')
         for filepath in dir_list:
-            if not filepath.startswith(ASSET_DIRS_TO_INCLUDE_IN_DOWNLOADS):
+            if not filepath.startswith(asset_dirs_to_include_in_downloads):
                 continue
             file_contents = fs.get(filepath)
 

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1885,7 +1885,8 @@ title: A title
         zf = zipfile.ZipFile(python_utils.string_io(
             buffer_value=zip_file_output))
 
-        self.assertEqual(zf.namelist(), ['A title.yaml', 'assets/image/abc.png'])
+        self.assertEqual(
+            zf.namelist(), ['A title.yaml', 'assets/image/abc.png'])
         self.assertEqual(
             zf.open('A title.yaml').read(), self.SAMPLE_YAML_CONTENT)
         self.assertEqual(zf.open('assets/image/abc.png').read(), raw_image)

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1874,6 +1874,7 @@ title: A title
             fs_domain.GcsFileSystem(
                 feconf.ENTITY_TYPE_EXPLORATION, self.EXP_0_ID))
         fs.commit('abc.png', raw_image)
+        # Audio files should not be included in asset downloads.
         with python_utils.open_file(
             os.path.join(feconf.TESTS_DATA_DIR, 'cafe.mp3'),
             mode='rb', encoding=None) as f:

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1874,6 +1874,11 @@ title: A title
             fs_domain.GcsFileSystem(
                 feconf.ENTITY_TYPE_EXPLORATION, self.EXP_0_ID))
         fs.commit('abc.png', raw_image)
+        with python_utils.open_file(
+            os.path.join(feconf.TESTS_DATA_DIR, 'cafe.mp3'),
+            mode='rb', encoding=None) as f:
+            raw_audio = f.read()
+        fs.commit('audio/cafe.mp3', raw_audio)
 
         zip_file_output = exp_services.export_to_zip_file(self.EXP_0_ID)
         zf = zipfile.ZipFile(python_utils.string_io(

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1873,7 +1873,7 @@ title: A title
         fs = fs_domain.AbstractFileSystem(
             fs_domain.GcsFileSystem(
                 feconf.ENTITY_TYPE_EXPLORATION, self.EXP_0_ID))
-        fs.commit('abc.png', raw_image)
+        fs.commit('image/abc.png', raw_image)
         # Audio files should not be included in asset downloads.
         with python_utils.open_file(
             os.path.join(feconf.TESTS_DATA_DIR, 'cafe.mp3'),
@@ -1885,10 +1885,10 @@ title: A title
         zf = zipfile.ZipFile(python_utils.string_io(
             buffer_value=zip_file_output))
 
-        self.assertEqual(zf.namelist(), ['A title.yaml', 'assets/abc.png'])
+        self.assertEqual(zf.namelist(), ['A title.yaml', 'assets/image/abc.png'])
         self.assertEqual(
             zf.open('A title.yaml').read(), self.SAMPLE_YAML_CONTENT)
-        self.assertEqual(zf.open('assets/abc.png').read(), raw_image)
+        self.assertEqual(zf.open('assets/image/abc.png').read(), raw_image)
 
     def test_export_by_versions(self):
         """Test export_to_zip_file() for different versions."""


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of NA.
2. This PR does the following: Adds a check to disallow bundling of audio assets when explorations are downloaded

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
