### PR TITLE
Increase ExplorationMigrationJobManager sharding to 64 and adds check to prevent processing of private explorations for DragAndDropSortInputInteractionOneOffJob

### DIFF
--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -93,7 +93,9 @@ class DragAndDropSortInputInteractionOneOffJob(
     def map(item):
         if item.deleted:
             return
-
+        exp_status = rights_manager.get_exploration_rights(item.id).status
+        if exp_status == rights_manager.ACTIVITY_STATUS_PRIVATE:
+            return
         exploration = exp_fetchers.get_exploration_from_model(item)
         validation_errors = []
         for state_name, state in exploration.states.items():
@@ -354,6 +356,11 @@ class ExplorationMigrationJobManager(jobs.BaseMapReduceOneOffJobManager):
     @classmethod
     def entity_classes_to_map_over(cls):
         return [exp_models.ExplorationModel]
+
+    @classmethod
+    def enqueue(cls, job_id, additional_job_params=None):
+        super(ExplorationMigrationJobManager, cls).enqueue(
+			job_id, shard_count=64)
 
     @staticmethod
     def map(item):

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -360,7 +360,7 @@ class ExplorationMigrationJobManager(jobs.BaseMapReduceOneOffJobManager):
     @classmethod
     def enqueue(cls, job_id, additional_job_params=None):
         super(ExplorationMigrationJobManager, cls).enqueue(
-			job_id, shard_count=64)
+            job_id, shard_count=64)
 
     @staticmethod
     def map(item):


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of NA.
2. This PR does the following:

- Increase sharding to 64 for ExplorationMigrationJobManager.
- Do not process private explorations for DragAndDropSortInputInteractionOneOffJob.


## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
