### PR TITLE
Fixes Part of #8472: Migrate Expression Interpolation Service

### DIFF
--- a/core/templates/expressions/expression-interpolation.service.spec.ts
+++ b/core/templates/expressions/expression-interpolation.service.spec.ts
@@ -1,5 +1,5 @@
 
-// Copyright 2014 The Oppia Authors. All Rights Reserved.
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,89 +17,85 @@
  * @fileoverview Unit tests for ExpressionInterpolationService.
  */
 
-// TODO(#7222): Remove the following block of unnnecessary imports once
-// the code corresponding to the spec is upgraded to Angular 8.
-import { UpgradedServices } from 'services/UpgradedServices';
-// ^^^ This block is to be removed.
+import { HttpClientTestingModule } from
+  '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
 
-require('App.ts');
-require('expressions/expression-interpolation.service.ts');
+import { ExpressionInterpolationService } from
+  'expressions/expression-interpolation.service';
 
-describe('Expression interpolation service', function() {
-  beforeEach(angular.mock.module('oppia'));
-  beforeEach(angular.mock.module('oppia', function($provide) {
-    var ugs = new UpgradedServices();
-    for (let [key, value] of Object.entries(ugs.getUpgradedServices())) {
-      $provide.value(key, value);
-    }
-  }));
+import 'App';
 
-  describe('expression interpolation service', function() {
-    var ExpressionInterpolationService = null;
+describe('expression interpolation service', ()=> {
+  let expressionInterpolationService:
+    ExpressionInterpolationService = null;
 
-    beforeEach(angular.mock.inject(function($injector) {
-      ExpressionInterpolationService = $injector.get(
-        'ExpressionInterpolationService');
-    }));
-
-    it('should correctly interpolate and escape HTML strings', function() {
-      expect(ExpressionInterpolationService.processHtml('abc', [{}])).toEqual(
-        'abc');
-      expect(ExpressionInterpolationService.processHtml('abc{{a}}', [{
-        a: 'b'
-      }])).toEqual('abcb');
-      expect(ExpressionInterpolationService.processHtml('abc{{a}}', [{
-        a: '<script></script>'
-      }])).toEqual('abc&lt;script&gt;&lt;/script&gt;');
-      expect(ExpressionInterpolationService.processHtml(
-        'abc{{a}}', [{}])
-      ).toEqual('abc<oppia-expression-error-tag></oppia-expression-error-tag>');
-      expect(ExpressionInterpolationService.processHtml('abc{{a{{b}}}}', [{
-        a: '1',
-        b: '2'
-      }])).toEqual(
-        'abc<oppia-expression-error-tag></oppia-expression-error-tag>}}');
-
-      expect(ExpressionInterpolationService.processHtml('abc{{a+b}}', [{
-        a: '1',
-        b: '2'
-      }])).toEqual('abc3');
-      expect(ExpressionInterpolationService.processHtml('abc{{a+b}}', [{
-        a: '1',
-        b: 'hello'
-      }])).toEqual(
-        'abc<oppia-expression-error-tag></oppia-expression-error-tag>');
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
     });
+    expressionInterpolationService =
+      TestBed.get(ExpressionInterpolationService);
+  });
 
-    it('should correctly interpolate unicode strings', function() {
-      expect(ExpressionInterpolationService.processUnicode(
-        'abc', [{}])).toEqual('abc');
-      expect(ExpressionInterpolationService.processUnicode('abc{{a}}', [{
-        a: 'b'
-      }])).toEqual('abcb');
-      expect(ExpressionInterpolationService.processUnicode('abc{{a}}', [{
-        a: '<script></script>'
-      }])).toEqual('abc<script></script>');
-      expect(ExpressionInterpolationService.processUnicode(
-        'abc{{a}}', [{}])).toBeNull();
+  it('should correctly interpolate and escape HTML strings', ()=> {
+    expect(expressionInterpolationService.processHtml('abc', [{}])).toEqual(
+      'abc');
+    expect(expressionInterpolationService.processHtml('abc{{a}}', [{
+      a: 'b'
+    }])).toEqual('abcb');
+    expect(expressionInterpolationService.processHtml('abc{{a}}', [{
+      a: '<script></script>'
+    }])).toEqual('abc&lt;script&gt;&lt;/script&gt;');
+    expect(expressionInterpolationService.processHtml(
+      'abc{{a}}', [{}])
+    ).toEqual('abc<oppia-expression-error-tag></oppia-expression-error-tag>');
+    expect(expressionInterpolationService.processHtml('abc{{a{{b}}}}', [{
+      a: '1',
+      b: '2'
+    }])).toEqual(
+      'abc<oppia-expression-error-tag></oppia-expression-error-tag>}}');
 
-      expect(ExpressionInterpolationService.processUnicode('abc{{a+b}}', [{
-        a: '1',
-        b: '2'
-      }])).toEqual('abc3');
-      expect(ExpressionInterpolationService.processUnicode('abc{{a+b}}', [{
-        a: '1',
-        b: 'hello'
-      }])).toBeNull();
-    });
+    expect(expressionInterpolationService.processHtml('abc{{a+b}}', [{
+      a: '1',
+      b: '2'
+    }])).toEqual('abc3');
+    expect(expressionInterpolationService.processHtml('abc{{a+b}}', [{
+      a: '1',
+      b: 'hello'
+    }])).toEqual(
+      'abc<oppia-expression-error-tag></oppia-expression-error-tag>');
+  });
 
-    it('should correctly get params from strings', function() {
-      expect(ExpressionInterpolationService.getParamsFromString(
-        'abc')).toEqual([]);
-      expect(ExpressionInterpolationService.getParamsFromString(
-        'abc{{a}}')).toEqual(['a']);
-      expect(ExpressionInterpolationService.getParamsFromString(
-        'abc{{a+b}}')).toEqual(['a', 'b']);
-    });
+  it('should correctly interpolate unicode strings', ()=> {
+    expect(expressionInterpolationService.processUnicode(
+      'abc', [{}])).toEqual('abc');
+    expect(expressionInterpolationService.processUnicode('abc{{a}}', [{
+      a: 'b'
+    }])).toEqual('abcb');
+    expect(expressionInterpolationService.processUnicode('abc{{a}}', [{
+      a: '<script></script>'
+    }])).toEqual('abc<script></script>');
+    expect(expressionInterpolationService.processUnicode(
+      'abc{{a}}', [{}])).toBeNull();
+
+    expect(expressionInterpolationService.processUnicode('abc{{a+b}}', [{
+      a: '1',
+      b: '2'
+    }])).toEqual('abc3');
+    expect(expressionInterpolationService.processUnicode('abc{{a+b}}', [{
+      a: '1',
+      b: 'hello'
+    }])).toBeNull();
+  });
+
+  it('should correctly get params from strings', ()=> {
+    expect(expressionInterpolationService.getParamsFromString(
+      'abc')).toEqual([]);
+    expect(expressionInterpolationService.getParamsFromString(
+      'abc{{a}}')).toEqual(['a']);
+    expect(expressionInterpolationService.getParamsFromString(
+      'abc{{a+b}}')).toEqual(['a', 'b']);
   });
 });
+

--- a/core/templates/expressions/expression-interpolation.service.spec.ts
+++ b/core/templates/expressions/expression-interpolation.service.spec.ts
@@ -98,4 +98,3 @@ describe('expression interpolation service', ()=> {
       'abc{{a+b}}')).toEqual(['a', 'b']);
   });
 });
