### PR TITLE
FIx #10915: Remove newlines from profile picture data URLs before rendering

### DIFF
--- a/core/templates/components/profile-link-directives/profile-link-image-backend-api.service.ts
+++ b/core/templates/components/profile-link-directives/profile-link-image-backend-api.service.ts
@@ -42,10 +42,14 @@ export class ProfileLinkImageBackendApiService {
       // "data:image/png;base64,". But URL encoded data contains "%" (%2B for
       // "+" and "%3D" for ="). Hence the image is decoded here to conform to
       // the security restrictions imposed by angular.
+      // TODO(#10463): Remove the 'replace newlines' logic after moving
+      // profile pictures to GCS.
       map(response => {
         return (
           response.profile_picture_data_url_for_username &&
-          decodeURIComponent(response.profile_picture_data_url_for_username));
+          decodeURIComponent(
+            response.profile_picture_data_url_for_username
+          ).replace(/\n/g, ''));
       })).toPromise();
   }
 }


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #10915
2. This PR does the following: 
Remove newlines from profile picture data URLs before rendering. Please see [doc](https://docs.google.com/document/d/1Yjf3RaUWz0zzN195SP-AAA7OrELW8OsshEX6ReyIzUU/edit?usp=sharing) for a detailed analysis / reasoning.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
