### PR TITLE
Migrates CaseSensitiveEquals RuleSpecs to Equals

### DIFF
--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -168,6 +168,29 @@ class DraftUpgradeUtil(python_utils.OBJECT):
     """Wrapper class that contains util functions to upgrade drafts."""
 
     @classmethod
+    def _convert_states_v36_dict_to_v37_dict(cls, draft_change_list):
+        """Converts draft change list from version 36 to 37.
+
+        Args:
+            draft_change_list: list(ExplorationChange). The list of
+                ExplorationChange domain objects to upgrade.
+
+        Returns:
+            list(ExplorationChange). The converted draft_change_list.
+        """
+        for change in draft_change_list:
+            if (change.property_name ==
+                    exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS):
+                # Find all RuleSpecs in AnwerGroups and change
+                # CaseSensitiveEquals rule types to Equals.
+                for answer_group_dict in change.new_value:
+                   for rule_spec_dict in answer_group_dict['rule_specs']:
+                       if rule_spec_dict['rule_type'] == 'CaseSensitiveEquals':
+                           rule_spec_dict['rule_type'] = 'Equals'
+
+        return draft_change_list
+
+    @classmethod
     def _convert_states_v35_dict_to_v36_dict(cls, draft_change_list):
         """Converts draft change list from version 35 to 36.
 

--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -184,9 +184,9 @@ class DraftUpgradeUtil(python_utils.OBJECT):
                 # Find all RuleSpecs in AnwerGroups and change
                 # CaseSensitiveEquals rule types to Equals.
                 for answer_group_dict in change.new_value:
-                   for rule_spec_dict in answer_group_dict['rule_specs']:
-                       if rule_spec_dict['rule_type'] == 'CaseSensitiveEquals':
-                           rule_spec_dict['rule_type'] = 'Equals'
+                    for rule_spec_dict in answer_group_dict['rule_specs']:
+                        if rule_spec_dict['rule_type'] == 'CaseSensitiveEquals':
+                            rule_spec_dict['rule_type'] = 'Equals'
 
         return draft_change_list
 

--- a/core/domain/draft_upgrade_services_test.py
+++ b/core/domain/draft_upgrade_services_test.py
@@ -377,6 +377,151 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
             msg='Current schema version is %d but DraftUpgradeUtil.%s is '
             'unimplemented.' % (state_schema_version, conversion_fn_name))
 
+    def test_convert_states_v36_dict_to_v37_dict(self):
+        draft_change_list_v36 = [
+            exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'state_name': 'Intro',
+                'property_name': 'content',
+                'new_value': 'new value'
+            }),
+            exp_domain.ExplorationChange({
+                'cmd': 'edit_state_property',
+                'state_name': 'Intro',
+                'property_name': 'answer_groups',
+                'new_value': [{
+                    'rule_specs': [{
+                        'rule_type': 'CaseSensitiveEquals',
+                        'inputs': {
+                            'x': 'test'
+                        }
+                    }],
+                    'outcome': {
+                        'dest': 'Introduction',
+                        'feedback': {
+                            'content_id': 'feedback',
+                            'html': '<p>Content</p>'
+                        },
+                        'param_changes': [],
+                        'labelled_as_correct': False,
+                        'refresher_exploration_id': None,
+                        'missing_prerequisite_skill_id': None
+                    },
+                    'training_data': [],
+                    'tagged_skill_misconception_id': None
+                }]
+            })
+        ]
+        draft_change_list_v37 = [
+            exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'state_name': 'Intro',
+                'property_name': 'content',
+                'new_value': 'new value'
+            }),
+            exp_domain.ExplorationChange({
+                'cmd': 'edit_state_property',
+                'state_name': 'Intro',
+                'property_name': 'answer_groups',
+                'new_value': [{
+                    'rule_specs': [{
+                        'rule_type': 'Equals',
+                        'inputs': {
+                            'x': 'test'
+                        }
+                    }],
+                    'outcome': {
+                        'dest': 'Introduction',
+                        'feedback': {
+                            'content_id': 'feedback',
+                            'html': '<p>Content</p>'
+                        },
+                        'param_changes': [],
+                        'labelled_as_correct': False,
+                        'refresher_exploration_id': None,
+                        'missing_prerequisite_skill_id': None
+                    },
+                    'training_data': [],
+                    'tagged_skill_misconception_id': None
+                }]
+            })
+        ]
+
+        # Migrate exploration to state schema version 37.
+        self.create_and_migrate_new_exploration('36', '37')
+        migrated_draft_change_list_v37 = (
+            draft_upgrade_services.try_upgrading_draft_to_exp_version(
+                draft_change_list_v36, 1, 2, self.EXP_ID))
+
+        # Change draft change lists into a list of dicts so that it is
+        # easy to compare the whole draft change list.
+        draft_change_list_v37_dict_list = [
+            change.to_dict() for change in draft_change_list_v37
+        ]
+        migrated_draft_change_list_v37_dict_list = [
+            change.to_dict() for change in migrated_draft_change_list_v37
+        ]
+        self.assertEqual(
+            draft_change_list_v37_dict_list,
+            migrated_draft_change_list_v37_dict_list)
+
+    def test_convert_states_v35_dict_to_v36_dict(self):
+        draft_change_list_1_v35 = [
+            exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'state_name': 'Intro',
+                'property_name': 'content',
+                'new_value': 'new value'
+            }),
+            exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'state_name': 'Intro',
+                'property_name': 'widget_id',
+                'new_value': 'MathExpressionInput'
+            }),
+            exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'state_name': 'Intro',
+                'property_name': 'widget_customization_args',
+                'new_value': {}
+            })
+        ]
+        draft_change_list_2_v35 = [
+            exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'state_name': 'Intro',
+                'property_name': 'content',
+                'new_value': 'new value'
+            }),
+            exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'state_name': 'Intro',
+                'property_name': 'widget_id',
+                'new_value': 'MathExpressionInput'
+            })
+        ]
+        # Migrate exploration to state schema version 36.
+        self.create_and_migrate_new_exploration('35', '36')
+        migrated_draft_change_list_1_v36 = (
+            draft_upgrade_services.try_upgrading_draft_to_exp_version(
+                draft_change_list_1_v35, 1, 2, self.EXP_ID))
+        self.assertIsNone(migrated_draft_change_list_1_v36)
+
+        migrated_draft_change_list_2_v36 = (
+            draft_upgrade_services.try_upgrading_draft_to_exp_version(
+                draft_change_list_2_v35, 1, 2, self.EXP_ID))
+        # Change draft change lists into a list of dicts so that it is
+        # easy to compare the whole draft change list.
+        draft_change_list_2_v35_dict_list = [
+            change.to_dict() for change in draft_change_list_2_v35
+        ]
+        migrated_draft_change_list_2_v36_dict_list = [
+            change.to_dict() for change in migrated_draft_change_list_2_v36
+        ]
+        self.assertEqual(
+            draft_change_list_2_v35_dict_list,
+            migrated_draft_change_list_2_v36_dict_list)
+
     def test_convert_states_v34_dict_to_v35_dict(self):
         draft_change_list_1_v34 = [
             exp_domain.ExplorationChange({
@@ -447,63 +592,6 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             draft_change_list_2_v34_dict_list,
             migrated_draft_change_list_2_v35_dict_list)
-
-    def test_convert_states_v35_dict_to_v36_dict(self):
-        draft_change_list_1_v35 = [
-            exp_domain.ExplorationChange({
-                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': 'Intro',
-                'property_name': 'content',
-                'new_value': 'new value'
-            }),
-            exp_domain.ExplorationChange({
-                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': 'Intro',
-                'property_name': 'widget_id',
-                'new_value': 'MathExpressionInput'
-            }),
-            exp_domain.ExplorationChange({
-                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': 'Intro',
-                'property_name': 'widget_customization_args',
-                'new_value': {}
-            })
-        ]
-        draft_change_list_2_v35 = [
-            exp_domain.ExplorationChange({
-                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': 'Intro',
-                'property_name': 'content',
-                'new_value': 'new value'
-            }),
-            exp_domain.ExplorationChange({
-                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': 'Intro',
-                'property_name': 'widget_id',
-                'new_value': 'MathExpressionInput'
-            })
-        ]
-        # Migrate exploration to state schema version 36.
-        self.create_and_migrate_new_exploration('35', '36')
-        migrated_draft_change_list_1_v36 = (
-            draft_upgrade_services.try_upgrading_draft_to_exp_version(
-                draft_change_list_1_v35, 1, 2, self.EXP_ID))
-        self.assertIsNone(migrated_draft_change_list_1_v36)
-
-        migrated_draft_change_list_2_v36 = (
-            draft_upgrade_services.try_upgrading_draft_to_exp_version(
-                draft_change_list_2_v35, 1, 2, self.EXP_ID))
-        # Change draft change lists into a list of dicts so that it is
-        # easy to compare the whole draft change list.
-        draft_change_list_2_v35_dict_list = [
-            change.to_dict() for change in draft_change_list_2_v35
-        ]
-        migrated_draft_change_list_2_v36_dict_list = [
-            change.to_dict() for change in migrated_draft_change_list_2_v36
-        ]
-        self.assertEqual(
-            draft_change_list_2_v35_dict_list,
-            migrated_draft_change_list_2_v36_dict_list)
 
     def test_convert_states_v33_dict_to_v34_dict(self):
         html_content = (

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -2766,6 +2766,14 @@ class Exploration(python_utils.OBJECT):
         customization arguments, normalizes customization arguments against
         its schema, and changes PencilCodeEditor's customization argument
         name from initial_code to initialCode.
+
+        Args:
+            states_dict: dict. A dict where each key-value pair represents,
+                respectively, a state name and a dict used to initialize a
+                State domain object.
+
+        Returns:
+            dict. The converted states_dict.
         """
         for state_dict in states_dict.values():
             max_existing_content_id_index = -1
