### PR TITLE
Fix #11639 : Modified the look of the hamburger icon

### DIFF
--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
@@ -346,9 +346,9 @@
     width: 15px;
   }
   top-navigation-bar .oppia-navbar-menu {
+    background-color: #009D89;
     margin-left: 10px;
     opacity: 0.9;
-    background-color: #009D89;
     outline-color: transparent;
     padding: 18.5px 15px;
   }

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
@@ -348,8 +348,8 @@
   top-navigation-bar .oppia-navbar-menu {
     margin-left: 10px;
     opacity: 0.9;
-    outline-color: transparent;
     background-color: #009D89;
+    outline-color: transparent;
     padding: 18.5px 15px;
   }
   top-navigation-bar .oppia-navbar-menu:hover {

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
@@ -349,8 +349,8 @@
     margin-left: 10px;
     opacity: 0.9;
     outline-color: transparent;
-    padding: 18.5px 15px;
     background-color: #009D89;
+    padding: 18.5px 15px;
   }
   top-navigation-bar .oppia-navbar-menu:hover {
     opacity: 1;

--- a/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/top-navigation-bar.directive.html
@@ -349,7 +349,8 @@
     margin-left: 10px;
     opacity: 0.9;
     outline-color: transparent;
-    padding-top: 20px;
+    padding: 18.5px 15px;
+    background-color: #009D89;
   }
   top-navigation-bar .oppia-navbar-menu:hover {
     opacity: 1;
@@ -372,7 +373,7 @@
   }
   top-navigation-bar .oppia-navbar-close-icon {
     color: #fff;
-    margin-right: 4px;
+    margin-right: 2px;
     margin-top: -10px;
   }
   top-navigation-bar .oppia-signin-text {


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #11639.
2. This PR does the following: Added some extra padding to the hamburger icon while adding a background-color to it. The icon should not be clearly visible on smaller screens.

## Essential Checklist

- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The linter/Karma presubmit checks have passed locally on your machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [X] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://imgur.com/6KRGKuC