### PR TITLE
Fix part of #6271: Refactor update_interaction_answer_groups method

### DIFF
--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -529,7 +529,8 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id': None
         })
 
-        init_state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict(old_answer_groups))
+        init_state.update_interaction_answer_groups(
+          state_domain.AnswerGroup.from_dict(old_answer_groups))
 
         exploration.validate()
 
@@ -729,7 +730,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         answer_groups_list = [
             answer_group.to_dict() for answer_group in answer_groups]
         init_state.update_interaction_answer_groups(
-          state_domain.AnswerGroup.from_dict(answer_groups_list))
+            state_domain.AnswerGroup.from_dict(answer_groups_list))
         init_state.update_interaction_default_outcome(default_outcome)
         exploration.validate()
         solution_dict = {
@@ -775,7 +776,8 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'training_data': [],
             'tagged_skill_misconception_id': 1
         }
-        init_state.update_interaction_answer_groups([state_domain.AnswerGroup.from_dict(answer_groups_dict)])
+        init_state.update_interaction_answer_groups(
+          [state_domain.AnswerGroup.from_dict(answer_groups_dict)])
 
         self._assert_validation_error(
             exploration,
@@ -803,7 +805,8 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id':
                 'invalid_tagged_skill_misconception_id'
         }
-        init_state.update_interaction_answer_groups([state_domain.AnswerGroup.from_dict(answer_groups_dict)])
+        init_state.update_interaction_answer_groups(
+          [state_domain.AnswerGroup.from_dict(answer_groups_dict)])
 
         self._assert_validation_error(
             exploration,
@@ -1227,7 +1230,8 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id': None
         }
         # Adds 1 to content count to exploration (feedback_1).
-        init_state.update_interaction_answer_groups([state_domain.AnswerGroup.from_dict(answer_group_dict)])
+        init_state.update_interaction_answer_groups(
+          [state_domain.AnswerGroup.from_dict(answer_group_dict)])
 
         hints_list = [
             state_domain.Hint(
@@ -1604,7 +1608,8 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id': None
         }]
 
-        exploration.init_state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict(answer_groups))
+        exploration.init_state.update_interaction_answer_groups(
+          state_domain.AnswerGroup.from_dict(answer_groups))
         with self.assertRaisesRegexp(
             Exception,
             'The parameter ParamChange was used in an answer group, '
@@ -9897,8 +9902,10 @@ class HtmlCollectionTests(test_utils.GenericTestBase):
             'training_data': [],
             'tagged_skill_misconception_id': None
         }]
-        state2.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict(answer_group_list2))
-        state3.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict(answer_group_list3))
+        state2.update_interaction_answer_groups(
+          state_domain.AnswerGroup.from_dict(answer_group_list2))
+        state3.update_interaction_answer_groups(
+          state_domain.AnswerGroup.from_dict(answer_group_list3))
 
         expected_html_list = [
             '',

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -529,7 +529,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id': None
         })
 
-        init_state.update_interaction_answer_groups(old_answer_groups)
+        init_state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict(old_answer_groups))
 
         exploration.validate()
 
@@ -728,7 +728,8 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         self.set_interaction_for_state(init_state, 'TextInput')
         answer_groups_list = [
             answer_group.to_dict() for answer_group in answer_groups]
-        init_state.update_interaction_answer_groups(answer_groups_list)
+        init_state.update_interaction_answer_groups(
+          state_domain.AnswerGroup.from_dict(answer_groups_list))
         init_state.update_interaction_default_outcome(default_outcome)
         exploration.validate()
         solution_dict = {
@@ -774,7 +775,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'training_data': [],
             'tagged_skill_misconception_id': 1
         }
-        init_state.update_interaction_answer_groups([answer_groups_dict])
+        init_state.update_interaction_answer_groups([state_domain.AnswerGroup.from_dict(answer_groups_dict)])
 
         self._assert_validation_error(
             exploration,
@@ -802,7 +803,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id':
                 'invalid_tagged_skill_misconception_id'
         }
-        init_state.update_interaction_answer_groups([answer_groups_dict])
+        init_state.update_interaction_answer_groups([state_domain.AnswerGroup.from_dict(answer_groups_dict)])
 
         self._assert_validation_error(
             exploration,
@@ -1226,7 +1227,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id': None
         }
         # Adds 1 to content count to exploration (feedback_1).