@@ -2941,6 +2949,14 @@ class Exploration(python_utils.OBJECT):
     def _convert_states_v36_dict_to_v37_dict(cls, states_dict):
         """Converts from version 36 to 37. Version 37 changes all rule with type
         CaseSensitiveEquals to Equals.
+
+        Args:
+            states_dict: dict. A dict where each key-value pair represents,
+                respectively, a state name and a dict used to initialize a
+                State domain object.
+
+        Returns:
+            dict. The converted states_dict.
         """
         for state_dict in states_dict.values():
             answer_groups = state_dict['interaction']['answer_groups']

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -3793,6 +3793,7 @@ class Exploration(python_utils.OBJECT):
             dict. The dict representation of the Exploration domain object,
             following schema version v35.
         """
+        raise Exception('haha')
         exploration_dict['schema_version'] = 35
 
         exploration_dict['states'] = cls._convert_states_v29_dict_to_v30_dict(

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -3793,7 +3793,6 @@ class Exploration(python_utils.OBJECT):
             dict. The dict representation of the Exploration domain object,
             following schema version v35.
         """
-        raise Exception('haha')
         exploration_dict['schema_version'] = 35
 
         exploration_dict['states'] = cls._convert_states_v29_dict_to_v30_dict(

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -6073,7 +6073,146 @@ tags: []
 title: Title
 """)
 
-    _LATEST_YAML_CONTENT = YAML_CONTENT_V41
+    YAML_CONTENT_V42 = (
+        """author_notes: ''
+auto_tts_enabled: true
+blurb: ''
+category: Category
+correctness_feedback_enabled: false
+init_state_name: (untitled state)
+language_code: en
+objective: ''
+param_changes: []
+param_specs: {}
+schema_version: 42
+states:
+  (untitled state):
+    classifier_model_id: null
+    content:
+      content_id: content
+      html: ''
+    interaction:
+      answer_groups:
+      - outcome:
+          dest: END
+          feedback:
+            content_id: feedback_1
+            html: <p>Correct!</p>
+          labelled_as_correct: false
+          missing_prerequisite_skill_id: null
+          param_changes: []
+          refresher_exploration_id: null
+        rule_specs:
+        - inputs:
+            x: InputString
+          rule_type: Equals
+        tagged_skill_misconception_id: null
+        training_data: []
+      confirmed_unclassified_answers: []
+      customization_args:
+        placeholder:
+          value:
+            content_id: ca_placeholder_2
+            unicode_str: ''
+        rows:
+          value: 1
+      default_outcome:
+        dest: (untitled state)
+        feedback:
+          content_id: default_outcome
+          html: ''
+        labelled_as_correct: false
+        missing_prerequisite_skill_id: null
+        param_changes: []
+        refresher_exploration_id: null
+      hints: []
+      id: TextInput
+      solution: null
+    next_content_id_index: 3
+    param_changes: []
+    recorded_voiceovers:
+      voiceovers_mapping:
+        ca_placeholder_2: {}
+        content: {}
+        default_outcome: {}
+        feedback_1: {}
+    solicit_answer_details: false
+    written_translations:
+      translations_mapping:
+        ca_placeholder_2: {}
+        content: {}
+        default_outcome: {}
+        feedback_1: {}
+  END:
+    classifier_model_id: null
+    content:
+      content_id: content
+      html: <p>Congratulations, you have finished!</p>
+    interaction:
+      answer_groups: []
+      confirmed_unclassified_answers: []
+      customization_args:
+        recommendedExplorationIds:
+          value: []
+      default_outcome: null
+      hints: []
+      id: EndExploration
+      solution: null
+    next_content_id_index: 0
+    param_changes: []
+    recorded_voiceovers:
+      voiceovers_mapping:
+        content: {}
+    solicit_answer_details: false
+    written_translations:
+      translations_mapping:
+        content: {}
+  New state:
+    classifier_model_id: null
+    content:
+      content_id: content
+      html: ''
+    interaction:
+      answer_groups: []
+      confirmed_unclassified_answers: []
+      customization_args:
+        placeholder:
+          value:
+            content_id: ca_placeholder_0
+            unicode_str: ''
+        rows:
+          value: 1
+      default_outcome:
+        dest: END
+        feedback:
+          content_id: default_outcome
+          html: ''
+        labelled_as_correct: false
+        missing_prerequisite_skill_id: null
+        param_changes: []
+        refresher_exploration_id: null
+      hints: []
+      id: TextInput
+      solution: null
+    next_content_id_index: 1
+    param_changes: []
+    recorded_voiceovers:
+      voiceovers_mapping:
+        ca_placeholder_0: {}
+        content: {}
+        default_outcome: {}
+    solicit_answer_details: false
+    written_translations:
+      translations_mapping:
+        ca_placeholder_0: {}
+        content: {}
+        default_outcome: {}
+states_schema_version: 37
+tags: []
+title: Title
+""")
+
+    _LATEST_YAML_CONTENT = YAML_CONTENT_V42
 
     def test_load_from_v1(self):
         """Test direct loading from a v1 yaml file."""
@@ -6513,7 +6652,7 @@ language_code: en
 objective: ''
 param_changes: []
 param_specs: {}
-schema_version: 41
+schema_version: 42
 states:
   (untitled state):
     classifier_model_id: null
@@ -6636,7 +6775,7 @@ states:
       translations_mapping:
         content: {}
         default_outcome: {}
-states_schema_version: 36
+states_schema_version: 37
 tags: []
 title: Title
 """)
