### PR TITLE
One off jobs to delete deprecated Question and Skill Models

### DIFF
--- a/core/domain/skill_validators.py
+++ b/core/domain/skill_validators.py
@@ -137,8 +137,8 @@ class SkillCommitLogEntryModelValidator(
 
     @classmethod
     def _get_model_id_regex(cls, item):
-        # Valid id: [skill/rights]-[skill_id]-[skill_version].
-        regex_string = '^(skill|rights)-%s-\\d+$' % (
+        # Valid id: [skill]-[skill_id]-[skill_version].
+        regex_string = '^(skill)-%s-\\d+$' % (
             item.skill_id)
 
         return regex_string

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -91,6 +91,7 @@ ONE_OFF_JOB_MANAGERS = [
     recommendations_jobs_one_off.DeleteAllExplorationRecommendationsOneOffJob,
     recommendations_jobs_one_off.ExplorationRecommendationsOneOffJob,
     recommendations_jobs_one_off.CleanUpExplorationRecommendationsOneOffJob,
+    skill_jobs_one_off.DeleteInvalidSkillCommitLogEntryModelOneOffJob,
     skill_jobs_one_off.SkillMigrationOneOffJob,
     skill_jobs_one_off.SkillCommitCmdMigrationOneOffJob,
     skill_jobs_one_off.MissingSkillMigrationOneOffJob,

--- a/core/jobs_registry.py
+++ b/core/jobs_registry.py
@@ -85,6 +85,7 @@ ONE_OFF_JOB_MANAGERS = [
         opportunity_jobs_one_off.
         RenameExplorationOpportunitySummaryModelPropertiesJob),
     opportunity_jobs_one_off.SkillOpportunityModelRegenerationJob,
+    question_jobs_one_off.DeleteInvalidQuestionModelsOneOffJob,
     question_jobs_one_off.QuestionMigrationOneOffJob,
     question_jobs_one_off.RegenerateQuestionSummaryOneOffJob,
     question_jobs_one_off.MissingQuestionMigrationOneOffJob,


### PR DESCRIPTION
## Overview

1. This PR does the following: 

- Deletes SkillCommitLogEntryModels that corresponds to skill rights and private skills, since we don't have skill rights anymore and all skills are public.
- Deletes QuestionModel and its correponding CommitLogEntry and Snapshot models if the latter models does not exist for version 1. According to an earlier audit job run, there are only 2 question IDs that have this issue.

Both the above issues don't exist anymore and the jobs are just to clean up the datastore.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