-        init_state.update_interaction_answer_groups([answer_group_dict])
+        init_state.update_interaction_answer_groups([state_domain.AnswerGroup.from_dict(answer_group_dict)])
 
         hints_list = [
             state_domain.Hint(
@@ -1603,7 +1604,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id': None
         }]
 
-        exploration.init_state.update_interaction_answer_groups(answer_groups)
+        exploration.init_state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict(answer_groups))
         with self.assertRaisesRegexp(
             Exception,
             'The parameter ParamChange was used in an answer group, '
@@ -9896,8 +9897,8 @@ class HtmlCollectionTests(test_utils.GenericTestBase):
             'training_data': [],
             'tagged_skill_misconception_id': None
         }]
-        state2.update_interaction_answer_groups(answer_group_list2)
-        state3.update_interaction_answer_groups(answer_group_list3)
+        state2.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict(answer_group_list2))
+        state3.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict(answer_group_list3))
 
         expected_html_list = [
             '',

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -530,7 +530,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         })
 
         init_state.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict(old_answer_groups))
+            state_domain.AnswerGroup.from_dicts(old_answer_groups))
 
         exploration.validate()
 
@@ -730,7 +730,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         answer_groups_list = [
             answer_group.to_dict() for answer_group in answer_groups]
         init_state.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict(answer_groups_list))
+            state_domain.AnswerGroup.from_dicts(answer_groups_list))
         init_state.update_interaction_default_outcome(default_outcome)
         exploration.validate()
         solution_dict = {
@@ -1609,7 +1609,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         }]
 
         exploration.init_state.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict(answer_groups))
+            state_domain.AnswerGroup.from_dicts(answer_groups))
         with self.assertRaisesRegexp(
             Exception,
             'The parameter ParamChange was used in an answer group, '
@@ -9903,9 +9903,9 @@ class HtmlCollectionTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id': None
         }]
         state2.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict(answer_group_list2))
+            state_domain.AnswerGroup.from_dicts(answer_group_list2))
         state3.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict(answer_group_list3))
+            state_domain.AnswerGroup.from_dicts(answer_group_list3))
 
         expected_html_list = [
             '',

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -530,7 +530,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         })
 
         init_state.update_interaction_answer_groups(
-          state_domain.AnswerGroup.from_dict(old_answer_groups))
+            state_domain.AnswerGroup.from_dict(old_answer_groups))
 
         exploration.validate()
 
