### PR TITLE
Fix #8124: Broken symlink OS errors in `pre_commit_hook` and `pre_push_hook`

### DIFF
--- a/scripts/pre_commit_hook.py
+++ b/scripts/pre_commit_hook.py
@@ -71,8 +71,9 @@ def install_hook():
         # file instead of the .py file.
         this_file = __file__.replace('pyc', 'py')
         # If its a broken symlink, delete it.
-        if os.path.islink(pre_commit_file) and (
-            not os.path.exists(pre_commit_file)):
+        is_link = os.path.islink(pre_commit_file)
+        exists = os.path.exists(pre_commit_file)
+        if is_link and not exists:
             os.unlink(pre_commit_file)
             python_utils.PRINT('Removing broken symlink')
         try:

--- a/scripts/pre_commit_hook.py
+++ b/scripts/pre_commit_hook.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import argparse
+import errno
 import os
 import shutil
 import subprocess
@@ -78,7 +79,9 @@ def install_hook():
             if e.errno == errno.EEXIST:
                 os.unlink(pre_commit_file)
                 os.symlink(os.path.abspath(this_file), pre_commit_file)
-                python_utils.PRINT('Unlinked and created symlink in .git/hooks directory')
+                python_utils.PRINT(
+                    'Unlinked and created symlink in .git/hooks directory'
+                )
             else:       # Fail safe
                 shutil.copy(this_file, pre_commit_file)
                 python_utils.PRINT('Copied file to .git/hooks directory')

--- a/scripts/pre_commit_hook.py
+++ b/scripts/pre_commit_hook.py
@@ -30,7 +30,6 @@ from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import argparse
-import errno
 import os
 import shutil
 import subprocess

--- a/scripts/pre_commit_hook.py
+++ b/scripts/pre_commit_hook.py
@@ -71,7 +71,8 @@ def install_hook():
         # file instead of the .py file.
         this_file = __file__.replace('pyc', 'py')
         # If its a broken symlink, delete it.
-        if os.path.islink(pre_commit_file) and not os.path.exists(pre_commit_file):
+        if os.path.islink(pre_commit_file) and (
+            not os.path.exists(pre_commit_file)):
             os.unlink(pre_commit_file)
             python_utils.PRINT('Removing broken symlink')
         try:

--- a/scripts/pre_commit_hook.py
+++ b/scripts/pre_commit_hook.py
@@ -74,7 +74,7 @@ def install_hook():
         try:
             os.symlink(os.path.abspath(this_file), pre_commit_file)
             python_utils.PRINT('Created symlink in .git/hooks directory')
-        # Raises OSError when the symlink already exists but is broken
+        # Raises OSError when the symlink already exists but is broken.
         except OSError as e:
             if e.errno == errno.EEXIST:
                 os.unlink(pre_commit_file)
@@ -82,10 +82,10 @@ def install_hook():
                 python_utils.PRINT(
                     'Unlinked and created symlink in .git/hooks directory'
                 )
-            else:       # Fail safe
+            else:       # Fail safe.
                 shutil.copy(this_file, pre_commit_file)
                 python_utils.PRINT('Copied file to .git/hooks directory')
-        # Raises AttributeError on windows
+        # Raises AttributeError on windows.
         except AttributeError:
             shutil.copy(this_file, pre_commit_file)
             python_utils.PRINT('Copied file to .git/hooks directory')

--- a/scripts/pre_commit_hook.py
+++ b/scripts/pre_commit_hook.py
@@ -64,16 +64,16 @@ def install_hook():
     hooks_dir = os.path.join(oppia_dir, '.git', 'hooks')
     pre_commit_file = os.path.join(hooks_dir, 'pre-commit')
     chmod_cmd = ['chmod', '+x', pre_commit_file]
-    if os.path.islink(pre_commit_file) and os.path.exists(pre_commit_file):
+    file_is_symlink = os.path.islink(pre_commit_file)
+    file_exists = os.path.exists(pre_commit_file)
+    if file_is_symlink and file_exists:
         python_utils.PRINT('Symlink already exists')
     else:
         # This is needed, because otherwise some systems symlink/copy the .pyc
         # file instead of the .py file.
         this_file = __file__.replace('pyc', 'py')
         # If its a broken symlink, delete it.
