### PR TITLE
Fix part of #10798: Replace click() with action.click() in core/tests/protractor_utils/LearnerDashboardPage.js

### DIFF
--- a/core/tests/protractor_utils/LearnerDashboardPage.js
+++ b/core/tests/protractor_utils/LearnerDashboardPage.js
@@ -18,6 +18,7 @@
  */
 
 var waitFor = require('./waitFor.js');
+var action = require('./action.js');
 
 var LearnerDashboardPage = function() {
   var LEARNER_DASHBOARD_URL = '/learner-dashboard';
@@ -54,47 +55,47 @@ var LearnerDashboardPage = function() {
   };
 
   this.navigateToPlayLaterExplorationSection = async function() {
-    await action.click('Play Later Explorations Tab', playLaterSection);
+    await action.click('Play Later Explorations tab', playLaterSection);
   };
 
   this.navigateToCompletedSection = async function() {
-    await action.click('Completed Tab', completedSection);
+    await action.click('Completed tab', completedSection);
   };
 
   this.navigateToInCompleteSection = async function() {
-    await action.click('In Progress Tab', incompleteSection);
+    await action.click('In Progress tab', incompleteSection);
   };
 
   this.navigateToIncompleteCollectionsSection = async function() {
     await action.click(
-      'In Progress Collections Tab', incompleteCollectionsSection);
+      'In Progress Collections tab', incompleteCollectionsSection);
   };
 
   this.navigateToIncompleteExplorationsSection = async function() {
     await action.click(
-      'In Progress Explorations Tab', incompleteExplorationsSection);
+      'In Progress Explorations tab', incompleteExplorationsSection);
   };
 
   this.navigateToCompletedCollectionsSection = async function() {
     await action.click(
-      'Completed Collections Tab', completedCollectionsSection);
+      'Completed Collections tab', completedCollectionsSection);
   };
 
   this.navigateToCompletedExplorationsSection = async function() {
     await action.click(
-      'Completed Explorations Tab', completedExplorationsSection);
+      'Completed Explorations tab', completedExplorationsSection);
   };
 
   this.navigateToFeedbackSection = async function() {
-    await action.click('Feedback Tab', feedbackSection);
+    await action.click('Feedback tab', feedbackSection);
   };
 
   this.navigateToFeedbackThread = async function() {
-    await action.click('Feedback Thread Tab', feedbackThread);
+    await action.click('Feedback Thread tab', feedbackThread);
   };
 
   this.navigateToSubscriptionsSection = async function() {
-    await action.click('Subscriptions Tab', subscriptionsSection);
+    await action.click('Subscriptions tab', subscriptionsSection);
   };
 
   this.expectTitleOfCollectionSummaryTileToMatch = async function(title) {

--- a/core/tests/protractor_utils/LearnerDashboardPage.js
+++ b/core/tests/protractor_utils/LearnerDashboardPage.js
@@ -117,6 +117,7 @@ var LearnerDashboardPage = function() {
     // that is the exploration with the title passed as a parameter.
     var explorationTitle = element(
       by.cssContainingText('.protractor-test-exp-summary-tile-title', title));
+    waitFor.visibilityOf(explorationTitle, 'Exploration title takes too long to appear');
     expect(await explorationTitle.getText()).toMatch(title);
   };
 

--- a/core/tests/protractor_utils/LearnerDashboardPage.js
+++ b/core/tests/protractor_utils/LearnerDashboardPage.js
@@ -117,7 +117,8 @@ var LearnerDashboardPage = function() {
     // that is the exploration with the title passed as a parameter.
     var explorationTitle = element(
       by.cssContainingText('.protractor-test-exp-summary-tile-title', title));
-    waitFor.visibilityOf(explorationTitle, 'Exploration title takes too long to appear');
+    waitFor.visibilityOf(explorationTitle,
+      'Exploration title takes too long to appear');
     expect(await explorationTitle.getText()).toMatch(title);
   };
 

--- a/core/tests/protractor_utils/LearnerDashboardPage.js
+++ b/core/tests/protractor_utils/LearnerDashboardPage.js
@@ -57,34 +57,38 @@ var LearnerDashboardPage = function() {
     await waitFor.elementToBeClickable(
       playLaterSection,
       'Play Later Exploration Section tab takes too long to be clickable');
-    await action.click('Play Later Explorations Tab', playLaterSection);
+    await action.click(
+      'Play Later Explorations Tab', playLaterSection);
   };
 
   this.navigateToCompletedSection = async function() {
     await waitFor.elementToBeClickable(
       completedSection, 'Completed tab takes too long to be clickable');
-    await action.click('Completed Tab', completedSection);
+    await action.click(
+      'Completed Tab', completedSection);
   };
 
   this.navigateToInCompleteSection = async function() {
     await waitFor.elementToBeClickable(
       incompleteSection, 'In Progress tab takes too long to be clickable');
-    await action.click('In Progress Tab', incompleteSection);
+    await action.click(
+      'In Progress Tab', incompleteSection);
   };
 
   this.navigateToIncompleteCollectionsSection = async function() {
     await waitFor.elementToBeClickable(
       incompleteCollectionsSection,
-      'In Progress Collections Section tab takes too long to be clickable');
-    await action.click('In Progress Collections Tab', 
-      incompleteCollectionsSection);
+      'In Progress Collections tab takes too long to be clickable');
+    await action.click(
+      'In Progress Collections Tab', incompleteCollectionsSection);
   };
 
   this.navigateToIncompleteExplorationsSection = async function() {
     await waitFor.elementToBeClickable(
       incompleteExplorationsSection,
-      'In Progress Explorations Section tab takes too long to be clickable');
-    await action.click('In Progress Explorations Tab', 
+      'In Progress Explorations tab takes too long to be clickable');
+    await action.click(
+      'In Progress Explorations Tab', 
       incompleteExplorationsSection);
   };
 
