### PR TITLE
Fix #10538: Revert CODEOWNER files back to @vojtechjelinek

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,8 +39,7 @@
 /core/templates/domain/ @kevintab95
 /core/templates/pages/ @seanlip
 /core/templates/services/ @nithusha21
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/extensions/ @seanlip
+/extensions/ @vojtechjelinek
 /scripts/ @ankita240796
 
 
@@ -68,8 +67,7 @@
 /core/templates/services/UpgradedServices.ts @bansalnitish @srijanreddy98
 /typings/ @ankita240796
 /tsconfig.json @ankita240796
-# TODO(#10538): Add @vojtechjelinek as an owner after 2020-09-06.
-/tsconfig-strict.json @nishantwrp
+/tsconfig-strict.json @nishantwrp @vojtechjelinek
 
 
 # Answer classification team.
@@ -175,16 +173,14 @@
 # Exploration project.
 /core/controllers/editor*.py @aks681
 /core/controllers/reader*.py @aks681
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/core/controllers/resources*.py @seanlip
+/core/controllers/resources*.py @vojtechjelinek
 /core/domain/exp*.py @aks681
 /core/domain/fs*.py @aks681
 /core/domain/param_domain*.py @aks681
 /core/domain/rating_services*.py @aks681
 /core/domain/state_domain*.py @aks681
 /core/domain/summary_services*.py @aks681
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/core/domain/value_generators_domain*.py @seanlip
+/core/domain/value_generators_domain*.py @vojtechjelinek
 /core/storage/exploration/ @aks681
 /core/templates/components/entity-creation-services/exploration-creation.service*.ts @kevintab95
 /core/templates/components/button-directives/hint-and-solution-buttons.directive*.ts @kevintab95
@@ -294,11 +290,9 @@
 /core/templates/services/guppy-initialization.service.ts @aks681
 /core/templates/services/math-interactions.service.ts @aks681
 /extensions/domain*.py @brianrodri
-# TODO(#10538): Add @vojtechjelinek as an owner after 2020-09-06.
-/extensions/interactions/ @aks681 @seanlip
+/extensions/interactions/ @aks681 @vojtechjelinek
 /extensions/objects/ @aks681
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/extensions/value_generators/ @seanlip
+/extensions/value_generators/ @vojtechjelinek
 /extensions/__init__.py @aks681
 
 
@@ -451,8 +445,7 @@
 /core/templates/app.constants.ajs.ts @ankita240796
 /core/templates/app-type.constants.ts @nishantwrp @ankita240796
 /core/templates/combined-tests.spec.ts @ankita240796
-# TODO(#10538): Add @vojtechjelinek as an owner after 2020-09-06.
-/core/templates/pages/interaction-specs.constants.ajs.ts @jameesjohn
+/core/templates/pages/interaction-specs.constants.ajs.ts @jameesjohn @vojtechjelinek
 /core/templates/pages/interaction-specs.constants.ts @bansalnitish
 /core/templates/I18nFooter.ts @nithusha21
 /core/templates/i18n-footer.directive.html @nithusha21
@@ -508,14 +501,10 @@
 /core/templates/services/rte-helper.service*.ts @aks681
 /core/templates/services/rte-helper-modal.controller*.ts @aks681
 /core/domain/image_validation_services*.py @DubeySandeep
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/core/domain/rte_component_registry*.py @seanlip
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/extensions/ckeditor_plugins/ @seanlip
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/extensions/rich_text_components/ @seanlip
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/assets/rich_text_components_definitions.ts @seanlip
+/core/domain/rte_component_registry*.py @vojtechjelinek
+/extensions/ckeditor_plugins/ @vojtechjelinek
+/extensions/rich_text_components/ @vojtechjelinek
+/assets/rich_text_components_definitions.ts @vojtechjelinek
 
 
 # Suggestion and feedback team.
@@ -539,68 +528,63 @@
 /core/templates/pages/exploration-editor-page/feedback-tab/ @nithusha21
 
 
