### PR TITLE
Fix part of #8423: Add a lint check to ensure that there are no blank lines below the function definition

### DIFF
--- a/scripts/linters/pylint_extensions.py
+++ b/scripts/linters/pylint_extensions.py
@@ -1858,21 +1858,36 @@ class SingleSpaceAfterKeyWordChecker(checkers.BaseChecker):
                         line=line_num)
 
 
-    class BlankSpaceBelowFunctionDefChecker(checkers.BaseChecker):
-        """Custom pylint checker which checks that there isn't a blank space
-        below the function definition.
-        """
+class BlankLineBelowFunctionDefChecker(checkers.BaseChecker):
+    """Custom pylint checker which ensures that there isn't a blank space
+    below a function definition.
+    """
 
-        __implements__ = interfaces.ITokenChecker
-        name = "no-blank-line-after-function-definition"
-        priority = -1
-        msgs = {
-            'C0030' : (
-                "Blank line not permitted below function definition",
-                "no-blank-line-after-function-definition",
-                "Blank line below the funciton definition should be removed",
-            ),
-        }
+    __implements__ = interfaces.IAstroidChecker
+    name = "blank-line-below-function-definition"
+    priority = -1
+    msgs = {
+        'C0030' : (
+            "Blank line not permitted below function definition",
+            "blank-line-below-function-definition",
+            "The Blank line below the function definition should be removed",
+        ),
+    }
+
+    def visit_functiondef(self, node):
+        """Visit every function definition in a module and check if there is a
+        blank line below the function definition.
+
+        Args:
+            node: astroid.nodes.FunctionDef. Node for a function definition
+                in the AST.
+        """
+        line_number = node.fromlineno
+        line_number += 1
+        if linecache.getline(node.root().file, line_number).strip() == b'':
+            self.add_message(
+                'blank-line-below-function-definition', line=line_number
+            )
 
 
 def register(linter):
@@ -1894,3 +1909,4 @@ def register(linter):
     linter.register_checker(BlankLineBelowFileOverviewChecker(linter))
     linter.register_checker(SingleLinePragmaChecker(linter))
     linter.register_checker(SingleSpaceAfterKeyWordChecker(linter))
+    linter.register_checker(BlankLineBelowFunctionDefChecker(linter))

--- a/scripts/linters/pylint_extensions.py
+++ b/scripts/linters/pylint_extensions.py
@@ -1858,6 +1858,23 @@ class SingleSpaceAfterKeyWordChecker(checkers.BaseChecker):
                         line=line_num)
 
 
+    class BlankSpaceBelowFunctionDefChecker(checkers.BaseChecker):
+        """Custom pylint checker which checks that there isn't a blank space
+        below the function definition.
+        """
+
+        __implements__ = interfaces.ITokenChecker
+        name = "no-blank-line-after-function-definition"
+        priority = -1
+        msgs = {
+            'C0030' : (
+                "Blank line not permitted below function definition",
+                "no-blank-line-after-function-definition",
+                "Blank line below the funciton definition should be removed",
+            ),
+        }
+
+
 def register(linter):
     """Registers the checker with pylint.
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #8423 
2. This PR does the following: Add a lint check to ensure that there are no blank lines below the function definition

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