@@ -6669,7 +6808,7 @@ language_code: en
 objective: ''
 param_changes: []
 param_specs: {}
-schema_version: 41
+schema_version: 42
 states:
   (untitled state):
     classifier_model_id: null
@@ -6797,7 +6936,7 @@ states:
         content: {}
         default_outcome: {}
         hint_1: {}
-states_schema_version: 36
+states_schema_version: 37
 tags: []
 title: Title
 """)
@@ -6848,7 +6987,7 @@ language_code: en
 objective: ''
 param_changes: []
 param_specs: {}
-schema_version: 41
+schema_version: 42
 states:
   (untitled state):
     classifier_model_id: null
@@ -6983,7 +7122,7 @@ states:
         default_outcome: {}
         hint_1: {}
         solution: {}
-states_schema_version: 36
+states_schema_version: 37
 tags: []
 title: Title
 """)
@@ -7016,7 +7155,7 @@ language_code: en
 objective: ''
 param_changes: []
 param_specs: {}
-schema_version: 41
+schema_version: 42
 states:
   (untitled state):
     classifier_model_id: null
@@ -7143,7 +7282,7 @@ states:
         ca_customPlaceholder_0: {}
         content: {}
         default_outcome: {}
-states_schema_version: 36
+states_schema_version: 37
 tags: []
 title: Title
 """)
@@ -7206,7 +7345,7 @@ language_code: en
 objective: ''
 param_changes: []
 param_specs: {}
-schema_version: 41
+schema_version: 42
 states:
   (untitled state):
     classifier_model_id: null
@@ -7326,7 +7465,7 @@ states:
       translations_mapping:
         content: {}
         default_outcome: {}
-states_schema_version: 36
+states_schema_version: 37
 tags: []
 title: Title
 """)
@@ -7502,7 +7641,7 @@ language_code: en
 objective: ''
 param_changes: []
 param_specs: {}
-schema_version: 41
+schema_version: 42
 states:
   (untitled state):
     classifier_model_id: null
@@ -7629,7 +7768,285 @@ states:
         ca_placeholder_0: {}
         content: {}
         default_outcome: {}
