### PR TITLE
Fixes part of #11462: Update install_backend_python_libs to respect direct urls from GitHub

### DIFF
--- a/core/tests/data/third_party/invalid_git_requirements_test.txt
+++ b/core/tests/data/third_party/invalid_git_requirements_test.txt
@@ -6,8 +6,7 @@ dependency1==1.6.1      # via -r requirements.in, dependency3
 dependency2==4.9.1      # via -r requirements.in
 dependency3==3.1.5      # via -r requirements.in
 dependency4==0.3.0.1    # via -r requirements.in, dependency3
-git+git://github.com/oppia/dependency5@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa#egg=dependency5
-git+git://github.com/oppia/dependency7@bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb#egg=dependency7
+git+git://github.com/oppia/dependency5@v3.2.1#egg=dependency5
 
 # Developers: Please do not add to this auto-generated file. If
 # you want to add, remove, upgrade, or downgrade libraries,

--- a/requirements.in
+++ b/requirements.in
@@ -13,7 +13,7 @@ contextlib2==0.6.0.post1
 # then, we must depend on a patched version of firebase-admin==3.2.1 (hosted on
 # the following repository) because that is the last version which supports
 # Python 2, but is missing a feature which we were forced to patch in.
-git+git://github.com/oppia/firebase-admin-python@py2-emulator-support#egg=firebase-admin
+git+git://github.com/oppia/firebase-admin-python@8d6deee889733d09ef5327d78c09e4d7b17785ac#egg=firebase-admin
 future==0.18.2
 GoogleAppEngineCloudStorageClient==1.9.22.1
 GoogleAppEngineMapReduce==1.9.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ docopt==0.6.2             # via hdfs
 elasticsearch==7.10.0     # via -r requirements.in
 enum34==1.1.10            # via google-cloud-tasks, grpcio, pyarrow
 fastavro==0.23.6          # via apache-beam
-git+git://github.com/oppia/firebase-admin-python@py2-emulator-support#egg=firebase-admin  # via -r requirements.in
+git+git://github.com/oppia/firebase-admin-python@8d6deee889733d09ef5327d78c09e4d7b17785ac#egg=firebase-admin  # via -r requirements.in
 funcsigs==1.0.2           # via apache-beam, mock
 future==0.18.2            # via -r requirements.in, apache-beam
 futures==3.3.0            # via apache-beam, google-api-core, grpcio, pyarrow

--- a/scripts/install_backend_python_libs.py
+++ b/scripts/install_backend_python_libs.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
 import collections
+import json
 import os
 import re
 import shutil
@@ -26,16 +27,14 @@ import sys
 
 import python_utils
 from scripts import common
+import utils
 
 import pkg_resources
 
-# We depend on a patched version of firebase-admin which is hosted on a git
-# repository. For this reason, we exclude firebase-admin from mismatch checks.
-# TODO(#11474): Remove this special-case logic once we can use the Python 3
-# version of the Firebase SDK.
-IGNORED_LIBRARY_NAME_MISMATCHES = (
-    'firebase-admin',
-)
+GIT_DIRECT_URL_REQUIREMENT_PATTERN = (
+    # NOTE: Direct URLs to GitHub must specify a specific commit hash in their
+    # definition. This helps stabilize the implementation we depend upon.
+    re.compile(r'^(git\+git://github\.com/.*?@[0-9a-f]{40})#egg=([^\s]*)'))
 
 
 def normalize_python_library_name(library_name):
@@ -131,21 +130,31 @@ def _get_requirements_file_contents():
     requirements_contents = collections.defaultdict()
     with python_utils.open_file(
         common.COMPILED_REQUIREMENTS_FILE_PATH, 'r') as f:
-        lines = f.readlines()
-        for line in lines:
-            trimmed_line = line.strip()
-            if trimmed_line.startswith(('#', 'git')) or len(trimmed_line) == 0:
+        trimmed_lines = (line.strip() for line in f.readlines())
+        for line_num, line in enumerate(trimmed_lines, start=1):
+            if not line or line.startswith('#'):
                 continue
-            library_name_and_version_string = trimmed_line.split(
-                ' ')[0].split('==')
+
+            elif line.startswith('git'):
+                match = GIT_DIRECT_URL_REQUIREMENT_PATTERN.match(line)
+                if not match:
+                    raise Exception(
+                        '%r on line %d of %s does not match '
+                        'GIT_DIRECT_URL_REQUIREMENT_PATTERN=%r' % (
+                            line, line_num,
+                            common.COMPILED_REQUIREMENTS_FILE_PATH,
+                            GIT_DIRECT_URL_REQUIREMENT_PATTERN.pattern))
+                library_name, version_string = match.group(2, 1)
+
+            else:
+                library_name, version_string = line.split(' ')[0].split('==')
+
             # Libraries with different case are considered equivalent libraries:
             # e.g 'Flask' is the same library as 'flask'. Therefore, we
             # normalize all library names in order to compare libraries without
             # ambiguities.
             normalized_library_name = (
-                normalize_python_library_name(
-                    library_name_and_version_string[0]))
-            version_string = library_name_and_version_string[1]
+                normalize_python_library_name(library_name))
             requirements_contents[normalized_library_name] = version_string
     return requirements_contents
 
