### PR TITLE
Fix #11154: Modify additional rules indicator to show every time

### DIFF
--- a/core/templates/components/state-directives/response-header/response-header.directive.html
+++ b/core/templates/components/state-directives/response-header/response-header.directive.html
@@ -13,17 +13,16 @@
         Correct
       </div>
     </div>
-    <span ng-attr-title="<[$ctrl.getSummary()]>">
-      <[$ctrl.getShortSummary()]>
+    <span class="oppia-response-summary" ng-attr-title="<[$ctrl.getSummary()]>">
+      <span class="oppia-response-short-summary"><[$ctrl.getShortSummary()]></span>
       <span ng-if="$ctrl.getNumRules() > 1" class="badge badge-primary position-relative oppia-num-rules">
         +<[$ctrl.getNumRules() - 1]>
       </span>
     </span>
-    <span>&nbsp;</span>
   </div>
 
   <br class="break-in-mobile">
-  <span ng-if="$ctrl.getOutcome()">→</span>
+  <span ng-if="$ctrl.getOutcome()"> →</span>
   <span ng-if="$ctrl.isCorrect() && $ctrl.isInQuestionMode()">
     Correct
   </span>
@@ -96,8 +95,13 @@
   response-header .oppia-response-tick {
     color: #00645C;
   }
-  response-header .oppia-num-rules {
-    bottom: 4px;
+  response-header .oppia-response-summary {
+    display: flex;
+    flex-flow: row;
+  }
+  response-header .oppia-response-short-summary {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   /* This is to break the line only when screen is too narrow to have both divs
      in same line.*/


### PR DESCRIPTION
## Overview

1. This PR fixes #11154.
2. This PR does the following:
![image](https://user-images.githubusercontent.com/10142938/99905197-c03ce200-2ccf-11eb-8e5b-1ac09999c1da.png)

![image](https://user-images.githubusercontent.com/10142938/99905192-b915d400-2ccf-11eb-93aa-8c71532af9a1.png)


## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
