### PR TITLE
Remove self from codeowners while I'm on holiday

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,7 +46,8 @@
 
 
 # Android team
-/core/domain/android_validation_constants*.py @BenHenning
+# TODO(#11083): Revert owner to @BenHenning after 2020-11-15.
+/core/domain/android_validation_constants*.py @rt4914
 
 
 # Angular Migration team
@@ -147,7 +148,8 @@
 
 
 # Dev workflow team.
-/.circleci/ @BenHenning @U8NWXD @kevintab95 @vinitamurthi
+# TODO(#11083): Re-add owner @BenHenning after 2020-11-15.
+/.circleci/ @U8NWXD @kevintab95 @vinitamurthi
 # TODO(#10619): Add @bansalnitish as owner after 2020-10-31
 /.eslintignore @DubeySandeep @Hudda
 # TODO(#10619): Add @bansalnitish as owner after 2020-10-31
@@ -164,7 +166,8 @@
 /.pylintrc @DubeySandeep @Hudda
 # TODO(#10619): Add @bansalnitish as owner after 2020-10-31
 /.stylelintrc @DubeySandeep @Hudda
-/.travis.yml @BenHenning @vinitamurthi @U8NWXD @kevintab95
+# TODO(#11083): Re-add owner @BenHenning after 2020-11-15.
+/.travis.yml @vinitamurthi @U8NWXD @kevintab95
 /.yarnrc @DubeySandeep
 # TODO(#11045): Add @nithusha21 as owner after 2020-11-2
 /codecov.yml @U8NWXD
@@ -639,14 +642,15 @@
 
 
 # Dynamic Feature Gating project
-/core/controllers/platform_feature*.py @BenHenning @vinitamurthi
-/core/domain/platform_feature_services*.py @BenHenning @vinitamurthi
-/core/domain/platform_parameter*.py @BenHenning @vinitamurthi
-/core/platform_feature*.py @BenHenning @vinitamurthi
-/core/storage/config/ @BenHenning @vinitamurthi
-/core/templates/domain/platform_feature/ @BenHenning @vinitamurthi
-/core/templates/pages/admin-page/features-tab/ @BenHenning @vinitamurthi
-/core/templates/services/platform-feature*.ts @BenHenning @vinitamurthi
+# TODO(#11083): Re-add owner @BenHenning after 2020-11-15 (to all patterns in this section).
+/core/controllers/platform_feature*.py @vinitamurthi
+/core/domain/platform_feature_services*.py @vinitamurthi
+/core/domain/platform_parameter*.py @vinitamurthi
+/core/platform_feature*.py @vinitamurthi
+/core/storage/config/ @vinitamurthi
+/core/templates/domain/platform_feature/ @vinitamurthi
+/core/templates/pages/admin-page/features-tab/ @vinitamurthi
+/core/templates/services/platform-feature*.ts @vinitamurthi
 
 
 # Frontend unit tests
@@ -705,4 +709,5 @@
 /.github/ @DubeySandeep
 /.github/CODEOWNERS @DubeySandeep
 /.github/stale.yml @vojtechjelinek
-/.github/workflows/ @BenHenning @vinitamurthi
+# TODO(#11083): Re-add owner @BenHenning after 2020-11-15.
+/.github/workflows/ @vinitamurthi


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of N/A.
2. This PR does the following: Remove self from codeowners while I'm on holiday.

#11083 is filed to re-add me.

## Essential Checklist

- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".): N/A for the bug part
- [X] The linter/Karma presubmit checks have passed locally on your machine: N/A since this is a codeowner change.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.): N/A since this isn't on a fork.
  - This lets reviewers restart your CircleCI tests for you.
- [X] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
