### PR TITLE
Adds the i18n language service code to notify angular for translation language code change wherever $translate.use is used

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.ts
@@ -44,14 +44,14 @@ angular.module('oppia').directive('topNavigationBar', [
       controller: [
         '$http', '$scope', '$timeout', '$translate', '$window',
         'ClassroomBackendApiService', 'DebouncerService', 'DeviceInfoService',
-        'NavigationService', 'SidebarStatusService', 'SiteAnalyticsService',
-        'UserService', 'WindowDimensionsService',
+        'I18nLanguageCodeService', 'NavigationService', 'SidebarStatusService',
+        'SiteAnalyticsService', 'UserService', 'WindowDimensionsService',
         'LABEL_FOR_CLEARING_FOCUS', 'LOGOUT_URL',
         function(
             $http, $scope, $timeout, $translate, $window,
             ClassroomBackendApiService, DebouncerService, DeviceInfoService,
-            NavigationService, SidebarStatusService, SiteAnalyticsService,
-            UserService, WindowDimensionsService,
+            I18nLanguageCodeService, NavigationService, SidebarStatusService,
+            SiteAnalyticsService, UserService, WindowDimensionsService,
             LABEL_FOR_CLEARING_FOCUS, LOGOUT_URL) {
           var ctrl = this;
           var NAV_MODE_SIGNUP = 'signup';
@@ -248,6 +248,8 @@ angular.module('oppia').directive('topNavigationBar', [
             UserService.getUserInfoAsync().then(function(userInfo) {
               if (userInfo.getPreferredSiteLanguageCode()) {
                 $translate.use(userInfo.getPreferredSiteLanguageCode());
+                I18nLanguageCodeService.setI18nLanguageCode(
+                  userInfo.getPreferredSiteLanguageCode());
               }
               ctrl.isModerator = userInfo.isModerator();
               ctrl.isAdmin = userInfo.isAdmin();

--- a/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.directive.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.directive.ts
@@ -354,8 +354,9 @@ angular.module('oppia').directive('conversationSkin', [
         'ExplorationRecommendationsService',
         'FatigueDetectionService', 'FocusManagerService',
         'GuestCollectionProgressService', 'HintsAndSolutionManagerService',
-        'ImagePreloaderService', 'LearnerAnswerInfoService', 'LoaderService',
-        'LearnerParamsService', 'LearnerViewRatingService', 'MessengerService',
+        'ImagePreloaderService', 'I18nLanguageCodeService',
+        'LearnerAnswerInfoService', 'LoaderService', 'LearnerParamsService',
+        'LearnerViewRatingService', 'MessengerService',
         'NumberAttemptsService', 'PlayerCorrectnessFeedbackEnabledService',
         'PlayerPositionService', 'PlayerTranscriptService',
         'QuestionPlayerEngineService', 'QuestionPlayerStateService',
@@ -385,8 +386,9 @@ angular.module('oppia').directive('conversationSkin', [
             ExplorationRecommendationsService,
             FatigueDetectionService, FocusManagerService,
             GuestCollectionProgressService, HintsAndSolutionManagerService,
-            ImagePreloaderService, LearnerAnswerInfoService, LoaderService,
-            LearnerParamsService, LearnerViewRatingService, MessengerService,
+            ImagePreloaderService, I18nLanguageCodeService,
+            LearnerAnswerInfoService, LoaderService, LearnerParamsService,
+            LearnerViewRatingService, MessengerService,
             NumberAttemptsService, PlayerCorrectnessFeedbackEnabledService,
             PlayerPositionService, PlayerTranscriptService,
             QuestionPlayerEngineService, QuestionPlayerStateService,
@@ -802,8 +804,11 @@ angular.module('oppia').directive('conversationSkin', [
                 ExplorationPlayerStateService.getLanguageCode());
               if (langCodes.indexOf(explorationLanguageCode) !== -1) {
                 $translate.use(explorationLanguageCode);
+                I18nLanguageCodeService.setI18nLanguageCode(
+                  explorationLanguageCode);
               } else {
                 $translate.use('en');
+                I18nLanguageCodeService.setI18nLanguageCode('en');
               }
             }
             $scope.adjustPageHeight(false, null);

--- a/core/templates/pages/preferences-page/preferences-page.component.ts
+++ b/core/templates/pages/preferences-page/preferences-page.component.ts
@@ -46,16 +46,16 @@ angular.module('oppia').component('preferencesPage', {
   template: require('./preferences-page.component.html'),
   controller: [
     '$http', '$q', '$translate', '$timeout', '$window',
-    '$uibModal', 'AlertsService', 'LanguageUtilService', 'LoaderService',
-    'UrlInterpolationService', 'UserService',
-    'DASHBOARD_TYPE_CREATOR', 'DASHBOARD_TYPE_LEARNER',
+    '$uibModal', 'AlertsService', 'I18nLanguageCodeService',
+    'LanguageUtilService', 'LoaderService', 'UrlInterpolationService',
+    'UserService', 'DASHBOARD_TYPE_CREATOR', 'DASHBOARD_TYPE_LEARNER',
     'ENABLE_ACCOUNT_DELETION', 'ENABLE_ACCOUNT_EXPORT',
     'SUPPORTED_AUDIO_LANGUAGES', 'SUPPORTED_SITE_LANGUAGES',
     function(
         $http, $q, $translate, $timeout, $window,
-        $uibModal, AlertsService, LanguageUtilService, LoaderService,
-        UrlInterpolationService, UserService,
-        DASHBOARD_TYPE_CREATOR, DASHBOARD_TYPE_LEARNER,
+        $uibModal, AlertsService, I18nLanguageCodeService,
+        LanguageUtilService, LoaderService, UrlInterpolationService,
+        UserService, DASHBOARD_TYPE_CREATOR, DASHBOARD_TYPE_LEARNER,
         ENABLE_ACCOUNT_DELETION, ENABLE_ACCOUNT_EXPORT,
         SUPPORTED_AUDIO_LANGUAGES, SUPPORTED_SITE_LANGUAGES) {
       var ctrl = this;
@@ -95,6 +95,8 @@ angular.module('oppia').component('preferencesPage', {
       ctrl.savePreferredSiteLanguageCodes = function(
           preferredSiteLanguageCode) {
         $translate.use(preferredSiteLanguageCode);
+        I18nLanguageCodeService.setI18nLanguageCode(
+          preferredSiteLanguageCode);
         _forceSelect2Refresh();
         _saveDataItem(
           'preferred_site_language_code', preferredSiteLanguageCode);


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of N/A.
2. This PR does the following:

Mechanical change. Adds the code to notify angular for translation language code change wherever `$translate.use` is used

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