@@ -92,33 +96,38 @@ var LearnerDashboardPage = function() {
     await waitFor.elementToBeClickable(
       completedCollectionsSection,
       'Completed Collection tab takes too long to be clickable');
-    await action.click('Completed Collections Tab', completedCollectionsSection);
+    await action.click(
+      'Completed Collections Tab', completedCollectionsSection);
   };
 
   this.navigateToCompletedExplorationsSection = async function() {
     await waitFor.elementToBeClickable(
       completedExplorationsSection,
       'Completed Exploration tab takes too long to be clickable');
-    await action.click('Completed Explorations Tab', completedExplorationsSection);
+    await action.click(
+      'Completed Explorations Tab', completedExplorationsSection);
   };
 
   this.navigateToFeedbackSection = async function() {
     await waitFor.elementToBeClickable(
       feedbackSection, 'Feedback Section tab takes too long to be clickable');
-    await action.click('Feedback Tab', feedbackSection);
+    await action.click(
+      'Feedback Tab', feedbackSection);
   };
 
   this.navigateToFeedbackThread = async function() {
     await waitFor.elementToBeClickable(
       feedbackThread, 'Feedback Thread tab takes too long to be clickable');
-    await action.click('Feedback Thread Tab', feedbackThread);
+    await action.click(
+      'Feedback Thread Tab', feedbackThread);
   };
 
   this.navigateToSubscriptionsSection = async function() {
     await waitFor.elementToBeClickable(
       subscriptionsSection,
-      'Subscriptions Section tab takes too long to be clickable');
-    await action.click('Subscriptions Tab', subscriptionsSection);
+      'Subscriptions tab takes too long to be clickable');
+    await action.click(
+      'Subscriptions Tab', subscriptionsSection);
   };
 
   this.expectTitleOfCollectionSummaryTileToMatch = async function(title) {

--- a/core/tests/protractor_utils/LearnerDashboardPage.js
+++ b/core/tests/protractor_utils/LearnerDashboardPage.js
@@ -76,27 +76,29 @@ var LearnerDashboardPage = function() {
     await waitFor.elementToBeClickable(
       incompleteCollectionsSection,
       'In Progress Collections Section tab takes too long to be clickable');
-    await action.click('In Progress Collections Tab', incompleteCollectionsSection);
+    await action.click('In Progress Collections Tab', 
+      incompleteCollectionsSection);
   };
 
   this.navigateToIncompleteExplorationsSection = async function() {
     await waitFor.elementToBeClickable(
       incompleteExplorationsSection,
       'In Progress Explorations Section tab takes too long to be clickable');
-    await action.click('In Progress Explorations Tab', incompleteExplorationsSection);
+    await action.click('In Progress Explorations Tab', 
+      incompleteExplorationsSection);
   };
 
   this.navigateToCompletedCollectionsSection = async function() {
     await waitFor.elementToBeClickable(
       completedCollectionsSection,
-      'Completed Collection Section tab takes too long to be clickable');
+      'Completed Collection tab takes too long to be clickable');
     await action.click('Completed Collections Tab', completedCollectionsSection);
   };
 
   this.navigateToCompletedExplorationsSection = async function() {
     await waitFor.elementToBeClickable(
       completedExplorationsSection,
-      'Completed Exploration Section tab takes too long to be clickable');
+      'Completed Exploration tab takes too long to be clickable');
     await action.click('Completed Explorations Tab', completedExplorationsSection);
   };
 

