### PR TITLE
Fix #11947 and #11993: Fix URLs Reported to E2E Logging Server and Report Branch Name

### DIFF
--- a/scripts/flake_checker.py
+++ b/scripts/flake_checker.py
@@ -38,7 +38,7 @@ CI_INFO = {
             'identifier': 'CIRCLECI',
             'user_info': 'CIRCLE_USERNAME',
             'branch': 'CIRCLE_BRANCH',
-            'template_vars': ['CIRCLE_BUILD_URL']
+            'build_url_template_vars': ['CIRCLE_BUILD_URL']
         },
         'build_url_template': '%s',
     },
@@ -47,7 +47,7 @@ CI_INFO = {
             'identifier': 'GITHUB_ACTIONS',
             'user_info': 'GITHUB_ACTOR',
             'branch': 'GITHUB_REF',
-            'template_vars': ['GITHUB_REPOSITORY', 'GITHUB_RUN_ID'],
+            'build_url_template_vars': ['GITHUB_REPOSITORY', 'GITHUB_RUN_ID'],
         },
         'build_url_template': 'https://github.com/%s/actions/runs/%s',
     }
@@ -91,7 +91,7 @@ def _get_build_info():
             continue
 
         template_values = []
-        for template_var in ci_env['template_vars']:
+        for template_var in ci_env['build_url_template_vars']:
             value = os.getenv(template_var)
             if value is None:
                 raise RuntimeError(

--- a/scripts/flake_checker.py
+++ b/scripts/flake_checker.py
@@ -37,6 +37,7 @@ CI_INFO = {
         'env': {
             'identifier': 'CIRCLECI',
             'user_info': 'CIRCLE_USERNAME',
+            'branch': 'CIRCLE_BRANCH',
             'template_vars': ['CIRCLE_BUILD_URL']
         },
         'build_url_template': '%s',
@@ -45,7 +46,8 @@ CI_INFO = {
         'env': {
             'identifier': 'GITHUB_ACTIONS',
             'user_info': 'GITHUB_ACTOR',
-            'template_vars': ['GITHUB_REPOSITORY', 'GITHUB_RUN_ID']
+            'branch': 'GITHUB_REF',
+            'template_vars': ['GITHUB_REPOSITORY', 'GITHUB_RUN_ID'],
         },
         'build_url_template': 'https://github.com/%s/actions/runs/%s',
     }
@@ -102,6 +104,7 @@ def _get_build_info():
         build_info['username'] = os.getenv(ci_env['user_info'])
         build_info['build_url'] = build_url
         build_info['timestamp'] = timestamp
+        build_info['branch'] = os.getenv(ci_env['branch'])
 
         return build_info
 

--- a/scripts/flake_checker.py
+++ b/scripts/flake_checker.py
@@ -37,18 +37,17 @@ CI_INFO = {
         'env': {
             'identifier': 'CIRCLECI',
             'user_info': 'CIRCLE_USERNAME',
-            'build_url': 'CIRCLE_BUILD_URL',
-            'build_id': None
-        }
+            'template_vars': ['CIRCLE_BUILD_URL']
+        },
+        'build_url_template': '%s',
     },
     'githubActions': {
         'env': {
             'identifier': 'GITHUB_ACTIONS',
             'user_info': 'GITHUB_ACTOR',
-            'build_url': None,
-            'build_id': 'GITHUB_RUN_ID',
+            'template_vars': ['GITHUB_REPOSITORY', 'GITHUB_RUN_ID']
         },
-        'build_url_template': 'https://github.com/oppia/oppia/actions/runs/%s'
+        'build_url_template': 'https://github.com/%s/actions/runs/%s',
     }
 }
 
@@ -89,11 +88,15 @@ def _get_build_info():
         if not os.getenv(ci_env['identifier']):
             continue
 
-        if os.getenv(ci_env['build_url']) is not None:
-            build_url = os.getenv(ci_env['build_url'])
-        else:
-            build_url = info['build_url_template'] % os.getenv(
-                ci_env['build_id'])
+        template_values = []
+        for template_var in ci_env['template_vars']:
+            value = os.getenv(template_var)
+            if value is None:
+                raise RuntimeError(
+                    'Expected environment variable %s missing' %
+                    template_var)
+            template_values.append(value)
+        build_url = info['build_url_template'] % tuple(template_values)
         timestamp = datetime.datetime.utcnow().isoformat() + '+00:00'
 
         build_info['username'] = os.getenv(ci_env['user_info'])

