### PR TITLE
Fix part of #10798: Fixing e2e tests with action.js and waitFor.js of ExplorationHistoryTab

### DIFF
--- a/core/tests/protractor_utils/ExplorationEditorHistoryTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorHistoryTab.js
@@ -86,8 +86,8 @@ var ExplorationEditorHistoryTab = function() {
         var matched = false;
         for (var i = 0; i < listOfNames.length; i++) {
           if (listOfNames[i] === stateName) {
-            var getStateNodes = stateNodes.get(i);
-            await action.click('Get State Nodes', getStateNodes);
+            var stateNode = stateNodes.get(i);
+            await action.click('Get State Nodes', stateNode);
             matched = true;
           }
         }
@@ -101,8 +101,8 @@ var ExplorationEditorHistoryTab = function() {
           closeStateHistoryButton,
           'Close State History button is not clickable');
         expect(await closeStateHistoryButton.isDisplayed()).toBe(true);
-        await action.click('Closes State History button',
-            closeStateHistoryButton);
+        await action.click(
+            'Close State History button', closeStateHistoryButton);
         await waitFor.invisibilityOf(
           closeStateHistoryButton,
           'Close State History button takes too long to disappear.');

--- a/core/tests/protractor_utils/ExplorationEditorHistoryTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorHistoryTab.js
@@ -102,7 +102,7 @@ var ExplorationEditorHistoryTab = function() {
           'Close State History button is not clickable');
         expect(await closeStateHistoryButton.isDisplayed()).toBe(true);
         await action.click(
-            'Close State History button', closeStateHistoryButton);
+          'Close State History button', closeStateHistoryButton);
         await waitFor.invisibilityOf(
           closeStateHistoryButton,
           'Close State History button takes too long to disappear.');

--- a/core/tests/protractor_utils/ExplorationEditorHistoryTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorHistoryTab.js
@@ -86,7 +86,8 @@ var ExplorationEditorHistoryTab = function() {
         var matched = false;
         for (var i = 0; i < listOfNames.length; i++) {
           if (listOfNames[i] === stateName) {
-            await stateNodes.get(i).click();
+            var getStateNodes = stateNodes.get(i);
+            await action.click('Get State Nodes', getStateNodes);
             matched = true;
           }
         }
@@ -100,7 +101,7 @@ var ExplorationEditorHistoryTab = function() {
           closeStateHistoryButton,
           'Close State History button is not clickable');
         expect(await closeStateHistoryButton.isDisplayed()).toBe(true);
-        await closeStateHistoryButton.click();
+        await action.click("Closes State History button", closeStateHistoryButton);
         await waitFor.invisibilityOf(
           closeStateHistoryButton,
           'Close State History button takes too long to disappear.');

--- a/core/tests/protractor_utils/ExplorationEditorHistoryTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorHistoryTab.js
@@ -101,7 +101,8 @@ var ExplorationEditorHistoryTab = function() {
           closeStateHistoryButton,
           'Close State History button is not clickable');
         expect(await closeStateHistoryButton.isDisplayed()).toBe(true);
-        await action.click("Closes State History button", closeStateHistoryButton);
+        await action.click('Closes State History button',
+            closeStateHistoryButton);
         await waitFor.invisibilityOf(
           closeStateHistoryButton,
           'Close State History button takes too long to disappear.');

--- a/core/tests/protractor_utils/ExplorationEditorHistoryTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorHistoryTab.js
@@ -100,13 +100,12 @@ var ExplorationEditorHistoryTab = function() {
         await waitFor.elementToBeClickable(
           closeStateHistoryButton,
           'Close State History button is not clickable');
-        expect(await closeStateHistoryButton.isDisplayed()).toBe(true);
         await action.click(
           'Close State History button', closeStateHistoryButton);
         await waitFor.invisibilityOf(
           closeStateHistoryButton,
           'Close State History button takes too long to disappear.');
-      },
+      };
       deselectVersion: async function() {
         await action.click('Reset graph button', resetGraphButton);
       },


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #10798 .
2. This PR does the following: Instead of calling .click() on an element, use action.click() from action.js

## Essential Checklist

- [ x ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ x ] The linter/Karma presubmit checks have passed locally on your machine.
- [ x ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ x ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
