### PR TITLE
Remove manual check for feconf verification

### DIFF
--- a/scripts/release_scripts/update_configs.py
+++ b/scripts/release_scripts/update_configs.py
@@ -147,7 +147,7 @@ def check_updates_to_terms_of_service(
 
 def verify_feconf(release_feconf_path):
     """Verifies that feconf is updated correctly to include
-    mailgun api key.
+    mailgun api key and redishost.
 
     Args:
         release_feconf_path: str. The path to feconf file in release
@@ -157,9 +157,11 @@ def verify_feconf(release_feconf_path):
         release_feconf_path, 'r').read()
     if ('MAILGUN_API_KEY' not in feconf_contents or
             'MAILGUN_API_KEY = None' in feconf_contents):
-        raise Exception(
-            'The mailgun API key must be added '
-            'before deployment.')
+        raise Exception('The mailgun API key must be added before deployment.')
+
+    if ('REDISHOST' not in feconf_contents or
+            'REDISHOST = \'localhost\'' in feconf_contents):
+        raise Exception('REDISHOST must be updated before deployment.')
 
 
 def add_mailgun_api_key(release_feconf_path):
@@ -232,11 +234,3 @@ def main(
         release_feconf_path, feconf_config_path, FECONF_REGEX)
     apply_changes_based_on_config(
         release_constants_path, constants_config_path, CONSTANTS_REGEX)
-
-    common.ask_user_to_confirm(
-        'Done! Please check %s and %s to ensure that '
-        'the changes made are correct. Specifically verify that the '
-        'MAILGUN_API_KEY and REDISHOST are updated correctly and '
-        'other config changes are corresponding to %s and %s.\n' % (
-            release_feconf_path, release_constants_path,
-            feconf_config_path, constants_config_path))

--- a/scripts/release_scripts/update_configs.py
+++ b/scripts/release_scripts/update_configs.py
@@ -145,17 +145,19 @@ def check_updates_to_terms_of_service(
                 f.write(line)
 
 
-def verify_feconf(release_feconf_path):
+def verify_feconf(release_feconf_path, verify_mailgun_api):
     """Verifies that feconf is updated correctly to include
     mailgun api key and redishost.
 
     Args:
+        verify_mailgun_api: bool. Whether to verify mailgun api key.
         release_feconf_path: str. The path to feconf file in release
             directory.
     """
     feconf_contents = python_utils.open_file(
         release_feconf_path, 'r').read()
-    if ('MAILGUN_API_KEY' not in feconf_contents or
+    if verify_mailgun_api and (
+            'MAILGUN_API_KEY' not in feconf_contents or
             'MAILGUN_API_KEY = None' in feconf_contents):
         raise Exception('The mailgun API key must be added before deployment.')
 
@@ -193,8 +195,6 @@ def add_mailgun_api_key(release_feconf_path):
             if line == 'MAILGUN_API_KEY = None\n':
                 line = line.replace('None', '\'%s\'' % mailgun_api_key)
             f.write(line)
-
-    verify_feconf(release_feconf_path)
 
 
 def main(
@@ -234,3 +234,4 @@ def main(
         release_feconf_path, feconf_config_path, FECONF_REGEX)
     apply_changes_based_on_config(
         release_constants_path, constants_config_path, CONSTANTS_REGEX)
+    verify_feconf(release_feconf_path, prompt_for_mailgun_and_terms_update)

--- a/scripts/release_scripts/update_configs_test.py
+++ b/scripts/release_scripts/update_configs_test.py
@@ -144,6 +144,7 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
 
         temp_feconf_path = tempfile.NamedTemporaryFile().name
         feconf_text = (
+            'REDISHOST = \'192.13.2.1\'\n'
             '# When the site terms were last updated, in UTC.\n'
             'REGISTRATION_PAGE_LAST_UPDATED_UTC = '
             'datetime.datetime(2015, 10, 14, 2, 40, 0)\n'
@@ -180,6 +181,7 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
 
         temp_feconf_path = tempfile.NamedTemporaryFile().name
         feconf_text = (
+            'REDISHOST = \'192.13.2.1\'\n'
             'MAILGUN_API_KEY = None\n'
             '# When the site terms were last updated, in UTC.\n'
             'REGISTRATION_PAGE_LAST_UPDATED_UTC = '
@@ -190,6 +192,7 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
             '# the existing storage models for UserStatsModel.\n'
             'DASHBOARD_STATS_DATETIME_STRING_FORMAT = \'YY-mm-dd\'\n')
         expected_feconf_text = (
+            'REDISHOST = \'192.13.2.1\'\n'
             'MAILGUN_API_KEY = \'%s\'\n'
             '# When the site terms were last updated, in UTC.\n'
             'REGISTRATION_PAGE_LAST_UPDATED_UTC = '
@@ -217,6 +220,7 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
 
         temp_feconf_path = tempfile.NamedTemporaryFile().name
         feconf_text = (
+            'REDISHOST = \'192.13.2.1\'\n'
             'MAILGUN_API_KEY = None\n'
             '# When the site terms were last updated, in UTC.\n'
             'REGISTRATION_PAGE_LAST_UPDATED_UTC = '
@@ -227,6 +231,7 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
             '# the existing storage models for UserStatsModel.\n'
             'DASHBOARD_STATS_DATETIME_STRING_FORMAT = \'YY-mm-dd\'\n')
         expected_feconf_text = (
+            'REDISHOST = \'192.13.2.1\'\n'
             'MAILGUN_API_KEY = \'%s\'\n'
             '# When the site terms were last updated, in UTC.\n'
             'REGISTRATION_PAGE_LAST_UPDATED_UTC = '
@@ -245,11 +250,12 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
         with python_utils.open_file(temp_feconf_path, 'r') as f:
             self.assertEqual(f.read(), expected_feconf_text)
 
-    def test_feconf_verification_with_key_present(self):
+    def test_feconf_verification_with_correct_config(self):
         mailgun_api_key = ('key-%s' % ('').join(['1'] * 32))
         temp_feconf_path = tempfile.NamedTemporaryFile().name
         feconf_text = (
             'MAILGUN_API_KEY = \'%s\'\n'
+            'REDISHOST = \'192.13.2.1\'\n'
             '# When the site terms were last updated, in UTC.\n'
             'REGISTRATION_PAGE_LAST_UPDATED_UTC = '
             'datetime.datetime(2015, 10, 14, 2, 40, 0)\n'
@@ -266,6 +272,7 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
     def test_feconf_verification_with_key_absent(self):
         temp_feconf_path = tempfile.NamedTemporaryFile().name
         feconf_text = (
+            'REDISHOST = \'192.13.2.1\'\n'
             '# When the site terms were last updated, in UTC.\n'
             'REGISTRATION_PAGE_LAST_UPDATED_UTC = '
             'datetime.datetime(2015, 10, 14, 2, 40, 0)\n'
@@ -278,6 +285,26 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
             f.write(feconf_text)
         with self.assertRaisesRegexp(
             Exception, 'The mailgun API key must be added before deployment.'):
+            update_configs.verify_feconf(temp_feconf_path)
+
+    def test_feconf_verification_with_redishost_absent(self):
+        mailgun_api_key = ('key-%s' % ('').join(['1'] * 32))
+        temp_feconf_path = tempfile.NamedTemporaryFile().name
+        feconf_text = (
+            'MAILGUN_API_KEY = \'%s\'\n'
+            '# When the site terms were last updated, in UTC.\n'
+            'REGISTRATION_PAGE_LAST_UPDATED_UTC = '
+            'datetime.datetime(2015, 10, 14, 2, 40, 0)\n'
+            '# Format of string for dashboard statistics logs.\n'
+            '# NOTE TO DEVELOPERS: This format should not be changed, '
+            'since it is used in\n'
+            '# the existing storage models for UserStatsModel.\n'
+            'DASHBOARD_STATS_DATETIME_STRING_FORMAT = \'YY-mm-dd\'\n' % (
+                mailgun_api_key))
+        with python_utils.open_file(temp_feconf_path, 'w') as f:
+            f.write(feconf_text)
+        with self.assertRaisesRegexp(
+            Exception, 'REDISHOST must be updated before deployment.'):
             update_configs.verify_feconf(temp_feconf_path)
 
     def test_invalid_config(self):
@@ -319,14 +346,12 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
         check_function_calls = {
             'check_updates_to_terms_of_service_gets_called': False,
             'add_mailgun_api_key_gets_called': False,
-            'apply_changes_based_on_config_gets_called': False,
-            'ask_user_to_confirm_gets_called': False
+            'apply_changes_based_on_config_gets_called': False
         }
         expected_check_function_calls = {
             'check_updates_to_terms_of_service_gets_called': True,
             'add_mailgun_api_key_gets_called': True,
-            'apply_changes_based_on_config_gets_called': True,
-            'ask_user_to_confirm_gets_called': True
+            'apply_changes_based_on_config_gets_called': True
         }
         def mock_check_updates(
                 unused_release_feconf_path, unused_personal_access_token):
@@ -339,8 +364,6 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
                 unused_expected_config_line_regex):
             check_function_calls[
                 'apply_changes_based_on_config_gets_called'] = True
-        def mock_ask_user_to_confirm(unused_msg):
-            check_function_calls['ask_user_to_confirm_gets_called'] = True
 
         check_updates_swap = self.swap(
             update_configs, 'check_updates_to_terms_of_service',
@@ -349,37 +372,29 @@ class UpdateConfigsTests(test_utils.GenericTestBase):
             update_configs, 'add_mailgun_api_key', mock_add_mailgun_api_key)
         apply_changes_swap = self.swap(
             update_configs, 'apply_changes_based_on_config', mock_apply_changes)
-        ask_user_swap = self.swap(
-            common, 'ask_user_to_confirm', mock_ask_user_to_confirm)
 
         with self.url_open_swap, check_updates_swap, add_mailgun_api_key_swap:
-            with apply_changes_swap, ask_user_swap:
+            with apply_changes_swap:
                 update_configs.main(
                     'test-release-dir', 'test-deploy-dir', 'test-token', True)
         self.assertEqual(check_function_calls, expected_check_function_calls)
 
     def test_function_calls_without_prompt_for_feconf_and_terms_update(self):
         check_function_calls = {
-            'apply_changes_based_on_config_gets_called': False,
-            'ask_user_to_confirm_gets_called': False
+            'apply_changes_based_on_config_gets_called': False
         }
         expected_check_function_calls = {
-            'apply_changes_based_on_config_gets_called': True,
-            'ask_user_to_confirm_gets_called': True
+            'apply_changes_based_on_config_gets_called': True
         }
         def mock_apply_changes(
                 unused_local_filepath, unused_config_filepath,
                 unused_expected_config_line_regex):
             check_function_calls[
                 'apply_changes_based_on_config_gets_called'] = True
-        def mock_ask_user_to_confirm(unused_msg):
-            check_function_calls['ask_user_to_confirm_gets_called'] = True
 
         apply_changes_swap = self.swap(
             update_configs, 'apply_changes_based_on_config', mock_apply_changes)
-        ask_user_swap = self.swap(
-            common, 'ask_user_to_confirm', mock_ask_user_to_confirm)
-        with ask_user_swap, apply_changes_swap:
+        with apply_changes_swap:
             update_configs.main(
                 'test-release-dir', 'test-deploy-dir', 'test-token', False)
         self.assertEqual(check_function_calls, expected_check_function_calls)


### PR DESCRIPTION
## Overview

~~1. This PR fixes or fixes part of N/A.~~
2. This PR does the following: Removes manual check for verification of addition of mailgun api key and redishost to feconf, instead a verify function does that automatically to ease the process.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
