### PR TITLE
Log process info before terminating or killing.

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -849,8 +849,8 @@ def managed_process(
         for proc in procs_to_kill:
             if proc.is_running():
                 procs_still_alive.append(proc)
-                proc.terminate()
                 logging.info('Terminating %s...' % get_debug_info(proc))
+                proc.terminate()
             else:
                 logging.info('%s has ended.' % get_debug_info(proc))
 
@@ -859,8 +859,8 @@ def managed_process(
         for proc in procs_gone:
             logging.info('%s has ended.' % get_debug_info(proc))
         for proc in procs_still_alive:
-            proc.kill()
             logging.warn('Forced to kill %s!' % get_debug_info(proc))
+            proc.kill()
 
         if proc_name_to_kill is not None:
             python_utils.PRINT(
@@ -870,8 +870,8 @@ def managed_process(
                     proc_name_to_kill in cmd_part
                     for cmd_part in proc.cmdline())
                 if proc_should_be_killed:
-                    proc.kill()
                     logging.warn('Forced to kill %s!' % get_debug_info(proc))
+                    proc.kill()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: 

It attempts to fix an e2e problem that arises where a process is killed before we can print debug logs for it. This results in unnecessary errors in the e2e tests. This PR therefore obtains the debug logs for the process *before* killing it.

```
Killing remaining elasticsearch processes
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/runner/work/oppia/oppia/scripts/run_e2e_tests.py", line 612, in <module>
    main()
  File "/home/runner/work/oppia/oppia/scripts/run_e2e_tests.py", line 590, in main
    output, return_code = run_tests(parsed_args)
  File "/home/runner/work/oppia/oppia/scripts/run_e2e_tests.py", line 578, in run_tests
    return output_lines, p.returncode
  File "/home/runner/work/oppia/oppia/third_party/python_libs/contextlib2.py", line 479, in __exit__
    _reraise_with_existing_context(exc_details)
  File "/home/runner/work/oppia/oppia/third_party/python_libs/contextlib2.py", line 353, in _reraise_with_existing_context
    exec("raise exc_type, exc_value, exc_tb")
  File "/home/runner/work/oppia/oppia/third_party/python_libs/contextlib2.py", line 468, in __exit__
    if cb(*exc_details):
  File "/home/runner/work/oppia/oppia/third_party/python_libs/contextlib2.py", line 396, in _exit_wrapper
    return cm_exit(cm, *exc_details)
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/contextlib.py", line 24, in __exit__
    self.gen.next()
  File "scripts/common.py", line 932, in managed_dev_appserver
    yield proc
  File "/opt/hostedtoolcache/Python/2.7.18/x64/lib/python2.7/contextlib.py", line 24, in __exit__
    self.gen.next()
  File "scripts/common.py", line 853, in managed_process
    logging.info('Terminating %s...' % get_debug_info(proc))
  File "scripts/common.py", line 846, in <lambda>
    if proc.is_running() else 'Process(pid=%d)' % (proc.pid,))
  File "/home/runner/work/oppia/oppia/../oppia_tools/psutil-5.7.3/psutil/__init__.py", line 615, in name
    name = self._proc.name()
  File "/home/runner/work/oppia/oppia/../oppia_tools/psutil-5.7.3/psutil/_pslinux.py", line 1517, in wrapper
    return fun(self, *args, **kwargs)
  File "/home/runner/work/oppia/oppia/../oppia_tools/psutil-5.7.3/psutil/_pslinux.py", line 1612, in name
    name = self._parse_stat_file()['name']
  File "/home/runner/work/oppia/oppia/../oppia_tools/psutil-5.7.3/psutil/_pslinux.py", line 1524, in wrapper
    raise NoSuchProcess(self.pid, self._name)
psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=30002)
```

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

This is not a user-facing PR. It just moves some logging statements around. I have verified that all logging statements that use get_debug_info() are now placed before the command that they describe is executed.

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
