### PR TITLE
Fix #11055: Modify validation for prereq skills

### DIFF
--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -527,56 +527,6 @@ class StoryContents(python_utils.OBJECT):
                 raise utils.ValidationError(
                     'Expected all chapter titles to be distinct.')
 
-            # nodes_queue stores the pending nodes to visit in the story that
-            # are unlocked, in a 'queue' form with a First In First Out
-            # structure.
-            nodes_queue = []
-            is_node_visited = [False] * len(self.nodes)
-            starting_node_index = self.get_node_index(self.initial_node_id)
-            nodes_queue.append(self.nodes[starting_node_index].id)
-
-            # The user is assumed to have all the prerequisite skills of the
-            # starting node before starting the story. Also, this list models
-            # the skill IDs acquired by a learner as they progress through the
-            # story.
-            simulated_skill_ids = copy.deepcopy(
-                self.nodes[starting_node_index].prerequisite_skill_ids)
-
-            # The following loop employs a Breadth First Search from the given
-            # starting node and makes sure that the user has acquired all the
-            # prerequisite skills required by the destination nodes 'unlocked'
-            # by visiting a particular node by the time that node is finished.
-            while len(nodes_queue) > 0:
-                current_node_id = nodes_queue.pop()
-                current_node_index = self.get_node_index(current_node_id)
-                is_node_visited[current_node_index] = True
-                current_node = self.nodes[current_node_index]
-
-                for skill_id in current_node.acquired_skill_ids:
-                    simulated_skill_ids.append(skill_id)
-
-                for node_id in current_node.destination_node_ids:
-                    node_index = self.get_node_index(node_id)
-                    # The following condition checks whether the destination
-                    # node for a particular node, has already been visited, in
-                    # which case the story would have loops, which are not
-                    # allowed.
-                    if is_node_visited[node_index]:
-                        raise utils.ValidationError(
-                            'Loops are not allowed in stories.')
-                    destination_node = self.nodes[node_index]
-                    if not (
-                            set(
-                                destination_node.prerequisite_skill_ids
-                            ).issubset(simulated_skill_ids)):
-                        raise utils.ValidationError(
-                            'The prerequisite skills ' +
-                            ' '.join(
-                                set(destination_node.prerequisite_skill_ids) -
-                                set(simulated_skill_ids)) +
-                            ' were not completed before the node with id %s'
-                            ' was unlocked.' % node_id)
-                    nodes_queue.append(node_id)
 
     def get_node_index(self, node_id):
         """Returns the index of the story node with the given node

--- a/core/domain/story_domain.py
+++ b/core/domain/story_domain.py
@@ -527,7 +527,6 @@ class StoryContents(python_utils.OBJECT):
                 raise utils.ValidationError(
                     'Expected all chapter titles to be distinct.')
 
-
     def get_node_index(self, node_id):
         """Returns the index of the story node with the given node
         id, or None if the node id is not in the story contents dict.

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -795,110 +795,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
 
     def test_all_nodes_visited(self):
         self.story.story_contents.next_node_id = 'node_4'
-        # Case 1: Prerequisite skills not acquired.
-        node_1 = {
-            'id': 'node_1',
-            'thumbnail_filename': 'image.svg',
-            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
-                'chapter'][0],
-            'title': 'Title 1',
-            'description': 'Description 1',
-            'destination_node_ids': ['node_2', 'node_3'],
-            'acquired_skill_ids': ['skill_2'],
-            'prerequisite_skill_ids': ['skill_1'],
-            'outline': '',
-            'outline_is_finalized': False,
-            'exploration_id': None
-        }
-        node_2 = {
-            'id': 'node_2',
-            'thumbnail_filename': 'image.svg',
-            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
-                'chapter'][0],
-            'title': 'Title 2',
-            'description': 'Description 2',
-            'destination_node_ids': [],
-            'acquired_skill_ids': ['skill_3'],
-            'prerequisite_skill_ids': ['skill_2'],
-            'outline': '',
-            'outline_is_finalized': False,
-            'exploration_id': None
-        }
-        node_3 = {
-            'id': 'node_3',
-            'thumbnail_filename': 'image.svg',
-            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
-                'chapter'][0],
-            'title': 'Title 3',
-            'description': 'Description 3',
-            'destination_node_ids': [],
-            'acquired_skill_ids': ['skill_4'],
-            'prerequisite_skill_ids': ['skill_3'],
-            'outline': '',
-            'outline_is_finalized': False,
-            'exploration_id': None
-        }
-        self.story.story_contents.initial_node_id = 'node_1'
-        self.story.story_contents.nodes = [
-            story_domain.StoryNode.from_dict(node_1),
-            story_domain.StoryNode.from_dict(node_2),
-            story_domain.StoryNode.from_dict(node_3)
-        ]
-        self._assert_validation_error(
-            'The prerequisite skills skill_3 were not completed before '
-            'the node with id node_3 was unlocked.')
-
-        # Case 2: Story with loops.
-        node_1 = {
-            'id': 'node_1',
-            'thumbnail_filename': 'image.svg',
-            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
-                'chapter'][0],
-            'title': 'Title 1',
-            'description': 'Description 1',
-            'destination_node_ids': ['node_2'],
-            'acquired_skill_ids': ['skill_2'],
-            'prerequisite_skill_ids': ['skill_1'],
-            'outline': '',
-            'outline_is_finalized': False,
-            'exploration_id': None
-        }
-        node_2 = {
-            'id': 'node_2',
-            'thumbnail_filename': 'image.svg',
-            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
-                'chapter'][0],
-            'title': 'Title 2',
-            'description': 'Description 2',
-            'destination_node_ids': ['node_3'],
-            'acquired_skill_ids': ['skill_3'],
-            'prerequisite_skill_ids': ['skill_2'],
-            'outline': '',
-            'outline_is_finalized': False,
-            'exploration_id': None
-        }
-        node_3 = {
-            'id': 'node_3',
-            'thumbnail_filename': 'image.svg',
-            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
-                'chapter'][0],
-            'title': 'Title 3',
-            'description': 'Description 3',
-            'destination_node_ids': ['node_2'],
-            'acquired_skill_ids': ['skill_4'],
-            'prerequisite_skill_ids': ['skill_3'],
-            'outline': '',
-            'outline_is_finalized': False,
-            'exploration_id': None
-        }
-        self.story.story_contents.nodes = [
-            story_domain.StoryNode.from_dict(node_1),
-            story_domain.StoryNode.from_dict(node_2),
-            story_domain.StoryNode.from_dict(node_3)
-        ]
-        self._assert_validation_error('Loops are not allowed in stories.')
-
-        # Case 3: Disconnected graph.
+        # Case 1: Disconnected graph.
         node_1 = {
             'id': 'node_1',
             'thumbnail_filename': 'image.svg',
@@ -947,7 +844,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
             story_domain.StoryNode.from_dict(node_3)
         ]
 
