### PR TITLE
Changes default log level to 'error' for e2e tests

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -464,7 +464,7 @@ class BaseHandler(webapp2.RequestHandler):
                     current_user_services.create_login_url(self.request.uri))
             return
 
-        logging.info(b''.join(traceback.format_exception(*sys.exc_info())))
+        logging.error(b''.join(traceback.format_exception(*sys.exc_info())))
 
         if isinstance(exception, self.PageNotFoundException):
             logging.warning('Invalid URL requested: %s', self.request.uri)

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -1027,6 +1027,13 @@ class StateInteractionStatsHandlerTests(test_utils.GenericTestBase):
                 'Available states: [u\'Introduction\']'
             ]
         )
+        # The last log message is the traceback for an Exception. It cannot be
+        # exactly compared to a static string because the traceback includes
+        # filepaths which will vary depending on the machine that runs the
+        # test. So the starting portion of traceback that will remain
+        # constant is matched instead.
+        self.assertTrue(
+            'Traceback (most recent call last):' in observed_log_messages[2])
 
         self.logout()
 

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -1030,7 +1030,7 @@ class StateInteractionStatsHandlerTests(test_utils.GenericTestBase):
         # The last log message is the traceback for an Exception. It cannot be
         # exactly compared to a static string because the traceback includes
         # filepaths which will vary depending on the machine that runs the
-        # test. So the starting portion of traceback that will remain
+        # test. So the starting portion of the traceback that will remain
         # constant is matched instead.
         self.assertTrue(
             'Traceback (most recent call last):' in observed_log_messages[2])

--- a/core/controllers/editor_test.py
+++ b/core/controllers/editor_test.py
@@ -1019,8 +1019,9 @@ class StateInteractionStatsHandlerTests(test_utils.GenericTestBase):
                     exp_id, 'invalid_state_name'),
                 expected_status_int=404)
 
+        self.assertEqual(len(observed_log_messages), 3)
         self.assertEqual(
-            observed_log_messages,
+            observed_log_messages[:2],
             [
                 'Could not find state: invalid_state_name',
                 'Available states: [u\'Introduction\']'

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -139,8 +139,8 @@ _PARSER.add_argument(
 _PARSER.add_argument(
     '--server_log_level',
     help='Sets the log level for the appengine server. The default value is '
-         'set to critical.',
-    default='critical',
+         'set to error.',
+    default='error',
     choices=['critical', 'error', 'warning', 'info'])
 
 _PARSER.add_argument(

--- a/scripts/run_e2e_tests_test.py
+++ b/scripts/run_e2e_tests_test.py
@@ -785,8 +785,8 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
 
         expected_command = (
             '%s %s/dev_appserver.py --host 0.0.0.0 --port %s '
-            '--clear_datastore=yes --dev_appserver_log_level=critical '
-            '--log_level=critical --skip_sdk_update_check=true %s' % (
+            '--clear_datastore=yes --dev_appserver_log_level=error '
+            '--log_level=error --skip_sdk_update_check=true %s' % (
                 common.CURRENT_PYTHON_BIN, common.GOOGLE_APP_ENGINE_SDK_HOME,
                 run_e2e_tests.GOOGLE_APP_ENGINE_PORT,
                 'app_dev.yaml'))
@@ -800,14 +800,14 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
                 'shell': True,
             }])
         with popen_swap:
-            run_e2e_tests.start_google_app_engine_server(True, 'critical')
+            run_e2e_tests.start_google_app_engine_server(True, 'error')
 
     def test_start_google_app_engine_server_in_prod_mode(self):
 
         expected_command = (
             '%s %s/dev_appserver.py --host 0.0.0.0 --port %s '
-            '--clear_datastore=yes --dev_appserver_log_level=critical '
-            '--log_level=critical --skip_sdk_update_check=true %s' % (
+            '--clear_datastore=yes --dev_appserver_log_level=error '
+            '--log_level=error --skip_sdk_update_check=true %s' % (
                 common.CURRENT_PYTHON_BIN, common.GOOGLE_APP_ENGINE_SDK_HOME,
                 run_e2e_tests.GOOGLE_APP_ENGINE_PORT,
                 'app.yaml'))
@@ -821,7 +821,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
                 'shell': True,
             }])
         with popen_swap:
-            run_e2e_tests.start_google_app_engine_server(False, 'critical')
+            run_e2e_tests.start_google_app_engine_server(False, 'error')
 
     def test_start_tests_when_other_instances_not_stopped(self):
         def mock_exit(unused_exit_code):
@@ -916,7 +916,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         start_google_app_engine_server_swap = self.swap_with_checks(
             run_e2e_tests, 'start_google_app_engine_server',
             mock_start_google_app_engine_server,
-            expected_args=[(True, 'critical')])
+            expected_args=[(True, 'error')])
         wait_swap = self.swap_with_checks(
             common, 'wait_for_port_to_be_open',
             mock_wait_for_port_to_be_open,
@@ -1035,7 +1035,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         start_google_app_engine_server_swap = self.swap_with_checks(
             run_e2e_tests, 'start_google_app_engine_server',
             mock_start_google_app_engine_server,
-            expected_args=[(True, 'critical')])
+            expected_args=[(True, 'error')])
         wait_swap = self.swap_with_checks(
             common, 'wait_for_port_to_be_open',
             mock_wait_for_port_to_be_open,
@@ -1208,7 +1208,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         start_google_app_engine_server_swap = self.swap_with_checks(
             run_e2e_tests, 'start_google_app_engine_server',
             mock_start_google_app_engine_server,
-            expected_args=[(True, 'critical')])
+            expected_args=[(True, 'error')])
         wait_swap = self.swap_with_checks(
             common, 'wait_for_port_to_be_open',
             mock_wait_for_port_to_be_open,
@@ -1332,7 +1332,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         start_google_app_engine_server_swap = self.swap_with_checks(
             run_e2e_tests, 'start_google_app_engine_server',
             mock_start_google_app_engine_server,
-            expected_args=[(True, 'critical')])
+            expected_args=[(True, 'error')])
         wait_swap = self.swap_with_checks(
             common, 'wait_for_port_to_be_open',
             mock_wait_for_port_to_be_open,


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. ~This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following: 
Changes default log level to 'error' for e2e tests

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
