### PR TITLE
Adds server_log_level arg for run_e2e_tests script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,15 +239,15 @@ jobs:
       - run:
           name: Run e2e topics and skills dashboard test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="topicsAndSkillsDashboard"
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="topicsAndSkillsDashboard" --server_log_level=info
       - run:
           name: Run e2e topics and story editor
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="topicAndStoryEditor"
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="topicAndStoryEditor" --server_log_level=info
       - run:
           name: Run e2e classroom page test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="classroomPageFileUploadFeatures"
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="classroomPageFileUploadFeatures" --server_log_level=info
       - run:
           name: Run e2e topic and story editor test
           command: |

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -135,6 +135,13 @@ _PARSER.add_argument(
     action='store_true')
 
 _PARSER.add_argument(
+    '--server_log_level',
+    help='Sets the log level for the appengine server. The default value is '
+         'set to critical.',
+    default='critical',
+    choices=['critical', 'error', 'warning', 'info'])
+
+_PARSER.add_argument(
     '--community_dashboard_enabled', action='store_true',
     help='Run the test after enabling the community dashboard page.')
 
@@ -414,21 +421,23 @@ def get_e2e_test_parameters(
     return commands
 
 
-def start_google_app_engine_server(dev_mode_setting):
+def start_google_app_engine_server(dev_mode_setting, log_level):
     """Start the Google App Engine server.
 
     Args:
         dev_mode_setting: bool. Represents whether to run the related commands
             in dev mode.
+        log_level: str. The log level for the google app engine server.
     """
     app_yaml_filepath = 'app%s.yaml' % ('_dev' if dev_mode_setting else '')
 
     p = subprocess.Popen(
         '%s %s/dev_appserver.py --host 0.0.0.0 --port %s '
-        '--clear_datastore=yes --dev_appserver_log_level=critical '
-        '--log_level=critical --skip_sdk_update_check=true %s' % (
+        '--clear_datastore=yes --dev_appserver_log_level=%s '
+        '--log_level=%s --skip_sdk_update_check=true %s' % (
             common.CURRENT_PYTHON_BIN, common.GOOGLE_APP_ENGINE_HOME,
-            GOOGLE_APP_ENGINE_PORT, app_yaml_filepath), shell=True)
+            GOOGLE_APP_ENGINE_PORT, log_level, log_level, app_yaml_filepath),
+        shell=True)
     SUBPROCESSES.append(p)
 
 
@@ -472,7 +481,7 @@ def main(args=None):
         else CHROME_DRIVER_VERSION)
     start_webdriver_manager(version)
 
-    start_google_app_engine_server(dev_mode)
+    start_google_app_engine_server(dev_mode, parsed_args.server_log_level)
 
     wait_for_port_to_be_open(WEB_DRIVER_PORT)
     wait_for_port_to_be_open(GOOGLE_APP_ENGINE_PORT)

--- a/scripts/run_e2e_tests_test.py
+++ b/scripts/run_e2e_tests_test.py
@@ -675,7 +675,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
             expected_args=[(expected_command,)],
             expected_kwargs=[{'shell': True}])
         with popen_swap:
-            run_e2e_tests.start_google_app_engine_server(True)
+            run_e2e_tests.start_google_app_engine_server(True, 'critical')
 
     def test_start_google_app_engine_server_in_prod_mode(self):
 
@@ -690,7 +690,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
             expected_args=[(expected_command,)],
             expected_kwargs=[{'shell': True}])
         with popen_swap:
-            run_e2e_tests.start_google_app_engine_server(False)
+            run_e2e_tests.start_google_app_engine_server(False, 'critical')
 
     def test_start_tests_when_other_instances_not_stopped(self):
         def mock_exit(unused_exit_code):
@@ -726,7 +726,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         def mock_start_webdriver_manager(unused_arg):
             return
 
-        def mock_start_google_app_engine_server(unused_arg):
+        def mock_start_google_app_engine_server(unused_arg, unused_log_level):
             return
 
         def mock_wait_for_port_to_be_open(unused_port):
@@ -772,7 +772,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         start_google_app_engine_server_swap = self.swap_with_checks(
             run_e2e_tests, 'start_google_app_engine_server',
             mock_start_google_app_engine_server,
-            expected_args=[(True,)])
+            expected_args=[(True, 'critical')])
         wait_swap = self.swap_with_checks(
             run_e2e_tests, 'wait_for_port_to_be_open',
             mock_wait_for_port_to_be_open,
@@ -819,7 +819,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         def mock_start_webdriver_manager(unused_arg):
             return
 
-        def mock_start_google_app_engine_server(unused_arg):
+        def mock_start_google_app_engine_server(unused_arg, unused_log_level):
             return
 
         def mock_wait_for_port_to_be_open(unused_port):
@@ -865,7 +865,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         start_google_app_engine_server_swap = self.swap_with_checks(
             run_e2e_tests, 'start_google_app_engine_server',
             mock_start_google_app_engine_server,
-            expected_args=[(True,)])
+            expected_args=[(True, 'critical')])
         wait_swap = self.swap_with_checks(
             run_e2e_tests, 'wait_for_port_to_be_open',
             mock_wait_for_port_to_be_open,
@@ -912,7 +912,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         def mock_start_webdriver_manager(unused_arg):
             return
 
-        def mock_start_google_app_engine_server(unused_arg):
+        def mock_start_google_app_engine_server(unused_arg, unused_log_level):
             return
 
         def mock_wait_for_port_to_be_open(unused_port):
@@ -965,7 +965,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         start_google_app_engine_server_swap = self.swap_with_checks(
             run_e2e_tests, 'start_google_app_engine_server',
             mock_start_google_app_engine_server,
-            expected_args=[(True,)])
+            expected_args=[(True, 'critical')])
         wait_swap = self.swap_with_checks(
             run_e2e_tests, 'wait_for_port_to_be_open',
             mock_wait_for_port_to_be_open,


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

This functionality will allow us to check the server logs in the e2e test which are throwing 500 errors.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
