### PR TITLE
Update Chrome version used to run e2e tests from v77 to v83

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,11 +45,11 @@ commands:
     description: "Install Chrome"
     steps:
       - run:
-          name:  Install chrome version 77.0.3865.75-1
+          name:  Install chrome version 83.0.4103.116-1
           command: |
             sudo apt-get update
             sudo apt-get install lsb-release
-            curl -L -o google-chrome.deb https://github.com/webnicer/chrome-downloads/raw/master/x64.deb/google-chrome-stable_77.0.3865.75-1_amd64.deb
+            curl -L -o google-chrome.deb https://github.com/webnicer/chrome-downloads/raw/master/x64.deb/google-chrome-stable_83.0.4103.116-1_amd64.deb
             sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
             sudo dpkg -i google-chrome.deb
             google-chrome --version

--- a/scripts/install_chrome_on_travis.py
+++ b/scripts/install_chrome_on_travis.py
@@ -38,10 +38,10 @@ def main(args=None):
     home_directory = os.environ.get('HOME')
     oppia_dir = os.getcwd()
 
-    # CHROME_SOURCE_URL is an environment variable set in Oppia's Travis repo
-    # settings. It can be found under 'Environment Variables' header here:
+    # CHROME_SOURCE_URL_83 is an environment variable set in Oppia's Travis
+    # repo settings. It can be found under 'Environment Variables' header here:
     # https://travis-ci.com/oppia/oppia/settings.
-    chrome_source_url = os.environ.get('CHROME_SOURCE_URL')
+    chrome_source_url = os.environ.get('CHROME_SOURCE_URL_83')
     travis_chrome_path = os.path.join(
         home_directory, '.cache/TravisChrome/',
         os.path.basename(chrome_source_url))

--- a/scripts/install_chrome_on_travis_test.py
+++ b/scripts/install_chrome_on_travis_test.py
@@ -31,8 +31,8 @@ class InstallChromeOnTravisTests(test_utils.GenericTestBase):
 
     def test_main(self):
         chrome_source_url = (
-            'https://github.com/webnicer/chrome-downloads/blob/master/x64.deb/'
-            'google-chrome-stable_83.0.4103.116-1_amd64.deb')
+            'https://github.com/webnicer/chrome-downloads/raw/master/x64.deb'
+            '/google-chrome-stable_83.0.4103.116-1_amd64.deb')
 
         def mock_isfile(unused_path):
             return False

--- a/scripts/install_chrome_on_travis_test.py
+++ b/scripts/install_chrome_on_travis_test.py
@@ -31,8 +31,8 @@ class InstallChromeOnTravisTests(test_utils.GenericTestBase):
 
     def test_main(self):
         chrome_source_url = (
-            'https://github.com/webnicer/chrome-downloads/raw/master/x64.deb'
-            '/google-chrome-stable_77.0.3865.75-1_amd64.deb')
+            'https://github.com/webnicer/chrome-downloads/blob/master/x64.deb/'
+            'google-chrome-stable_83.0.4103.116-1_amd64.deb')
 
         def mock_isfile(unused_path):
             return False
@@ -62,7 +62,7 @@ class InstallChromeOnTravisTests(test_utils.GenericTestBase):
             os.path, 'isfile', mock_isfile,
             expected_args=[(os.path.join(
                 'HOME', '.cache/TravisChrome/',
-                'google-chrome-stable_77.0.3865.75-1_amd64.deb'),)])
+                'google-chrome-stable_83.0.4103.116-1_amd64.deb'),)])
         chdir_swap = self.swap_with_checks(
             os, 'chdir', mock_chdir, expected_args=[
                 (os.path.join('HOME', '.cache/TravisChrome/'),),
@@ -71,17 +71,17 @@ class InstallChromeOnTravisTests(test_utils.GenericTestBase):
             python_utils, 'url_retrieve', mock_url_retrieve,
             expected_args=[(chrome_source_url,)],
             expected_kwargs=[{
-                'filename': 'google-chrome-stable_77.0.3865.75-1_amd64.deb'
+                'filename': 'google-chrome-stable_83.0.4103.116-1_amd64.deb'
             }])
         check_call_swap = self.swap_with_checks(
             subprocess, 'check_call', mock_check_call, expected_args=[(
                 ['sudo', 'dpkg', '-i', os.path.join(
                     'HOME', '.cache/TravisChrome/',
-                    'google-chrome-stable_77.0.3865.75-1_amd64.deb')
+                    'google-chrome-stable_83.0.4103.116-1_amd64.deb')
                 ],)])
         environ_swap = self.swap(
             os, 'environ', {
-                'CHROME_SOURCE_URL': chrome_source_url,
+                'CHROME_SOURCE_URL_83': chrome_source_url,
                 'HOME': 'HOME'
             })
         with isdir_swap, isfile_swap, makedirs_swap, chdir_swap:

--- a/scripts/run_e2e_tests_test.py
+++ b/scripts/run_e2e_tests_test.py
@@ -37,7 +37,7 @@ from scripts import install_third_party_libs
 from scripts import run_e2e_tests
 
 
-CHROME_DRIVER_VERSION = '77.0.3865.40'
+CHROME_DRIVER_VERSION = '83.0.4103.116'
 
 
 class MockProcessClass(python_utils.OBJECT):
@@ -371,7 +371,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
 
                 def read(self):
                     """Return required method."""
-                    return '77.0.3865'
+                    return '83.0.4103'
             return Ret()
 
         popen_swap = self.swap(os, 'popen', mock_popen)


### PR DESCRIPTION


## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of NA.
2. This PR does the following:
- Update Chrome version from 77.0.3865.40 to 83.0.4103.116

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