@@ -777,7 +777,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id': 1
         }
         init_state.update_interaction_answer_groups(
-          [state_domain.AnswerGroup.from_dict(answer_groups_dict)])
+            [state_domain.AnswerGroup.from_dict(answer_groups_dict)])
 
         self._assert_validation_error(
             exploration,
@@ -806,7 +806,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
                 'invalid_tagged_skill_misconception_id'
         }
         init_state.update_interaction_answer_groups(
-          [state_domain.AnswerGroup.from_dict(answer_groups_dict)])
+            [state_domain.AnswerGroup.from_dict(answer_groups_dict)])
 
         self._assert_validation_error(
             exploration,
@@ -1231,7 +1231,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         }
         # Adds 1 to content count to exploration (feedback_1).
         init_state.update_interaction_answer_groups(
-          [state_domain.AnswerGroup.from_dict(answer_group_dict)])
+            [state_domain.AnswerGroup.from_dict(answer_group_dict)])
 
         hints_list = [
             state_domain.Hint(
@@ -1609,7 +1609,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
         }]
 
         exploration.init_state.update_interaction_answer_groups(
-          state_domain.AnswerGroup.from_dict(answer_groups))
+            state_domain.AnswerGroup.from_dict(answer_groups))
         with self.assertRaisesRegexp(
             Exception,
             'The parameter ParamChange was used in an answer group, '
@@ -9903,9 +9903,9 @@ class HtmlCollectionTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id': None
         }]
         state2.update_interaction_answer_groups(
-          state_domain.AnswerGroup.from_dict(answer_group_list2))
+            state_domain.AnswerGroup.from_dict(answer_group_list2))
         state3.update_interaction_answer_groups(
-          state_domain.AnswerGroup.from_dict(answer_group_list3))
+            state_domain.AnswerGroup.from_dict(answer_group_list3))
 
         expected_html_list = [
             '',

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -1475,7 +1475,7 @@ class ExplorationMathSvgFilenameValidationOneOffJobTests(
         state2.update_interaction_customization_args(
             customization_args_dict)
         state2.update_next_content_id_index(4)
-        state2.update_interaction_answer_groups([answer_group_dict])
+        state2.update_interaction_answer_groups([state_domain.AnswerGroup.from_dict(answer_group_dict)])
         state2.update_written_translations(
             state_domain.WrittenTranslations.from_dict(
                 written_translations_dict))
@@ -1780,7 +1780,7 @@ class ExplorationRteMathContentValidationOneOffJobTests(
         state2.update_interaction_customization_args(
             customization_args_dict)
         state2.update_next_content_id_index(4)
-        state2.update_interaction_answer_groups([answer_group_dict])
+        state2.update_interaction_answer_groups([state_domain.AnswerGroup.from_dict(answer_group_dict)])
         state2.update_written_translations(
             state_domain.WrittenTranslations.from_dict(
                 written_translations_dict))

--- a/core/domain/exp_jobs_one_off_test.py
+++ b/core/domain/exp_jobs_one_off_test.py
@@ -1475,7 +1475,8 @@ class ExplorationMathSvgFilenameValidationOneOffJobTests(
         state2.update_interaction_customization_args(
             customization_args_dict)
         state2.update_next_content_id_index(4)
-        state2.update_interaction_answer_groups([state_domain.AnswerGroup.from_dict(answer_group_dict)])
+        state2.update_interaction_answer_groups(
+            [state_domain.AnswerGroup.from_dict(answer_group_dict)])
         state2.update_written_translations(
             state_domain.WrittenTranslations.from_dict(
                 written_translations_dict))
@@ -1780,7 +1781,8 @@ class ExplorationRteMathContentValidationOneOffJobTests(
         state2.update_interaction_customization_args(
             customization_args_dict)
         state2.update_next_content_id_index(4)
-        state2.update_interaction_answer_groups([state_domain.AnswerGroup.from_dict(answer_group_dict)])
+        state2.update_interaction_answer_groups(
+            [state_domain.AnswerGroup.from_dict(answer_group_dict)])
         state2.update_written_translations(
             state_domain.WrittenTranslations.from_dict(
                 written_translations_dict))

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -385,7 +385,8 @@ def apply_change_list(exploration_id, change_list):
                         'Editing interaction handlers is no longer supported')
                 elif (change.property_name ==
                       exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS):
-                    state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(change.new_value))
+                    state.update_interaction_answer_groups(
+                        state_domain.AnswerGroup.from_dict_list(change.new_value))
                 elif (change.property_name ==
                       exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME):
                     new_outcome = None

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -386,7 +386,8 @@ def apply_change_list(exploration_id, change_list):
                 elif (change.property_name ==
                       exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS):
                     state.update_interaction_answer_groups(
-                        state_domain.AnswerGroup.from_dict_list(change.new_value))
+                        state_domain.AnswerGroup.from_dict_list(
+                            change.new_value))
                 elif (change.property_name ==
                       exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME):
                     new_outcome = None

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -386,7 +386,7 @@ def apply_change_list(exploration_id, change_list):
                 elif (change.property_name ==
                       exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS):
                     state.update_interaction_answer_groups(
-                        state_domain.AnswerGroup.from_dict_list(
+                        state_domain.AnswerGroup.from_dicts(
                             change.new_value))
                 elif (change.property_name ==
                       exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME):

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -385,7 +385,7 @@ def apply_change_list(exploration_id, change_list):
                         'Editing interaction handlers is no longer supported')
                 elif (change.property_name ==
                       exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS):
-                    state.update_interaction_answer_groups(change.new_value)
+                    state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(change.new_value))
                 elif (change.property_name ==
                       exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME):
                     new_outcome = None

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1738,8 +1738,10 @@ class GetImageFilenamesFromExplorationTests(ExplorationServicesUnitTests):
             'training_data': [],
             'tagged_skill_misconception_id': None
         }]
-        state2.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(answer_group_list2))
-        state3.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(answer_group_list3))
+        state2.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_group_list2))
+        state3.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_group_list3))
 
         filenames = (
             exp_services.get_image_filenames_from_exploration(exploration))

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1738,8 +1738,8 @@ class GetImageFilenamesFromExplorationTests(ExplorationServicesUnitTests):
             'training_data': [],
             'tagged_skill_misconception_id': None
         }]
