### PR TITLE
Fixes issue which caused Skill Editor to not load completely unless a digest loop was triggered

### DIFF
--- a/core/templates/pages/skill-editor-page/navbar/skill-editor-navbar.directive.ts
+++ b/core/templates/pages/skill-editor-page/navbar/skill-editor-navbar.directive.ts
@@ -31,6 +31,8 @@ require('services/alerts.service.ts');
 
 require('pages/skill-editor-page/skill-editor-page.constants.ajs.ts');
 
+import { Subscription } from 'rxjs';
+
 angular.module('oppia').directive('skillEditorNavbar', [
   'UrlInterpolationService', function(UrlInterpolationService) {
     return {
@@ -46,6 +48,7 @@ angular.module('oppia').directive('skillEditorNavbar', [
             SkillEditorRoutingService, SkillEditorStateService,
             UndoRedoService) {
           var ctrl = this;
+          ctrl.directiveSubscriptions = new Subscription();
           var ACTIVE_TAB_EDITOR = 'Editor';
           var ACTIVE_TAB_QUESTIONS = 'Questions';
           var ACTIVE_TAB_PREVIEW = 'Preview';
@@ -140,6 +143,9 @@ angular.module('oppia').directive('skillEditorNavbar', [
           ctrl.$onInit = function() {
             $scope.activeTab = ACTIVE_TAB_EDITOR;
             ctrl.skill = SkillEditorStateService.getSkill();
+            ctrl.directiveSubscriptions.add(
+              SkillEditorStateService.onSkillChange.subscribe(
+                () => $rootScope.$applyAsync()));
           };
         }]
     };

--- a/core/templates/pages/skill-editor-page/services/skill-editor-state.service.ts
+++ b/core/templates/pages/skill-editor-page/services/skill-editor-state.service.ts
@@ -66,8 +66,8 @@ export class SkillEditorStateService {
 
   private _setSkill = (skill: Skill) => {
     this._skill.copyFromSkill(skill);
-    this._skillChangedEventEmitter.emit();
     this._skillIsInitialized = true;
+    this._skillChangedEventEmitter.emit();
   };
 
   private _updateSkill = (skill: Skill) => {

--- a/core/templates/pages/skill-editor-page/skill-editor-page.component.spec.ts
+++ b/core/templates/pages/skill-editor-page/skill-editor-page.component.spec.ts
@@ -16,6 +16,8 @@
  * @fileoverview Unit tests for skill editor page component.
  */
 
+import { EventEmitter } from '@angular/core';
+
 // TODO(#7222): Remove the following block of unnnecessary imports once
 // Skill editor page is upgraded to Angular 8.
 import { importAllAngularServices } from 'tests/unit-test-utils';
@@ -31,6 +33,8 @@ describe('Skill editor page', function() {
   var UndoRedoService = null;
   var $uibModal = null;
   var UrlService = null;
+  var $rootScope = null;
+  var mockOnSkillChangeEmitter = new EventEmitter();
 
   importAllAngularServices();
 
@@ -41,6 +45,7 @@ describe('Skill editor page', function() {
     SkillObjectFactory = $injector.get('SkillObjectFactory');
     UndoRedoService = $injector.get('UndoRedoService');
     UrlService = $injector.get('UrlService');
+    $rootScope = $injector.get('$rootScope');
     ctrl = $componentController('skillEditorPage');
   }));
 
@@ -52,6 +57,18 @@ describe('Skill editor page', function() {
       ctrl.$onInit();
       expect(SkillEditorStateService.loadSkill).toHaveBeenCalledWith('skill_1');
     });
+
+  it('should trigger a digest loop when onSkillChange is emitted', () => {
+    spyOnProperty(SkillEditorStateService, 'onSkillChange').and.returnValue(
+      mockOnSkillChangeEmitter);
+    spyOn(SkillEditorStateService, 'loadSkill').and.stub();
+    spyOn(UrlService, 'getSkillIdFromUrl').and.returnValue('skill_1');
+    spyOn($rootScope, '$applyAsync').and.callThrough();
+
+    ctrl.$onInit();
+    mockOnSkillChangeEmitter.emit();
+    expect($rootScope.$applyAsync).toHaveBeenCalled();
+  });
 
   it('should call confirm before leaving', function() {
     spyOn(UndoRedoService, 'getChangeCount').and.returnValue(10);

--- a/core/templates/pages/skill-editor-page/skill-editor-page.component.ts
+++ b/core/templates/pages/skill-editor-page/skill-editor-page.component.ts
@@ -39,17 +39,20 @@ require('services/bottom-navbar-status.service.ts');
 require('services/page-title.service.ts');
 require('services/contextual/window-ref.service');
 
+import { Subscription } from 'rxjs';
+
 angular.module('oppia').component('skillEditorPage', {
   template: require('./skill-editor-page.component.html'),
   controller: [
-    '$uibModal', 'BottomNavbarStatusService',
+    '$rootScope', '$uibModal', 'BottomNavbarStatusService',
     'SkillEditorRoutingService', 'SkillEditorStateService',
     'UndoRedoService', 'UrlInterpolationService', 'UrlService', 'WindowRef',
     function(
-        $uibModal, BottomNavbarStatusService,
+        $rootScope, $uibModal, BottomNavbarStatusService,
         SkillEditorRoutingService, SkillEditorStateService,
         UndoRedoService, UrlInterpolationService, UrlService, WindowRef) {
       var ctrl = this;
+      ctrl.directiveSubscriptions = new Subscription();
       ctrl.getActiveTabName = function() {
         return SkillEditorRoutingService.getActiveTabName();
       };
@@ -104,6 +107,9 @@ angular.module('oppia').component('skillEditorPage', {
         ctrl.setUpBeforeUnload();
         SkillEditorStateService.loadSkill(UrlService.getSkillIdFromUrl());
         ctrl.skill = SkillEditorStateService.getSkill();
+        ctrl.directiveSubscriptions.add(
+          SkillEditorStateService.onSkillChange.subscribe(
+            () => $rootScope.$applyAsync()));
       };
     }
   ]

--- a/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.component.ts
+++ b/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.component.ts
@@ -37,14 +37,16 @@ require(
   'domain/topics_and_skills_dashboard/' +
     'topics-and-skills-dashboard-backend-api.service.ts');
 
+import { Subscription } from 'rxjs';
+
 angular.module('oppia').component('skillPreviewTab', {
   template: require('./skill-preview-tab.component.html'),
   controllerAs: '$ctrl',
   controller: [
-    '$scope', 'ContextService', 'QuestionBackendApiService',
+    '$rootScope', '$scope', 'ContextService', 'QuestionBackendApiService',
     'QuestionPlayerEngineService', 'SkillEditorStateService', 'UrlService',
     function(
-        $scope, ContextService, QuestionBackendApiService,
+        $rootScope, $scope, ContextService, QuestionBackendApiService,
         QuestionPlayerEngineService, SkillEditorStateService, UrlService) {
       var ctrl = this;
       var QUESTION_COUNT = 20;
@@ -55,6 +57,7 @@ angular.module('oppia').component('skillPreviewTab', {
         NUMERIC_INPUT: 'Numeric Input',
         ITEM_SELECTION: 'Item Selection'
       };
+      ctrl.directiveSubscriptions = new Subscription();
       ctrl.$onInit = function() {
         ctrl.skillId = UrlService.getSkillIdFromUrl();
         SkillEditorStateService.loadSkill(ctrl.skillId);
@@ -79,6 +82,9 @@ angular.module('oppia').component('skillPreviewTab', {
             ctrl.selectQuestionToPreview(0);
           }
         });
+        ctrl.directiveSubscriptions.add(
+          SkillEditorStateService.onSkillChange.subscribe(
+            () => $rootScope.$applyAsync()));
       };
 
       ctrl.initializeQuestionCard = function(card) {

--- a/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.controller.spec.ts
+++ b/core/templates/pages/skill-editor-page/skill-preview-tab/skill-preview-tab.controller.spec.ts
@@ -16,6 +16,8 @@
  * @fileoverview Unit tests for skill preview tab controller.
  */
 
+import { EventEmitter } from '@angular/core';
+
 // TODO(#7222): Remove the following block of unnnecessary imports once
 // the code corresponding to the spec is upgraded to Angular 8.
 import { importAllAngularServices } from 'tests/unit-test-utils';
@@ -25,6 +27,10 @@ describe('Skill preview tab', function() {
   var $scope = null;
   var ctrl = null;
   var UrlService = null;
+  var SkillEditorStateService = null;
+  var $rootScope = null;
+  var mockOnSkillChangeEmitter = new EventEmitter();
+
   var questionDict1 = {
     question_state_data: {
       content: {
@@ -133,8 +139,9 @@ describe('Skill preview tab', function() {
   importAllAngularServices();
 
   beforeEach(angular.mock.inject(function($injector, $componentController) {
-    var $rootScope = $injector.get('$rootScope');
+    $rootScope = $injector.get('$rootScope');
     UrlService = $injector.get('UrlService');
+    SkillEditorStateService = $injector.get('SkillEditorStateService');
     var skillId = 'df432fe';
     $scope = $rootScope.$new();
     var MockQuestionBackendApiService = {
@@ -156,6 +163,17 @@ describe('Skill preview tab', function() {
     expect(ctrl.ALLOWED_QUESTION_INTERACTIONS).toEqual([
       'All', 'Text Input', 'Multiple Choice', 'Numeric Input',
       'Item Selection']);
+  });
+
+  it('should trigger a digest loop when onSkillChange is emitted', () => {
+    spyOnProperty(SkillEditorStateService, 'onSkillChange').and.returnValue(
+      mockOnSkillChangeEmitter);
+    spyOn(SkillEditorStateService, 'loadSkill').and.stub();
+    spyOn($rootScope, '$applyAsync').and.callThrough();
+
+    ctrl.$onInit();
+    mockOnSkillChangeEmitter.emit();
+    expect($rootScope.$applyAsync).toHaveBeenCalled();
   });
 
   it('should initialize the question card', function() {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. ~This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following: When SkillEditorStateService was migrated (https://github.com/oppia/oppia/pull/11355), few `$rootScope.$apply()` calls were removed but they were not added in the appropriate places in the parent component that used async methods in SkillEditorStateService. This PR adds directive subscriptions in the component files to listen for the onSkillChange event and then calls `$rootScope.$applyAsync()` to update the DOM.

This issue resulted in instability of e2e tests that relied on the Skill Editor (see debugging [doc](https://docs.google.com/document/d/1cI8fqAIFqsmZj5v35y49ohhNvgmE0_vH_sT02Aws77Y/edit#) which includes verification of the fix).
## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
NA

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes made in this PR work correctly.
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