@@ -160,17 +169,28 @@ def _get_third_party_python_libs_directory_contents():
         installed as the key and the version string of that library as the
         value.
     """
-    installed_packages = [
-        (d.project_name, d.version)
-        for d in pkg_resources.find_distributions(
-            common.THIRD_PARTY_PYTHON_LIBS_DIR)]
+    direct_url_packages, standard_packages = utils.partition(
+        pkg_resources.find_distributions(common.THIRD_PARTY_PYTHON_LIBS_DIR),
+        predicate=lambda dist: dist.has_metadata('direct_url.json'))
+
+    installed_packages = {
+        pkg.project_name: pkg.version for pkg in standard_packages
+    }
+
+    for pkg in direct_url_packages:
+        metadata = json.loads(pkg.get_metadata('direct_url.json'))
+        version_string = '%s+%s@%s' % (
+            metadata['vcs_info']['vcs'], metadata['url'],
+            metadata['vcs_info']['commit_id'])
+        installed_packages[pkg.project_name] = version_string
+
     # Libraries with different case are considered equivalent libraries:
     # e.g 'Flask' is the same library as 'flask'. Therefore, we
     # normalize all library names in order to compare libraries without
     # ambiguities.
     directory_contents = {
         normalize_python_library_name(library_name): version_string
-        for library_name, version_string in installed_packages
+        for library_name, version_string in installed_packages.items()
     }
 
     return directory_contents
@@ -242,25 +262,35 @@ def _rectify_third_party_directory(mismatches):
         _reinstall_all_dependencies()
         return
 
-    for normalized_library_name, versions in mismatches.items():
+    # The library is installed in the directory but is not listed in
+    # requirements. We don't have functionality to remove a library cleanly, and
+    # if we ignore the library, this might cause issues when pushing the branch
+    # to develop as there might be possible hidden use cases of a deleted
+    # library that the developer did not catch. The only way to enforce the
+    # removal of a library is to clean out the folder and reinstall everything
+    # from scratch.
+    if any(required is None for required, _ in mismatches.values()):
+        if os.path.isdir(common.THIRD_PARTY_PYTHON_LIBS_DIR):
+            shutil.rmtree(common.THIRD_PARTY_PYTHON_LIBS_DIR)
+        _reinstall_all_dependencies()
+        return
+
+    git_mismatches, pip_mismatches = (
+        utils.partition(mismatches.items(), predicate=_is_git_url_mismatch))
+
+    for normalized_library_name, versions in git_mismatches:
+        requirements_version, directory_version = versions
+
+        # The library listed in 'requirements.txt' is not in the
+        # 'third_party/python_libs' directory.
+        if not directory_version or requirements_version != directory_version:
+            _install_direct_url(normalized_library_name, requirements_version)
+
+    for normalized_library_name, versions in pip_mismatches:
         requirements_version = (
             pkg_resources.parse_version(versions[0]) if versions[0] else None)
         directory_version = (
             pkg_resources.parse_version(versions[1]) if versions[1] else None)
-
-        # The library is installed in the directory but is not listed in
-        # requirements.
-        # We don't have functionality to remove a library cleanly, and if we
-        # ignore the library, this might cause issues when pushing the branch to
-        # develop as there might be possible hidden use cases of a deleted
-        # library that the developer did not catch. The only way to enforce the
-        # removal of a library is to clean out the folder and reinstall
-        # everything from scratch.
-        if not requirements_version:
-            if os.path.isdir(common.THIRD_PARTY_PYTHON_LIBS_DIR):
-                shutil.rmtree(common.THIRD_PARTY_PYTHON_LIBS_DIR)
-            _reinstall_all_dependencies()
-            return
 
         # The library listed in 'requirements.txt' is not in the
         # 'third_party/python_libs' directory.
@@ -279,6 +309,40 @@ def _rectify_third_party_directory(mismatches):
                 python_utils.convert_to_bytes(directory_version))
 
 
+def _is_git_url_mismatch(mismatch_item):
+    """Returns whether the given mismatch item is for a GitHub URL."""
+    _, (required, _) = mismatch_item
+    return required.startswith('git')
+
+
+def _install_direct_url(library_name, direct_url):
+    """Installs a direct URL to GitHub into the third_party/python_libs folder.
+
+    Args:
+        library_name: str. Name of the library to install.
+        direct_url: str. Full definition of the URL to install. Must match
+            GIT_DIRECT_URL_REQUIREMENT_PATTERN.
+    """
+    pip_install(
+        '%s#egg=%s' % (direct_url, library_name),
+        common.THIRD_PARTY_PYTHON_LIBS_DIR,
+        upgrade=True,
+        no_dependencies=True)
+
+
+def _get_pip_versioned_package_string(library_name, version_string):
+    """Returns the standard 'library==version' string for the given values.
+
+    Args:
+        library_name: str. The normalized name of the library.
+        version_string: str. The version of the package as a string.
+
+    Returns:
+        str. The standard versioned library package name.
+    """
+    return '%s==%s' % (library_name, version_string)
+
+
 def _install_library(library_name, version_string):
     """Installs a library with a certain version to the
     'third_party/python_libs' folder.
@@ -288,8 +352,7 @@ def _install_library(library_name, version_string):
         version_string: str. Stringified version of the library to install.
     """
     pip_install(
-        library_name,
-        version_string,
+        _get_pip_versioned_package_string(library_name, version_string),
         common.THIRD_PARTY_PYTHON_LIBS_DIR,
         upgrade=True,
         no_dependencies=True
@@ -421,17 +484,16 @@ def pip_install_to_system(package, version):
         package: str. The package name.
         version: str. The package version.
     """
