### PR TITLE
Fix part of #10064: Revert import github changes

### DIFF
--- a/scripts/release_scripts/deploy.py
+++ b/scripts/release_scripts/deploy.py
@@ -48,7 +48,6 @@ import shutil
 import subprocess
 import sys
 
-import github
 import python_utils
 import release_constants
 from scripts import common
@@ -59,6 +58,8 @@ from scripts.release_scripts import update_configs
 _PARENT_DIR = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
 _PY_GITHUB_PATH = os.path.join(_PARENT_DIR, 'oppia_tools', 'PyGithub-1.43.7')
 sys.path.insert(0, _PY_GITHUB_PATH)
+
+import github  # isort:skip pylint: disable=wrong-import-position
 
 _PARSER = argparse.ArgumentParser()
 _PARSER.add_argument(

--- a/scripts/release_scripts/deploy_test.py
+++ b/scripts/release_scripts/deploy_test.py
@@ -26,13 +26,14 @@ import sys
 import tempfile
 
 from core.tests import test_utils
-import github
 import python_utils
 from scripts import common
 from scripts import install_third_party_libs
 from scripts.release_scripts import deploy
 from scripts.release_scripts import gcloud_adapter
 from scripts.release_scripts import update_configs
+
+import github  # isort:skip pylint: disable=wrong-import-position
 
 RELEASE_TEST_DIR = os.path.join('core', 'tests', 'release_sources', '')
 

--- a/scripts/release_scripts/generate_release_info_test.py
+++ b/scripts/release_scripts/generate_release_info_test.py
@@ -24,12 +24,13 @@ import os
 import tempfile
 
 from core.tests import test_utils
-import github
 import python_utils
 import release_constants
 from scripts import common
 from scripts.release_scripts import generate_release_info
 from scripts.release_scripts import update_changelog_and_credits
+
+import github  # isort:skip pylint: disable=wrong-import-position
 
 RELEASE_TEST_DIR = os.path.join('core', 'tests', 'release_sources', '')
 

--- a/scripts/release_scripts/update_changelog_and_credits.py
+++ b/scripts/release_scripts/update_changelog_and_credits.py
@@ -27,7 +27,6 @@ import os
 import subprocess
 import sys
 
-import github
 import python_utils
 import release_constants
 from scripts import common
@@ -36,6 +35,8 @@ from scripts.release_scripts import generate_release_info
 _PARENT_DIR = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
 _PY_GITHUB_PATH = os.path.join(_PARENT_DIR, 'oppia_tools', 'PyGithub-1.43.7')
 sys.path.insert(0, _PY_GITHUB_PATH)
+
+import github  # isort:skip pylint: disable=wrong-import-position
 
 ABOUT_PAGE_CONSTANTS_FILEPATH = os.path.join(
     'core', 'templates', 'pages', 'about-page',

--- a/scripts/release_scripts/update_changelog_and_credits_test.py
+++ b/scripts/release_scripts/update_changelog_and_credits_test.py
@@ -26,12 +26,13 @@ import sys
 import tempfile
 
 from core.tests import test_utils
-import github
 import python_utils
 import release_constants
 from scripts import common
 from scripts.release_scripts import generate_release_info
 from scripts.release_scripts import update_changelog_and_credits
+
+import github  # isort:skip pylint: disable=wrong-import-position
 
 RELEASE_TEST_DIR = os.path.join('core', 'tests', 'release_sources', '')
 

--- a/scripts/release_scripts/update_configs.py
+++ b/scripts/release_scripts/update_configs.py
@@ -29,7 +29,6 @@ import os
 import re
 import sys
 
-import github
 import python_utils
 import release_constants
 from scripts import common
@@ -37,6 +36,8 @@ from scripts import common
 _PARENT_DIR = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
 _PY_GITHUB_PATH = os.path.join(_PARENT_DIR, 'oppia_tools', 'PyGithub-1.43.7')
 sys.path.insert(0, _PY_GITHUB_PATH)
+
+import github  # isort:skip pylint: disable=wrong-import-position
 
 FECONF_CONFIG_PATH = os.path.join(
     os.getcwd(), os.pardir, 'release-scripts', 'feconf_updates.config')

--- a/scripts/release_scripts/update_configs_test.py
+++ b/scripts/release_scripts/update_configs_test.py
@@ -24,10 +24,11 @@ import os
 import tempfile
 
 from core.tests import test_utils
-import github
 import python_utils
 from scripts import common
 from scripts.release_scripts import update_configs
+
+import github  # isort:skip pylint: disable=wrong-import-position
 
 INVALID_FECONF_CONFIG_PATH = os.path.join(
     os.getcwd(), 'core', 'tests', 'release_sources',

--- a/scripts/release_scripts/wrap_up_release.py
+++ b/scripts/release_scripts/wrap_up_release.py
@@ -22,7 +22,6 @@ from __future__ import unicode_literals  # pylint: disable=import-only-modules
 import os
 import sys
 
-import github
 import python_utils
 import release_constants
 from scripts import common
@@ -30,6 +29,8 @@ from scripts import common
 _PARENT_DIR = os.path.abspath(os.path.join(os.getcwd(), os.pardir))
 _PY_GITHUB_PATH = os.path.join(_PARENT_DIR, 'oppia_tools', 'PyGithub-1.43.7')
 sys.path.insert(0, _PY_GITHUB_PATH)
+
+import github  # isort:skip pylint: disable=wrong-import-position
 
 
 def remove_release_labels(repo):

--- a/scripts/release_scripts/wrap_up_release_test.py
+++ b/scripts/release_scripts/wrap_up_release_test.py
@@ -23,10 +23,11 @@ import getpass
 import os
 
 from core.tests import test_utils
-import github
 import release_constants
 from scripts import common
 from scripts.release_scripts import wrap_up_release
+
+import github  # isort:skip pylint: disable=wrong-import-position
 
 
 class WrapReleaseTests(test_utils.GenericTestBase):


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #10064 
2. This PR does the following: Revert import changes of #9922 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
