### PR TITLE
Wait for language selector to be present before clicking on it

### DIFF
--- a/core/tests/protractor_desktop/userJourneys.js
+++ b/core/tests/protractor_desktop/userJourneys.js
@@ -16,6 +16,7 @@
  * @fileoverview End-to-end tests for user management.
  */
 
+var action = require('../protractor_utils/action.js');
 var AdminPage = require('../protractor_utils/AdminPage.js');
 var CollectionEditorPage =
   require('../protractor_utils/CollectionEditorPage.js');
@@ -32,8 +33,10 @@ var waitFor = require('../protractor_utils/waitFor.js');
 var workflow = require('../protractor_utils/workflow.js');
 
 var _selectLanguage = async function(language) {
-  await element(by.css('.protractor-test-i18n-language-selector'))
-    .element(by.cssContainingText('option', language)).click();
+  await action.select(
+    'Language Selector',
+    element(by.css('.protractor-test-i18n-language-selector')),
+    language);
   // Wait for the language-change request to reach the backend.
   await waitFor.pageToFullyLoad();
 };


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. ~This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following: wait for language selector to be present before clicking on it. Should fix failure in [build](https://app.circleci.com/pipelines/github/kevintab95/oppia/563/workflows/975b0527-26a0-421e-bb63-1a722ec88ce7/jobs/4318/steps).

Analysis:
Based on the screenshot from the CI failure, it seemed like the about page failed to load.
![image](https://user-images.githubusercontent.com/11008603/103717177-d5a16d80-4fea-11eb-90d5-d8d3ff938d51.png)

This matched what the screen looks like while the about page loads, see dev console screenshot:


My fix is to use `action.select` to ensure that the element is present on the page before interacting with it.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

NA
<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes made in this PR work correctly.
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