-states_schema_version: 36
+states_schema_version: 37
+tags: []
+title: Title
+""")
+        exploration = exp_domain.Exploration.from_yaml(
+            'eid', sample_yaml_content)
+        self.assertEqual(exploration.to_yaml(), latest_sample_yaml_content)
+
+    def test_load_from_v41_special_cases(self):
+        """Test to cover some special cases that occurs in the migration from
+        v41 to v42 exploration schema. This includes containing an AnswerGroup
+        that has a CaseSensitiveEquals rule.
+        """
+        sample_yaml_content = (
+            """author_notes: ''
+auto_tts_enabled: true
+blurb: ''
+category: Category
+correctness_feedback_enabled: false
+init_state_name: (untitled state)
+language_code: en
+objective: ''
+param_changes: []
+param_specs: {}
+schema_version: 40
+states:
+  (untitled state):
+    classifier_model_id: null
+    content:
+      content_id: content
+      html: ''
+    interaction:
+      answer_groups:
+      - outcome:
+          dest: END
+          feedback:
+            content_id: feedback_1
+            html: <p>Correct!</p>
+          labelled_as_correct: false
+          missing_prerequisite_skill_id: null
+          param_changes: []
+          refresher_exploration_id: null
+        rule_specs:
+        - inputs:
+            x: InputString
+          rule_type: CaseSensitiveEquals
+        tagged_skill_misconception_id: null
+        training_data: []
+      confirmed_unclassified_answers: []
+      customization_args: {}
+      default_outcome:
+        dest: (untitled state)
+        feedback:
+          content_id: default_outcome
+          html: ''
+        labelled_as_correct: false
+        missing_prerequisite_skill_id: null
+        param_changes: []
+        refresher_exploration_id: null
+      hints: []
+      id: MultipleChoiceInput
+      solution: null
+    param_changes: []
+    recorded_voiceovers:
+      voiceovers_mapping:
+        content: {}
+        default_outcome: {}
+        feedback_1: {}
+    solicit_answer_details: false
+    written_translations:
+      translations_mapping:
+        content:
+            en:
+                html: <p>Translation</p>
+                needs_update: false
+        default_outcome: {}
+        feedback_1: {}
+  END:
+    classifier_model_id: null
+    content:
+      content_id: content
+      html: <p>Congratulations, you have finished!</p>
+    interaction:
+      answer_groups: []
+      confirmed_unclassified_answers: []
+      customization_args:
+        recommendedExplorationIds:
+          value: []
+      default_outcome: null
+      hints: []
+      id: EndExploration
+      solution: null
+    param_changes: []
+    recorded_voiceovers:
+      voiceovers_mapping:
+        content: {}
+    solicit_answer_details: false
+    written_translations:
+      translations_mapping:
+        content: {}
+  New state:
+    classifier_model_id: null
+    content:
+      content_id: content
+      html: ''
+    interaction:
+      answer_groups: []
+      confirmed_unclassified_answers: []
+      customization_args:
+        placeholder:
+          value: ''
+        rows:
+          value: 1
+      default_outcome:
+        dest: END
+        feedback:
+          content_id: default_outcome
+          html: ''
+        labelled_as_correct: false
+        missing_prerequisite_skill_id: null
+        param_changes: []
+        refresher_exploration_id: null
+      hints: []
+      id: TextInput
+      solution: null
+    param_changes: []
+    recorded_voiceovers:
+      voiceovers_mapping:
+        content: {}
+        default_outcome: {}
+    solicit_answer_details: false
+    written_translations:
+      translations_mapping:
+        content: {}
+        default_outcome: {}
+states_schema_version: 35
+tags: []
+title: Title
+""")
+
+        latest_sample_yaml_content = (
+            """author_notes: ''
+auto_tts_enabled: true
+blurb: ''
+category: Category
+correctness_feedback_enabled: false
+init_state_name: (untitled state)
+language_code: en
+objective: ''
+param_changes: []
+param_specs: {}
+schema_version: 42
+states:
+  (untitled state):
+    classifier_model_id: null
+    content:
+      content_id: content
+      html: ''
+    interaction:
+      answer_groups:
+      - outcome:
+          dest: END
+          feedback:
+            content_id: feedback_1
+            html: <p>Correct!</p>
+          labelled_as_correct: false
+          missing_prerequisite_skill_id: null
+          param_changes: []
+          refresher_exploration_id: null
+        rule_specs:
+        - inputs:
+            x: InputString
+          rule_type: Equals
+        tagged_skill_misconception_id: null
+        training_data: []
+      confirmed_unclassified_answers: []
+      customization_args:
+        choices:
+          value:
+          - content_id: ca_choices_2
+            html: ''
+        showChoicesInShuffledOrder:
+          value: true
+      default_outcome:
+        dest: (untitled state)
+        feedback:
+          content_id: default_outcome
+          html: ''
+        labelled_as_correct: false
+        missing_prerequisite_skill_id: null
+        param_changes: []
+        refresher_exploration_id: null
+      hints: []
+      id: MultipleChoiceInput
+      solution: null
+    next_content_id_index: 3
+    param_changes: []
+    recorded_voiceovers:
+      voiceovers_mapping:
+        ca_choices_2: {}
+        content: {}
+        default_outcome: {}
+        feedback_1: {}
+    solicit_answer_details: false
+    written_translations:
+      translations_mapping:
+        ca_choices_2: {}
+        content:
+          en:
+            data_format: html
+            needs_update: false
+            translation: <p>Translation</p>
+        default_outcome: {}
+        feedback_1: {}
+  END:
+    classifier_model_id: null
+    content:
+      content_id: content
+      html: <p>Congratulations, you have finished!</p>
+    interaction:
+      answer_groups: []
+      confirmed_unclassified_answers: []
+      customization_args:
+        recommendedExplorationIds:
+          value: []
+      default_outcome: null
+      hints: []
+      id: EndExploration
+      solution: null
+    next_content_id_index: 0
+    param_changes: []
+    recorded_voiceovers:
+      voiceovers_mapping:
+        content: {}
+    solicit_answer_details: false
+    written_translations:
+      translations_mapping:
+        content: {}
+  New state:
+    classifier_model_id: null
+    content:
+      content_id: content
+      html: ''
+    interaction:
+      answer_groups: []
+      confirmed_unclassified_answers: []
+      customization_args:
+        placeholder:
+          value:
+            content_id: ca_placeholder_0
+            unicode_str: ''
+        rows:
+          value: 1
+      default_outcome:
+        dest: END
+        feedback:
+          content_id: default_outcome
+          html: ''
+        labelled_as_correct: false
+        missing_prerequisite_skill_id: null
+        param_changes: []
+        refresher_exploration_id: null
+      hints: []
+      id: TextInput
+      solution: null
+    next_content_id_index: 1
+    param_changes: []
+    recorded_voiceovers:
+      voiceovers_mapping:
+        ca_placeholder_0: {}
+        content: {}
+        default_outcome: {}
+    solicit_answer_details: false
+    written_translations:
+      translations_mapping:
+        ca_placeholder_0: {}
+        content: {}
+        default_outcome: {}
+states_schema_version: 37
 tags: []
 title: Title
 """)
@@ -8066,7 +8483,7 @@ title: title
 """)
 
 # pylint: disable=line-too-long, single-line-pragma
