### PR TITLE
Add build only flag for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,14 @@ commands:
               circleci-agent step halt
             fi
 
+  webpack_build:
+    description: "Build Javascript files"
+    steps:
+      - run:
+          name: Builds Javascript files
+          command: |
+            python -m scripts.run_e2e_tests --prod_env --build-only
+
 jobs:
   setup_and_typescript_tests:
     <<: *job_defaults
@@ -140,12 +148,13 @@ jobs:
       - checkout
       - merge_target_branch
       - install_chrome
+      - webpack_build
       - attach_workspace:
           at: /home/circleci/
       - run:
           name: Run e2e navigation test
           command: |
-            python -m scripts.run_e2e_tests --prod_env --deparallelize_terser --skip-install --suite="navigation"
+            python -m scripts.run_e2e_tests --prod_env --deparallelize_terser --skip-install --skip-build --suite="navigation"
       - check_release_changelog_update_branch
       - run:
           name: Run e2e admin page test
@@ -168,6 +177,7 @@ jobs:
       - check_release_changelog_update_branch
       - merge_target_branch
       - install_chrome
+      - webpack_build
       - attach_workspace:
           at: /home/circleci/
       - run:
@@ -198,6 +208,7 @@ jobs:
       - check_release_changelog_update_branch
       - merge_target_branch
       - install_chrome
+      - webpack_build
       - attach_workspace:
           at: /home/circleci/
       - run:
@@ -231,12 +242,13 @@ jobs:
       - check_release_changelog_update_branch
       - merge_target_branch
       - install_chrome
+      - webpack_build
       - attach_workspace:
           at: /home/circleci/
       - run:
           name: Run e2e file upload features test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --suite="fileUploadFeatures"
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="fileUploadFeatures"
       - run:
           name: Run e2e play voiceovers test
           command: |
@@ -257,12 +269,13 @@ jobs:
       - check_release_changelog_update_branch
       - merge_target_branch
       - install_chrome
+      - webpack_build
       - attach_workspace:
           at: /home/circleci/
       - run:
           name: Run e2e topics and skills dashboard test
           command: |
-            python -m scripts.run_e2e_tests --skip-install --suite="topicsAndSkillsDashboard" --server_log_level=info
+            python -m scripts.run_e2e_tests --skip-install --skip-build --suite="topicsAndSkillsDashboard" --server_log_level=info
       - run:
           name: Run e2e topics and story editor
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,9 +148,9 @@ jobs:
       - checkout
       - merge_target_branch
       - install_chrome
-      - webpack_build
       - attach_workspace:
           at: /home/circleci/
+      - webpack_build
       - run:
           name: Run e2e navigation test
           command: |
@@ -177,9 +177,9 @@ jobs:
       - check_release_changelog_update_branch
       - merge_target_branch
       - install_chrome
-      - webpack_build
       - attach_workspace:
           at: /home/circleci/
+      - webpack_build
       - run:
           name: Run e2e publication test
           command: |
@@ -208,9 +208,9 @@ jobs:
       - check_release_changelog_update_branch
       - merge_target_branch
       - install_chrome
-      - webpack_build
       - attach_workspace:
           at: /home/circleci/
+      - webpack_build
       - run:
           name: Run e2e users test
           command: |
@@ -242,9 +242,9 @@ jobs:
       - check_release_changelog_update_branch
       - merge_target_branch
       - install_chrome
-      - webpack_build
       - attach_workspace:
           at: /home/circleci/
+      - webpack_build
       - run:
           name: Run e2e file upload features test
           command: |
@@ -269,9 +269,9 @@ jobs:
       - check_release_changelog_update_branch
       - merge_target_branch
       - install_chrome
-      - webpack_build
       - attach_workspace:
           at: /home/circleci/
+      - webpack_build
       - run:
           name: Run e2e topics and skills dashboard test
           command: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,15 +62,15 @@ script:
 - if [[ "$TRAVIS_PULL_REQUEST" == "false" ]] && [[ "$TRAVIS_PULL_REQUEST_BRANCH" == update-changelog-for-release* ]]; then RUN_TESTS=false; fi
 
 # Run the e2e tests in the production environment (using --prod_env).
