### PR TITLE
Fix linting error caused by new eslint checks

### DIFF
--- a/core/templates/domain/platform_feature/platform-parameter-filter-object.factory.ts
+++ b/core/templates/domain/platform_feature/platform-parameter-filter-object.factory.ts
@@ -45,15 +45,15 @@ export enum ServerMode {
  */
 export interface PlatformParameterFilterBackendDict {
   'type': PlatformParameterFilterType;
-  'conditions': Array<[string, string]>;
+  'conditions': [string, string][];
 }
 
 export class PlatformParameterFilter {
   type: PlatformParameterFilterType;
-  conditions: Array<[string, string]>;
+  conditions: [string, string][];
 
   constructor(
-      type: PlatformParameterFilterType, conditions: Array<[string, string]>) {
+      type: PlatformParameterFilterType, conditions: [string, string][]) {
     this.type = type;
     this.conditions = conditions;
   }


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of N/A.
2. This PR does the following:
    - fixed linting error on `Array<T>`, replaced them with `T[]`

#10190 introduced linting error on usage of `Array<T>` to the develop branch, this PR fixes this.

@nishantwrp Sorry for the inconvenience caused, I did not noticed the latest changes on eslint config before I merged #10190, could you PTAL at this fix?

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
