### PR TITLE
Add an arg to specify chrome driver version while running e2e test

### DIFF
--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -123,6 +123,10 @@ _PARSER.add_argument(
     action='store_true')
 
 _PARSER.add_argument(
+    '--chrome_driver_version',
+    help='Uses the specified version of the chrome driver ')
+
+_PARSER.add_argument(
     '--debug_mode',
     help='Runs the protractor test in debugging mode. Follow the instruction '
          'provided in following URL to run e2e tests in debugging mode: '
@@ -467,7 +471,8 @@ def main(args=None):
     if not parsed_args.skip_build:
         build_js_files(
             dev_mode, deparallelize_terser=parsed_args.deparallelize_terser)
-    version = (
+
+    version = parsed_args.chrome_driver_version or (
         get_chrome_driver_version() if parsed_args.auto_select_chromedriver
         else CHROME_DRIVER_VERSION)
     start_webdriver_manager(version)


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #N/A.
2. This PR does the following:
- Adds an argument to manually specify the chrome driver version as autoselect was not working on macs.

Example command: 

`python -m scripts.run_e2e_tests --suite="fileUploadFeatures" --chrome_driver_version="83.0.4103.116"`

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
