### PR TITLE
Fixes the e2e failure "Expected 'Rejected' to be 'Revisions Requested'."

### DIFF
--- a/core/tests/protractor_desktop/contributorDashboard.js
+++ b/core/tests/protractor_desktop/contributorDashboard.js
@@ -218,7 +218,7 @@ describe('Contributor dashboard page', function() {
     await contributorDashboardPage.waitForOpportunitiesToLoad();
     await contributorDashboardPage.expectNumberOfOpportunitiesToBe(2);
     await contributorDashboardPage.expectOpportunityWithPropertiesToExist(
-      'Question 1', SKILL_DESCRIPTIONS[0], 'Rejected', null);
+      'Question 1', SKILL_DESCRIPTIONS[0], 'Revisions Requested', null);
     await users.logout();
   });
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. ~This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following: 

Fixes the e2e failure "Expected 'Rejected' to be 'Revisions Requested'."

Example of the failure: https://app.circleci.com/pipelines/github/kevintab95/oppia/649/workflows/e203e30c-509f-4b7b-91d5-3c6b9968df28/jobs/4904


## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct


```
Servers have come up.
Note: If ADD_SCREENSHOT_REPORTER is set to true in core/tests/protractor.conf.js, you can view screenshots of the failed tests in ../protractor-screenshots/
[07:04:09] I/launcher - Running 1 instances of WebDriver
[07:04:09] I/hosted - Using the selenium server at http://localhost:4444/wd/hub
Started
Jasmine started
[07:05:59] W/element - more than one element found for locator by.cssContainingText("option", "QUESTION") - the first result will be used
ERROR    2021-03-16 01:36:00,060 email_manager.py:48] This app cannot send emails to users.
.
  Contributor dashboard page
    ? should allow user to switch to translate text tab
[07:06:06] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
[07:06:07] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
[07:06:25] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
[07:06:31] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
[07:06:35] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
[07:06:35] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
.    ? should allow reviewer to accept question suggestions
[07:06:38] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
[07:06:39] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
[07:06:57] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
[07:07:02] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
[07:07:05] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
[07:07:05] W/element - more than one element found for locator By(css selector, .protractor-test-opportunity-list-item-heading) - the first result will be used
.    ? should allow reviewer to reject question suggestions

ERROR    2021-03-16 01:38:00,832 email_manager.py:48] This app cannot send emails to users.
.  Admin page contribution rights form
    ? should allow admin to add translation reviewer
ERROR    2021-03-16 01:38:22,699 email_manager.py:48] This app cannot send emails to users.
.    ? should allow admin to add voiceover reviewer
[07:08:44] W/element - more than one element found for locator by.cssContainingText("option", "QUESTION") - the first result will be used
ERROR    2021-03-16 01:38:45,102 email_manager.py:48] This app cannot send emails to users.
.    ? should allow admin to add question reviewer
.    ? should allow admin to add question contributor

.  Translation contribution featured languages
    ? should show correct featured languages
.    ? should show correct explanation




9 specs, 0 failures
Finished in 326.772 seconds

Executed 9 of 9 specs SUCCESS in 5 mins 27 secs.
[07:09:37] I/launcher - 0 instance(s) of WebDriver still running
[07:09:37] I/launcher - chrome #01 passed
 
```

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes made in this PR work correctly.
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
