### PR TITLE
Add flag to provide custom release data dir for deployment

### DIFF
--- a/scripts/release_scripts/deploy.py
+++ b/scripts/release_scripts/deploy.py
@@ -70,6 +70,10 @@ _PARSER.add_argument(
     '--version', help='version to deploy', type=str)
 _PARSER.add_argument(
     '--maintenance_mode', action='store_true', default=False)
+_PARSER.add_argument(
+    '--release_dir_path',
+    help='Path to directory which contains all the files to be released',
+    type=str)
 
 APP_NAME_OPPIASERVER = 'oppiaserver'
 APP_NAME_OPPIATESTSERVER = 'oppiatestserver'
@@ -81,6 +85,7 @@ APP_DEV_YAML_PATH = os.path.join('.', 'app_dev.yaml')
 LOG_FILE_PATH = os.path.join('..', 'deploy.log')
 INDEX_YAML_PATH = os.path.join('.', 'index.yaml')
 THIRD_PARTY_DIR = os.path.join('.', 'third_party')
+FECONF_FILE_PATH = os.path.join('.', 'feconf.py')
 
 FILES_AT_ROOT = ['favicon.ico', 'robots.txt']
 IMAGE_DIRS = ['avatar', 'general', 'sidebar', 'logo']
@@ -521,15 +526,6 @@ def execute_deployment():
 
     current_branch_name = common.get_current_branch_name()
 
-    release_dir_name = 'deploy-%s-%s-%s' % (
-        '-'.join('-'.join(app_name.split('.')).split(':')),
-        current_branch_name,
-        CURRENT_DATETIME.strftime('%Y%m%d-%H%M%S'))
-    release_dir_path = os.path.join(os.getcwd(), '..', release_dir_name)
-
-    deploy_data_path = os.path.join(
-        os.getcwd(), os.pardir, 'release-scripts', 'deploy_data', app_name)
-
     install_third_party_libs.main()
 
     if not (common.is_current_branch_a_release_branch() or (
@@ -592,15 +588,39 @@ def execute_deployment():
     current_git_revision = subprocess.check_output(
         ['git', 'rev-parse', 'HEAD']).strip()
 
-    # Create a folder in which to save the release candidate.
-    python_utils.PRINT('Ensuring that the release directory parent exists')
-    common.ensure_directory_exists(os.path.dirname(release_dir_path))
+    if parsed_args.release_dir_path:
+        release_dir_path = parsed_args.release_dir_path
+        release_dir_name = os.path.basename(release_dir_path)
 
-    # Copy files to the release directory. Omits the .git subfolder.
-    python_utils.PRINT('Copying files to the release directory')
-    shutil.copytree(
-        os.getcwd(), release_dir_path,
-        ignore=shutil.ignore_patterns('.git'))
+        # These files are copied even when a existing dir is supplied
+        # since we want to overwrite any previous changes that were made
+        # to the config.
+        config_filepaths = [
+            APP_DEV_YAML_PATH, common.CONSTANTS_FILE_PATH,
+            FECONF_FILE_PATH, INDEX_YAML_PATH,
+        ]
+        for filepath in config_filepaths:
+            shutil.copyfile(
+                filepath, os.path.join(release_dir_path, filepath))
+    else:
+        release_dir_name = 'deploy-%s-%s-%s' % (
+            '-'.join('-'.join(app_name.split('.')).split(':')),
+            current_branch_name,
+            CURRENT_DATETIME.strftime('%Y%m%d-%H%M%S'))
+        release_dir_path = os.path.join(os.getcwd(), '..', release_dir_name)
+
+        # Create a folder in which to save the release candidate.
+        python_utils.PRINT('Ensuring that the release directory parent exists')
+        common.ensure_directory_exists(os.path.dirname(release_dir_path))
+
+        # Copy files to the release directory. Omits the .git subfolder.
+        python_utils.PRINT('Copying files to the release directory')
+        shutil.copytree(
+            os.getcwd(), release_dir_path,
+            ignore=shutil.ignore_patterns('.git'))
+
+    deploy_data_path = os.path.join(
+        os.getcwd(), os.pardir, 'release-scripts', 'deploy_data', app_name)
 
     # Change the current directory to the release candidate folder.
     with common.CD(release_dir_path):

--- a/scripts/release_scripts/deploy.py
+++ b/scripts/release_scripts/deploy.py
@@ -592,7 +592,7 @@ def execute_deployment():
         release_dir_path = parsed_args.release_dir_path
         release_dir_name = os.path.basename(release_dir_path)
 
-        # These files are copied even when a existing dir is supplied
+        # These files are copied even when an existing dir is supplied
         # since we want to overwrite any previous changes that were made
         # to the config.
         config_filepaths = [


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

~~1. This PR fixes or fixes part of N/A.~~
2. This PR does the following: Adds a flag to support deployment via a pre-existing release directory.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