-        state2.update_interaction_answer_groups(answer_group_list2)
-        state3.update_interaction_answer_groups(answer_group_list3)
+        state2.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(answer_group_list2))
+        state3.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(answer_group_list3))
 
         filenames = (
             exp_services.get_image_filenames_from_exploration(exploration))

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -1739,9 +1739,9 @@ class GetImageFilenamesFromExplorationTests(ExplorationServicesUnitTests):
             'tagged_skill_misconception_id': None
         }]
         state2.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_group_list2))
+            state_domain.AnswerGroup.from_dicts(answer_group_list2))
         state3.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_group_list3))
+            state_domain.AnswerGroup.from_dicts(answer_group_list3))
 
         filenames = (
             exp_services.get_image_filenames_from_exploration(exploration))

--- a/core/domain/interaction_jobs_one_off_test.py
+++ b/core/domain/interaction_jobs_one_off_test.py
@@ -218,7 +218,7 @@ class DragAndDropSortInputInteractionOneOffJobTests(test_utils.GenericTestBase):
         state1.update_interaction_customization_args(customization_args_dict1)
         state1.update_next_content_id_index(2)
         state1.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_group_list1))
+            state_domain.AnswerGroup.from_dicts(answer_group_list1))
         exp_services.save_new_exploration(self.albert_id, exploration)
         rights_manager.publish_exploration(owner, self.VALID_EXP_ID)
 
@@ -240,7 +240,7 @@ class DragAndDropSortInputInteractionOneOffJobTests(test_utils.GenericTestBase):
         state2.update_interaction_customization_args(customization_args_dict2)
         state2.update_next_content_id_index(2)
         state2.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_group_list2))
+            state_domain.AnswerGroup.from_dicts(answer_group_list2))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
         rights_manager.publish_exploration(owner, self.VALID_EXP_ID)
@@ -333,7 +333,7 @@ class DragAndDropSortInputInteractionOneOffJobTests(test_utils.GenericTestBase):
         state1.update_interaction_customization_args(customization_args_dict)
         state1.update_next_content_id_index(2)
         state1.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_group_list))
+            state_domain.AnswerGroup.from_dicts(answer_group_list))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
 
@@ -408,7 +408,7 @@ class MultipleChoiceInteractionOneOffJobTests(test_utils.GenericTestBase):
         state1.update_interaction_customization_args(customization_args_dict1)
         state1.update_next_content_id_index(2)
         state1.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_group_list1))
+            state_domain.AnswerGroup.from_dicts(answer_group_list1))
         exp_services.save_new_exploration(self.albert_id, exploration)
 
         # Start MultipleChoiceInteractionOneOffJob job on sample exploration.
@@ -468,7 +468,7 @@ class MultipleChoiceInteractionOneOffJobTests(test_utils.GenericTestBase):
         state2.update_interaction_customization_args(customization_args_dict2)
         state2.update_next_content_id_index(4)
         state2.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_group_list2))
+            state_domain.AnswerGroup.from_dicts(answer_group_list2))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
 
@@ -539,7 +539,7 @@ class MultipleChoiceInteractionOneOffJobTests(test_utils.GenericTestBase):
         state1.update_interaction_customization_args(customization_args_dict)
         state1.update_next_content_id_index(2)
         state1.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_group_list))
+            state_domain.AnswerGroup.from_dicts(answer_group_list))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
 
@@ -621,7 +621,7 @@ class ItemSelectionInteractionOneOffJobTests(test_utils.GenericTestBase):
         state1.update_interaction_customization_args(customization_args_dict1)
         state1.update_next_content_id_index(2)
         state1.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_group_list1))
+            state_domain.AnswerGroup.from_dicts(answer_group_list1))
         exp_services.save_new_exploration(self.albert_id, exploration)
 
         # Start ItemSelectionInteractionOneOff job on sample exploration.
@@ -680,7 +680,7 @@ class ItemSelectionInteractionOneOffJobTests(test_utils.GenericTestBase):
         state2.update_interaction_customization_args(customization_args_dict2)
         state2.update_next_content_id_index(2)
         state2.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_group_list2))
+            state_domain.AnswerGroup.from_dicts(answer_group_list2))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
 
