### PR TITLE
Milestone 3.2:   Score 100% in Chrome accessibility audits on Skill_Editor, Stewards, Story_Editor, Review_tests pages

### DIFF
--- a/core/templates/pages/skill-editor-page/navbar/skill-editor-navbar.directive.html
+++ b/core/templates/pages/skill-editor-page/navbar/skill-editor-navbar.directive.html
@@ -27,7 +27,7 @@
         </span>
       </button>
       <button type="button" style="height: 34px;" class="btn btn-light uib-dropdown-toggle dropdown-toggle"
-              ng-disabled="!getChangeListCount()" uib-dropdown-toggle>
+              ng-disabled="!getChangeListCount()" aria-label="Dropdown toggle" uib-dropdown-toggle>
       </button>
       <ul uib-dropdown-menu role="menu" style="min-width: 125px; right: inherit;" ng-style="{ width: getChangeListCount() ? '150px' : '120px' }">
         <li title="Discard all pending changes"><a ng-click="discardChanges()" ng-class="{'oppia-disabled-link': !getChangeListCount()}" class="dropdown-item">Discard Draft</a></li>

--- a/core/templates/pages/skill-editor-page/skill-editor-page.component.html
+++ b/core/templates/pages/skill-editor-page/skill-editor-page.component.html
@@ -8,7 +8,7 @@
         <li ng-class="{'uib-dropdown': $ctrl.getWarningsCount(), 'navbar-tab-active': $ctrl.getActiveTabName() === 'main'}"
             ng-attr-uib-dropdown="<[$ctrl.getWarningsCount()]>"
             ng-click="$ctrl.selectMainTab()" class="navbar-tab nav-list-item">
-          <a uib-tooltip="Main Editor" tooltip-placement="bottom" class=" protractor-test-main-tab">
+          <a uib-tooltip="Main Editor" tooltip-placement="bottom" class="protractor-test-main-tab">
             <i class="material-icons navbar-tab-icon" ng-class="{'navbar-tab-active-icon': $ctrl.getActiveTabName() === 'main'}">&#xE254;</i>
           </a>
           <div ng-show="$ctrl.getWarningsCount()"
@@ -29,12 +29,12 @@
         <li class="navbar-tab icon nav-list-item protractor-test-questions-tab"
             ng-class="{'navbar-tab-active': $ctrl.getActiveTabName() === 'questions'}"
             ng-click="$ctrl.selectQuestionsTab()">
-          <a uib-tooltip="Questions" tooltip-placement="bottom">
+          <a uib-tooltip="Questions" tooltip-placement="bottom" aria-label="Questions">
             <i class="fa fa-book navbar-tab-icon" ng-class="{'navbar-tab-active-icon': $ctrl.getActiveTabName() === 'questions'}"></i>
           </a>
         </li>
-        <li class="navbar-tab icon nav-list-item" ng-class="{'navbar-tab-active': $ctrl.getActiveTabName() === 'preview'}">
-          <a ng-click="$ctrl.selectPreviewTab()" class="nav-link" uib-tooltip="Preview" tooltip-placement="bottom" tabindex="0">
+        <li class="navbar-tab icon nav-list-item" ng-class="{'navbar-tab-active': $ctrl.getActiveTabName() === 'preview'}" ng-click="$ctrl.selectPreviewTab()" >
+          <a class="nav-link" uib-tooltip="Preview" tooltip-placement="bottom" aria-label="Preview">
             <i class="material-icons navbar-tab-icon" ng-class="{'navbar-tab-active-icon': $ctrl.getActiveTabName() === 'preview'}">&#xE037;</i>
           </a>
         </li>

--- a/core/templates/pages/story-editor-page/editor-tab/story-editor.directive.html
+++ b/core/templates/pages/story-editor-page/editor-tab/story-editor.directive.html
@@ -191,7 +191,7 @@
                       <span class="protractor-test-chapter-title"><[node.getTitle()]></span>
                     </div>
                     <div class="edit-options-container">
