### PR TITLE
Fix #10385: Initialize directiveSubscriptions in music notes interaction directive

### DIFF
--- a/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.directive.ts
+++ b/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.directive.ts
@@ -119,7 +119,7 @@ angular.module('oppia').directive('oppiaInteractiveMusicNotesInput', [
         scope.initialSequence = scope.interactionIsActive ?
           initialSequence :
           scope.getLastAnswer();
-
+        scope.directiveSubscriptions = new Subscription();
         scope.directiveSubscriptions.add(
           PlayerPositionService.onNewCardAvailable.subscribe(() => {
             scope.interactionIsActive = false;


### PR DESCRIPTION

## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of https://github.com/oppia/oppia/issues/10385.
2. This PR does the following:
- Initialize directiveSubscriptions in music notes interaction directive 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