@@ -755,7 +755,7 @@ class ItemSelectionInteractionOneOffJobTests(test_utils.GenericTestBase):
         state1.update_interaction_customization_args(customization_args_dict)
         state1.update_next_content_id_index(2)
         state1.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_group_list))
+            state_domain.AnswerGroup.from_dicts(answer_group_list))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
 

--- a/core/domain/interaction_jobs_one_off_test.py
+++ b/core/domain/interaction_jobs_one_off_test.py
@@ -23,6 +23,7 @@ from core.domain import exp_domain
 from core.domain import exp_services
 from core.domain import interaction_jobs_one_off
 from core.domain import rights_manager
+from core.domain import state_domain
 from core.domain import taskqueue_services
 from core.domain import user_services
 from core.platform import models
@@ -216,7 +217,8 @@ class DragAndDropSortInputInteractionOneOffJobTests(test_utils.GenericTestBase):
         state1.update_interaction_id('DragAndDropSortInput')
         state1.update_interaction_customization_args(customization_args_dict1)
         state1.update_next_content_id_index(2)
-        state1.update_interaction_answer_groups(answer_group_list1)
+        state1.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_group_list1))
         exp_services.save_new_exploration(self.albert_id, exploration)
         rights_manager.publish_exploration(owner, self.VALID_EXP_ID)
 
@@ -237,7 +239,8 @@ class DragAndDropSortInputInteractionOneOffJobTests(test_utils.GenericTestBase):
         state2.update_interaction_id('DragAndDropSortInput')
         state2.update_interaction_customization_args(customization_args_dict2)
         state2.update_next_content_id_index(2)
-        state2.update_interaction_answer_groups(answer_group_list2)
+        state2.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_group_list2))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
         rights_manager.publish_exploration(owner, self.VALID_EXP_ID)
@@ -329,7 +332,8 @@ class DragAndDropSortInputInteractionOneOffJobTests(test_utils.GenericTestBase):
 
         state1.update_interaction_customization_args(customization_args_dict)
         state1.update_next_content_id_index(2)
-        state1.update_interaction_answer_groups(answer_group_list)
+        state1.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_group_list))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
 
@@ -403,7 +407,8 @@ class MultipleChoiceInteractionOneOffJobTests(test_utils.GenericTestBase):
         state1.update_interaction_id('MultipleChoiceInput')
         state1.update_interaction_customization_args(customization_args_dict1)
         state1.update_next_content_id_index(2)
-        state1.update_interaction_answer_groups(answer_group_list1)
+        state1.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_group_list1))
         exp_services.save_new_exploration(self.albert_id, exploration)
 
         # Start MultipleChoiceInteractionOneOffJob job on sample exploration.
@@ -462,7 +467,8 @@ class MultipleChoiceInteractionOneOffJobTests(test_utils.GenericTestBase):
         state2.update_interaction_id('MultipleChoiceInput')
         state2.update_interaction_customization_args(customization_args_dict2)
         state2.update_next_content_id_index(4)
-        state2.update_interaction_answer_groups(answer_group_list2)
+        state2.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_group_list2))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
 
@@ -532,7 +538,8 @@ class MultipleChoiceInteractionOneOffJobTests(test_utils.GenericTestBase):
 
         state1.update_interaction_customization_args(customization_args_dict)
         state1.update_next_content_id_index(2)
-        state1.update_interaction_answer_groups(answer_group_list)
+        state1.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_group_list))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
 
@@ -613,7 +620,8 @@ class ItemSelectionInteractionOneOffJobTests(test_utils.GenericTestBase):
         state1.update_interaction_id('ItemSelectionInput')
         state1.update_interaction_customization_args(customization_args_dict1)
         state1.update_next_content_id_index(2)
-        state1.update_interaction_answer_groups(answer_group_list1)
+        state1.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_group_list1))
         exp_services.save_new_exploration(self.albert_id, exploration)
 
         # Start ItemSelectionInteractionOneOff job on sample exploration.
@@ -671,7 +679,8 @@ class ItemSelectionInteractionOneOffJobTests(test_utils.GenericTestBase):
         state2.update_interaction_id('ItemSelectionInput')
         state2.update_interaction_customization_args(customization_args_dict2)
         state2.update_next_content_id_index(2)
-        state2.update_interaction_answer_groups(answer_group_list2)
+        state2.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_group_list2))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
 
@@ -745,7 +754,8 @@ class ItemSelectionInteractionOneOffJobTests(test_utils.GenericTestBase):
 
         state1.update_interaction_customization_args(customization_args_dict)
         state1.update_next_content_id_index(2)
