### PR TITLE
Fix #10535: Use a variable for custom schema

### DIFF
--- a/extensions/objects/templates/image-with-regions-editor.directive.html
+++ b/extensions/objects/templates/image-with-regions-editor.directive.html
@@ -1,6 +1,6 @@
 <div ng-if="$ctrl.value.imagePath === ''">
   <schema-based-editor local-value="$ctrl.value.imagePath"
-                       schema="{type: 'custom', obj_type: 'Filepath'}">
+                       schema="$ctrl.SCHEMA">
   </schema-based-editor>
 </div>
 <div class="position-relative" ng-if="$ctrl.value.imagePath !== ''">

--- a/extensions/objects/templates/image-with-regions-editor.directive.ts
+++ b/extensions/objects/templates/image-with-regions-editor.directive.ts
@@ -531,6 +531,10 @@ angular.module('oppia').directive('imageWithRegionsEditor', [
             // The initializeEditor function is written separately since it
             // is also called in resetEditor function.
             ctrl.initializeEditor();
+            ctrl.SCHEMA = {
+              type: 'custom',
+              obj_type: 'Filepath'
+            };
           };
         }
       ]


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #10535
2. This PR does the following:

Uses a variable to pass schema object to schema-based-editor.

GIF
![imageClick](https://user-images.githubusercontent.com/11008603/91960355-70312d80-ed27-11ea-9544-5ae5b8a8680b.gif)



## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