-                      <i class="fa fa-ellipsis-v chapter-edit-toggle-button protractor-test-edit-options" ng-click="toggleChapterEditOptions($index);$event.stopPropagation()"></i>
+                      <i class="fa fa-ellipsis-v chapter-edit-toggle-button protractor-test-edit-options" ng-click="toggleChapterEditOptions($index);$event.stopPropagation()" aria-label="Chapter edit"></i>
                     </div>
                     <div class="chapter-option-box" ng-if="selectedChapterIndex === $index" ng-mouseleave="toggleChapterEditOptions(-1)" ng-click="toggleChapterEditOptions(-1);$event.stopPropagation()">
                       <div class="chapter-edit-option protractor-test-delete-chapter-button" ng-click="deleteNode(node.getId())">

--- a/core/templates/pages/story-editor-page/navbar/story-editor-navbar.directive.html
+++ b/core/templates/pages/story-editor-page/navbar/story-editor-navbar.directive.html
@@ -24,7 +24,7 @@
         </span>
       </button>
       <button type="button" style="height: 34px;" class="btn btn-light uib-dropdown-toggle dropdown-toggle"
-              ng-disabled="!getChangeListLength()" uib-dropdown-toggle>
+              ng-disabled="!getChangeListLength()" aria-label="Dropdown toggle" uib-dropdown-toggle>
       </button>
       <ul uib-dropdown-menu role="menu" style="min-width: 125px; right: inherit;" ng-style="{ width: getChangeListLength() ? '150px' : '120px' }">
         <li title="Discard all pending changes"><a ng-click="discardChanges()" ng-class="{'oppia-disabled-link': !getChangeListLength()}" class="dropdown-item">Discard Draft</a></li>

--- a/core/templates/pages/story-editor-page/story-editor-page.component.html
+++ b/core/templates/pages/story-editor-page/story-editor-page.component.html
@@ -35,7 +35,7 @@
         </li>
 
         <li ng-if="!($ctrl.getActiveTab() === 'chapter_editor')" ng-class="{'navbar-tab-active': $ctrl.getActiveTab() === 'story_preview'}" class="nav-item icon nav-list-item" ng-click="$ctrl.navigateToStoryPreviewTab()">
-          <a class="nav-link navbar-tab" uib-tooltip="Preview" tooltip-placement="bottom">
+          <a class="nav-link navbar-tab" uib-tooltip="Preview" aria-label="Preview" tooltip-placement="bottom">
             <i class="material-icons navbar-tab-icon" ng-class="{'navbar-tab-active-icon': $ctrl.getActiveTab() === 'story_preview'}">&#xE037;</i>
           </a>
         </li>

--- a/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.directive.html
+++ b/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.directive.html
@@ -25,7 +25,7 @@
         </span>
       </button>
       <button type="button" style="height: 34px;" class="btn btn-light uib-dropdown-toggle dropdown-toggle"
-              ng-disabled="!getChangeListLength()" uib-dropdown-toggle>
+              ng-disabled="!getChangeListLength()" aria-label="Dropdown toggle" uib-dropdown-toggle>
       </button>
       <ul uib-dropdown-menu role="menu" style="min-width: 125px; right: inherit;" ng-style="{ width: getChangeListLength() && topicRights.isPublished() ? '150px' : '120px' }">
         <li title="Discard all pending changes"><a ng-click="discardChanges()" ng-class="{'oppia-disabled-link': !getChangeListLength()}" class="dropdown-item">Discard Draft</a></li>

--- a/core/templates/pages/topics-and-skills-dashboard-page/templates/create-new-skill-modal.template.html
+++ b/core/templates/pages/topics-and-skills-dashboard-page/templates/create-new-skill-modal.template.html
@@ -11,7 +11,7 @@
       </div>
       <input type="text" class="form-control protractor-test-new-skill-description-field"
              placeholder="eg: Adding Fractions" ng-change="updateSkillDescription()" ng-model="newSkillDescription"
-             autofocus maxlength="<[MAX_CHARS_IN_SKILL_DESCRIPTION]>">
+             autofocus maxlength="<[MAX_CHARS_IN_SKILL_DESCRIPTION]>" aria-label="Skill Description">
       <span class="oppia-input-box-subtitle">
         <i>
           Skill description should be at most <[MAX_CHARS_IN_SKILL_DESCRIPTION]> characters.


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->


**This PR does the following:** 

1. Labels unlabeled buttons and form elements in the Skill_Editor, Stewards, Story_Editor page
2. Moved ng-click="$ctrl.selectPreviewTab() from `<a>` tag to `<li> `tag
3. Review_tests loads the question-player-component which was already fixed in practice sessions.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
