### PR TITLE
Fix #11566 (added flexbox for fixing overflow of component)

### DIFF
--- a/core/templates/pages/donate-page/donate-page.component.html
+++ b/core/templates/pages/donate-page/donate-page.component.html
@@ -145,8 +145,8 @@
 
   @media only screen and (max-width: 1160px) {
       .oppia-donation-card-content-wide {
-      width: 100%;
       display: flex;
+      width: 100%;
     }
 
     .oppia-donate-info {

--- a/core/templates/pages/donate-page/donate-page.component.html
+++ b/core/templates/pages/donate-page/donate-page.component.html
@@ -94,7 +94,7 @@
     float: right;
     font-family: "Capriola", "Roboto", Arial, sans-serif;
     padding: 10px 10px 35px 10px;
-    width: 340px;
+    width: 50%;
   }
   .donate-page .btn.oppia-donate-options-button {
     background-color: rgba(0,0,0,0.2);
@@ -114,10 +114,7 @@
   .donate-page .oppia-donate-info {
     float: left;
     padding-bottom: 30px;
-    width: -webkit-calc(100% - 340px);
-    width: -moz-calc(100% - 340px);
-    width: -o-calc(100% - 340px);
-    width: calc(100% - 340px);
+    width: 50%;
   }
   .donate-page .oppia-gift-funds-text {
     color: #fff;
@@ -145,18 +142,21 @@
   .donate-page .oppia-vision-text {
     font-size: 0.825em;
   }
-  @media only screen and (max-width: 1140px) {
-    .oppia-donation-card-content-wide {
-      margin-bottom: 90px;
+
+  @media only screen and (max-width: 1160px) {
+      .oppia-donation-card-content-wide {
+      width: 100%;
+      display: flex;
     }
+
     .oppia-donate-info {
-      display: block;
-      position: inherit;
-      width: 100%;
+      flex: 1;
+      justify-content: flex-end;
     }
+
     .oppia-donate-options {
-      float: clear;
-      width: 100%;
+      flex: 1;
+      justify-content: flex-start;
     }
   }
 </style>


### PR DESCRIPTION
## Overview

1. This PR fixes #11566.
2. This PR does the following: Added a flexbox rendering for the two components of the screen. Text from the donation options component should not overflow its container anymore.

## Essential Checklist

- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The linter/Karma presubmit checks have passed locally on your machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [X] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://imgur.com/RVCaov5