-    _run_pip_command([
-        'install', '%s==%s' % (package, version)])
+    _run_pip_command(
+        ['install', _get_pip_versioned_package_string(package, version)])
 
 
 def pip_install(
-        package, version, install_path, upgrade=False, no_dependencies=False):
+        versioned_package, install_path, upgrade=False, no_dependencies=False):
     """Installs third party libraries with pip to a specific path.
 
     Args:
-        package: str. The package name.
-        version: str. The package version.
+        versioned_package: str. A 'lib==version' formatted string.
         install_path: str. The installation path for the package.
         upgrade: bool. Whether to call pip with the --upgrade flag.
         no_dependencies: bool. Whether call the pip with --no-dependencies flag.
@@ -443,7 +505,7 @@ def pip_install(
         additional_pip_args.append('--no-dependencies')
 
     _run_pip_command([
-        'install', '%s==%s' % (package, version), '--target', install_path
+        'install', versioned_package, '--target', install_path
     ] + additional_pip_args)
 
 
@@ -492,10 +554,6 @@ def get_mismatches():
 
     mismatches = {}
     for normalized_library_name in requirements_contents:
-        # TODO(#11474): Remove this special-case logic once we can use the
-        # Python 3 version of the Firebase SDK.
-        if normalized_library_name in IGNORED_LIBRARY_NAME_MISMATCHES:
-            continue
         # Library exists in the directory and the requirements file.
         if normalized_library_name in directory_contents:
             # Library matches but version doesn't match.
@@ -510,10 +568,6 @@ def get_mismatches():
                 requirements_contents[normalized_library_name], None)
 
     for normalized_library_name in directory_contents:
-        # TODO(#11474): Remove this special-case logic once we can use the
-        # Python 3 version of the Firebase SDK.
-        if normalized_library_name in IGNORED_LIBRARY_NAME_MISMATCHES:
-            continue
         # Library exists in the directory but is not in the requirements file.
         if normalized_library_name not in requirements_contents:
             mismatches[normalized_library_name] = (
@@ -523,35 +577,37 @@ def get_mismatches():
 
 
 def validate_metadata_directories():
-    """Validates that for each installed library in the
-    'third_party/python_libs' folder, there exists a corresponding metadata
-    directory following the correct naming conventions that are detailed by
-    the PEP-427 and PEP-376 python guidelines.
+    """Validates that each library installed in the 'third_party/python_libs'
+    has a corresponding metadata directory following the correct naming
+    conventions detailed in PEP-427, PEP-376, and common Python guidelines.
 
     Raises:
         Exception. An installed library's metadata does not exist in the
-            'third_party/python_libs' directory in the format that we expect
+            'third_party/python_libs' directory in the format which we expect
             (following the PEP-427 and PEP-376 python guidelines).
     """
     directory_contents = _get_third_party_python_libs_directory_contents()
     # Each python metadata directory name contains a python library name that
-    # does not have uniform case. This is because we cannot guarantee the
-    # casing of the directory names generated and there are no options that we
-    # can provide to `pip install` to actually guarantee that a certain casing
+    # does not have uniform case. This is because we cannot guarantee the casing
+    # of the directory names generated and there are no options that we can
+    # provide to `pip install` to actually guarantee that a certain casing
     # format is used to create the directory names. The only official guidelines
     # for naming directories is that it must start with the string:
     # '<library_name>-<library-version>' but no casing guidelines are specified.
     # Therefore, in order to efficiently check if a python library's metadata
     # exists in a directory, we need to normalize the directory name. Otherwise,
     # we would need to check every permutation of the casing.
-    normalized_directory_names = set(
-        [
-            normalize_directory_name(name)
-            for name in os.listdir(common.THIRD_PARTY_PYTHON_LIBS_DIR)
-            if os.path.isdir(
-                os.path.join(common.THIRD_PARTY_PYTHON_LIBS_DIR, name))
-        ])
+    normalized_directory_names = {
+        normalize_directory_name(name)
+        for name in os.listdir(common.THIRD_PARTY_PYTHON_LIBS_DIR)
+        if os.path.isdir(os.path.join(common.THIRD_PARTY_PYTHON_LIBS_DIR, name))
+    }
     for normalized_library_name, version_string in directory_contents.items():
