### PR TITLE
Added '--disable_host_checking' flag to startup script

### DIFF
--- a/scripts/start.py
+++ b/scripts/start.py
@@ -57,7 +57,8 @@ _PARSER.add_argument(
     help=(
         'optional; if specified, disables host checking so that the dev '
         'server can be accessed by any device on the same network using the '
-        'host device\'s IP address.'),
+        'host device\'s IP address. DO NOT use this flag if you\'re running '
+        'on an untrusted network.'),
     action='store_true')
 _PARSER.add_argument(
     '--prod_env',

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -53,6 +53,10 @@ _PARSER.add_argument(
     help='optional; if specified, enables console.',
     action='store_true')
 _PARSER.add_argument(
+    '--disable_host_checking',
+    help='optional; if specified, disables host checking.',
+    action='store_true')
+_PARSER.add_argument(
     '--prod_env',
     help='optional; if specified, runs Oppia in a production environment.',
     action='store_true')
@@ -105,6 +109,9 @@ def main(args=None):
         '' if parsed_args.save_datastore else '--clear_datastore=true')
     enable_console_arg = (
         '--enable_console=true' if parsed_args.enable_console else '')
+    disable_host_checking_arg = (
+        '--enable_host_checking=False'
+        if parsed_args.disable_host_checking else '')
     no_auto_restart = (
         '--automatic_restart=no' if parsed_args.no_auto_restart else '')
 
@@ -134,9 +141,9 @@ def main(args=None):
     python_utils.PRINT('Starting GAE development server')
     background_processes.append(subprocess.Popen(
         'python %s/dev_appserver.py %s %s %s --admin_host 0.0.0.0 --admin_port '
-        '8000 --host 0.0.0.0 --port %s --skip_sdk_update_check true %s' % (
+        '8000 --host 0.0.0.0 --port %s %s --skip_sdk_update_check true %s' % (
             common.GOOGLE_APP_ENGINE_HOME, clear_datastore_arg,
-            enable_console_arg, no_auto_restart,
+            enable_console_arg, disable_host_checking_arg, no_auto_restart,
             python_utils.UNICODE(PORT_NUMBER_FOR_GAE_SERVER),
             app_yaml_filepath), shell=True))
 

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -110,7 +110,7 @@ def main(args=None):
     enable_console_arg = (
         '--enable_console=true' if parsed_args.enable_console else '')
     disable_host_checking_arg = (
-        '--enable_host_checking=False'
+        '--enable_host_checking=false'
         if parsed_args.disable_host_checking else '')
     no_auto_restart = (
         '--automatic_restart=no' if parsed_args.no_auto_restart else '')

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -54,7 +54,10 @@ _PARSER.add_argument(
     action='store_true')
 _PARSER.add_argument(
     '--disable_host_checking',
-    help='optional; if specified, disables host checking.',
+    help=(
+        'optional; if specified, disables host checking so that the dev '
+        'server can be accessed by any device on the same network using the '
+        'device\'s IP address.'),
     action='store_true')
 _PARSER.add_argument(
     '--prod_env',

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -57,7 +57,7 @@ _PARSER.add_argument(
     help=(
         'optional; if specified, disables host checking so that the dev '
         'server can be accessed by any device on the same network using the '
-        'device\'s IP address.'),
+        'host device\'s IP address.'),
     action='store_true')
 _PARSER.add_argument(
     '--prod_env',


### PR DESCRIPTION
## Overview

1. This PR does the following: Adds a '--disable_host_checking' flag to startup script. This can be useful when you want to access the server on another device on the same network, which is not possible currently. This is the case when the server has to be accessed on:
- A mobile device (without going through the steps to enable debugging using Chrome) 
- The host machine when the server is in a VM (which is what I use this for).

If this PR is merged, then the wiki for 'Running Oppia on Windows in a VM' and 'Mobile Development' can be modified to include this flag when running the server. For the latter, this can be used to just view pages without full fledged Chrome debugging.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
