### PR TITLE
Suppress AppEnginePlatformWarning warning

### DIFF
--- a/appengine_config.py
+++ b/appengine_config.py
@@ -73,12 +73,14 @@ reload(six) # pylint: disable=reload-builtin
 import requests_toolbelt.adapters.appengine # isort:skip  pylint: disable=wrong-import-position, wrong-import-order
 requests_toolbelt.adapters.appengine.monkeypatch()
 old_get_distribution = pkg_resources.get_distribution # pylint: disable=invalid-name
+
 # Disables "AppEnginePlatformWarning" because it is a "warning" that occurs
 # frequently and tends to bury other important logs.
-import requests
+import requests # isort:skip  pylint: disable=wrong-import-position, wrong-import-order
 requests.packages.urllib3.disable_warnings(
     requests.packages.urllib3.contrib.appengine.AppEnginePlatformWarning
 )
+
 
 class MockDistribution(python_utils.OBJECT):
     """Mock distribution object for the monkeypatching function."""

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -73,7 +73,12 @@ reload(six) # pylint: disable=reload-builtin
 import requests_toolbelt.adapters.appengine # isort:skip  pylint: disable=wrong-import-position, wrong-import-order
 requests_toolbelt.adapters.appengine.monkeypatch()
 old_get_distribution = pkg_resources.get_distribution # pylint: disable=invalid-name
-
+# Disables "AppEnginePlatformWarning" because it is a "warning" that occurs
+# frequently and tends to bury other important logs.
+import requests
+requests.packages.urllib3.disable_warnings(
+    requests.packages.urllib3.contrib.appengine.AppEnginePlatformWarning
+)
 
 class MockDistribution(python_utils.OBJECT):
     """Mock distribution object for the monkeypatching function."""

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -76,6 +76,8 @@ old_get_distribution = pkg_resources.get_distribution # pylint: disable=invalid-
 
 # Disables "AppEnginePlatformWarning" because it is a "warning" that occurs
 # frequently and tends to bury other important logs.
+# It should be fine to ignore this, see https://stackoverflow.com/a/47494229
+# and https://github.com/urllib3/urllib3/issues/1138#issuecomment-290325277.
 import requests # isort:skip  pylint: disable=wrong-import-position, wrong-import-order
 requests.packages.urllib3.disable_warnings(
     requests.packages.urllib3.contrib.appengine.AppEnginePlatformWarning


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. ~This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following: Suppresses AppEnginePlatformWarning because it isn't a serious error and occurs too frequently that it buries other important logs. 

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
