### PR TITLE
Fix #9415: Adds feature to update version in package.json with each release

### DIFF
--- a/core/tests/release_sources/mock_package.json
+++ b/core/tests/release_sources/mock_package.json
@@ -1,0 +1,12 @@
+{
+  "name": "oppia",
+  "version": "2.8.4",
+  "description": "Oppia enables the creation of interactive online lessons.",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/oppia/oppia.git"
+  },
+}

--- a/scripts/release_scripts/update_changelog_and_credits.py
+++ b/scripts/release_scripts/update_changelog_and_credits.py
@@ -44,6 +44,7 @@ ABOUT_PAGE_CONSTANTS_FILEPATH = os.path.join(
 AUTHORS_FILEPATH = os.path.join('', 'AUTHORS')
 CHANGELOG_FILEPATH = os.path.join('', 'CHANGELOG')
 CONTRIBUTORS_FILEPATH = os.path.join('', 'CONTRIBUTORS')
+PACKAGE_JSON_PATH = os.path.join('', 'package.json')
 GIT_CMD_CHECKOUT = 'git checkout -- %s %s %s %s' % (
     CHANGELOG_FILEPATH, AUTHORS_FILEPATH, CONTRIBUTORS_FILEPATH,
     ABOUT_PAGE_CONSTANTS_FILEPATH)
@@ -474,6 +475,18 @@ def get_release_summary_lines():
     return release_summary_lines
 
 
+def update_package_json():
+    """Updates version param in package json file to match the current
+    release version.
+    """
+    release_version = common.get_current_release_version_number(
+        common.get_current_branch_name())
+
+    common.inplace_replace_file(
+        PACKAGE_JSON_PATH, '"version": ".*"',
+        '"version": "%s"' % release_version)
+
+
 def main():
     """Collects necessary info and dumps it to disk."""
     branch_name = common.get_current_branch_name()
@@ -557,12 +570,13 @@ def main():
     update_authors(release_summary_lines)
     update_contributors(release_summary_lines)
     update_developer_names(release_summary_lines)
+    update_package_json()
 
     message = (
         'Please check the changes and make updates if required in the '
-        'following files:\n1. %s\n2. %s\n3. %s\n4. %s\n' % (
+        'following files:\n1. %s\n2. %s\n3. %s\n4. %s\n5. %s\n' % (
             CHANGELOG_FILEPATH, AUTHORS_FILEPATH, CONTRIBUTORS_FILEPATH,
-            ABOUT_PAGE_CONSTANTS_FILEPATH))
+            ABOUT_PAGE_CONSTANTS_FILEPATH, PACKAGE_JSON_PATH))
     common.ask_user_to_confirm(message)
 
     create_branch(


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #9415.
2. This PR does the following: Adds a new feature to update version in package.json with each release

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
