### PR TITLE
Fix #8038: http calls moved from translation-file-hash-loader.service.ts  to *backend.api.service 

### DIFF
--- a/core/templates/services/UpgradedServices.ts
+++ b/core/templates/services/UpgradedServices.ts
@@ -1216,7 +1216,8 @@ export class UpgradedServices {
         upgradedServices['UrlInterpolationService']);
     upgradedServices['TranslationsBackendApiService'] =
       new TranslationsBackendApiService(
-        upgradedServices['HttpClient']);
+        upgradedServices['HttpClient'],
+        upgradedServices['UrlInterpolationService']);
 
     // Topological level: 4.
     upgradedServices['CollectionCreationService'] =

--- a/core/templates/services/translate.service.ts
+++ b/core/templates/services/translate.service.ts
@@ -77,7 +77,8 @@ export class TranslateService {
    * translations
    */
   fetchTranslations(languageCode: string): Promise<TranslationsDict> {
-    return this.translationsBackendApiService.fetchTranslations(languageCode);
+    return this.translationsBackendApiService
+      .fetchTranslationsAsync(languageCode);
   }
 
   /**

--- a/core/templates/services/translation-file-hash-loader.service.ts
+++ b/core/templates/services/translation-file-hash-loader.service.ts
@@ -17,10 +17,11 @@
  */
 
 require('domain/utilities/url-interpolation.service.ts');
+require('./translations-backend-api.service.ts')
 
 angular.module('oppia').factory('TranslationFileHashLoaderService', [
-  '$http', '$q', 'UrlInterpolationService',
-  function($http, $q, UrlInterpolationService) {
+  '$q', 'TranslationsBackendApiService', 'UrlInterpolationService',
+  function($q, TranslationsBackendApiService, UrlInterpolationService) {
     /* Options object contains:
      *  prefix: added before key, defined by developer
      *  key: language key, determined internally by i18n library
@@ -32,10 +33,10 @@ angular.module('oppia').factory('TranslationFileHashLoaderService', [
         options.key,
         options.suffix
       ].join('');
-      return $http.get(
+      return TranslationsBackendApiService.loadTranslationFileHash(
         UrlInterpolationService.getStaticAssetUrl(fileUrl)
       ).then(function(result) {
-        return result.data;
+        return result;
       }, function() {
         return $q.reject(options.key);
       });

--- a/core/templates/services/translation-file-hash-loader.service.ts
+++ b/core/templates/services/translation-file-hash-loader.service.ts
@@ -17,7 +17,7 @@
  */
 
 require('domain/utilities/url-interpolation.service.ts');
-require('./translations-backend-api.service.ts')
+require('./translations-backend-api.service.ts');
 
 angular.module('oppia').factory('TranslationFileHashLoaderService', [
   '$q', 'TranslationsBackendApiService', 'UrlInterpolationService',
@@ -25,7 +25,7 @@ angular.module('oppia').factory('TranslationFileHashLoaderService', [
     /* Options object contains:
      *  prefix: added before key, defined by developer
      *  key: language key, determined internally by i18n library
-     *  suffix: added after key, defined by developer
+     *  suffix: added after key, defined by developer.
      */
     return function(options) {
       var fileUrl = [

--- a/core/templates/services/translation-file-hash-loader.service.ts
+++ b/core/templates/services/translation-file-hash-loader.service.ts
@@ -16,12 +16,11 @@
  * @fileoverview Service to load the i18n translation file.
  */
 
-require('domain/utilities/url-interpolation.service.ts');
 require('./translations-backend-api.service.ts');
 
 angular.module('oppia').factory('TranslationFileHashLoaderService', [
-  '$q', 'TranslationsBackendApiService', 'UrlInterpolationService',
-  function($q, TranslationsBackendApiService, UrlInterpolationService) {
+  '$q', 'TranslationsBackendApiService',
+  function($q, TranslationsBackendApiService) {
     /* Options object contains:
      *  prefix: added before key, defined by developer
      *  key: language key, determined internally by i18n library
@@ -33,13 +32,12 @@ angular.module('oppia').factory('TranslationFileHashLoaderService', [
         options.key,
         options.suffix
       ].join('');
-      return TranslationsBackendApiService.loadTranslationFileHash(
-        UrlInterpolationService.getStaticAssetUrl(fileUrl)
-      ).then(function(result) {
-        return result;
-      }, function() {
-        return $q.reject(options.key);
-      });
+      return TranslationsBackendApiService.loadTranslationFileAsync(fileUrl)
+        .then(function(result) {
+          return result;
+        }, function() {
+          return $q.reject(options.key);
+        });
     };
   }
 ]);

--- a/core/templates/services/translation-file-hash-loader.service.ts
+++ b/core/templates/services/translation-file-hash-loader.service.ts
@@ -32,9 +32,9 @@ angular.module('oppia').factory('TranslationFileHashLoaderService', [
         options.key,
         options.suffix
       ].join('');
-      return TranslationsBackendApiService.loadTranslationFileAsync(fileUrl)
-        .then(function(result) {
-          return result;
+      TranslationsBackendApiService.loadTranslationFileAsync(fileUrl)
+        .then((result) => {
+          return result.body;
         }, function() {
           return $q.reject(options.key);
         });

--- a/core/templates/services/translations-backend-api.service.spec.ts
+++ b/core/templates/services/translations-backend-api.service.spec.ts
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 /**
  * @fileoverview Unit tests for TranslationsBackendApiService.
  */
@@ -45,13 +44,31 @@ describe('Translations backend API service', () => {
       I18N_T_1: 'Hello'
     };
 
-    translationsBackendApiService.fetchTranslations('en').then(response => {
-      expect(response).toEqual(translations);
-    });
+    translationsBackendApiService
+      .fetchTranslationsAsync('en').then(response => {
+        expect(response).toEqual(translations);
+      });
 
     let req = httpTestingController.expectOne('/assets/i18n/en.json');
     expect(req.request.method).toEqual('GET');
     req.flush(translations);
+
+    flushMicrotasks();
+  }));
+
+  it('should correctly fetch translation files.', fakeAsync(() => {
+    const loadedFile = {
+      I18N_ABOUT_PAGE_ABOUT_TAB_CREATE: 'Create an Exploration'
+    };
+
+    translationsBackendApiService.loadTranslationFileAsync('/i18n/en.json')
+      .then(response => {
+        expect(response).toContain(loadedFile);
+      });
+
+    let req = httpTestingController.expectOne('/i18n/en.json');
+    expect(req.request.method).toEqual('GET');
+    req.flush(loadedFile);
 
     flushMicrotasks();
   }));

--- a/core/templates/services/translations-backend-api.service.ts
+++ b/core/templates/services/translations-backend-api.service.ts
@@ -45,7 +45,8 @@ export class TranslationsBackendApiService {
 
   async loadTranslationFileAsync(url: string): Promise<Object> {
     return this.http.get<TranslationsDict>(
-      this.urlInterpolationService.getStaticAssetUrl(url), { observe: 'response' }).toPromise();
+      this.urlInterpolationService
+        .getStaticAssetUrl(url), { observe: 'response' }).toPromise();
   }
 }
 

--- a/core/templates/services/translations-backend-api.service.ts
+++ b/core/templates/services/translations-backend-api.service.ts
@@ -37,8 +37,8 @@ export class TranslationsBackendApiService {
     return this.http.get<TranslationsDict>(
       `${this.prefix}${languageCode}${this.suffix}`).toPromise();
   }
-  loadTranslationFileHash(url: string): Promise<String> {
-    return this.http.get<String>(url).toPromise();
+  loadTranslationFileHash(url: string): Promise<string> {
+    return this.http.get<string>(url).toPromise();
   }
 }
 

--- a/core/templates/services/translations-backend-api.service.ts
+++ b/core/templates/services/translations-backend-api.service.ts
@@ -37,6 +37,9 @@ export class TranslationsBackendApiService {
     return this.http.get<TranslationsDict>(
       `${this.prefix}${languageCode}${this.suffix}`).toPromise();
   }
+  loadTranslationFileHash(url: string): Promise<String> {
+    return this.http.get<String>(url).toPromise();
+  }
 }
 
 angular.module('oppia').factory(

--- a/core/templates/services/translations-backend-api.service.ts
+++ b/core/templates/services/translations-backend-api.service.ts
@@ -19,6 +19,8 @@
 import { downgradeInjectable } from '@angular/upgrade/static';
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { UrlInterpolationService } from
+  'domain/utilities/url-interpolation.service';
 
 export interface TranslationsDict {
   [translation: string]: string;
@@ -31,14 +33,19 @@ export class TranslationsBackendApiService {
   private prefix = '/assets/i18n/';
   private suffix = '.json';
 
-  constructor(private http: HttpClient) {}
+  constructor(
+    private http: HttpClient,
+    private urlInterpolationService: UrlInterpolationService) {}
 
-  fetchTranslations(languageCode: string): Promise<TranslationsDict> {
+  async fetchTranslationsAsync(
+      languageCode: string): Promise<TranslationsDict> {
     return this.http.get<TranslationsDict>(
       `${this.prefix}${languageCode}${this.suffix}`).toPromise();
   }
-  loadTranslationFileHash(url: string): Promise<string> {
-    return this.http.get<string>(url).toPromise();
+
+  async loadTranslationFileAsync(url: string): Promise<TranslationsDict> {
+    return this.http.get<TranslationsDict>(
+      this.urlInterpolationService.getStaticAssetUrl(url)).toPromise();
   }
 }
 

--- a/core/templates/services/translations-backend-api.service.ts
+++ b/core/templates/services/translations-backend-api.service.ts
@@ -43,9 +43,9 @@ export class TranslationsBackendApiService {
       `${this.prefix}${languageCode}${this.suffix}`).toPromise();
   }
 
-  async loadTranslationFileAsync(url: string): Promise<TranslationsDict> {
+  async loadTranslationFileAsync(url: string): Promise<Object> {
     return this.http.get<TranslationsDict>(
-      this.urlInterpolationService.getStaticAssetUrl(url)).toPromise();
+      this.urlInterpolationService.getStaticAssetUrl(url), { observe: 'response' }).toPromise();
   }
 }
 


### PR DESCRIPTION
@DubeySandeep PTAL
Hello, this is my third PR under Fix #8038. I moved http call from translation-file-hash-loader.service.ts  to translations-backend-api.service (already existing file). I was thinking of creating a new *backend-api.service but decided for cleaner file structure and moved the http call to an existing file (most appropriate for translation hash loader service). 

This PR fixes or fixes part of #8035.
This PR does the following: http class is used in newly created suggestion-modal-for-creator-dashboard-backend-api.service.
[x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
[x] The linter/Karma presubmit checks have passed locally on your machine.
[x] "Allow edits from maintainers" is checked. (See here for instructions on how to enable it.)
This lets reviewers restart your CircleCI tests for you.
[x] The PR is made from a branch that's not called "develop".