### PR TITLE
Fix #11584: Upgrade Redis CLI to 6.0.10

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -69,10 +69,6 @@ BUF_VERSION = '0.29.0'
 # the version of protobuf library being used.
 PROTOC_VERSION = PROTOBUF_VERSION
 
-# We use redis 6.0.5 instead of the latest stable build of redis (6.0.6) because
-# there is a `make test` bug in redis 6.0.6 where the solution has not been
-# released. This is explained in this issue:
-# https://github.com/redis/redis/issues/7540.
 # IMPORTANT STEPS FOR DEVELOPERS TO UPGRADE REDIS:
 # 1. Download the new version of the redis cli.
 # 2. Extract the cli in the folder that it was downloaded, most likely
@@ -88,7 +84,7 @@ PROTOC_VERSION = PROTOBUF_VERSION
 #    this message, and that all of the `make test` tests pass before you commit
 #    the upgrade to develop.
 # 7. If any tests fail, DO NOT upgrade to this newer version of the redis cli.
-REDIS_CLI_VERSION = '6.0.5'
+REDIS_CLI_VERSION = '6.0.10'
 ELASTICSEARCH_VERSION = '7.10.1'
 
 RELEASE_BRANCH_NAME_PREFIX = 'release-'


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #11584.
2. This PR does the following: Upgrades the version of the Redis CLI to 6.0.10 for compatibility with M1 Macs.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

The [original issue](https://github.com/redis/redis/issues/4360) that caused us to not upgrade the Redis CLI has been closed. I also ran the tests in version 6.0.10 and confirmed that they pass:

```
$ make distclean
...
$ make
...
$ make test
...
\o/ All tests passed without errors!

Cleanup: may take some time... OK
```

On #11584, @krishita30j has also confirmed that with this change the Oppia server and e2e tests run successfully without running the redis server in a separate terminal.

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
