### PR TITLE
Fix Part of #11431: Start using transaction decorator instead of `run_in_transaction`

### DIFF
--- a/core/domain/wipeout_service.py
+++ b/core/domain/wipeout_service.py
@@ -642,7 +642,8 @@ def _pseudonymize_config_models(pending_deletion_request):
         )
     )
 
-    def _pseudonymize_models(activity_related_models, pseudonymized_id):
+    @transaction_services.run_in_transaction_wrapper
+    def _pseudonymize_models_transactional(activity_related_models, pseudonymized_id):
         """Pseudonymize user ID fields in the models.
 
         This function is run in a transaction, with the maximum number of
@@ -674,8 +675,7 @@ def _pseudonymize_config_models(pending_deletion_request):
                 0,
                 len(config_related_models),
                 feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-            transaction_services.run_in_transaction(
-                _pseudonymize_models,
+                _pseudonymize_models_transactional(
                 config_related_models[
                     i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION],
                 pseudonymized_id
@@ -724,7 +724,8 @@ def _pseudonymize_activity_models_without_associated_rights_models(
         )
     )
 
-    def _pseudonymize_models(activity_related_models, pseudonymized_id):
+    @transaction_services.run_in_transaction_wrapper
+    def _pseudonymize_models_transactional(activity_related_models, pseudonymized_id):
         """Pseudonymize user ID fields in the models.
 
         This function is run in a transaction, with the maximum number of
