### PR TITLE
Fix backend test error introduced in #10021

### DIFF
--- a/core/controllers/admin_test.py
+++ b/core/controllers/admin_test.py
@@ -852,7 +852,7 @@ class AdminIntegrationTest(test_utils.GenericTestBase):
             self.assertEqual(
                 response['error'],
                 'Feature in dev stage cannot be enabled in test or production '
-                'environment.')
+                'environments.')
 
         platform_parameter_registry.Registry.parameter_registry.pop(
             feature.name)


### PR DESCRIPTION
## Overview

Merging #10021 and #10368 caused a mismatch in the error message that caused the backend test of develop branch to fail, this PR fixed this.

1. This PR fixes or fixes part of N/A.
2. This PR does the following:
  * fixed the backend test error, [logs](https://github.com/oppia/oppia/runs/1009184274)

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