--- a/core/tests/protractor_utils/LearnerDashboardPage.js
+++ b/core/tests/protractor_utils/LearnerDashboardPage.js
@@ -57,66 +57,66 @@ var LearnerDashboardPage = function() {
     await waitFor.elementToBeClickable(
       playLaterSection,
       'Play Later Exploration Section tab takes too long to be clickable');
-    await playLaterSection.click();
+    await action.click('Play Later Explorations Tab', playLaterSection);
   };
 
   this.navigateToCompletedSection = async function() {
     await waitFor.elementToBeClickable(
       completedSection, 'Completed tab takes too long to be clickable');
-    await completedSection.click();
+    await action.click('Completed Tab', completedSection);
   };
 
   this.navigateToInCompleteSection = async function() {
     await waitFor.elementToBeClickable(
       incompleteSection, 'In Progress tab takes too long to be clickable');
-    await incompleteSection.click();
+    await action.click('In Progress Tab', incompleteSection);
   };
 
   this.navigateToIncompleteCollectionsSection = async function() {
     await waitFor.elementToBeClickable(
       incompleteCollectionsSection,
-      'Incomplete Collection Section tab takes too long to be clickable');
-    await incompleteCollectionsSection.click();
+      'In Progress Collections Section tab takes too long to be clickable');
+    await action.click('In Progress Collections Tab', incompleteCollectionsSection);
   };
 
   this.navigateToIncompleteExplorationsSection = async function() {
     await waitFor.elementToBeClickable(
       incompleteExplorationsSection,
-      'Incomplete Collection Section tab takes too long to be clickable');
-    await incompleteExplorationsSection.click();
+      'In Progress Explorations Section tab takes too long to be clickable');
+    await action.click('In Progress Explorations Tab', incompleteExplorationsSection);
   };
 
   this.navigateToCompletedCollectionsSection = async function() {
     await waitFor.elementToBeClickable(
       completedCollectionsSection,
       'Completed Collection Section tab takes too long to be clickable');
-    await completedCollectionsSection.click();
+    await action.click('Completed Collections Tab', completedCollectionsSection);
   };
 
   this.navigateToCompletedExplorationsSection = async function() {
     await waitFor.elementToBeClickable(
       completedExplorationsSection,
-      'Completed Collection Section tab takes too long to be clickable');
-    await completedExplorationsSection.click();
+      'Completed Exploration Section tab takes too long to be clickable');
+    await action.click('Completed Explorations Tab', completedExplorationsSection);
   };
 
   this.navigateToFeedbackSection = async function() {
     await waitFor.elementToBeClickable(
       feedbackSection, 'Feedback Section tab takes too long to be clickable');
-    await feedbackSection.click();
+    await action.click('Feedback Tab', feedbackSection);
   };
 
   this.navigateToFeedbackThread = async function() {
     await waitFor.elementToBeClickable(
       feedbackThread, 'Feedback Thread tab takes too long to be clickable');
-    await feedbackThread.click();
+    await action.click('Feedback Thread Tab', feedbackThread);
   };
 
   this.navigateToSubscriptionsSection = async function() {
     await waitFor.elementToBeClickable(
       subscriptionsSection,
       'Subscriptions Section tab takes too long to be clickable');
-    await subscriptionsSection.click();
+    await action.click('Subscriptions Tab', subscriptionsSection);
   };
 
   this.expectTitleOfCollectionSummaryTileToMatch = async function(title) {

--- a/core/tests/protractor_utils/LearnerDashboardPage.js
+++ b/core/tests/protractor_utils/LearnerDashboardPage.js
@@ -54,80 +54,45 @@ var LearnerDashboardPage = function() {
   };
 
   this.navigateToPlayLaterExplorationSection = async function() {
-    await waitFor.elementToBeClickable(
-      playLaterSection,
-      'Play Later Exploration Section tab takes too long to be clickable');
-    await action.click(
-      'Play Later Explorations Tab', playLaterSection);
+    await action.click('Play Later Explorations Tab', playLaterSection);
   };
 
   this.navigateToCompletedSection = async function() {
-    await waitFor.elementToBeClickable(
-      completedSection, 'Completed tab takes too long to be clickable');
-    await action.click(
-      'Completed Tab', completedSection);
+    await action.click('Completed Tab', completedSection);
   };
 
   this.navigateToInCompleteSection = async function() {
-    await waitFor.elementToBeClickable(
-      incompleteSection, 'In Progress tab takes too long to be clickable');
-    await action.click(
-      'In Progress Tab', incompleteSection);
+    await action.click('In Progress Tab', incompleteSection);
   };
 
   this.navigateToIncompleteCollectionsSection = async function() {
-    await waitFor.elementToBeClickable(
-      incompleteCollectionsSection,
-      'In Progress Collections tab takes too long to be clickable');
     await action.click(
       'In Progress Collections Tab', incompleteCollectionsSection);
   };
 
   this.navigateToIncompleteExplorationsSection = async function() {
-    await waitFor.elementToBeClickable(
-      incompleteExplorationsSection,
-      'In Progress Explorations tab takes too long to be clickable');
     await action.click(
-      'In Progress Explorations Tab',
-      incompleteExplorationsSection);
+      'In Progress Explorations Tab', incompleteExplorationsSection);
   };
 
   this.navigateToCompletedCollectionsSection = async function() {
-    await waitFor.elementToBeClickable(
-      completedCollectionsSection,
-      'Completed Collection tab takes too long to be clickable');
-    await action.click(
-      'Completed Collections Tab', completedCollectionsSection);
+    await action.click('Completed Collections Tab', completedCollectionsSection);
   };
 
   this.navigateToCompletedExplorationsSection = async function() {
-    await waitFor.elementToBeClickable(
-      completedExplorationsSection,
-      'Completed Exploration tab takes too long to be clickable');
-    await action.click(
-      'Completed Explorations Tab', completedExplorationsSection);
+    await action.click('Completed Explorations Tab', completedExplorationsSection);
   };
 
   this.navigateToFeedbackSection = async function() {
-    await waitFor.elementToBeClickable(
-      feedbackSection, 'Feedback Section tab takes too long to be clickable');
-    await action.click(
-      'Feedback Tab', feedbackSection);
+    await action.click('Feedback Tab', feedbackSection);
   };
 
   this.navigateToFeedbackThread = async function() {
-    await waitFor.elementToBeClickable(
-      feedbackThread, 'Feedback Thread tab takes too long to be clickable');
-    await action.click(
-      'Feedback Thread Tab', feedbackThread);
+    await action.click('Feedback Thread Tab', feedbackThread);
   };
 
   this.navigateToSubscriptionsSection = async function() {
-    await waitFor.elementToBeClickable(
-      subscriptionsSection,
-      'Subscriptions tab takes too long to be clickable');
-    await action.click(
-      'Subscriptions Tab', subscriptionsSection);
+    await action.click('Subscriptions Tab', subscriptionsSection);
   };
 
   this.expectTitleOfCollectionSummaryTileToMatch = async function(title) {

--- a/core/tests/protractor_utils/LearnerDashboardPage.js
+++ b/core/tests/protractor_utils/LearnerDashboardPage.js
@@ -88,7 +88,7 @@ var LearnerDashboardPage = function() {
       incompleteExplorationsSection,
       'In Progress Explorations tab takes too long to be clickable');
     await action.click(
-      'In Progress Explorations Tab', 
+      'In Progress Explorations Tab',
       incompleteExplorationsSection);
   };
 

