### PR TITLE
Fix part of #11329: top-navigation-bar.directive.ts (removing:addclass and removeclass)

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
@@ -2,8 +2,8 @@
   <a ng-if="$ctrl.windowIsNarrow" ng-click="$ctrl.toggleSidebar()"
      class="navbar-brand oppia-navbar-menu oppia-transition-200 protractor-mobile-test-navbar-button"
      tabindex="0">
-    <i class="material-icons oppia-navbar-menu-icon" ng-if="!$ctrl.isSidebarShown()" >&#xE5D2;</i>
-    <i class="material-icons oppia-navbar-close-icon" ng-if="$ctrl.isSidebarShown()" >&#10005;</i>
+    <i class="material-icons oppia-navbar-menu-icon" ng-if="!$ctrl.isSidebarShown()" ng-class="{'oppia-stop-scroll':!$ctrl.isSidebarShown() }" >&#xE5D2;</i>
+    <i class="material-icons oppia-navbar-close-icon" ng-if="$ctrl.isSidebarShown()" ng-class="{'oppia-stop-scroll':$ctrl.isSidebarShown() }" >&#10005;</i>
   </a>
 
   <a class="oppia-navbar-brand-name oppia-transition-200 protractor-test-oppia-main-logo d-none d-sm-block" href="/"

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.ts
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.ts
@@ -138,11 +138,6 @@ angular.module('oppia').directive('topNavigationBar', [
           };
 
           ctrl.isSidebarShown = function() {
-            if (SidebarStatusService.isSidebarShown()) {
-              angular.element(document.body).addClass('oppia-stop-scroll');
-            } else {
-              angular.element(document.body).removeClass('oppia-stop-scroll');
-            }
             return SidebarStatusService.isSidebarShown();
           };
           ctrl.toggleSidebar = function() {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #11329.
2. This PR does the following: top-navigation-bar.directive.ts(removes addclass and removeclass) 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
