### PR TITLE
Fix images not loading when offline

### DIFF
--- a/extensions/rich_text_components/Image/directives/oppia-noninteractive-image.directive.ts
+++ b/extensions/rich_text_components/Image/directives/oppia-noninteractive-image.directive.ts
@@ -69,7 +69,7 @@ angular.module('oppia').directive('oppiaNoninteractiveImage', [
           // preloader service beforehand.
           if (
             ImagePreloaderService.inExplorationPlayer() &&
-            !ContextService.getEntityType() === ENTITY_TYPE.SKILL) {
+            ContextService.getEntityType() !== ENTITY_TYPE.SKILL) {
             ctrl.isLoadingIndicatorShown = true;
             // For aligning the gif to the center of it's container.
             var loadingIndicatorSize = (


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: All images for an exploration should be loaded at the very start of the exploration so that it can still be playable if the user goes offline. However, this feature stopped working. This PR fixes might be a fix for this bug.

Note that I cannot reproduce the original bug on localhost even when changing the Chrome dev network to offline.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

![ezgif com-gif-maker](https://user-images.githubusercontent.com/21316782/108013192-2a1c0d80-6fd9-11eb-833d-5ab8f0670a14.gif)

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
