### PR TITLE
Add NumericExpressionInput to android validation constants

### DIFF
--- a/core/domain/android_validation_constants.py
+++ b/core/domain/android_validation_constants.py
@@ -26,7 +26,7 @@ from __future__ import unicode_literals  # pylint: disable=import-only-modules
 VALID_INTERACTION_IDS = [
     'Continue', 'DragAndDropSortInput', 'EndExploration', 'FractionInput',
     'ImageClickInput', 'ItemSelectionInput', 'MultipleChoiceInput',
-    'NumericInput', 'NumberWithUnits', 'TextInput'
+    'NumericExpressionInput', 'NumericInput', 'NumberWithUnits', 'TextInput'
 ]
 
 SUPPORTED_LANGUAGES = ['en']

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -1156,6 +1156,8 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         self.assertTrue(init_state.interaction.is_supported_on_android_app())
         init_state.update_interaction_id('TextInput')
         self.assertTrue(init_state.interaction.is_supported_on_android_app())
+        init_state.update_interaction_id('NumericExpressionInput')
+        self.assertTrue(init_state.interaction.is_supported_on_android_app())
 
         # Invalid interactions.
         init_state.update_interaction_id('CodeRepl')


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. ~This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following: Add NumericExpressionInput to android validation constants
 
## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