-    YAML_CONTENT_V41_IMAGE_DIMENSIONS = (
+    YAML_CONTENT_V42_IMAGE_DIMENSIONS = (
         """author_notes: ''
 auto_tts_enabled: true
 blurb: ''
@@ -8077,7 +8494,7 @@ language_code: en
 objective: ''
 param_changes: []
 param_specs: {}
-schema_version: 41
+schema_version: 42
 states:
   Introduction:
     classifier_model_id: null
@@ -8330,7 +8747,7 @@ states:
         content: {}
         default_outcome: {}
         feedback_1: {}
-states_schema_version: 36
+states_schema_version: 37
 tags: []
 title: title
 """)
@@ -8579,7 +8996,7 @@ tags: []
 title: Title
 """)
 
-    YAML_CONTENT_V41_WITH_IMAGE_CAPTION = (
+    YAML_CONTENT_V42_WITH_IMAGE_CAPTION = (
         """author_notes: ''
 auto_tts_enabled: true
 blurb: ''
@@ -8590,7 +9007,7 @@ language_code: en
 objective: ''
 param_changes: []
 param_specs: {}
-schema_version: 41
+schema_version: 42
 states:
   (untitled state):
     classifier_model_id: null
@@ -8717,7 +9134,7 @@ states:
         ca_placeholder_0: {}
         content: {}
         default_outcome: {}
-states_schema_version: 36
+states_schema_version: 37
 tags: []
 title: Title
 """)
@@ -8734,7 +9151,7 @@ title: Title
             exploration = exp_domain.Exploration.from_yaml(
                 'eid', self.YAML_CONTENT_V26_TEXTANGULAR)
         self.assertEqual(
-            exploration.to_yaml(), self.YAML_CONTENT_V41_IMAGE_DIMENSIONS)
+            exploration.to_yaml(), self.YAML_CONTENT_V42_IMAGE_DIMENSIONS)
 
 
     def test_load_from_v27_without_image_caption(self):
@@ -8747,7 +9164,7 @@ title: Title
             exploration = exp_domain.Exploration.from_yaml(
                 'eid', self.YAML_CONTENT_V27_WITHOUT_IMAGE_CAPTION)
         self.assertEqual(
-            exploration.to_yaml(), self.YAML_CONTENT_V41_WITH_IMAGE_CAPTION)
+            exploration.to_yaml(), self.YAML_CONTENT_V42_WITH_IMAGE_CAPTION)
 
 
 class ConversionUnitTests(test_utils.GenericTestBase):

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -275,11 +275,13 @@ class ExplorationMigrationAuditJob(jobs.BaseMapReduceOneOffJobManager):
         current_state_schema_version = feconf.CURRENT_STATE_SCHEMA_VERSION
         if item.states_schema_version == current_state_schema_version - 1:
             try:
+                current_exp_schema_version = (
+                    exp_domain.Exploration.CURRENT_EXP_SCHEMA_VERSION)
                 conversion_fn = getattr(
                     exp_domain.Exploration,
                     '_convert_v%i_dict_to_v%i_dict' % (
-                        current_state_schema_version - 1,
-                        current_state_schema_version)
+                        current_exp_schema_version - 1,
+                        current_exp_schema_version)
                 )
                 conversion_fn(item.to_dict())
                 yield ('SUCCESS', None)

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -276,7 +276,7 @@ class ExplorationMigrationAuditJob(jobs.BaseMapReduceOneOffJobManager):
         if item.states_schema_version == current_state_schema_version - 1:
             try:
                 conversion_fn = getattr(
-                     exp_domain.Exploration,
+                    exp_domain.Exploration,
                     '_convert_v%i_dict_to_v%i_dict' % (
                         current_state_schema_version - 1,
                         current_state_schema_version)

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -288,7 +288,7 @@ class ExplorationMigrationAuditJob(jobs.BaseMapReduceOneOffJobManager):
             except Exception as e:
                 error_message = (
                     'Exploration %s failed migration to v%s: %s' %
-                    (current_exp_schema_version, item.id, e))
+                    (item.id, current_exp_schema_version, e))
                 logging.error(error_message)
                 yield ('MIGRATION_ERROR', error_message.encode('utf-8'))
         else:

--- a/core/domain/exp_jobs_one_off.py
+++ b/core/domain/exp_jobs_one_off.py
@@ -287,8 +287,8 @@ class ExplorationMigrationAuditJob(jobs.BaseMapReduceOneOffJobManager):
                 yield ('SUCCESS', None)
             except Exception as e:
                 error_message = (
-                    'Exploration %s failed migration to v41: %s' %
-                    (item.id, e))
+                    'Exploration %s failed migration to v%s: %s' %
+                    (current_exp_schema_version, item.id, e))
                 logging.error(error_message)
                 yield ('MIGRATION_ERROR', error_message.encode('utf-8'))
         else:

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -1189,6 +1189,7 @@ class ExplorationMigrationAuditJobTests(test_utils.GenericTestBase):
             ]
             self.assertEqual(actual_output, expected_output)
 
+
 class ExplorationMigrationJobTests(test_utils.GenericTestBase):
 
     ALBERT_EMAIL = 'albert@example.com'

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -1172,7 +1172,8 @@ class ExplorationMigrationAuditJobTests(test_utils.GenericTestBase):
             lambda cls, exploration_dict: exploration_dict['property_that_dne'])
 
         with self.swap(
-                exp_domain.Exploration, conversion_fn_name, mock_conversion):
+            exp_domain.Exploration, conversion_fn_name, mock_conversion
+        ):
             job_id = exp_jobs_one_off.ExplorationMigrationAuditJob.create_new()
             exp_jobs_one_off.ExplorationMigrationAuditJob.enqueue(job_id)
             self.process_and_flush_pending_tasks()

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -935,6 +935,160 @@ class ExplorationValidityJobManagerTests(test_utils.GenericTestBase):
             self, exp_jobs_one_off.ExplorationValidityJobManager)
 
 
+class ExplorationMigrationAuditJobTests(test_utils.GenericTestBase):
+    """Tests for ExplorationMigrationAuditJob."""
+
+    ALBERT_EMAIL = 'albert@example.com'
+    ALBERT_NAME = 'albert'
+
+    VALID_EXP_ID = 'exp_id0'
+    NEW_EXP_ID = 'exp_id1'
+    EXP_TITLE = 'title'
+
+    def setUp(self):
+        super(ExplorationMigrationAuditJobTests, self).setUp()
+
+        # Setup user who will own the test explorations.
+        self.signup(self.ALBERT_EMAIL, self.ALBERT_NAME)
+        self.albert_id = self.get_user_id_from_email(self.ALBERT_EMAIL)
+        self.process_and_flush_pending_tasks()
+
+    def test_migration_audit_job_skips_deleted_explorations(self):
+        """Tests that the exploration migration job skips deleted explorations
+        and does not attempt to migrate.
+        """
+        self.save_new_exp_with_states_schema_v0(
+            self.NEW_EXP_ID, self.albert_id, self.EXP_TITLE)
+
+        # Note: This creates a summary based on the upgraded model (which is
+        # fine). A summary is needed to delete the exploration.
+        exp_services.create_exploration_summary(
+            self.NEW_EXP_ID, None)
+
+        # Delete the exploration before migration occurs.
+        exp_services.delete_exploration(self.albert_id, self.NEW_EXP_ID)
+
+        # Ensure the exploration is deleted.
+        with self.assertRaisesRegexp(Exception, 'Entity .* not found'):
+            exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
+
+        # Start migration job on sample exploration.
+        job_id = exp_jobs_one_off.ExplorationMigrationAuditJob.create_new()
+        exp_jobs_one_off.ExplorationMigrationAuditJob.enqueue(job_id)
+
+        # This running without errors indicates the deleted exploration is
+        # being ignored, since otherwise exp_fetchers.get_exploration_by_id
+        # (used within the job) will raise an error.
+        self.process_and_flush_pending_tasks()
+
+        # Ensure the exploration is still deleted.
+        with self.assertRaisesRegexp(Exception, 'Entity .* not found'):
+            exp_fetchers.get_exploration_by_id(self.NEW_EXP_ID)
+
+    def test_audit_job_only_runs_for_previous_state_schema_version(self):
+        """Tests that the exploration migration job does not convert
+        explorations with a state schema that is not the previous state schema
+        version.
+        """
+        self.save_new_exp_with_states_schema_v0(
+            self.NEW_EXP_ID, self.albert_id, self.EXP_TITLE)
+
+        job_id = exp_jobs_one_off.ExplorationMigrationAuditJob.create_new()
+        exp_jobs_one_off.ExplorationMigrationAuditJob.enqueue(job_id)
+        self.process_and_flush_pending_tasks()
+        actual_output = (
+            exp_jobs_one_off.ExplorationMigrationAuditJob.get_output(job_id))
+
+        self.assertEqual(
+            actual_output,
+            [
+                u'[u\'WRONG_STATE_VERSION\', [u\'Exploration exp_id1 was not ' +
+                'migrated because its states schema verison is 0\']]'
+            ])
+
+    def test_migration_job_audit_success(self):
+        """Test that the audit job runs correctly on explorations of the
+        previous state schema.
+        """
+        states_dict = state_domain.State.from_dict({
+            'content': {
+                'content_id': 'content_1',
+                'html': 'Question 1'
+            },
+            'recorded_voiceovers': {
+                'voiceovers_mapping': {
+                    'content_1': {},
+                    'feedback_2': {},
+                    'hint_1': {},
+                    'content_2': {}
+                }
+            },
+            'written_translations': {
+                'translations_mapping': {
+                    'content_1': {},
+                    'feedback_2': {},
+                    'hint_1': {},
+                    'content_2': {}
+                }
+            },
+            'interaction': {
+                'answer_groups': [],
+                'confirmed_unclassified_answers': [],
+                'customization_args': {},
+                'default_outcome': {
+                    'dest': 'Introduction',
+                    'feedback': {
+                        'content_id': 'feedback_2',
+                        'html': 'Correct Answer'
+                    },
+                    'param_changes': [],
+                    'refresher_exploration_id': None,
+                    'labelled_as_correct': True,
+                    'missing_prerequisite_skill_id': None
+                },
+                'hints': [{
+                    'hint_content': {
+                        'content_id': 'hint_1',
+                        'html': 'Hint 1'
+                    }
+                }],
+                'solution': {
+                    'correct_answer': {
+                        'ascii': 'x+y',
+                        'latex': 'x+y'
+                    },
+                    'answer_is_exclusive': False,
+                    'explanation': {
+                        'html': 'Solution explanation',
+                        'content_id': 'content_2'
+                    }
+                },
+                'id': 'MathExpressionInput'
+            },
+            'next_content_id_index': 0,
+            'param_changes': [],
+            'solicit_answer_details': False,
+            'classifier_model_id': None
+        }).to_dict()
+
+        self.save_new_exp_with_states_schema_v35(
+            self.NEW_EXP_ID, self.albert_id, {
+                'Introduction': states_dict
+            })
+
+        job_id = exp_jobs_one_off.ExplorationMigrationAuditJob.create_new()
+        exp_jobs_one_off.ExplorationMigrationAuditJob.enqueue(job_id)
+        self.process_and_flush_pending_tasks()
+
+        actual_output = (
+            exp_jobs_one_off.ExplorationMigrationAuditJob.get_output(
+                job_id)
+        )
+
+        expected_output = ['[u\'SUCCESS\', 1]']
+        self.assertEqual(actual_output, expected_output)
+
+
 class ExplorationMigrationJobTests(test_utils.GenericTestBase):
 
     ALBERT_EMAIL = 'albert@example.com'

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -1088,6 +1088,105 @@ class ExplorationMigrationAuditJobTests(test_utils.GenericTestBase):
         expected_output = ['[u\'SUCCESS\', 1]']
         self.assertEqual(actual_output, expected_output)
 
+    def test_migration_job_audit_failure(self):
+        """Test that the audit job runs correctly on explorations of the
+        previous state schema and catches any errors that occur during the
+        migration.
+        """
+        states_dict = state_domain.State.from_dict({
+            'content': {
+                'content_id': 'content_1',
+                'html': 'Question 1'
+            },
+            'recorded_voiceovers': {
+                'voiceovers_mapping': {
+                    'content_1': {},
+                    'feedback_2': {},
+                    'hint_1': {},
+                    'content_2': {}
+                }
+            },
+            'written_translations': {
+                'translations_mapping': {
+                    'content_1': {},
+                    'feedback_2': {},
+                    'hint_1': {},
+                    'content_2': {}
+                }
+            },
+            'interaction': {
+                'answer_groups': [],
+                'confirmed_unclassified_answers': [],
+                'customization_args': {},
+                'default_outcome': {
+                    'dest': 'Introduction',
+                    'feedback': {
+                        'content_id': 'feedback_2',
+                        'html': 'Correct Answer'
+                    },
+                    'param_changes': [],
+                    'refresher_exploration_id': None,
+                    'labelled_as_correct': True,
+                    'missing_prerequisite_skill_id': None
+                },
+                'hints': [{
+                    'hint_content': {
+                        'content_id': 'hint_1',
+                        'html': 'Hint 1'
+                    }
+                }],
+                'solution': {
+                    'correct_answer': {
+                        'ascii': 'x+y',
+                        'latex': 'x+y'
+                    },
+                    'answer_is_exclusive': False,
+                    'explanation': {
+                        'html': 'Solution explanation',
+                        'content_id': 'content_2'
+                    }
+                },
+                'id': 'MathExpressionInput'
+            },
+            'next_content_id_index': 0,
+            'param_changes': [],
+            'solicit_answer_details': False,
+            'classifier_model_id': None
+        }).to_dict()
+
+        self.save_new_exp_with_states_schema_v35(
+            self.NEW_EXP_ID, self.albert_id, {
+                'Introduction': states_dict
+            })
+
+        current_exp_schema_version = (
+            exp_domain.Exploration.CURRENT_EXP_SCHEMA_VERSION)
+        conversion_fn_name = (
+            '_convert_v%i_dict_to_v%i_dict' % (
+                current_exp_schema_version - 1,
+                current_exp_schema_version)
+        )
+
+        # Make a mock conversion function that raises an error.
+        mock_conversion = classmethod(
+            lambda cls, exploration_dict: exploration_dict['property_that_dne'])
+
+        with self.swap(
+                exp_domain.Exploration, conversion_fn_name, mock_conversion):
+            job_id = exp_jobs_one_off.ExplorationMigrationAuditJob.create_new()
+            exp_jobs_one_off.ExplorationMigrationAuditJob.enqueue(job_id)
+            self.process_and_flush_pending_tasks()
+
+            actual_output = (
+                exp_jobs_one_off.ExplorationMigrationAuditJob.get_output(
+                    job_id)
+            )
+
+            expected_output = [
+                u'[u\'MIGRATION_ERROR\', [u"Exploration exp_id1 failed migratio'
+                'n to v41: u\'property_that_dne\'"]]'
+            ]
+            self.assertEqual(actual_output, expected_output)
 
 class ExplorationMigrationJobTests(test_utils.GenericTestBase):
 

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -472,6 +472,14 @@ class Question(python_utils.OBJECT):
         customization arguments, normalizes customization arguments against
         its schema, and changes PencilCodeEditor's customization argument
         name from initial_code to initialCode.
+
+        Args:
+            question_state_dict: dict. A dict where each key-value pair
+                represents respectively, a state name and a dict used to
+                initialize a State domain object.
+
+        Returns:
+            dict. The converted question_state_dict.
         """
         max_existing_content_id_index = -1
         translations_mapping = question_state_dict[
@@ -639,6 +647,27 @@ class Question(python_utils.OBJECT):
             question_state_dict[
                 'recorded_voiceovers'][
                     'voiceovers_mapping'][new_content_id] = {}
+
+        return question_state_dict
+
+    @classmethod
+    def _convert_state_v36_dict_to_v37_dict(cls, question_state_dict):
+        """Converts from version 36 to 37. Version 37 changes all rule with type
+        CaseSensitiveEquals to Equals.
+
+        Args:
+            question_state_dict: dict. A dict where each key-value pair
+                represents respectively, a state name and a dict used to
+                initialize a State domain object.
+
+        Returns:
+            dict. The converted question_state_dict.
+        """
+        answer_groups = question_state_dict['interaction']['answer_groups']
+        for answer_group in answer_groups:
+            for rule_spec_dict in answer_group['rule_specs']:
+                if rule_spec_dict['rule_type'] == 'CaseSensitiveEquals':
+                    rule_spec_dict['rule_type'] = 'Equals'
 
         return question_state_dict
 

--- a/core/domain/question_services_test.py
+++ b/core/domain/question_services_test.py
@@ -1864,3 +1864,92 @@ class QuestionMigrationTests(test_utils.GenericTestBase):
                 },
                 'showChoicesInShuffledOrder': {'value': True}
             })
