### PR TITLE
Fix part of #10306: added the async keyword in Email Dashboard data service

### DIFF
--- a/core/templates/pages/email-dashboard-pages/email-dashboard-data.service.spec.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-data.service.spec.ts
@@ -68,7 +68,7 @@ describe('Email Dashboard Services', () => {
             }
           }].map(emailDashboardQueryObjectFactory.createFromBackendDict);
 
-        emailDashboardDataService.getNextQueries();
+        emailDashboardDataService.getNextQueriesAsync();
 
         var req = httpTestingController.expectOne(
           req => (/.*?emaildashboarddatahandler?.*/g).test(req.url));
@@ -103,7 +103,7 @@ describe('Email Dashboard Services', () => {
         });
         var expectedQueries = [queryData];
 
-        emailDashboardDataService.submitQuery(data);
+        emailDashboardDataService.submitQueryAsync(data);
 
         var req = httpTestingController.expectOne('/emaildashboarddatahandler');
         expect(req.request.method).toEqual('POST');
@@ -137,7 +137,7 @@ describe('Email Dashboard Services', () => {
           status: 'processing'
         }].map(emailDashboardQueryObjectFactory.createFromQueryDict);
 
-        emailDashboardDataService.getNextQueries();
+        emailDashboardDataService.getNextQueriesAsync();
 
         var req = httpTestingController.expectOne(
           req => (/.*?emaildashboarddatahandler?.*/g).test(req.url));
