### PR TITLE
Fix part of #7450: modified library_test.LibraryPageTests to use public API

### DIFF
--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -141,8 +141,7 @@ class LibraryPageTests(test_utils.GenericTestBase):
         exploration = self.save_new_valid_exploration(
             'A', self.admin_id, title='Title A', category='Category A',
             objective='Objective A')
-        exp_services._save_exploration(  # pylint: disable=protected-access
-            self.admin_id, exploration, 'Exploration A', [])
+        exp_services.update_exploration(self.admin_id, 'A', [], 'Exploration A')
 
         # Test that the private exploration isn't displayed.
         response_dict = self.get_json(feconf.LIBRARY_SEARCH_DATA_URL)
@@ -152,8 +151,7 @@ class LibraryPageTests(test_utils.GenericTestBase):
         exploration = self.save_new_valid_exploration(
             'B', self.admin_id, title='Title B', category='Category B',
             objective='Objective B')
-        exp_services._save_exploration(  # pylint: disable=protected-access
-            self.admin_id, exploration, 'Exploration B', [])
+        exp_services.update_exploration(self.admin_id, 'B', [], 'Exploration B')
         rights_manager.publish_exploration(self.admin, 'B')
 
         # Publish exploration A.

--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -138,7 +138,7 @@ class LibraryPageTests(test_utils.GenericTestBase):
         }, response_dict)
 
         # Create exploration A.
-        exploration = self.save_new_valid_exploration(
+        self.save_new_valid_exploration(
             'A', self.admin_id, title='Title A', category='Category A',
             objective='Objective A')
         exp_services.update_exploration(self.admin_id, 'A', [], 'Exploration A')
@@ -148,7 +148,7 @@ class LibraryPageTests(test_utils.GenericTestBase):
         self.assertEqual(response_dict['activity_list'], [])
 
         # Create exploration B.
-        exploration = self.save_new_valid_exploration(
+        self.save_new_valid_exploration(
             'B', self.admin_id, title='Title B', category='Category B',
             objective='Objective B')
         exp_services.update_exploration(self.admin_id, 'B', [], 'Exploration B')


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #7450 .
2. This PR does the following:
`Changes library_test.LibraryPageTests.test_library_handler_for_created_explorations` to use the public method `exp_services.update_exploration` instead of the private method `exp_services._save_exploration`

## Essential Checklist
- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
