### PR TITLE
Fix #7712: Added 50 character limit to the continue button label.

### DIFF
--- a/extensions/interactions/Continue/Continue.py
+++ b/extensions/interactions/Continue/Continue.py
@@ -46,7 +46,11 @@ class Continue(base.BaseInteraction):
         'description': 'Button label',
         'schema': {
             'type': 'custom',
-            'obj_type': 'SubtitledUnicode'
+            'obj_type': 'SubtitledUnicode',
+            'validators': [{
+                'max_value': 50,
+                'id': 'has_length_at_most'
+            }]
         },
         'default_value': {
             'content_id': None,

--- a/extensions/interactions/Continue/directives/continue-validation.service.spec.ts
+++ b/extensions/interactions/Continue/directives/continue-validation.service.spec.ts
@@ -86,6 +86,15 @@ describe('ContinueValidationService', () => {
         message: 'The button text should not be empty.'
       }]);
 
+      customizationArguments.buttonText.value = (
+        new SubtitledUnicode('a'.repeat(51), 'ca_buttonText'));
+      warnings = validatorService.getAllWarnings(
+        currentState, customizationArguments, [], goodDefaultOutcome);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.CRITICAL,
+        message: 'The button text shouldn\'t be longer than 50 characters.'
+      }]);
+
       expect(() => {
         validatorService.getAllWarnings(
           // This throws "Argument of type '{}' is not assignable to

--- a/extensions/interactions/Continue/directives/continue-validation.service.ts
+++ b/extensions/interactions/Continue/directives/continue-validation.service.ts
@@ -29,6 +29,7 @@ import { Outcome } from
   'domain/exploration/OutcomeObjectFactory';
 
 import { AppConstants } from 'app.constants';
+import { InteractionSpecsConstants } from 'pages/interaction-specs.constants';
 
 @Injectable({
   providedIn: 'root'
@@ -44,10 +45,23 @@ export class ContinueValidationService {
     this.baseInteractionValidationServiceInstance.requireCustomizationArguments(
       customizationArgs, ['buttonText']);
 
+    var textSpecs = InteractionSpecsConstants.INTERACTION_SPECS.Continue;
+    var customizationArgSpecs = textSpecs.customization_arg_specs;
+    var buttonTextMaxLength = (
+      customizationArgSpecs[0].schema.validators[0].max_value);
+
     if (customizationArgs.buttonText.value.getUnicode().length === 0) {
       warningsList.push({
         type: AppConstants.WARNING_TYPES.CRITICAL,
         message: 'The button text should not be empty.'
+      });
+    }
+
+    if (customizationArgs.buttonText.value.getUnicode().length > (
+      buttonTextMaxLength)) {
+      warningsList.push({
+        type: AppConstants.WARNING_TYPES.CRITICAL,
+        message: 'The button text shouldn\'t be longer than 50 characters.'
       });
     }
     return warningsList;

--- a/extensions/interactions/interaction_specs.json
+++ b/extensions/interactions/interaction_specs.json
@@ -266,7 +266,13 @@
         "name": "buttonText",
         "schema": {
           "type": "custom",
-          "obj_type": "SubtitledUnicode"
+          "obj_type": "SubtitledUnicode",
+          "validators": [
+            {
+              "max_value": 50,
+              "id": "has_length_at_most"
+            }
+          ]
         },
         "default_value": {
           "content_id": null,


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #7712.
2. This PR does the following: Adds a validation that disallows continue button labels to be longer than 50 characters.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
