### PR TITLE
Fix transaction error in stats recording.

### DIFF
--- a/core/domain/stats_jobs_one_off.py
+++ b/core/domain/stats_jobs_one_off.py
@@ -151,7 +151,7 @@ class RegenerateMissingStateStatsOneOffJob(jobs.BaseMapReduceOneOffJobManager):
                         '%s.%s: %s' % (exp.id, exp.version, state_name)
                         ).encode('utf-8'))
 
-            stats_services.save_stats_model_transactional(stats)
+            stats_services.save_stats_model(stats)
 
     @staticmethod
     def reduce(reduce_key, values):

--- a/core/domain/stats_services_test.py
+++ b/core/domain/stats_services_test.py
@@ -74,7 +74,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             'Home': stats_domain.StateStats.create_default(),
             '🙂': stats_domain.StateStats.create_default(),
         }
-        stats_services.save_stats_model_transactional(exploration_stats)
+        stats_services.save_stats_model(exploration_stats)
 
         # Pass in exploration start event to stats model created in setup
         # function.
@@ -173,7 +173,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
         exploration_stats.state_stats_mapping = {
             'Home': stats_domain.StateStats.create_default()
         }
-        stats_services.save_stats_model_transactional(exploration_stats)
+        stats_services.save_stats_model(exploration_stats)
 
         aggregated_stats = {
             'num_starts': 1,
@@ -210,7 +210,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             'Home': stats_domain.StateStats.create_default(),
             # No stats for '🙂'.
         }
-        stats_services.save_stats_model_transactional(exploration_stats)
+        stats_services.save_stats_model(exploration_stats)
 
         aggregated_stats = {
             'num_starts': 1,
@@ -451,7 +451,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
         exploration_stats.num_starts_v2 = 3
         exploration_stats.num_actual_starts_v2 = 2
         exploration_stats.num_completions_v2 = 1
-        stats_services.save_stats_model_transactional(exploration_stats)
+        stats_services.save_stats_model(exploration_stats)
 
         # Update exploration to next version 2 and its stats.
         exp_services.update_exploration(
@@ -461,7 +461,7 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
         exploration_stats.num_starts_v2 = 4
         exploration_stats.num_actual_starts_v2 = 3
         exploration_stats.num_completions_v2 = 2
-        stats_services.save_stats_model_transactional(exploration_stats)
+        stats_services.save_stats_model(exploration_stats)
 
         # Revert to an older version.
         exp_services.revert_exploration(
@@ -1088,14 +1088,14 @@ class StatisticsServicesTests(test_utils.GenericTestBase):
             model.unresolved_issues[0],
             exp_issues.unresolved_issues[0].to_dict())
 
-    def test_save_stats_model_transactional(self):
-        """Test the save_stats_model_transactional method."""
+    def test_save_stats_model(self):
+        """Test the save_stats_model method."""
         exploration_stats = stats_services.get_exploration_stats_by_id(
             self.exp_id, self.exp_version)
         exploration_stats.num_starts_v2 += 15
         exploration_stats.num_actual_starts_v2 += 5
         exploration_stats.num_completions_v2 += 2
-        stats_services.save_stats_model_transactional(exploration_stats)
+        stats_services.save_stats_model(exploration_stats)
 
         exploration_stats = stats_services.get_exploration_stats_by_id(
             self.exp_id, self.exp_version)

--- a/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.html
+++ b/core/templates/pages/creator-dashboard-page/creator-dashboard-page.component.html
@@ -155,7 +155,7 @@
             <col class="oppia-colgroup-col-6">
           </colgroup>
           <tr>
-            <th ng-repeat="(key, value) in EXPLORATIONS_SORT_BY_KEYS"
+            <th ng-repeat="(key, value) in $ctrl.EXPLORATIONS_SORT_BY_KEYS"
                 class="oppia-dashboard-table-headings"
                 ng-click="$ctrl.setExplorationsSortingOptions(value)">
               <p ng-if="key === 'TITLE'" translate="I18N_DASHBOARD_TABLE_HEADING_EXPLORATION"></p>


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #N/A.
2. This PR does the following: This PR fixes a bug in the stats services that is leading to a failure in the e2e test. The transaction logic was implemented incorrectly, leading to a failure of stats to get recorded. The PR also fixes an error in the creator dashboard where the headers of the list view were not showing up.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