-- if [ "$RUN_E2E_TESTS_ADDITIONAL_EDITOR_PLAYER_FEATURES" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="additionalEditorFeatures" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="additionalPlayerFeatures" --prod_env; fi
-- if [ "$RUN_E2E_TESTS_CORE_EDITOR_AND_PLAYER_FEATURES" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="coreEditorAndPlayerFeatures" --prod_env; fi
-- if [ "$RUN_E2E_TESTS_CREATOR_DASHBOARD_AND_IMPROVEMENTS_TAB" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="creatorDashboard" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationImprovementsTab" --prod_env; fi
-- if [ "$RUN_E2E_TESTS_EXPLORATION_FEEDBACK_AND_HISTORY_TAB" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="explorationFeedbackTab" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationHistoryTab" --prod_env; fi
-- if [ "$RUN_E2E_TESTS_EXPLORATION_STATISTICS_AND_TRANSLATION_TAB" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="explorationStatisticsTab" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationTranslationTab" --prod_env; fi
-- if [ "$RUN_E2E_TESTS_EXTENSIONS" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="extensions" --prod_env; fi
-- if [ "$RUN_E2E_TESTS_LEARNER" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="learner" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env; fi
-- if [ "$RUN_E2E_TESTS_SKILL_EDITOR" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="skillEditor" --prod_env; fi
-- if [ "$RUN_E2E_TESTS_EMBEDDING" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="embedding" --prod_env; fi
+- if [ "$RUN_E2E_TESTS_ADDITIONAL_EDITOR_PLAYER_FEATURES" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --skip-build --skip-install --suite="additionalEditorFeatures" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="additionalPlayerFeatures" --prod_env; fi
+- if [ "$RUN_E2E_TESTS_CORE_EDITOR_AND_PLAYER_FEATURES" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --skip-build --skip-install --suite="coreEditorAndPlayerFeatures" --prod_env; fi
+- if [ "$RUN_E2E_TESTS_CREATOR_DASHBOARD_AND_IMPROVEMENTS_TAB" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --skip-build --skip-install --suite="creatorDashboard" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationImprovementsTab" --prod_env; fi
+- if [ "$RUN_E2E_TESTS_EXPLORATION_FEEDBACK_AND_HISTORY_TAB" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationFeedbackTab" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationHistoryTab" --prod_env; fi
+- if [ "$RUN_E2E_TESTS_EXPLORATION_STATISTICS_AND_TRANSLATION_TAB" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationStatisticsTab" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationTranslationTab" --prod_env; fi
+- if [ "$RUN_E2E_TESTS_EXTENSIONS" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --skip-build --skip-install --suite="extensions" --prod_env; fi
+- if [ "$RUN_E2E_TESTS_LEARNER" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learner" --prod_env && python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env; fi
+- if [ "$RUN_E2E_TESTS_SKILL_EDITOR" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --skip-build --skip-install --suite="skillEditor" --prod_env; fi
+- if [ "$RUN_E2E_TESTS_EMBEDDING" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --skip-build --skip-install --suite="embedding" --prod_env; fi
 
 cache:
   # Cache Oppia's dependencies.

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -264,6 +264,7 @@ def build_js_files(
     Args:
         dev_mode_setting: bool. Represents whether to run the related commands
             in dev mode.
+        build_only: bool. Represents whether to run the build and exit.
         deparallelize_terser: bool. Represents whether to use webpack
             compilation config that disables parallelism on terser plugin.
         source_maps: bool. Represents whether to use source maps while
@@ -283,7 +284,7 @@ def build_js_files(
         build.main(args=[])
         run_webpack_compilation(source_maps=source_maps)
     if build_only:
-        sys.exit(1)
+        sys.exit(0)
 
 
 @contextlib.contextmanager

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -101,6 +101,11 @@ _PARSER.add_argument(
     help='If true, skips building files. The default value is false.',
     action='store_true')
 _PARSER.add_argument(
+    '--build-only',
+    help='If true, runs webpack build process and exits. The default '
+         'value is false.',
+    action='store_true')
+_PARSER.add_argument(
     '--sharding-instances', type=int, default=3,
     help='Sets the number of parallel browsers to open while sharding.'
          'Sharding must be disabled (either by passing in false to --sharding'
@@ -252,7 +257,8 @@ def setup_and_install_dependencies(skip_install):
 
 
 def build_js_files(
-        dev_mode_setting, deparallelize_terser=False, source_maps=False):
+        dev_mode_setting, build_only=False, deparallelize_terser=False,
+        source_maps=False):
     """Build the javascript files.
 
     Args:
@@ -276,6 +282,8 @@ def build_js_files(
     else:
         build.main(args=[])
         run_webpack_compilation(source_maps=source_maps)
+    if build_only:
+        sys.exit(1)
 
 
 @contextlib.contextmanager
@@ -537,7 +545,8 @@ def main(args=None):
         build.modify_constants(prod_env=parsed_args.prod_env)
     else:
         build_js_files(
-            dev_mode, deparallelize_terser=parsed_args.deparallelize_terser,
+            dev_mode, build_only=parsed_args.build_only,
+            deparallelize_terser=parsed_args.deparallelize_terser,
             source_maps=parsed_args.source_maps)
     version = parsed_args.chrome_driver_version or get_chrome_driver_version()
     python_utils.PRINT('\n\nCHROMEDRIVER VERSION: %s\n\n' % version)


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. ~This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following: Add build only flag for e2e tests and creates a new step in the CI configs that will just build javascript files.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
