### PR TITLE
Mitigate unicode comparison error in e2e script

### DIFF
--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -664,6 +664,11 @@ def run_tests(args=None):
     suite_name = parsed_args.suite.lower()
     if len(flaky_tests_list) > 0 and p.returncode != 0:
         for i, line in enumerate(output_lines):
+            try:
+                line = python_utils.UNICODE(line)
+            except:
+                # Not a unicode line, can skip it.
+                continue
             if line == u'*                    Failures                    *':
                 test_name = output_lines[i + 3][3:].strip().lower()
 

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -664,7 +664,7 @@ def run_tests(args=None):
     suite_name = parsed_args.suite.lower()
     if len(flaky_tests_list) > 0 and p.returncode != 0:
         for i, line in enumerate(output_lines):
-            if line == '*                    Failures                    *':
+            if line == u'*                    Failures                    *':
                 test_name = output_lines[i + 3][3:].strip().lower()
 
                 # Remove coloring characters.
@@ -678,10 +678,10 @@ def run_tests(args=None):
                     flaky_error_message = row[2].strip().lower()
                     if (
                             suite_name == flaky_suite_name or
-                            flaky_suite_name == '[general]'):
+                            flaky_suite_name == u'[general]'):
                         if (
                                 test_name == flaky_test_message or
-                                flaky_test_message == 'many'):
+                                flaky_test_message == u'many'):
                             if flaky_error_message in failure_log:
                                 update_flaky_tests_count(sheet, index, row[3])
                                 try:

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -666,7 +666,7 @@ def run_tests(args=None):
         for i, line in enumerate(output_lines):
             try:
                 line = python_utils.UNICODE(line)
-            except:
+            except UnicodeDecodeError:
                 # Not a unicode line, can skip it.
                 continue
             if line == u'*                    Failures                    *':


### PR DESCRIPTION
## Overview
There are some unicode comparison errors that arise during execution on CI. These errors are mostly useless, and can be ignored. Patching it to prevent confusion while reading the logs.

1. This PR fixes or fixes part of .

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
