### PR TITLE
Replace logging mocks with TestBase.capture_logging

### DIFF
--- a/core/domain/wipeout_service_test.py
+++ b/core/domain/wipeout_service_test.py
@@ -928,14 +928,6 @@ class WipeoutServiceDeleteCollectionModelsTests(test_utils.GenericTestBase):
             collection_mappings[self.COL_1_ID])
 
     def test_one_collection_with_missing_snapshot_is_pseudonymized(self):
-        observed_log_messages = []
-
-        def _mock_logging_function(msg, *args):
-            """Mocks logging.warning()."""
-            observed_log_messages.append(msg % args)
-
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
-
         collection_models.CollectionCommitLogEntryModel(
             id='collection-%s-1' % self.COL_2_ID,
             collection_id=self.COL_2_ID,
@@ -946,14 +938,14 @@ class WipeoutServiceDeleteCollectionModelsTests(test_utils.GenericTestBase):
             version=1
         ).put()
 
-        with logging_swap:
+        with self.capture_logging(min_level=logging.ERROR) as log_messages:
             wipeout_service.pre_delete_user(self.user_1_id)
             self.process_and_flush_pending_tasks()
             wipeout_service.delete_user(
                 wipeout_service.get_pending_deletion_request(self.user_1_id))
 
         self.assertItemsEqual(
-            observed_log_messages,
+            log_messages,
             [
                 '[WIPEOUT] The commit log model '
                 '\'CollectionCommitLogEntryModel\' and '
@@ -1334,14 +1326,6 @@ class WipeoutServiceDeleteExplorationModelsTests(test_utils.GenericTestBase):
             commit_log_model_2.user_id, exploration_mappings[self.EXP_1_ID])
 
     def test_one_exploration_with_missing_snapshot_is_pseudonymized(self):
-        observed_log_messages = []
-
-        def _mock_logging_function(msg, *args):
-            """Mocks logging.warning()."""
-            observed_log_messages.append(msg % args)
-
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
-
         exp_models.ExplorationCommitLogEntryModel(
             id='exploration-%s-1' % self.EXP_2_ID,
             exploration_id=self.EXP_2_ID,
@@ -1352,14 +1336,14 @@ class WipeoutServiceDeleteExplorationModelsTests(test_utils.GenericTestBase):
             version=1
         ).put()
 
-        with logging_swap:
+        with self.capture_logging(min_level=logging.ERROR) as log_messages:
             wipeout_service.pre_delete_user(self.user_1_id)
             self.process_and_flush_pending_tasks()
             wipeout_service.delete_user(
                 wipeout_service.get_pending_deletion_request(self.user_1_id))
 
         self.assertItemsEqual(
-            observed_log_messages,
+            log_messages,
             [
                 '[WIPEOUT] The commit log model '
                 '\'ExplorationCommitLogEntryModel\' and '
@@ -2203,14 +2187,6 @@ class WipeoutServiceDeleteQuestionModelsTests(test_utils.GenericTestBase):
             commit_log_model.user_id, question_mappings[self.QUESTION_1_ID])
 
     def test_one_question_with_missing_snapshot_is_pseudonymized(self):
-        observed_log_messages = []
-
-        def _mock_logging_function(msg, *args):
-            """Mocks logging.warning()."""
-            observed_log_messages.append(msg % args)
-
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
-
         question_models.QuestionCommitLogEntryModel(
             id='question-%s-1' % self.QUESTION_2_ID,
             question_id=self.QUESTION_2_ID,
@@ -2221,12 +2197,12 @@ class WipeoutServiceDeleteQuestionModelsTests(test_utils.GenericTestBase):
             version=1
         ).put()
 
-        with logging_swap:
+        with self.capture_logging(min_level=logging.ERROR) as log_messages:
             wipeout_service.delete_user(
                 wipeout_service.get_pending_deletion_request(self.user_1_id))
 
         self.assertEqual(
-            observed_log_messages,
+            log_messages,
             ['[WIPEOUT] The commit log model \'QuestionCommitLogEntryModel\' '
              'and snapshot models [\'QuestionSnapshotMetadataModel\'] IDs '
              'differ. Snapshots without commit logs: [], '
@@ -2601,14 +2577,6 @@ class WipeoutServiceDeleteSkillModelsTests(test_utils.GenericTestBase):
             commit_log_model.user_id, skill_mappings[self.SKILL_1_ID])
 
     def test_one_skill_with_missing_snapshot_is_pseudonymized(self):
-        observed_log_messages = []
-
-        def _mock_logging_function(msg, *args):
-            """Mocks logging.warning()."""
-            observed_log_messages.append(msg % args)
-
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
-
         skill_models.SkillCommitLogEntryModel(
             id='skill-%s-1' % self.SKILL_2_ID,
             skill_id=self.SKILL_2_ID,
@@ -2619,12 +2587,12 @@ class WipeoutServiceDeleteSkillModelsTests(test_utils.GenericTestBase):
             version=1
         ).put()
 
-        with logging_swap:
+        with self.capture_logging(min_level=logging.ERROR) as log_messages:
             wipeout_service.delete_user(
                 wipeout_service.get_pending_deletion_request(self.user_1_id))
 
         self.assertEqual(
-            observed_log_messages,
+            log_messages,
             ['[WIPEOUT] The commit log model \'SkillCommitLogEntryModel\' and '
              'snapshot models [\'SkillSnapshotMetadataModel\'] IDs differ. '
              'Snapshots without commit logs: [], '
@@ -2913,14 +2881,6 @@ class WipeoutServiceDeleteStoryModelsTests(test_utils.GenericTestBase):
             commit_log_model.user_id, story_mappings[self.STORY_1_ID])
 
     def test_one_story_with_missing_snapshot_is_pseudonymized(self):
-        observed_log_messages = []
-
-        def _mock_logging_function(msg, *args):
-            """Mocks logging.warning()."""
-            observed_log_messages.append(msg % args)
-
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
-
         story_models.StoryCommitLogEntryModel(
             id='story-%s-1' % self.STORY_2_ID,
             story_id=self.STORY_2_ID,
@@ -2931,12 +2891,12 @@ class WipeoutServiceDeleteStoryModelsTests(test_utils.GenericTestBase):
             version=1
         ).put()
 
-        with logging_swap:
+        with self.capture_logging(min_level=logging.ERROR) as log_messages:
             wipeout_service.delete_user(
                 wipeout_service.get_pending_deletion_request(self.user_1_id))
 
         self.assertEqual(
-            observed_log_messages,
+            log_messages,
             ['[WIPEOUT] The commit log model \'StoryCommitLogEntryModel\' and '
              'snapshot models [\'StorySnapshotMetadataModel\'] IDs differ. '
              'Snapshots without commit logs: [], '
@@ -3240,14 +3200,6 @@ class WipeoutServiceDeleteSubtopicModelsTests(test_utils.GenericTestBase):
             subtopic_mappings['%s-%s' % (self.TOP_1_ID, self.SUBTOP_1_ID)])
 
     def test_one_subtopic_with_missing_snapshot_is_pseudonymized(self):
-        observed_log_messages = []
-
-        def _mock_logging_function(msg, *args):
-            """Mocks logging.warning()."""
-            observed_log_messages.append(msg % args)
-
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
-
         subtopic_models.SubtopicPageCommitLogEntryModel(
             id='%s-%s-1' % (self.TOP_1_ID, self.SUBTOP_2_ID),
             subtopic_page_id=self.SUBTOP_2_ID,
@@ -3258,12 +3210,12 @@ class WipeoutServiceDeleteSubtopicModelsTests(test_utils.GenericTestBase):
             version=1
         ).put()
 
-        with logging_swap:
+        with self.capture_logging(min_level=logging.ERROR) as log_messages:
             wipeout_service.delete_user(
                 wipeout_service.get_pending_deletion_request(self.user_1_id))
 
         self.assertEqual(
-            observed_log_messages,
+            log_messages,
             ['[WIPEOUT] The commit log model '
              '\'SubtopicPageCommitLogEntryModel\' and snapshot models '
              '[\'SubtopicPageSnapshotMetadataModel\'] IDs differ. '
@@ -3801,14 +3753,6 @@ class WipeoutServiceDeleteTopicModelsTests(test_utils.GenericTestBase):
             commit_log_model_1.user_id, topic_mappings[self.TOP_1_ID])
 
     def test_one_topic_with_missing_snapshot_is_pseudonymized(self):
-        observed_log_messages = []
-
-        def _mock_logging_function(msg, *args):
-            """Mocks logging.warning()."""
-            observed_log_messages.append(msg % args)
-
-        logging_swap = self.swap(logging, 'error', _mock_logging_function)
-
         topic_models.TopicCommitLogEntryModel(
             id='topic-%s-1' % self.TOP_2_ID,
             topic_id=self.TOP_2_ID,
@@ -3819,14 +3763,14 @@ class WipeoutServiceDeleteTopicModelsTests(test_utils.GenericTestBase):
             version=1
         ).put()
 
-        with logging_swap:
+        with self.capture_logging(min_level=logging.ERROR) as log_messages:
             wipeout_service.pre_delete_user(self.user_1_id)
             self.process_and_flush_pending_tasks()
             wipeout_service.delete_user(
                 wipeout_service.get_pending_deletion_request(self.user_1_id))
 
         self.assertItemsEqual(
-            observed_log_messages,
+            log_messages,
             [
                 '[WIPEOUT] The commit log model \'TopicCommitLogEntryModel\' '
                 'and snapshot models [\'TopicSnapshotMetadataModel\', '


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. ~~This PR fixes or fixes part of #N/A.~~
2. This PR does the following: Replaces logging mocks with `TestBase.capture_logging`.

    Current logging swaps do not respect the different ways logging functions can be used, and raise exceptions when encountered (e.g. `logging.error(exception_obj)`).

    `TestBase.capture_logging` provides the same behavior without mocking/swapping anything by registering a custom `StreamHandler` ([Logging Cookbook: Using a context manager for selective logging](https://docs.python.org/3/howto/logging-cookbook.html#using-a-context-manager-for-selective-logging)), which eliminates this class of errors entirely: https://github.com/oppia/oppia/blob/4318095e6d41830abc312e62cb4114d0fe4ce927/core/tests/test_utils.py#L978-L1018

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes made in this PR work correctly.
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
