### PR TITLE
Fix part of #10083: Removes events 'searchBarLoaded', 'totalQuestionsReceived', 'stateEditorInitialized' & 'stateEditorDirectiveInitialized'

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.ts
@@ -247,7 +247,10 @@ angular.module('oppia').directive('topNavigationBar', [
 
             ctrl.directiveSubscriptions.add(
               SearchService.onSearchBarLoaded.subscribe(
-                () => $timeout(truncateNavbar, 100)
+                () => {
+                  console.log('Caught: searchBarLoaded');
+                  $timeout(truncateNavbar, 100);
+                }
               )
             );
 

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.ts
@@ -27,7 +27,10 @@ require('services/site-analytics.service.ts');
 require('services/user.service.ts');
 require('services/contextual/device-info.service.ts');
 require('services/contextual/window-dimensions.service.ts');
+require('services/search.service.ts');
 require('constants.ts');
+
+import { Subscription } from 'rxjs';
 
 angular.module('oppia').directive('topNavigationBar', [
   'UrlInterpolationService', function(UrlInterpolationService) {
@@ -44,16 +47,17 @@ angular.module('oppia').directive('topNavigationBar', [
       controller: [
         '$http', '$scope', '$timeout', '$translate', '$window',
         'ClassroomBackendApiService', 'DebouncerService', 'DeviceInfoService',
-        'I18nLanguageCodeService', 'NavigationService', 'SidebarStatusService',
-        'SiteAnalyticsService', 'UserService', 'WindowDimensionsService',
-        'LABEL_FOR_CLEARING_FOCUS', 'LOGOUT_URL',
+        'I18nLanguageCodeService', 'NavigationService', 'SearchService',
+        'SidebarStatusService', 'SiteAnalyticsService', 'UserService',
+        'WindowDimensionsService', 'LABEL_FOR_CLEARING_FOCUS', 'LOGOUT_URL',
         function(
             $http, $scope, $timeout, $translate, $window,
             ClassroomBackendApiService, DebouncerService, DeviceInfoService,
-            I18nLanguageCodeService, NavigationService, SidebarStatusService,
-            SiteAnalyticsService, UserService, WindowDimensionsService,
-            LABEL_FOR_CLEARING_FOCUS, LOGOUT_URL) {
+            I18nLanguageCodeService, NavigationService, SearchService,
+            SidebarStatusService, SiteAnalyticsService, UserService,
+            WindowDimensionsService, LABEL_FOR_CLEARING_FOCUS, LOGOUT_URL) {
           var ctrl = this;
+          ctrl.directiveSubscriptions = new Subscription();
           var NAV_MODE_SIGNUP = 'signup';
           var NAV_MODES_WITH_CUSTOM_LOCAL_NAV = [
             'create', 'explore', 'collection', 'collection_editor',
@@ -241,9 +245,11 @@ angular.module('oppia').directive('topNavigationBar', [
               }
             });
 
-            $scope.$on('searchBarLoaded', function() {
-              $timeout(truncateNavbar, 100);
-            });
+            ctrl.directiveSubscriptions.add(
+              SearchService.onSearchBarLoaded.subscribe(
+                () => $timeout(truncateNavbar, 100)
+              )
+            );
 
             UserService.getUserInfoAsync().then(function(userInfo) {
               if (userInfo.getPreferredSiteLanguageCode()) {
@@ -288,8 +294,8 @@ angular.module('oppia').directive('topNavigationBar', [
               ctrl.navElementsVisibilityStatus[NAV_ELEMENTS_ORDER[i]] = true;
             }
 
-            ctrl.resizeSubscription = WindowDimensionsService.getResizeEvent().
-              subscribe(evt => {
+            ctrl.directiveSubscriptions.add(
+              WindowDimensionsService.getResizeEvent().subscribe(evt => {
                 ctrl.windowIsNarrow = WindowDimensionsService.isWindowNarrow();
                 // If window is resized larger, try displaying the hidden
                 // elements.
@@ -314,7 +320,8 @@ angular.module('oppia').directive('topNavigationBar', [
                 // TODO(#8521): Remove the use of $rootScope.$apply()
                 // once the directive is migrated to angular.
                 $scope.$applyAsync();
-              });
+              })
+            );
             // The function needs to be run after i18n. A timeout of 0 appears
             // to run after i18n in Chrome, but not other browsers. The function
             // will check if i18n is complete and set a new timeout if it is
@@ -324,9 +331,7 @@ angular.module('oppia').directive('topNavigationBar', [
           };
 
           ctrl.$onDestroy = function() {
-            if (ctrl.resizeSubscription) {
-              ctrl.resizeSubscription.unsubscribe();
-            }
+            ctrl.directiveSubscriptions.unsubscribe();
           };
         }
       ]

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.ts
@@ -248,7 +248,6 @@ angular.module('oppia').directive('topNavigationBar', [
             ctrl.directiveSubscriptions.add(
               SearchService.onSearchBarLoaded.subscribe(
                 () => {
-                  console.log('Caught: searchBarLoaded');
                   $timeout(truncateNavbar, 100);
                 }
               )

--- a/core/templates/components/question-directives/question-editor/question-editor.directive.ts
+++ b/core/templates/components/question-directives/question-editor/question-editor.directive.ts
@@ -104,7 +104,6 @@ angular.module('oppia').directive('questionEditor', [
             var stateData = ctrl.questionStateData;
             stateData.interaction.defaultOutcome.setDestination(null);
             if (stateData) {
-              console.log('Emitted: stateEditorInitialized in question-editor');
               StateEditorService.onStateEditorInitialized.emit(stateData);
 
               if (stateData.content.getHtml() || stateData.interaction.id) {
@@ -205,10 +204,7 @@ angular.module('oppia').directive('questionEditor', [
           ctrl.$onInit = function() {
             ctrl.directiveSubscriptions.add(
               StateEditorService.onStateEditorDirectiveInitialized.subscribe(
-                () => {
-                  console.log('Caught: stateEditorDirectiveInitialized');
-                  _init();
-                }
+                () => _init()
               )
             );
 

--- a/core/templates/components/question-directives/question-editor/question-editor.directive.ts
+++ b/core/templates/components/question-directives/question-editor/question-editor.directive.ts
@@ -39,6 +39,8 @@ require('services/editability.service.ts');
 
 require('pages/interaction-specs.constants.ajs.ts');
 
+import { Subscription } from 'rxjs';
+
 angular.module('oppia').directive('questionEditor', [
   'UrlInterpolationService', function(UrlInterpolationService) {
     return {
@@ -69,6 +71,7 @@ angular.module('oppia').directive('questionEditor', [
             QuestionObjectFactory, QuestionUpdateService, ResponsesService,
             SolutionValidityService, StateEditorService, INTERACTION_SPECS) {
           var ctrl = this;
+          ctrl.directiveSubscriptions = new Subscription();
           ctrl.getStateContentPlaceholder = function() {
             return 'Type your question here.';
           };
@@ -101,7 +104,8 @@ angular.module('oppia').directive('questionEditor', [
             var stateData = ctrl.questionStateData;
             stateData.interaction.defaultOutcome.setDestination(null);
             if (stateData) {
-              $rootScope.$broadcast('stateEditorInitialized', stateData);
+              console.log('Emitted: stateEditorInitialized in question-editor');
+              StateEditorService.onStateEditorInitialized.emit(stateData);
 
               if (stateData.content.getHtml() || stateData.interaction.id) {
                 ctrl.interactionIsShown = true;
@@ -199,9 +203,14 @@ angular.module('oppia').directive('questionEditor', [
           };
 
           ctrl.$onInit = function() {
-            $scope.$on('stateEditorDirectiveInitialized', function(evt) {
-              _init();
-            });
+            ctrl.directiveSubscriptions.add(
+              StateEditorService.onStateEditorDirectiveInitialized.subscribe(
+                () => {
+                  console.log('Caught: stateEditorDirectiveInitialized');
+                  _init();
+                }
+              )
+            );
 
             $scope.$on('interactionEditorInitialized', function(evt) {
               _init();
@@ -227,6 +236,9 @@ angular.module('oppia').directive('questionEditor', [
             // The _init function is written separately since it is also called
             // in $scope.$on when some external events are triggered.
             _init();
+          };
+          ctrl.$onDestroy = function() {
+            ctrl.directiveSubscriptions.unsubscribe();
           };
         }
       ]

--- a/core/templates/components/question-directives/question-player/question-player.directive.ts
+++ b/core/templates/components/question-directives/question-player/question-player.directive.ts
@@ -117,6 +117,10 @@ require('domain/utilities/url-interpolation.service.ts');
 require('services/alerts.service.ts');
 require('services/user.service.ts');
 require('services/contextual/url.service.ts');
+require(
+  'pages/exploration-player-page/services/exploration-player-state.service.ts');
+
+import { Subscription } from 'rxjs';
 
 require('pages/interaction-specs.constants.ajs.ts');
 
@@ -138,7 +142,7 @@ angular.module('oppia').directive('questionPlayer', [
         'HASH_PARAM', 'MAX_SCORE_PER_QUESTION',
         '$scope', '$sce', '$rootScope', '$location',
         '$sanitize', '$uibModal', '$window',
-        'AlertsService', 'HtmlEscaperService',
+        'AlertsService', 'ExplorationPlayerStateService', 'HtmlEscaperService',
         'QuestionBackendApiService', 'SkillMasteryBackendApiService',
         'UrlService', 'UserService', 'COLORS_FOR_PASS_FAIL_MODE',
         'MAX_MASTERY_GAIN_PER_QUESTION', 'MAX_MASTERY_LOSS_PER_QUESTION',
@@ -149,7 +153,7 @@ angular.module('oppia').directive('questionPlayer', [
             HASH_PARAM, MAX_SCORE_PER_QUESTION,
             $scope, $sce, $rootScope, $location,
             $sanitize, $uibModal, $window,
-            AlertsService, HtmlEscaperService,
+            AlertsService, ExplorationPlayerStateService, HtmlEscaperService,
             QuestionBackendApiService, SkillMasteryBackendApiService,
             UrlService, UserService, COLORS_FOR_PASS_FAIL_MODE,
             MAX_MASTERY_GAIN_PER_QUESTION, MAX_MASTERY_LOSS_PER_QUESTION,
@@ -157,6 +161,7 @@ angular.module('oppia').directive('questionPlayer', [
             VIEW_HINT_PENALTY_FOR_MASTERY,
             WRONG_ANSWER_PENALTY, WRONG_ANSWER_PENALTY_FOR_MASTERY) {
           var ctrl = this;
+          ctrl.directiveSubscriptions = new Subscription();
           var initResults = function() {
             $scope.resultsLoaded = false;
             ctrl.currentQuestion = 0;
@@ -537,9 +542,14 @@ angular.module('oppia').directive('questionPlayer', [
               updateCurrentQuestion(result + 1);
             });
 
-            $rootScope.$on('totalQuestionsReceived', function(event, result) {
-              updateTotalQuestions(result);
-            });
+            ctrl.directiveSubscriptions.add(
+              ExplorationPlayerStateService.onTotalQuestionsReceived.subscribe(
+                (result) => {
+                  console.log('Caught: totalQuestionsReceived');
+                  updateTotalQuestions(result);
+                }
+              )
+            );
 
             $rootScope.$on('questionSessionCompleted', function(event, result) {
               $location.hash(HASH_PARAM +
@@ -573,6 +583,10 @@ angular.module('oppia').directive('questionPlayer', [
             // called in $scope.$on when some external events are triggered.
             initResults();
             ctrl.questionPlayerConfig = ctrl.getQuestionPlayerConfig();
+          };
+
+          ctrl.$onDestroy = function() {
+            ctrl.directiveSubscriptions.unsubscribe();
           };
         }
       ]

--- a/core/templates/components/question-directives/question-player/question-player.directive.ts
+++ b/core/templates/components/question-directives/question-player/question-player.directive.ts
@@ -545,7 +545,6 @@ angular.module('oppia').directive('questionPlayer', [
             ctrl.directiveSubscriptions.add(
               ExplorationPlayerStateService.onTotalQuestionsReceived.subscribe(
                 (result) => {
-                  console.log('Caught: totalQuestionsReceived');
                   updateTotalQuestions(result);
                 }
               )

--- a/core/templates/components/state-editor/state-editor-properties-services/state-editor.service.ts
+++ b/core/templates/components/state-editor/state-editor-properties-services/state-editor.service.ts
@@ -20,7 +20,7 @@
 import cloneDeep from 'lodash/cloneDeep';
 
 import { downgradeInjectable } from '@angular/upgrade/static';
-import { Injectable, EventEmitter } from '@angular/core';
+import { EventEmitter, Injectable } from '@angular/core';
 
 /* eslint-disable max-len */
 import { AnswerGroup } from
@@ -51,6 +51,9 @@ interface AnswerChoice {
 export class StateEditorService {
   constructor(private solutionValidityService: SolutionValidityService) {}
 
+  private _stateEditorInitializedEventEmitter = new EventEmitter();
+  private _stateEditorDirectiveInitializedEventEmitter = new EventEmitter();
+
   activeStateName: string = null;
   stateNames: string[] = [];
   correctnessFeedbackEnabled: boolean = null;
@@ -69,8 +72,6 @@ export class StateEditorService {
   stateHintsEditorInitialised: boolean = false;
   stateSolutionEditorInitialised: boolean = false;
   stateEditorDirectiveInitialised: boolean = false;
-  _stateEditorInitializedEventEmitter = new EventEmitter();
-  _stateEditorDirectiveInitializedEventEmitter = new EventEmitter();
 
   updateStateContentEditorInitialised(): void {
     this.stateContentEditorInitialised = true;

--- a/core/templates/components/state-editor/state-editor-properties-services/state-editor.service.ts
+++ b/core/templates/components/state-editor/state-editor-properties-services/state-editor.service.ts
@@ -20,7 +20,7 @@
 import cloneDeep from 'lodash/cloneDeep';
 
 import { downgradeInjectable } from '@angular/upgrade/static';
-import { Injectable } from '@angular/core';
+import { Injectable, EventEmitter } from '@angular/core';
 
 /* eslint-disable max-len */
 import { AnswerGroup } from
@@ -69,6 +69,8 @@ export class StateEditorService {
   stateHintsEditorInitialised: boolean = false;
   stateSolutionEditorInitialised: boolean = false;
   stateEditorDirectiveInitialised: boolean = false;
+  _stateEditorInitializedEventEmitter = new EventEmitter();
+  _stateEditorDirectiveInitializedEventEmitter = new EventEmitter();
 
   updateStateContentEditorInitialised(): void {
     this.stateContentEditorInitialised = true;
@@ -236,6 +238,14 @@ export class StateEditorService {
 
   deleteCurrentSolutionValidity(): void {
     this.solutionValidityService.deleteSolutionValidity(this.activeStateName);
+  }
+
+  get onStateEditorInitialized() {
+    return this._stateEditorInitializedEventEmitter;
+  }
+
+  get onStateEditorDirectiveInitialized() {
+    return this._stateEditorDirectiveInitializedEventEmitter;
   }
 }
 

--- a/core/templates/components/state-editor/state-editor.directive.ts
+++ b/core/templates/components/state-editor/state-editor.directive.ts
@@ -100,7 +100,6 @@ angular.module('oppia').directive('stateEditor', [
           };
 
           $scope.reinitializeEditor = function() {
-            console.log('Emitted: stateEditorInitialized in question-editor');
             StateEditorService.onStateEditorInitialized.emit($scope.stateData);
           };
           ctrl.$onInit = function() {
@@ -118,7 +117,6 @@ angular.module('oppia').directive('stateEditor', [
             ctrl.directiveSubscriptions.add(
               StateEditorService.onStateEditorInitialized.subscribe(
                 (stateData) => {
-                  console.log('Caught: stateEditorInitialized in question-editor');
                   if (stateData === undefined || $.isEmptyObject(stateData)) {
                     throw new Error(
                       'Expected stateData to be defined but ' +
@@ -147,7 +145,6 @@ angular.module('oppia').directive('stateEditor', [
                 }
               )
             );
-            console.log('Emitted: stateEditorDirectiveInitialized');
             StateEditorService.onStateEditorDirectiveInitialized.emit();
             StateEditorService.updateStateEditorDirectiveInitialised();
           };

--- a/core/templates/components/state-editor/state-editor.directive.ts
+++ b/core/templates/components/state-editor/state-editor.directive.ts
@@ -48,6 +48,8 @@ require(
   'components/state-editor/state-editor-properties-services/' +
   'state-solicit-answer-details.service.ts');
 
+import { Subscription } from 'rxjs';
+
 angular.module('oppia').directive('stateEditor', [
   'UrlInterpolationService', function(UrlInterpolationService) {
     return {
@@ -86,6 +88,7 @@ angular.module('oppia').directive('stateEditor', [
             StateParamChangesService, StateSolicitAnswerDetailsService,
             StateSolutionService, INTERACTION_SPECS) {
           var ctrl = this;
+          ctrl.directiveSubscriptions = new Subscription();
           var updateInteractionVisibility = function(newInteractionId) {
             $scope.interactionIdIsSet = Boolean(newInteractionId);
             $scope.currentInteractionCanHaveSolution = Boolean(
@@ -97,7 +100,8 @@ angular.module('oppia').directive('stateEditor', [
           };
 
           $scope.reinitializeEditor = function() {
-            $rootScope.$broadcast('stateEditorInitialized', $scope.stateData);
+            console.log('Emitted: stateEditorInitialized in question-editor');
+            StateEditorService.onStateEditorInitialized.emit($scope.stateData);
           };
           ctrl.$onInit = function() {
             $scope.oppiaBlackImgUrl = UrlInterpolationService.getStaticImageUrl(
@@ -111,36 +115,44 @@ angular.module('oppia').directive('stateEditor', [
                 updateInteractionVisibility(newInteractionId);
               });
 
-            $scope.$on('stateEditorInitialized', function(evt, stateData) {
-              if (stateData === undefined || $.isEmptyObject(stateData)) {
-                throw new Error(
-                  'Expected stateData to be defined but ' +
-                  'received ' + stateData);
-              }
-              $scope.stateData = stateData;
-              $scope.stateName = StateEditorService.getActiveStateName();
-              StateEditorService.setInteraction(stateData.interaction);
-              StateContentService.init(
-                $scope.stateName, stateData.content);
-              StateHintsService.init(
-                $scope.stateName, stateData.interaction.hints);
-              StateInteractionIdService.init(
-                $scope.stateName, stateData.interaction.id);
-              StateCustomizationArgsService.init(
-                $scope.stateName, stateData.interaction.customizationArgs);
-              StateNameService.init($scope.stateName, stateData.name);
-              StateParamChangesService.init(
-                $scope.stateName, stateData.paramChanges);
-              StateSolicitAnswerDetailsService.init(
-                $scope.stateName, stateData.solicitAnswerDetails);
-              StateSolutionService.init(
-                $scope.stateName, stateData.interaction.solution);
-              updateInteractionVisibility(stateData.interaction.id);
-              $scope.servicesInitialized = true;
-            });
-
-            $rootScope.$broadcast('stateEditorDirectiveInitialized');
+            ctrl.directiveSubscriptions.add(
+              StateEditorService.onStateEditorInitialized.subscribe(
+                (stateData) => {
+                  console.log('Caught: stateEditorInitialized in question-editor');
+                  if (stateData === undefined || $.isEmptyObject(stateData)) {
+                    throw new Error(
+                      'Expected stateData to be defined but ' +
+                      'received ' + stateData);
+                  }
+                  $scope.stateData = stateData;
+                  $scope.stateName = StateEditorService.getActiveStateName();
+                  StateEditorService.setInteraction(stateData.interaction);
+                  StateContentService.init(
+                    $scope.stateName, stateData.content);
+                  StateHintsService.init(
+                    $scope.stateName, stateData.interaction.hints);
+                  StateInteractionIdService.init(
+                    $scope.stateName, stateData.interaction.id);
+                  StateCustomizationArgsService.init(
+                    $scope.stateName, stateData.interaction.customizationArgs);
+                  StateNameService.init($scope.stateName, stateData.name);
+                  StateParamChangesService.init(
+                    $scope.stateName, stateData.paramChanges);
+                  StateSolicitAnswerDetailsService.init(
+                    $scope.stateName, stateData.solicitAnswerDetails);
+                  StateSolutionService.init(
+                    $scope.stateName, stateData.interaction.solution);
+                  updateInteractionVisibility(stateData.interaction.id);
+                  $scope.servicesInitialized = true;
+                }
+              )
+            );
+            console.log('Emitted: stateEditorDirectiveInitialized');
+            StateEditorService.onStateEditorDirectiveInitialized.emit();
             StateEditorService.updateStateEditorDirectiveInitialised();
+          };
+          ctrl.$onDestroy = function() {
+            ctrl.directiveSubscriptions.unsubscribe();
           };
         }
       ]

--- a/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.directive.ts
+++ b/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.directive.ts
@@ -265,7 +265,6 @@ angular.module('oppia').directive('stateInteractionEditor', [
             ctrl.directiveSubscriptions.add(
               StateEditorService.onStateEditorInitialized.subscribe(
                 (stateData) => {
-                  console.log('Caught: stateEditorInitialized in state-interaction-editor');
                   if (stateData === undefined || $.isEmptyObject(stateData)) {
                     throw new Error(
                       'Expected stateData to be defined but ' +

--- a/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.directive.ts
+++ b/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.directive.ts
@@ -55,6 +55,8 @@ require('services/editability.service.ts');
 require('services/exploration-html-formatter.service.ts');
 require('services/html-escaper.service.ts');
 
+import { Subscription } from 'rxjs';
+
 angular.module('oppia').directive('stateInteractionEditor', [
   'UrlInterpolationService', function(UrlInterpolationService) {
     return {
@@ -94,6 +96,7 @@ angular.module('oppia').directive('stateInteractionEditor', [
             StateSolutionService, StateHintsService,
             StateContentService) {
           var ctrl = this;
+          ctrl.directiveSubscriptions = new Subscription();
           var DEFAULT_TERMINAL_STATE_CONTENT =
             'Congratulations, you have finished!';
 
@@ -259,26 +262,31 @@ angular.module('oppia').directive('stateInteractionEditor', [
             $scope.StateInteractionIdService = StateInteractionIdService;
             $scope.hasLoaded = false;
             $scope.customizationModalReopened = false;
-            $scope.$on('stateEditorInitialized', function(evt, stateData) {
-              if (stateData === undefined || $.isEmptyObject(stateData)) {
-                throw new Error(
-                  'Expected stateData to be defined but ' +
-                  'received ' + stateData);
-              }
-              $scope.hasLoaded = false;
-              InteractionDetailsCacheService.reset();
-              $rootScope.$broadcast('initializeAnswerGroups', {
-                interactionId: stateData.interaction.id,
-                answerGroups: stateData.interaction.answerGroups,
-                defaultOutcome: stateData.interaction.defaultOutcome,
-                confirmedUnclassifiedAnswers: (
-                  stateData.interaction.confirmedUnclassifiedAnswers)
-              });
+            ctrl.directiveSubscriptions.add(
+              StateEditorService.onStateEditorInitialized.subscribe(
+                (stateData) => {
+                  console.log('Caught: stateEditorInitialized in state-interaction-editor');
+                  if (stateData === undefined || $.isEmptyObject(stateData)) {
+                    throw new Error(
+                      'Expected stateData to be defined but ' +
+                      'received ' + stateData);
+                  }
+                  $scope.hasLoaded = false;
+                  InteractionDetailsCacheService.reset();
+                  $rootScope.$broadcast('initializeAnswerGroups', {
+                    interactionId: stateData.interaction.id,
+                    answerGroups: stateData.interaction.answerGroups,
+                    defaultOutcome: stateData.interaction.defaultOutcome,
+                    confirmedUnclassifiedAnswers: (
+                      stateData.interaction.confirmedUnclassifiedAnswers)
+                  });
 
-              _updateInteractionPreview();
-              _updateAnswerChoices();
-              $scope.hasLoaded = true;
-            });
+                  _updateInteractionPreview();
+                  _updateAnswerChoices();
+                  $scope.hasLoaded = true;
+                }
+              )
+            );
 
             $scope.getStaticImageUrl = function(imagePath) {
               return UrlInterpolationService.getStaticImageUrl(imagePath);
@@ -286,6 +294,10 @@ angular.module('oppia').directive('stateInteractionEditor', [
 
             $rootScope.$broadcast('interactionEditorInitialized');
             StateEditorService.updateStateInteractionEditorInitialised();
+          };
+
+          ctrl.$onDestroy = function() {
+            ctrl.directiveSubscriptions.unsubscribe();
           };
         }
       ]

--- a/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.spec.ts
@@ -65,6 +65,7 @@ import { WrittenTranslationsObjectFactory } from
 import { SolutionObjectFactory } from
   'domain/exploration/SolutionObjectFactory';
 
+
 describe('Exploration editor tab component', function() {
   var ctrl;
   var $q = null;
@@ -598,11 +599,18 @@ describe('Exploration editor tab component', function() {
 
     $rootScope.$broadcast('refreshStateEditor');
 
-    spyOn($rootScope, '$broadcast');
+    const stateEditorInitializedSpy = jasmine.createSpy(
+      'stateEditorInitialized');
+    let testsubscription =
+      stateEditorService.onStateEditorInitialized.subscribe(
+        stateEditorInitializedSpy);
+
     $scope.$apply();
 
-    expect($rootScope.$broadcast).toHaveBeenCalledWith(
-      'stateEditorInitialized',
-      explorationStatesService.getState('Second State'));
+    expect(stateEditorInitializedSpy).toHaveBeenCalledWith(
+      explorationStatesService.getState('Second State')
+    );
+
+    testsubscription.unsubscribe();
   });
 });

--- a/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.ts
@@ -119,7 +119,8 @@ angular.module('oppia').component('explorationEditorTab', {
             ExplorationStatesService.isInitialized()) {
               var stateData = (
                 ExplorationStatesService.getState(ctrl.stateName));
-              $rootScope.$broadcast('stateEditorInitialized', stateData);
+              console.log('Emitted: stateEditorInitialized in exploration-editor-tab');
+              StateEditorService.onStateEditorInitialized.emit(stateData);
             }
           });
 

--- a/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.ts
@@ -119,7 +119,6 @@ angular.module('oppia').component('explorationEditorTab', {
             ExplorationStatesService.isInitialized()) {
               var stateData = (
                 ExplorationStatesService.getState(ctrl.stateName));
-              console.log('Emitted: stateEditorInitialized in exploration-editor-tab');
               StateEditorService.onStateEditorInitialized.emit(stateData);
             }
           });

--- a/core/templates/pages/exploration-player-page/services/exploration-player-state.service.ts
+++ b/core/templates/pages/exploration-player-page/services/exploration-player-state.service.ts
@@ -175,7 +175,6 @@ angular.module('oppia').factory('ExplorationPlayerStateService', [
         questionPlayerConfig.questionCount,
         questionPlayerConfig.questionsSortedByDifficulty
       ).then(function(questionData) {
-        console.log('Emitter: totalQuestionsReceived');
         _totalQuestionsReceivedEventEmitter.emit(questionData.length);
         initializeQuestionPlayerServices(questionData, callback);
       });

--- a/core/templates/pages/exploration-player-page/services/exploration-player-state.service.ts
+++ b/core/templates/pages/exploration-player-page/services/exploration-player-state.service.ts
@@ -19,6 +19,7 @@
 
 import { OppiaAngularRootComponent } from
   'components/oppia-angular-root.component';
+import { EventEmitter } from '@angular/core';
 
 require('domain/exploration/editable-exploration-backend-api.service.ts');
 require('domain/exploration/read-only-exploration-backend-api.service.ts');
@@ -44,7 +45,7 @@ require(
   'pages/exploration-player-page/exploration-player-page.constants.ajs.ts');
 
 angular.module('oppia').factory('ExplorationPlayerStateService', [
-  '$q', '$rootScope', 'ContextService', 'EditableExplorationBackendApiService',
+  '$q', 'ContextService', 'EditableExplorationBackendApiService',
   'ExplorationEngineService', 'ExplorationFeaturesBackendApiService',
   'ExplorationFeaturesService', 'NumberAttemptsService',
   'PlayerCorrectnessFeedbackEnabledService', 'PlayerTranscriptService',
@@ -54,7 +55,7 @@ angular.module('oppia').factory('ExplorationPlayerStateService', [
   'StatsReportingService', 'UrlInterpolationService', 'UrlService',
   'EXPLORATION_MODE',
   function(
-      $q, $rootScope, ContextService, EditableExplorationBackendApiService,
+      $q, ContextService, EditableExplorationBackendApiService,
       ExplorationEngineService, ExplorationFeaturesBackendApiService,
       ExplorationFeaturesService, NumberAttemptsService,
       PlayerCorrectnessFeedbackEnabledService, PlayerTranscriptService,
@@ -65,6 +66,7 @@ angular.module('oppia').factory('ExplorationPlayerStateService', [
       EXPLORATION_MODE) {
     StatsReportingService = (
       OppiaAngularRootComponent.statsReportingService);
+    var _totalQuestionsReceivedEventEmitter = new EventEmitter();
     var currentEngineService = null;
     var explorationMode = EXPLORATION_MODE.OTHER;
     var editorPreviewMode = ContextService.isInExplorationEditorPage();
@@ -173,7 +175,7 @@ angular.module('oppia').factory('ExplorationPlayerStateService', [
         questionPlayerConfig.questionCount,
         questionPlayerConfig.questionsSortedByDifficulty
       ).then(function(questionData) {
-        $rootScope.$broadcast('totalQuestionsReceived', questionData.length);
+        _totalQuestionsReceivedEventEmitter.emit(questionData.length);
         initializeQuestionPlayerServices(questionData, callback);
       });
     };
@@ -266,5 +268,8 @@ angular.module('oppia').factory('ExplorationPlayerStateService', [
       recordNewCardAdded: function() {
         return currentEngineService.recordNewCardAdded();
       },
+      get onTotalQuestionsReceived() {
+        return _totalQuestionsReceivedEventEmitter;
+      }
     };
   }]);

--- a/core/templates/pages/exploration-player-page/services/exploration-player-state.service.ts
+++ b/core/templates/pages/exploration-player-page/services/exploration-player-state.service.ts
@@ -175,6 +175,7 @@ angular.module('oppia').factory('ExplorationPlayerStateService', [
         questionPlayerConfig.questionCount,
         questionPlayerConfig.questionsSortedByDifficulty
       ).then(function(questionData) {
+        console.log('Emitter: totalQuestionsReceived');
         _totalQuestionsReceivedEventEmitter.emit(questionData.length);
         initializeQuestionPlayerServices(questionData, callback);
       });

--- a/core/templates/pages/library-page/search-bar/search-bar.directive.ts
+++ b/core/templates/pages/library-page/search-bar/search-bar.directive.ts
@@ -274,7 +274,7 @@ angular.module('oppia').directive('searchBar', [
 
                 // Notify the function that handles overflow in case the search
                 // elements load after it has already been run.
-                $rootScope.$broadcast('searchBarLoaded', true);
+                SearchService.onSearchBarLoaded.emit();
               }
             );
             $rootScope.$on('$translateChangeSuccess', refreshSearchBarLabels);

--- a/core/templates/pages/library-page/search-bar/search-bar.directive.ts
+++ b/core/templates/pages/library-page/search-bar/search-bar.directive.ts
@@ -274,7 +274,6 @@ angular.module('oppia').directive('searchBar', [
 
                 // Notify the function that handles overflow in case the search
                 // elements load after it has already been run.
-                console.log('Emitted: searchBarLoaded');
                 SearchService.onSearchBarLoaded.emit();
               }
             );

--- a/core/templates/pages/library-page/search-bar/search-bar.directive.ts
+++ b/core/templates/pages/library-page/search-bar/search-bar.directive.ts
@@ -274,6 +274,7 @@ angular.module('oppia').directive('searchBar', [
 
                 // Notify the function that handles overflow in case the search
                 // elements load after it has already been run.
+                console.log('Emitted: searchBarLoaded');
                 SearchService.onSearchBarLoaded.emit();
               }
             );

--- a/core/templates/services/search.service.spec.ts
+++ b/core/templates/services/search.service.spec.ts
@@ -23,6 +23,8 @@ import { UpgradedServices } from 'services/UpgradedServices';
 // The import below is to successfully mock Jquery.
 import $ from 'jquery';
 
+import { EventEmitter } from '@angular/core';
+
 require('services/search.service.ts');
 
 describe('Search service', function() {
@@ -453,4 +455,9 @@ describe('Search service', function() {
       expect(successHandler).not.toHaveBeenCalled();
       expect(failHandler).toHaveBeenCalledWith(true);
     });
+
+  it('should fetch searchBarLoaded EventEmitter', function() {
+    let searchBarLoadedEmitter = new EventEmitter();
+    expect(SearchService.onSearchBarLoaded).toEqual(searchBarLoadedEmitter);
+  });
 });

--- a/core/templates/services/search.service.ts
+++ b/core/templates/services/search.service.ts
@@ -18,6 +18,8 @@
 
 require('services/services.constants.ajs.ts');
 
+import { EventEmitter } from '@angular/core';
+
 angular.module('oppia').factory('SearchService', [
   '$http', '$log', '$rootScope', '$translate', 'SEARCH_DATA_URL',
   function($http, $log, $rootScope, $translate, SEARCH_DATA_URL) {
@@ -27,7 +29,7 @@ angular.module('oppia').factory('SearchService', [
     var _searchCursor = null;
     var _isCurrentlyFetchingResults = false;
     var numSearchesInProgress = 0;
-
+    var _searchBarLoadedEventEmitter = new EventEmitter();
     // Appends a suffix to the query describing allowed category and language
     // codes to filter on.
     var _getSuffixForQuery =
@@ -215,6 +217,10 @@ angular.module('oppia').factory('SearchService', [
             successCallback(response.data, hasReachedEndOfPage());
           }
         });
+      },
+
+      get onSearchBarLoaded() {
+        return _searchBarLoadedEventEmitter;
       }
     };
   }


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #10083 
2. This PR does the following: Removes events 'searchBarLoaded', 'totalQuestionsReceived', 'stateEditorInitialized' & 'stateEditorDirectiveInitialized'
Testing video: https://vimeo.com/443016100

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