-

--- a/core/templates/expressions/expression-interpolation.service.spec.ts
+++ b/core/templates/expressions/expression-interpolation.service.spec.ts
@@ -24,8 +24,6 @@ import { TestBed } from '@angular/core/testing';
 import { ExpressionInterpolationService } from
   'expressions/expression-interpolation.service';
 
-import 'App';
-
 describe('expression interpolation service', ()=> {
   let expressionInterpolationService:
     ExpressionInterpolationService = null;

--- a/core/templates/expressions/expression-interpolation.service.ts
+++ b/core/templates/expressions/expression-interpolation.service.ts
@@ -48,7 +48,7 @@ export class ExpressionInterpolationService {
           this.expressionEvaluatorService.evaluateExpression(
             convertHtmlToUnicode(p1), envs) as string);
       } catch (e) {
-        var EXPRESSION_ERROR_TAG = (
+        const EXPRESSION_ERROR_TAG = (
           '<oppia-expression-error-tag></oppia-expression-error-tag>');
         if ((e instanceof this.expressionParserService.SyntaxError) ||
             (e instanceof this.expressionSyntaxTreeService.ExpressionError)) {
@@ -78,17 +78,17 @@ export class ExpressionInterpolationService {
   }
 
   getParamsFromString(sourceString: string): string[] {
-    var matches = sourceString.match(/{{([^}]*)}}/g) || [];
+    let matches = sourceString.match(/{{([^}]*)}}/g) || [];
 
-    var allParams = [];
-    for (var i = 0; i < matches.length; i++) {
+    let allParams = [];
+    for (let i = 0; i < matches.length; i++) {
       // Trim the '{{' and '}}'.
       matches[i] = matches[i].substring(2, matches[i].length - 2);
 
-      var params = this.expressionSyntaxTreeService.getParamsUsedInExpression(
+      let params = this.expressionSyntaxTreeService.getParamsUsedInExpression(
         convertHtmlToUnicode(matches[i]));
 
-      for (var j = 0; j < params.length; j++) {
+      for (let j = 0; j < params.length; j++) {
         if (allParams.indexOf(params[j]) === -1) {
           allParams.push(params[j]);
         }

--- a/core/templates/expressions/expression-interpolation.service.ts
+++ b/core/templates/expressions/expression-interpolation.service.ts
@@ -1,4 +1,4 @@
-// Copyright 2014 The Oppia Authors. All Rights Reserved.
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,96 +16,89 @@
  * @fileoverview Service for interpolating expressions.
  */
 
-require('filters/convert-html-to-unicode.filter.ts');
-require('expressions/expression-evaluator.service.ts');
-require('expressions/expression-parser.service.ts');
-require('expressions/expression-syntax-tree.service.ts');
-require('services/html-escaper.service.ts');
+import { Injectable } from '@angular/core';
+import { downgradeInjectable } from '@angular/upgrade/static';
 
-// Interpolates an HTML or a unicode string containing expressions.
-// The input value is evaluated against the supplied environments.
-//
-// Examples:
-//   processHtml('abc{{a}}', [{'a': 'b'}]) gives 'abcb'.
-//   processHtml('abc{{a}}', [{}]) returns null.
-//   processHtml('abc', [{}]) returns 'abc'.
-//   processHtml('{[a}}', [{'a': '<button></button>'}])
-//     returns '&lt;button&gt;&lt;/button&gt;'.
-//   processUnicode('abc{{a}}', [{'a': 'b'}]) gives 'abcb'.
-//   processUnicode('abc{{a}}', [{}]) returns null.
-//   processUnicode('{[a}}', [{'a': '<button></button>'}]) returns
-//     '<button></button>'.
-angular.module('oppia').factory('ExpressionInterpolationService', [
-  '$filter', 'ExpressionEvaluatorService', 'ExpressionParserService',
-  'ExpressionSyntaxTreeService', 'HtmlEscaperService',
-  function(
-      $filter, ExpressionEvaluatorService, ExpressionParserService,
-      ExpressionSyntaxTreeService, HtmlEscaperService) {
-    return {
-      // This method should only be used if its result would immediately be
-      // displayed on the screen without passing through further computation.
-      // It differs from other methods in this service in that it
-      // auto-escapes the returned HTML, and returns an 'error' label if the
-      // evaluation fails.
-      processHtml: function(sourceHtml, envs) {
-        return sourceHtml.replace(/{{([^}]*)}}/g, function(match, p1) {
-          try {
-            // TODO(sll): Remove the call to $filter once we have a
-            // custom UI for entering expressions. It is only needed because
-            // expressions are currently input inline via the RTE.
-            return HtmlEscaperService.unescapedStrToEscapedStr(
-              ExpressionEvaluatorService.evaluateExpression(
-                $filter('convertHtmlToUnicode')(p1), envs));
-          } catch (e) {
-            var EXPRESSION_ERROR_TAG = (
-              '<oppia-expression-error-tag></oppia-expression-error-tag>');
-            if ((e instanceof ExpressionParserService.SyntaxError) ||
-                (e instanceof ExpressionSyntaxTreeService.ExpressionError)) {
-              return EXPRESSION_ERROR_TAG;
-            }
-            throw e;
-          }
-        });
-      },
-      // Returns null if the evaluation fails.
-      processUnicode: function(sourceUnicode, envs) {
-        try {
-          return sourceUnicode.replace(/{{([^}]*)}}/g, function(match, p1) {
-            // TODO(sll): Remove the call to $filter once we have a
-            // custom UI for entering expressions. It is only needed because
-            // expressions are currently input inline via the RTE.
-            return ExpressionEvaluatorService.evaluateExpression(
-              $filter('convertHtmlToUnicode')(p1), envs);
-          });
-        } catch (e) {
-          if ((e instanceof ExpressionParserService.SyntaxError) ||
-              (e instanceof ExpressionSyntaxTreeService.ExpressionError)) {
-            return null;
-          }
-          throw e;
+import { convertHtmlToUnicode } from 'filters/convert-html-to-unicode.filter';
+import { ExpressionEvaluatorService } from
+  'expressions/expression-evaluator.service';
+import { ExpressionParserService } from 'expressions/expression-parser.service';
+import { ExpressionSyntaxTreeService } from
+  'expressions/expression-syntax-tree.service';
+import { HtmlEscaperService } from 'services/html-escaper.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ExpressionInterpolationService {
+  constructor(
+    private expressionEvaluatorService: ExpressionEvaluatorService,
+    private expressionParserService: ExpressionParserService,
+    private expressionSyntaxTreeService: ExpressionSyntaxTreeService,
+    private htmlEscaperService: HtmlEscaperService
+  ) {}
+
+  processHtml(sourceHtml: string, envs: [{}]): string {
+    return sourceHtml.replace(/{{([^}]*)}}/g, (match, p1)=> {
+      try {
+        // TODO(sll): Remove the call to $filter once we have a
+        // custom UI for entering expressions. It is only needed because
+        // expressions are currently input inline via the RTE.
+        return this.htmlEscaperService.unescapedStrToEscapedStr(
+          this.expressionEvaluatorService.evaluateExpression(
+            convertHtmlToUnicode(p1), envs) as string);
+      } catch (e) {
+        var EXPRESSION_ERROR_TAG = (
+          '<oppia-expression-error-tag></oppia-expression-error-tag>');
+        if ((e instanceof this.expressionParserService.SyntaxError) ||
+            (e instanceof this.expressionSyntaxTreeService.ExpressionError)) {
+          return EXPRESSION_ERROR_TAG;
         }
-      },
-      // This works for both unicode and HTML.
-      getParamsFromString: function(sourceString) {
-        var matches = sourceString.match(/{{([^}]*)}}/g) || [];
-
-        var allParams = [];
-        for (var i = 0; i < matches.length; i++) {
-          // Trim the '{{' and '}}'.
-          matches[i] = matches[i].substring(2, matches[i].length - 2);
-
-          var params = ExpressionSyntaxTreeService.getParamsUsedInExpression(
-            $filter('convertHtmlToUnicode')(matches[i]));
-
-          for (var j = 0; j < params.length; j++) {
-            if (allParams.indexOf(params[j]) === -1) {
-              allParams.push(params[j]);
-            }
-          }
-        }
-
-        return allParams.sort();
+        throw e;
       }
-    };
+    });
   }
-]);
+
+  processUnicode(sourceUnicode: string, envs: [{}]): string {
+    try {
+      return sourceUnicode.replace(/{{([^}]*)}}/g, (match, p1)=> {
+        // TODO(sll): Remove the call to $filter once we have a
+        // custom UI for entering expressions. It is only needed because
+        // expressions are currently input inline via the RTE.
+        return this.expressionEvaluatorService.evaluateExpression(
+          convertHtmlToUnicode(p1), envs) as string;
+      });
+    } catch (e) {
+      if ((e instanceof this.expressionParserService.SyntaxError) ||
+          (e instanceof this.expressionSyntaxTreeService.ExpressionError)) {
+        return null;
+      }
+      throw e;
+    }
+  }
+
+  getParamsFromString(sourceString: string): string[] {
+    var matches = sourceString.match(/{{([^}]*)}}/g) || [];
+
+    var allParams = [];
+    for (var i = 0; i < matches.length; i++) {
+      // Trim the '{{' and '}}'.
+      matches[i] = matches[i].substring(2, matches[i].length - 2);
+
+      var params = this.expressionSyntaxTreeService.getParamsUsedInExpression(
+        convertHtmlToUnicode(matches[i]));
+
+      for (var j = 0; j < params.length; j++) {
+        if (allParams.indexOf(params[j]) === -1) {
+          allParams.push(params[j]);
+        }
+      }
+    }
+
+    return allParams.sort();
+  }
+}
+
+angular.module('oppia').factory(
+  'ExpressionInterpolationService',
+  downgradeInjectable(ExpressionInterpolationService));

--- a/core/templates/expressions/expression-interpolation.service.ts
+++ b/core/templates/expressions/expression-interpolation.service.ts
@@ -38,7 +38,7 @@ export class ExpressionInterpolationService {
     private htmlEscaperService: HtmlEscaperService
   ) {}
 
-  processHtml(sourceHtml: string, envs: [{}]): string {
+  processHtml(sourceHtml: string, envs: Record<string, string>[]): string {
     return sourceHtml.replace(/{{([^}]*)}}/g, (match, p1)=> {
       try {
         // TODO(sll): Remove the call to $filter once we have a
@@ -59,7 +59,8 @@ export class ExpressionInterpolationService {
     });
   }
 
-  processUnicode(sourceUnicode: string, envs: [{}]): string {
+  processUnicode(
+      sourceUnicode: string, envs: Record<string, string>[]): string {
     try {
       return sourceUnicode.replace(/{{([^}]*)}}/g, (match, p1)=> {
         // TODO(sll): Remove the call to $filter once we have a

--- a/core/templates/filters/convert-html-to-unicode.filter.ts
+++ b/core/templates/filters/convert-html-to-unicode.filter.ts
@@ -16,8 +16,12 @@
  * @fileoverview Converts HTML to unicode.
  */
 
+export const convertHtmlToUnicode = (html: string): string => {
+  return angular.element('<div>' + html + '</div>').text();
+};
+
 angular.module('oppia').filter('convertHtmlToUnicode', [function() {
   return function(html) {
-    return angular.element('<div>' + html + '</div>').text();
+    return convertHtmlToUnicode(html);
   };
 }]);

--- a/core/templates/pages/exploration-editor-page/editor-navigation/editor-navigation.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/editor-navigation/editor-navigation.component.spec.ts
@@ -22,8 +22,7 @@ import { of, Subscription } from 'rxjs';
 import { WindowDimensionsService } from
   'services/contextual/window-dimensions.service';
 
-// TODO(#7222): Remove usage of UpgradedServices once upgraded to Angular 8.
-import { UpgradedServices } from 'services/UpgradedServices';
+import { importAllAngularServices } from 'tests/unit-test-utils';
 
 describe('Editor Navigation Component', function() {
   var ctrl = null;
@@ -60,12 +59,7 @@ describe('Editor Navigation Component', function() {
   };
   var isImprovementsTabEnabledAsyncSpy = null;
 
-  beforeEach(angular.mock.module('oppia', function($provide) {
-    const ugs = new UpgradedServices();
-    for (const [key, value] of Object.entries(ugs.getUpgradedServices())) {
-      $provide.value(key, value);
-    }
-  }));
+  importAllAngularServices();
 
   beforeEach(function() {
     windowDimensionsService = TestBed.get(WindowDimensionsService);

--- a/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.spec.ts
@@ -60,8 +60,7 @@ import { SolutionObjectFactory } from
 import { SubtitledUnicode } from
   'domain/exploration/SubtitledUnicodeObjectFactory';
 
-// TODO(#7222): Remove usage of UpgradedServices once upgraded to Angular 8.
-import { UpgradedServices } from 'services/UpgradedServices';
+import { importAllAngularServices } from 'tests/unit-test-utils';
 
 describe('Exploration editor tab component', function() {
   var ctrl;
@@ -84,12 +83,7 @@ describe('Exploration editor tab component', function() {
 
   var mockRefreshStateEditorEventEmitter = null;
 
-  beforeEach(angular.mock.module('oppia', function($provide) {
-    const ugs = new UpgradedServices();
-    for (const [key, value] of Object.entries(ugs.getUpgradedServices())) {
-      $provide.value(key, value);
-    }
-  }));
+  importAllAngularServices();
 
   beforeEach(function() {
     answerGroupObjectFactory = TestBed.get(AnswerGroupObjectFactory);

--- a/core/templates/pages/exploration-editor-page/editor-tab/graph-directives/state-graph-visualization.directive.spec.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/graph-directives/state-graph-visualization.directive.spec.ts
@@ -50,6 +50,7 @@ import * as d3 from 'd3';
 import { of } from 'rxjs';
 import { StateEditorRefreshService } from
   'pages/exploration-editor-page/services/state-editor-refresh.service';
+import { importAllAngularServices } from 'tests/unit-test-utils';
 
 require(
   'pages/exploration-editor-page/editor-tab/graph-directives/' +
@@ -100,6 +101,9 @@ describe('State Graph Visualization directive', function() {
   };
 
   beforeEach(angular.mock.module('directiveTemplates'));
+
+  importAllAngularServices();
+
   beforeEach(function() {
     stateGraphLayoutService = TestBed.get(StateGraphLayoutService);
   });

--- a/core/templates/pages/exploration-editor-page/editor-tab/training-panel/training-modal.controller.spec.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/training-panel/training-modal.controller.spec.ts
@@ -16,10 +16,7 @@
  * @fileoverview Unit tests for TrainingModalController.
  */
 
-// TODO(#7222): Remove the following block of unnnecessary imports once
-// the code corresponding to the spec is upgraded to Angular 8.
-import { UpgradedServices } from 'services/UpgradedServices';
-// ^^^ This block is to be removed.
+import { importAllAngularServices } from 'tests/unit-test-utils';
 
 describe('Training Modal Controller', function() {
   var $rootScope = null;
@@ -33,6 +30,9 @@ describe('Training Modal Controller', function() {
   var InteractionObjectFactory = null;
 
   beforeEach(angular.mock.module('oppia'));
+
+  importAllAngularServices();
+
   beforeEach(angular.mock.module(function($provide) {
     $provide.value('ExplorationDataService', {
       explorationId: 0,
@@ -40,12 +40,7 @@ describe('Training Modal Controller', function() {
       discardDraft: function() {}
     });
   }));
-  beforeEach(angular.mock.module('oppia', function($provide) {
-    var ugs = new UpgradedServices();
-    for (let [key, value] of Object.entries(ugs.getUpgradedServices())) {
-      $provide.value(key, value);
-    }
-  }));
+
   beforeEach(angular.mock.inject(function($injector) {
     $rootScope = $injector.get('$rootScope');
     StateEditorService = $injector.get('StateEditorService');

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.spec.ts
@@ -44,8 +44,7 @@ import { SiteAnalyticsService } from 'services/site-analytics.service';
 import { StateTopAnswersStatsBackendApiService } from
   'services/state-top-answers-stats-backend-api.service';
 
-// TODO(#7222): Remove usage of UpgradedServices once upgraded to Angular 8.
-import { UpgradedServices } from 'services/UpgradedServices';
+import { importAllAngularServices } from 'tests/unit-test-utils';
 
 require('pages/exploration-editor-page/exploration-editor-page.component.ts');
 require(
@@ -53,6 +52,8 @@ require(
   'state-tutorial-first-time.service.ts');
 
 describe('Exploration editor page component', function() {
+  importAllAngularServices();
+
   var ctrl = null;
 
   var $q = null;
@@ -203,10 +204,6 @@ describe('Exploration editor page component', function() {
   });
 
   beforeEach(angular.mock.module('oppia', function($provide) {
-    const ugs = new UpgradedServices();
-    for (const [key, value] of Object.entries(ugs.getUpgradedServices())) {
-      $provide.value(key, value);
-    }
     $provide.value('ExplorationDataService', mockExplorationDataService);
   }));
 

--- a/core/templates/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.component.spec.ts
@@ -50,6 +50,7 @@ import { StatesObjectFactory } from 'domain/exploration/StatesObjectFactory';
 import { ExplorationImprovementsTaskRegistryService } from
   'services/exploration-improvements-task-registry.service';
 import { ExplorationStatsService } from 'services/exploration-stats.service';
+import { importAllAngularServices } from 'tests/unit-test-utils';
 
 describe('Exploration save and publish buttons component', function() {
   var ctrl = null;
@@ -66,6 +67,8 @@ describe('Exploration save and publish buttons component', function() {
   var mockExternalSaveEventEmitter = null;
 
   beforeEach(angular.mock.module('oppia'));
+
+  importAllAngularServices();
 
   beforeEach(function() {
     TestBed.configureTestingModule({

--- a/core/templates/pages/exploration-editor-page/services/exploration-warnings.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-warnings.service.spec.ts
@@ -58,8 +58,8 @@ import { WrittenTranslationObjectFactory } from
   'domain/exploration/WrittenTranslationObjectFactory';
 import { WrittenTranslationsObjectFactory } from
   'domain/exploration/WrittenTranslationsObjectFactory';
-import { UpgradedServices } from 'services/UpgradedServices';
-// ^^^ This block is to be removed.
+
+import { importAllAngularServices } from 'tests/unit-test-utils';
 
 require('pages/exploration-editor-page/services/graph-data.service');
 require('pages/exploration-editor-page/services/exploration-property.service');
@@ -73,6 +73,9 @@ describe('Exploration Warnings Service', function() {
   var StateTopAnswersStatsBackendApiService = null;
 
   beforeEach(angular.mock.module('oppia'));
+
+  importAllAngularServices();
+
   beforeEach(angular.mock.module('oppia', function($provide) {
     $provide.value('AngularNameService', new AngularNameService());
     $provide.value(
@@ -117,12 +120,6 @@ describe('Exploration Warnings Service', function() {
       'WrittenTranslationsObjectFactory',
       new WrittenTranslationsObjectFactory(
         new WrittenTranslationObjectFactory()));
-  }));
-  beforeEach(angular.mock.module('oppia', function($provide) {
-    var ugs = new UpgradedServices();
-    for (let [key, value] of Object.entries(ugs.getUpgradedServices())) {
-      $provide.value(key, value);
-    }
   }));
 
   describe('when exploration param changes has jinja values', function() {

--- a/core/templates/pages/exploration-editor-page/services/parameter-metadata.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/parameter-metadata.service.spec.ts
@@ -16,7 +16,7 @@
  * @fileoverview Unit tests for ParameterMetadataService.
  */
 
-import { UpgradedServices } from 'services/UpgradedServices';
+import { importAllAngularServices } from 'tests/unit-test-utils';
 
 require('pages/exploration-editor-page/services/parameter-metadata.service');
 require('expressions/expression-interpolation.service.ts');
@@ -34,12 +34,9 @@ describe('Parameter Metadata Service', function() {
   var StatesObjectFactory = null;
 
   beforeEach(angular.mock.module('oppia'));
-  beforeEach(angular.mock.module('oppia', function($provide) {
-    var ugs = new UpgradedServices();
-    for (let [key, value] of Object.entries(ugs.getUpgradedServices())) {
-      $provide.value(key, value);
-    }
-  }));
+
+  importAllAngularServices();
+
   beforeEach(angular.mock.module('oppia', function($provide) {
     $provide.value('ExplorationParamChangesService', {
       savedMemento: [{

--- a/core/templates/pages/exploration-editor-page/services/router.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/router.service.spec.ts
@@ -19,8 +19,7 @@
 import { fakeAsync, flushMicrotasks } from '@angular/core/testing';
 import $ from 'jquery';
 import { Subscription } from 'rxjs';
-
-import { UpgradedServices } from 'services/UpgradedServices';
+import { importAllAngularServices } from 'tests/unit-test-utils';
 
 describe('Router Service', () => {
   var RouterService = null;
@@ -41,12 +40,8 @@ describe('Router Service', () => {
   var refreshVersionHistorySpy = null;
   var refreshStateEditorSpy = null;
 
-  beforeEach(angular.mock.module('oppia', $provide => {
-    var ugs = new UpgradedServices();
-    for (let [key, value] of Object.entries(ugs.getUpgradedServices())) {
-      $provide.value(key, value);
-    }
-  }));
+  importAllAngularServices();
+
   beforeEach(angular.mock.inject($injector => {
     RouterService = $injector.get('RouterService');
     ExplorationStatesService = $injector.get('ExplorationStatesService');

--- a/core/templates/pages/exploration-editor-page/settings-tab/settings-tab.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/settings-tab/settings-tab.component.spec.ts
@@ -46,6 +46,7 @@ import { WindowDimensionsService } from
   'services/contextual/window-dimensions.service';
 
 import { Subscription } from 'rxjs';
+import { importAllAngularServices } from 'tests/unit-test-utils';
 
 class MockRouterService {
   private refreshSettingsTabEventEmitter: EventEmitter<void>;
@@ -95,6 +96,8 @@ describe('Settings Tab Component', function() {
   var mockWindowDimensionsService = {
     isWindowNarrow: () => true
   };
+
+  importAllAngularServices();
 
   beforeEach(function() {
     TestBed.configureTestingModule({

--- a/core/templates/services/angular-services.index.ts
+++ b/core/templates/services/angular-services.index.ts
@@ -166,6 +166,7 @@ import { BrowserCheckerService } from 'domain/utilities/browser-checker.service'
 import { LanguageUtilService } from 'domain/utilities/language-util.service';
 import { UrlInterpolationService } from 'domain/utilities/url-interpolation.service';
 import { ExpressionEvaluatorService } from 'expressions/expression-evaluator.service';
+import { ExpressionInterpolationService } from 'expressions/expression-interpolation.service';
 import { ExpressionParserService } from 'expressions/expression-parser.service';
 import { ExpressionSyntaxTreeService } from 'expressions/expression-syntax-tree.service';
 import { FormatTimePipe } from 'filters/format-timer.pipe';
@@ -419,6 +420,7 @@ export const angularServices: [string, unknown][] = [
   ['ExplorationStatsService', ExplorationStatsService],
   ['ExplorationTaskObjectFactory', ExplorationTaskObjectFactory],
   ['ExpressionEvaluatorService', ExpressionEvaluatorService],
+  ['ExpressionInterpolationService', ExpressionInterpolationService],
   ['ExpressionParserService', ExpressionParserService],
   ['ExpressionSyntaxTreeService', ExpressionSyntaxTreeService],
   ['ExtensionTagAssemblerService', ExtensionTagAssemblerService],


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #8472 
2. This PR does the following: Migrates expression-interpolation-service to angular 8

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".