-        state1.update_interaction_answer_groups(answer_group_list)
+        state1.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_group_list))
 
         exp_services.save_new_exploration(self.albert_id, exploration)
 

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -112,7 +112,7 @@ class AnswerGroup(python_utils.OBJECT):
         """Return a AnswerGroup list domain objects from a dict list.
 
         Args:
-            answer_group_dict_list: dict list. The dict list 
+            answer_group_dict_list: dict list. The dict list
                 representation of AnswerGroup list.
 
         Returns:
@@ -2726,7 +2726,7 @@ class State(python_utils.OBJECT):
         """Update the list of AnswerGroup in InteractionInstance domain object.
 
         Args:
-            answer_groups_list: List of AnswerGroup domain object.
+            answer_groups_list: list. List of AnswerGroup domain object.
         """
         if not isinstance(answer_groups_list, list):
             raise Exception(

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -107,7 +107,6 @@ class AnswerGroup(python_utils.OBJECT):
             answer_group_dict['tagged_skill_misconception_id']
         )
 
-
     @classmethod
     def from_dict_list(cls, answer_group_dict_list):
         """Return a AnswerGroup list domain objects from a dict list.
@@ -127,10 +126,9 @@ class AnswerGroup(python_utils.OBJECT):
         answer_groups = []
 
         for answer_group_dict in answer_group_dict_list:
-            answer_groups.append( cls.from_dict(answer_group_dict))
+            answer_groups.append(cls.from_dict(answer_group_dict))
 
         return answer_groups
-
 
     def validate(self, interaction, exp_param_specs_dict):
         """Verifies that all rule classes are valid, and that the AnswerGroup

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -108,24 +108,24 @@ class AnswerGroup(python_utils.OBJECT):
         )
 
     @classmethod
-    def from_dict_list(cls, answer_group_dict_list):
-        """Return a AnswerGroup list domain objects from a dict list.
+    def from_dicts(cls, answer_group_dicts):
+        """Creates a list of AnswerGroup dict into a list of objects.
 
         Args:
-            answer_group_dict_list: dict list. The dict list
-                representation of AnswerGroup list.
+            answer_group_dicts: list(dict). The list of dict representation
+                of AnswerGroup.
 
         Returns:
-            AnswerGroup list. The corresponding AnswerGroup domain object list.
+            list(AnswerGroup). The corresponding AnswerGroup domain object list.
         """
-        if not isinstance(answer_group_dict_list, list):
+        if not isinstance(answer_group_dicts, list):
             raise Exception(
                 'Expected interaction_answer_groups to be a list, received %s'
-                % answer_group_dict_list)
+                % answer_group_dicts)
 
         answer_groups = []
 
-        for answer_group_dict in answer_group_dict_list:
+        for answer_group_dict in answer_group_dicts:
             answer_groups.append(cls.from_dict(answer_group_dict))
 
         return answer_groups
