### PR TITLE
Add ImageClickInput to the list of supported Android interactions.

### DIFF
--- a/core/domain/android_validation_constants.py
+++ b/core/domain/android_validation_constants.py
@@ -25,8 +25,8 @@ from __future__ import unicode_literals  # pylint: disable=import-only-modules
 # interactions or remove existing ones.
 VALID_INTERACTION_IDS = [
     'Continue', 'DragAndDropSortInput', 'EndExploration', 'FractionInput',
-    'ItemSelectionInput', 'MultipleChoiceInput', 'NumericInput',
-    'NumberWithUnits', 'TextInput'
+    'ImageClickInput', 'ItemSelectionInput', 'MultipleChoiceInput',
+    'NumericInput', 'NumberWithUnits', 'TextInput'
 ]
 
 SUPPORTED_LANGUAGES = ['en']

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -1156,13 +1156,13 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         self.assertTrue(init_state.interaction.is_supported_on_android_app())
         init_state.update_interaction_id('TextInput')
         self.assertTrue(init_state.interaction.is_supported_on_android_app())
+        init_state.update_interaction_id('ImageClickInput')
+        self.assertTrue(init_state.interaction.is_supported_on_android_app())
 
         # Invalid interactions.
         init_state.update_interaction_id('CodeRepl')
         self.assertFalse(init_state.interaction.is_supported_on_android_app())
         init_state.update_interaction_id('GraphInput')
-        self.assertFalse(init_state.interaction.is_supported_on_android_app())
-        init_state.update_interaction_id('ImageClickInput')
         self.assertFalse(init_state.interaction.is_supported_on_android_app())
         init_state.update_interaction_id('InteractiveMap')
         self.assertFalse(init_state.interaction.is_supported_on_android_app())


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of N/A.
2. This PR does the following: Adds ImageClickInput to the list of supported Android interactions.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
