### PR TITLE
Fixes flaky frontend tests

### DIFF
--- a/core/templates/pages/exploration-editor-page/services/router.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/router.service.spec.ts
@@ -185,9 +185,9 @@ describe('Router Service', () => {
 
         expect(broadcastSpy).toHaveBeenCalled();
 
+        expect(applyAsyncSpy).toHaveBeenCalled();
         done();
 
-        expect(applyAsyncSpy).toHaveBeenCalled();
       }, 20);
       $timeout.flush(150);
     }, 400);
@@ -223,8 +223,6 @@ describe('Router Service', () => {
 
         expect(broadcastSpy).toHaveBeenCalled();
 
-        done();
-
         expect(applyAsyncSpy).toHaveBeenCalled();
 
         RouterService.navigateToMainTab('newState');
@@ -232,6 +230,7 @@ describe('Router Service', () => {
         $rootScope.$apply();
 
         expect(RouterService.getActiveTabName()).toBe('main');
+        done();
       }, 20);
       $timeout.flush(150);
     }, 400);

--- a/core/templates/pages/exploration-editor-page/services/router.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/router.service.spec.ts
@@ -187,7 +187,6 @@ describe('Router Service', () => {
 
         expect(applyAsyncSpy).toHaveBeenCalled();
         done();
-
       }, 20);
       $timeout.flush(150);
     }, 400);

--- a/core/templates/pages/exploration-editor-page/translation-tab/audio-translation-bar/audio-translation-bar.directive.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/audio-translation-bar/audio-translation-bar.directive.spec.ts
@@ -203,6 +203,8 @@ describe('State Graph Visualization directive', function() {
     spyOn(voiceoverRecordingService, 'status').and.returnValue({
       isAvailable: false
     });
+    spyOn(voiceoverRecordingService, 'startRecording').and.returnValue(
+      $q.resolve());
     $scope.checkAndStartRecording();
 
     expect($scope.unsupportedBrowser).toBe(true);

--- a/core/templates/pages/exploration-editor-page/translation-tab/audio-translation-bar/audio-translation-bar.directive.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/audio-translation-bar/audio-translation-bar.directive.spec.ts
@@ -219,6 +219,20 @@ describe('State Graph Visualization directive', function() {
       $q.resolve());
     spyOn($scope.voiceoverRecorder, 'getMp3Data').and.returnValue(
       $q.resolve([]));
+    var waveSurferObjSpy = {
+      load: () => {},
+      on: () => {},
+      pause: () => {},
+      play: () => {},
+    };
+    // This throws "Argument of type '{ load: () => void; ... }'
+    // is not assignable to parameter of type 'WaveSurfer'."
+    // This is because the actual 'WaveSurfer.create` function returns a
+    // object with around 50 more properties than `waveSurferObjSpy`.
+    // We are suppressing this error because we have defined the properties
+    // we need for this test in 'waveSurferObjSpy' object.
+    // @ts-expect-error
+    spyOn(WaveSurfer, 'create').and.returnValue(waveSurferObjSpy);
 
     $scope.checkAndStartRecording();
     $scope.$apply();
@@ -400,6 +414,20 @@ describe('State Graph Visualization directive', function() {
     });
     spyOn($scope.voiceoverRecorder, 'getMp3Data').and.returnValue(
       $q.resolve([]));
+    var waveSurferObjSpy = {
+      load: () => {},
+      on: () => {},
+      pause: () => {},
+      play: () => {},
+    };
+    // This throws "Argument of type '{ load: () => void; ... }'
+    // is not assignable to parameter of type 'WaveSurfer'."
+    // This is because the actual 'WaveSurfer.create` function returns a
+    // object with around 50 more properties than `waveSurferObjSpy`.
+    // We are suppressing this error because we have defined the properties
+    // we need for this test in 'waveSurferObjSpy' object.
+    // @ts-expect-error
+    spyOn(WaveSurfer, 'create').and.returnValue(waveSurferObjSpy);
 
     document.body.dispatchEvent(keyEvent);
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of NA.
2. This PR does the following:

### Fixes 2 flaky frontend tests: ###

1. Add mocks for `voiceoverRecordingService.startRecording()` and wavesurfer methods as a fix for the error (wavesurfer internally calls `decodeAudioData` which can cause this error ([code](https://github.com/katspaugh/wavesurfer.js/blob/master/src/webaudio.js#L351))):
```
Unhandled promise rejection: EncodingError: Unable to decode audio data
```


2. Move `done()` in `router.service.spec.ts` methods so that it executes only after all the statements in the async method has executed. This fixes the following error:

```
   An error was thrown in afterAll
   Error: Expected spy $applyAsync to have been called.
       at <Jasmine>
       at core/templates/combined-tests.spec.js:64978:39
       at ZoneDelegate../node_modules/zone.js/dist/zone.js.ZoneDelegate.invokeTask (core/templates/pages/about-page/about-page.module.js:289961:35)
       at ProxyZoneSpec../node_modules/zone.js/dist/proxy.js.ProxyZoneSpec.onInvokeTask (core/templates/combined-tests.spec.js:500303:43)
   Error: No deferred tasks to be flushed
       at Function.self.defer.flush (third_party/static/angularjs-1.7.9/angular-mocks.js:193:13)
       at Function.$delegate.flush (third_party/static/angularjs-1.7.9/angular-mocks.js:2388:20)
       at core/templates/combined-tests.spec.js:64980:26
       at ZoneDelegate../node_modules/zone.js/dist/zone.js.ZoneDelegate.invokeTask (core/templates/pages/about-page/about-page.module.js:289961:35)
       at ProxyZoneSpec../node_modules/zone.js/dist/proxy.js.ProxyZoneSpec.onInvokeTask (core/templates/combined-tests.spec.js:500303:43)
       at ZoneDelegate../node_modules/zone.js/dist/zone.js.ZoneDelegate.invokeTask (core/templates/pages/about-page/about-page.module.js:289960:40)
       at Zone../node_modules/zone.js/dist/zone.js.Zone.runTask (core/templates/pages/about-page/about-page.module.js:289728:51)
       at ./node_modules/zone.js/dist/zone.js.ZoneTask.invokeTask (core/templates/pages/about-page/about-page.module.js:290043:38)
       at ZoneTask.invoke (core/templates/pages/about-page/about-page.module.js:290032:52)
       at timer (core/templates/pages/about-page/about-page.module.js:292574:33)

```

### Note: These fixes have been confirmed to successfully run on the CI based on 100 runs of `run_frontend_tests.py` script (see [build](https://github.com/kevintab95/oppia/pull/8/checks?check_run_id=969554814)). ###



## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
