### PR TITLE
Fixing e2e flake -- "Could not click on the topics and skills dashboard link"

### DIFF
--- a/core/tests/protractor/profileMenuFlow.js
+++ b/core/tests/protractor/profileMenuFlow.js
@@ -45,11 +45,7 @@ describe('Profile menu flow', function() {
     beforeEach(async function() {
       await users.login('desktopAndMobileVisitor@profileMenuFlow.com');
       await learnerDashboardPage.get();
-      var profileDropdown = element(by.css(
-        '.protractor-test-profile-dropdown'));
-      await waitFor.elementToBeClickable(
-        profileDropdown, 'Could not click profile dropdown');
-      await profileDropdown.click();
+      await general.openProfileDropdown();
     });
 
     it('should visit the profile page from the profile dropdown menu',
@@ -103,18 +99,7 @@ describe('Profile menu flow', function() {
 
       await users.login('desktopAndMobileAdm@profileMenuFlow.com');
       await learnerDashboardPage.get();
-      var profileDropdown = element(by.css(
-        '.protractor-test-profile-dropdown'));
-      await waitFor.elementToBeClickable(
-        profileDropdown, 'Could not click profile dropdown');
-      await profileDropdown.click();
-
-      var topicsAndSkillsDashboardLink = element(by.css(
-        '.protractor-test-topics-and-skills-dashboard-link'));
-      await waitFor.elementToBeClickable(
-        topicsAndSkillsDashboardLink,
-        'Could not click on the topics and skills dashboard link');
-      await topicsAndSkillsDashboardLink.click();
+      await general.navigateToTopicsAndSkillsDashboardPage();
       await waitFor.pageToFullyLoad();
       expect(await browser.getCurrentUrl()).toEqual(
         'http://localhost:9001/topics-and-skills-dashboard');

--- a/core/tests/protractor_desktop/userJourneys.js
+++ b/core/tests/protractor_desktop/userJourneys.js
@@ -69,11 +69,7 @@ describe('Basic user journeys', function() {
 
       await users.login('mod@userManagement.com');
       await browser.get(general.MODERATOR_URL_SUFFIX);
-      var profileDropdown = element(
-        by.css('.protractor-test-profile-dropdown'));
-      await waitFor.elementToBeClickable(
-        profileDropdown, 'Could not click profile dropdown');
-      await profileDropdown.click();
+      await general.openProfileDropdown();
       await users.logout();
       await general.checkForConsoleErrors([]);
     });

--- a/core/tests/protractor_utils/TopicsAndSkillsDashboardPage.js
+++ b/core/tests/protractor_utils/TopicsAndSkillsDashboardPage.js
@@ -20,6 +20,7 @@
 var waitFor = require('./waitFor.js');
 var SkillEditorPage = require('./SkillEditorPage.js');
 var workflow = require('./workflow.js');
+var general = require('../protractor_utils/general.js');
 
 var TopicsAndSkillsDashboardPage = function() {
   var DASHBOARD_URL = '/topics-and-skills-dashboard';
@@ -126,18 +127,8 @@ var TopicsAndSkillsDashboardPage = function() {
 
   this.get = async function() {
     await browser.get('/');
-    var profileDropdown = element(
-      by.css('.protractor-test-profile-dropdown'));
-    await waitFor.elementToBeClickable(
-      profileDropdown, 'Could not click profile dropdown');
-    await profileDropdown.click();
-    var topicsAndSkillsDashboardLink = element(by.css(
-      '.protractor-test-topics-and-skills-dashboard-link'));
-    await waitFor.elementToBeClickable(
-      topicsAndSkillsDashboardLink,
-      'Could not click on the topics and skills dashboard link');
-    await topicsAndSkillsDashboardLink.click();
     await waitFor.pageToFullyLoad();
+    await general.navigateToTopicsAndSkillsDashboardPage();
     expect(await browser.getCurrentUrl()).toEqual(
       'http://localhost:9001/topics-and-skills-dashboard');
   };

--- a/core/tests/protractor_utils/general.js
+++ b/core/tests/protractor_utils/general.js
@@ -21,6 +21,7 @@ var ExplorationEditorPage = require(
   '../protractor_utils/ExplorationEditorPage.js');
 var waitFor = require('./waitFor.js');
 var dragAndDropScript = require('html-dnd').code;
+var action = require('../protractor_utils/action.js');
 
 var dragAndDrop = async function(fromElement, toElement) {
   await browser.executeScript(dragAndDropScript, fromElement, toElement);
@@ -195,6 +196,24 @@ var goToHomePage = async function() {
   return await waitFor.pageToFullyLoad();
 };
 
+var openProfileDropdown = async function() {
+  var profileDropdown = element(
+    by.css('.protractor-test-profile-dropdown'));
+  await action.click(
+    'Profile dropdown taking too long to be clickable.',
+    profileDropdown);
+};
+
+var navigateToTopicsAndSkillsDashboardPage = async function() {
+  await openProfileDropdown();
+  var topicsAndSkillsDashboardLink = element(by.css(
+    '.protractor-test-topics-and-skills-dashboard-link'));
+  await action.click(
+    'Topics and skills dashboard link from dropdown',
+    topicsAndSkillsDashboardLink);
+  await waitFor.pageToFullyLoad();
+};
+
 exports.acceptAlert = acceptAlert;
 exports.scrollToTop = scrollToTop;
 exports.checkForConsoleErrors = checkForConsoleErrors;
@@ -223,3 +242,6 @@ exports.ensurePageHasNoTranslationIds = ensurePageHasNoTranslationIds;
 exports.checkConsoleErrorsExist = checkConsoleErrorsExist;
 
 exports.goToHomePage = goToHomePage;
+exports.openProfileDropdown = openProfileDropdown;
+exports.navigateToTopicsAndSkillsDashboardPage = (
+  navigateToTopicsAndSkillsDashboardPage);


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR tries to fix the flake happening in topicEditors "Could not click on the topics and skills dashboard link"
Relevant error logs [here](https://app.circleci.com/pipelines/github/oppia/oppia/11318/workflows/5c8b042b-fa7d-4f15-af78-ae9fd35f2207/jobs/65197).

2. Reduced code duplication.
## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The linter/Karma presubmit checks have passed locally on your machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [X] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
