### PR TITLE
Fix #11309: Minor changes to the failing test

### DIFF
--- a/core/tests/protractor_desktop/additionalPlayerFeatures.js
+++ b/core/tests/protractor_desktop/additionalPlayerFeatures.js
@@ -165,8 +165,7 @@ describe('Full exploration editor', function() {
     await general.moveToPlayer();
     await explorationPlayerPage.submitAnswer('Continue');
     var backButton = element(by.css('.protractor-test-back-button'));
-    expect(await backButton.isPresent()).toEqual(
-      true, 'Back button is not present');
+    expect(await backButton.isPresent()).toEqual(true);
     await explorationPlayerPage.submitAnswer('LogicProof');
     await waitFor.invisibilityOf(
       backButton, 'Back button takes too long to disappear.');

--- a/core/tests/protractor_desktop/additionalPlayerFeatures.js
+++ b/core/tests/protractor_desktop/additionalPlayerFeatures.js
@@ -164,10 +164,12 @@ describe('Full exploration editor', function() {
 
     await general.moveToPlayer();
     await explorationPlayerPage.submitAnswer('Continue');
-    var buttons = element.all(by.css('.protractor-test-back-button'));
-    expect(await buttons.count()).toBe(1);
+    var backButton = element(by.css('.protractor-test-back-button'));
+    expect(await backButton.isPresent()).toEqual(
+      true, 'Back button is not present');
     await explorationPlayerPage.submitAnswer('LogicProof');
-    expect(await buttons.count()).toBe(0);
+    await waitFor.invisibilityOf(
+      backButton, 'Back button takes too long to disappear.');
 
     await explorationPlayerPage.clickThroughToNextCard();
     await explorationPlayerPage.expectExplorationToBeOver();


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #11309.
2. This PR does the following: 
In a supplemental card view in the exploration player, when the help card is shown, the back button to view the previous cards is expected to be disabled. However, there seems to be a slight delay between showing the help card and hiding the back button, the test does not account for it. I have made changes such that we wait for the back button to disappear before continuing operation. An error is thrown if the back button does not disappear even after a default wait time has elapsed.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
