### PR TITLE
Revert "temporarily disable cache on Travis"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,14 @@ script:
 - if [ "$RUN_E2E_TESTS_SKILL_EDITOR" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="skillEditor" --prod_env; fi
 - if [ "$RUN_E2E_TESTS_EMBEDDING" == 'true' ] && [ "$RUN_TESTS" == 'true' ]; then python -m scripts.run_e2e_tests --suite="embedding" --prod_env; fi
 
-cache: false
+cache:
+  # Cache Oppia's dependencies.
+  directories:
+    - ../oppia_tools/
+    - node_modules/
+    - third_party/
+    - $HOME/.cache/pip
+    - $HOME/.cache/TravisChrome/
 
 before_cache:
   # Delete python bytecode to prevent cache rebuild.


### PR DESCRIPTION
Reverts oppia/oppia#11061

Enabling caches that were disabled in #11061 to clear existing bad cache in the server.

### [This PR can be merged once [the latest build](https://travis-ci.com/github/oppia/oppia/builds/194100173) completes.]