### PR TITLE
i18n translate pluralization for angular2+ codebase

### DIFF
--- a/core/templates/filters/translate.pipe.spec.ts
+++ b/core/templates/filters/translate.pipe.spec.ts
@@ -40,7 +40,11 @@ class MockTranslateService {
     I18n_t_1: 'Hello',
     I18n_t_2: 'Hello <[val]>',
     I18n_rogue_1: '<script>alert(\'Oppia\');</script>Hello',
-    I18n_rogue_2: '<oppia-img>Me</oppia-img>Hola'
+    I18n_rogue_2: '<oppia-img>Me</oppia-img>Hola',
+    I18n_plural_1: ('You have' +
+     ' {lessonCount, plural, =1{1 lesson} other{# lessons}} left.'),
+    I18n_plural_2: ('You have' +
+     ' {lessonCount, plural, one{1 lesson} other{# lessons}} left.')
   };
 
   getInterpolatedString(key: string,
@@ -92,6 +96,16 @@ describe('TranslatePipe', () => {
     expect(pipe.transform('I18n_t_2', {val: '<script>World</script>'})).toBe(
       'Hello <script>World</script>');
     expect(pipe.transform('I18n_t_3')).toBe('I18n_t_3');
+    expect(pipe.transform('I18n_plural_1', {lessonCount: 1})).toBe(
+      'You have 1 lesson left.');
+    expect(pipe.transform('I18n_plural_2', {lessonCount: 1})).toBe(
+      'You have 1 lesson left.');
+    expect(pipe.transform('I18n_plural_1', {lessonCount: 12})).toBe(
+      'You have 12 lessons left.');
+    expect(pipe.transform('I18n_plural_1', {lessonCount: '1'})).toBe(
+      'You have 1 lesson left.');
+    expect(pipe.transform('I18n_plural_1', {lessonCount: '12'})).toBe(
+      'You have 12 lessons left.');
     expect(pipe.transform('')).toBe('');
     translateService.onLangChange.emit({newLanguageCode: 'en'});
   });

--- a/core/templates/filters/translate.pipe.spec.ts
+++ b/core/templates/filters/translate.pipe.spec.ts
@@ -44,7 +44,9 @@ class MockTranslateService {
     I18n_plural_1: ('You have' +
      ' {lessonCount, plural, =1{1 lesson} other{# lessons}} left.'),
     I18n_plural_2: ('You have' +
-     ' {lessonCount, plural, one{1 lesson} other{# lessons}} left.')
+     ' {lessonCount, plural, one{1 lesson} other{# lessons}} left.'),
+    I18n_plural_3: '{ xy, plural, one{ hello other# world',
+    I18n_plural_4: ' xy, plural, one hello } other# world}}',
   };
 
   getInterpolatedString(key: string,
@@ -106,6 +108,13 @@ describe('TranslatePipe', () => {
       'You have 1 lesson left.');
     expect(pipe.transform('I18n_plural_1', {lessonCount: '12'})).toBe(
       'You have 12 lessons left.');
+    expect(pipe.transform('I18n_plural_1', {lessonCounts: '12'})).toBe(
+      'You have' +
+     ' {lessonCount, plural, =1{1 lesson} other{# lessons}} left.');
+    expect(pipe.transform('I18n_plural_3', {xy: '12'})).toBe(
+      '{ xy, plural, one{ hello other# world');
+    expect(pipe.transform('I18n_plural_4', {xy: '12'})).toBe(
+      ' xy, plural, one hello } other# world}}');
     expect(pipe.transform('')).toBe('');
     translateService.onLangChange.emit({newLanguageCode: 'en'});
   });

--- a/core/templates/filters/translate.pipe.ts
+++ b/core/templates/filters/translate.pipe.ts
@@ -178,7 +178,7 @@ export class TranslatePipe implements PipeTransform, OnDestroy {
      */
     const pluralizationKey = codeText.split(
       ', plural,')[0];
-    if (pluralizationKey === undefined) {
+    if (pluralizationParams[pluralizationKey] === undefined) {
       return interpolatedValue;
     }
     let pluralizedValue = '';


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->
Introduces pluralization support in angular2+ i18n translations.

What do I mean by pluralization? Translations where the count if something changes the translation text. Such a mechanism is called pluralization.

1. How did we do i18n pluralization in the past?
We used a format called messageformat. To use the same in angular we need to add a package (https://www.npmjs.com/package/messageformat)
```
span translate="I18N_TOPIC_SUMMARY_TILE_LESSONS"
    translate-values="{lessonCount: $ctrl.getTopicSummary().getCanonicalStoryCount()}"
      translate-interpolation="messageformat"
```

However, looking at the usecase (only pluralization), we can just implement it ourselves without having to use an external library and increase the bundle size.

2. Why can't we do it that way, going forward?
Because it uses $translate, which can't be used in angular.

3. What is the proposed solution (which this PR implements):
This pr implements a function to handle cases where the I18n-translation looks like:
`{lessonCount, plural, =1{1 lesson} other{# lessons}}`. Based on `lessonCount`, the text will change (i.e. singular vs plural).

4. What changes need to happen in the codebase going forward -- i.e. what is the new "status quo", especially in terms of the "instructions for developers":
Nothing, they just follow the migration guide as they did before. I have made the changes in such a way that it doesn't affect the way people migrate.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
