### PR TITLE
Revert "Fix part of #10083: Eliminates events refreshGraph, refreshStatisticsTab, refreshSettingsTab, refreshTranslationTab"

### DIFF
--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
@@ -16,7 +16,6 @@
  * @fileoverview Unit tests for exploration editor page component.
  */
 
-import { EventEmitter } from '@angular/core';
 import { TestBed, fakeAsync, flushMicrotasks } from '@angular/core/testing';
 
 import { StateEditorService } from
@@ -73,7 +72,6 @@ describe('Exploration editor page component', function() {
   var stass = null;
   var tds = null;
   var ueps = null;
-  var refreshGraphEmitter = new EventEmitter();
 
   var explorationId = 'exp1';
   var explorationData = {
@@ -298,15 +296,10 @@ describe('Exploration editor page component', function() {
       spyOn(tds, 'getOpenThreadsCountAsync').and.returnValue($q.resolve(1));
       spyOn(ueps, 'getPermissionsAsync')
         .and.returnValue($q.resolve({canEdit: false}));
-      spyOnProperty(ess, 'onRefreshGraph').and.returnValue(refreshGraphEmitter);
 
       explorationData.is_version_of_draft_valid = true;
 
       ctrl.$onInit();
-    });
-
-    afterEach(() => {
-      ctrl.$onDestroy();
     });
 
     it('should link exploration to story when initing exploration page', () => {
@@ -360,8 +353,7 @@ describe('Exploration editor page component', function() {
     });
 
     it('should react when refreshing graph', () => {
-      // $rootScope.$broadcast('refreshGraph');
-      refreshGraphEmitter.emit();
+      $rootScope.$broadcast('refreshGraph');
 
       expect(gds.recompute).toHaveBeenCalled();
       expect(ews.updateWarnings).toHaveBeenCalled();
@@ -684,10 +676,6 @@ describe('Exploration editor page component', function() {
       explorationData.is_version_of_draft_valid = true;
     });
 
-    afterEach(() => {
-      ctrl.$onDestroy();
-    });
-
     it('should recognize when improvements tab is enabled', fakeAsync(() => {
       spyOn(eibas, 'getConfigAsync')
         .and.returnValue(Promise.resolve({improvementsTabIsEnabled: true}));
@@ -738,9 +726,6 @@ describe('Exploration editor page component', function() {
       explorationData.is_version_of_draft_valid = true;
 
       ctrl.$onInit();
-    });
-    afterEach(() => {
-      ctrl.$onDestroy();
     });
 
     it('should callback state-added method for stats', fakeAsync(() => {

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.ts
@@ -149,8 +149,6 @@ require(
   'pages/exploration-editor-page/exploration-editor-page.constants.ajs.ts');
 require('pages/interaction-specs.constants.ajs.ts');
 
-import { Subscription } from 'rxjs';
-
 angular.module('oppia').component('explorationEditorPage', {
   template: require('./exploration-editor-page.component.html'),
   controller: [
@@ -192,7 +190,6 @@ angular.module('oppia').component('explorationEditorPage', {
         UserEmailPreferencesService, UserExplorationPermissionsService,
         EVENT_EXPLORATION_PROPERTY_CHANGED) {
       var ctrl = this;
-      ctrl.directiveSubscriptions = new Subscription();
       var _ID_TUTORIAL_STATE_CONTENT = '#tutorialStateContent';
       var _ID_TUTORIAL_STATE_INTERACTION = '#tutorialStateInteraction';
       var _ID_TUTORIAL_PREVIEW_TAB = '#tutorialPreviewTab';
@@ -347,7 +344,8 @@ angular.module('oppia').component('explorationEditorPage', {
               ChangeListService.getChangeList());
             return;
           }
-          RouterService.onRefreshStatisticsTab.emit();
+
+          $scope.$broadcast('refreshStatisticsTab');
           $scope.$broadcast('refreshVersionHistory', {
             forceRefresh: true
           });
@@ -452,11 +450,10 @@ angular.module('oppia').component('explorationEditorPage', {
 
       ctrl.$onInit = function() {
         $scope.$on(EVENT_EXPLORATION_PROPERTY_CHANGED, setPageTitle);
-        ctrl.directiveSubscriptions.add(
-          ExplorationStatesService.onRefreshGraph.subscribe(() => {
-            GraphDataService.recompute();
-            ExplorationWarningsService.updateWarnings();
-          }));
+        $scope.$on('refreshGraph', function() {
+          GraphDataService.recompute();
+          ExplorationWarningsService.updateWarnings();
+        });
         $scope.$on('initExplorationPage', (unusedEvtData, successCallback) => {
           ctrl.initExplorationPage().then(successCallback);
         });
@@ -625,9 +622,6 @@ angular.module('oppia').component('explorationEditorPage', {
         $templateCache.put(
           'ng-joyride-title-tplv1.html', ngJoyrideTemplate);
         ctrl.tutorialInProgress = false;
-      };
-      ctrl.$onDestroy = function() {
-        ctrl.directiveSubscriptions.unsubscribe();
       };
     }
   ]

--- a/core/templates/pages/exploration-editor-page/services/exploration-states.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-states.service.ts
@@ -42,8 +42,6 @@ require('services/alerts.service.ts');
 require('services/context.service.ts');
 require('services/validators.service.ts');
 
-import { EventEmitter } from '@angular/core';
-
 angular.module('oppia').factory('ExplorationStatesService', [
   '$filter', '$injector', '$location', '$q', '$rootScope', '$uibModal',
   'AlertsService', 'AngularNameService', 'AnswerClassificationService',
@@ -62,8 +60,6 @@ angular.module('oppia').factory('ExplorationStatesService', [
     var stateDeletedCallbacks = [];
     var stateRenamedCallbacks = [];
     var stateInteractionSavedCallbacks = [];
-    /** @private */
-    var refreshGraphEventEmitter = new EventEmitter();
 
     // Properties that have a different backend representation from the
     // frontend and must be converted.
@@ -170,7 +166,7 @@ angular.module('oppia').factory('ExplorationStatesService', [
     var _setState = function(stateName, stateData, refreshGraph) {
       _states.setState(stateName, angular.copy(stateData));
       if (refreshGraph) {
-        refreshGraphEventEmitter.emit();
+        $rootScope.$broadcast('refreshGraph');
       }
     };
 
@@ -410,7 +406,7 @@ angular.module('oppia').factory('ExplorationStatesService', [
         stateAddedCallbacks.forEach(function(callback) {
           callback(newStateName);
         });
-        refreshGraphEventEmitter.emit();
+        $rootScope.$broadcast('refreshGraph');
         if (successCallback) {
           successCallback(newStateName);
         }
@@ -451,7 +447,7 @@ angular.module('oppia').factory('ExplorationStatesService', [
             callback(deleteStateName);
           });
           $location.path('/gui/' + StateEditorService.getActiveStateName());
-          refreshGraphEventEmitter.emit();
+          $rootScope.$broadcast('refreshGraph');
           // This ensures that if the deletion changes rules in the current
           // state, they get updated in the view.
           $rootScope.$broadcast('refreshStateEditor');
@@ -490,7 +486,7 @@ angular.module('oppia').factory('ExplorationStatesService', [
         stateRenamedCallbacks.forEach(function(callback) {
           callback(oldStateName, newStateName);
         });
-        refreshGraphEventEmitter.emit();
+        $rootScope.$broadcast('refreshGraph');
       },
       registerOnStateAddedCallback: function(callback) {
         stateAddedCallbacks.push(callback);
@@ -503,9 +499,6 @@ angular.module('oppia').factory('ExplorationStatesService', [
       },
       registerOnStateInteractionSavedCallback: function(callback) {
         stateInteractionSavedCallbacks.push(callback);
-      },
-      get onRefreshGraph() {
-        return refreshGraphEventEmitter;
       }
     };
   }

--- a/core/templates/pages/exploration-editor-page/services/router.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/router.service.spec.ts
@@ -20,7 +20,6 @@ import { fakeAsync, flushMicrotasks } from '@angular/core/testing';
 import $ from 'jquery';
 
 import { UpgradedServices } from 'services/UpgradedServices';
-import { Subscription } from 'rxjs';
 
 describe('Router Service', () => {
   var RouterService = null;
@@ -30,10 +29,6 @@ describe('Router Service', () => {
   var $rootScope = null;
   var $location = null;
   var $timeout = null, $interval = null;
-  var testSubscriptions = null;
-  var refreshStatisticsTabSpy = null;
-  var refreshSettingsTabSpy = null;
-  var refreshTranslationTabSpy = null;
 
   beforeEach(angular.mock.module('oppia', $provide => {
     var ugs = new UpgradedServices();
@@ -142,24 +137,6 @@ describe('Router Service', () => {
     });
   }));
 
-  beforeEach(() => {
-    refreshStatisticsTabSpy = jasmine.createSpy('refreshStatisticsTab');
-    refreshSettingsTabSpy = jasmine.createSpy('refreshSettingsTab');
-    refreshTranslationTabSpy = jasmine.createSpy('refreshTranslationTab');
-    testSubscriptions = new Subscription();
-    testSubscriptions.add(
-      RouterService.onRefreshStatisticsTab.subscribe(refreshStatisticsTabSpy));
-    testSubscriptions.add(
-      RouterService.onRefreshSettingsTab.subscribe(refreshSettingsTabSpy));
-    testSubscriptions.add(
-      RouterService.onRefreshTranslationTab.subscribe(
-        refreshTranslationTabSpy));
-  });
-
-  afterEach(() => {
-    testSubscriptions.unsubscribe();
-  });
-
   it('should navigate to main tab when tab is already on main', done => {
     var broadcastSpy = spyOn($rootScope, '$broadcast').and.callThrough();
     var applyAsyncSpy = spyOn($rootScope, '$applyAsync').and.callThrough();
@@ -252,7 +229,7 @@ describe('Router Service', () => {
 
     expect(broadcastSpy).toHaveBeenCalledWith('externalSave');
     expect(RouterService.getActiveTabName()).toBe('stats');
-    expect(refreshStatisticsTabSpy).toHaveBeenCalled();
+    expect(broadcastSpy).toHaveBeenCalledWith('refreshStatisticsTab');
 
     expect(RouterService.isLocationSetToNonStateEditorTab()).toBe(true);
     $rootScope.$apply();
@@ -283,7 +260,7 @@ describe('Router Service', () => {
     expect(RouterService.getActiveTabName()).toBe('translation');
     $interval.flush(300);
 
-    expect(refreshTranslationTabSpy).toHaveBeenCalled();
+    expect(broadcastSpy).toHaveBeenCalledWith('refreshTranslationTab');
 
     expect(RouterService.isLocationSetToNonStateEditorTab()).toBe(true);
     $rootScope.$apply();
@@ -320,7 +297,7 @@ describe('Router Service', () => {
 
     expect(broadcastSpy).toHaveBeenCalledWith('externalSave');
     expect(RouterService.getActiveTabName()).toBe('stats');
-    expect(refreshStatisticsTabSpy).toHaveBeenCalled();
+    expect(broadcastSpy).toHaveBeenCalledWith('refreshStatisticsTab');
 
     expect(RouterService.isLocationSetToNonStateEditorTab()).toBe(true);
     $rootScope.$apply();
@@ -449,7 +426,7 @@ describe('Router Service', () => {
 
     expect(broadcastSpy).toHaveBeenCalledWith('externalSave');
     expect(RouterService.getActiveTabName()).toBe('settings');
-    expect(refreshSettingsTabSpy).toHaveBeenCalled();
+    expect(broadcastSpy).toHaveBeenCalledWith('refreshSettingsTab');
 
     expect(RouterService.isLocationSetToNonStateEditorTab()).toBe(true);
     $rootScope.$apply();

--- a/core/templates/pages/exploration-editor-page/services/router.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/router.service.ts
@@ -25,8 +25,6 @@ require(
 require('pages/exploration-editor-page/services/exploration-states.service.ts');
 require('services/exploration-improvements.service.ts');
 
-import { EventEmitter } from '@angular/core';
-
 angular.module('oppia').factory('RouterService', [
   '$interval', '$location', '$q', '$rootScope', '$timeout', '$window',
   'ExplorationImprovementsService', 'ExplorationInitStateNameService',
@@ -66,13 +64,6 @@ angular.module('oppia').factory('RouterService', [
 
     var activeTabName = TABS.MAIN.name;
 
-    /** @private */
-    var refreshSettingsTabEventEmitter = new EventEmitter();
-    /** @private */
-    var refreshStatisticsTabEventEmitter = new EventEmitter();
-    /** @private */
-    var refreshTranslationTabEventEmitter = new EventEmitter();
-
     // When the URL path changes, reroute to the appropriate tab in the
     // exploration editor page.
     $rootScope.$watch(() => $location.path(), (newPath, oldPath) => {
@@ -99,7 +90,7 @@ angular.module('oppia').factory('RouterService', [
               StateEditorService.setActiveStateName(
                 ExplorationInitStateNameService.savedMemento);
             }
-            refreshTranslationTabEventEmitter.emit();
+            $rootScope.$broadcast('refreshTranslationTab');
           }
         }, 300);
       } else if (newPath.indexOf(TABS.PREVIEW.path) === 0) {
@@ -107,10 +98,10 @@ angular.module('oppia').factory('RouterService', [
         _doNavigationWithState(newPath, SLUG_PREVIEW);
       } else if (newPath === TABS.SETTINGS.path) {
         activeTabName = TABS.SETTINGS.name;
-        refreshSettingsTabEventEmitter.emit();
+        $rootScope.$broadcast('refreshSettingsTab');
       } else if (newPath === TABS.STATS.path) {
         activeTabName = TABS.STATS.name;
-        refreshStatisticsTabEventEmitter.emit();
+        $rootScope.$broadcast('refreshStatisticsTab');
       } else if (newPath === TABS.IMPROVEMENTS.path) {
         activeTabName = TABS.IMPROVEMENTS.name;
         $q.when(ExplorationImprovementsService.isImprovementsTabEnabledAsync())
@@ -269,15 +260,6 @@ angular.module('oppia').factory('RouterService', [
         _savePendingChanges();
         $location.path(TABS.FEEDBACK.path);
       },
-      get onRefreshSettingsTab() {
-        return refreshSettingsTabEventEmitter;
-      },
-      get onRefreshStatisticsTab() {
-        return refreshStatisticsTabEventEmitter;
-      },
-      get onRefreshTranslationTab() {
-        return refreshTranslationTabEventEmitter;
-      }
     };
 
     return RouterService;

--- a/core/templates/pages/exploration-editor-page/settings-tab/settings-tab.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/settings-tab/settings-tab.component.spec.ts
@@ -16,7 +16,6 @@
  * @fileoverview Unit tests for settingsTab.
  */
 
-import { EventEmitter } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { AnswerGroupsCacheService } from
   // eslint-disable-next-line max-len
@@ -41,16 +40,6 @@ import { UserExplorationPermissionsService } from
   'pages/exploration-editor-page/services/user-exploration-permissions.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
-class MockRouterService {
-  private refreshSettingsTabEmitter: EventEmitter<void>;
-  get onRefreshSettingsTab() {
-    return this.refreshSettingsTabEmitter;
-  }
-  set Emitter(val) {
-    this.refreshSettingsTabEmitter = val;
-  }
-}
-
 describe('Settings Tab Component', function() {
   var ctrl = null;
   var $httpBackend = null;
@@ -74,7 +63,6 @@ describe('Settings Tab Component', function() {
   var userEmailPreferencesService = null;
   var userExplorationPermissionsService = null;
   var windowRef = null;
-  var routerService = null;
 
   var explorationId = 'exp1';
   var userPermissions = {
@@ -92,7 +80,6 @@ describe('Settings Tab Component', function() {
     userExplorationPermissionsService = (
       TestBed.get(UserExplorationPermissionsService));
     windowRef = TestBed.get(WindowRef);
-    routerService = new MockRouterService();
   });
 
   beforeEach(angular.mock.module('oppia', function($provide) {
@@ -148,22 +135,16 @@ describe('Settings Tab Component', function() {
 
     explorationCategoryService.init('Astrology');
 
-    routerService.Emitter = new EventEmitter();
     $scope = $rootScope.$new();
     ctrl = $componentController('settingsTab', {
       $scope: $scope,
       AlertsService: alertsService,
       UserExplorationPermissionsService: userExplorationPermissionsService,
-      RouterService: routerService,
       WindowRef: windowRef
     });
     ctrl.$onInit();
     $scope.$apply();
   }));
-
-  afterEach(() => {
-    ctrl.$onDestroy();
-  });
 
   it('should evaluate controller properties after its initialization',
     function() {
@@ -501,11 +482,4 @@ describe('Settings Tab Component', function() {
 
     expect(explorationRightsService.setViewability).toHaveBeenCalledWith(true);
   });
-
-  it('should refresh settings tab when refreshSettingsTab event occurs',
-    function() {
-      spyOn(ctrl, 'refreshSettingsTab').and.callThrough();
-      routerService.onRefreshSettingsTab.emit();
-      expect(ctrl.refreshSettingsTab).toHaveBeenCalled();
-    });
 });

--- a/core/templates/pages/exploration-editor-page/settings-tab/settings-tab.component.ts
+++ b/core/templates/pages/exploration-editor-page/settings-tab/settings-tab.component.ts
@@ -77,12 +77,9 @@ require(
 require('services/alerts.service.ts');
 require('services/editability.service.ts');
 require('services/exploration-features.service.ts');
-require('pages/exploration-editor-page/services/router.service.ts');
 
 require(
   'pages/exploration-editor-page/exploration-editor-page.constants.ajs.ts');
-
-import { Subscription } from 'rxjs';
 
 angular.module('oppia').component('settingsTab', {
   bindings: {
@@ -102,7 +99,7 @@ angular.module('oppia').component('settingsTab', {
     'ExplorationParamSpecsService', 'ExplorationRightsService',
     'ExplorationStatesService', 'ExplorationTagsService',
     'ExplorationTitleService', 'ExplorationWarningsService',
-    'RouterService', 'UrlInterpolationService', 'UserEmailPreferencesService',
+    'UrlInterpolationService', 'UserEmailPreferencesService',
     'UserExplorationPermissionsService', 'WindowRef', 'ALL_CATEGORIES',
     'EXPLORATION_TITLE_INPUT_FOCUS_LABEL', 'TAG_REGEX',
     function(
@@ -117,14 +114,13 @@ angular.module('oppia').component('settingsTab', {
         ExplorationParamSpecsService, ExplorationRightsService,
         ExplorationStatesService, ExplorationTagsService,
         ExplorationTitleService, ExplorationWarningsService,
-        RouterService, UrlInterpolationService, UserEmailPreferencesService,
+        UrlInterpolationService, UserEmailPreferencesService,
         UserExplorationPermissionsService, WindowRef, ALL_CATEGORIES,
         EXPLORATION_TITLE_INPUT_FOCUS_LABEL, TAG_REGEX) {
       var ctrl = this;
+
       var CREATOR_DASHBOARD_PAGE_URL = '/creator-dashboard';
       var EXPLORE_PAGE_PREFIX = '/explore/';
-
-      ctrl.directiveSubscriptions = new Subscription();
 
       ctrl.getExplorePageUrl = function() {
         return (
@@ -362,13 +358,7 @@ angular.module('oppia').component('settingsTab', {
       };
 
       ctrl.$onInit = function() {
-        ctrl.directiveSubscriptions.add(
-          RouterService.onRefreshSettingsTab.subscribe(
-            () => {
-              ctrl.refreshSettingsTab();
-            }
-          )
-        );
+        $scope.$on('refreshSettingsTab', ctrl.refreshSettingsTab);
         ctrl.EXPLORATION_TITLE_INPUT_FOCUS_LABEL = (
           EXPLORATION_TITLE_INPUT_FOCUS_LABEL);
         ctrl.EditabilityService = EditabilityService;
@@ -432,9 +422,6 @@ angular.module('oppia').component('settingsTab', {
           width: '16.66666667%',
           'vertical-align': 'top'
         });
-      };
-      ctrl.$onDestroy = function() {
-        ctrl.directiveSubscriptions.unsubscribe();
       };
     }
   ]

--- a/core/templates/pages/exploration-editor-page/statistics-tab/statistics-tab.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/statistics-tab/statistics-tab.component.spec.ts
@@ -24,17 +24,6 @@ import { StatesObjectFactory } from 'domain/exploration/StatesObjectFactory';
 import { AlertsService } from 'services/alerts.service';
 import { ComputeGraphService } from 'services/compute-graph.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { EventEmitter } from '@angular/core';
-
-class MockRouterService {
-  private refreshStatsticsTabEmitter: EventEmitter<void>;
-  get onRefreshStatisticsTab() {
-    return this.refreshStatsticsTabEmitter;
-  }
-  set refreshStatisticsTabEmitter(val) {
-    this.refreshStatsticsTabEmitter = val;
-  }
-}
 
 describe('Statistics Tab Component', function() {
   var ctrl = null;
@@ -48,7 +37,6 @@ describe('Statistics Tab Component', function() {
   var readOnlyExplorationBackendApiService = null;
   var stateInteractionStatsService = null;
   var statesObjectFactory = null;
-  var routerService = null;
 
   var explorationId = 'exp1';
   var state = {
@@ -119,7 +107,6 @@ describe('Statistics Tab Component', function() {
     explorationStatsService = TestBed.get(ExplorationStatsService);
     stateInteractionStatsService = TestBed.get(StateInteractionStatsService);
     statesObjectFactory = TestBed.get(StatesObjectFactory);
-    routerService = new MockRouterService();
   });
 
   beforeEach(angular.mock.module('oppia', function($provide) {
@@ -155,23 +142,17 @@ describe('Statistics Tab Component', function() {
         visualizationsInfo: {}
       }));
 
-    routerService.refreshStatisticsTabEmitter = new EventEmitter();
     $scope = $rootScope.$new();
     ctrl = $componentController('statisticsTab', {
       $scope: $scope,
       AlertsService: alertsService,
       ComputeGraphService: computeGraphService,
       ExplorationStatsService: explorationStatsService,
-      RouterService: routerService,
       StateInteractionStatsService: stateInteractionStatsService,
       StatesObjectFactory: statesObjectFactory
     });
     ctrl.$onInit();
   }));
-
-  afterEach(() => {
-    ctrl.$onDestroy();
-  });
 
   it('should evaluate controller properties after its initialization',
     function() {
@@ -181,7 +162,7 @@ describe('Statistics Tab Component', function() {
 
   it('should refresh exploration statistics when broadcasting' +
     ' refreshStatisticsTab', function() {
-    routerService.onRefreshStatisticsTab.emit();
+    $rootScope.$broadcast('refreshStatisticsTab');
 
     // Resolve promise.
     $scope.$apply();
@@ -210,7 +191,7 @@ describe('Statistics Tab Component', function() {
   });
 
   it('should open state stats modal using $uibModal', function() {
-    routerService.onRefreshStatisticsTab.emit();
+    $rootScope.$broadcast('refreshStatisticsTab');
 
     // Resolve promise.
     $scope.$apply();
@@ -226,7 +207,7 @@ describe('Statistics Tab Component', function() {
 
   it('should open state stats modal and close it when clicking in stats' +
     ' graph', function() {
-    routerService.onRefreshStatisticsTab.emit();
+    $rootScope.$broadcast('refreshStatisticsTab');
 
     // Resolve promise.
     $scope.$apply();
@@ -243,7 +224,7 @@ describe('Statistics Tab Component', function() {
 
   it('should open state stats modal and dismiss it when clicking in' +
     ' stats graph', function() {
-    routerService.onRefreshStatisticsTab.emit();
+    $rootScope.$broadcast('refreshStatisticsTab');
 
     // Resolve promise.
     $scope.$apply();

--- a/core/templates/pages/exploration-editor-page/statistics-tab/statistics-tab.component.ts
+++ b/core/templates/pages/exploration-editor-page/statistics-tab/statistics-tab.component.ts
@@ -17,8 +17,6 @@
  * exploration editor.
  */
 
-import { Subscription } from 'rxjs';
-
 require(
   'pages/exploration-editor-page/statistics-tab/templates/' +
   'state-stats-modal.controller.ts');
@@ -31,7 +29,6 @@ require('services/alerts.service.ts');
 require('services/compute-graph.service.ts');
 require('services/exploration-stats.service.ts');
 require('services/state-interaction-stats.service.ts');
-require('pages/admin-page/services/admin-router.service.ts');
 
 require(
   'pages/exploration-editor-page/exploration-editor-page.constants.ajs.ts');
@@ -41,17 +38,15 @@ angular.module('oppia').component('statisticsTab', {
   controller: [
     '$q', '$scope', '$uibModal', 'AlertsService', 'ComputeGraphService',
     'ExplorationDataService', 'ExplorationStatsService',
-    'ReadOnlyExplorationBackendApiService', 'RouterService',
-    'StateInteractionStatsService', 'StatesObjectFactory',
-    'UrlInterpolationService',
+    'ReadOnlyExplorationBackendApiService', 'StateInteractionStatsService',
+    'StatesObjectFactory', 'UrlInterpolationService',
     function(
         $q, $scope, $uibModal, AlertsService, ComputeGraphService,
         ExplorationDataService, ExplorationStatsService,
-        ReadOnlyExplorationBackendApiService, RouterService,
-        StateInteractionStatsService, StatesObjectFactory,
-        UrlInterpolationService) {
-      this.directiveSubscriptions = new Subscription();
+        ReadOnlyExplorationBackendApiService, StateInteractionStatsService,
+        StatesObjectFactory, UrlInterpolationService) {
       const expId = ExplorationDataService.explorationId;
+
       const refreshExplorationStatistics = () => {
         $q.all([
           ReadOnlyExplorationBackendApiService.loadLatestExploration(expId),
@@ -130,17 +125,7 @@ angular.module('oppia').component('statisticsTab', {
           }
         };
         $scope.explorationHasBeenVisited = false;
-        this.directiveSubscriptions.add(
-          RouterService.onRefreshStatisticsTab.subscribe(
-            () => {
-              refreshExplorationStatistics();
-            }
-          )
-        );
-      };
-
-      this.$onDestroy = function() {
-        this.directiveSubscriptions.unsubscribe();
+        $scope.$on('refreshStatisticsTab', refreshExplorationStatistics);
       };
     },
   ],

--- a/core/templates/pages/exploration-editor-page/translation-tab/translation-tab.directive.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/translation-tab.directive.ts
@@ -52,9 +52,6 @@ require(
   'state-recorded-voiceovers.service.ts');
 require('services/context.service.ts');
 require('services/editability.service.ts');
-require('pages/admin-page/services/admin-router.service.ts');
-
-import { Subscription } from 'rxjs';
 
 angular.module('oppia').directive('translationTab', [
   'UrlInterpolationService',
@@ -68,32 +65,28 @@ angular.module('oppia').directive('translationTab', [
 
       controller: ['$scope', '$templateCache', '$uibModal',
         'ContextService', 'EditabilityService', 'ExplorationStatesService',
-        'LoaderService', 'RouterService', 'SiteAnalyticsService',
-        'StateEditorService', 'StateRecordedVoiceoversService',
-        'StateTutorialFirstTimeService', 'StateWrittenTranslationsService',
-        'TranslationTabActiveModeService',
+        'LoaderService', 'SiteAnalyticsService', 'StateEditorService',
+        'StateRecordedVoiceoversService', 'StateTutorialFirstTimeService',
+        'StateWrittenTranslationsService', 'TranslationTabActiveModeService',
         'UserExplorationPermissionsService',
         function($scope, $templateCache, $uibModal,
             ContextService, EditabilityService, ExplorationStatesService,
-            LoaderService, RouterService, SiteAnalyticsService,
-            StateEditorService, StateRecordedVoiceoversService,
-            StateTutorialFirstTimeService, StateWrittenTranslationsService,
-            TranslationTabActiveModeService,
+            LoaderService, SiteAnalyticsService, StateEditorService,
+            StateRecordedVoiceoversService, StateTutorialFirstTimeService,
+            StateWrittenTranslationsService, TranslationTabActiveModeService,
             UserExplorationPermissionsService) {
           var ctrl = this;
-          var _ID_TUTORIAL_TRANSLATION_LANGUAGE = (
-            '#tutorialTranslationLanguage');
+          var _ID_TUTORIAL_TRANSLATION_LANGUAGE =
+            '#tutorialTranslationLanguage';
           var _ID_TUTORIAL_TRANSLATION_STATE = '#tutorialTranslationState';
-          var _ID_TUTORIAL_TRANSLATION_OVERVIEW = (
-            '#tutorialTranslationOverview');
+          var _ID_TUTORIAL_TRANSLATION_OVERVIEW =
+            '#tutorialTranslationOverview';
           // Replace the ng-joyride template with one that uses
           // <[...]> interpolators instead of/ {{...}} interpolators.
-          var ngJoyrideTemplate = (
-            $templateCache.get('ng-joyride-title-tplv1.html'));
+          var ngJoyrideTemplate =
+            $templateCache.get('ng-joyride-title-tplv1.html');
           ngJoyrideTemplate = ngJoyrideTemplate.replace(
             /\{\{/g, '<[').replace(/\}\}/g, ']>');
-
-          ctrl.directiveSubscriptions = new Subscription();
 
           var initTranslationTab = function() {
             StateTutorialFirstTimeService.initTranslation(
@@ -159,13 +152,9 @@ angular.module('oppia').directive('translationTab', [
             LoaderService.showLoadingScreen('Loading');
             $scope.isTranslationTabBusy = false;
             $scope.showTranslationTabSubDirectives = false;
-            ctrl.directiveSubscriptions.add(
-              RouterService.onRefreshTranslationTab.subscribe(
-                () => {
-                  initTranslationTab();
-                }
-              )
-            );
+            $scope.$on('refreshTranslationTab', function() {
+              initTranslationTab();
+            });
             // Toggles the translation tab tutorial on/off.
             $scope.translationTutorial = false;
             $scope.TRANSLATION_TUTORIAL_OPTIONS = [{
@@ -331,9 +320,6 @@ angular.module('oppia').directive('translationTab', [
               $scope.showWelcomeTranslationModal
             );
             $scope.$on('openTranslationTutorial', $scope.onStartTutorial);
-          };
-          ctrl.$onDestroy = function() {
-            ctrl.directiveSubscriptions.unsubscribe();
           };
         }]
     };


### PR DESCRIPTION
Reverts oppia/oppia#10112

## Maybe the cause for unit test failures.