### PR TITLE
Fix backend test broken on develop

### DIFF
--- a/core/domain/user_jobs_one_off_test.py
+++ b/core/domain/user_jobs_one_off_test.py
@@ -2180,6 +2180,7 @@ class ProfilePictureAuditOneOffJobTests(test_utils.GenericTestBase):
         user_settings_model = (
             user_models.UserSettingsModel.get_by_id(self.owner_id))
         user_settings_model.username = None
+        user_settings_model.update_timestamps()
         user_settings_model.put()
         output = self._run_one_off_job()
         self.assertEqual(output, [['SUCCESS - NOT REGISTERED', 1]])
@@ -2188,6 +2189,7 @@ class ProfilePictureAuditOneOffJobTests(test_utils.GenericTestBase):
         user_settings_model = (
             user_models.UserSettingsModel.get_by_id(self.owner_id))
         user_settings_model.deleted = True
+        user_settings_model.update_timestamps()
         user_settings_model.put()
         output = self._run_one_off_job()
         self.assertEqual(output, [['SUCCESS - DELETED', 1]])
@@ -2212,6 +2214,7 @@ class ProfilePictureAuditOneOffJobTests(test_utils.GenericTestBase):
         user_settings_model = (
             user_models.UserSettingsModel.get_by_id(moderator_id))
         user_settings_model.deleted = True
+        user_settings_model.update_timestamps()
         user_settings_model.put()
 
         output = self._run_one_off_job()


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: #10981 was merged 21 Oct 10:45 PM and #10961 was merged 22 Oct 8:28 PM, since the backend tests on #10961 were run before #10981 was merged some of the newly added features failed on them. The backend tests on #10961 were 6 days old. This should be mitigated after we add this feature https://github.com/oppia/oppiabot/issues/117.

TL;DR: Race condition between #10981 and #10961

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