-        # Case 4: Graph with duplicate nodes.
+        # Case 2: Graph with duplicate nodes.
         node_1 = {
             'id': 'node_1',
             'thumbnail_filename': 'image.svg',
@@ -997,7 +894,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         ]
         self._assert_validation_error('Expected all node ids to be distinct')
 
-        # Case 5: Graph with duplicate titles.
+        # Case 3: Graph with duplicate titles.
         node_1 = {
             'id': 'node_1',
             'title': 'Title 1',
@@ -1049,7 +946,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
             'Expected all chapter titles to be distinct.')
 
         self.story.story_contents.next_node_id = 'node_5'
-        # Case 6: A valid graph.
+        # Case 4: A valid graph.
         node_1 = {
             'id': 'node_1',
             'thumbnail_filename': 'image.svg',

--- a/core/domain/story_jobs_one_off.py
+++ b/core/domain/story_jobs_one_off.py
@@ -60,6 +60,8 @@ class StoryMigrationOneOffJob(jobs.BaseMapReduceOneOffJobManager):
         story = story_fetchers.get_story_by_id(item.id)
         try:
             story.validate()
+            story_services.validate_prerequisite_skills_in_story_contents(
+                story.corresponding_topic_id, story.story_contents)
         except Exception as e:
             logging.error(
                 'Story %s failed validation: %s' % (item.id, e))

--- a/core/domain/story_services.py
+++ b/core/domain/story_services.py
@@ -23,6 +23,7 @@ storage model to be changed without affecting this module and others above it.
 from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
+import copy
 import logging
 
 from constants import constants
@@ -234,6 +235,72 @@ def does_story_exist_with_url_fragment(url_fragment):
     return story is not None
 
 
+def validate_prerequisite_skills_in_story_contents(
+        corresponding_topic_id, story_contents):
+    if len(story_contents.nodes) == 0:
+        return
+    # nodes_queue stores the pending nodes to visit in the story that
+    # are unlocked, in a 'queue' form with a First In First Out
+    # structure.
+    nodes_queue = []
+    is_node_visited = [False] * len(story_contents.nodes)
+    starting_node_index = story_contents.get_node_index(
+        story_contents.initial_node_id)
+    nodes_queue.append(story_contents.nodes[starting_node_index].id)
+
+    # The user is assumed to have all the prerequisite skills of the
+    # starting node before starting the story. Also, this list models
+    # the skill IDs acquired by a learner as they progress through the
+    # story.
+    simulated_skill_ids = copy.deepcopy(
+        story_contents.nodes[starting_node_index].prerequisite_skill_ids)
+
+    # The following loop employs a Breadth First Search from the given
+    # starting node and makes sure that the user has acquired all the
+    # prerequisite skills required by the destination nodes 'unlocked'
+    # by visiting a particular node by the time that node is finished.
+    while len(nodes_queue) > 0:
+        current_node_id = nodes_queue.pop()
+        current_node_index = story_contents.get_node_index(current_node_id)
+        is_node_visited[current_node_index] = True
+        current_node = story_contents.nodes[current_node_index]
+
+        for skill_id in current_node.acquired_skill_ids:
+            simulated_skill_ids.append(skill_id)
+
+        for node_id in current_node.destination_node_ids:
+            node_index = story_contents.get_node_index(node_id)
+            # The following condition checks whether the destination
+            # node for a particular node, has already been visited, in
+            # which case the story would have loops, which are not
+            # allowed.
+            if is_node_visited[node_index]:
+                raise utils.ValidationError(
+                    'Loops are not allowed in stories.')
+            destination_node = story_contents.nodes[node_index]
+            skill_ids_present_in_topic = (
+                topic_fetchers.get_topic_by_id(
+                    corresponding_topic_id).get_all_skill_ids())
+            # Include only skill ids relevant to the topic for validation.
+            topic_relevant_skill_ids = list(
+                set(skill_ids_present_in_topic).intersection(
+                    set(destination_node.prerequisite_skill_ids)))
+            if not (
+                    set(
+                        topic_relevant_skill_ids
+                    ).issubset(simulated_skill_ids)):
+                raise utils.ValidationError(
+                    'The skills with ids ' +
+                    ' '.join(
+                        set(topic_relevant_skill_ids) -
+                        set(simulated_skill_ids)) +
+                    ' were specified as prerequisites for Chapter %s,'
+                    ' but were not taught in any chapter before it.'
+                    % destination_node.title)
+            nodes_queue.append(node_id)
+
+
+
 def validate_explorations_for_story(exp_ids, raise_error):
     """Validates the explorations in the given story and checks whether they
     are compatible with the mobile app and ready for publishing.
@@ -398,6 +465,8 @@ def _save_story(
             'save story %s: %s' % (story.id, change_list))
 
     story.validate()
+    validate_prerequisite_skills_in_story_contents(
+        story.corresponding_topic_id, story.story_contents)
 
     if story_is_published:
         exp_ids = []

--- a/core/domain/story_services.py
+++ b/core/domain/story_services.py
@@ -243,8 +243,10 @@ def validate_prerequisite_skills_in_story_contents(
         corresponding_topic_id: str. The corresponding topic id of the story.
         story_contents: StoryContents. The story contents.
 
-    Returns:
-        list(str). The validation error srtings.
+    Raises:
+        ValidationError. Expected prerequisite skills to have been acquired in
+            previous nodes.
+        ValidationError. Expected story to not contain loops.
     """
     if len(story_contents.nodes) == 0:
         return

--- a/core/domain/story_services.py
+++ b/core/domain/story_services.py
@@ -237,6 +237,15 @@ def does_story_exist_with_url_fragment(url_fragment):
 
 def validate_prerequisite_skills_in_story_contents(
         corresponding_topic_id, story_contents):
+    """Validates the prerequisites skills in the story contents.
+
+    Args:
+        corresponding_topic_id: str. The corresponding topic id of the story.
+        story_contents: StoryContents. The story contents.
+
+    Returns:
+        list(str). The validation error srtings.
+    """
     if len(story_contents.nodes) == 0:
         return
     # nodes_queue stores the pending nodes to visit in the story that
@@ -298,7 +307,6 @@ def validate_prerequisite_skills_in_story_contents(
                     ' but were not taught in any chapter before it.'
                     % destination_node.title)
             nodes_queue.append(node_id)
-
 
 
 def validate_explorations_for_story(exp_ids, raise_error):

--- a/core/domain/story_services_test.py
+++ b/core/domain/story_services_test.py
@@ -32,6 +32,7 @@ from core.platform import models
 from core.tests import test_utils
 
 import feconf
+import utils
 
 (story_models, user_models) = models.Registry.import_models(
     [models.NAMES.story, models.NAMES.user])
@@ -63,7 +64,7 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
             abbreviated_name='topic-one', url_fragment='topic-one',
             description='A new topic',
             canonical_story_ids=[], additional_story_ids=[],
-            uncategorized_skill_ids=[], subtopics=[], next_subtopic_id=0)
+            uncategorized_skill_ids=['skill_4'], subtopics=[], next_subtopic_id=0)
         self.save_new_story(self.STORY_ID, self.USER_ID, self.TOPIC_ID)
         topic_services.add_canonical_story(
             self.USER_ID, self.TOPIC_ID, self.STORY_ID)
