### PR TITLE
Add RatioExpressionInput to android validation constants; Fix font size issues with classroom topic cards;

### DIFF
--- a/core/domain/android_validation_constants.py
+++ b/core/domain/android_validation_constants.py
@@ -27,7 +27,7 @@ VALID_INTERACTION_IDS = [
     'AlgebraicExpressionInput', 'Continue', 'DragAndDropSortInput',
     'EndExploration', 'FractionInput', 'ImageClickInput', 'ItemSelectionInput',
     'MathEquationInput', 'MultipleChoiceInput', 'NumericExpressionInput',
-    'NumericInput', 'NumberWithUnits', 'TextInput'
+    'NumericInput', 'NumberWithUnits', 'RatioExpressionInput', 'TextInput'
 ]
 
 SUPPORTED_LANGUAGES = ['en']

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -1181,6 +1181,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         _verify_interaction_supports_android(self, 'NumericInput')
         _verify_interaction_supports_android(self, 'TextInput')
         _verify_interaction_supports_android(self, 'NumericExpressionInput')
+        _verify_interaction_supports_android(self, 'RatioExpressionInput')
         _verify_interaction_supports_android(self, None)
 
         _verify_interaction_does_not_support_android(self, 'CodeRepl')
@@ -1189,8 +1190,6 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         _verify_interaction_does_not_support_android(self, 'LogicProof')
         _verify_interaction_does_not_support_android(self, 'MusicNotesInput')
         _verify_interaction_does_not_support_android(self, 'PencilCodeEditor')
-        _verify_interaction_does_not_support_android(
-            self, 'RatioExpressionInput')
         _verify_interaction_does_not_support_android(self, 'SetInput')
 
         _verify_all_interaction_ids_checked(self)

--- a/core/templates/components/summary-tile/topic-summary-tile.directive.html
+++ b/core/templates/components/summary-tile/topic-summary-tile.directive.html
@@ -96,10 +96,10 @@
     border-radius: 0 0 0.2em 0.2em;
     color: #ffffff;
     font-family: Roboto, Arial, sans-serif;
-    font-size: 0.9em;
+    font-size: 0.8em;
     height: 100px;
     letter-spacing: 0.5px;
-    padding: 10px 5px 5px 15px;
+    padding: 4px 12px;
   }
 
   @media(max-width: 1150px) {


### PR DESCRIPTION
…ze issues with classroom topic cards

## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. ~This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following: Add RatioExpressionInput to android validation constants; Fix font size issues with classroom topic cards;

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
