### PR TITLE
Added blanket codeowners for broad directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,22 @@
 # - You do not need to assign yourself as a codeowner (unless you are a project
 #   lead listed on the page above).
 
+# Blanket codeowners
+# This is for the case when new files are created in any directories that aren't
+# covered as a whole, since in these cases, codeowners are not recognized for
+# those files when reviewing, even if the PR does add it. Unless new
+# files/folders are created in the following directories, these codeowners would
+# be superseded by the relevant codeowners mentioned elsewhere in this file.
+# (Reference: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners)
+/core/controllers/ @aks681
+/core/domain/ @DubeySandeep
+/core/templates/services/ @nithusha21
+/core/templates/pages/ @seanlip
+/core/templates/domain/ @kevintab95
+/extensions/ @vojtechjelinek
+/scripts/ @ankita240796
 
+/core/templates/components/ @bansalnitish
 # Android team
 /core/domain/android_validation_constants*.py @BenHenning
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@
 # - You do not need to assign yourself as a codeowner (unless you are a project
 #   lead listed on the page above).
 
+
 # Blanket codeowners
 # This is for the case when new files are created in any directories that aren't
 # covered as a whole, since in these cases, codeowners are not recognized for
@@ -21,15 +22,17 @@
 # (Reference: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners)
 /core/controllers/ @aks681
 /core/domain/ @DubeySandeep
-/core/templates/services/ @nithusha21
-/core/templates/pages/ @seanlip
+/core/templates/components/ @bansalnitish
 /core/templates/domain/ @kevintab95
+/core/templates/pages/ @seanlip
+/core/templates/services/ @nithusha21
 /extensions/ @vojtechjelinek
 /scripts/ @ankita240796
 
-/core/templates/components/ @bansalnitish
+
 # Android team
 /core/domain/android_validation_constants*.py @BenHenning
+
 
 # Angular Migration team
 /core/templates/components/shared-component.module.ts @bansalnitish @srijanreddy98


### PR DESCRIPTION
## Overview

1. This PR does the following: Adds blanket codeowners for broad directories so that in case new files are created there, these codeowners would be assigned to the PR that adds them as well.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