+
+    def test_migrate_question_state_from_v36_to_latest(self):
+        # Test restructuring of written_translations.
+        question_state_dict = {
+            'content': {
+                'content_id': 'content_1',
+                'html': 'Question 1'
+            },
+            'recorded_voiceovers': {
+                'voiceovers_mapping': {}
+            },
+            'written_translations': {
+                'translations_mapping': {}
+            },
+            'interaction': {
+                'answer_groups': [{
+                    'outcome': {
+                        'dest': None,
+                        'feedback': {
+                            'content_id': 'feedback_1',
+                            'html': 'Correct Answer'
+                        },
+                        'param_changes': [],
+                        'refresher_exploration_id': None,
+                        'labelled_as_correct': True,
+                        'missing_prerequisite_skill_id': None
+                    },
+                    'rule_specs': [{
+                        'inputs': {'x': 'test'},
+                        'rule_type': 'CaseSensitiveEquals'
+                    }],
+                    'tagged_skill_misconception_id': None,
+                    'training_data': []
+                }],
+                'confirmed_unclassified_answers': [],
+                'customization_args': {},
+                'default_outcome': {
+                    'dest': None,
+                    'feedback': {
+                        'content_id': 'feedback_1',
+                        'html': 'Correct Answer'
+                    },
+                    'param_changes': [],
+                    'refresher_exploration_id': None,
+                    'labelled_as_correct': True,
+                    'missing_prerequisite_skill_id': None
+                },
+                'hints': [],
+                'solution': {},
+                'id': None
+            },
+            'next_content_id_index': 2,
+            'param_changes': [],
+            'solicit_answer_details': False,
+            'classifier_model_id': None
+        }
+
+        question_model = (
+            question_models.QuestionModel(
+                id='question_id',
+                question_state_data=question_state_dict,
+                language_code='en',
+                version=0,
+                linked_skill_ids=['skill_id'],
+                question_state_data_schema_version=36))
+        commit_cmd = (
+            question_domain.QuestionChange({
+                'cmd': question_domain.CMD_CREATE_NEW
+            }))
+        commit_cmd_dicts = [commit_cmd.to_dict()]
+        question_model.commit(
+            'user_id_admin', 'question model created', commit_cmd_dicts)
+
+        question = question_fetchers.get_question_from_model(question_model)
+        self.assertEqual(
+            question.question_state_data_schema_version,
+            feconf.CURRENT_STATE_SCHEMA_VERSION)
+
+        migrated_rule_spec = (
+            question
+            .question_state_data
+            .interaction.answer_groups[0]
+            .rule_specs[0].to_dict())
+        self.assertEqual(
+            migrated_rule_spec,
+            {
+                'inputs': {'x': 'test'},
+                'rule_type': 'Equals'
+            })

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -56,6 +56,7 @@ ONE_OFF_JOB_MANAGERS = [
     exp_jobs_one_off.ExplorationMockMathMigrationOneOffJob,
     exp_jobs_one_off.ExplorationMathRichTextInfoModelGenerationOneOffJob,
     exp_jobs_one_off.ExplorationMathRichTextInfoModelDeletionOneOffJob,
+    exp_jobs_one_off.ExplorationMigrationAuditJob,
     exp_jobs_one_off.ExplorationMigrationJobManager,
     exp_jobs_one_off.ExplorationValidityJobManager,
     exp_jobs_one_off.HintsAuditOneOffJob,

--- a/core/templates/filters/parameterize-rule-description.filter.spec.ts
+++ b/core/templates/filters/parameterize-rule-description.filter.spec.ts
@@ -61,7 +61,10 @@ describe('Testing filters', function() {
       ];
       expect($filter('parameterizeRuleDescription')(ruleMultipleChoice,
         interactionIdMultipleChoice, choicesMultipleChoice)
-      ).toEqual('is equal to \'$10 should not become $$10\'');
+      ).toEqual(
+        'is equal to \'$10 should not become $$10\', without taking case' +
+        ' into account'
+      );
 
       choicesMultipleChoice = [
         {
@@ -71,7 +74,9 @@ describe('Testing filters', function() {
       ];
       expect($filter('parameterizeRuleDescription')(ruleMultipleChoice,
         interactionIdMultipleChoice, choicesMultipleChoice)
-      ).toEqual('is equal to \'$xyz should not become $$xyz\'');
+      ).toEqual(
+        'is equal to \'$xyz should not become $$xyz\', ' +
+        'without taking case into account');
     }));
 
   it('should correctly display RTE components in Answer Group Header',
@@ -144,13 +149,14 @@ describe('Testing filters', function() {
       expect($filter('convertToPlainText')($filter('formatRtePreview')(
         $filter('parameterizeRuleDescription')(ruleMath, interactionIdMath,
           choicesMath)))
-      ).toEqual('is ' + 'equal to \'[Math]\'');
+      ).toEqual(
+        'is ' + 'equal to \'[Math]\', without taking case into account');
 
       expect($filter('convertToPlainText')($filter('formatRtePreview')(
         $filter('parameterizeRuleDescription')(ruleMixed, interactionIdMixed,
           choicesMixed)))
       ).toEqual('is ' + 'equal to \'[Image] This is a text ' +
-        'input. [Image]  [Link]\'');
+        'input. [Image]  [Link]\', without taking case into account');
     })
   );
 });

