### PR TITLE
Fix part of #10667: make alt text in image editor into paragraph text

### DIFF
--- a/assets/rich_text_components_definitions.ts
+++ b/assets/rich_text_components_definitions.ts
@@ -83,7 +83,8 @@ export = {
           "id": "is_nonempty"
         }],
         "ui_config": {
-          "placeholder": "Description of Image (Example : George Handel, 18th century baroque composer)"
+          "placeholder": "Description of Image (Example : George Handel, 18th century baroque composer)",
+          "rows": 3
         }
       },
       "default_value": ""

--- a/core/templates/services/rte-helper.service.spec.ts
+++ b/core/templates/services/rte-helper.service.spec.ts
@@ -99,7 +99,8 @@ describe('Rte Helper Service', function() {
           }],
           ui_config: {
             placeholder: 'Description of Image (Example : George Handel,' +
-            ' 18th century baroque composer)'
+            ' 18th century baroque composer)',
+            rows: 3
           }
         },
         default_value: ''


### PR DESCRIPTION
## Overview

1. This PR fixes part of #10667.
2. This PR does the following: Make alt text in image editor into paragraph text. Currently, hard to see all of it.

For paragraph texts, I checked the codebase and it seems like 80px is the default height of paragraph text boxes. This is approximately equivalent to 3 lines, which is what I use in this PR.

![oppia](https://user-images.githubusercontent.com/21316782/100795805-a432f200-33ed-11eb-9375-8455487e0103.png)


## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
