### PR TITLE
Fix #8038: http calls moved from suggestion-modal-for-creator-view.service.ts to *backend.api.service

### DIFF
--- a/core/templates/pages/creator-dashboard-page/suggestion-modal-for-creator-view/suggestion-modal-for-creator-dashboard-backend-api.service.spec.ts
+++ b/core/templates/pages/creator-dashboard-page/suggestion-modal-for-creator-view/suggestion-modal-for-creator-dashboard-backend-api.service.spec.ts
@@ -1,0 +1,140 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for
+ * * SuggestionModalForCreatorDashboardBackendApiService.
+ */
+import { HttpClientTestingModule, HttpTestingController } from
+  '@angular/common/http/testing';
+import { TestBed, fakeAsync, flushMicrotasks } from '@angular/core/testing';
+
+import { SuggestionModalForCreatorDashboardBackendApiService } from
+  './suggestion-modal-for-creator-dashboard-backend-api.service';
+import { SuggestionObjectFactory } from
+  'domain/suggestion/SuggestionObjectFactory';
+
+describe('SuggestionModalForCreatorDashboardBackendApiService', () => {
+  let sugBackendApiService: SuggestionModalForCreatorDashboardBackendApiService;
+  let httpTestingController: HttpTestingController;
+  let suggestionObjectFactory: SuggestionObjectFactory;
+  let suggestionBackendDict = {
+    suggestion_id: '1',
+    suggestion_type: 'edit_exploration_state_content',
+    target_type: 'exploration',
+    target_id: '2',
+    target_version_at_submission: 1,
+    status: 'accepted',
+    author_name: 'author',
+    change: {
+      cmd: 'edit_state_property',
+      property_name: 'content',
+      state_name: 'state_1',
+      new_value: {
+        html: 'new suggestion content'
+      },
+      old_value: {
+        html: 'old suggestion content'
+      }
+    },
+    last_updated_msecs: 1000
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [SuggestionModalForCreatorDashboardBackendApiService]
+    });
+
+    httpTestingController = TestBed.get(HttpTestingController);
+    suggestionObjectFactory = TestBed.get(SuggestionObjectFactory);
+    sugBackendApiService = TestBed
+      .get(SuggestionModalForCreatorDashboardBackendApiService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should make a request to update the suggestion in the backend',
+    fakeAsync(() => {
+      const suggestion = suggestionObjectFactory
+        .createFromBackendDict(suggestionBackendDict);
+      const backendResponse = {
+        suggestion: suggestionBackendDict
+      };
+
+      let urlDetails = {
+        targetType: 'exploration',
+        targetId: 0,
+        suggestionId: 0
+      };
+
+      let updateData = {
+        action: 'accept',
+        commitMessage: 'commit message',
+        reviewMessage: 'review message'
+      };
+
+      sugBackendApiService._updateSuggestion(urlDetails, updateData)
+        .then(response => {
+          expect(response).toEqual(suggestion);
+        });
+
+      let req = httpTestingController
+        .expectOne('/suggestionactionhandler/exploration/0/0');
+      expect(req.request.method).toEqual('PUT');
+      req.flush(backendResponse);
+
+      flushMicrotasks();
+    })
+  );
+
+  it('should use rejection handler if suggestion update in the backend failed',
+    fakeAsync(() => {
+      let successHandler = jasmine.createSpy('success');
+      let failHandler = jasmine.createSpy('fail');
+
+      let urlDetails = {
+        targetType: 'exploration',
+        targetId: 0,
+        suggestionId: 0
+      };
+
+      let updateData = {
+        action: 'accept',
+        commitMessage: 'commit message',
+        reviewMessage: 'review message'
+      };
+
+      sugBackendApiService._updateSuggestion(
+        urlDetails, updateData).then(successHandler, failHandler);
+
+      let req = httpTestingController
+        .expectOne('/suggestionactionhandler/exploration/0/0');
+      expect(req.request.method).toEqual('PUT');
+
+      req.flush({
+        error: 'Error updating suggestion.'
+      }, {
+        status: 500, statusText: 'Error updating suggestion.'
+      });
+
+      flushMicrotasks();
+
+      expect(successHandler).not.toHaveBeenCalled();
+      expect(failHandler).toHaveBeenCalledWith('Error updating suggestion.');
+    })
+  );
+});

