### PR TITLE
Fix part of #11202: Add retry to queue.yaml and remove retry from Cloud Tasks

### DIFF
--- a/core/platform/taskqueue/cloud_taskqueue_services.py
+++ b/core/platform/taskqueue/cloud_taskqueue_services.py
@@ -92,7 +92,7 @@ def create_http_task(
 
     # Use the CLIENT to build and send the task.
     # Note: retry=retry.Retry() means that the default retry arguments are used.
-    response = CLIENT.create_task(parent, task, retry=retry.Retry())
+    response = CLIENT.create_task(parent, task)
 
     logging.info('Created task %s' % response.name)
     return response

--- a/queue.yaml
+++ b/queue.yaml
@@ -8,9 +8,24 @@ queue:
   rate: 2/m
 - name: emails
   rate: 5/s
+  retry_parameters:
+    task_retry_limit: 8
+    min_backoff_seconds: 0.1
+    max_backoff_seconds: 12.8
+    max_doublings: 8
 - name: events
   rate: 5/s
+  retry_parameters:
+    task_retry_limit: 8
+    min_backoff_seconds: 0.1
+    max_backoff_seconds: 12.8
+    max_doublings: 8
 - name: one-off-jobs
   rate: 10/s
 - name: stats
   rate: 10/m
+  retry_parameters:
+    task_retry_limit: 8
+    min_backoff_seconds: 0.1
+    max_backoff_seconds: 12.8
+    max_doublings: 8


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #11202.
2. This PR does the following: Add retry to queue.yaml and remove retry from Cloud Tasks to try if this helps with the ServiceUnavailable problem

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