@@ -766,8 +767,7 @@ def _pseudonymize_activity_models_without_associated_rights_models(
                 0,
                 len(activity_related_models),
                 feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-            transaction_services.run_in_transaction(
-                _pseudonymize_models,
+                _pseudonymize_models_transactional(
                 activity_related_models[
                     i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION],
                 pseudonymized_id)
@@ -823,7 +823,8 @@ def _pseudonymize_activity_models_with_associated_rights_models(
         )
     )
 
-    def _pseudonymize_models(activity_related_models, pseudonymized_id):
+    @transaction_services.run_in_transaction_wrapper
+    def _pseudonymize_models_transactional(activity_related_models, pseudonymized_id):
         """Pseudonymize user ID fields in the models.
 
         This function is run in a transaction, with the maximum number of
@@ -953,8 +954,7 @@ def _pseudonymize_activity_models_with_associated_rights_models(
                 0,
                 len(activity_related_models),
                 feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-            transaction_services.run_in_transaction(
-                _pseudonymize_models,
+                _pseudonymize_models_transactional(
                 activity_related_models[
                     i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION],
                 pseudonymized_id
@@ -975,7 +975,8 @@ def _remove_user_id_from_contributors_in_summary_models(
         summary_model_class.contributor_ids == user_id
     ).fetch()
 
-    def _remove_user_id_from_models(summary_models):
+    @transaction_services.run_in_transaction_wrapper
+    def _remove_user_id_from_models_transactional(summary_models):
         """Remove the user ID from contributor_ids and contributor_summary
         fields.
 
@@ -1001,8 +1002,7 @@ def _remove_user_id_from_contributors_in_summary_models(
             0,
             len(related_summary_models),
             feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-        transaction_services.run_in_transaction(
-            _remove_user_id_from_models,
+            _remove_user_id_from_models_transactional(
             related_summary_models[
                 i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION])
 
@@ -1048,7 +1048,8 @@ def _pseudonymize_feedback_models(pending_deletion_request):
     _save_pseudonymizable_entity_mappings(
         pending_deletion_request, models.NAMES.feedback, feedback_ids)
 
-    def _pseudonymize_models(feedback_related_models, pseudonymized_id):
+    @transaction_services.run_in_transaction_wrapper
+    def _pseudonymize_models_transactional(feedback_related_models, pseudonymized_id):
         """Pseudonymize user ID fields in the models.
 
         This function is run in a transaction, with the maximum number of
@@ -1111,8 +1112,7 @@ def _pseudonymize_feedback_models(pending_deletion_request):
                 0,
                 len(feedback_related_models),
                 feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-            transaction_services.run_in_transaction(
-                _pseudonymize_models,
+                _pseudonymize_models_transactional(
                 feedback_related_models[
                     i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION],
                 pseudonymized_id)
@@ -1139,7 +1139,8 @@ def _pseudonymize_suggestion_models(pending_deletion_request):
     _save_pseudonymizable_entity_mappings(
         pending_deletion_request, models.NAMES.suggestion, suggestion_ids)
 
-    def _pseudonymize_models(voiceover_application_models):
+    @transaction_services.run_in_transaction_wrapper
+    def _pseudonymize_models_transactional(voiceover_application_models):
         """Pseudonymize user ID fields in the models.
 
         This function is run in a transaction, with the maximum number of
@@ -1170,8 +1171,7 @@ def _pseudonymize_suggestion_models(pending_deletion_request):
             0,
             len(voiceover_application_models),
             feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-        transaction_services.run_in_transaction(
-            _pseudonymize_models,
+            _pseudonymize_models_transactional(
             voiceover_application_models[
                 i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION]
         )

--- a/core/domain/wipeout_service.py
+++ b/core/domain/wipeout_service.py
@@ -643,7 +643,8 @@ def _pseudonymize_config_models(pending_deletion_request):
     )
 
     @transaction_services.run_in_transaction_wrapper
-    def _pseudonymize_models_transactional(activity_related_models, pseudonymized_id):
+    def _pseudonymize_models_transactional(
+        activity_related_models, pseudonymized_id):
         """Pseudonymize user ID fields in the models.
 
         This function is run in a transaction, with the maximum number of
@@ -675,7 +676,7 @@ def _pseudonymize_config_models(pending_deletion_request):
                 0,
                 len(config_related_models),
                 feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-                _pseudonymize_models_transactional(
+            _pseudonymize_models_transactional(
                 config_related_models[
                     i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION],
                 pseudonymized_id
@@ -725,7 +726,8 @@ def _pseudonymize_activity_models_without_associated_rights_models(
     )
 
     @transaction_services.run_in_transaction_wrapper
-    def _pseudonymize_models_transactional(activity_related_models, pseudonymized_id):
+    def _pseudonymize_models_transactional(
+        activity_related_models, pseudonymized_id):
         """Pseudonymize user ID fields in the models.
 
         This function is run in a transaction, with the maximum number of
@@ -767,7 +769,7 @@ def _pseudonymize_activity_models_without_associated_rights_models(
                 0,
                 len(activity_related_models),
                 feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-                _pseudonymize_models_transactional(
+            _pseudonymize_models_transactional(
                 activity_related_models[
                     i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION],
                 pseudonymized_id)
@@ -824,7 +826,8 @@ def _pseudonymize_activity_models_with_associated_rights_models(
     )
 
     @transaction_services.run_in_transaction_wrapper
-    def _pseudonymize_models_transactional(activity_related_models, pseudonymized_id):
+    def _pseudonymize_models_transactional(
+        activity_related_models, pseudonymized_id):
         """Pseudonymize user ID fields in the models.
 
         This function is run in a transaction, with the maximum number of
@@ -954,7 +957,7 @@ def _pseudonymize_activity_models_with_associated_rights_models(
                 0,
                 len(activity_related_models),
                 feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-                _pseudonymize_models_transactional(
+            _pseudonymize_models_transactional(
                 activity_related_models[
                     i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION],
                 pseudonymized_id
@@ -1002,7 +1005,7 @@ def _remove_user_id_from_contributors_in_summary_models(
             0,
             len(related_summary_models),
             feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-            _remove_user_id_from_models_transactional(
+        _remove_user_id_from_models_transactional(
             related_summary_models[
                 i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION])
 
@@ -1049,7 +1052,8 @@ def _pseudonymize_feedback_models(pending_deletion_request):
         pending_deletion_request, models.NAMES.feedback, feedback_ids)
 
     @transaction_services.run_in_transaction_wrapper
-    def _pseudonymize_models_transactional(feedback_related_models, pseudonymized_id):
+    def _pseudonymize_models_transactional(
+        feedback_related_models, pseudonymized_id):
         """Pseudonymize user ID fields in the models.
 
         This function is run in a transaction, with the maximum number of
@@ -1112,7 +1116,7 @@ def _pseudonymize_feedback_models(pending_deletion_request):
                 0,
                 len(feedback_related_models),
                 feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-                _pseudonymize_models_transactional(
+            _pseudonymize_models_transactional(
                 feedback_related_models[
                     i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION],
                 pseudonymized_id)
@@ -1171,7 +1175,7 @@ def _pseudonymize_suggestion_models(pending_deletion_request):
             0,
             len(voiceover_application_models),
             feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION):
-            _pseudonymize_models_transactional(
+        _pseudonymize_models_transactional(
             voiceover_application_models[
                 i:i + feconf.MAX_NUMBER_OF_OPS_IN_TRANSACTION]
         )


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #11431.
2. Replaced all instances of ```run_in_transaction with``` with ```run_in_transaction_wrapper``` in the files assigned to me.

Files changed: 
- [x] wipeout_service.py
- [x] base_model/gae_models.py

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes made in this PR work correctly.
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
