### PR TITLE
Revert "Removes caching from Circle CI config"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,20 +98,15 @@ commands:
               circleci-agent step halt
             fi
 
-  install_dependencies:
-    description: "Install dependencies"
-    steps:
-      - run:
-          name: Install dependencies
-          command: python -m scripts.install_third_party_libs
-
 jobs:
   setup_and_typescript_tests:
     <<: *job_defaults
     steps:
       - checkout
       - merge_target_branch
-      - install_dependencies
+      - run:
+          name: Install dependencies
+          command: python -m scripts.install_third_party_libs
       - run:
           name: Check that all e2e test files are captured in protractor.conf.js
           command: python -m scripts.check_e2e_tests_are_captured_in_ci
@@ -119,6 +114,12 @@ jobs:
           name: Run typescript tests
           command: |
             python -m scripts.typescript_checks
+      - persist_to_workspace:
+          root: /home/circleci/
+          paths:
+            - oppia/node_modules/
+            - oppia/third_party/
+            - oppia_tools/
 
   # Production environment e2e tests
   # The following e2e tests are run in the production environment. Tests that require uploading files
@@ -129,11 +130,12 @@ jobs:
       - checkout
       - merge_target_branch
       - install_chrome
-      - install_dependencies
+      - attach_workspace:
+          at: /home/circleci/
       - run:
           name: Run e2e navigation test
           command: |
-            python -m scripts.run_e2e_tests --prod_env --deparallelize_terser --suite="navigation"
+            python -m scripts.run_e2e_tests --prod_env --deparallelize_terser --skip-install --suite="navigation"
           # Provide a longer time period for this first test (which omits the
           # --skip-build flag), since the webpack build process itself can take
           # up to 10 minutes. If this is not done, then the test may stall due
@@ -143,7 +145,16 @@ jobs:
       - run:
           name: Run e2e admin page test
           command: |
-            python -m scripts.run_e2e_tests --deparallelize_terser --suite="adminPage" --prod_env
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="adminPage" --prod_env
+      - persist_to_workspace:
+          root: /home/circleci/
+          paths:
+            - oppia/app.yaml
+            - oppia/assets/constants.ts
+            - oppia/assets/hashes.json
+            - oppia/backend_prod_files/
+            - oppia/build/
+            - oppia/third_party/generated/
 
   e2e_library_and_collections:
     <<: *job_defaults
@@ -152,27 +163,28 @@ jobs:
       - check_release_chaneglog_update_branch
       - merge_target_branch
       - install_chrome
-      - install_dependencies
+      - attach_workspace:
+          at: /home/circleci/
       - run:
           name: Run e2e publication test
           command: |
-            python -m scripts.run_e2e_tests --deparallelize_terser --suite="publication" --prod_env
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="publication" --prod_env
       - run:
           name: Run e2e library test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --deparallelize_terser --suite="library" --prod_env
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="library" --prod_env
       - run:
           name: Run e2e classroomPage test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --deparallelize_terser --suite="classroomPage" --prod_env
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="classroomPage" --prod_env
       - run:
           name: Run e2e collections test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --deparallelize_terser --suite="collections" --prod_env
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="collections" --prod_env
       - run:
           name: Run e2e accessibility page test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --deparallelize_terser --suite="accessibility" --prod_env
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="accessibility" --prod_env
 
   e2e_users:
     <<: *job_defaults
@@ -181,27 +193,28 @@ jobs:
       - check_release_chaneglog_update_branch
       - merge_target_branch
       - install_chrome
-      - install_dependencies
+      - attach_workspace:
+          at: /home/circleci/
       - run:
           name: Run e2e users test
           command: |
-            python -m scripts.run_e2e_tests --deparallelize_terser --suite="users" --prod_env
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="users" --prod_env
       - run:
           name: Run e2e subscriptions test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --deparallelize_terser --suite="subscriptions" --prod_env
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="subscriptions" --prod_env
       - run:
           name: Run e2e profileMenu test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --deparallelize_terser --suite="profileMenu" --prod_env
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="profileMenu" --prod_env
       - run:
           name: Run e2e preferences test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --deparallelize_terser --suite="preferences" --prod_env
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="preferences" --prod_env
       - run:
           name: Run e2e profileFeatures test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --deparallelize_terser --suite="profileFeatures" --prod_env
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="profileFeatures" --prod_env
 
   # Non-prod e2e Tests
   # The following tests must be run in a non-production environment because they are uploading files.
@@ -213,35 +226,36 @@ jobs:
       - check_release_chaneglog_update_branch
       - merge_target_branch
       - install_chrome
-      - install_dependencies
+      - attach_workspace:
+          at: /home/circleci/
       - run:
           name: Run e2e file upload features test
           command: |
-            python -m scripts.run_e2e_tests --suite="fileUploadFeatures"
+            python -m scripts.run_e2e_tests --skip-install --suite="fileUploadFeatures"
       - run:
           name: Run e2e topics and skills dashboard test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicsAndSkillsDashboard" --server_log_level=info
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="topicsAndSkillsDashboard" --server_log_level=info
       - run:
           name: Run e2e topics and story editor
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryEditor" --server_log_level=info
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="topicAndStoryEditor" --server_log_level=info
       - run:
           name: Run e2e classroom page test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --suite="classroomPageFileUploadFeatures" --server_log_level=info
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="classroomPageFileUploadFeatures" --server_log_level=info
       - run:
           name: Run e2e topic and story editor test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryEditorFileUploadFeatures"
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="topicAndStoryEditorFileUploadFeatures"
       - run:
           name: Run e2e play voiceovers test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --suite="playVoiceovers"
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="playVoiceovers"
       - run:
           name: Run e2e file upload extensions test
           command: |
-            python -m scripts.run_e2e_tests --skip-build --skip-install --suite="fileUploadExtensions"
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="fileUploadExtensions"
 
 notify:
   webhooks:


### PR DESCRIPTION
Reverts oppia/oppia#10181


The "workspace persistence" error mentioned in #10181 has not occured in recent builds. This error is not seen in recent PR builds either. Therefore, changes in #10181 can be reverted.

Builds that were failing earlier but seem to pass recent builds:

https://app.circleci.com/pipelines/github/oppia/oppia?branch=pull%2F10136

https://app.circleci.com/pipelines/github/oppia/oppia?branch=pull%2F10173