@@ -159,7 +159,7 @@ describe('Email Dashboard Services', () => {
         expect(emailDashboardDataService.getQueries().length).toEqual(2);
         expect(emailDashboardDataService.getQueries()).toEqual(recentQueries);
 
-        emailDashboardDataService.fetchQuery('q123').then((query) => {
+        emailDashboardDataService.fetchQueryAsync('q123').then((query) => {
           expect(query.id).toEqual('q123');
           expect(query.status).toEqual('completed');
         });
@@ -185,7 +185,7 @@ describe('Email Dashboard Services', () => {
     it('should check simulation',
       fakeAsync(() => {
         // Get next page of queries.
-        emailDashboardDataService.getNextQueries();
+        emailDashboardDataService.getNextQueriesAsync();
 
         var req = httpTestingController.expectOne(
           req => (/.*?emaildashboarddatahandler?.*/g).test(req.url));
@@ -218,7 +218,7 @@ describe('Email Dashboard Services', () => {
             status: 'processing'
           };
 
-          emailDashboardDataService.submitQuery(data);
+          emailDashboardDataService.submitQueryAsync(data);
           totalQueries.unshift(queryData);
 
           var req = httpTestingController.expectOne(
@@ -239,7 +239,7 @@ describe('Email Dashboard Services', () => {
           totalQueriesResponse);
 
         // Check that queries on page 1 are correct.
-        emailDashboardDataService.getNextQueries().then(
+        emailDashboardDataService.getNextQueriesAsync().then(
           (queries) => {
             expect(queries.length).toEqual(10);
             expect(queries).toEqual(totalQueriesResponse.slice(10, 20));
@@ -247,7 +247,7 @@ describe('Email Dashboard Services', () => {
         expect(emailDashboardDataService.getCurrentPageIndex()).toEqual(1);
 
         // Check that queries on page 2 are correct.
-        emailDashboardDataService.getNextQueries().then(
+        emailDashboardDataService.getNextQueriesAsync().then(
           (queries) => {
             expect(queries.length).toEqual(5);
             expect(queries).toEqual(totalQueriesResponse.slice(20, 25));
@@ -265,7 +265,7 @@ describe('Email Dashboard Services', () => {
           status: 'processing'
         };
 
-        emailDashboardDataService.submitQuery(data);
+        emailDashboardDataService.submitQueryAsync(data);
 
         var req = httpTestingController.expectOne(
           '/emaildashboarddatahandler');
@@ -290,7 +290,7 @@ describe('Email Dashboard Services', () => {
           queryDataResponse);
 
         // Check queries on page 2.
-        emailDashboardDataService.getNextQueries().then(
+        emailDashboardDataService.getNextQueriesAsync().then(
           (queries) => {
             expect(queries.length).toEqual(6);
             expect(queries).toEqual(totalQueriesResponse.slice(20, 26));

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-data.service.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-data.service.ts
@@ -53,7 +53,7 @@ export class EmailDashboardDataService {
     return this.latestCursor;
   }
 
-  submitQuery(data: QueryData): Promise<EmailDashboardQuery[]> {
+  async submitQueryAsync(data: QueryData): Promise<EmailDashboardQuery[]> {
     var startQueryIndex = this.currentPageIndex * this.QUERIES_PER_PAGE;
     var endQueryIndex = (this.currentPageIndex + 1) * this.QUERIES_PER_PAGE;
 
@@ -65,7 +65,7 @@ export class EmailDashboardDataService {
     });
   }
 
-  getNextQueries(): Promise<EmailDashboardQuery[]> {
+  aync getNextQueriesAsync(): Promise<EmailDashboardQuery[]> {
     var startQueryIndex = (this.currentPageIndex + 1) * this.QUERIES_PER_PAGE;
     var endQueryIndex = (this.currentPageIndex + 2) * this.QUERIES_PER_PAGE;
 
@@ -102,7 +102,7 @@ export class EmailDashboardDataService {
     return (this.currentPageIndex > 0);
   }
 
-  fetchQuery(queryId: string): Promise<EmailDashboardQuery> {
+  async fetchQueryAsync(queryId: string): Promise<EmailDashboardQuery> {
     return this.emailDashboardBackendApiService.fetchQuery(queryId)
       .then(newQuery => {
         this.queries.forEach(function(query, index, queries) {

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-data.service.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-data.service.ts
@@ -65,7 +65,7 @@ export class EmailDashboardDataService {
     });
   }
 
-  aync getNextQueriesAsync(): Promise<EmailDashboardQuery[]> {
+  async getNextQueriesAsync(): Promise<EmailDashboardQuery[]> {
     var startQueryIndex = (this.currentPageIndex + 1) * this.QUERIES_PER_PAGE;
     var endQueryIndex = (this.currentPageIndex + 2) * this.QUERIES_PER_PAGE;
 

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.html
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.html
@@ -1,5 +1,5 @@
 <div class="oppia-query-form">
-  <form class="form" ng-submit="$ctrl.submitQuery()">
+  <form class="form" ng-submit="$ctrl.submitQueryAsync()">
     <label for="label-target-not-logged-n-days">Has not logged in for n days: </label>
     <input id="label-target-not-logged-n-days" type="number" min="0" ng-model="$ctrl.hasNotLoggedInForNDays">
     <br>

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.spec.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.spec.ts
@@ -113,13 +113,13 @@ describe('Email Dashboard Page', function() {
     ctrl.editedAtLeastNExps = true;
     ctrl.editedFewerThanNExps = false;
 
-    spyOn(EmailDashboardDataService, 'submitQuery').and.callFake(function() {
+    spyOn(EmailDashboardDataService, 'submitQueryAsync').and.callFake(function() {
       var deferred = $q.defer();
       deferred.resolve(firstPageQueries);
       return deferred.promise;
     });
 
-    ctrl.submitQuery();
+    ctrl.submitQueryAsync();
     $scope.$apply();
 
     expect(ctrl.currentPageOfQueries).toEqual(firstPageQueries);
@@ -134,7 +134,7 @@ describe('Email Dashboard Page', function() {
   });
 
   it('should get next page of queries', function() {
-    spyOn(EmailDashboardDataService, 'getNextQueries').and.callFake(
+    spyOn(EmailDashboardDataService, 'getNextQueriesAsync').and.callFake(
       function() {
         var deferred = $q.defer();
         deferred.resolve(secondPageQueries);
@@ -167,7 +167,7 @@ describe('Email Dashboard Page', function() {
   describe('recheckStatus', function() {
     it('should fetch query page again when getting next page of queries',
       function() {
-        spyOn(EmailDashboardDataService, 'getNextQueries').and.callFake(
+        spyOn(EmailDashboardDataService, 'getNextQueriesAsync').and.callFake(
           function() {
             var deferred = $q.defer();
             deferred.resolve(secondPageQueries);
@@ -180,7 +180,7 @@ describe('Email Dashboard Page', function() {
         expect(ctrl.currentPageOfQueries).toEqual(secondPageQueries);
 
         var updatedQuery = {id: 3, status: 'completed'};
-        spyOn(EmailDashboardDataService, 'fetchQuery').and.callFake(
+        spyOn(EmailDashboardDataService, 'fetchQueryAsync').and.callFake(
           function() {
             var deferred = $q.defer();
             deferred.resolve(updatedQuery);
@@ -202,7 +202,7 @@ describe('Email Dashboard Page', function() {
 
   it('should get user info and next queries after controller initialization',
     function() {
-      spyOn(EmailDashboardDataService, 'getNextQueries').and.callFake(
+      spyOn(EmailDashboardDataService, 'getNextQueriesAsync').and.callFake(
         function() {
           var deferred = $q.defer();
           deferred.resolve(secondPageQueries);

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.spec.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.spec.ts
@@ -113,7 +113,8 @@ describe('Email Dashboard Page', function() {
     ctrl.editedAtLeastNExps = true;
     ctrl.editedFewerThanNExps = false;
 
-    spyOn(EmailDashboardDataService, 'submitQueryAsync').and.callFake(function() {
+    spyOn(EmailDashboardDataService, 'submitQueryAsync').and.callFake(
+      function() {
       var deferred = $q.defer();
       deferred.resolve(firstPageQueries);
       return deferred.promise;

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.spec.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.spec.ts
@@ -115,10 +115,10 @@ describe('Email Dashboard Page', function() {
 
     spyOn(EmailDashboardDataService, 'submitQueryAsync').and.callFake(
       function() {
-      var deferred = $q.defer();
-      deferred.resolve(firstPageQueries);
-      return deferred.promise;
-    });
+        var deferred = $q.defer();
+        deferred.resolve(firstPageQueries);
+        return deferred.promise;
+      });
 
     ctrl.submitQueryAsync();
     $scope.$apply();

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.ts
@@ -45,7 +45,8 @@ angular.module('oppia').component('emailDashboardPage', {
           editedAtLeastNExps: ctrl.editedAtLeastNExps,
           editedFewerThanNExps: ctrl.editedFewerThanNExps
         };
-        EmailDashboardDataService.submitQueryAsync(data).then(function(queries) {
+        EmailDashboardDataService.submitQueryAsync(data).then(
+          function(queries) {
           ctrl.currentPageOfQueries = queries;
           // TODO(#8521): Remove the use of $rootScope.$apply()
           // once the directive is migrated to angular.

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.ts
@@ -47,11 +47,11 @@ angular.module('oppia').component('emailDashboardPage', {
         };
         EmailDashboardDataService.submitQueryAsync(data).then(
           function(queries) {
-          ctrl.currentPageOfQueries = queries;
-          // TODO(#8521): Remove the use of $rootScope.$apply()
-          // once the directive is migrated to angular.
-          $rootScope.$apply();
-        });
+            ctrl.currentPageOfQueries = queries;
+            // TODO(#8521): Remove the use of $rootScope.$apply()
+            // once the directive is migrated to angular.
+            $rootScope.$apply();
+          });
         ctrl.resetForm();
         ctrl.showSuccessMessage = true;
       };

--- a/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.ts
+++ b/core/templates/pages/email-dashboard-pages/email-dashboard-page.component.ts
@@ -36,7 +36,7 @@ angular.module('oppia').component('emailDashboardPage', {
         ctrl.editedFewerThanNExps = null;
       };
 
-      ctrl.submitQuery = function() {
+      ctrl.submitQueryAsync = async function() {
         var data = {
           hasNotLoggedInForNDays: ctrl.hasNotLoggedInForNDays,
           inactiveInLastNDays: ctrl.inactiveInLastNDays,
@@ -45,7 +45,7 @@ angular.module('oppia').component('emailDashboardPage', {
           editedAtLeastNExps: ctrl.editedAtLeastNExps,
           editedFewerThanNExps: ctrl.editedFewerThanNExps
         };
-        EmailDashboardDataService.submitQuery(data).then(function(queries) {
+        EmailDashboardDataService.submitQueryAsync(data).then(function(queries) {
           ctrl.currentPageOfQueries = queries;
           // TODO(#8521): Remove the use of $rootScope.$apply()
           // once the directive is migrated to angular.
@@ -57,7 +57,7 @@ angular.module('oppia').component('emailDashboardPage', {
 
       ctrl.getNextPageOfQueries = function() {
         if (EmailDashboardDataService.isNextPageAvailable()) {
-          EmailDashboardDataService.getNextQueries().then(
+          EmailDashboardDataService.getNextQueriesAsync().then(
             function(queries) {
               ctrl.currentPageOfQueries = queries;
               // TODO(#8521): Remove the use of $rootScope.$apply()
@@ -87,7 +87,7 @@ angular.module('oppia').component('emailDashboardPage', {
           ctrl.currentPageOfQueries[index] : null;
         if (query) {
           var queryId = query.id;
-          EmailDashboardDataService.fetchQuery(queryId).then(
+          EmailDashboardDataService.fetchQueryAsync(queryId).then(
             function(query) {
               ctrl.currentPageOfQueries[index] = query;
               // TODO(#8521): Remove the use of $rootScope.$apply()
@@ -110,7 +110,7 @@ angular.module('oppia').component('emailDashboardPage', {
         });
 
         ctrl.currentPageOfQueries = [];
-        EmailDashboardDataService.getNextQueries().then(function(queries) {
+        EmailDashboardDataService.getNextQueriesAsync().then(function(queries) {
           ctrl.currentPageOfQueries = queries;
           // TODO(#8521): Remove the use of $rootScope.$apply()
           // once the directive is migrated to angular.


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #10306 .
2. This PR added the async keyword in the ```oppia/oppia/core/templates/pages/email-dashboard-pages/email-dashboard-data.service.ts```.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