@@ -294,6 +295,121 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(story.story_contents.nodes[0].destination_node_ids, [])
         self.assertEqual(
             story.story_contents.nodes[0].outline_is_finalized, False)
+
+    def test_prerequisite_skills_validation(self):
+        self.story.story_contents.next_node_id = 'node_4'
+        node_1 = {
+            'id': 'node_1',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'][0],
+            'title': 'Title 1',
+            'description': 'Description 1',
+            'destination_node_ids': ['node_2', 'node_3'],
+            'acquired_skill_ids': ['skill_2'],
+            'prerequisite_skill_ids': ['skill_1'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': None
+        }
+        node_2 = {
+            'id': 'node_2',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'][0],
+            'title': 'Title 2',
+            'description': 'Description 2',
+            'destination_node_ids': [],
+            'acquired_skill_ids': ['skill_3'],
+            'prerequisite_skill_ids': ['skill_2'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': None
+        }
+        node_3 = {
+            'id': 'node_3',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'][0],
+            'title': 'Title 3',
+            'description': 'Description 3',
+            'destination_node_ids': [],
+            'acquired_skill_ids': [],
+            'prerequisite_skill_ids': ['skill_4'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': None
+        }
+        self.story.story_contents.initial_node_id = 'node_1'
+        self.story.story_contents.nodes = [
+            story_domain.StoryNode.from_dict(node_1),
+            story_domain.StoryNode.from_dict(node_2),
+            story_domain.StoryNode.from_dict(node_3)
+        ]
+
+        expected_error_string = (
+            'The skills with ids skill_4 were specified as prerequisites for '
+            'Chapter Title 3, but were not taught in any chapter before it')
+        with self.assertRaisesRegexp(
+            utils.ValidationError, expected_error_string):
+            story_services.validate_prerequisite_skills_in_story_contents(
+                self.story.corresponding_topic_id, self.story.story_contents)
+
+    def test_story_with_loop(self):
+        self.story.story_contents.next_node_id = 'node_4'
+        node_1 = {
+            'id': 'node_1',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'][0],
+            'title': 'Title 1',
+            'description': 'Description 1',
+            'destination_node_ids': ['node_2'],
+            'acquired_skill_ids': ['skill_2'],
+            'prerequisite_skill_ids': ['skill_1'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': None
+        }
+        node_2 = {
+            'id': 'node_2',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'][0],
+            'title': 'Title 2',
+            'description': 'Description 2',
+            'destination_node_ids': ['node_3'],
+            'acquired_skill_ids': ['skill_3'],
+            'prerequisite_skill_ids': ['skill_2'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': None
+        }
+        node_3 = {
+            'id': 'node_3',
+            'thumbnail_filename': 'image.svg',
+            'thumbnail_bg_color': constants.ALLOWED_THUMBNAIL_BG_COLORS[
+                'chapter'][0],
+            'title': 'Title 3',
+            'description': 'Description 3',
+            'destination_node_ids': ['node_2'],
+            'acquired_skill_ids': ['skill_4'],
+            'prerequisite_skill_ids': ['skill_3'],
+            'outline': '',
+            'outline_is_finalized': False,
+            'exploration_id': None
+        }
+        self.story.story_contents.nodes = [
+            story_domain.StoryNode.from_dict(node_1),
+            story_domain.StoryNode.from_dict(node_2),
+            story_domain.StoryNode.from_dict(node_3)
+        ]
+        expected_error_string = 'Loops are not allowed in stories.'
+        with self.assertRaisesRegexp(
+            utils.ValidationError, expected_error_string):
+            story_services.validate_prerequisite_skills_in_story_contents(
+                self.story.corresponding_topic_id, self.story.story_contents)
+        
 
     def test_does_story_exist_with_url_fragment(self):
         story_id_1 = story_services.get_new_story_id()

--- a/core/domain/story_services_test.py
+++ b/core/domain/story_services_test.py
@@ -64,7 +64,8 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
             abbreviated_name='topic-one', url_fragment='topic-one',
             description='A new topic',
             canonical_story_ids=[], additional_story_ids=[],
-            uncategorized_skill_ids=['skill_4'], subtopics=[], next_subtopic_id=0)
+            uncategorized_skill_ids=['skill_4'], subtopics=[],
+            next_subtopic_id=0)
         self.save_new_story(self.STORY_ID, self.USER_ID, self.TOPIC_ID)
         topic_services.add_canonical_story(
             self.USER_ID, self.TOPIC_ID, self.STORY_ID)
@@ -409,7 +410,6 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
             utils.ValidationError, expected_error_string):
             story_services.validate_prerequisite_skills_in_story_contents(
                 self.story.corresponding_topic_id, self.story.story_contents)
-        
 
     def test_does_story_exist_with_url_fragment(self):
         story_id_1 = story_services.get_new_story_id()

--- a/core/templates/domain/story/StoryContentsObjectFactory.ts
+++ b/core/templates/domain/story/StoryContentsObjectFactory.ts
@@ -165,62 +165,6 @@ export class StoryContents {
           'Initial node - ' + this._initialNodeId +
           ' - is not present in the story');
       }
-
-      // All the validations above should be successfully completed before
-      // going to validating the story node graph.
-      if (issues.length > 0) {
-        return issues;
-      }
-
-      // Variable nodesQueue stores the pending nodes to visit in a queue form.
-      var nodesQueue = [];
-      var nodeIsVisited = new Array(nodeIds.length).fill(false);
-      var startingNode = nodes[this.getNodeIndex(this._initialNodeId)];
-      nodesQueue.push(startingNode.getId());
-
-      // The user is assumed to have all the prerequisite skills of the
-      // starting node before starting the story. Also, this list models the
-      // skill IDs acquired by a learner as they progress through the story.
-      var simulatedSkillIds = new Set(startingNode.getPrerequisiteSkillIds());
-
-      // The following loop employs a Breadth First Search from the given
-      // starting node and makes sure that the user has acquired all the
-      // prerequisite skills required by the destination nodes 'unlocked' by
-      // visiting a particular node by the time that node is finished.
-      while (nodesQueue.length > 0) {
-        var currentNodeIndex = this.getNodeIndex(nodesQueue.shift());
-        nodeIsVisited[currentNodeIndex] = true;
-        var currentNode = nodes[currentNodeIndex];
-
-        currentNode.getAcquiredSkillIds().forEach((skillId) => {
-          simulatedSkillIds.add(skillId);
-        });
-        for (var i = 0; i < currentNode.getDestinationNodeIds().length; i++) {
-          var nodeId = currentNode.getDestinationNodeIds()[i];
-          var nodeIndex = this.getNodeIndex(nodeId);
-          // The following condition checks whether the destination node
-          // for a particular node, has already been visited, in which case
-          // the story would have loops, which are not allowed.
-          if (nodeIsVisited[nodeIndex]) {
-            issues.push('Loops are not allowed in the node graph');
-            // If a loop is encountered, then all further checks are halted,
-            // since it can lead to same error being reported again.
-            return issues;
-          }
-          var destinationNode = nodes[nodeIndex];
-          destinationNode.getPrerequisiteSkillIds().forEach(
-            (skillId: string) => {
-              if (!simulatedSkillIds.has(skillId)) {
-                issues.push(
-                  'The prerequisite skill with id ' + skillId +
-                  ' was not completed before node with id ' + nodeId +
-                  ' was unlocked');
-              }
-            }
-          );
-          nodesQueue.push(nodeId);
-        }
-      }
     }
     return issues;
   }

