### PR TITLE
Fix part of #10474: fixes Typescript errors from strict checks for ExplorationFeaturesService

### DIFF
--- a/core/templates/domain/utilities/url-interpolation.service.ts
+++ b/core/templates/domain/utilities/url-interpolation.service.ts
@@ -112,7 +112,7 @@ export class UrlInterpolationService {
    */
   interpolateUrl(
       urlTemplate: string,
-      interpolationValues: InterpolationValuesType): string {
+      interpolationValues: InterpolationValuesType): string | null {
     if (!urlTemplate) {
       this.alertsService.fatalWarning(
         'Invalid or empty URL template passed in: \'' + urlTemplate + '\'');
@@ -152,7 +152,7 @@ export class UrlInterpolationService {
           ([key, val]) => key + ': ' + angular.toJson(val)).join(', ') + '}');
     }
 
-    let escapedInterpolationValues = {};
+    let escapedInterpolationValues: {[key: string]: string} = {};
     for (let varName in interpolationValues) {
       let value = interpolationValues[varName];
       escapedInterpolationValues[varName] = encodeURIComponent(value);

--- a/core/templates/services/contextual/url.service.ts
+++ b/core/templates/services/contextual/url.service.ts
@@ -61,7 +61,7 @@ export class UrlService {
   So exact type of this function can not be determined
   https://github.com/oppia/oppia/pull/7834#issuecomment-547896982 */
   getUrlParams(): UrlParamsType {
-    let params = {};
+    let params: {[key: string]: string} = {};
     this.getCurrentQueryString().replace(
       /[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
         return params[decodeURIComponent(key)] = decodeURIComponent(value);
@@ -115,7 +115,7 @@ export class UrlService {
     throw new Error('Invalid URL for topic');
   }
 
-  getStoryUrlFragmentFromLearnerUrl(): string {
+  getStoryUrlFragmentFromLearnerUrl(): string | null {
     let pathname = this.getPathname();
     // The following segment is for getting the fragment from the new learner
     // pages.

--- a/core/templates/services/exploration-features-backend-api.service.ts
+++ b/core/templates/services/exploration-features-backend-api.service.ts
@@ -46,7 +46,7 @@ export class ExplorationFeaturesBackendApiService {
   fetchExplorationFeatures(
       explorationId: string): Promise<ExplorationFeatures> {
     return this.http.get<ExplorationFeaturesBackendDict>(
-      this.urlInterpolationService.interpolateUrl(
+      <string> this.urlInterpolationService.interpolateUrl(
         ServicesConstants.EXPLORATION_FEATURES_URL,
         {exploration_id: explorationId}
       )

--- a/core/templates/services/utils.service.ts
+++ b/core/templates/services/utils.service.ts
@@ -70,14 +70,15 @@ export class UtilsService {
    * @param {Object} b - the second object to be compared.
    * @return {boolean} - true if a is equivalent to b, false otherwise.
    */
-  isEquivalent(a: Object, b: Object): boolean {
+  isEquivalent(a: Object, b: Object):
+  boolean {
     if (a === null || b === null) {
       return a === b;
     }
     if (typeof a !== typeof b) {
       return false;
     }
-    if (typeof a !== 'object') {
+    if (typeof a !== 'object' || typeof b !== 'object') {
       return a === b;
     }
     // Create arrays of property names.
@@ -88,7 +89,9 @@ export class UtilsService {
     }
     for (var i = 0; i < aProps.length; i++) {
       var propName = aProps[i];
-      if (!this.isEquivalent(a[propName], b[propName])) {
+      const aObj = a as {[index: string]: Object};
+      const bObj = b as {[index: string]: Object};
+      if (!this.isEquivalent(aObj[propName], bObj[propName])) {
         return false;
       }
     }

--- a/tsconfig-strict.json
+++ b/tsconfig-strict.json
@@ -59,6 +59,7 @@
     "core/templates/pages/exploration-editor-page/services/angular-name.service.spec.ts",
     "core/templates/services/app.service.ts",
     "core/templates/services/app.service.spec.ts",
+    "core/templates/services/exploration-features.service.ts",
     "core/templates/services/external-save.service.ts",
     "core/templates/services/external-save.service.spec.ts",
     "core/templates/services/audio-bar-status.service.ts",


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #10474.
2. This PR does the following: fixes Typescript errors caused by --strict_checks flag.


## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
