### PR TITLE
Fix #10247: Set CodeMirror viewportMargin to 100 and fix e2e flake

### DIFF
--- a/core/templates/pages/exploration-editor-page/modal-templates/state-diff-modal.controller.ts
+++ b/core/templates/pages/exploration-editor-page/modal-templates/state-diff-modal.controller.ts
@@ -88,7 +88,7 @@ angular.module('oppia').controller('StateDiffModalController', [
       lineNumbers: true,
       readOnly: true,
       mode: 'yaml',
-      viewportMargin: 20
+      viewportMargin: 100
     };
   }
 ]);

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -597,10 +597,9 @@ var toRichText = async function(text) {
  * loads more divs.
  */
 var CodeMirrorChecker = function(elem, codeMirrorPaneToScroll) {
-  // The number of pixels to scroll between reading different sections of
-  // CodeMirror's text. 400 pixels is about 15 lines, which will work if
-  // codemirror's buffer (viewportMargin) is set to at least 10 (the default).
-  var CODEMIRROR_SCROLL_AMOUNT_IN_PIXELS = 400;
+  // The number of lines to scroll between reading different sections of
+  // CodeMirror's text.
+  var NUMBER_OF_LINE_TO_SCROLL = 15;
 
   /**
    * This recursive function is used by expectTextWithHighlightingToBe().
@@ -623,6 +622,9 @@ var CodeMirrorChecker = function(elem, codeMirrorPaneToScroll) {
     await browser.executeScript(
       '$(\'.CodeMirror-vscrollbar\').' + codeMirrorPaneToScroll +
       '().scrollTop(' + String(scrollTo) + ');');
+    var lineHeight = await elem.element(
+      by.css('.CodeMirror-linenumber')).getAttribute(
+        'clientHeight');
     var lineNumbers = await elem.all(by.xpath('./div')).map(
       async function(lineElement) {
         var lineNumber = await lineElement.element(
@@ -649,7 +651,7 @@ var CodeMirrorChecker = function(elem, codeMirrorPaneToScroll) {
     if (largestLineNumber !== currentLineNumber) {
       await _compareTextAndHighlightingFromLine(
         largestLineNumber,
-        scrollTo + CODEMIRROR_SCROLL_AMOUNT_IN_PIXELS,
+        scrollTo + lineHeight * NUMBER_OF_LINE_TO_SCROLL,
         compareDict);
     } else {
       for (var lineNumber in compareDict) {
@@ -684,6 +686,9 @@ var CodeMirrorChecker = function(elem, codeMirrorPaneToScroll) {
       '$(\'.CodeMirror-vscrollbar\').' + codeMirrorPaneToScroll +
       '().scrollTop(' + String(scrollTo) + ');');
     var text = await elem.getText();
+    var lineHeight = await elem.element(
+      by.css('.CodeMirror-linenumber')).getAttribute(
+        'clientHeight');
     // The 'text' arg is a string 2n lines long representing n lines of text
     // codemirror has loaded. The (2i)th line contains a line number and the
     // (2i+1)th line contains the text on that line.
@@ -706,7 +711,7 @@ var CodeMirrorChecker = function(elem, codeMirrorPaneToScroll) {
     if (largestLineNumber !== currentLineNumber) {
       await _compareTextFromLine(
         largestLineNumber,
-        scrollTo + CODEMIRROR_SCROLL_AMOUNT_IN_PIXELS,
+        scrollTo + lineHeight * NUMBER_OF_LINE_TO_SCROLL,
         compareDict);
     } else {
       for (var dictLineNumber in compareDict) {

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -624,7 +624,7 @@ var CodeMirrorChecker = function(elem, codeMirrorPaneToScroll) {
       '().scrollTop(' + String(scrollTo) + ');');
     var lineHeight = await elem.element(
       by.css('.CodeMirror-linenumber')).getAttribute(
-        'clientHeight');
+      'clientHeight');
     var lineNumbers = await elem.all(by.xpath('./div')).map(
       async function(lineElement) {
         var lineNumber = await lineElement.element(
@@ -688,7 +688,7 @@ var CodeMirrorChecker = function(elem, codeMirrorPaneToScroll) {
     var text = await elem.getText();
     var lineHeight = await elem.element(
       by.css('.CodeMirror-linenumber')).getAttribute(
-        'clientHeight');
+      'clientHeight');
     // The 'text' arg is a string 2n lines long representing n lines of text
     // codemirror has loaded. The (2i)th line contains a line number and the
     // (2i+1)th line contains the text on that line.

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -636,7 +636,7 @@ var CodeMirrorChecker = function(elem, codeMirrorPaneToScroll) {
       var lineHeight = await elem.element(
         by.css('.CodeMirror-linenumber')).getAttribute('clientHeight');
       var currentScrollTop = await browser.executeScript(
-        'return arguments[0].scrollTop;', scrollBarWebElement)
+        'return arguments[0].scrollTop;', scrollBarWebElement);
       if (currentScrollTop === prevScrollTop) {
         break;
       } else {
@@ -652,9 +652,6 @@ var CodeMirrorChecker = function(elem, codeMirrorPaneToScroll) {
         if (lineNumber && !compareDict.hasOwnProperty(lineNumber)) {
           throw new Error('Line ' + lineNumber + ' not found in CodeMirror');
         }
-        // if (actualDiffDict[lineNumber]) {
-        //   continue;
-        // }
         var lineDivElement = await lineDivElements.get(i);
         var lineElement = await lineContentElements.get(i);
         var isHighlighted = await lineDivElement.element(
@@ -663,7 +660,7 @@ var CodeMirrorChecker = function(elem, codeMirrorPaneToScroll) {
         actualDiffDict[lineNumber] = {
           text: text,
           highlighted: isHighlighted
-        }
+        };
       }
       scrollTo = scrollTo + lineHeight * NUMBER_OF_LINES_TO_SCROLL;
     }


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #10247 
2. This PR does the following:

- CodeMirror uses the viewportMargin property to determine how many lines are shown above and below the viewport currently scrolled into view (see [doc](https://codemirror.net/doc/manual.html#option_viewportMargin)). The number of lines shown depends on the viewPort height this may vary depending on the screensize and the zoom level set in the browser. In a deskstop screen with a 1920x1080 resolution, the History tab diff (this is where CodeMirror is used), shows approximately 20 lines (and renders 20 in the top and 20 in the bottom that are hidden from view). Scrolling upwards or downwards (E.g. scrolling 40+ lines) quickly causes the rendering to be a bit slow because those lines are not yet processed by CodeMirror. By increasing the viewportMargin to 100, we allow more lines to be processed before scrolling. This makes the scrolling experience a bit better (E.g. scrolling past 50-100 lines of code does not need any processing). This also helps protractor tests run smoothly because it does not have to "figure out" if the lines on the screen have been processed or not.
- Fixes e2e flake by re-writing the logic for checking the history tab diff.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".


## Screenshots from consecutive Travis runs ##
Please note, the affected test was run 10 times on Travis to ensure that the flake has indeed been fixed. Here are the screenshots for runs 3 to 10. Runs 1 & 2 do not have screenshots because the jobs were restarted before a screenshot could be saved.

<details>
 <summary>Run 3</summary>
<img width="960" alt="run3" src="https://user-images.githubusercontent.com/11008603/90040244-5a5eb880-dce5-11ea-93cd-cc9650b1fbe8.PNG">
</details>

<details>
 <summary>Run 4</summary>
<img width="960" alt="run4" src="https://user-images.githubusercontent.com/11008603/90040277-634f8a00-dce5-11ea-9af9-2296f0f1a121.PNG">
</details>

<details>
 <summary>Run 5</summary>
<img width="960" alt="run5" src="https://user-images.githubusercontent.com/11008603/90040298-68acd480-dce5-11ea-9292-a77a837c2d9f.PNG">
</details>


<details>
 <summary>Run 6</summary>
<img width="960" alt="run6" src="https://user-images.githubusercontent.com/11008603/90040316-6ea2b580-dce5-11ea-8066-b231d02d5064.PNG">
</details>

<details>
 <summary>Run 7</summary>
<img width="960" alt="run7" src="https://user-images.githubusercontent.com/11008603/90040337-72ced300-dce5-11ea-9486-1692da63ee44.PNG">
</details>


<details>
 <summary>Run 8</summary>
<img width="960" alt="run8" src="https://user-images.githubusercontent.com/11008603/90040361-782c1d80-dce5-11ea-874c-5c1964f3a0d1.PNG">
</details>

<details>
 <summary>Run 9</summary>
<img width="960" alt="run9" src="https://user-images.githubusercontent.com/11008603/90040474-985bdc80-dce5-11ea-8372-fb2fa6168eb0.PNG">
</details>

<details>
 <summary>Run 10</summary>
<img width="960" alt="run10" src="https://user-images.githubusercontent.com/11008603/90043270-811eee00-dce9-11ea-9c3e-a95c836142af.PNG">
</details>