### PR TITLE
Fix part of #10474: Enable strict check on ImprovementsService

### DIFF
--- a/tsconfig-strict.json
+++ b/tsconfig-strict.json
@@ -109,6 +109,8 @@
     "core/templates/services/i18n-language-code.service.spec.ts",
     "core/templates/services/id-generation.service.ts",
     "core/templates/services/id-generation.service.spec.ts",
+    "core/templates/services/improvements.service.ts",
+    "core/templates/services/improvements.service.spec.ts",
     "core/templates/services/loader.service.ts",
     "core/templates/services/loader.service.spec.ts",
     "core/templates/services/math-interactions.service.ts",


### PR DESCRIPTION
## Overview
1. This PR fixes part of #10474: Enabled strict check on ImprovementsService

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".