--- a/extensions/interactions/TextInput/directives/text-input-rules.service.spec.ts
+++ b/extensions/interactions/TextInput/directives/text-input-rules.service.spec.ts
@@ -61,15 +61,6 @@ describe('Text Input rules service', () => {
     expect(tirs.FuzzyEquals('ghi jkl', RULE_INPUT)).toBe(false);
   });
 
-  it('should have a correct \'case sensitive equals\' rule', () => {
-    expect(tirs.CaseSensitiveEquals('abc def', RULE_INPUT)).toBe(true);
-    expect(tirs.CaseSensitiveEquals('abc   def ', RULE_INPUT)).toBe(true);
-    expect(tirs.CaseSensitiveEquals('ABC def', RULE_INPUT)).toBe(false);
-    expect(tirs.CaseSensitiveEquals('abc DeF', RULE_INPUT)).toBe(false);
-    expect(tirs.CaseSensitiveEquals('', RULE_INPUT)).toBe(false);
-    expect(tirs.CaseSensitiveEquals('abc', RULE_INPUT)).toBe(false);
-  });
-
   it('should have a correct \'starts with\' rule', () => {
     expect(tirs.StartsWith('  ABC  DEFGHI', RULE_INPUT)).toBe(true);
     expect(tirs.StartsWith('abc defghi', RULE_INPUT)).toBe(true);

--- a/extensions/interactions/TextInput/directives/text-input-rules.service.ts
+++ b/extensions/interactions/TextInput/directives/text-input-rules.service.ts
@@ -63,12 +63,6 @@ export class TextInputRulesService {
     }
     return editDistance[inputString.length][answerString.length] === 1;
   }
-  CaseSensitiveEquals(
-      answer: TextInputAnswer, inputs: TextInputRuleInputs): boolean {
-    var normalizedAnswer = this.nws.transform(answer);
-    var normalizedInput = this.nws.transform(inputs.x);
-    return normalizedAnswer === normalizedInput;
-  }
   StartsWith(answer: TextInputAnswer, inputs: TextInputRuleInputs): boolean {
     var normalizedAnswer = this.nws.transform(answer);
     var normalizedInput = this.nws.transform(inputs.x);

--- a/extensions/interactions/interaction_specs.json
+++ b/extensions/interactions/interaction_specs.json
@@ -757,8 +757,7 @@
     "rule_descriptions": {
       "StartsWith": "starts with {{x|NormalizedString}}",
       "Contains": "contains {{x|NormalizedString}}",
-      "Equals": "is equal to {{x|NormalizedString}}",
-      "CaseSensitiveEquals": "is equal to {{x|NormalizedString}}, taking case into account",
+      "Equals": "is equal to {{x|NormalizedString}}, without taking case into account",
       "FuzzyEquals": "is equal to {{x|NormalizedString}}, misspelled by at most one character"
     }
   },

--- a/extensions/interactions/rule_templates.json
+++ b/extensions/interactions/rule_templates.json
@@ -252,10 +252,7 @@
   },
   "TextInput": {
     "Equals": {
-      "description": "is equal to {{x|NormalizedString}}"
-    },
-    "CaseSensitiveEquals": {
-      "description": "is equal to {{x|NormalizedString}}, taking case into account"
+      "description": "is equal to {{x|NormalizedString}}, without taking case into account"
     },
     "StartsWith": {
       "description": "starts with {{x|NormalizedString}}"

--- a/feconf.py
+++ b/feconf.py
@@ -210,7 +210,7 @@ CURRENT_DASHBOARD_STATS_SCHEMA_VERSION = 1
 # incompatible changes are made to the states blob schema in the data store,
 # this version number must be changed and the exploration migration job
 # executed.
-CURRENT_STATE_SCHEMA_VERSION = 36
+CURRENT_STATE_SCHEMA_VERSION = 37
 
 # The current version of the all collection blob schemas (such as the nodes
 # structure within the Collection domain object). If any backward-incompatible

--- a/typings/karma-fixtures.d.ts
+++ b/typings/karma-fixtures.d.ts
@@ -208,7 +208,6 @@ interface RuleTemplates {
   };
   TextInput: {
     Equals: IRuleDescription;
-    CaseSensitiveEquals: IRuleDescription;
     StartsWith: IRuleDescription;
     Contains: IRuleDescription;
     FuzzyEquals: IRuleDescription;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR implements changes required here: [Interaction Rules Translation Design Doc](https://docs.google.com/document/d/1PtNQDuVo_lHm3DVP_PelwcKrZpjrsLRMKVLEbftnpbU/edit?usp=sharing)
2. This PR does the following:
* Creates a state migration that migrates CaseSensitiveEquals RuleSpecs to Equals
* Removes the ability to create CaseSensitiveEquals rules on the frontend

