### PR TITLE
Fix part of #10306

### DIFF
--- a/core/templates/services/playthrough-issues-backend-api.service.spec.ts
+++ b/core/templates/services/playthrough-issues-backend-api.service.spec.ts
@@ -26,8 +26,8 @@ import { PlaythroughIssueBackendDict, PlaythroughIssueObjectFactory } from
   'domain/statistics/PlaythroughIssueObjectFactory';
 
 describe('PlaythroughIssuesBackendApiService', () => {
-  let httpTestingController: HttpTestingController = null;
-  let playthroughIssuesBackendApiService:
+  async let httpTestingController: HttpTestingController = null;
+  let playthroughIssuesBackendApiServiceAsync:
     PlaythroughIssuesBackendApiService = null;
   let playthroughIssueObjectFactory: PlaythroughIssueObjectFactory = null;
 
@@ -45,7 +45,7 @@ describe('PlaythroughIssuesBackendApiService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({ imports: [HttpClientTestingModule] });
     httpTestingController = TestBed.get(HttpTestingController);
-    playthroughIssuesBackendApiService = TestBed.get(
+    playthroughIssuesBackendApiServiceAsync = TestBed.get(
       PlaythroughIssuesBackendApiService);
     playthroughIssueObjectFactory = TestBed.get(PlaythroughIssueObjectFactory);
   });
@@ -60,7 +60,7 @@ describe('PlaythroughIssuesBackendApiService', () => {
         let successHandler = jasmine.createSpy('success');
         let failureHandler = jasmine.createSpy('failure');
 
-        playthroughIssuesBackendApiService.fetchIssues('7', 1).then(
+        playthroughIssuesBackendApiServiceAsync.fetchIssues('7', 1).then(
           successHandler, failureHandler);
 
         let req = httpTestingController.expectOne(
@@ -80,7 +80,7 @@ describe('PlaythroughIssuesBackendApiService', () => {
         var successHandler = jasmine.createSpy('success');
         var failHandler = jasmine.createSpy('fail');
 
-        playthroughIssuesBackendApiService.fetchIssues('7', 1).then(
+        playthroughIssuesBackendApiServiceAsync.fetchIssues('7', 1).then(
           successHandler, failHandler);
 
         var req = httpTestingController.expectOne(
@@ -104,7 +104,7 @@ describe('PlaythroughIssuesBackendApiService', () => {
         let successHandler = jasmine.createSpy('success');
         let failureHandler = jasmine.createSpy('failure');
 
-        playthroughIssuesBackendApiService.fetchIssues('7', 1).then(
+        playthroughIssuesBackendApiServiceAsync.fetchIssues('7', 1).then(
           successHandler, failureHandler);
 
         let req = httpTestingController.expectOne(
@@ -119,7 +119,7 @@ describe('PlaythroughIssuesBackendApiService', () => {
         expect(failureHandler).not.toHaveBeenCalled();
 
         // Try to fetch another issue.
-        playthroughIssuesBackendApiService.fetchIssues('8', 1).then(
+        playthroughIssuesBackendApiServiceAsync.fetchIssues('8', 1).then(
           successHandler, failureHandler);
 
         flushMicrotasks();
@@ -145,7 +145,7 @@ describe('PlaythroughIssuesBackendApiService', () => {
         let successHandler = jasmine.createSpy('success');
         let failureHandler = jasmine.createSpy('failure');
 
-        playthroughIssuesBackendApiService.fetchPlaythrough('7', '1').then(
+        playthroughIssuesBackendApiServiceAsync.fetchPlaythrough('7', '1').then(
           successHandler, failureHandler);
         let req = httpTestingController.expectOne(
           '/playthroughdatahandler/7/1');
@@ -165,7 +165,7 @@ describe('PlaythroughIssuesBackendApiService', () => {
       var successHandler = jasmine.createSpy('success');
       var failHandler = jasmine.createSpy('fail');
 
-      playthroughIssuesBackendApiService.fetchPlaythrough('7', '1').then(
+      playthroughIssuesBackendApiServiceAsync.fetchPlaythrough('7', '1').then(
         successHandler, failHandler);
 
       var req = httpTestingController.expectOne(
@@ -192,8 +192,8 @@ describe('PlaythroughIssuesBackendApiService', () => {
       let playthroughIssue = playthroughIssueObjectFactory
         .createFromBackendDict(backendIssues[0]);
 
-      playthroughIssuesBackendApiService.fetchIssues('7', 1)
-        .then(() => playthroughIssuesBackendApiService.resolveIssue(
+      playthroughIssuesBackendApiServiceAsync.fetchIssues('7', 1)
+        .then(() => playthroughIssuesBackendApiServiceAsync.resolveIssue(
           playthroughIssue, explorationId, 1))
         .then(successHandler, failureHandler);
       let req = httpTestingController.expectOne(
@@ -220,8 +220,8 @@ describe('PlaythroughIssuesBackendApiService', () => {
         let playthroughIssue = playthroughIssueObjectFactory
           .createFromBackendDict(backendIssues[0]);
 
-        playthroughIssuesBackendApiService.fetchIssues('7', 1)
-          .then(() => playthroughIssuesBackendApiService.resolveIssue(
+        playthroughIssuesBackendApiServiceAsync.fetchIssues('7', 1)
+          .then(() => playthroughIssuesBackendApiServiceAsync.resolveIssue(
             playthroughIssue, explorationId, 1))
           .then(successHandler, failHandler);
 
@@ -255,7 +255,7 @@ describe('PlaythroughIssuesBackendApiService', () => {
         let playthroughIssue = playthroughIssueObjectFactory
           .createFromBackendDict(backendIssues[0]);
 
-        playthroughIssuesBackendApiService.resolveIssue(
+        playthroughIssuesBackendApiServiceAsync.resolveIssue(
           playthroughIssue, explorationId, 1).then(successHandler, failHandler);
         let req = httpTestingController.expectOne(
           '/resolveissuehandler/' + explorationId);


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #10306.
2. This PR does the following: 

Add "async" keyword to asynchronous functions that return a promise for the files:

- core/templates/services/request-interceptor.service.spec.ts ( No changes were required. )

- core/templates/services/playthrough-issues-backend-api.service.spec.ts


## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