+        # Direct URL libraries are guaranteed to have metadata directories,
+        # because that's how _get_third_party_python_libs_directory_contents
+        # obtains the version_string being checked here.
+        if version_string.startswith('git+'):
+            continue
         # Possible names of the metadata directory installed when <library_name>
         # is installed.
         possible_normalized_directory_names = (

--- a/scripts/install_backend_python_libs.py
+++ b/scripts/install_backend_python_libs.py
@@ -31,6 +31,7 @@ import utils
 
 import pkg_resources
 
+OPPIA_REQUIRED_PIP_VERSION = '20.3.4'
 GIT_DIRECT_URL_REQUIREMENT_PATTERN = (
     # NOTE: Direct URLs to GitHub must specify a specific commit hash in their
     # definition. This helps stabilize the implementation we depend upon.
@@ -403,16 +404,15 @@ def _get_possible_normalized_metadata_directory_names(
     }
 
 
-def _verify_pip_is_installed():
+def verify_pip_is_installed():
     """Verify that pip is installed.
 
     Raises:
         ImportError. Error importing pip.
     """
+    python_utils.PRINT('Checking if pip is installed on the local machine')
     try:
-        python_utils.PRINT('Checking if pip is installed on the local machine')
-        # Importing pip just to check if its installed.
-        import pip  #pylint: disable=unused-variable
+        import pip
     except ImportError as e:
         common.print_each_string_after_two_new_lines([
             'Pip is required to install Oppia dependencies, but pip wasn\'t '
@@ -434,11 +434,16 @@ def _verify_pip_is_installed():
                 'Windows%29')
         raise ImportError('Error importing pip: %s' % e)
     else:
-        if pip.__version__ != '20.3.4':
+        if pip.__version__ != OPPIA_REQUIRED_PIP_VERSION:
             raise ImportError(
-                'Oppia requires pip==20.3.4, but you are using %s. Please '
-                'update your verison by running pip install pip==20.3.1 (yes, '
-                'using pip to do this is OK).' % pip.__version__)
+                'Oppia requires pip==%s, but you have pip==%s installed. '
+                'Please upgrade pip by running:\n'
+                '\n'
+                '    pip install pip==%s\n'
+                '\n'
+                'NOTE: This is not a typo, pip is able to upgrade itself.' % (
+                    OPPIA_REQUIRED_PIP_VERSION, pip.__version__,
+                    OPPIA_REQUIRED_PIP_VERSION))
 
 
 def _run_pip_command(cmd_parts):
@@ -451,7 +456,7 @@ def _run_pip_command(cmd_parts):
     Raises:
         Exception. Error installing package.
     """
-    _verify_pip_is_installed()
+    verify_pip_is_installed()
     # The call to python -m is used to ensure that Python and Pip versions are
     # compatible.
     command = [sys.executable, '-m', 'pip'] + cmd_parts
@@ -643,6 +648,7 @@ def main():
     mismatches, regenerate the 'requirements.txt' file and correct the
     mismatches.
     """
+    verify_pip_is_installed()
     python_utils.PRINT('Regenerating "requirements.txt" file...')
     # Calls the script to regenerate requirements. The reason we cannot call the
     # regenerate requirements functionality inline is because the python script

--- a/scripts/install_backend_python_libs.py
+++ b/scripts/install_backend_python_libs.py
@@ -436,14 +436,12 @@ def verify_pip_is_installed():
     else:
         if pip.__version__ != OPPIA_REQUIRED_PIP_VERSION:
             common.print_each_string_after_two_new_lines([
-                'Oppia requires pip==%s, but you have pip==%s installed. '
-                'Please upgrade pip by running:' % (
+                'Oppia requires pip==%s, but you have pip==%s installed.' % (
                     OPPIA_REQUIRED_PIP_VERSION, pip.__version__),
-                '    pip install pip==%s' % OPPIA_REQUIRED_PIP_VERSION,
-                'NOTE: This is not a typo, pip is able to upgrade itself.'
+                'Upgrading pip on your behalf...',
             ])
-            raise ImportError(
-                'pip==%s is not installed' % OPPIA_REQUIRED_PIP_VERSION)
+            _run_pip_command(
+                ['install', 'pip==%s' % OPPIA_REQUIRED_PIP_VERSION])
 
 
 def _run_pip_command(cmd_parts):
@@ -456,7 +454,6 @@ def _run_pip_command(cmd_parts):
     Raises:
         Exception. Error installing package.
     """
-    verify_pip_is_installed()
     # The call to python -m is used to ensure that Python and Pip versions are
     # compatible.
     command = [sys.executable, '-m', 'pip'] + cmd_parts
@@ -495,6 +492,7 @@ def pip_install_to_system(package, version):
         package: str. The package name.
         version: str. The package version.
     """
+    verify_pip_is_installed()
     _run_pip_command(
         ['install', _get_pip_versioned_package_string(package, version)])
 
@@ -509,6 +507,8 @@ def pip_install(
         upgrade: bool. Whether to call pip with the --upgrade flag.
         no_dependencies: bool. Whether call the pip with --no-dependencies flag.
     """
+    verify_pip_is_installed()
+
     additional_pip_args = []
     if upgrade:
         additional_pip_args.append('--upgrade')
@@ -527,6 +527,7 @@ def _pip_install_requirements(install_path, requirements_path):
         install_path: str. The installation path for the packages.
         requirements_path: str. The path to the requirements file.
     """
+    verify_pip_is_installed()
     _run_pip_command([
         'install', '--target', install_path, '--no-dependencies',
         '-r', requirements_path, '--upgrade'

--- a/scripts/install_backend_python_libs.py
+++ b/scripts/install_backend_python_libs.py
@@ -433,6 +433,12 @@ def _verify_pip_is_installed():
                 'https://github.com/oppia/oppia/wiki/Installing-Oppia-%28'
                 'Windows%29')
         raise ImportError('Error importing pip: %s' % e)
+    else:
+        if pip.__version__ != '20.3.4':
+            raise ImportError(
+                'Oppia requires pip==20.3.4, but you are using %s. Please '
+                'update your verison by running pip install pip==20.3.1 (yes, '
+                'using pip to do this is OK).' % pip.__version__)
 
 
 def _run_pip_command(cmd_parts):

--- a/scripts/install_backend_python_libs.py
+++ b/scripts/install_backend_python_libs.py
@@ -435,15 +435,15 @@ def verify_pip_is_installed():
         raise ImportError('Error importing pip: %s' % e)
     else:
         if pip.__version__ != OPPIA_REQUIRED_PIP_VERSION:
-            raise ImportError(
+            common.print_each_string_after_two_new_lines([
                 'Oppia requires pip==%s, but you have pip==%s installed. '
-                'Please upgrade pip by running:\n'
-                '\n'
-                '    pip install pip==%s\n'
-                '\n'
-                'NOTE: This is not a typo, pip is able to upgrade itself.' % (
-                    OPPIA_REQUIRED_PIP_VERSION, pip.__version__,
-                    OPPIA_REQUIRED_PIP_VERSION))
+                'Please upgrade pip by running:' % (
+                    OPPIA_REQUIRED_PIP_VERSION, pip.__version__),
+                '    pip install pip==%s' % OPPIA_REQUIRED_PIP_VERSION,
+                'NOTE: This is not a typo, pip is able to upgrade itself.'
+            ])
+            raise ImportError(
+                'pip==%s is not installed' % OPPIA_REQUIRED_PIP_VERSION)
 
 
 def _run_pip_command(cmd_parts):

--- a/scripts/install_backend_python_libs_test.py
+++ b/scripts/install_backend_python_libs_test.py
@@ -19,6 +19,8 @@
 from __future__ import absolute_import  # pylint: disable=import-only-modules
 from __future__ import unicode_literals  # pylint: disable=import-only-modules
 
+import itertools
+import json
 import os
 import re
 import shutil
@@ -33,16 +35,58 @@ from scripts import install_backend_python_libs
 import pkg_resources
 
 
+class Distribution(python_utils.OBJECT):
+    """Mock distribution object containing python library information."""
+
+    def __init__(self, library_name, version_string, metadata_dict):
+        """Creates mock distribution metadata class that contains the name and
+        version information for a python library.
+
+        Args:
+            library_name: str. The name of the library this object is
+                representing.
+            version_string: str. The stringified version of this library.
+            metadata_dict: dict(str: str). The stringified metadata contents of
+                the library.
+        """
+        self.project_name = library_name
+        self.version = version_string
+        self.metadata_dict = metadata_dict
+
+    def has_metadata(self, key):
+        """Returns whether the given metadata key exists.
+
+        Args:
+            key: str. The key corresponding to the metadata.
+
+        Returns:
+            bool. Whether the metadata exists.
+        """
+        return key in self.metadata_dict
+
+    def get_metadata(self, key):
+        """The contents of the corresponding metadata.
+
+        Args:
+            key: str. The key corresponding to the metadata.
+
+        Returns:
+            str. The contents of the metadata.
+        """
+        return self.metadata_dict[key]
+
+
 class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
     """Tests for installing backend python libraries."""
 
     THIRD_PARTY_DATA_DIRECTORY_FILE_PATH = os.path.join(
         common.CURR_DIR, 'core', 'tests', 'data', 'third_party')
 
-    TEST_REQUIREMENTS_TXT_FILE_PATH = os.path.join(
+    REQUIREMENTS_TEST_TXT_FILE_PATH = os.path.join(
         THIRD_PARTY_DATA_DIRECTORY_FILE_PATH, 'requirements_test.txt')
-    TEST_IGNORABLE_REQUIREMENTS_TXT_FILE_PATH = os.path.join(
-        THIRD_PARTY_DATA_DIRECTORY_FILE_PATH, 'ignorable_requirements_test.txt')
+    INVALID_GIT_REQUIREMENTS_TEST_TXT_FILE_PATH = os.path.join(
+        THIRD_PARTY_DATA_DIRECTORY_FILE_PATH,
+        'invalid_git_requirements_test.txt')
 
     def setUp(self):
         super(InstallBackendPythonLibsTests, self).setUp()
@@ -112,87 +156,69 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         self.swap_Popen_error = self.swap(
             subprocess, 'Popen', mock_check_call_error)
 
+    def get_git_version_string(self, name, sha1_piece):
+        """Utility function for constructing a GitHub URL for testing.
+
+        Args:
+            name: str. Name of the package.
+            sha1_piece: str. Commit hash of the package. The piece is
+                concatenated with itself to construct a full 40-character hash.
+
+        Returns:
+            str. The full GitHub URL dependency.
+        """
+        sha1 = ''.join(itertools.islice(itertools.cycle(sha1_piece), 40))
+        return 'git+git://github.com/oppia/%s@%s' % (name, sha1)
+
+    def test_invalid_git_dependency_raises_an_exception(self):
+        swap_requirements = self.swap(
+            common, 'COMPILED_REQUIREMENTS_FILE_PATH',
+            self.INVALID_GIT_REQUIREMENTS_TEST_TXT_FILE_PATH)
+
+        with swap_requirements:
+            self.assertRaisesRegexp(
+                Exception, 'does not match GIT_DIRECT_URL_REQUIREMENT_PATTERN',
+                install_backend_python_libs.get_mismatches)
+
     def test_multiple_discrepancies_returns_correct_mismatches(self):
         swap_requirements = self.swap(
             common, 'COMPILED_REQUIREMENTS_FILE_PATH',
-            self.TEST_REQUIREMENTS_TXT_FILE_PATH)
+            self.REQUIREMENTS_TEST_TXT_FILE_PATH)
 
         def mock_find_distributions(paths): # pylint: disable=unused-argument
-            class Distribution(python_utils.OBJECT):
-                """Distribution object containing python library information."""
-
-                def __init__(self, library_name, version_string):
-                    """Creates mock distribution metadata class that contains
-                    the name and version information for a python library.
-
-                    Args:
-                        library_name: str. The name of the library this object
-                            is representing.
-                        version_string: str. The stringified version of this
-                            library.
-                    """
-                    self.project_name = library_name
-                    self.version = version_string
             return [
-                Distribution('dependency1', '1.5.1'),
-                Distribution('dependency2', '4.9.1.2'),
-                Distribution('dependency5', '0.5.3')
+                Distribution('dependency1', '1.5.1', {}),
+                Distribution('dependency2', '4.9.1.2', {}),
+                Distribution('dependency5', '0.5.3', {
+                    'direct_url.json': json.dumps({
+                        'url': 'git://github.com/oppia/dependency5',
+                        'vcs_info': {'vcs': 'git', 'commit_id': 'b' * 40},
+                    })
+                }),
+                Distribution('dependency6', '0.5.3', {
+                    'direct_url.json': json.dumps({
+                        'url': 'git://github.com/oppia/dependency6',
+                        'vcs_info': {'vcs': 'git', 'commit_id': 'z' * 40},
+                    })
+                })
             ]
 
         swap_find_distributions = self.swap(
             pkg_resources, 'find_distributions', mock_find_distributions)
         with swap_requirements, swap_find_distributions:
-            self.assertEqual(
-                {
-                    u'dependency1': (u'1.6.1', u'1.5.1'),
-                    u'dependency2': (u'4.9.1', u'4.9.1.2'),
-                    u'dependency3': (u'3.1.5', None),
-                    u'dependency4': (u'0.3.0.1', None),
-                    u'dependency5': (None, u'0.5.3')
-                },
-                install_backend_python_libs.get_mismatches())
-
-    # TODO(#11474): Remove this test for special-case logic once we can use the
-    # Python 3 version of the Firebase SDK.
-    def test_ignored_library_name_mismatches_are_respected(self):
-        swap_requirements = self.swap(
-            common, 'COMPILED_REQUIREMENTS_FILE_PATH',
-            self.TEST_IGNORABLE_REQUIREMENTS_TXT_FILE_PATH)
-
-        def mock_find_distributions(paths): # pylint: disable=unused-argument
-            class Distribution(python_utils.OBJECT):
-                """Distribution object containing python library information."""
-
-                def __init__(self, library_name, version_string):
-                    """Creates mock distribution metadata class that contains
-                    the name and version information for a python library.
-
-                    Args:
-                        library_name: str. The name of the library this object
-                            is representing.
-                        version_string: str. The stringified version of this
-                            library.
-                    """
-                    self.project_name = library_name
-                    self.version = version_string
-            return [
-                Distribution('dependency1', '1.5.1'),
-                Distribution('dependency2', '4.9.1.2'),
-                Distribution('dependency3', '0.5.3'),
-            ]
-
-        swap_find_distributions = self.swap(
-            pkg_resources, 'find_distributions', mock_find_distributions)
-        swap_ignored_names = self.swap(
-            install_backend_python_libs, 'IGNORED_LIBRARY_NAME_MISMATCHES',
-            ('dependency3', 'dependency4'))
-        with swap_requirements, swap_find_distributions, swap_ignored_names:
-            self.assertEqual(
-                {
-                    u'dependency1': (u'1.6.1', u'1.5.1'),
-                    u'dependency2': (u'4.9.1', u'4.9.1.2'),
-                },
-                install_backend_python_libs.get_mismatches())
+            self.assertEqual(install_backend_python_libs.get_mismatches(), {
+                u'dependency1': (u'1.6.1', u'1.5.1'),
+                u'dependency2': (u'4.9.1', u'4.9.1.2'),
+                u'dependency3': (u'3.1.5', None),
+                u'dependency4': (u'0.3.0.1', None),
+                u'dependency5': (
+                    self.get_git_version_string('dependency5', 'a'),
+                    self.get_git_version_string('dependency5', 'b')),
+                u'dependency6': (
+                    None, self.get_git_version_string('dependency6', 'z')),
+                u'dependency7': (
+                    self.get_git_version_string('dependency7', 'b'), None),
+            })
 
     def test_library_removal_runs_correct_commands(self):
         """Library exists in the 'third_party/python_libs' directory but it is
@@ -205,7 +231,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         def mock_get_mismatches():
             return {
                 u'flask': (None, u'10.0.1'),
-                u'six': (None, u'10.13.0.1')
+                u'six': (None, u'10.13.0.1'),
             }
 
         def mock_validate_metadata_directories():
@@ -223,12 +249,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                 with swap_validate_metadata_directories:
                     install_backend_python_libs.main()
 
-        self.assertEqual(
-            removed_dirs,
-            [
-                common.THIRD_PARTY_PYTHON_LIBS_DIR
-            ]
-        )
+        self.assertEqual(removed_dirs, [common.THIRD_PARTY_PYTHON_LIBS_DIR])
 
         self.assertEqual(
             self.cmd_token_list,
@@ -252,7 +273,11 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             return {
                 u'flask': (u'1.1.0.1', u'1.1.1.0'),
                 u'six': (u'1.15.0', None),
-                u'protobuf': (u'2.0.1.3', u'2.0.0.0')
+                u'git-dep1': (
+                    self.get_git_version_string('git-dep1', 'a'),
+                    self.get_git_version_string('git-dep1', 'b')),
+                u'git-dep2': (
+                    self.get_git_version_string('git-dep2', 'a'), None),
             }
 
         def mock_validate_metadata_directories():
@@ -273,6 +298,20 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
             [
                 ['scripts.regenerate_requirements'],
                 [
+                    'pip', 'install',
+                    '%s#egg=git-dep1' % (
+                        self.get_git_version_string('git-dep1', 'a')),
+                    '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
+                    '--upgrade', '--no-dependencies',
+                ],
+                [
+                    'pip', 'install',
+                    '%s#egg=git-dep2' % (
+                        self.get_git_version_string('git-dep2', 'a')),
+                    '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
+                    '--upgrade', '--no-dependencies',
+                ],
+                [
                     'pip', 'install', '%s==%s' % ('flask', '1.1.0.1'),
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
@@ -282,11 +321,6 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                     '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
                     '--upgrade', '--no-dependencies',
                 ],
-                [
-                    'pip', 'install', '%s==%s' % ('protobuf', '2.0.1.3'),
-                    '--target', common.THIRD_PARTY_PYTHON_LIBS_DIR,
-                    '--upgrade', '--no-dependencies',
-                ]
             ]
         )
 
@@ -528,25 +562,16 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
     def test_exception_raised_when_metadata_directory_names_are_missing(self):
         def mock_find_distributions(paths): # pylint: disable=unused-argument
-            class Distribution(python_utils.OBJECT):
-                """Distribution object containing python library information."""
-
-                def __init__(self, library_name, version_string):
-                    """Creates mock distribution metadata class that contains
-                    the name and version information for a python library.
-
-                    Args:
-                        library_name: str. The name of the library this object
-                            is representing.
-                        version_string: str. The stringified version of this
-                            library.
-                    """
-                    self.project_name = library_name
-                    self.version = version_string
             return [
-                Distribution('dependency1', '1.5.1'),
-                Distribution('dependency2', '5.0.0'),
-                Distribution('dependency5', '0.5.3')
+                Distribution('dependency1', '1.5.1', {}),
+                Distribution('dependency2', '5.0.0', {}),
+                Distribution('dependency5', '0.5.3', {}),
+                Distribution('dependency6', '0.5.3', {
+                    'direct_url.json': json.dumps({
+                        'url': 'git://github.com/oppia/dependency6',
+                        'vcs_info': {'vcs': 'git', 'commit_id': 'z' * 40},
+                    })
+                }),
             ]
 
         def mock_list_dir(path): # pylint: disable=unused-argument
@@ -603,18 +628,16 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
     def test_pip_install_without_import_error(self):
         with self.swap_Popen:
-            install_backend_python_libs.pip_install(
-                'package', 'version', 'path')
+            install_backend_python_libs.pip_install('package==version', 'path')
 
     def test_pip_install_with_user_prefix_error(self):
         with self.swap_Popen_error, self.swap_check_call:
-            install_backend_python_libs.pip_install('pkg', 'ver', 'path')
+            install_backend_python_libs.pip_install('pkg==ver', 'path')
 
     def test_pip_install_exception_handling(self):
         with self.assertRaisesRegexp(
             Exception, 'Error installing package') as context:
-            install_backend_python_libs.pip_install(
-                'package', 'version', 'path')
+            install_backend_python_libs.pip_install('package==version', 'path')
         self.assertTrue('Error installing package' in context.exception)
 
     def test_pip_install_with_import_error_and_darwin_os(self):
@@ -627,7 +650,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                 with self.assertRaisesRegexp(
                     ImportError, 'Error importing pip: No module named pip'):
                     install_backend_python_libs.pip_install(
-                        'package', 'version', 'path')
+                        'package==version', 'path')
         finally:
             sys.modules['pip'] = pip
         self.assertTrue(
@@ -644,7 +667,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                 with self.assertRaisesRegexp(
                     Exception, 'Error importing pip: No module named pip'):
                     install_backend_python_libs.pip_install(
-                        'package', 'version', 'path')
+                        'package==version', 'path')
         finally:
             sys.modules['pip'] = pip
         self.assertTrue(
@@ -660,7 +683,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                 with self.assertRaisesRegexp(
                     Exception, 'Error importing pip: No module named pip'):
                     install_backend_python_libs.pip_install(
-                        'package', 'version', 'path')
+                        'package==version', 'path')
         finally:
             sys.modules['pip'] = pip
         self.assertTrue(

--- a/scripts/install_backend_python_libs_test.py
+++ b/scripts/install_backend_python_libs_test.py
@@ -172,10 +172,21 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
     def test_wrong_pip_version_raises_import_error(self):
         import pip
-        with self.swap(pip, '__version__', '20.2.4'):
-            self.assertRaisesRegexp(
-                ImportError, 'pip==20.3.4 is not installed',
-                install_backend_python_libs.verify_pip_is_installed)
+
+        with self.swap_Popen, self.swap(pip, '__version__', '20.2.4'):
+            install_backend_python_libs.verify_pip_is_installed()
+
+        self.assertEqual(self.cmd_token_list, [
+            ['pip', 'install', 'pip==20.3.4'],
+        ])
+
+    def test_correct_pip_version_does_nothing(self):
+        import pip
+
+        with self.swap_check_call, self.swap(pip, '__version__', '20.3.4'):
+            install_backend_python_libs.verify_pip_is_installed()
+
+        self.assertEqual(self.cmd_token_list, [])
 
     def test_invalid_git_dependency_raises_an_exception(self):
         swap_requirements = self.swap(

--- a/scripts/install_backend_python_libs_test.py
+++ b/scripts/install_backend_python_libs_test.py
@@ -32,6 +32,7 @@ import python_utils
 from scripts import common
 from scripts import install_backend_python_libs
 
+import pip
 import pkg_resources
 
 
@@ -169,6 +170,12 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         """
         sha1 = ''.join(itertools.islice(itertools.cycle(sha1_piece), 40))
         return 'git+git://github.com/oppia/%s@%s' % (name, sha1)
+
+    def test_wrong_pip_version_raises_import_error(self):
+        with self.swap(pip, '__version__', '20.2.4'):
+            self.assertRaisesRegexp(
+                ImportError, 'Please upgrade pip',
+                install_backend_python_libs.verify_pip_is_installed)
 
     def test_invalid_git_dependency_raises_an_exception(self):
         swap_requirements = self.swap(
@@ -466,13 +473,12 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
                 install_backend_python_libs.main()
 
         self.assertEqual(check_function_calls, expected_check_function_calls)
-        self.assertEqual(
-            print_statements,
-            [
-                'Regenerating "requirements.txt" file...',
-                'All third-party Python libraries are already installed '
-                'correctly.'
-            ])
+        self.assertEqual(print_statements, [
+            'Checking if pip is installed on the local machine',
+            'Regenerating "requirements.txt" file...',
+            'All third-party Python libraries are already installed '
+            'correctly.'
+        ])
 
     def test_library_version_change_is_handled_correctly(self):
         directory_names = [

--- a/scripts/install_backend_python_libs_test.py
+++ b/scripts/install_backend_python_libs_test.py
@@ -32,7 +32,6 @@ import python_utils
 from scripts import common
 from scripts import install_backend_python_libs
 
-import pip
 import pkg_resources
 
 
@@ -172,6 +171,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
         return 'git+git://github.com/oppia/%s@%s' % (name, sha1)
 
     def test_wrong_pip_version_raises_import_error(self):
+        import pip
         with self.swap(pip, '__version__', '20.2.4'):
             self.assertRaisesRegexp(
                 ImportError, 'pip==20.3.4 is not installed',

--- a/scripts/install_backend_python_libs_test.py
+++ b/scripts/install_backend_python_libs_test.py
@@ -174,7 +174,7 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
     def test_wrong_pip_version_raises_import_error(self):
         with self.swap(pip, '__version__', '20.2.4'):
             self.assertRaisesRegexp(
-                ImportError, 'Please upgrade pip',
+                ImportError, 'pip==20.3.4 is not installed',
                 install_backend_python_libs.verify_pip_is_installed)
 
     def test_invalid_git_dependency_raises_an_exception(self):

--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -41,4 +41,4 @@ sudo apt-get install python-yaml
 sudo apt-get install python-matplotlib
 # TODO(#11547): Pip 21 doesn't support Python 2, so we need to stay on pip 20
 # until we migrate to Python 3.
-sudo pip install --upgrade pip==20.2.4
+sudo pip install --upgrade pip==20.3.4

--- a/scripts/install_third_party_libs.py
+++ b/scripts/install_third_party_libs.py
@@ -186,7 +186,7 @@ def ensure_pip_library_is_installed(package, version, path):
     if not os.path.exists(exact_lib_path):
         python_utils.PRINT('Installing %s' % package)
         install_backend_python_libs.pip_install(
-            package, version, exact_lib_path)
+            '%s==%s' % (package, version), exact_lib_path)
 
 
 def ensure_system_python_libraries_are_installed(package, version):

--- a/scripts/install_third_party_libs_test.py
+++ b/scripts/install_third_party_libs_test.py
@@ -303,7 +303,7 @@ class InstallThirdPartyLibsTests(test_utils.GenericTestBase):
         }
         def mock_exists(unused_path):
             return False
-        def mock_pip_install(unused_package, unused_version, unused_path):
+        def mock_pip_install(unused_versioned_package, unused_path):
             check_function_calls['pip_install_is_called'] = True
 
         exists_swap = self.swap(os.path, 'exists', mock_exists)

--- a/utils.py
+++ b/utils.py
@@ -22,6 +22,7 @@ import collections
 import datetime
 import hashlib
 import imghdr
+import itertools
 import json
 import os
 import random
@@ -1005,3 +1006,72 @@ class OrderedCounter(collections.Counter, collections.OrderedDict):
     """Counter that remembers the order elements are first encountered."""
 
     pass
+
+
+def grouper(iterable, chunk_len, fillvalue=None):
+    """Collect data into fixed-length chunks.
+
+    Source: https://docs.python.org/3/library/itertools.html#itertools-recipes.
+
+    Example:
+        grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx
+
+    Args:
+        iterable: iterable. Any kind of iterable object.
+        chunk_len: int. The chunk size of each group.
+        fillvalue: *. The value used to fill out the last chunk in case the
+            iterable is exhausted.
+
+    Returns:
+        iterable(iterable). A sequence of chunks over the input data.
+    """
+    # To understand how/why this works, please refer to the following
+    # Stack Overflow answer: https://stackoverflow.com/a/49181132/4859885.
+    args = [iter(iterable)] * chunk_len
+    return itertools.izip_longest(*args, fillvalue=fillvalue) # pylint: disable=deprecated-itertools-function
+
+
+def partition(iterable, predicate=bool, enumerated=False):
+    """Returns two generators which split the iterable based on the predicate.
+
+    NOTE: The predicate is called AT MOST ONCE per item.
+
+    Example:
+        is_even = lambda n: (n % 2) == 0
+        evens, odds = partition([10, 8, 1, 5, 6, 4, 3, 7], is_even)
+        assert list(evens) == [10, 8, 6, 4]
+        assert list(odds) == [1, 5, 3, 7]
+
+
+        logs = ['ERROR: foo', 'INFO: bar', 'INFO: fee', 'ERROR: fie']
+        is_error = lambda msg: msg.startswith('ERROR: ')
+        errors, others = partition(logs, is_error, enumerated=True)
+
+        for i, error in errors:
+            raise Exception('Log index=%d failed for reason: %s' % (i, error))
+        for i, message in others:
+            logging.info('Log index=%d: %s' % (i, message))
+
+    Args:
+        iterable: iterable. Any kind of iterable object.
+        predicate: callable. A function which accepts an item and returns True
+            or False.
+        enumerated: bool. Whether the partitions should include their original
+            indices.
+
+    Returns:
+        tuple(iterable, iterable). Two distinct generators. The first generator
+        will hold values which passed the predicate. The second will hold the
+        values which did not. If enumerated is True, then the generators will
+        yield (index, item) pairs. Otherwise, the generators will yield items by
+        themselves.
+    """
+    if enumerated:
+        iterable = enumerate(iterable)
+        old_predicate = predicate
+        predicate = lambda pair: old_predicate(pair[1])
+    # Creates two distinct generators over the same iterable. Memory-efficient.
+    true_part, false_part = itertools.tee((i, predicate(i)) for i in iterable)
+    return (
+        (i for i, predicate_is_true in true_part if predicate_is_true),
+        (i for i, predicate_is_true in false_part if not predicate_is_true))

--- a/utils_test.py
+++ b/utils_test.py
@@ -633,3 +633,32 @@ class UtilsTests(test_utils.GenericTestBase):
         self.assertEqual(
             dt,
             datetime.datetime.fromtimestamp(python_utils.divide(msecs, 1000.0)))
+
+    def test_grouper(self):
+        self.assertEqual(
+            [list(g) for g in utils.grouper(python_utils.RANGE(7), 3)],
+            [[0, 1, 2], [3, 4, 5], [6, None, None]])
+        # Returns an iterable of iterables, so we need to combine them into
+        # strings for easier comparison.
+        self.assertEqual(
+            [''.join(g) for g in utils.grouper('ABCDEFG', 3, fillvalue='x')],
+            ['ABC', 'DEF', 'Gxx'])
+
+    def test_partition(self):
+        is_even = lambda n: (n % 2) == 0
+
+        evens, odds = (
+            utils.partition([10, 8, 1, 5, 6, 4, 3, 7], predicate=is_even))
+
+        self.assertEqual(list(evens), [10, 8, 6, 4])
+        self.assertEqual(list(odds), [1, 5, 3, 7])
+
+    def test_enumerated_partition(self):
+        logs = ['ERROR: foo', 'INFO: bar', 'INFO: fee', 'ERROR: fie']
+        is_error = lambda msg: msg.startswith('ERROR: ')
+
+        errors, others = (
+            utils.partition(logs, predicate=is_error, enumerated=True))
+
+        self.assertEqual(list(errors), [(0, 'ERROR: foo'), (3, 'ERROR: fie')])
+        self.assertEqual(list(others), [(1, 'INFO: bar'), (2, 'INFO: fee')])


### PR DESCRIPTION
Reverts oppia/oppia#12363

Upgrading to `pip==20.3.4` fixes direct URL dependencies, this PR adds a prompt for users to upgrade when they're using a wrong version.