--- a/core/templates/pages/creator-dashboard-page/suggestion-modal-for-creator-view/suggestion-modal-for-creator-dashboard-backend-api.service.ts
+++ b/core/templates/pages/creator-dashboard-page/suggestion-modal-for-creator-view/suggestion-modal-for-creator-dashboard-backend-api.service.ts
@@ -1,0 +1,79 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+/**
+ * @fileoverview Service to update suggestion in creator view
+ */
+
+import { downgradeInjectable } from '@angular/upgrade/static';
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+import { UrlInterpolationService } from 'domain/utilities/url-interpolation.service';
+import { Suggestion, SuggestionBackendDict, SuggestionObjectFactory } from 'domain/suggestion/SuggestionObjectFactory';
+
+export interface SuggestionData {
+  action: string,
+  commitMessage: string,
+  reviewMessage: string
+}
+
+export interface UrlDetails {
+  targetType: string,
+  targetId: number,
+  suggestionId: number
+}
+
+export interface UpdateSuggestionBackendResponse {
+  suggestion: SuggestionBackendDict;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SuggestionModalForCreatorDashboardBackendApiService {
+  constructor(
+    private http: HttpClient,
+    private urlInterpolationService: UrlInterpolationService,
+    private suggestionObjectFactory: SuggestionObjectFactory) { }
+
+  _updateSuggestion(
+      urlDetails: UrlDetails,
+      data: SuggestionData): Promise<Suggestion> {
+    return new Promise((resolve, reject) => {
+      var HANDLE_SUGGESTION_URL_TEMPLATE = (
+        '/suggestionactionhandler/<target_type>/<target_id>/<suggestion_id>');
+      const url = this.urlInterpolationService.interpolateUrl(
+        HANDLE_SUGGESTION_URL_TEMPLATE, {
+          target_type: urlDetails.targetType,
+          target_id: urlDetails.targetId.toString(),
+          suggestion_id: urlDetails.suggestionId.toString()
+        }
+      );
+
+      this.http.put<UpdateSuggestionBackendResponse>(url, data).toPromise()
+        .then(response => {
+          resolve(
+            this.suggestionObjectFactory
+              .createFromBackendDict(response.suggestion));
+        }, errorResponse => {
+          reject(errorResponse.error.error);
+        });
+    });
+  }
+}
+
+angular.module('oppia').factory(
+  'SuggestionModalForCreatorDashboardBackendApiService',
+  downgradeInjectable(SuggestionModalForCreatorDashboardBackendApiService));
+  

--- a/core/templates/pages/creator-dashboard-page/suggestion-modal-for-creator-view/suggestion-modal-for-creator-view.service.ts
+++ b/core/templates/pages/creator-dashboard-page/suggestion-modal-for-creator-view/suggestion-modal-for-creator-view.service.ts
@@ -18,16 +18,21 @@
 require('components/ck-editor-helpers/ck-editor-4-rte.directive.ts');
 require('components/ck-editor-helpers/ck-editor-4-widgets.initializer.ts');
 
-require('domain/utilities/url-interpolation.service.ts');
-require('services/suggestion-modal.service.ts');
 require(
   'pages/creator-dashboard-page/suggestion-modal-for-creator-view/' +
-  'suggestion-modal-for-creator-view.controller');
+'suggestion-modal-for-creator-dashboard-backend-api.service.ts');
+require(
+  'pages/creator-dashboard-page/suggestion-modal-for-creator-view/' +
+'suggestion-modal-for-creator-view.controller');
+require('services/suggestion-modal.service.ts');
+require('domain/utilities/url-interpolation.service.ts');
 
 angular.module('oppia').factory('SuggestionModalForCreatorDashboardService', [
-  '$http', '$log', '$uibModal', 'UrlInterpolationService',
+  '$log', '$uibModal', 'SuggestionModalForCreatorDashboardBackendApiService',
+  'UrlInterpolationService',
   function(
-      $http, $log, $uibModal, UrlInterpolationService) {
+      $log, $uibModal, SuggestionModalForCreatorDashboardBackendApiService,
+      UrlInterpolationService) {
     var _showEditStateContentSuggestionModal = function(
         activeThread, suggestionsToReviewList, clearActiveThread,
         canReviewActiveThread) {
@@ -68,9 +73,6 @@ angular.module('oppia').factory('SuggestionModalForCreatorDashboardService', [
       }).result.then(function(result) {
         var RESUBMIT_SUGGESTION_URL_TEMPLATE = (
           '/suggestionactionhandler/resubmit/<suggestion_id>');
-        var HANDLE_SUGGESTION_URL_TEMPLATE = (
-          '/suggestionactionhandler/<target_type>/<target_id>/<suggestion_id>');
-
         var url = null;
         var data = null;
         if (result.action === 'resubmit' &&
@@ -94,31 +96,32 @@ angular.module('oppia').factory('SuggestionModalForCreatorDashboardService', [
             }
           };
         } else {
-          url = UrlInterpolationService.interpolateUrl(
-            HANDLE_SUGGESTION_URL_TEMPLATE, {
-              target_type: activeThread.suggestion.targetType,
-              target_id: activeThread.suggestion.targetId,
-              suggestion_id: activeThread.suggestion.suggestionId
-            }
-          );
           data = {
             action: result.action,
-            commit_message: result.commitMessage,
-            review_message: result.reviewMessage
+            commitMessage: result.commitMessage,
+            reviewMessage: result.reviewMessage
+          };
+
+          url = {
+            targetType: activeThread.suggestion.targetType,
+            targetId: activeThread.suggestion.targetId,
+            suggestionId: activeThread.suggestion.suggestionId
           };
         }
 
-        $http.put(url, data).then(function() {
-          for (var i = 0; i < suggestionsToReviewList.length; i++) {
-            if (suggestionsToReviewList[i] === activeThread) {
-              suggestionsToReviewList.splice(i, 1);
-              break;
+        SuggestionModalForCreatorDashboardBackendApiService
+          ._updateSuggestion(url, data)
+          .then(function() {
+            for (var i = 0; i < suggestionsToReviewList.length; i++) {
+              if (suggestionsToReviewList[i] === activeThread) {
+                suggestionsToReviewList.splice(i, 1);
+                break;
+              }
             }
-          }
-          clearActiveThread();
-        })['catch'](function() {
-          $log.error('Error resolving suggestion');
-        });
+            clearActiveThread();
+          })['catch'](function() {
+            $log.error('Error resolving suggestion');
+          });
       });
     };
 

--- a/core/templates/services/angular-services.index.ts
+++ b/core/templates/services/angular-services.index.ts
@@ -293,6 +293,7 @@ import { TranslateService } from 'services/translate.service';
 import { TranslationsBackendApiService } from 'services/translations-backend-api.service';
 import { UtilsService } from 'services/utils.service';
 import { ValidatorsService } from 'services/validators.service';
+import { SuggestionModalForCreatorDashboardBackendApiService } from 'pages/creator-dashboard-page/suggestion-modal-for-creator-view/suggestion-modal-for-creator-dashboard-backend-api.service';
 
 export const angularServices: [string, unknown][] = [
   ['AdminBackendApiService', AdminBackendApiService],
@@ -597,4 +598,6 @@ export const angularServices: [string, unknown][] = [
   ['WrittenTranslationObjectFactory', WrittenTranslationObjectFactory],
   ['WrittenTranslationsObjectFactory', WrittenTranslationsObjectFactory],
   ['baseInteractionValidationService', baseInteractionValidationService],
+  ['SuggestionModalForCreatorDashboardBackendApiService',
+    SuggestionModalForCreatorDashboardBackendApiService],
 ];


### PR DESCRIPTION
@DubeySandeep  PTAL
Hello, this is my first pull request and I would appereciate your advice on how/why something should be changed.
The new file is written according to Angular"+ but as I can see it fails frontend tests. (When I did it locally with 'fit' and 'fdescribe', it passed tests.

1. This PR fixes or fixes part of #[8035].
2. This PR does the following: [http class is used in newly created suggestion-modal-for-creator-dashboard-backend-api.service]


- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".


