### PR TITLE
Fix appengine_config to monkeypatch versions for get_distribution

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -40,8 +40,7 @@ THIRD_PARTY_PYTHON_LIBS_PATH = os.path.join(THIRD_PARTY_PATH, 'python_libs')
 # Oppia in production mode locally, where a built-in PIL won't be available.
 # Hence the check for oppia_tools instead.
 if os.path.isdir(OPPIA_TOOLS_PATH):
-    PIL_PATH = os.path.join(
-        OPPIA_TOOLS_PATH, 'Pillow-6.2.2')
+    PIL_PATH = os.path.join(OPPIA_TOOLS_PATH, 'Pillow-6.2.2')
     if not os.path.isdir(PIL_PATH):
         raise Exception('Invalid path for oppia_tools library: %s' % PIL_PATH)
     sys.path.insert(0, PIL_PATH)

--- a/appengine_config_test.py
+++ b/appengine_config_test.py
@@ -1,0 +1,79 @@
+# coding: utf-8
+#
+# Copyright 2014 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for appengine_config.py."""
+
+from __future__ import absolute_import  # pylint: disable=import-only-modules
+from __future__ import unicode_literals  # pylint: disable=import-only-modules
+
+import appengine_config
+from core.tests import test_utils
+import pkg_resources
+
+
+class AppengineConfigTests(test_utils.GenericTestBase):
+    """Test the appengine config mock methods."""
+
+    def _mock_get_distribution_which_raises_error(self, distribution_name):
+        """Mock function for pkg_resources.get_distribution().
+
+        Args:
+            distribution_name: str. The name of the distribution to get the
+                Distribution object for.
+
+        Raises:
+            DistributionNotFound. This is always raised, in order to simulate
+            the case where the distribution does not exist (which is what
+            currently happens in a prod environment).
+        """
+        raise pkg_resources.DistributionNotFound(distribution_name, 'tests')
+
+    def test_monkeypatched_get_distribution_for_google_api_core(self):
+        """Test that the monkey-patched get_distribution() method returns an
+        object with a suitable version string for google-api-core.
+        """
+        with self.swap(
+            appengine_config, 'old_get_distribution',
+            self._mock_get_distribution_which_raises_error
+            ):
+            mock_distribution = appengine_config.monkeypatched_get_distribution(
+                'google-api-core')
+        self.assertEqual(mock_distribution.version, '1.22.2')
+
+    def test_monkeypatched_get_distribution_for_google_cloud_tasks(self):
+        """Test that the monkey-patched get_distribution() method returns an
+        object with a suitable version string for google-cloud-tasks.
+        """
+        with self.swap(
+            appengine_config, 'old_get_distribution',
+            self._mock_get_distribution_which_raises_error
+            ):
+            mock_distribution = appengine_config.monkeypatched_get_distribution(
+                'google-cloud-tasks')
+        self.assertEqual(mock_distribution.version, '1.5.0')
+
+    def test_monkeypatched_get_distribution_behaves_like_existing_one(self):
+        """Test that the monkey-patched get_distribution() method returns an
+        object with a suitable version string for google-cloud-tasks.
+        """
+        assert_raises_regexp_context_manager = self.assertRaisesRegexp(
+            pkg_resources.DistributionNotFound, 'invalid-lib')
+        with self.swap(
+            appengine_config, 'old_get_distribution',
+            self._mock_get_distribution_which_raises_error
+            ):
+            with assert_raises_regexp_context_manager:
+                appengine_config.monkeypatched_get_distribution('invalid-lib')


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A
2. This PR does the following: #10699 is causing the app to show 500 errors when deployed to production. This is due to issues with how third-party App Engine libs for Python 3 handle get_distribution(). This PR fixes it and has been tested to work in both dev and prod.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