--- a/scripts/flake_checker_test.py
+++ b/scripts/flake_checker_test.py
@@ -218,6 +218,28 @@ class ReportPassTests(test_utils.GenericTestBase):
                 Exception, 'Unknown build environment.'):
                 flake_checker.report_pass('suiteName')
 
+    def test_missing_environment_variable(self):
+
+        def mock_getenv(variable):
+            environment_vars = {
+                'CIRCLECI': 1,
+                'CIRCLE_USERNAME': 'user',
+                'CIRCLE_BRANCH': 'develop',
+            }
+            return environment_vars.get(variable)
+
+        def mock_post(url, json, allow_redirects, headers):  # pylint: disable=unused-argument
+            raise AssertionError('requests.post called.')
+
+        getenv_swap = self.swap(os, 'getenv', mock_getenv)
+        post_swap = self.swap(requests, 'post', mock_post)
+
+        with getenv_swap, post_swap:
+            with self.assertRaisesRegexp(
+                RuntimeError,
+                'Expected environment variable CIRCLE_BUILD_URL missing'):
+                flake_checker.report_pass('suiteName')
+
 
 class MockResponse(python_utils.OBJECT):
 

--- a/scripts/flake_checker_test.py
+++ b/scripts/flake_checker_test.py
@@ -84,6 +84,7 @@ class ReportPassTests(test_utils.GenericTestBase):
                 'CIRCLECI': 1,
                 'CIRCLE_USERNAME': 'user',
                 'CIRCLE_BUILD_URL': 'https://example.com',
+                'CIRCLE_BRANCH': 'develop',
             }
             return environment_vars.get(variable)
 
@@ -96,6 +97,7 @@ class ReportPassTests(test_utils.GenericTestBase):
                 'username': 'user',
                 'build_url': 'https://example.com',
                 'timestamp': '2020-01-01T00:00:00.000001+00:00',
+                'branch': 'develop',
             }
         }
 
@@ -123,6 +125,8 @@ class ReportPassTests(test_utils.GenericTestBase):
                 'GITHUB_ACTIONS': 1,
                 'GITHUB_ACTOR': 'user',
                 'GITHUB_RUN_ID': 1234,
+                'GITHUB_REF': 'develop',
+                'GITHUB_REPOSITORY': 'foo/oppia',
             }
             return environment_vars.get(variable)
 
@@ -133,8 +137,9 @@ class ReportPassTests(test_utils.GenericTestBase):
             'suite': 'suiteName',
             'metadata': {
                 'username': 'user',
-                'build_url': 'https://github.com/oppia/oppia/actions/runs/1234',
+                'build_url': 'https://github.com/foo/oppia/actions/runs/1234',
                 'timestamp': '2020-01-01T00:00:00.000001+00:00',
+                'branch': 'develop',
             }
         }
 
@@ -162,6 +167,7 @@ class ReportPassTests(test_utils.GenericTestBase):
                 'CIRCLECI': 1,
                 'CIRCLE_USERNAME': 'user',
                 'CIRCLE_BUILD_URL': 'https://example.com',
+                'CIRCLE_BRANCH': 'develop',
             }
             return environment_vars.get(variable)
 
@@ -174,6 +180,7 @@ class ReportPassTests(test_utils.GenericTestBase):
                 'username': 'user',
                 'build_url': 'https://example.com',
                 'timestamp': '2020-01-01T00:00:00.000001+00:00',
+                'branch': 'develop',
             },
         }
 
@@ -243,6 +250,7 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
                 'CIRCLECI': 1,
                 'CIRCLE_USERNAME': 'user',
                 'CIRCLE_BUILD_URL': 'https://example.com',
+                'CIRCLE_BRANCH': 'develop',
             }
             return environment_vars.get(variable)
 
@@ -265,6 +273,7 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
                 'username': 'user',
                 'build_url': 'https://example.com',
                 'timestamp': '2020-01-01T00:00:00.000001+00:00',
+                'branch': 'develop',
             }
         }
 
@@ -294,6 +303,8 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
                 'GITHUB_ACTIONS': 1,
                 'GITHUB_ACTOR': 'user',
                 'GITHUB_RUN_ID': 1234,
+                'GITHUB_REF': 'develop',
+                'GITHUB_REPOSITORY': 'foo/oppia'
             }
             return environment_vars.get(variable)
 
@@ -314,8 +325,9 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
             'output_lines': ['line1', 'line2'],
             'metadata': {
                 'username': 'user',
-                'build_url': 'https://github.com/oppia/oppia/actions/runs/1234',
+                'build_url': 'https://github.com/foo/oppia/actions/runs/1234',
                 'timestamp': '2020-01-01T00:00:00.000001+00:00',
+                'branch': 'develop',
             }
         }
 
