### PR TITLE
Convert base-undo-redo service to a typescript class.

### DIFF
--- a/core/templates/domain/editor/undo_redo/base-undo-redo.service.ts
+++ b/core/templates/domain/editor/undo_redo/base-undo-redo.service.ts
@@ -121,7 +121,7 @@ export class BaseUndoRedo {
     return committableChangeList;
   }
 
-  setChangesList(changeList: Change[]): void {
+  setChangeList(changeList: Change[]): void {
     this._appliedChanges = changeList;
   }
 

--- a/core/templates/domain/editor/undo_redo/base-undo-redo.service.ts
+++ b/core/templates/domain/editor/undo_redo/base-undo-redo.service.ts
@@ -13,179 +13,144 @@
 // limitations under the License.
 
 /**
- * @fileoverview Service which maintains a stack of changes to a domain object.
+ * @fileoverview class which maintains a stack of changes to a domain object.
  * Changes may be undone, redone, or replaced.
  */
 
 import { EventEmitter } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { BackendChangeObject, Change } from './ChangeObjectFactory';
 
 /**
  * Stores a stack of changes to a domain object. Please note that only one
- * instance of this service exists at a time, so multiple undo/redo stacks are
+ * instance of this class exists at a time, so multiple undo/redo stacks are
  * not currently supported.
  */
-angular.module('oppia').factory('BaseUndoRedoService', [
-  function() {
-    var BaseUndoRedoService = {};
+export class BaseUndoRedo {
+  private _appliedChanges: Change[] = [];
+  private _undoneChanges: Change[] = [];
+  _undoRedoChangeEventEmitter: EventEmitter<void> = new EventEmitter();
 
+  private _dispatchMutation(): void {
+    this._undoRedoChangeEventEmitter.emit();
+  }
+
+  private _applyChange(
+      Change: Change, domainObject: BackendChangeObject): void {
+    Change.applyChange(domainObject);
+    this._dispatchMutation();
+  }
+
+  private _reverseChange(
+      Change: Change, domainObject: BackendChangeObject): void {
+    Change.reverseChange(domainObject);
+    this._dispatchMutation();
+  }
+
+  init(): void {
     this._appliedChanges = [];
     this._undoneChanges = [];
-    var _undoRedoChangeEventEmitter = new EventEmitter();
-
-    var _dispatchMutation = () => {
-      _undoRedoChangeEventEmitter.emit();
-    };
-    var _applyChange = (changeObject, domainObject) => {
-      changeObject.applyChange(domainObject);
-      _dispatchMutation();
-    };
-    var _reverseChange = (changeObject, domainObject) => {
-      changeObject.reverseChange(domainObject);
-      _dispatchMutation();
-    };
-
-    // TODO(ankita240796): Remove the bracket notation once Angular2 gets in.
-    /* eslint-disable dot-notation */
-    BaseUndoRedoService['init'] = function() {
-      /* eslint-enable dot-notation */
-      this._appliedChanges = [];
-      this._undoneChanges = [];
-      _undoRedoChangeEventEmitter = new EventEmitter();
-    };
-
-    /**
-     * Pushes a change domain object onto the change stack and applies it to the
-     * provided domain object. When a new change is applied, all undone changes
-     * are lost and cannot be redone. This will fire an event as defined by the
-     * constant EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED.
-     */
-    // TODO(ankita240796): Remove the bracket notation once Angular2 gets in.
-    /* eslint-disable dot-notation */
-    BaseUndoRedoService['applyChange'] = function(changeObject, domainObject) {
-    /* eslint-enable dot-notation */
-      _applyChange(changeObject, domainObject);
-      this._appliedChanges.push(changeObject);
-      this._undoneChanges = [];
-    };
-
-    /**
-     * Undoes the last change to the provided domain object. This function
-     * returns false if there are no changes to undo, and true otherwise. This
-     * will fire an event as defined by the constant
-     * EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED.
-     */
-    // TODO(ankita240796): Remove the bracket notation once Angular2 gets in.
-    /* eslint-disable dot-notation */
-    BaseUndoRedoService['undoChange'] = function(domainObject) {
-      /* eslint-enable dot-notation */
-      if (this._appliedChanges.length !== 0) {
-        var change = this._appliedChanges.pop();
-        this._undoneChanges.push(change);
-        _reverseChange(change, domainObject);
-        return true;
-      }
-      return false;
-    };
-
-    /**
-     * Reverses an undo for the given domain object. This function returns false
-     * if there are no changes to redo, and true if otherwise. This will fire an
-     * event as defined by the constant EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED.
-     */
-    // TODO(ankita240796): Remove the bracket notation once Angular2 gets in.
-    /* eslint-disable dot-notation */
-    BaseUndoRedoService['redoChange'] = function(domainObject) {
-      /* eslint-enable dot-notation */
-      if (this._undoneChanges.length !== 0) {
-        var change = this._undoneChanges.pop();
-        this._appliedChanges.push(change);
-        _applyChange(change, domainObject);
-        return true;
-      }
-      return false;
-    };
-
-    /**
-     * Returns the current list of changes applied to the provided domain
-     * object. This list will not contain undone actions. Changes to the
-     * returned list will not be reflected in this service.
-     */
-    // TODO(ankita240796): Remove the bracket notation once Angular2 gets in.
-    /* eslint-disable dot-notation */
-    BaseUndoRedoService['getChangeList'] = function() {
-      /* eslint-enable dot-notation */
-      // TODO(bhenning): Consider integrating something like Immutable.js to
-      // avoid the slice here and ensure the returned object is truly an
-      // immutable copy.
-      return this._appliedChanges.slice();
-    };
-
-    /**
-     * Returns a list of commit dict updates representing all chosen changes in
-     * this service. Changes to the returned list will not affect this service.
-     * Furthermore, the returned list is ready to be sent to the backend.
-     */
-    // TODO(ankita240796): Remove the bracket notation once Angular2 gets in.
-    /* eslint-disable dot-notation */
-    BaseUndoRedoService['getCommittableChangeList'] = function() {
-      /* eslint-enable dot-notation */
-      var committableChangeList = [];
-      for (var i = 0; i < this._appliedChanges.length; i++) {
-        committableChangeList[i] =
-          this._appliedChanges[i].getBackendChangeObject();
-      }
-      return committableChangeList;
-    };
-
-    // TODO(ankita240796): Remove the bracket notation once Angular2 gets in.
-    /* eslint-disable dot-notation */
-    BaseUndoRedoService['setChangeList'] = function(changeList) {
-      /* eslint-enable dot-notation */
-      this._appliedChanges = angular.copy(changeList);
-    };
-
-    /**
-     * Returns the number of changes that have been applied to the domain
-     * object.
-     */
-    // TODO(ankita240796): Remove the bracket notation once Angular2 gets in.
-    /* eslint-disable dot-notation */
-    BaseUndoRedoService['getChangeCount'] = function() {
-      /* eslint-enable dot-notation */
-      return this._appliedChanges.length;
-    };
-
-    /**
-     * Returns whether this service has any applied changes.
-     */
-    // TODO(ankita240796): Remove the bracket notation once Angular2 gets in.
-    /* eslint-disable dot-notation */
-    BaseUndoRedoService['hasChanges'] = function() {
-    /* eslint-enable dot-notation */
-      return this._appliedChanges.length !== 0;
-    };
-
-    /**
-     * Clears the change history. This does not reverse any of the changes
-     * applied from applyChange() or redoChange(). This will fire an event as
-     * defined by the constant EVENT_UNDO_REDO_SERVICE_CHANGE_APPLIED.
-     */
-    // TODO(ankita240796): Remove the bracket notation once Angular2 gets in.
-    /* eslint-disable dot-notation */
-    BaseUndoRedoService['clearChanges'] = function() {
-      /* eslint-enable dot-notation */
-      this._appliedChanges = [];
-      this._undoneChanges = [];
-      this._undoRedoChangeAppliedEventEmitter = new EventEmitter();
-      _dispatchMutation();
-    };
-
-    /* eslint-disable dot-notation */
-    BaseUndoRedoService['onUndoRedoChangeApplied'] = function() {
-      /* eslint-enable dot-notation */
-      return _undoRedoChangeEventEmitter;
-    };
-
-    return BaseUndoRedoService;
   }
-]);
+
+  /**
+   * Pushes a change domain object onto the change stack and applies it to the
+   * provided domain object. When a new change is applied, all undone changes
+   * are lost and cannot be redone. This fires mutation event.
+   */
+  applyChange(change: Change, domainObject: BackendChangeObject): void {
+    this._applyChange(change, domainObject);
+    this._appliedChanges.push(change);
+    this._undoneChanges = [];
+  }
+
+  /**
+   * Undoes the last change to the provided domain object. This function
+   * returns false if there are no changes to undo, and true otherwise. This
+   * fires mutation event.
+   */
+  undoChange(domainObject: BackendChangeObject): boolean {
+    if (this._appliedChanges.length !== 0) {
+      var change = this._appliedChanges.pop();
+      this._undoneChanges.push(change);
+      this._reverseChange(change, domainObject);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Returns the current list of changes applied to the provided domain
+   * object. This list will not contain undone actions. Changes to the
+   * returned list will not be reflected in this class instance.
+   */
+  redoChange(domainObject: BackendChangeObject): boolean {
+    if (this._undoneChanges.length !== 0) {
+      var change = this._undoneChanges.pop();
+      this._appliedChanges.push(change);
+      this._applyChange(change, domainObject);
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Returns the current list of changes applied to the provided domain
+   * object. This list will not contain undone actions. Changes to the
+   * returned list will not be reflected in this class instance.
+   */
+  getChangeList(): Change[] {
+    // TODO(bhenning): Consider integrating something like Immutable.js to
+    // avoid the slice here and ensure the returned object is truly an
+    // immutable copy.
+    return this._appliedChanges.slice();
+  }
+
+  /**
+   * Returns a list of commit dict updates representing all chosen changes in
+   * this class instance. Changes to the returned list will not affect this
+   * instance. Furthermore, the returned list is ready to be sent to the
+   * backend.
+   */
+  getCommittableChangeList(): BackendChangeObject[] {
+    const committableChangeList: BackendChangeObject[] = [];
+    for (let i = 0; i < this._appliedChanges.length; i++) {
+      committableChangeList[i] =
+        this._appliedChanges[i].getBackendChangeObject();
+    }
+    return committableChangeList;
+  }
+
+  setChangesList(changeList: Change[]): void {
+    this._appliedChanges = changeList;
+  }
+
+  /**
+   * Returns the number of changes that have been applied to the domain
+   * object.
+   */
+  getChangeCount(): number {
+    return this._appliedChanges.length;
+  }
+
+  /**
+   * Returns whether this objcet has any applied changes.
+   */
+  hasChanges(): boolean {
+    return this._appliedChanges.length !== 0;
+  }
+
+  /**
+   * Clears the change history. This does not reverse any of the changes
+   * applied from applyChange() or redoChange(). This fires mutation event.
+   */
+  clearChanges(): void {
+    this._appliedChanges = [];
+    this._undoneChanges = [];
+    this._dispatchMutation();
+  }
+
+  onUndoRedoChangeApplied$(): Observable<void> {
+    return this._undoRedoChangeEventEmitter.asObservable();
+  }
+}

--- a/core/templates/domain/editor/undo_redo/question-undo-redo.service.ts
+++ b/core/templates/domain/editor/undo_redo/question-undo-redo.service.ts
@@ -17,9 +17,11 @@
  * domain object.
  */
 
+import { BaseUndoRedo } from './base-undo-redo.service';
+
 angular.module('oppia').factory('QuestionUndoRedoService', [
-  'BaseUndoRedoService', function(BaseUndoRedoService) {
-    var child = Object.create(BaseUndoRedoService);
+  function() {
+    var child = new BaseUndoRedo();
     child.init();
     return child;
   }

--- a/core/templates/domain/editor/undo_redo/undo-redo.service.ts
+++ b/core/templates/domain/editor/undo_redo/undo-redo.service.ts
@@ -16,11 +16,11 @@
  * @fileoverview Undo Redo Service.
  */
 
-require('domain/editor/undo_redo/base-undo-redo.service.ts');
+import { BaseUndoRedo } from './base-undo-redo.service';
 
 angular.module('oppia').factory('UndoRedoService', [
-  'BaseUndoRedoService', function(BaseUndoRedoService) {
-    var child = Object.create(BaseUndoRedoService);
+  function() {
+    var child = new BaseUndoRedo();
     child.init();
     return child;
   }

--- a/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.directive.ts
+++ b/core/templates/pages/collection-editor-page/navbar/collection-editor-navbar.directive.ts
@@ -211,7 +211,7 @@ angular.module('oppia').directive('collectionEditorNavbar', [
               )
             );
             ctrl.directiveSubscriptions.add(
-              UndoRedoService.onUndoRedoChangeApplied().subscribe(
+              UndoRedoService.onUndoRedoChangeApplied$().subscribe(
                 () => _validateCollection()
               )
             );

--- a/core/templates/pages/story-editor-page/navbar/story-editor-navbar.directive.ts
+++ b/core/templates/pages/story-editor-page/navbar/story-editor-navbar.directive.ts
@@ -211,7 +211,7 @@ angular.module('oppia').directive('storyEditorNavbar', [
             $scope.validationIssues = [];
             $scope.prepublishValidationIssues = [];
             ctrl.directiveSubscriptions.add(
-              UndoRedoService.onUndoRedoChangeApplied().subscribe(
+              UndoRedoService.onUndoRedoChangeApplied$().subscribe(
                 () => _validateStory()
               )
             );

--- a/core/templates/pages/story-editor-page/story-editor-page.component.spec.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.component.spec.ts
@@ -301,7 +301,7 @@ describe('Story editor page', function() {
 
   it('should init page on undo redo change applied', () => {
     let mockUndoRedoChangeEventEmitter = new EventEmitter();
-    spyOn(UndoRedoService, 'onUndoRedoChangeApplied').and.returnValue(
+    spyOn(UndoRedoService, 'onUndoRedoChangeApplied$').and.returnValue(
       mockUndoRedoChangeEventEmitter);
     spyOn(UrlService, 'getStoryIdFromUrl').and.returnValue('story_1');
     spyOn(PageTitleService, 'setPageTitle');

--- a/core/templates/pages/story-editor-page/story-editor-page.component.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.component.ts
@@ -211,7 +211,7 @@ angular.module('oppia').component('storyEditorPage', {
           StoryEditorNavigationService.navigateToStoryPreviewTab();
         }
         ctrl.directiveSubscriptions.add(
-          UndoRedoService.onUndoRedoChangeApplied().subscribe(
+          UndoRedoService.onUndoRedoChangeApplied$().subscribe(
             () => _initPage()
           )
         );

--- a/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.directive.ts
+++ b/core/templates/pages/topic-editor-page/navbar/topic-editor-navbar.directive.ts
@@ -316,7 +316,7 @@ angular.module('oppia').directive('topicEditorNavbar', [
             $scope.prepublishValidationIssues = [];
             $scope.topicRights = TopicEditorStateService.getTopicRights();
             ctrl.directiveSubscriptions.add(
-              UndoRedoService.onUndoRedoChangeApplied().subscribe(
+              UndoRedoService.onUndoRedoChangeApplied$().subscribe(
                 () => _validateTopic()
               )
             );

--- a/core/templates/pages/topic-editor-page/topic-editor-page.component.ts
+++ b/core/templates/pages/topic-editor-page/topic-editor-page.component.ts
@@ -191,7 +191,7 @@ angular.module('oppia').directive('topicEditorPage', [
             ctrl.warningsAreShown = false;
             BottomNavbarStatusService.markBottomNavbarStatus(true);
             ctrl.directiveSubscriptions.add(
-              UndoRedoService.onUndoRedoChangeApplied().subscribe(
+              UndoRedoService.onUndoRedoChangeApplied$().subscribe(
                 () => setPageTitle()
               )
             );


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #N/A.
2. This PR does the following:

- Converts base-undo-redo service to a ts class.


## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
