### PR TITLE
Make customization args modal have a static backdrop.

### DIFF
--- a/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.directive.ts
+++ b/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.directive.ts
@@ -228,7 +228,7 @@ angular.module('oppia').directive('stateInteractionEditor', [
                   showMarkAllAudioAsNeedingUpdateModalIfRequired: () =>
                     $scope.showMarkAllAudioAsNeedingUpdateModalIfRequired
                 },
-                backdrop: true,
+                backdrop: 'static',
                 windowClass: 'customize-interaction-modal',
                 controller: 'CustomizeInteractionModalController'
               }).result.then(


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of N/A
2. This PR does the following: Makes the customization args modal in the exploration editor have a static backdrop, so that it doesn't close when you accidentally click outside it. (This keeps happening to me when editing explorations.)

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers
- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