@@ -345,6 +357,7 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
                 'CIRCLECI': 1,
                 'CIRCLE_USERNAME': 'user',
                 'CIRCLE_BUILD_URL': 'https://example.com',
+                'CIRCLE_BRANCH': 'develop',
             }
             return environment_vars.get(variable)
 
@@ -358,6 +371,7 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
                 'username': 'user',
                 'build_url': 'https://example.com',
                 'timestamp': '2020-01-01T00:00:00.000001+00:00',
+                'branch': 'develop',
             },
         }
 
@@ -387,6 +401,7 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
                 'CIRCLECI': 1,
                 'CIRCLE_USERNAME': 'user',
                 'CIRCLE_BUILD_URL': 'https://example.com',
+                'CIRCLE_BRANCH': 'develop',
             }
             return environment_vars.get(variable)
 
@@ -400,6 +415,7 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
                 'username': 'user',
                 'build_url': 'https://example.com',
                 'timestamp': '2020-01-01T00:00:00.000001+00:00',
+                'branch': 'develop',
             },
         }
 
@@ -429,6 +445,7 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
                 'CIRCLECI': 1,
                 'CIRCLE_USERNAME': 'user',
                 'CIRCLE_BUILD_URL': 'https://example.com',
+                'CIRCLE_BRANCH': 'develop',
             }
             return environment_vars.get(variable)
 
@@ -442,6 +459,7 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
                 'username': 'user',
                 'build_url': 'https://example.com',
                 'timestamp': '2020-01-01T00:00:00.000001+00:00',
+                'branch': 'develop',
             },
         }
 


### PR DESCRIPTION
## Overview