--- a/core/templates/domain/story/StoryContentsObjectFactorySpec.ts
+++ b/core/templates/domain/story/StoryContentsObjectFactorySpec.ts
@@ -104,27 +104,6 @@ describe('Story contents object factory', () => {
     expect(storyContents.getNodes()[0].getTitle()).toEqual('Title 1');
   });
 
-  it('should correctly correctly validate case where prerequisite skills ' +
-     'are not acquired by the user', () => {
-    _sampleStoryContents.addNode('Title 2');
-    _sampleStoryContents.addDestinationNodeIdToNode('node_1', 'node_3');
-    _sampleStoryContents.addPrerequisiteSkillIdToNode('node_3', 'skill_3');
-    expect(_sampleStoryContents.validate()).toEqual([
-      'The prerequisite skill with id skill_3 was not completed before node ' +
-      'with id node_3 was unlocked'
-    ]);
-  });
-
-  it('should correctly correctly validate the case where the story graph ' +
-    'has loops', () => {
-    _sampleStoryContents.addNode('Title 2');
-    _sampleStoryContents.addDestinationNodeIdToNode('node_2', 'node_3');
-    _sampleStoryContents.addDestinationNodeIdToNode('node_3', 'node_1');
-    expect(_sampleStoryContents.validate()).toEqual([
-      'Loops are not allowed in the node graph'
-    ]);
-  });
-
   it('should correctly throw error when node id is invalid for any function',
     () => {
       expect(() => {

--- a/core/templates/domain/story/story-validation.service.spec.ts
+++ b/core/templates/domain/story/story-validation.service.spec.ts
@@ -1,0 +1,126 @@
+// Copyright 2015 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for UrlInterpolationService.
+ */
+import { TestBed } from '@angular/core/testing';
+
+import { StoryValidationService } from
+  'domain/story/story-validation.service';
+import { StoryContentsObjectFactory } from 'domain/story/StoryContentsObjectFactory';
+
+describe('Story Validation Service', () => {
+  let svs: StoryValidationService = null;
+  let storyContentsObjectFactory: StoryContentsObjectFactory = null;
+  beforeEach(() => {
+    svs = TestBed.get(StoryValidationService);
+    storyContentsObjectFactory = TestBed.get(StoryContentsObjectFactory);
+  });
+
+  it('should report a validation error when skill is not aquired in previous' +
+     ' chapter', () => {
+    let sampleStoryContentsBackendDict = {
+      initial_node_id: 'node_1',
+      nodes: [
+        {
+          id: 'node_1',
+          title: 'Title 1',
+          description: 'Description 1',
+          prerequisite_skill_ids: ['skill_1'],
+          acquired_skill_ids: ['skill_2'],
+          destination_node_ids: ['node_2'],
+          outline: 'Outline',
+          exploration_id: null,
+          outline_is_finalized: false,
+          thumbnail_bg_color: '#a33f40',
+          thumbnail_filename: 'filename'
+        }, {
+          id: 'node_2',
+          title: 'Title 2',
+          description: 'Description 2',
+          prerequisite_skill_ids: ['skill_3'],
+          acquired_skill_ids: [],
+          destination_node_ids: [],
+          outline: 'Outline 2',
+          exploration_id: 'exp_1',
+          outline_is_finalized: true,
+          thumbnail_bg_color: '#a33f40',
+          thumbnail_filename: 'filename'
+        }
+      ],
+      next_node_id: 'node_3'
+    };
+    let sampleStoryContents = storyContentsObjectFactory.createFromBackendDict(
+      sampleStoryContentsBackendDict);
+    let issues = svs.validatePrerequisiteSkillsInStoryContents(
+      ['skill_3'], sampleStoryContents);
+    let expected_error_string = (
+      'The skill with id skill_3 was specified as a prerequisite for ' +
+      'Chapter Title 2 but was not taught in any chapter before it.')
+    expect(issues).toEqual([expected_error_string])
+  });
+
+  it('should report a validation error when the story graph has loops', () => {
+    let sampleStoryContentsBackendDict = {
+      initial_node_id: 'node_1',
+      nodes: [
+        {
+          id: 'node_1',
+          title: 'Title 1',
+          description: 'Description 1',
+          prerequisite_skill_ids: ['skill_1'],
+          acquired_skill_ids: ['skill_2'],
+          destination_node_ids: ['node_2'],
+          outline: 'Outline',
+          exploration_id: null,
+          outline_is_finalized: false,
+          thumbnail_bg_color: '#a33f40',
+          thumbnail_filename: 'filename'
+        }, {
+          id: 'node_2',
+          title: 'Title 2',
+          description: 'Description 2',
+          prerequisite_skill_ids: ['skill_3'],
+          acquired_skill_ids: [],
+          destination_node_ids: ['node_3'],
+          outline: 'Outline 2',
+          exploration_id: 'exp_1',
+          outline_is_finalized: true,
+          thumbnail_bg_color: '#a33f40',
+          thumbnail_filename: 'filename'
+        }, {
+          id: 'node_3',
+          title: 'Title 3',
+          description: 'Description 3',
+          prerequisite_skill_ids: ['skill_4'],
+          acquired_skill_ids: [],
+          destination_node_ids: ['node_1'],
+          outline: 'Outline 2',
+          exploration_id: 'exp_1',
+          outline_is_finalized: true,
+          thumbnail_bg_color: '#a33f40',
+          thumbnail_filename: 'filename'
+        }
+      ],
+      next_node_id: 'node_4'
+    };
+    let sampleStoryContents = storyContentsObjectFactory.createFromBackendDict(
+      sampleStoryContentsBackendDict);
+    let issues = svs.validatePrerequisiteSkillsInStoryContents(
+      [], sampleStoryContents);
+    let expected_error_string = 'Loops are not allowed in the node graph';
+    expect(issues).toEqual([expected_error_string])
+  });
+});

--- a/core/templates/domain/story/story-validation.service.spec.ts
+++ b/core/templates/domain/story/story-validation.service.spec.ts
@@ -66,10 +66,10 @@ describe('Story Validation Service', () => {
       sampleStoryContentsBackendDict);
     let issues = svs.validatePrerequisiteSkillsInStoryContents(
       ['skill_3'], sampleStoryContents);
-    let expected_error_string = (
+    let expectedErrorString = (
       'The skill with id skill_3 was specified as a prerequisite for ' +
-      'Chapter Title 2 but was not taught in any chapter before it.')
-    expect(issues).toEqual([expected_error_string])
+      'Chapter Title 2 but was not taught in any chapter before it.');
+    expect(issues).toEqual([expectedErrorString]);
   });
 
   it('should report a validation error when the story graph has loops', () => {
@@ -120,7 +120,7 @@ describe('Story Validation Service', () => {
       sampleStoryContentsBackendDict);
     let issues = svs.validatePrerequisiteSkillsInStoryContents(
       [], sampleStoryContents);
-    let expected_error_string = 'Loops are not allowed in the node graph';
-    expect(issues).toEqual([expected_error_string])
+    let expectedErrorString = 'Loops are not allowed in the node graph';
+    expect(issues).toEqual([expectedErrorString]);
   });
 });

--- a/core/templates/domain/story/story-validation.service.ts
+++ b/core/templates/domain/story/story-validation.service.ts
@@ -1,0 +1,96 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Service to validate a story.
+ */
+
+import { Injectable } from '@angular/core';
+import { downgradeInjectable } from '@angular/upgrade/static';
+
+import { StoryContents } from 'domain/story/StoryContentsObjectFactory'
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StoryValidationService {
+
+  /**
+   * Validates the prerequisite skills in the story contents.
+   *
+   * @returns {string[]} - List of validation issues.
+   */
+  validatePrerequisiteSkillsInStoryContents(
+      topicRelevantSkills: string[], storyContents: StoryContents): string[] {
+    let issues = [];
+    let nodeIds = storyContents.getNodeIds();
+    let nodes = storyContents.getNodes();
+    // Variable nodesQueue stores the pending nodes to visit in a queue form.
+    let nodesQueue = [];
+    let nodeIsVisited = new Array(nodeIds.length).fill(false);
+    let startingNode = nodes[storyContents.getNodeIndex(
+      storyContents.getInitialNodeId())];
+    nodesQueue.push(startingNode.getId());
+
+    // The user is assumed to have all the prerequisite skills of the
+    // starting node before starting the story. Also, this list models the
+    // skill IDs acquired by a learner as they progress through the story.
+    var simulatedSkillIds = new Set(startingNode.getPrerequisiteSkillIds());
+
+    // The following loop employs a Breadth First Search from the given
+    // starting node and makes sure that the user has acquired all the
+    // prerequisite skills required by the destination nodes 'unlocked' by
+    // visiting a particular node by the time that node is finished.
+    while (nodesQueue.length > 0) {
+      var currentNodeIndex = storyContents.getNodeIndex(nodesQueue.shift());
+      nodeIsVisited[currentNodeIndex] = true;
+      var currentNode = nodes[currentNodeIndex];
+
+      currentNode.getAcquiredSkillIds().forEach((skillId) => {
+        simulatedSkillIds.add(skillId);
+      });
+      for (var i = 0; i < currentNode.getDestinationNodeIds().length; i++) {
+        var nodeId = currentNode.getDestinationNodeIds()[i];
+        var nodeIndex = storyContents.getNodeIndex(nodeId);
+        // The following condition checks whether the destination node
+        // for a particular node, has already been visited, in which case
+        // the story would have loops, which are not allowed.
+        if (nodeIsVisited[nodeIndex]) {
+          issues.push('Loops are not allowed in the node graph');
+          // If a loop is encountered, then all further checks are halted,
+          // since it can lead to same error being reported again.
+          return issues;
+        }
+        var destinationNode = nodes[nodeIndex];
+        destinationNode.getPrerequisiteSkillIds().forEach(
+          (skillId: string) => {
+            if (
+                topicRelevantSkills.includes(skillId) &&
+                !simulatedSkillIds.has(skillId)) {
+              issues.push(
+                `The skill with id ${skillId} was specified as a ` +
+                `prerequisite for Chapter ${destinationNode.getTitle()} but ` +
+                'was not taught in any chapter before it.');
+            }
+          }
+        );
+        nodesQueue.push(nodeId);
+      }
+    }
+    return issues;
+  }
+}
+
+angular.module('oppia').factory(
+  'StoryValidationService', downgradeInjectable(StoryValidationService));

--- a/core/templates/domain/story/story-validation.service.ts
+++ b/core/templates/domain/story/story-validation.service.ts
@@ -19,13 +19,12 @@
 import { Injectable } from '@angular/core';
 import { downgradeInjectable } from '@angular/upgrade/static';
 
-import { StoryContents } from 'domain/story/StoryContentsObjectFactory'
+import { StoryContents } from 'domain/story/StoryContentsObjectFactory';
 
 @Injectable({
   providedIn: 'root'
 })
 export class StoryValidationService {
-
   /**
    * Validates the prerequisite skills in the story contents.
    *
@@ -76,8 +75,8 @@ export class StoryValidationService {
         destinationNode.getPrerequisiteSkillIds().forEach(
           (skillId: string) => {
             if (
-                topicRelevantSkills.includes(skillId) &&
-                !simulatedSkillIds.has(skillId)) {
+              topicRelevantSkills.includes(skillId) &&
+              !simulatedSkillIds.has(skillId)) {
               issues.push(
                 `The skill with id ${skillId} was specified as a ` +
                 `prerequisite for Chapter ${destinationNode.getTitle()} but ` +

--- a/core/templates/pages/story-editor-page/navbar/story-editor-navbar.directive.ts
+++ b/core/templates/pages/story-editor-page/navbar/story-editor-navbar.directive.ts
@@ -95,8 +95,8 @@ angular.module('oppia').directive('storyEditorNavbar', [
             if ($scope.validationIssues.length === 0 && nodes.length > 0) {
               let prerequisiteSkillValidationIssues = (
                 StoryValidationService
-                .validatePrerequisiteSkillsInStoryContents(
-                  skillIdsInTopic, $scope.story.getStoryContents()));
+                  .validatePrerequisiteSkillsInStoryContents(
+                    skillIdsInTopic, $scope.story.getStoryContents()));
               $scope.validationIssues = (
                 $scope.validationIssues.concat(
                   prerequisiteSkillValidationIssues));

--- a/core/templates/pages/story-editor-page/navbar/story-editor-navbar.directive.ts
+++ b/core/templates/pages/story-editor-page/navbar/story-editor-navbar.directive.ts
@@ -24,6 +24,7 @@ require(
 require('domain/editor/undo_redo/base-undo-redo.service.ts');
 require('domain/editor/undo_redo/undo-redo.service.ts');
 require('domain/story/editable-story-backend-api.service.ts');
+require('domain/story/story-validation.service');
 require('domain/utilities/url-interpolation.service.ts');
 require('pages/story-editor-page/services/story-editor-state.service.ts');
 require('pages/story-editor-page/services/story-editor-navigation.service.ts');
@@ -41,11 +42,11 @@ angular.module('oppia').directive('storyEditorNavbar', [
       controller: [
         '$rootScope', '$scope', '$uibModal', 'EditableStoryBackendApiService',
         'StoryEditorNavigationService', 'StoryEditorStateService',
-        'UndoRedoService',
+        'StoryValidationService', 'UndoRedoService',
         function(
             $rootScope, $scope, $uibModal, EditableStoryBackendApiService,
             StoryEditorNavigationService, StoryEditorStateService,
-            UndoRedoService) {
+            StoryValidationService, UndoRedoService) {
           var ctrl = this;
           var EDITOR = 'Editor';
           var PREVIEW = 'Preview';
@@ -87,13 +88,25 @@ angular.module('oppia').directive('storyEditorNavbar', [
 
           var _validateStory = function() {
             $scope.validationIssues = $scope.story.validate();
+            let nodes = $scope.story.getStoryContents().getNodes();
+            let skillIdsInTopic = (
+              StoryEditorStateService.getSkillSummaries().map(
+                skill => skill.id));
+            if ($scope.validationIssues.length === 0 && nodes.length > 0) {
+              let prerequisiteSkillValidationIssues = (
+                StoryValidationService
+                .validatePrerequisiteSkillsInStoryContents(
+                  skillIdsInTopic, $scope.story.getStoryContents()));
+              $scope.validationIssues = (
+                $scope.validationIssues.concat(
+                  prerequisiteSkillValidationIssues));
+            }
             if (StoryEditorStateService.getStoryWithUrlFragmentExists()) {
               $scope.validationIssues.push(
                 'Story URL fragment already exists.');
             }
             $scope.forceValidateExplorations = true;
             _validateExplorations();
-            var nodes = $scope.story.getStoryContents().getNodes();
             var storyPrepublishValidationIssues = (
               $scope.story.prepublishValidate());
             var nodePrepublishValidationIssues = (

--- a/core/templates/pages/story-editor-page/story-editor-page.component.spec.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.component.spec.ts
@@ -231,6 +231,9 @@ describe('Story editor page', function() {
     spyOn(
       StoryEditorStateService,
       'getStoryWithUrlFragmentExists').and.returnValue(true);
+    spyOn(StoryEditorStateService, 'getSkillSummaries').and.returnValue([{
+      id: 'skill_id'
+    }]);
     MockStoryEditorNavigationService.checkIfPresentInChapterEditor = () => true;
     ctrl.$onInit();
     expect(ctrl.validationIssues).toEqual(

--- a/core/templates/pages/story-editor-page/story-editor-page.component.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.component.ts
@@ -127,7 +127,7 @@ angular.module('oppia').component('storyEditorPage', {
         if (ctrl.validationIssues.length === 0 && nodes.length > 0) {
           let prerequisiteSkillValidationIssues = (
             StoryValidationService.validatePrerequisiteSkillsInStoryContents(
-              skillIdsInTopic ,ctrl.story.getStoryContents()));
+              skillIdsInTopic, ctrl.story.getStoryContents()));
           ctrl.validationIssues = (
             ctrl.validationIssues.concat(prerequisiteSkillValidationIssues));
         }

--- a/core/templates/pages/story-editor-page/story-editor-page.component.ts
+++ b/core/templates/pages/story-editor-page/story-editor-page.component.ts
@@ -38,6 +38,7 @@ require('pages/story-editor-page/services/story-editor-navigation.service');
 require(
   'pages/story-editor-page/chapter-editor/chapter-editor-tab.component.ts');
 require('domain/story/editable-story-backend-api.service.ts');
+require('domain/story/story-validation.service');
 require('pages/story-editor-page/story-editor-page.constants.ajs.ts');
 require('services/bottom-navbar-status.service.ts');
 require('services/page-title.service.ts');
@@ -52,13 +53,13 @@ angular.module('oppia').component('storyEditorPage', {
     '$uibModal', '$window', 'BottomNavbarStatusService',
     'EditableStoryBackendApiService', 'LoaderService',
     'PageTitleService', 'StoryEditorNavigationService',
-    'StoryEditorStateService', 'UndoRedoService',
+    'StoryEditorStateService', 'StoryValidationService', 'UndoRedoService',
     'UrlInterpolationService', 'UrlService', 'WindowRef',
     function(
         $uibModal, $window, BottomNavbarStatusService,
         EditableStoryBackendApiService, LoaderService,
         PageTitleService, StoryEditorNavigationService,
-        StoryEditorStateService, UndoRedoService,
+        StoryEditorStateService, StoryValidationService, UndoRedoService,
         UrlInterpolationService, UrlService, WindowRef) {
       var ctrl = this;
       ctrl.directiveSubscriptions = new Subscription();
@@ -120,12 +121,21 @@ angular.module('oppia').component('storyEditorPage', {
 
       var _validateStory = function() {
         ctrl.validationIssues = ctrl.story.validate();
+        var nodes = ctrl.story.getStoryContents().getNodes();
+        let skillIdsInTopic = StoryEditorStateService.getSkillSummaries().map(
+          skill => skill.id);
+        if (ctrl.validationIssues.length === 0 && nodes.length > 0) {
+          let prerequisiteSkillValidationIssues = (
+            StoryValidationService.validatePrerequisiteSkillsInStoryContents(
+              skillIdsInTopic ,ctrl.story.getStoryContents()));
+          ctrl.validationIssues = (
+            ctrl.validationIssues.concat(prerequisiteSkillValidationIssues));
+        }
         if (StoryEditorStateService.getStoryWithUrlFragmentExists()) {
           ctrl.validationIssues.push(
             'Story URL fragment already exists.');
         }
         _validateExplorations();
-        var nodes = ctrl.story.getStoryContents().getNodes();
         var storyPrepublishValidationIssues = (
           ctrl.story.prepublishValidate());
         var nodePrepublishValidationIssues = (

--- a/core/templates/services/angular-services.index.ts
+++ b/core/templates/services/angular-services.index.ts
@@ -120,6 +120,7 @@ import { PlaythroughBackendApiService } from 'domain/statistics/playthrough-back
 import { StateTopAnswersStatsObjectFactory } from 'domain/statistics/state-top-answers-stats-object.factory';
 import { StoryContentsObjectFactory } from 'domain/story/StoryContentsObjectFactory';
 import { StoryObjectFactory } from 'domain/story/StoryObjectFactory';
+import { StoryValidationService } from 'domain/story/story-validation.service';
 import { StoryViewerBackendApiService } from 'domain/story_viewer/story-viewer-backend-api.service';
 import { ReadOnlySubtopicPageObjectFactory } from 'domain/subtopic_viewer/ReadOnlySubtopicPageObjectFactory';
 import { SubtopicViewerBackendApiService } from 'domain/subtopic_viewer/subtopic-viewer-backend-api.service';
@@ -582,6 +583,7 @@ export const angularServices: [string, unknown][] = [
   ['StoryEditorNavigationService', StoryEditorNavigationService],
   ['StoryObjectFactory', StoryObjectFactory],
   ['StoryReferenceObjectFactory', StoryReferenceObjectFactory],
+  ['StoryValidationService', StoryValidationService],
   ['StoryViewerBackendApiService', StoryViewerBackendApiService],
   ['SubtitledHtmlObjectFactory', SubtitledHtmlObjectFactory],
   ['SubtitledUnicodeObjectFactory', SubtitledUnicodeObjectFactory],


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #11055
2. This PR does the following: Modifies prereq skills validation logic to only validate skills belonging to the topic corresponding to the story and accept skills from topics external to the story.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
