### PR TITLE
Removed Hudda as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -148,27 +148,27 @@
 
 # Dev workflow team.
 /.circleci/ @BenHenning @U8NWXD @kevintab95 @vinitamurthi
-/.eslintignore @DubeySandeep @Hudda
-/.eslintrc @DubeySandeep @Hudda
-/.htmllintrc @DubeySandeep @Hudda
-/.coveragerc @DubeySandeep @Hudda
+/.eslintignore @DubeySandeep
+/.eslintrc @DubeySandeep
+/.htmllintrc @DubeySandeep
+/.coveragerc @DubeySandeep
 /.gitattributes @DubeySandeep
 /.gitignore @DubeySandeep
-/.isort.cfg @DubeySandeep @Hudda
-/.pylintrc @DubeySandeep @Hudda
-/.stylelintrc @DubeySandeep @Hudda
+/.isort.cfg @DubeySandeep
+/.pylintrc @DubeySandeep
+/.stylelintrc @DubeySandeep
 /.travis.yml @BenHenning @vinitamurthi @U8NWXD @kevintab95
 /.yarnrc @DubeySandeep
 /codecov.yml @nithusha21
-/core/templates/css/.stylelintrc @DubeySandeep @Hudda
-/tox.ini @DubeySandeep @Hudda
+/core/templates/css/.stylelintrc @DubeySandeep
+/tox.ini @DubeySandeep
 /scripts/*.py @DubeySandeep
 /scripts/check_e2e_tests_are_captured_in_ci*.py @kevintab95 @DubeySandeep
 /scripts/check_frontend_coverage*.py @DubeySandeep @nithusha21
 /scripts/create_topological_sort_of_all_services*.py @DubeySandeep
 /scripts/install_prerequisites.sh @DubeySandeep
 /scripts/typescript_checks*.py @nishantwrp @DubeySandeep
-/scripts/linters/ @DubeySandeep @Hudda
+/scripts/linters/ @DubeySandeep
 /scripts/linters/ts_ignore_exceptions.json @nishantwrp
 /ubuntu_dockerfile @DubeySandeep
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

~~1. This PR fixes or fixes part of #[fill_in_number_here].~~
2. This PR does the following: Removing Hudda as a codeowner

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