-# TODO(#10538): Add @vojtechjelinek as an owner for all simple pages
-# after 2020-09-06.
 # Simple pages.
-/core/controllers/pages*.py @jameesjohn
-/core/controllers/custom_landing_pages*.py @jameesjohn
-/core/templates/pages/contact-page/ @jameesjohn
-/core/templates/pages/delete-account-page/ @jameesjohn
-/core/templates/pages/donate-page/ @jameesjohn
-/core/templates/pages/error-pages/ @jameesjohn
-/core/templates/pages/get-started-page/ @jameesjohn
-/core/templates/pages/landing-pages/ @jameesjohn
-/core/templates/pages/maintenance-page/ @jameesjohn
-/core/templates/pages/pending-account-deletion-page/ @jameesjohn
-/core/templates/pages/preferences-page/ @jameesjohn
-/core/templates/pages/signup-page/ @jameesjohn
-/core/templates/pages/splash-page/ @jameesjohn
-/core/templates/pages/teach-page/ @jameesjohn
-/core/templates/pages/thanks-page/ @jameesjohn
+/core/controllers/pages*.py @jameesjohn @vojtechjelinek
+/core/controllers/custom_landing_pages*.py @jameesjohn @vojtechjelinek
+/core/templates/pages/contact-page/ @jameesjohn @vojtechjelinek
+/core/templates/pages/delete-account-page/ @jameesjohn @vojtechjelinek
+/core/templates/pages/donate-page/ @jameesjohn @vojtechjelinek
+/core/templates/pages/error-pages/ @jameesjohn @vojtechjelinek
+/core/templates/pages/get-started-page/ @jameesjohn @vojtechjelinek
+/core/templates/pages/landing-pages/ @jameesjohn @vojtechjelinek
+/core/templates/pages/maintenance-page/ @jameesjohn @vojtechjelinek
+/core/templates/pages/pending-account-deletion-page/ @jameesjohn @vojtechjelinek
+/core/templates/pages/preferences-page/ @jameesjohn @vojtechjelinek
+/core/templates/pages/signup-page/ @jameesjohn @vojtechjelinek
+/core/templates/pages/splash-page/ @jameesjohn @vojtechjelinek
+/core/templates/pages/teach-page/ @jameesjohn @vojtechjelinek
+/core/templates/pages/thanks-page/ @jameesjohn @vojtechjelinek
 
 
-# TODO(#10538): Add @vojtechjelinek as an owner or replace @seanlip for all
-# Speed Improvement team files after 2020-09-06.
 # Speed Improvement team.
-/app_dev.yaml @seanlip
-/core/templates/google-analytics.initializer.ts @jameesjohn
-/core/templates/base-components/ @jameesjohn
-/core/templates/pages/Base.ts @jameesjohn
-/core/templates/pages/oppia_footer_directive.html @jameesjohn
-/core/templates/pages/OppiaFooterDirective.ts @jameesjohn
-/core/templates/pages/footer_js_libs.html @jameesjohn
-/core/templates/pages/header_css_libs.html @jameesjohn
-/core/templates/pages/header_js_libs.html @jameesjohn
-/core/templates/services/csrf-token.service*.ts @jameesjohn
-/core/templates/third-party-imports/ @nishantwrp
-/jinja_utils*.py @jameesjohn
-/.lighthouserc.js @jimbyo @jameesjohn
-/puppeteer-login-script.js @jimbyo
-/scripts/run_lighthouse_tests.py @jameesjohn
-/webpack.*.ts @nishantwrp
+/app_dev.yaml @vojtechjelinek
+/core/templates/google-analytics.initializer.ts @jameesjohn @vojtechjelinek
+/core/templates/base-components/ @jameesjohn @vojtechjelinek
+/core/templates/pages/Base.ts @jameesjohn @vojtechjelinek
+/core/templates/pages/oppia_footer_directive.html @jameesjohn @vojtechjelinek
+/core/templates/pages/OppiaFooterDirective.ts @jameesjohn @vojtechjelinek
+/core/templates/pages/footer_js_libs.html @jameesjohn @vojtechjelinek
+/core/templates/pages/header_css_libs.html @jameesjohn @vojtechjelinek
+/core/templates/pages/header_js_libs.html @jameesjohn @vojtechjelinek
+/core/templates/services/csrf-token.service*.ts @jameesjohn @vojtechjelinek
+/core/templates/third-party-imports/ @nishantwrp @vojtechjelinek
+/jinja_utils*.py @jameesjohn @vojtechjelinek
+/.lighthouserc.js @jimbyo @jameesjohn @vojtechjelinek
+/puppeteer-login-script.js @jimbyo @vojtechjelinek
+/scripts/run_lighthouse_tests.py @jameesjohn @vojtechjelinek
+/webpack.*.ts @nishantwrp @vojtechjelinek
+
 
 # Typings.
 /typings @ankita240796 @nishantwrp
 /typings/tests/ @shavavo
 