1. This PR fixes #11947 and fixes #11993.
2. This PR does the following: Fixes the URLs reported to the E2E logging server to incorporate the repository name. This corrects the URLs from tests running on developers' forks. This PR also reports the branch name to the server as part of the metadata. This isn't used by the server yet (it's ignored), but once this goes in, I will update the server to store the branch name. This will let us highlight failures on develop, which are the most critical to fix.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

The test results from this PR were successfully reported, as shown by the server logs:

```
2021-02-21T04:51:45.922324+00:00 app[web.1]: [redacted] - - [21/Feb/2021:04:51:45 +0000] "POST /check-flake-and-report HTTP/1.1" 200 481 "-" "python-requests/2.24.0"
2021-02-21T04:51:45.923798+00:00 heroku[router]: at=info method=POST path="/check-flake-and-report" host=oppia-e2e-test-results-logger.herokuapp.com request_id=[redacted] fwd="[redacted]" dyno=web.1 connect=0ms service=209ms status=200 bytes=634 protocol=https
2021-02-21T04:51:57.506209+00:00 app[web.1]: 2021-02-21 04:51:57,505 core.models.flake:28 DEBUG Validating suite "preferences".
2021-02-21T04:51:57.516664+00:00 app[web.1]: 2021-02-21 04:51:57,516 core.models.flake:40 DEBUG Suite valid.
2021-02-21T04:51:57.516930+00:00 app[web.1]: 2021-02-21 04:51:57,516 core.models.metadata:103 INFO JSON {'username': 'U8NWXD', 'timestamp': '2021-02-21T04:51:57.441366+00:00', 'build_url': 'https://circleci.com/gh/U8NWXD/oppia/2001', 'branch': 'fix-e2e-logging'} for Metadata creation has extra key branch
2021-02-21T04:51:57.517235+00:00 app[web.1]: 2021-02-21 04:51:57,516 core.models.metadata:106 INFO Creating Metadata from {'username': 'U8NWXD', 'timestamp': '2021-02-21T04:51:57.441366+00:00', 'build_url': 'https://circleci.com/gh/U8NWXD/oppia/2001', 'branch': 'fix-e2e-logging'}
2021-02-21T04:51:57.517508+00:00 app[web.1]: 2021-02-21 04:51:57,517 core.models.metadata:15 DEBUG Validating username "U8NWXD"
2021-02-21T04:51:57.524702+00:00 app[web.1]: 2021-02-21 04:51:57,517 core.models.metadata:22 DEBUG Username valid
2021-02-21T04:51:57.528642+00:00 app[web.1]: 2021-02-21 04:51:57,524 core.models.metadata:27 DEBUG Validating build URL "https://circleci.com/gh/U8NWXD/oppia/2001"
2021-02-21T04:51:57.529001+00:00 app[web.1]: 2021-02-21 04:51:57,528 core.models.metadata:39 DEBUG URL valid
2021-02-21T04:51:57.529309+00:00 app[web.1]: 2021-02-21 04:51:57,529 core.models.metadata:44 DEBUG Validating timestamp "2021-02-21T04:51:57.441366+00:00"
2021-02-21T04:51:57.529643+00:00 app[web.1]: 2021-02-21 04:51:57,529 core.models.metadata:15 DEBUG Validating username "U8NWXD"
2021-02-21T04:51:57.529951+00:00 app[web.1]: 2021-02-21 04:51:57,529 core.models.metadata:22 DEBUG Username valid
2021-02-21T04:51:57.530255+00:00 app[web.1]: 2021-02-21 04:51:57,530 core.models.metadata:27 DEBUG Validating build URL "https://circleci.com/gh/U8NWXD/oppia/2001"
2021-02-21T04:51:57.530570+00:00 app[web.1]: 2021-02-21 04:51:57,530 core.models.metadata:39 DEBUG URL valid
2021-02-21T04:51:57.536886+00:00 app[web.1]: 2021-02-21 04:51:57,530 core.models.metadata:44 DEBUG Validating timestamp "2021-02-21T04:51:57.441366+00:00"
2021-02-21T04:51:57.537284+00:00 app[web.1]: 2021-02-21 04:51:57,536 core.app:77 INFO Logging pass in suite "preferences" with metadata "Metadata[username=U8NWXD, build_url=https://circleci.com/gh/U8NWXD/oppia/2001, timestamp=2021-02-21T04:51:57.441366+00:00]"
2021-02-21T04:51:57.537588+00:00 app[web.1]: 2021-02-21 04:51:57,537 core.services.flake_report_service:26 INFO Logging reported pass of preferences with metadata Metadata[username=U8NWXD, build_url=https://circleci.com/gh/U8NWXD/oppia/2001, timestamp=2021-02-21T04:51:57.441366+00:00].
2021-02-21T04:51:57.537976+00:00 app[web.1]: 2021-02-21 04:51:57,537 core.models.flake:28 DEBUG Validating suite "preferences".
2021-02-21T04:51:57.538265+00:00 app[web.1]: 2021-02-21 04:51:57,538 core.models.flake:40 DEBUG Suite valid.
2021-02-21T04:51:57.538695+00:00 app[web.1]: 2021-02-21 04:51:57,538 core.models.metadata:15 DEBUG Validating username "U8NWXD"
2021-02-21T04:51:57.544679+00:00 app[web.1]: 2021-02-21 04:51:57,544 core.models.metadata:22 DEBUG Username valid
2021-02-21T04:51:57.544988+00:00 app[web.1]: 2021-02-21 04:51:57,544 core.models.metadata:27 DEBUG Validating build URL "https://circleci.com/gh/U8NWXD/oppia/2001"
2021-02-21T04:51:57.545305+00:00 app[web.1]: 2021-02-21 04:51:57,545 core.models.metadata:39 DEBUG URL valid
2021-02-21T04:51:57.545580+00:00 app[web.1]: 2021-02-21 04:51:57,545 core.models.metadata:44 DEBUG Validating timestamp "2021-02-21T04:51:57.441366+00:00"
2021-02-21T04:51:57.545964+00:00 app[web.1]: 2021-02-21 04:51:57,545 core.data:28 DEBUG Found DB URL: [redacted]
2021-02-21T04:51:57.552648+00:00 app[web.1]: 2021-02-21 04:51:57,552 core.data:61 DEBUG Creating DatabaseConnector with url: [redacted]
2021-02-21T04:51:57.614813+00:00 app[web.1]: 2021-02-21 04:51:57,614 core.data:35 DEBUG Checking whether table "report" exists in schema "public".
2021-02-21T04:51:57.628206+00:00 app[web.1]: 2021-02-21 04:51:57,627 core.data:47 DEBUG Whether table exists: True
2021-02-21T04:51:57.628588+00:00 app[web.1]: 2021-02-21 04:51:57,628 core.data:35 DEBUG Checking whether table "request" exists in schema "public".
2021-02-21T04:51:57.641856+00:00 app[web.1]: 2021-02-21 04:51:57,639 core.data:47 DEBUG Whether table exists: True
2021-02-21T04:51:57.661634+00:00 app[web.1]: 2021-02-21 04:51:57,661 core.data:96 DEBUG Recording report: ['2021-02-21T04:51:57.545645', '2021-02-21T04:51:57.441366+00:00', 'U8NWXD', 'https://circleci.com/gh/U8NWXD/oppia/2001', 'preferences', '', '', 'Pass'].
2021-02-21T04:51:57.673755+00:00 app[web.1]: 2021-02-21 04:51:57,673 core.app:84 INFO Report successfully logged.
```

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