-        is_link = os.path.islink(pre_commit_file)
-        exists = os.path.exists(pre_commit_file)
-        if is_link and not exists:
+        if file_is_symlink and not file_exists:
             os.unlink(pre_commit_file)
             python_utils.PRINT('Removing broken symlink')
         try:

--- a/scripts/pre_commit_hook.py
+++ b/scripts/pre_commit_hook.py
@@ -71,22 +71,15 @@ def install_hook():
         # This is needed, because otherwise some systems symlink/copy the .pyc
         # file instead of the .py file.
         this_file = __file__.replace('pyc', 'py')
+        # If its a broken symlink, delete it.
+        if os.path.islink(pre_commit_file) and not os.path.exists(pre_commit_file):
+            os.unlink(pre_commit_file)
+            python_utils.PRINT('Removing broken symlink')
         try:
             os.symlink(os.path.abspath(this_file), pre_commit_file)
             python_utils.PRINT('Created symlink in .git/hooks directory')
-        # Raises OSError when the symlink already exists but is broken.
-        except OSError as e:
-            if e.errno == errno.EEXIST:
-                os.unlink(pre_commit_file)
-                os.symlink(os.path.abspath(this_file), pre_commit_file)
-                python_utils.PRINT(
-                    'Unlinked and created symlink in .git/hooks directory'
-                )
-            else:       # Fail safe.
-                shutil.copy(this_file, pre_commit_file)
-                python_utils.PRINT('Copied file to .git/hooks directory')
-        # Raises AttributeError on windows.
-        except AttributeError:
+        # Raises AttributeError on windows, OSError added as failsafe.
+        except (OSError, AttributeError):
             shutil.copy(this_file, pre_commit_file)
             python_utils.PRINT('Copied file to .git/hooks directory')
 