@@ -2726,7 +2726,8 @@ class State(python_utils.OBJECT):
         """Update the list of AnswerGroup in InteractionInstance domain object.
 
         Args:
-            answer_groups_list: list. List of AnswerGroup domain object.
+            answer_groups_list: list(AnswerGroup). List of AnswerGroup
+            domain object.
         """
         if not isinstance(answer_groups_list, list):
             raise Exception(

--- a/core/domain/state_domain.py
+++ b/core/domain/state_domain.py
@@ -2727,7 +2727,7 @@ class State(python_utils.OBJECT):
 
         Args:
             answer_groups_list: list(AnswerGroup). List of AnswerGroup
-            domain object.
+                domain object.
         """
         if not isinstance(answer_groups_list, list):
             raise Exception(

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -565,7 +565,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             state_domain.SubtitledHtml.from_dict(state_content_dict))
         state.update_interaction_id('ItemSelectionInput')
         state.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(state_answer_groups))
+            state_domain.AnswerGroup.from_dicts(state_answer_groups))
         state.update_interaction_customization_args(
             state_customization_args_dict)
         state.update_next_content_id_index(4)
@@ -649,7 +649,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
 
         state.update_interaction_id('ItemSelectionInput')
         state.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(state_answer_groups))
+            state_domain.AnswerGroup.from_dicts(state_answer_groups))
         mock_html_field_types_to_rule_specs_dict = json.loads(
             utils.get_file_contents(
                 feconf.HTML_FIELD_TYPES_TO_RULE_SPECS_FILE_PATH))
@@ -763,7 +763,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         state.update_interaction_customization_args(
             state_customization_args_dict)
         state.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(state_answer_groups))
+            state_domain.AnswerGroup.from_dicts(state_answer_groups))
 
         mock_html_field_types_to_rule_specs_dict = json.loads(
             utils.get_file_contents(
@@ -3577,7 +3577,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(
             Exception, 'Expected rule_inputs to be a dict'):
             exploration.init_state.update_interaction_answer_groups(
-                state_domain.AnswerGroup.from_dict_list(answer_groups_list))
+                state_domain.AnswerGroup.from_dicts(answer_groups_list))
 
     def test_cannot_update_answer_groups_with_non_list_rule_specs(self):
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')
@@ -3601,7 +3601,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(
             Exception, 'Expected answer group rule specs to be a list'):
             exploration.init_state.update_interaction_answer_groups(
-                state_domain.AnswerGroup.from_dict_list(answer_groups_list))
+                state_domain.AnswerGroup.from_dicts(answer_groups_list))
 
     def test_cannot_update_answer_groups_with_invalid_rule_input_value(self):
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')
@@ -3634,7 +3634,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             )
         ):
             exploration.init_state.update_interaction_answer_groups(
-                state_domain.AnswerGroup.from_dict_list(answer_groups_list))
+                state_domain.AnswerGroup.from_dicts(answer_groups_list))
 
     def test_validate_rule_spec(self):
         observed_log_messages = []
@@ -3668,7 +3668,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             'tagged_skill_misconception_id': None
         }]
         exploration.init_state.update_interaction_answer_groups(
-            state_domain.AnswerGroup.from_dict_list(answer_groups))
+            state_domain.AnswerGroup.from_dicts(answer_groups))
 
         with logging_swap, self.assertRaisesRegexp(KeyError, 'u\'x\''):
             (

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -564,7 +564,8 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         state.update_content(
             state_domain.SubtitledHtml.from_dict(state_content_dict))
         state.update_interaction_id('ItemSelectionInput')
-        state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(state_answer_groups))
+        state.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(state_answer_groups))
         state.update_interaction_customization_args(
             state_customization_args_dict)
         state.update_next_content_id_index(4)
@@ -647,7 +648,8 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         }]
 
         state.update_interaction_id('ItemSelectionInput')
-        state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(state_answer_groups))
+        state.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(state_answer_groups))
         mock_html_field_types_to_rule_specs_dict = json.loads(
             utils.get_file_contents(
                 feconf.HTML_FIELD_TYPES_TO_RULE_SPECS_FILE_PATH))
@@ -760,7 +762,8 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         state.update_interaction_id('ItemSelectionInput')
         state.update_interaction_customization_args(
             state_customization_args_dict)
-        state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(state_answer_groups))
+        state.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(state_answer_groups))
 
         mock_html_field_types_to_rule_specs_dict = json.loads(
             utils.get_file_contents(
@@ -3664,7 +3667,8 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             'training_data': [],
             'tagged_skill_misconception_id': None
         }]
-        exploration.init_state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(answer_groups))
+        exploration.init_state.update_interaction_answer_groups(
+            state_domain.AnswerGroup.from_dict_list(answer_groups))
 
         with logging_swap, self.assertRaisesRegexp(KeyError, 'u\'x\''):
             (

--- a/core/domain/state_domain_test.py
+++ b/core/domain/state_domain_test.py
@@ -320,7 +320,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             state.interaction.id, state_solution_dict)
         state.update_interaction_solution(solution)
         state.update_interaction_answer_groups(
-            [state_answer_group_dict])
+            [state_domain.AnswerGroup.from_dict(state_answer_group_dict)])
         state.update_written_translations(
             state_domain.WrittenTranslations.from_dict(
                 state_written_translations_dict))
@@ -446,7 +446,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         state.update_interaction_id('TextInput')
         state.update_interaction_customization_args(state_interaction_cust_args)
         state.update_interaction_answer_groups(
-            [state_answer_group_dict])
+            [state_domain.AnswerGroup.from_dict(state_answer_group_dict)])
         state.update_interaction_default_outcome(state_default_outcome)
         state.update_interaction_hints(state_hint_list)
         solution = state_domain.Solution.from_dict(
@@ -564,7 +564,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         state.update_content(
             state_domain.SubtitledHtml.from_dict(state_content_dict))
         state.update_interaction_id('ItemSelectionInput')
-        state.update_interaction_answer_groups(state_answer_groups)
+        state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(state_answer_groups))
         state.update_interaction_customization_args(
             state_customization_args_dict)
         state.update_next_content_id_index(4)
@@ -647,7 +647,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         }]
 
         state.update_interaction_id('ItemSelectionInput')
-        state.update_interaction_answer_groups(state_answer_groups)
+        state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(state_answer_groups))
         mock_html_field_types_to_rule_specs_dict = json.loads(
             utils.get_file_contents(
                 feconf.HTML_FIELD_TYPES_TO_RULE_SPECS_FILE_PATH))
@@ -760,7 +760,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         state.update_interaction_id('ItemSelectionInput')
         state.update_interaction_customization_args(
             state_customization_args_dict)
-        state.update_interaction_answer_groups(state_answer_groups)
+        state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(state_answer_groups))
 
         mock_html_field_types_to_rule_specs_dict = json.loads(
             utils.get_file_contents(
@@ -1090,7 +1090,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         }
 
         init_state.update_interaction_answer_groups(
-            [answer_group_dict])
+            [state_domain.AnswerGroup.from_dict(answer_group_dict)])
         self.assertFalse(init_state.is_rte_content_supported_on_android())
         answer_group_dict['outcome']['feedback']['html'] = (
             '<p><oppia-noninteractive-image caption-with-value="&amp;quot;'
@@ -1098,7 +1098,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             'quot;" alt-with-value="&amp;quot;&amp;quot;">'
             '</oppia-noninteractive-image></p>')
         init_state.update_interaction_answer_groups(
-            [answer_group_dict])
+            [state_domain.AnswerGroup.from_dict(answer_group_dict)])
         self.assertTrue(init_state.is_rte_content_supported_on_android())
 
         init_state.update_content(
@@ -1252,7 +1252,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         }
 
         init_state.update_interaction_answer_groups(
-            [answer_group_dict])
+            [state_domain.AnswerGroup.from_dict(answer_group_dict)])
         hints_list = [
             state_domain.Hint(
                 state_domain.SubtitledHtml('hint_1', '<p>hint one</p>')
@@ -3165,7 +3165,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         }
 
         exploration.init_state.update_interaction_answer_groups(
-            [answer_group_dict])
+            [state_domain.AnswerGroup.from_dict(answer_group_dict)])
         exploration.init_state.update_content(
             state_domain.SubtitledHtml.from_dict({
                 'content_id': 'feedback_1',
@@ -3574,7 +3574,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(
             Exception, 'Expected rule_inputs to be a dict'):
             exploration.init_state.update_interaction_answer_groups(
-                answer_groups_list)
+                state_domain.AnswerGroup.from_dict_list(answer_groups_list))
 
     def test_cannot_update_answer_groups_with_non_list_rule_specs(self):
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')
@@ -3598,7 +3598,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(
             Exception, 'Expected answer group rule specs to be a list'):
             exploration.init_state.update_interaction_answer_groups(
-                answer_groups_list)
+                state_domain.AnswerGroup.from_dict_list(answer_groups_list))
 
     def test_cannot_update_answer_groups_with_invalid_rule_input_value(self):
         exploration = self.save_new_valid_exploration('exp_id', 'owner_id')
@@ -3631,7 +3631,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             )
         ):
             exploration.init_state.update_interaction_answer_groups(
-                answer_groups_list)
+                state_domain.AnswerGroup.from_dict_list(answer_groups_list))
 
     def test_validate_rule_spec(self):
         observed_log_messages = []
@@ -3664,7 +3664,7 @@ class StateDomainUnitTests(test_utils.GenericTestBase):
             'training_data': [],
             'tagged_skill_misconception_id': None
         }]
-        exploration.init_state.update_interaction_answer_groups(answer_groups)
+        exploration.init_state.update_interaction_answer_groups(state_domain.AnswerGroup.from_dict_list(answer_groups))
 
         with logging_swap, self.assertRaisesRegexp(KeyError, 'u\'x\''):
             (


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #6271.
2. This PR does the following: updates update_interaction_answer_groups method to take list of objects instead of list of dicts

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