--- a/core/tests/protractor_utils/LearnerDashboardPage.js
+++ b/core/tests/protractor_utils/LearnerDashboardPage.js
@@ -117,8 +117,8 @@ var LearnerDashboardPage = function() {
     // that is the exploration with the title passed as a parameter.
     var explorationTitle = element(
       by.cssContainingText('.protractor-test-exp-summary-tile-title', title));
-    waitFor.visibilityOf(explorationTitle,
-      'Exploration title takes too long to appear');
+    waitFor.visibilityOf(
+      explorationTitle, 'Exploration title takes too long to appear');
     expect(await explorationTitle.getText()).toMatch(title);
   };
 

--- a/core/tests/protractor_utils/LearnerDashboardPage.js
+++ b/core/tests/protractor_utils/LearnerDashboardPage.js
@@ -76,11 +76,13 @@ var LearnerDashboardPage = function() {
   };
 
   this.navigateToCompletedCollectionsSection = async function() {
-    await action.click('Completed Collections Tab', completedCollectionsSection);
+    await action.click(
+      'Completed Collections Tab', completedCollectionsSection);
   };
 
   this.navigateToCompletedExplorationsSection = async function() {
-    await action.click('Completed Explorations Tab', completedExplorationsSection);
+    await action.click(
+      'Completed Explorations Tab', completedExplorationsSection);
   };
 
   this.navigateToFeedbackSection = async function() {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #10798 .
2. This PR does the following: Replaces instances of click() with action.click()

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
