### PR TITLE
Fixing bugs in the create new subtopic modal of missing validations.

### DIFF
--- a/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.template.html
+++ b/core/templates/pages/topic-editor-page/modal-templates/create-new-subtopic-modal.template.html
@@ -10,15 +10,16 @@
     </div>
     <input class="form-control protractor-test-new-subtopic-title-field" style="font-size: 12px;"
            placeholder="Enter a brief description for the subtopic that students can easily understand, e.g. 'Adding Fractions'"
-           ng-model="$ctrl.subtopicTitle" ng-change="$ctrl.resetErrorMsg()" maxlength="<[MAX_CHARS_IN_SUBTOPIC_TITLE]>" autofocus>
+           ng-model="$ctrl.subtopicTitle" ng-change="$ctrl.resetErrorMsg()" maxlength="<[$ctrl.MAX_CHARS_IN_SUBTOPIC_TITLE]>" autofocus>
     <span class="oppia-input-box-subtitle">
       <i>
-        Subtopic title should be at most <[MAX_CHARS_IN_SUBTOPIC_TITLE]> characters.
+        Subtopic title should be at most <[$ctrl.MAX_CHARS_IN_SUBTOPIC_TITLE]> characters.
       </i>
     </span>
     <span class="form-text error-msg" ng-if="$ctrl.errorMsg">
-      <em><[errorMsg]></em>
+      <em><[$ctrl.errorMsg]></em>
     </span>
+
 
     <div class="thumbnail-editor">
       <thumbnail-uploader filename="$ctrl.editableThumbnailFilename"


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes validation not working while create new subtopic.
## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
