### PR TITLE
Fix part of #10474: Cover BrowserCheckerService and BackgroundMaskService with strict checks

### DIFF
--- a/core/templates/domain/utilities/browser-checker.service.spec.ts
+++ b/core/templates/domain/utilities/browser-checker.service.spec.ts
@@ -22,7 +22,7 @@ import { BrowserCheckerService } from
 import { WindowRef } from 'services/contextual/window-ref.service';
 
 describe('Browser Checker Service', function() {
-  let bcs, wrs;
+  let bcs: BrowserCheckerService, wrs: WindowRef;
 
   let mockUserAgent: (ua: string) => void;
 
@@ -61,8 +61,8 @@ describe('Browser Checker Service', function() {
   });
 
   it('should not support speech synthesis', () => {
-    spyOn(wrs.nativeWindow, 'hasOwnProperty').withArgs('speechSynthesis').and
-      .returnValue(false);
+    spyOn(<Object>wrs.nativeWindow, 'hasOwnProperty')
+      .withArgs('speechSynthesis').and.returnValue(false);
     expect(bcs.supportsSpeechSynthesis()).toBe(false);
   });
 

--- a/core/templates/services/stateful/background-mask.service.spec.ts
+++ b/core/templates/services/stateful/background-mask.service.spec.ts
@@ -20,7 +20,7 @@ import { BackgroundMaskService } from
   'services/stateful/background-mask.service';
 
 describe('Background Mask Service', () => {
-  let backgroundMaskService;
+  let backgroundMaskService: BackgroundMaskService;
 
   beforeEach(() => {
     backgroundMaskService = new BackgroundMaskService();

--- a/tsconfig-strict.json
+++ b/tsconfig-strict.json
@@ -31,6 +31,8 @@
     }
   },
   "files": [
+    "core/templates/domain/utilities/browser-checker.service.ts",
+    "core/templates/domain/utilities/browser-checker.service.spec.ts",
     "core/templates/pages/admin-page/services/admin-router.service.ts",
     "core/templates/pages/admin-page/services/admin-router.service.spec.ts",
     "core/templates/pages/admin-page/services/admin-task-manager.service.ts",
@@ -39,6 +41,8 @@
     "core/templates/pages/exploration-editor-page/services/angular-name.service.spec.ts",
     "core/templates/services/math-interactions.service.ts",
     "core/templates/services/math-interactions.service.spec.ts",
+    "core/templates/services/stateful/background-mask.service.ts",
+    "core/templates/services/stateful/background-mask.service.spec.ts",
     "extensions/interactions/AlgebraicExpressionInput/directives/algebraic-expression-input-rules.service.ts",
     "extensions/interactions/AlgebraicExpressionInput/directives/algebraic-expression-input-rules.service.spec.ts",
   ],


### PR DESCRIPTION
… checks

## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #10474.
2. This PR does the following: Covers browser-checker service and background-mask service with strict typescript checks

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
