### PR TITLE
Revert "Fix part of #8472: Migrate Editable Exploration Backend Api Service"

### DIFF
--- a/core/templates/domain/editor/undo_redo/change.model.ts
+++ b/core/templates/domain/editor/undo_redo/change.model.ts
@@ -39,58 +39,6 @@ import { Skill } from 'domain/skill/SkillObjectFactory';
 import { Story } from 'domain/story/StoryObjectFactory';
 import { Topic } from 'domain/topic/TopicObjectFactory';
 import { SubtopicPage } from 'domain/topic/SubtopicPageObjectFactory';
-import { ParamChangeBackendDict } from 'domain/exploration/ParamChangeObjectFactory';
-import { ParamSpecBackendDict } from 'domain/exploration/ParamSpecObjectFactory';
-import { InteractionBackendDict } from 'domain/exploration/InteractionObjectFactory';
-import { WrittenTranslationsBackendDict } from 'domain/exploration/WrittenTranslationsObjectFactory';
-
-export type ExplorationChange = (
-  ExplorationChangeAddState |
-  ExplorationChangeRenameState |
-  ExplorationChangeDeleteState |
-  ExplorationChangeEditStateProperty |
-  ExplorationChangeEditExplorationProperty);
-
-interface ExplorationChangeAddState {
-  cmd: 'add_state';
-  'state_name': string;
-}
-
-interface ExplorationChangeRenameState {
-  cmd: 'rename_state',
-  'new_state_name': string;
-  'old_state_name': string;
-}
-
-interface ExplorationChangeDeleteState {
-  cmd: 'delete_state';
-  'state_name': string;
-}
-
-interface ExplorationChangeEditStateProperty {
-  cmd: 'edit_state_property',
-  'new_value': SubtitledHtmlBackendDict |
-    InteractionBackendDict |
-    ParamChangeBackendDict[] |
-    RecordedVoiceOverBackendDict |
-    WrittenTranslationsBackendDict |
-    boolean | number | string;
-  'old_value': SubtitledHtmlBackendDict |
-    InteractionBackendDict |
-    ParamChangeBackendDict[] |
-    RecordedVoiceOverBackendDict |
-    WrittenTranslationsBackendDict |
-    boolean | number | string;
-  'state_name': string;
-  'property_name': string;
-}
-
-interface ExplorationChangeEditExplorationProperty {
-  cmd: 'edit_exploration_property';
-  'new_value': ParamChangeBackendDict[] | ParamSpecBackendDict | string;
-  'old_value': ParamChangeBackendDict[] | ParamSpecBackendDict | string;
-  'property_name': string;
-}
 
 interface CollectionTitleChange {
   'cmd': 'edit_collection_property';

--- a/core/templates/domain/exploration/editable-exploration-backend-api.service.ts
+++ b/core/templates/domain/exploration/editable-exploration-backend-api.service.ts
@@ -16,123 +16,152 @@
  * @fileoverview Service to send changes to a exploration to the backend.
  */
 
-import { HttpClient } from '@angular/common/http';
-import { ReadOnlyExplorationBackendApiService } from 'domain/exploration/read-only-exploration-backend-api.service';
-import { UrlInterpolationService } from 'domain/utilities/url-interpolation.service';
-import { AppConstants } from 'app.constants';
-import { ExplorationBackendDict } from './ExplorationObjectFactory';
-import { ExplorationChange } from 'domain/editor/undo_redo/change.model';
-import { tap } from 'rxjs/operators';
-import { downgradeInjectable } from '@angular/upgrade/static';
-import { Injectable } from '@angular/core';
+require('domain/exploration/read-only-exploration-backend-api.service.ts');
+require('domain/utilities/url-interpolation.service.ts');
 
-@Injectable({
-  providedIn: 'root'
-})
-export class EditableExplorationBackendApiService {
-  constructor(
-    private httpClient: HttpClient,
-    private readOnlyExplorationBackendApiService:
-      ReadOnlyExplorationBackendApiService,
-    private urlInterpolationService: UrlInterpolationService) {}
-  private _fetchExploration(
-      explorationId: string,
-      applyDraft: boolean): Promise<ExplorationBackendDict> {
-    return this.httpClient.get<ExplorationBackendDict>(
-      this._getExplorationUrl(explorationId, applyDraft)).toPromise();
-  }
+require(
+  'pages/exploration-player-page/exploration-player-page.constants.ajs.ts');
 
-  private _updateExploration(
-      explorationId: string,
-      explorationVersion: string,
-      commitMessage: string,
-      changeList: ExplorationChange[]): Promise<ExplorationBackendDict> {
-    const putData = {
-      version: explorationVersion,
-      commit_message: commitMessage,
-      change_list: changeList
+angular.module('oppia').factory('EditableExplorationBackendApiService', [
+  '$http', '$q', 'ReadOnlyExplorationBackendApiService',
+  'UrlInterpolationService', 'EDITABLE_EXPLORATION_DATA_DRAFT_URL_TEMPLATE',
+  'EDITABLE_EXPLORATION_DATA_URL_TEMPLATE',
+  function(
+      $http, $q, ReadOnlyExplorationBackendApiService,
+      UrlInterpolationService, EDITABLE_EXPLORATION_DATA_DRAFT_URL_TEMPLATE,
+      EDITABLE_EXPLORATION_DATA_URL_TEMPLATE) {
+    var _fetchExploration = function(
+        explorationId, applyDraft, successCallback, errorCallback) {
+      var editableExplorationDataUrl = _getExplorationUrl(
+        explorationId, applyDraft);
+      $http.get(editableExplorationDataUrl).then(function(response) {
+        var exploration = angular.copy(response.data);
+        if (successCallback) {
+          successCallback(exploration);
+        }
+      }, function(errorResponse) {
+        if (errorCallback) {
+          errorCallback(errorResponse.data);
+        }
+      });
     };
 
-    return this.httpClient.put<ExplorationBackendDict>(
-      this._getExplorationUrl(explorationId, false), putData).pipe(tap(
-      // Delete from the ReadOnlyExplorationBackendApiService's cache
-      // As the two versions of the data (learner and editor) now differ.
-      _ => this.readOnlyExplorationBackendApiService.deleteExplorationFromCache(
-        explorationId)
-    )).toPromise();
-  }
+    var _updateExploration = function(
+        explorationId, explorationVersion, commitMessage, changeList,
+        successCallback, errorCallback) {
+      var editableExplorationDataUrl = _getExplorationUrl(
+        explorationId, null);
 
-  private _deleteExploration(explorationId: string): Promise<void> {
-    return this.httpClient['delete']<void>(
-      this._getExplorationUrl(explorationId, false)).pipe(tap(
-      // Delete item from the ReadOnlyExplorationBackendApiService's cache.
-      _ => this.readOnlyExplorationBackendApiService.deleteExplorationFromCache(
-        explorationId)
-    )).toPromise();
-  }
+      var putData = {
+        version: explorationVersion,
+        commit_message: commitMessage,
+        change_list: changeList
+      };
+      $http.put(editableExplorationDataUrl, putData).then(
+        function(response) {
+          // The returned data is an updated exploration dict.
+          var exploration = angular.copy(response.data);
 
-  private _getExplorationUrl(
-      explorationId: string, applyDraft: boolean): string {
-    if (applyDraft) {
-      return this.urlInterpolationService.interpolateUrl(
-        AppConstants.EDITABLE_EXPLORATION_DATA_DRAFT_URL_TEMPLATE, {
-          exploration_id: explorationId,
-          apply_draft: JSON.stringify(applyDraft)
+          // Delete from the ReadOnlyExplorationBackendApiService's cache
+          // As the two versions of the data (learner and editor) now differ.
+          ReadOnlyExplorationBackendApiService.deleteExplorationFromCache(
+            explorationId, exploration);
+
+          if (successCallback) {
+            successCallback(exploration);
+          }
+        }, function(errorResponse) {
+          if (errorCallback) {
+            errorCallback(errorResponse.data);
+          }
         }
       );
-    }
-    return this.urlInterpolationService.interpolateUrl(
-      AppConstants.EDITABLE_EXPLORATION_DATA_URL_TEMPLATE, {
-        exploration_id: explorationId
+    };
+
+    var _deleteExploration = function(
+        explorationId, successCallback, errorCallback) {
+      var editableExplorationDataUrl = _getExplorationUrl(explorationId, null);
+
+      $http['delete'](editableExplorationDataUrl).then(function() {
+        // Delete item from the ReadOnlyExplorationBackendApiService's cache.
+        ReadOnlyExplorationBackendApiService.deleteExplorationFromCache(
+          explorationId);
+        if (successCallback) {
+          successCallback({});
+        }
+      }, function(errorResponse) {
+        if (errorCallback) {
+          errorCallback(errorResponse.data);
+        }
+      });
+    };
+
+    var _getExplorationUrl = function(explorationId, applyDraft) {
+      if (applyDraft) {
+        return UrlInterpolationService.interpolateUrl(
+          EDITABLE_EXPLORATION_DATA_DRAFT_URL_TEMPLATE, {
+            exploration_id: explorationId,
+            apply_draft: JSON.stringify(applyDraft)
+          }
+        );
       }
-    );
-  }
+      return UrlInterpolationService.interpolateUrl(
+        EDITABLE_EXPLORATION_DATA_URL_TEMPLATE, {
+          exploration_id: explorationId
+        }
+      );
+    };
 
-  fetchExploration(explorationId: string):Promise<ExplorationBackendDict> {
-    return this._fetchExploration(explorationId, false);
-  }
+    return {
+      fetchExploration: function(explorationId) {
+        return $q(function(resolve, reject) {
+          _fetchExploration(explorationId, null, resolve, reject);
+        });
+      },
 
-  fetchApplyDraftExploration(
-      explorationId: string): Promise<ExplorationBackendDict> {
-    return this._fetchExploration(explorationId, true);
-  }
+      fetchApplyDraftExploration: function(explorationId) {
+        return $q(function(resolve, reject) {
+          _fetchExploration(explorationId, true, resolve, reject);
+        });
+      },
 
-  /**
-   * Updates an exploration in the backend with the provided exploration
-   * ID. The changes only apply to the exploration of the given version
-   * and the request to update the exploration will fail if the provided
-   * exploration version is older than the current version stored in the
-   * backend. Both the changes and the message to associate with those
-   * changes are used to commit a change to the exploration.
-   * The new exploration is passed to the success callback,
-   * if one is provided to the returned promise object. Errors are passed
-   * to the error callback, if one is provided. Please note, once this is
-   * called the cached exploration in ReadOnlyExplorationBackendApiService
-   * will be deleted. This is due to the differences in the back-end
-   * editor object and the back-end player object. As it stands now,
-   * we are unable to cache any Exploration object obtained from the
-   * editor beackend.
-   */
-  updateExploration(
-      explorationId: string,
-      explorationVersion: string,
-      commitMessage: string,
-      changeList: ExplorationChange[]): Promise<ExplorationBackendDict> {
-    return this._updateExploration(
-      explorationId, explorationVersion, commitMessage, changeList);
-  }
+      /**
+       * Updates an exploration in the backend with the provided exploration
+       * ID. The changes only apply to the exploration of the given version
+       * and the request to update the exploration will fail if the provided
+       * exploration version is older than the current version stored in the
+       * backend. Both the changes and the message to associate with those
+       * changes are used to commit a change to the exploration.
+       * The new exploration is passed to the success callback,
+       * if one is provided to the returned promise object. Errors are passed
+       * to the error callback, if one is provided. Please note, once this is
+       * called the cached exploration in ReadOnlyExplorationBackendApiService
+       * will be deleted. This is due to the differences in the back-end
+       * editor object and the back-end player object. As it stands now,
+       * we are unable to cache any Exploration object obtained from the
+       * editor beackend.
+       */
+      updateExploration: function(
+          explorationId, explorationVersion, commitMessage, changeList) {
+        return $q(function(resolve, reject) {
+          _updateExploration(
+            explorationId, explorationVersion, commitMessage, changeList,
+            resolve, reject);
+        });
+      },
 
-  /**
-   * Deletes an exploration in the backend with the provided exploration
-   * ID. If successful, the exploration will also be deleted from the
-   * ReadOnlyExplorationBackendApiService cache as well.
-   * Errors are passed to the error callback, if one is provided.
-   */
-  deleteExploration(explorationId: string): Promise<void> {
-    return this._deleteExploration(explorationId);
+      /**
+       * Deletes an exploration in the backend with the provided exploration
+       * ID. If successful, the exploration will also be deleted from the
+       * ReadOnlyExplorationBackendApiService cache as well.
+       * Errors are passed to the error callback, if one is provided.
+       */
+      deleteExploration: function(explorationId) {
+        return $q(function(resolve, reject) {
+          _deleteExploration(
+            explorationId, resolve, reject);
+        });
+      }
+    };
   }
-}
-
-angular.module('oppia').factory(
-  'EditableExplorationBackendApiService', downgradeInjectable(
-    EditableExplorationBackendApiService));
+]);

--- a/core/templates/pages/exploration-editor-page/editor-navigation/editor-navigation.component.ts
+++ b/core/templates/pages/exploration-editor-page/editor-navigation/editor-navigation.component.ts
@@ -134,9 +134,7 @@ angular.module('oppia').component('editorNavigation', {
           .then(function() {
             $scope.publishIsInProcess = false;
             $scope.loadingDotsAreShown = false;
-            $scope.$applyAsync();
           });
-        $scope.$applyAsync();
       };
 
       $scope.saveChanges = function() {
@@ -148,9 +146,7 @@ angular.module('oppia').component('editorNavigation', {
           .then(function() {
             $scope.saveIsInProcess = false;
             $scope.loadingDotsAreShown = false;
-            $scope.$applyAsync();
           });
-        $scope.$applyAsync();
       };
 
       $scope.toggleMobileNavOptions = function() {

--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.ts
@@ -405,7 +405,6 @@ angular.module('oppia').component('explorationEditorPage', {
 
           ExplorationWarningsService.updateWarnings();
           StateEditorRefreshService.onRefreshStateEditor.emit();
-          $scope.$applyAsync();
         });
       };
 

--- a/core/templates/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.component.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.component.ts
@@ -108,9 +108,7 @@ angular.module('oppia').component('explorationSaveAndPublishButtons', {
           .then(function() {
             $scope.publishIsInProcess = false;
             $scope.loadingDotsAreShown = false;
-            $scope.$applyAsync();
           });
-        $scope.$applyAsync();
       };
 
       $scope.saveChanges = function() {
@@ -121,9 +119,7 @@ angular.module('oppia').component('explorationSaveAndPublishButtons', {
           .then(function() {
             $scope.saveIsInProcess = false;
             $scope.loadingDotsAreShown = false;
-            $scope.$applyAsync();
           });
-        $scope.$applyAsync();
       };
       ctrl.$onInit = function() {
         $scope.saveIsInProcess = false;

--- a/core/templates/pages/exploration-editor-page/history-tab/history-tab.component.ts
+++ b/core/templates/pages/exploration-editor-page/history-tab/history-tab.component.ts
@@ -40,12 +40,12 @@ import cloneDeep from 'lodash/cloneDeep';
 angular.module('oppia').component('historyTab', {
   template: require('./history-tab.component.html'),
   controller: [
-    '$http', '$log', '$rootScope', '$uibModal', 'CompareVersionsService',
+    '$http', '$log', '$uibModal', 'CompareVersionsService',
     'DateTimeFormatService', 'EditabilityService', 'ExplorationDataService',
     'LoaderService', 'RouterService', 'UrlInterpolationService',
     'VersionTreeService', 'WindowRef',
     function(
-        $http, $log, $rootScope, $uibModal, CompareVersionsService,
+        $http, $log, $uibModal, CompareVersionsService,
         DateTimeFormatService, EditabilityService, ExplorationDataService,
         LoaderService, RouterService, UrlInterpolationService,
         VersionTreeService, WindowRef) {
@@ -140,9 +140,7 @@ angular.module('oppia').component('historyTab', {
               ctrl.totalExplorationVersionMetadata.reverse();
               LoaderService.hideLoadingScreen();
               ctrl.changeItemsPerPage();
-              $rootScope.$applyAsync();
             });
-          $rootScope.$applyAsync();
         });
       };
 

--- a/core/templates/pages/exploration-editor-page/preview-tab/preview-tab.component.ts
+++ b/core/templates/pages/exploration-editor-page/preview-tab/preview-tab.component.ts
@@ -58,7 +58,7 @@ import { Subscription } from 'rxjs';
 angular.module('oppia').component('previewTab', {
   template: require('./preview-tab.component.html'),
   controller: [
-    '$q', '$rootScope', '$timeout', '$uibModal', 'ContextService',
+    '$q', '$timeout', '$uibModal', 'ContextService',
     'EditableExplorationBackendApiService',
     'ExplorationDataService', 'ExplorationEngineService',
     'ExplorationFeaturesService', 'ExplorationInitStateNameService',
@@ -68,7 +68,7 @@ angular.module('oppia').component('previewTab', {
     'PlayerCorrectnessFeedbackEnabledService', 'RouterService',
     'StateEditorService', 'UrlInterpolationService',
     function(
-        $q, $rootScope, $timeout, $uibModal, ContextService,
+        $q, $timeout, $uibModal, ContextService,
         EditableExplorationBackendApiService,
         ExplorationDataService, ExplorationEngineService,
         ExplorationFeaturesService, ExplorationInitStateNameService,
@@ -196,9 +196,7 @@ angular.module('oppia').component('previewTab', {
               ctrl.loadPreviewState(
                 initStateNameForPreview, manualParamChanges);
             });
-          $rootScope.$applyAsync();
         });
-        $rootScope.$applyAsync();
         ctrl.allParams = {};
       };
       ctrl.$onDestroy = function() {

--- a/core/templates/pages/exploration-editor-page/services/exploration-data.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-data.service.ts
@@ -27,12 +27,12 @@ require('services/contextual/url.service.ts');
 require('services/services.constants.ajs.ts');
 
 angular.module('oppia').factory('ExplorationDataService', [
-  '$http', '$q', '$rootScope', 'AlertsService',
+  '$http', '$q', 'AlertsService',
   'EditableExplorationBackendApiService', 'LocalStorageService',
   'LoggerService', 'ReadOnlyExplorationBackendApiService',
   'UrlService', 'WindowRef',
   function(
-      $http, $q, $rootScope, AlertsService,
+      $http, $q, AlertsService,
       EditableExplorationBackendApiService, LocalStorageService,
       LoggerService, ReadOnlyExplorationBackendApiService,
       UrlService, WindowRef) {
@@ -138,7 +138,6 @@ angular.module('oppia').factory('ExplorationDataService', [
                   }
                 }
               }
-              $rootScope.$applyAsync();
               return response;
             })['catch'](function(error) {
               errorCallback(error);
@@ -197,7 +196,7 @@ angular.module('oppia').factory('ExplorationDataService', [
         );
       }
     };
-    $rootScope.$applyAsync();
+
     return explorationData;
   }
 ]);

--- a/core/templates/pages/exploration-editor-page/settings-tab/settings-tab.component.ts
+++ b/core/templates/pages/exploration-editor-page/settings-tab/settings-tab.component.ts
@@ -92,7 +92,7 @@ angular.module('oppia').component('settingsTab', {
   },
   template: require('./settings-tab.component.html'),
   controller: [
-    '$http', '$rootScope', '$uibModal', 'AlertsService', 'ChangeListService',
+    '$http', '$uibModal', 'AlertsService', 'ChangeListService',
     'EditabilityService', 'EditableExplorationBackendApiService',
     'ExplorationAutomaticTextToSpeechService',
     'ExplorationCategoryService', 'ExplorationCorrectnessFeedbackService',
@@ -107,7 +107,7 @@ angular.module('oppia').component('settingsTab', {
     'WindowRef', 'ALL_CATEGORIES',
     'EXPLORATION_TITLE_INPUT_FOCUS_LABEL', 'TAG_REGEX',
     function(
-        $http, $rootScope, $uibModal, AlertsService, ChangeListService,
+        $http, $uibModal, AlertsService, ChangeListService,
         EditabilityService, EditableExplorationBackendApiService,
         ExplorationAutomaticTextToSpeechService,
         ExplorationCategoryService, ExplorationCorrectnessFeedbackService,
@@ -163,9 +163,7 @@ angular.module('oppia').component('settingsTab', {
             ctrl.stateNames = ExplorationStatesService.getStateNames();
           }
           ctrl.hasPageLoaded = true;
-          $rootScope.$applyAsync();
         });
-        $rootScope.$applyAsync();
       };
 
       ctrl.saveExplorationTitle = function() {

--- a/core/templates/services/angular-services.index.ts
+++ b/core/templates/services/angular-services.index.ts
@@ -79,7 +79,6 @@ import { SubtitledUnicodeObjectFactory } from 'domain/exploration/SubtitledUnico
 import { VoiceoverObjectFactory } from 'domain/exploration/VoiceoverObjectFactory';
 import { WrittenTranslationObjectFactory } from 'domain/exploration/WrittenTranslationObjectFactory';
 import { WrittenTranslationsObjectFactory } from 'domain/exploration/WrittenTranslationsObjectFactory';
-import { EditableExplorationBackendApiService } from 'domain/exploration/editable-exploration-backend-api.service';
 import { ReadOnlyExplorationBackendApiService } from 'domain/exploration/read-only-exploration-backend-api.service';
 import { ExplorationPermissionsBackendApiService } from 'domain/exploration/exploration-permissions-backend-api.service';
 import { StateInteractionStatsBackendApiService } from 'domain/exploration/state-interaction-stats-backend-api.service';
@@ -393,8 +392,6 @@ export const angularServices: [string, Type<{}>][] = [
     DragAndDropSortInputValidationService],
   ['EditabilityService', EditabilityService],
   ['EditableCollectionBackendApiService', EditableCollectionBackendApiService],
-  ['EditableExplorationBackendApiService',
-    EditableExplorationBackendApiService],
   ['EditableTopicBackendApiService', EditableTopicBackendApiService],
   ['EditableStoryBackendApiService', EditableStoryBackendApiService],
   ['EditorFirstTimeEventsService', EditorFirstTimeEventsService],


### PR DESCRIPTION
Reverts oppia/oppia#11558. This PR does not exhibit the flakes documented [here](https://docs.google.com/document/d/1v5iMLV3pg_6xmU5OKZ2Wd6NoOs7Jm3Ex6KkEj_OjQvo/edit#heading=h.lncrkm53y5jv) which recently appeared on develop and are related on saving explorations.

## Test Runs

Library and Collections Workflow:

1. [Publication test passed on 2nd attempt](https://app.circleci.com/pipelines/github/oppia/oppia/17612/workflows/5a9186e9-321b-426e-bfd9-8a58cfc438c1/jobs/99195)
   ![Screen Shot 2021-01-04 at 15 48 12](https://user-images.githubusercontent.com/19878639/103578285-4ab65b00-4ea4-11eb-9723-755d2d94f666.png)
2. [Publication test passed on 1st attempt](https://app.circleci.com/pipelines/github/oppia/oppia/17612/workflows/5a9186e9-321b-426e-bfd9-8a58cfc438c1/jobs/99202)
   ![Screen Shot 2021-01-04 at 16 49 25](https://user-images.githubusercontent.com/19878639/103583005-f1065e80-4eac-11eb-9be0-79c8c2e6a143.png)
3. [Publication test passed on 1st attempt](https://app.circleci.com/pipelines/github/oppia/oppia/17612/workflows/5a9186e9-321b-426e-bfd9-8a58cfc438c1/jobs/99218)
   ![Screen Shot 2021-01-04 at 18 11 26](https://user-images.githubusercontent.com/19878639/103588957-53b12780-4eb8-11eb-965c-21dc45574ab8.png)