### PR TITLE
Fix 10590: Update the naming of UserContributionScoringModel to UserContributionProficiencyModel in index.yaml.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -306,13 +306,13 @@ indexes:
   - name: commit_message
   - name: commit_type
 
-- kind: UserContributionScoringModel
+- kind: UserContributionProficiencyModel
   properties:
   - name: deleted
   - name: user_id
   - name: score
 
-- kind: UserContributionScoringModel
+- kind: UserContributionProficiencyModel
   properties:
   - name: realtime_layer
   - name: created_on


### PR DESCRIPTION
## Overview 
1. This PR fixes #10590 
2. This PR does the following: updates the naming of UserContributionScoringModel to UserContributionProficiencyModel in inedx.yaml following PR #10458 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