-# TODO(#10538): Add @vojtechjelinek as an owner for all User Data Takeout files
-# after 2020-09-06.
+
 # User Data Takeout.
-/core/domain/takeout_*.py @seanlip
-/core/domain/wipeout_*.py @seanlip
+/core/domain/takeout_*.py @seanlip @vojtechjelinek
+/core/domain/wipeout_*.py @seanlip @vojtechjelinek
 
-# TODO(#10538): Revert ownership to @vojtechjelinek for all the User’s profile
-# page files after 2020-09-06.
+
 # User’s profile page.
-/core/controllers/profile*.py @seanlip
-/core/templates/domain/user/ @seanlip
-/core/templates/pages/profile-page/ @seanlip
-/core/templates/services/user.service*.ts @seanlip
+/core/controllers/profile*.py @vojtechjelinek
+/core/templates/domain/user/ @vojtechjelinek
+/core/templates/pages/profile-page/ @vojtechjelinek
+/core/templates/services/user.service*.ts @vojtechjelinek
 
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/core/templates/services/services.constants.ajs.ts @seanlip
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/core/templates/services/services.constants.ts @seanlip
+
+# Service constants
+/core/templates/services/services.constants.ajs.ts @vojtechjelinek
+/core/templates/services/services.constants.ts @vojtechjelinek
 
 
 # Dynamic Feature Gating project
@@ -627,8 +611,7 @@
 /core/tests/ @nithusha21
 /assets/ @nithusha21
 /data/ @nithusha21
-# TODO(#10538): Add @vojtechjelinek as an owner after 2020-09-06.
-/core/templates/karma.module.ts @nishantwrp
+/core/templates/karma.module.ts @nishantwrp @vojtechjelinek
 /core/tests/protractor_utils/ @U8NWXD @kevintab95
 /core/tests/protractor_desktop/ @U8NWXD @kevintab95
 /core/tests/protractor/ @U8NWXD @kevintab95
@@ -658,14 +641,10 @@
 /core/storage/ @seanlip
 /core/domain/user*.py @seanlip
 /export/ @seanlip
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/manifest.json @seanlip
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/package.json @seanlip
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/yarn.lock @seanlip
-# TODO(#10538): Revert ownership to @vojtechjelinek after 2020-09-06.
-/scripts/install_third_party_libs.py @seanlip
+/manifest.json @vojtechjelinek
+/package.json @vojtechjelinek
+/yarn.lock @vojtechjelinek
+/scripts/install_third_party_libs.py @vojtechjelinek
 /.github/ @DubeySandeep
 /.github/CODEOWNERS @DubeySandeep
 /.github/stale.yml @ankita240796


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #10538.
2. This PR does the following: Revert CODEOWNER files back to @vojtechjelinek.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays
- Never force push. If you do, your PR will be closed.
