### PR TITLE
Fixes #11155, #11156: Removed redundant rule for simplified value

### DIFF
--- a/extensions/interactions/RatioExpressionInput/directives/ratio-expression-input-validation.service.spec.ts
+++ b/extensions/interactions/RatioExpressionInput/directives/ratio-expression-input-validation.service.spec.ts
@@ -109,6 +109,15 @@ describe('RatioExpressionInputValidationService', () => {
     expect(warnings).toEqual([]);
   });
 
+  it('should be able to perform basic valid', () => {
+    // The second rule has a broader scope than first.
+    answerGroups[0].rules = [equals, isEquivalent];
+
+    warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups, goodDefaultOutcome);
+    expect(warnings).toEqual([]);
+  });
+
   it('should catch redundancy of rules with matching inputs', () => {
     // The third rule will never get matched.
     answerGroups[0].rules = [equals, equals];

--- a/extensions/interactions/RatioExpressionInput/directives/ratio-expression-input-validation.service.spec.ts
+++ b/extensions/interactions/RatioExpressionInput/directives/ratio-expression-input-validation.service.spec.ts
@@ -111,7 +111,7 @@ describe('RatioExpressionInputValidationService', () => {
 
   it('should catch redundancy of rules with matching inputs', () => {
     // The third rule will never get matched.
-    answerGroups[0].rules = [equals, isEquivalent];
+    answerGroups[0].rules = [equals, equals];
 
     warnings = validatorService.getAllWarnings(
       currentState, customizationArgs, answerGroups, goodDefaultOutcome);
@@ -136,14 +136,9 @@ describe('RatioExpressionInputValidationService', () => {
     expect(warnings).toEqual([{
       type: WARNING_TYPES.ERROR,
       message: 'Rule 2 from answer group 1 will never be matched because' +
-      ' provided input is not in its simplest form.'
-    }, {
-      type: WARNING_TYPES.ERROR,
-      message: 'Rule 2 from answer group 1 will never be matched because' +
       ' it is preceded by a \'IsEquivalent\' rule with a matching' +
       ' input.'
-    }
-    ]);
+    }]);
 
     let equalFourTerms = rof.createFromBackendDict({
       rule_type: 'Equals',

--- a/extensions/interactions/RatioExpressionInput/directives/ratio-expression-input-validation.service.ts
+++ b/extensions/interactions/RatioExpressionInput/directives/ratio-expression-input-validation.service.ts
@@ -87,19 +87,6 @@ export class RatioExpressionInputValidationService {
       this.baseInteractionValidationServiceInstance.getAllOutcomeWarnings(
         answerGroups, defaultOutcome, stateName));
 
-    // Checks whether currentInput is in simplest form or not.
-    let isInSimplestForm = function(
-        currentRuleType: string,
-        ratio: Ratio,
-        currentInput: number[]
-    ): boolean {
-      return (
-        currentRuleType === 'IsEquivalent' &&
-        !Ratio.arrayEquals(
-          ratio.convertToSimplestForm(), currentInput)
-      );
-    };
-
     // Checks whether currentInput has less number of terms than seenInput.
     let hasLessNumberOfTerms = function(
         currentRuleType: string,
@@ -161,20 +148,13 @@ export class RatioExpressionInputValidationService {
           }
         }
         ratio = Ratio.fromList(<number[]> currentInput);
-        if (isInSimplestForm(currentRuleType, ratio, currentInput)) {
-          warningsList.push({
-            type: AppConstants.WARNING_TYPES.ERROR,
-            message: (
-              `Rule ${j + 1} from answer group ${i + 1} will never be` +
-              ' matched because provided input is not in its simplest form.')
-          });
-        }
         for (let seenRule of seenRules) {
           let seenInput = seenRule.inputs.x || seenRule.inputs.y;
           let seenRuleType = <string> seenRule.type;
 
           if (
             seenRuleType === 'Equals' &&
+            currentRuleType !== 'IsEquivalent' &&
             currentRuleType !== 'HasNumberOfTermsEqualTo' && (
               ratioRulesService.Equals(
                 seenInput, {x: currentInput}))) {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #11155, fixes #11156.
2. This PR does the following: 
Removes redundant rule check for checking whether the input is in simplified form or not.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
