### PR TITLE
Revert "Fix #9052: Disable E2E Test Sharding by Default"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
       - run:
           name: Run e2e admin page test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="adminPage" --prod_env --sharding-instances=1
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="adminPage" --prod_env
       - persist_to_workspace:
           root: /home/circleci/
           paths:
@@ -172,7 +172,7 @@ jobs:
       - run:
           name: Run e2e library test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="library" --prod_env --sharding-instances=1
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="library" --prod_env
       - run:
           name: Run e2e classroomPage test
           command: |
@@ -180,15 +180,15 @@ jobs:
       - run:
           name: Run e2e collections test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="collections" --prod_env --sharding-instances=1
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="collections" --prod_env
       - run:
           name: Run e2e accessibility page test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="accessibility" --prod_env --sharding-instances=1
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="accessibility" --prod_env
       - run:
           name: Run e2e embedding page test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="embedding" --prod_env --sharding-instances=1
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="embedding" --prod_env
 
   e2e_users:
     <<: *job_defaults
@@ -202,15 +202,15 @@ jobs:
       - run:
           name: Run e2e users test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="users" --prod_env --sharding-instances=1
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="users" --prod_env
       - run:
           name: Run e2e subscriptions test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="subscriptions" --prod_env --sharding-instances=1
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="subscriptions" --prod_env
       - run:
           name: Run e2e profileMenu test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="profileMenu" --prod_env --sharding-instances=1
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="profileMenu" --prod_env
       - run:
           name: Run e2e preferences test
           command: |
@@ -239,7 +239,7 @@ jobs:
       - run:
           name: Run e2e topics and skills dashboard test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="topicsAndSkillsDashboard" --sharding-instances=1 --server_log_level=info
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="topicsAndSkillsDashboard" --server_log_level=info
       - run:
           name: Run e2e topics and story editor
           command: |
@@ -247,7 +247,7 @@ jobs:
       - run:
           name: Run e2e classroom page test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="classroomPageFileUploadFeatures" --sharding-instances=1 --server_log_level=info
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="classroomPageFileUploadFeatures" --server_log_level=info
       - run:
           name: Run e2e topic and story editor test
           command: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
 # Run the e2e tests in the production environment (using --prod_env).
 - if [ "$RUN_E2E_TESTS_ADDITIONAL_EDITOR_PLAYER_FEATURES" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="additionalEditorFeatures" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="additionalPlayerFeatures" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_COMMUNITY_DASHBOARD" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="communityDashboard"  --community_dashboard_enabled --prod_env; fi
-- if [ "$RUN_E2E_TESTS_CORE_EDITOR_AND_PLAYER_FEATURES" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="coreEditorAndPlayerFeatures" --prod_env --sharding-instances=1; fi
+- if [ "$RUN_E2E_TESTS_CORE_EDITOR_AND_PLAYER_FEATURES" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="coreEditorAndPlayerFeatures" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_CREATOR_DASHBOARD" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="creatorDashboard" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_EXPLORATION_FEEDBACK_AND_HISTORY_TAB" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="explorationFeedbackTab" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationHistoryTab" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_EXPLORATION_STATISTICS_AND_TRANSLATION_TAB" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="explorationStatisticsTab" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationTranslationTab" --prod_env; fi


### PR DESCRIPTION
Reverts oppia/oppia#9793 because the flakes it was intended to fix are still occurring. The fix slows down tests by disabling sharding, so we don't want it unless it's actually helpful.