### PR TITLE
Fix #11181: Modified button css throughout codebase

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -1313,9 +1313,9 @@ span.sort-explorations-select .sort-order {
 
 .oppia-dashboard-intro-button {
   background-color: #015c53;
-  border-radius: 0;
+  border-radius: 4px;
   color: #fff;
-  font-family: "Capriola", "Roboto", Arial, sans-serif;
+  font-family: "Roboto", Arial, sans-serif;
   font-size: 14px;
   margin-top: 10px;
   text-transform: uppercase;
@@ -1729,7 +1729,7 @@ pre.oppia-pre-wrapped-text {
   background-color: rgba(0,0,0,0.2);
   border-radius: 4px;
   color: rgba(255,255,255,1.0);
-  font-family: "Capriola", "Roboto", Arial, sans-serif;
+  font-family: "Roboto", Arial, sans-serif;
   font-size: 14px;
   margin-left: 5px;
   margin-right: 5px;
@@ -3359,9 +3359,9 @@ md-card.preview-conversation-skin-supplemental-card {
 
 .oppia-splash-button {
   background-color: #015c53;
-  border-radius: 0;
+  border-radius: 4px;
   color: #fff;
-  font-family: "Capriola", "Roboto", Arial, sans-serif;
+  font-family: "Roboto", Arial, sans-serif;
   font-size: 16px;
   margin-top: -20px;
   min-width: 360px;
@@ -4178,8 +4178,9 @@ oppia-noninteractive-link {
 
 .oppia-about-button {
   background-color: rgb(0, 121, 109);
+  border-radius: 4px;
   color: rgba(255,255,255,1.0);
-  font-family: "Capriola", "Roboto", Arial, sans-serif;
+  font-family: "Roboto", Arial, sans-serif;
   font-size: 18px;
   margin: 0 15px 15px 15px;
   max-width: 90%;

--- a/core/templates/pages/creator-dashboard-page/modal-templates/create-activity-modal.directive.html
+++ b/core/templates/pages/creator-dashboard-page/modal-templates/create-activity-modal.directive.html
@@ -46,9 +46,9 @@
 
   .oppia-create-activity-modal button {
     background-color: #015c53;
-    border-radius: 0;
+    border-radius: 4px;
     color: #fff;
-    font-family: "Capriola", "Roboto", Arial, sans-serif;
+    font-family: "Roboto", Arial, sans-serif;
     font-size: 14px;
     margin-top: 10px;
     text-align: center;

--- a/core/templates/pages/donate-page/donate-page.component.html
+++ b/core/templates/pages/donate-page/donate-page.component.html
@@ -98,8 +98,9 @@
   }
   .donate-page .btn.oppia-donate-options-button {
     background-color: rgba(0,0,0,0.2);
+    border-radius: 4px;
     color: rgba(255,255,255,1.0);
-    font-family: "Capriola", "Roboto", Arial, sans-serif;
+    font-family: "Roboto", Arial, sans-serif;
     font-size: 16px;
     height: 40px;
     margin: 10px auto;

--- a/core/templates/pages/exploration-editor-page/modal-templates/help-modal.template.html
+++ b/core/templates/pages/exploration-editor-page/modal-templates/help-modal.template.html
@@ -32,9 +32,9 @@
 
   .oppia-help-modal .oppia-help-modal-button {
     background-color: #015c53;
-    border-radius: 0;
+    border-radius: 4px;
     color: #fff;
-    font-family: "Capriola", "Roboto", Arial, sans-serif;
+    font-family: "Roboto", Arial, sans-serif;
     font-size: 14px;
     margin-right: 10px;
     margin-top: 10px;

--- a/core/templates/pages/exploration-editor-page/modal-templates/post-publish-modal.template.html
+++ b/core/templates/pages/exploration-editor-page/modal-templates/post-publish-modal.template.html
@@ -6,9 +6,9 @@
 
   .oppia-share-publish-modal .oppia-share-publish-close {
     background-color: #015c53;
-    border-radius: 0;
+    border-radius: 4px;
     color: #fff;
-    font-family: "Capriola", "Roboto", Arial, sans-serif;
+    font-family: "Roboto", Arial, sans-serif;
     font-size: 14px;
     margin-top: 10px;
     text-transform: uppercase;

--- a/core/templates/pages/exploration-editor-page/modal-templates/welcome-modal.template.html
+++ b/core/templates/pages/exploration-editor-page/modal-templates/welcome-modal.template.html
@@ -49,9 +49,9 @@
 
   .oppia-welcome-modal .oppia-welcome-modal-button {
     background-color: #015c53;
-    border-radius: 0;
+    border-radius: 4px;
     color: #fff;
-    font-family: "Capriola", "Roboto", Arial, sans-serif;
+    font-family: "Roboto", Arial, sans-serif;
     font-size: 14px;
     margin-top: 10px;
     text-transform: uppercase;

--- a/core/templates/pages/exploration-editor-page/translation-tab/modal-templates/welcome-translation-modal.template.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/modal-templates/welcome-translation-modal.template.html
@@ -49,9 +49,9 @@
 
   .oppia-welcome-modal .oppia-welcome-modal-button {
     background-color: #015c53;
-    border-radius: 0;
+    border-radius: 4px;
     color: #fff;
-    font-family: "Capriola", "Roboto", Arial, sans-serif;
+    font-family: "Roboto", Arial, sans-serif;
     font-size: 14px;
     margin-top: 10px;
     text-transform: uppercase;

--- a/core/templates/pages/landing-pages/stewards-landing-page/stewards-landing-page.component.html
+++ b/core/templates/pages/landing-pages/stewards-landing-page/stewards-landing-page.component.html
@@ -447,8 +447,8 @@
   }
 
   stewards-landing-page .oppia-stewards-button {
-    border-radius: 0;
-    font-family: "Capriola", "Roboto", Arial, sans-serif;
+    border-radius: 4px;
+    font-family: "Roboto", Arial, sans-serif;
     font-size: 20px;
     height: 56px;
     margin-bottom: 20px;

--- a/core/templates/pages/landing-pages/topic-landing-page/topic-landing-page.component.html
+++ b/core/templates/pages/landing-pages/topic-landing-page/topic-landing-page.component.html
@@ -77,7 +77,8 @@
 
 <style>
   .oppia-landing-page h2, button {
-    font-family: "Capriola", "Roboto", Arial, sans-serif;
+    border-radius: 4px;
+    font-family: "Roboto", Arial, sans-serif;
   }
   .oppia-landing-page h2, h3, p {
     line-height: 1.5;

--- a/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
+++ b/core/templates/pages/learner-dashboard-page/learner-dashboard-page.component.html
@@ -890,8 +890,9 @@
 
   .oppia-learner-dashboard-intro-button {
     background-color: #015c53;
+    border-radius: 4px;
     color: #fff;
-    font-family: "Capriola", "Roboto", Arial, sans-serif;
+    font-family: "Roboto", Arial, sans-serif;
     font-size: 16px;
     margin-top: 25px;
     padding: 8px;


### PR DESCRIPTION
## Overview

1. This PR fixes #11181 
2. This PR does the following: Modified the button css throughout the codebase to sue Roboto font and border-radius of 4px.
Eg:
![image](https://user-images.githubusercontent.com/22347970/101524072-77637980-39af-11eb-8b2f-6a7c9f0d478d.png)


## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
