### PR TITLE
Adds get_model_association_to_user function for the UserIdentifiersModel 

### DIFF
--- a/core/storage/user/gae_models.py
+++ b/core/storage/user/gae_models.py
@@ -2803,6 +2803,13 @@ class UserIdentifiersModel(base_models.BaseModel):
         """
         return base_models.DELETION_POLICY.DELETE_AT_END
 
+    @staticmethod
+    def get_model_association_to_user():
+        """Currently, the model holds identifiers relevant only for backend that
+        should not be exported.
+        """
+        return base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+
     @classmethod
     def get_export_policy(cls):
         """Currently, the model holds authentication details relevant only for


### PR DESCRIPTION
## This PR fixes backend test issue on develop branch

## Overview
1. This PR does the following: Adds get_model_association_to_user function for the UserIdentifiersModel 


## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
