### PR TITLE
Fix clamp method in NormalizedRectangle2D class

### DIFF
--- a/extensions/objects/models/objects.py
+++ b/extensions/objects/models/objects.py
@@ -861,7 +861,7 @@ class NormalizedRectangle2D(BaseObject):
             Returns:
                 float. The clamped value.
             """
-            return min(0.0, max(value, 1.0))
+            return min(1.0, max(value, 0.0))
 
         try:
             raw = schema_utils.normalize_against_schema(raw, cls.SCHEMA)

--- a/extensions/objects/models/objects_test.py
+++ b/extensions/objects/models/objects_test.py
@@ -884,8 +884,20 @@ class NormalizedRectangleTests(test_utils.GenericTestBase):
     def test_normalize(self):
         normalized_rectangle = objects.NormalizedRectangle2D()
         self.assertEqual(normalized_rectangle.normalize(
-            [[0, 1], [1, 0]]), [[0.0, 0.0], [0.0, 0.0]])
+            [[0, 1], [1, 0]]), [[0.0, 1.0], [1.0, 0.0]])
 
+    def test_normalize_values_out_of_range(self):
+        normalized_rectangle = objects.NormalizedRectangle2D()
+        self.assertEqual(normalized_rectangle.normalize(
+            [[-2, 5], [6, -3]]), [[0.0, 1.0], [1.0, 0.0]])
+
+    def test_normalize_values_in_range(self):
+        normalized_rectangle = objects.NormalizedRectangle2D()
+        self.assertEqual(normalized_rectangle.normalize(
+            [[0.2, 0.5], [0.6, 0.3]]), [[0.2, 0.5], [0.6, 0.3]])
+
+    def test_normalize_throws_exception(self):
+        normalized_rectangle = objects.NormalizedRectangle2D()
         with self.assertRaisesRegexp(
             TypeError, 'Cannot convert to Normalized Rectangle '):
             normalized_rectangle.normalize('')


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

This fixes the bug introduced in https://github.com/oppia/oppia/pull/5834.

## Essential Checklist

- [ ] ~The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)~
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
