### PR TITLE
Fixes part of #10978: Fixing End-to-End Tests with action.js and waitFor.js

### DIFF
--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -150,8 +150,8 @@ var ListEditor = function(elem) {
   };
   var deleteItem = async function(index) {
     var deleteEntryButton = _elem.element(
-    await by.repeater('item in localValue track by $index').row(index)
-      ).element(by.css('.protractor-test-delete-list-entry'));
+      await by.repeater('item in localValue track by $index').row(index)
+        ).element(by.css('.protractor-test-delete-list-entry'));
     await action.click('Test delete List Entry Button', deleteEntryButton);
   };
 
@@ -201,7 +201,8 @@ var RichTextEditor = async function(elem) {
     await waitFor.elementToBeClickable(
       elem.element(by.css('.' + buttonName)),
       'Toolbar button takes too long to be clickable.');
-    await action.click('Test Tool Bar Button', elem.element(by.css('.' + buttonName)));
+    await action.click('Test Tool Bar Button',
+      elem.element(by.css('.' + buttonName)));
   };
   var _clearContent = async function() {
     expect(

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -199,7 +199,8 @@ var RichTextEditor = async function(elem) {
   };
   var _clickToolbarButton = async function(buttonName) {
     await waitFor.elementToBeClickable(
-      elem.element(by.css('.' + buttonName)), 'Toolbar button takes too long to be clickable.');
+      elem.element(
+        by.css('.' + buttonName)), 'Toolbar button takes too long.');
     await action.click(
       'Test Tool Bar Button', elem.element(by.css('.' + buttonName)));
   };
@@ -367,8 +368,8 @@ var AutocompleteMultiDropdownEditor = function(elem) {
         var select2ContainerButton = elem.element(by.css('.select2-container'));
         await action.click('Test Container Button', select2ContainerButton);
         var select2SearchField = elem.element(by.css('.select2-search__field'));
-        await action.sendKeys('Select 2 Search Field',
-          select2SearchField, texts[i] + '\n');
+        await action.sendKeys(
+          'Select 2 Search Field', select2SearchField, texts[i] + '\n');
       }
     },
     expectCurrentSelectionToBe: async function(expectedCurrentSelection) {

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -199,10 +199,9 @@ var RichTextEditor = async function(elem) {
   };
   var _clickToolbarButton = async function(buttonName) {
     await waitFor.elementToBeClickable(
-      elem.element(by.css('.' + buttonName)),
-        'Toolbar button takes too long to be clickable.');
-    await action.click('Test Tool Bar Button',
-      elem.element(by.css('.' + buttonName)));
+      elem.element(by.css('.' + buttonName)), 'Toolbar button takes too long to be clickable.');
+    await action.click(
+      'Test Tool Bar Button', elem.element(by.css('.' + buttonName)));
   };
   var _clearContent = async function() {
     expect(

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -91,7 +91,6 @@ var GraphEditor = function(graphInputContainer) {
       var deleteButton = graphInputContainer.element(
         by.css('.protractor-test-Delete-button'));
       await action.click('Test delete Button', deleteButton);
-    
       // Sample graph comes with 3 vertices.
       for (var i = 2; i >= 0; i--) {
         await vertexElement(i).click();
@@ -133,9 +132,7 @@ var ListEditor = function(elem) {
   var addItem = async function(objectType = null) {
     var listLength = await _getLength();
     var addListEntryButton = elem.element(by.css('.protractor-test-add-list-entry'));
-    await action.click('Test add List Entry Button', addlistEntryButton);
-    
-    
+    await action.click('Test add List Entry Button', addListEntryButton);
     if (objectType !== null) {
       return await getEditor(objectType)(
         elem.element(
@@ -201,7 +198,6 @@ var RichTextEditor = async function(elem) {
     ).toBe(true);
     await (await elem.all(by.css('.oppia-rte')).first()).clear();
   };
-
   return {
     clear: async function() {
       await _clearContent();

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -360,7 +360,7 @@ var AutocompleteMultiDropdownEditor = function(elem) {
         var select2ContainerButton = elem.element(by.css('.select2-container'));
         await action.click('Test Container Button', select2ContainerButton);
         var select2SearchField = elem.element(by.css('.select2-search__field'));
-        await action.sendKeys('Search Field', select2SearchField, texts[i] + '\n');
+        await action.sendKeys('Field', select2SearchField, texts[i] + '\n');
       }
     },
     expectCurrentSelectionToBe: async function(expectedCurrentSelection) {
@@ -383,7 +383,9 @@ var MultiSelectEditor = function(elem) {
   var _toggleElementStatusesAndVerifyExpectedClass = async function(
       texts, expectedClassBeforeToggle) {
     // Open the dropdown menu.
-    var dropDownToggleButton = elem.element(by.css('.protractor-test-search-bar-dropdown-toggle'));
+    var dropDownToggleButton = elem.element(
+      by.css(
+        '.protractor-test-search-bar-dropdown-toggle'));
     await action.click('Test Dropdown Toggle', dropDownToggleButton);
     var filteredElementsCount = 0;
     for (var i = 0; i < texts.length; i++) {

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -111,6 +111,8 @@ var GraphEditor = function(graphInputContainer) {
         // dict's edges.
         var allEdgesElement = element.all(by.css(
           '.protractor-test-graph-edge'));
+        await waitFor.visibilityOf(allEdgesElement,
+            'Edges element taking too long to appear');
         expect(await allEdgesElement.count()).toEqual(edgesList.length);
       }
     }
@@ -328,6 +330,8 @@ var AutocompleteDropdownEditor = function(elem) {
             return await optionElem.getText();
           }
         );
+      await waitFor.visibilityOf(actualOptions,
+        'Actual options taking too long to appear');
       expect(actualOptions).toEqual(expectedOptions);
       // Re-close the dropdown.
       var select2DropDown = element(by.css('.select2-dropdown')).element(
@@ -390,6 +394,8 @@ var MultiSelectEditor = function(elem) {
           '.protractor-test-search-bar-dropdown-menu span', texts[i]));
       if (await filteredElement.isPresent()) {
         filteredElementsCount += 1;
+        await waitFor.visibilityOf(filteredElement,
+            'Filtered element taking too long to appear');
         expect(await filteredElement.getAttribute('class')).toMatch(
           expectedClassBeforeToggle);
         await action.click('Test Filtered Element', filteredElement);

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -150,8 +150,8 @@ var ListEditor = function(elem) {
   };
   var deleteItem = async function(index) {
     var deleteEntryButton = _elem.element(
-      await by.repeater('item in localValue track by $index').row(index)
-        ).element(by.css('.protractor-test-delete-list-entry'))
+    await by.repeater('item in localValue track by $index').row(index)
+      ).element(by.css('.protractor-test-delete-list-entry'));
     await action.click('Test delete List Entry Button', deleteEntryButton);
   };
 
@@ -284,7 +284,8 @@ var RichTextEditor = async function(elem) {
         await action.sendKeys('Oppia Rte', oppiaRte, protractor.Key.DOWN);
       }
       // Ensure that the cursor is at the end of the RTE.
-      var protractorChord = protractor.Key.chord(protractor.Key.CONTROL, protractor.Key.END);
+      var protractorChord = protractor.Key.chord(
+        protractor.Key.CONTROL, protractor.Key.END);
       await action.sendKeys('Oppia Rte', oppiaRte, protractorChord);
     }
   };
@@ -366,7 +367,8 @@ var AutocompleteMultiDropdownEditor = function(elem) {
         var select2ContainerButton = elem.element(by.css('.select2-container'));
         await action.click('Test Container Button', select2ContainerButton);
         var select2SearchField = elem.element(by.css('.select2-search__field'));
-        await action.sendKeys('Select 2 Search Field', select2SearchField, texts[i] + '\n');
+        await action.sendKeys('Select 2 Search Field',
+          select2SearchField, texts[i] + '\n');
       }
     },
     expectCurrentSelectionToBe: async function(expectedCurrentSelection) {

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -112,7 +112,7 @@ var GraphEditor = function(graphInputContainer) {
         var allEdgesElement = element.all(by.css(
           '.protractor-test-graph-edge'));
         await waitFor.visibilityOf(
-            allEdgesElement,'Edges element taking too long to appear');
+          allEdgesElement,'Edges element taking too long to appear');
         expect(await allEdgesElement.count()).toEqual(edgesList.length);
       }
     }
@@ -311,7 +311,7 @@ var AutocompleteDropdownEditor = function(elem) {
   return {
     setValue: async function(text) {
       var select2ContainerButton = elem.element(by.css('.select2-container'));
-      await action.click('Test Select2 Container Button', select2ContainerButton);
+      await action.click('Test Container Button', select2ContainerButton);
       // NOTE: the input field is top-level in the DOM, and is outside the
       // context of 'elem'. The 'select2-dropdown' id is assigned to the input
       // field when it is 'activated', i.e. when the dropdown is clicked.
@@ -321,15 +321,15 @@ var AutocompleteDropdownEditor = function(elem) {
     },
     expectOptionsToBe: async function(expectedOptions) {
       var select2ContainerButton = elem.element(by.css('.select2-container'));
-      await action.click('Test Select2 Container Button', select2ContainerButton);
+      await action.click('Test Container Button', select2ContainerButton);
       var actualOptions = await element(by.css('.select2-dropdown'))
         .all(by.tagName('li')).map(
           async function(optionElem) {
             return await optionElem.getText();
           }
         );
-      await waitFor.visibilityOf(actualOptions,
-        'Actual options taking too long to appear');
+      await waitFor.visibilityOf(
+        actualOptions,'Actual options taking too long to appear');
       expect(actualOptions).toEqual(expectedOptions);
       // Re-close the dropdown.
       var select2DropDown = element(by.css('.select2-dropdown')).element(

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -151,7 +151,7 @@ var ListEditor = function(elem) {
   var deleteItem = async function(index) {
     var deleteEntryButton = _elem.element(
       await by.repeater('item in localValue track by $index').row(index)
-        ).element(by.css('.protractor-test-delete-list-entry'));
+    ).element(by.css('.protractor-test-delete-list-entry'));
     await action.click('Test delete List Entry Button', deleteEntryButton);
   };
 
@@ -200,7 +200,7 @@ var RichTextEditor = async function(elem) {
   var _clickToolbarButton = async function(buttonName) {
     await waitFor.elementToBeClickable(
       elem.element(by.css('.' + buttonName)),
-      'Toolbar button takes too long to be clickable.');
+        'Toolbar button takes too long to be clickable.');
     await action.click('Test Tool Bar Button',
       elem.element(by.css('.' + buttonName)));
   };

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -63,9 +63,13 @@ var GraphEditor = function(graphInputContainer) {
     var addEdgeButton = graphInputContainer.element(
       by.css('.protractor-test-Add-Edge-button'));
     await action.click('Test Add Edge Button', addEdgeButton);
+    await waitFor.visibilityOf(
+      vertexElement(vertexIndex1), 'Vertex element taking too long to appear');
     await browser.actions().mouseMove(
       vertexElement(vertexIndex1)).perform();
     await browser.actions().mouseDown().perform();
+    await waitFor.visibilityOf(
+      vertexElement(vertexIndex2), 'Vertex element taking too long to appear');
     await browser.actions().mouseMove(
       vertexElement(vertexIndex2)).perform();
     await browser.actions().mouseUp().perform();
@@ -93,7 +97,7 @@ var GraphEditor = function(graphInputContainer) {
       await action.click('Test delete Button', deleteButton);
       // Sample graph comes with 3 vertices.
       for (var i = 2; i >= 0; i--) {
-        await vertexElement(i).click();
+        await action.click('Test vertex element', vertexElement(i));
       }
     },
     expectCurrentGraphToBe: async function(graphDict) {
@@ -103,6 +107,8 @@ var GraphEditor = function(graphInputContainer) {
         // Expecting total no. of vertices on the graph matches with the given
         // dict's vertices.
         for (var i = 0; i < nodeCoordinatesList.length; i++) {
+          await waitFor.visibilityOf(
+            vertexElement(i), 'Vertex element taking too long to appear');
           expect(await vertexElement(i).isDisplayed()).toBe(true);
         }
       }
@@ -143,9 +149,10 @@ var ListEditor = function(elem) {
     }
   };
   var deleteItem = async function(index) {
-    await _elem.element(
+    var deleteEntryButton = _elem.element(
       await by.repeater('item in localValue track by $index').row(index)
-    ).element(by.css('.protractor-test-delete-list-entry')).click();
+        ).element(by.css('.protractor-test-delete-list-entry'))
+    await action.click('Test delete List Entry Button', deleteEntryButton);
   };
 
   return {
@@ -194,13 +201,13 @@ var RichTextEditor = async function(elem) {
     await waitFor.elementToBeClickable(
       elem.element(by.css('.' + buttonName)),
       'Toolbar button takes too long to be clickable.');
-    await elem.element(by.css('.' + buttonName)).click();
+    await action.click('Test Tool Bar Button', elem.element(by.css('.' + buttonName)));
   };
   var _clearContent = async function() {
     expect(
       await (await elem.all(by.css('.oppia-rte')).first()).isPresent()
     ).toBe(true);
-    var oppiaRte = (await elem.all(by.css('.oppia-rte')).first());
+    var oppiaRte = await elem.all(by.css('.oppia-rte').first());
     await action.clear('oppia Rte', oppiaRte);
   };
   return {
@@ -269,17 +276,16 @@ var RichTextEditor = async function(elem) {
         modal, 'Customization modal taking too long to disappear.');
       // Ensure that focus is not on added component once it is added so that
       // the component is not overwritten by some other element.
+      var oppiaRte = elem.all(by.css('.oppia-rte')).first();
       if (
         [
           'Video', 'Image', 'Collapsible', 'Tabs', 'Svgdiagram'
         ].includes(componentName)) {
-        var oppiaRte = elem.all(by.css('.oppia-rte')).first();
         await action.sendKeys('Oppia Rte', oppiaRte, protractor.Key.DOWN);
       }
-
       // Ensure that the cursor is at the end of the RTE.
-      await elem.all(by.css('.oppia-rte')).first().sendKeys(
-        protractor.Key.chord(protractor.Key.CONTROL, protractor.Key.END));
+      var protractorChord = protractor.Key.chord(protractor.Key.CONTROL, protractor.Key.END);
+      await action.sendKeys('Oppia Rte', oppiaRte, protractorChord);
     }
   };
 };
@@ -325,11 +331,11 @@ var AutocompleteDropdownEditor = function(elem) {
       var actualOptions = await element(by.css('.select2-dropdown'))
         .all(by.tagName('li')).map(
           async function(optionElem) {
+            await waitFor.visibilityOf(
+              optionElem, 'Option elements taking too long to appear');
             return await optionElem.getText();
           }
         );
-      await waitFor.visibilityOf(
-        actualOptions, 'Actual options taking too long to appear');
       expect(actualOptions).toEqual(expectedOptions);
       // Re-close the dropdown.
       var select2DropDown = element(by.css('.select2-dropdown')).element(
@@ -353,20 +359,22 @@ var AutocompleteMultiDropdownEditor = function(elem) {
       // removes the element from the DOM. We also omit the last element
       // because it is the field for new input.
       for (var i = deleteButtons.length - 2; i >= 0; i--) {
-        await deleteButtons[i].click();
+        await action.click('Test delete button', deleteButtons[i]);
       }
 
       for (var i = 0; i < texts.length; i++) {
         var select2ContainerButton = elem.element(by.css('.select2-container'));
         await action.click('Test Container Button', select2ContainerButton);
         var select2SearchField = elem.element(by.css('.select2-search__field'));
-        await action.sendKeys('Field', select2SearchField, texts[i] + '\n');
+        await action.sendKeys('Select 2 Search Field', select2SearchField, texts[i] + '\n');
       }
     },
     expectCurrentSelectionToBe: async function(expectedCurrentSelection) {
       actualSelection = await elem.element(
         by.css('.select2-selection__rendered')
       ).all(by.tagName('li')).map(async function(choiceElem) {
+        await waitFor.visibilityOf(
+          choiceElem, 'Choice element taking too long to appear');
         return await choiceElem.getText();
       });
       // Remove the element corresponding to the last <li>, which actually
@@ -432,6 +440,8 @@ var MultiSelectEditor = function(elem) {
         by.css('.protractor-test-search-bar-dropdown-menu')
       ).all(by.css('.protractor-test-selected'))
         .map(async function(selectedElem) {
+          await waitFor.visibilityOf(
+            selectedElem, 'Selected element taking too long to appear');
           return await selectedElem.getText();
         });
       expect(actualSelection).toEqual(expectedCurrentSelection);
@@ -471,6 +481,8 @@ var expectRichText = function(elem) {
         // applying .getText() while the RichTextChecker is running would be
         // asynchronous and so not allow us to update the textPointer
         // synchronously.
+        await waitFor.visibilityOf(
+          entry, 'Entry element taking too long to appear');
         return await entry.getText();
       });
     // We re-derive the array of elements as we need it too.

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -111,8 +111,8 @@ var GraphEditor = function(graphInputContainer) {
         // dict's edges.
         var allEdgesElement = element.all(by.css(
           '.protractor-test-graph-edge'));
-        await waitFor.visibilityOf(allEdgesElement,
-            'Edges element taking too long to appear');
+        await waitFor.visibilityOf(
+            allEdgesElement,'Edges element taking too long to appear');
         expect(await allEdgesElement.count()).toEqual(edgesList.length);
       }
     }
@@ -273,7 +273,6 @@ var RichTextEditor = async function(elem) {
         [
           'Video', 'Image', 'Collapsible', 'Tabs', 'Svgdiagram'
         ].includes(componentName)) {
-        
         var oppiaRte = elem.all(by.css('.oppia-rte')).first();
         await action.sendKeys('Oppia Rte', oppiaRte, protractor.Key.DOWN);
       }
@@ -313,7 +312,6 @@ var AutocompleteDropdownEditor = function(elem) {
     setValue: async function(text) {
       var select2ContainerButton = elem.element(by.css('.select2-container'));
       await action.click('Test Select2 Container Button', select2ContainerButton);
-      
       // NOTE: the input field is top-level in the DOM, and is outside the
       // context of 'elem'. The 'select2-dropdown' id is assigned to the input
       // field when it is 'activated', i.e. when the dropdown is clicked.
@@ -395,7 +393,7 @@ var MultiSelectEditor = function(elem) {
       if (await filteredElement.isPresent()) {
         filteredElementsCount += 1;
         await waitFor.visibilityOf(filteredElement,
-            'Filtered element taking too long to appear');
+          'Filtered element taking too long to appear');
         expect(await filteredElement.getAttribute('class')).toMatch(
           expectedClassBeforeToggle);
         await action.click('Test Filtered Element', filteredElement);

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -172,18 +172,21 @@ var ListEditor = function(elem) {
 var RealEditor = function(elem) {
   return {
     setValue: async function(value) {
-      await elem.element(by.tagName('input')).clear();
-      await elem.element(by.tagName('input')).sendKeys(value);
+      var tagNameInput = elem.element(by.tagName('input'));
+      await action.clear('Tag Name Input', tagNameInput);
+      await action.sendKeys('Tag Name Input', tagNameInput, value);
     }
   };
 };
 
 var RichTextEditor = async function(elem) {
   // Set focus in the RTE.
-  await (await elem.all(by.css('.oppia-rte')).first()).click();
+  var oppiaRte = await elem.all(by.css('.oppia-rte')).first();
+  await action.click('Test Oppia Rte', oppiaRte);
 
   var _appendContentText = async function(text) {
-    await (await elem.all(by.css('.oppia-rte')).first()).sendKeys(text);
+    var oppiaRte = await elem.all(by.css('.oppia-rte')).first();
+    await action.sendKeys('Oppia Rte', oppiaRte, text);
   };
   var _clickToolbarButton = async function(buttonName) {
     await waitFor.elementToBeClickable(
@@ -195,7 +198,8 @@ var RichTextEditor = async function(elem) {
     expect(
       await (await elem.all(by.css('.oppia-rte')).first()).isPresent()
     ).toBe(true);
-    await (await elem.all(by.css('.oppia-rte')).first()).clear();
+    var oppiaRte = (await elem.all(by.css('.oppia-rte')).first());
+    await action.clear('oppia Rte', oppiaRte);
   };
   return {
     clear: async function() {
@@ -258,7 +262,7 @@ var RichTextEditor = async function(elem) {
       await waitFor.elementToBeClickable(
         doneButton,
         'save button taking too long to be clickable');
-      await doneButton.click();
+      await action.click('Test Done Button', doneButton);
       await waitFor.invisibilityOf(
         modal, 'Customization modal taking too long to disappear.');
       // Ensure that focus is not on added component once it is added so that
@@ -267,8 +271,9 @@ var RichTextEditor = async function(elem) {
         [
           'Video', 'Image', 'Collapsible', 'Tabs', 'Svgdiagram'
         ].includes(componentName)) {
-        await elem.all(
-          by.css('.oppia-rte')).first().sendKeys(protractor.Key.DOWN);
+        
+        var oppiaRte = elem.all(by.css('.oppia-rte')).first();
+        await action.sendKeys('Oppia Rte', oppiaRte, protractor.Key.DOWN);
       }
 
       // Ensure that the cursor is at the end of the RTE.
@@ -294,8 +299,9 @@ var SetOfHtmlStringEditor = function(elem) {
 var UnicodeEditor = function(elem) {
   return {
     setValue: async function(text) {
-      await elem.element(by.tagName('input')).clear();
-      await elem.element(by.tagName('input')).sendKeys(text);
+      var tagNameInput = elem.element(by.tagName('input'));
+      await action.clear('tag Name Input', tagNameInput);
+      await action.sendKeys('Tag Name Input', tagNameInput, text);
     }
   };
 };
@@ -303,15 +309,19 @@ var UnicodeEditor = function(elem) {
 var AutocompleteDropdownEditor = function(elem) {
   return {
     setValue: async function(text) {
-      await elem.element(by.css('.select2-container')).click();
+      var select2ContainerButton = elem.element(by.css('.select2-container'));
+      await action.click('Test Select2 Container Button', select2ContainerButton);
+      
       // NOTE: the input field is top-level in the DOM, and is outside the
       // context of 'elem'. The 'select2-dropdown' id is assigned to the input
       // field when it is 'activated', i.e. when the dropdown is clicked.
-      await element(by.css('.select2-dropdown')).element(
-        by.css('.select2-search input')).sendKeys(text + '\n');
+      var select2DropDown = element(by.css('.select2-dropdown')).element(
+        by.css('.select2-search input'));
+      await action.sendKeys('Select2 Drop Down', select2DropDown, text + '\n');
     },
     expectOptionsToBe: async function(expectedOptions) {
-      await elem.element(by.css('.select2-container')).click();
+      var select2ContainerButton = elem.element(by.css('.select2-container'));
+      await action.click('Test Select2 Container Button', select2ContainerButton);
       var actualOptions = await element(by.css('.select2-dropdown'))
         .all(by.tagName('li')).map(
           async function(optionElem) {
@@ -320,8 +330,9 @@ var AutocompleteDropdownEditor = function(elem) {
         );
       expect(actualOptions).toEqual(expectedOptions);
       // Re-close the dropdown.
-      await element(by.css('.select2-dropdown')).element(
-        by.css('.select2-search input')).sendKeys('\n');
+      var select2DropDown = element(by.css('.select2-dropdown')).element(
+        by.css('.select2-search input'));
+      await action.sendKeys('Select2 Drop Down', select2DropDown, '\n');
     }
   };
 };
@@ -344,9 +355,10 @@ var AutocompleteMultiDropdownEditor = function(elem) {
       }
 
       for (var i = 0; i < texts.length; i++) {
-        await elem.element(by.css('.select2-container')).click();
-        await elem.element(by.css('.select2-search__field')).sendKeys(
-          texts[i] + '\n');
+        var select2ContainerButton = elem.element(by.css('.select2-container'));
+        await action.click('Test Select2 Container Button', select2ContainerButton);
+        var select2SearchField = elem.element(by.css('.select2-search__field'));
+        await action.sendKeys('Select2 Search Field', select2SearchField, texts[i] + '\n');
       }
     },
     expectCurrentSelectionToBe: async function(expectedCurrentSelection) {
@@ -369,9 +381,8 @@ var MultiSelectEditor = function(elem) {
   var _toggleElementStatusesAndVerifyExpectedClass = async function(
       texts, expectedClassBeforeToggle) {
     // Open the dropdown menu.
-    await elem.element(by.css(
-      '.protractor-test-search-bar-dropdown-toggle')).click();
-
+    var dropDownToggleButton = elem.element(by.css('.protractor-test-search-bar-dropdown-toggle'));
+    await action.click('Test Dropdown Toggle', dropDownToggleButton);
     var filteredElementsCount = 0;
     for (var i = 0; i < texts.length; i++) {
       var filteredElement = elem.element(
@@ -381,7 +392,7 @@ var MultiSelectEditor = function(elem) {
         filteredElementsCount += 1;
         expect(await filteredElement.getAttribute('class')).toMatch(
           expectedClassBeforeToggle);
-        await filteredElement.click();
+        await action.click('Test Filtered Element', filteredElement);
       }
     }
 
@@ -392,8 +403,7 @@ var MultiSelectEditor = function(elem) {
     }
 
     // Close the dropdown menu at the end.
-    await elem.element(by.css(
-      '.protractor-test-search-bar-dropdown-toggle')).click();
+    await action.click('Test Dropdown Toggle', dropDownToggleButton);
   };
 
   return {
@@ -407,8 +417,8 @@ var MultiSelectEditor = function(elem) {
     },
     expectCurrentSelectionToBe: async function(expectedCurrentSelection) {
       // Open the dropdown menu.
-      await elem.element(by.css(
-        '.protractor-test-search-bar-dropdown-toggle')).click();
+      var dropDownToggleButton = elem.element(by.css('.protractor-test-search-bar-dropdown-toggle'));
+      await action.click('Test Dropdown Toggle', dropDownToggleButton);
 
       // Find the selected elements.
       var actualSelection = await elem.element(
@@ -420,8 +430,7 @@ var MultiSelectEditor = function(elem) {
       expect(actualSelection).toEqual(expectedCurrentSelection);
 
       // Close the dropdown menu at the end.
-      await elem.element(by.css(
-        '.protractor-test-search-bar-dropdown-toggle')).click();
+      await action.click('Test Dropdown Toggle', dropDownToggleButton);
     }
   };
 };
@@ -697,8 +706,9 @@ var CodeMirrorChecker = function(elem, codeMirrorPaneToScroll) {
 var CodeStringEditor = function(elem) {
   return {
     setValue: async function(code) {
-      await elem.element(by.tagName('textarea')).clear();
-      await elem.element(by.tagName('textarea')).sendKeys(code);
+      var tagNameTextArea = elem.element(by.tagName('textarea'));
+      await action.clear('tag Name Text Area', tagNameTextArea);
+      await action.sendKeys('Tag Name Text Area', tagNameTextArea, code);
     }
   };
 };

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -423,7 +423,8 @@ var MultiSelectEditor = function(elem) {
     },
     expectCurrentSelectionToBe: async function(expectedCurrentSelection) {
       // Open the dropdown menu.
-      var dropDownToggleButton = elem.element(by.css('.protractor-test-search-bar-dropdown-toggle'));
+      var dropDownToggleButton = elem.element(
+        by.css('.protractor-test-search-bar-dropdown-toggle'));
       await action.click('Test Dropdown Toggle', dropDownToggleButton);
 
       // Find the selected elements.

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -131,8 +131,8 @@ var ListEditor = function(elem) {
   // If objectType is not specified, this function returns nothing.
   var addItem = async function(objectType = null) {
     var listLength = await _getLength();
-    var addListEntryButton = elem.element(by.css('.protractor-test-add-list-entry'));
-    await action.click('Test add List Entry Button', addListEntryButton);
+    var addListButton = elem.element(by.css('.protractor-test-add-list-entry'));
+    await action.click('Test add List Entry Button', addListButton);
     if (objectType !== null) {
       return await getEditor(objectType)(
         elem.element(
@@ -189,7 +189,6 @@ var RichTextEditor = async function(elem) {
     await waitFor.elementToBeClickable(
       elem.element(by.css('.' + buttonName)),
       'Toolbar button takes too long to be clickable.');
-    
     await elem.element(by.css('.' + buttonName)).click();
   };
   var _clearContent = async function() {

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -24,6 +24,7 @@ var richTextComponents = require(
   '../../../extensions/rich_text_components/protractor.js');
 var objects = require('../../../extensions/objects/protractor.js');
 var waitFor = require('./waitFor.js');
+var action = require('./action.js');
 
 var DictionaryEditor = function(elem) {
   return {
@@ -51,7 +52,7 @@ var GraphEditor = function(graphInputContainer) {
   var createVertex = async function(xOffset, yOffset) {
     var addNodeButton = graphInputContainer.element(
       by.css('.protractor-test-Add-Node-button'));
-    await addNodeButton.click();
+    await action.click('Test Add Node Button', addNodeButton);
     // Offsetting from the graph container.
     await browser.actions().mouseMove(
       graphInputContainer, {x: xOffset, y: yOffset}).perform();
@@ -61,7 +62,7 @@ var GraphEditor = function(graphInputContainer) {
   var createEdge = async function(vertexIndex1, vertexIndex2) {
     var addEdgeButton = graphInputContainer.element(
       by.css('.protractor-test-Add-Edge-button'));
-    await addEdgeButton.click();
+    await action.click('Test Add Edge Button', addEdgeButton);
     await browser.actions().mouseMove(
       vertexElement(vertexIndex1)).perform();
     await browser.actions().mouseDown().perform();
@@ -89,7 +90,8 @@ var GraphEditor = function(graphInputContainer) {
     clearDefaultGraph: async function() {
       var deleteButton = graphInputContainer.element(
         by.css('.protractor-test-Delete-button'));
-      await deleteButton.click();
+      await action.click('Test delete Button', deleteButton);
+    
       // Sample graph comes with 3 vertices.
       for (var i = 2; i >= 0; i--) {
         await vertexElement(i).click();
@@ -130,7 +132,10 @@ var ListEditor = function(elem) {
   // If objectType is not specified, this function returns nothing.
   var addItem = async function(objectType = null) {
     var listLength = await _getLength();
-    await elem.element(by.css('.protractor-test-add-list-entry')).click();
+    var addListEntryButton = elem.element(by.css('.protractor-test-add-list-entry'));
+    await action.click('Test add List Entry Button', addlistEntryButton);
+    
+    
     if (objectType !== null) {
       return await getEditor(objectType)(
         elem.element(
@@ -187,6 +192,7 @@ var RichTextEditor = async function(elem) {
     await waitFor.elementToBeClickable(
       elem.element(by.css('.' + buttonName)),
       'Toolbar button takes too long to be clickable.');
+    
     await elem.element(by.css('.' + buttonName)).click();
   };
   var _clearContent = async function() {

--- a/core/tests/protractor_utils/forms.js
+++ b/core/tests/protractor_utils/forms.js
@@ -112,7 +112,7 @@ var GraphEditor = function(graphInputContainer) {
         var allEdgesElement = element.all(by.css(
           '.protractor-test-graph-edge'));
         await waitFor.visibilityOf(
-          allEdgesElement,'Edges element taking too long to appear');
+          allEdgesElement, 'Edges element taking too long to appear');
         expect(await allEdgesElement.count()).toEqual(edgesList.length);
       }
     }
@@ -329,7 +329,7 @@ var AutocompleteDropdownEditor = function(elem) {
           }
         );
       await waitFor.visibilityOf(
-        actualOptions,'Actual options taking too long to appear');
+        actualOptions, 'Actual options taking too long to appear');
       expect(actualOptions).toEqual(expectedOptions);
       // Re-close the dropdown.
       var select2DropDown = element(by.css('.select2-dropdown')).element(
@@ -358,9 +358,9 @@ var AutocompleteMultiDropdownEditor = function(elem) {
 
       for (var i = 0; i < texts.length; i++) {
         var select2ContainerButton = elem.element(by.css('.select2-container'));
-        await action.click('Test Select2 Container Button', select2ContainerButton);
+        await action.click('Test Container Button', select2ContainerButton);
         var select2SearchField = elem.element(by.css('.select2-search__field'));
-        await action.sendKeys('Select2 Search Field', select2SearchField, texts[i] + '\n');
+        await action.sendKeys('Search Field', select2SearchField, texts[i] + '\n');
       }
     },
     expectCurrentSelectionToBe: async function(expectedCurrentSelection) {
@@ -392,8 +392,8 @@ var MultiSelectEditor = function(elem) {
           '.protractor-test-search-bar-dropdown-menu span', texts[i]));
       if (await filteredElement.isPresent()) {
         filteredElementsCount += 1;
-        await waitFor.visibilityOf(filteredElement,
-          'Filtered element taking too long to appear');
+        await waitFor.visibilityOf(
+          filteredElement, 'Filtered element taking too long to appear');
         expect(await filteredElement.getAttribute('class')).toMatch(
           expectedClassBeforeToggle);
         await action.click('Test Filtered Element', filteredElement);


### PR DESCRIPTION
## Overview


1. This PR fixes or fixes part of #[10978], form.js.
2. This PR does the following: a. replace click(), clear(), sendkeys() to action.click(), action.clear(), action.sendkeys(), b. added more functions from waitfor.js according to the request.


