### PR TITLE
Fix #12380: Exploration statistics pie charts now show on page load

### DIFF
--- a/core/templates/pages/exploration-editor-page/statistics-tab/charts/pie-chart.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/statistics-tab/charts/pie-chart.component.spec.ts
@@ -18,7 +18,7 @@
 
 import { of } from 'rxjs';
 
-fdescribe('Pie Chart component', function() {
+describe('Pie Chart component', function() {
   var ctrl = null;
   var $flushPendingTasks = null;
   var $scope = null;

--- a/core/templates/pages/exploration-editor-page/statistics-tab/charts/pie-chart.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/statistics-tab/charts/pie-chart.component.spec.ts
@@ -18,7 +18,7 @@
 
 import { of } from 'rxjs';
 
-describe('Pie Chart component', function() {
+fdescribe('Pie Chart component', function() {
   var ctrl = null;
   var $flushPendingTasks = null;
   var $scope = null;

--- a/core/templates/pages/exploration-editor-page/statistics-tab/charts/pie-chart.component.ts
+++ b/core/templates/pages/exploration-editor-page/statistics-tab/charts/pie-chart.component.ts
@@ -42,6 +42,8 @@ angular.module('oppia').component('pieChart', {
       google.charts.setOnLoadCallback(function() {
         if (!chart) {
           chart = new google.visualization.PieChart($element[0]);
+          redrawChart();
+          $scope.$applyAsync();
         }
       });
       var redrawChart = function() {

--- a/core/templates/pages/exploration-editor-page/statistics-tab/charts/pie-chart.component.ts
+++ b/core/templates/pages/exploration-editor-page/statistics-tab/charts/pie-chart.component.ts
@@ -37,15 +37,6 @@ angular.module('oppia').component('pieChart', {
       var options = ctrl.options();
       var chart = null;
 
-      // Need to wait for load statement in editor template to finish.
-      // https://stackoverflow.com/questions/42714876/
-      google.charts.setOnLoadCallback(function() {
-        if (!chart) {
-          chart = new google.visualization.PieChart($element[0]);
-          redrawChart();
-          $scope.$applyAsync();
-        }
-      });
       var redrawChart = function() {
         if (chart !== null) {
           chart.draw(google.visualization.arrayToDataTable(ctrl.data()), {
@@ -69,6 +60,16 @@ angular.module('oppia').component('pieChart', {
           });
         }
       };
+
+      // Need to wait for load statement in editor template to finish.
+      // https://stackoverflow.com/questions/42714876/
+      google.charts.setOnLoadCallback(function() {
+        if (!chart) {
+          chart = new google.visualization.PieChart($element[0]);
+          redrawChart();
+          $scope.$applyAsync();
+        }
+      });
 
       $scope.$watch('data()', redrawChart);
 


### PR DESCRIPTION
## Overview
1. This PR fixes #12380.
2. This PR does the following: For exploration statistics, a pie chart is supposed to show up to display lesson completion statistics. We previously didn't calculate the pie chart or `applyAsync` on page load. Now, we do.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

**Before:**
![image](https://user-images.githubusercontent.com/21316782/113462071-2f001980-93ed-11eb-8d6d-83605b967837.png)

**Now:**
![image](https://user-images.githubusercontent.com/21316782/113462050-15f76880-93ed-11eb-8e34-17d45ea30794.png)


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