--- a/scripts/pre_commit_hook_test.py
+++ b/scripts/pre_commit_hook_test.py
@@ -102,8 +102,8 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             mock_start_subprocess_for_result)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with (islink_swap, exists_swap, subprocess_swap, symlink_swap, 
-            self.print_swap):
+        with islink_swap, exists_swap, subprocess_swap, self.print_swap, (
+            symlink_swap):
             pre_commit_hook.install_hook()
         self.assertTrue(check_function_calls['symlink_is_called'])
         self.assertTrue(
@@ -172,8 +172,8 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         unlink_swap = self.swap(os, 'unlink', mock_unlink)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with (islink_swap, exists_swap, subprocess_swap, unlink_swap,
-            symlink_swap, self.print_swap):
+        with islink_swap, exists_swap, subprocess_swap, self.print_swap, (
+            symlink_swap, unlink_swap):
             pre_commit_hook.install_hook()
         self.assertTrue(check_function_calls['unlink_is_called'])
         self.assertTrue(check_function_calls['symlink_is_called'])

--- a/scripts/pre_commit_hook_test.py
+++ b/scripts/pre_commit_hook_test.py
@@ -102,7 +102,8 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             mock_start_subprocess_for_result)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with islink_swap, exists_swap, subprocess_swap, symlink_swap, self.print_swap:
+        with islink_swap, exists_swap, subprocess_swap, symlink_swap, 
+            self.print_swap:
             pre_commit_hook.install_hook()
         self.assertTrue(check_function_calls['symlink_is_called'])
         self.assertTrue(
@@ -171,7 +172,8 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         unlink_swap = self.swap(os, 'unlink', mock_unlink)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with islink_swap, exists_swap, subprocess_swap, unlink_swap, symlink_swap, self.print_swap:
+        with islink_swap, exists_swap, subprocess_swap, unlink_swap,
+            symlink_swap, self.print_swap:
             pre_commit_hook.install_hook()
         self.assertTrue(check_function_calls['unlink_is_called'])
         self.assertTrue(check_function_calls['symlink_is_called'])

--- a/scripts/pre_commit_hook_test.py
+++ b/scripts/pre_commit_hook_test.py
@@ -44,15 +44,18 @@ class PreCommitHookTests(test_utils.GenericTestBase):
     def test_install_hook_with_existing_symlink(self):
         def mock_islink(unused_file):
             return True
+        def mock_exists(unused_file):
+            return True
         def mock_start_subprocess_for_result(unused_cmd_tokens):
             return ('Output', None)
 
         islink_swap = self.swap(os.path, 'islink', mock_islink)
+        exists_swap = self.swap(os.path, 'exists', mock_exists)
         subprocess_swap = self.swap(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
 
-        with islink_swap, subprocess_swap, self.print_swap:
+        with islink_swap, exists_swap, subprocess_swap, self.print_swap:
             pre_commit_hook.install_hook()
         self.assertTrue('Symlink already exists' in self.print_arr)
         self.assertTrue(
@@ -61,15 +64,18 @@ class PreCommitHookTests(test_utils.GenericTestBase):
     def test_install_hook_with_error_in_making_pre_push_executable(self):
         def mock_islink(unused_file):
             return True
+        def mock_exists(unused_file):
+            return True
         def mock_start_subprocess_for_result(unused_cmd_tokens):
             return ('Output', 'Error')
 
         islink_swap = self.swap(os.path, 'islink', mock_islink)
+        exists_swap = self.swap(os.path, 'exists', mock_exists)
         subprocess_swap = self.swap(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
 
-        with islink_swap, subprocess_swap, self.print_swap:
+        with islink_swap, exists_swap, subprocess_swap, self.print_swap:
             with self.assertRaisesRegexp(ValueError, 'Error'):
                 pre_commit_hook.install_hook()
         self.assertTrue('Symlink already exists' in self.print_arr)
@@ -82,18 +88,21 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         }
         def mock_islink(unused_file):
             return False
+        def mock_exists(unused_file):
+            return False
         def mock_start_subprocess_for_result(unused_cmd_tokens):
             return ('Output', None)
         def mock_symlink(unused_path, unused_file):
             check_function_calls['symlink_is_called'] = True
 
         islink_swap = self.swap(os.path, 'islink', mock_islink)
+        exists_swap = self.swap(os.path, 'exists', mock_exists)
         subprocess_swap = self.swap(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with islink_swap, subprocess_swap, symlink_swap, self.print_swap:
+        with islink_swap, exists_swap, subprocess_swap, symlink_swap, self.print_swap:
             pre_commit_hook.install_hook()
         self.assertTrue(check_function_calls['symlink_is_called'])
         self.assertTrue(
@@ -112,6 +121,8 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         }
         def mock_islink(unused_file):
             return False
+        def mock_exists(unused_file):
+            return False
         def mock_start_subprocess_for_result(unused_cmd_tokens):
             return ('Output', None)
         def mock_symlink(unused_path, unused_file):
@@ -121,19 +132,53 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             check_function_calls['copy_is_called'] = True
 
         islink_swap = self.swap(os.path, 'islink', mock_islink)
+        exists_swap = self.swap(os.path, 'exists', mock_exists)
         subprocess_swap = self.swap(
             pre_commit_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
         copy_swap = self.swap(shutil, 'copy', mock_copy)
 
-        with islink_swap, subprocess_swap, symlink_swap, copy_swap:
+        with islink_swap, exists_swap, subprocess_swap, symlink_swap, copy_swap:
             with self.print_swap:
                 pre_commit_hook.install_hook()
         self.assertEqual(check_function_calls, expected_check_function_calls)
         self.assertTrue('Copied file to .git/hooks directory' in self.print_arr)
         self.assertTrue(
             'pre-commit hook file is now executable!' in self.print_arr)
+
+    def test_install_hook_with_broken_symlink(self):
+        check_function_calls = {
+            'unlink_is_called': False,
+            'symlink_is_called': False
+        }
+        def mock_islink(unused_file):
+            return True
+        def mock_exists(unused_file):
+            return False
+        def mock_start_subprocess_for_result(unused_cmd_tokens):
+            return ('Output', None)
+        def mock_unlink(unused_file):
+            check_function_calls['unlink_is_called'] = True
+        def mock_symlink(unused_path, unused_file):
+            check_function_calls['symlink_is_called'] = True
+
+        islink_swap = self.swap(os.path, 'islink', mock_islink)
+        exists_swap = self.swap(os.path, 'exists', mock_exists)
+        subprocess_swap = self.swap(
+            pre_commit_hook, 'start_subprocess_for_result',
+            mock_start_subprocess_for_result)
+        unlink_swap = self.swap(os, 'unlink', mock_unlink)
+        symlink_swap = self.swap(os, 'symlink', mock_symlink)
+
+        with islink_swap, exists_swap, subprocess_swap, unlink_swap, symlink_swap, self.print_swap:
+            pre_commit_hook.install_hook()
+        self.assertTrue(check_function_calls['unlink_is_called'])
+        self.assertTrue(check_function_calls['symlink_is_called'])
+        self.assertTrue('Removing broken symlink' in self.print_arr)
+        self.assertTrue(
+            'pre-commit hook file is now executable!'in self.print_arr)
+
 
     def test_start_subprocess_for_result(self):
         process = subprocess.Popen(

--- a/scripts/pre_commit_hook_test.py
+++ b/scripts/pre_commit_hook_test.py
@@ -102,8 +102,8 @@ class PreCommitHookTests(test_utils.GenericTestBase):
             mock_start_subprocess_for_result)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with islink_swap, exists_swap, subprocess_swap, symlink_swap, 
-            self.print_swap:
+        with (islink_swap, exists_swap, subprocess_swap, symlink_swap, 
+            self.print_swap):
             pre_commit_hook.install_hook()
         self.assertTrue(check_function_calls['symlink_is_called'])
         self.assertTrue(
@@ -172,8 +172,8 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         unlink_swap = self.swap(os, 'unlink', mock_unlink)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with islink_swap, exists_swap, subprocess_swap, unlink_swap,
-            symlink_swap, self.print_swap:
+        with (islink_swap, exists_swap, subprocess_swap, unlink_swap,
+            symlink_swap, self.print_swap):
             pre_commit_hook.install_hook()
         self.assertTrue(check_function_calls['unlink_is_called'])
         self.assertTrue(check_function_calls['symlink_is_called'])

--- a/scripts/pre_commit_hook_test.py
+++ b/scripts/pre_commit_hook_test.py
@@ -172,9 +172,9 @@ class PreCommitHookTests(test_utils.GenericTestBase):
         unlink_swap = self.swap(os, 'unlink', mock_unlink)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with islink_swap, exists_swap, subprocess_swap, self.print_swap, (
-            symlink_swap, unlink_swap):
-            pre_commit_hook.install_hook()
+        with islink_swap, exists_swap, subprocess_swap, self.print_swap:
+            with unlink_swap, symlink_swap:
+                pre_commit_hook.install_hook()
         self.assertTrue(check_function_calls['unlink_is_called'])
         self.assertTrue(check_function_calls['symlink_is_called'])
         self.assertTrue('Removing broken symlink' in self.print_arr)

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -343,7 +343,9 @@ def install_hook():
             if e.errno == errno.EEXIST:
                 os.unlink(pre_push_file)
                 os.symlink(os.path.abspath(__file__), pre_push_file)
-                python_utils.PRINT('Unlinked and created symlink in .git/hooks directory')
+                python_utils.PRINT(
+                    'Unlinked and created symlink in .git/hooks directory'
+                )
             else:       # Fail safe
                 shutil.copy(__file__, pre_push_file)
                 python_utils.PRINT('Copied file to .git/hooks directory')

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -32,7 +32,6 @@ from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import argparse
 import collections
-import errno
 import os
 import pprint
 import shutil

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -335,22 +335,15 @@ def install_hook():
     if os.path.islink(pre_push_file) and os.path.exists(pre_push_file):
         python_utils.PRINT('Symlink already exists')
     else:
+        # If its a broken symlink, delete it.
+        if os.path.islink(pre_push_file) and not os.path.exists(pre_push_file):
+            os.unlink(pre_push_file)
+            python_utils.PRINT('Removing broken symlink')
         try:
             os.symlink(os.path.abspath(__file__), pre_push_file)
             python_utils.PRINT('Created symlink in .git/hooks directory')
-        # Raises OSError when the symlink already exists but is broken.
-        except OSError as e:
-            if e.errno == errno.EEXIST:
-                os.unlink(pre_push_file)
-                os.symlink(os.path.abspath(__file__), pre_push_file)
-                python_utils.PRINT(
-                    'Unlinked and created symlink in .git/hooks directory'
-                )
-            else:       # Fail safe.
-                shutil.copy(__file__, pre_push_file)
-                python_utils.PRINT('Copied file to .git/hooks directory')
-        # Raises AttributeError on windows.
-        except AttributeError:
+        # Raises AttributeError on windows, OSError added as failsafe.
+        except (OSError, AttributeError):
             shutil.copy(__file__, pre_push_file)
             python_utils.PRINT('Copied file to .git/hooks directory')
 

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -32,6 +32,7 @@ from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import argparse
 import collections
+import errno
 import os
 import pprint
 import shutil
@@ -331,14 +332,23 @@ def install_hook():
     hooks_dir = os.path.join(oppia_dir, '.git', 'hooks')
     pre_push_file = os.path.join(hooks_dir, 'pre-push')
     chmod_cmd = ['chmod', '+x', pre_push_file]
-    if os.path.islink(pre_push_file):
+    if os.path.islink(pre_push_file) and os.path.exists(pre_push_file):
         python_utils.PRINT('Symlink already exists')
     else:
         try:
             os.symlink(os.path.abspath(__file__), pre_push_file)
             python_utils.PRINT('Created symlink in .git/hooks directory')
-        # Raises AttributeError on windows, OSError added as failsafe.
-        except (OSError, AttributeError):
+        # Raises OSError when the symlink already exists but is broken
+        except OSError as e:
+            if e.errno == errno.EEXIST:
+                os.unlink(pre_push_file)
+                os.symlink(os.path.abspath(__file__), pre_push_file)
+                python_utils.PRINT('Unlinked and created symlink in .git/hooks directory')
+            else:       # Fail safe
+                shutil.copy(__file__, pre_push_file)
+                python_utils.PRINT('Copied file to .git/hooks directory')
+        # Raises AttributeError on windows
+        except AttributeError:
             shutil.copy(__file__, pre_push_file)
             python_utils.PRINT('Copied file to .git/hooks directory')
 

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -338,7 +338,7 @@ def install_hook():
         try:
             os.symlink(os.path.abspath(__file__), pre_push_file)
             python_utils.PRINT('Created symlink in .git/hooks directory')
-        # Raises OSError when the symlink already exists but is broken
+        # Raises OSError when the symlink already exists but is broken.
         except OSError as e:
             if e.errno == errno.EEXIST:
                 os.unlink(pre_push_file)
@@ -346,10 +346,10 @@ def install_hook():
                 python_utils.PRINT(
                     'Unlinked and created symlink in .git/hooks directory'
                 )
-            else:       # Fail safe
+            else:       # Fail safe.
                 shutil.copy(__file__, pre_push_file)
                 python_utils.PRINT('Copied file to .git/hooks directory')
-        # Raises AttributeError on windows
+        # Raises AttributeError on windows.
         except AttributeError:
             shutil.copy(__file__, pre_push_file)
             python_utils.PRINT('Copied file to .git/hooks directory')

--- a/scripts/pre_push_hook.py
+++ b/scripts/pre_push_hook.py
@@ -331,11 +331,13 @@ def install_hook():
     hooks_dir = os.path.join(oppia_dir, '.git', 'hooks')
     pre_push_file = os.path.join(hooks_dir, 'pre-push')
     chmod_cmd = ['chmod', '+x', pre_push_file]
-    if os.path.islink(pre_push_file) and os.path.exists(pre_push_file):
+    file_is_symlink = os.path.islink(pre_push_file)
+    file_exists = os.path.exists(pre_push_file)
+    if file_is_symlink and file_exists:
         python_utils.PRINT('Symlink already exists')
     else:
         # If its a broken symlink, delete it.
-        if os.path.islink(pre_push_file) and not os.path.exists(pre_push_file):
+        if file_is_symlink and not file_exists:
             os.unlink(pre_push_file)
             python_utils.PRINT('Removing broken symlink')
         try:

--- a/scripts/pre_push_hook_test.py
+++ b/scripts/pre_push_hook_test.py
@@ -517,9 +517,9 @@ class PrePushHookTests(test_utils.GenericTestBase):
         unlink_swap = self.swap(os, 'unlink', mock_unlink)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with islink_swap, exists_swap, subprocess_swap, unlink_swap, (
-            symlink_swap, self.print_swap):
-            pre_push_hook.install_hook()
+        with islink_swap, exists_swap, subprocess_swap, self.print_swap:
+            with unlink_swap, symlink_swap:
+                pre_push_hook.install_hook()
         self.assertTrue(check_function_calls['unlink_is_called'])
         self.assertTrue(check_function_calls['symlink_is_called'])
         self.assertTrue('Removing broken symlink' in self.print_arr)

--- a/scripts/pre_push_hook_test.py
+++ b/scripts/pre_push_hook_test.py
@@ -447,7 +447,8 @@ class PrePushHookTests(test_utils.GenericTestBase):
             mock_start_subprocess_for_result)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with islink_swap, exists_swap, subprocess_swap, symlink_swap, self.print_swap:
+        with islink_swap, exists_swap, subprocess_swap, symlink_swap, 
+            self.print_swap:
             pre_push_hook.install_hook()
         self.assertTrue(check_function_calls['symlink_is_called'])
         self.assertTrue(
@@ -484,7 +485,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
         copy_swap = self.swap(shutil, 'copy', mock_copy)
 
-        with islink_swap, subprocess_swap, symlink_swap, copy_swap:
+        with islink_swap, exists_swap, subprocess_swap, symlink_swap, copy_swap:
             with self.print_swap:
                 pre_push_hook.install_hook()
         self.assertEqual(check_function_calls, expected_check_function_calls)
@@ -516,7 +517,8 @@ class PrePushHookTests(test_utils.GenericTestBase):
         unlink_swap = self.swap(os, 'unlink', mock_unlink)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with islink_swap, exists_swap, subprocess_swap, unlink_swap, symlink_swap, self.print_swap:
+        with islink_swap, exists_swap, subprocess_swap, unlink_swap,
+            symlink_swap, self.print_swap:
             pre_push_hook.install_hook()
         self.assertTrue(check_function_calls['unlink_is_called'])
         self.assertTrue(check_function_calls['symlink_is_called'])

--- a/scripts/pre_push_hook_test.py
+++ b/scripts/pre_push_hook_test.py
@@ -447,8 +447,8 @@ class PrePushHookTests(test_utils.GenericTestBase):
             mock_start_subprocess_for_result)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with islink_swap, exists_swap, subprocess_swap, symlink_swap, 
-            self.print_swap:
+        with (islink_swap, exists_swap, subprocess_swap, symlink_swap,
+            self.print_swap):
             pre_push_hook.install_hook()
         self.assertTrue(check_function_calls['symlink_is_called'])
         self.assertTrue(
@@ -517,8 +517,8 @@ class PrePushHookTests(test_utils.GenericTestBase):
         unlink_swap = self.swap(os, 'unlink', mock_unlink)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with islink_swap, exists_swap, subprocess_swap, unlink_swap,
-            symlink_swap, self.print_swap:
+        with (islink_swap, exists_swap, subprocess_swap, unlink_swap,
+            symlink_swap, self.print_swap):
             pre_push_hook.install_hook()
         self.assertTrue(check_function_calls['unlink_is_called'])
         self.assertTrue(check_function_calls['symlink_is_called'])

--- a/scripts/pre_push_hook_test.py
+++ b/scripts/pre_push_hook_test.py
@@ -447,7 +447,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
             mock_start_subprocess_for_result)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with (islink_swap, exists_swap, subprocess_swap, symlink_swap,
+        with islink_swap, exists_swap, subprocess_swap, symlink_swap, (
             self.print_swap):
             pre_push_hook.install_hook()
         self.assertTrue(check_function_calls['symlink_is_called'])
@@ -517,7 +517,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
         unlink_swap = self.swap(os, 'unlink', mock_unlink)
         symlink_swap = self.swap(os, 'symlink', mock_symlink)
 
-        with (islink_swap, exists_swap, subprocess_swap, unlink_swap,
+        with islink_swap, exists_swap, subprocess_swap, unlink_swap, (
             symlink_swap, self.print_swap):
             pre_push_hook.install_hook()
         self.assertTrue(check_function_calls['unlink_is_called'])


### PR DESCRIPTION
## Overview
1. This PR fixes #8124 
2. This PR does the following: We add an additional check when ensuring that `pre_commit_hook.py` and `pre_push_hook.py` are symlinks. 
**Previously:** we only check if it is a symlink. **Now:** we also check if that symlink actually exists and is not broken. The cause of the bug in #8124 is that some local changes to the repo caused `pre_push_hook.py` to become a broken symlink, which still satisfies the check `os.path.islink(pre_push_file)`. 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".