### PR TITLE
Fix part of #11462: Include users marked for deletion when managing deleted users

### DIFF
--- a/core/platform/auth/firebase_auth_services.py
+++ b/core/platform/auth/firebase_auth_services.py
@@ -210,9 +210,6 @@ def delete_external_auth_associations(user_id):
         user_id: str. The unique ID of the user whose associations should be
             deleted.
     """
-    # NOTE: We use get_multi(include_deleted=True) because get() returns None
-    # for models with deleted=True, but we need to make changes to those models
-    # when managing deletion.
     auth_id = get_auth_id_from_user_id(user_id, include_deleted=True)
     if auth_id is None:
         return
@@ -240,9 +237,6 @@ def verify_external_auth_associations_are_deleted(user_id):
         bool. True if and only if we have successfully verified that all
         external associations have been deleted.
     """
-    # NOTE: We use get_multi(include_deleted=True) because get() returns None
-    # for models with deleted=True, but we need to make changes to those models
-    # when managing deletion.
     auth_id = get_auth_id_from_user_id(user_id, include_deleted=True)
     if auth_id is None:
         return True
@@ -347,9 +341,6 @@ def associate_auth_id_with_user_id(auth_id_user_id_pair):
     """
     auth_id, user_id = auth_id_user_id_pair
 
-    # NOTE: We use get_multi(include_deleted=True) because get() returns None
-    # for models with deleted=True, but we need to make changes to those models
-    # when managing deletion.
     user_id_collision = get_user_id_from_auth_id(auth_id, include_deleted=True)
     if user_id_collision is not None:
         raise Exception('auth_id=%r is already associated with user_id=%r' % (

--- a/core/platform/auth/firebase_auth_services.py
+++ b/core/platform/auth/firebase_auth_services.py
@@ -283,13 +283,11 @@ def get_auth_id_from_user_id(user_id, include_deleted=False):
         assoc_by_user_id_model.firebase_auth_id)
 
 
-def get_multi_auth_ids_from_user_ids(user_ids, include_deleted=False):
+def get_multi_auth_ids_from_user_ids(user_ids):
     """Returns the auth IDs associated with the given user IDs.
 
     Args:
         user_ids: list(str). The user IDs.
-        include_deleted: bool. Whether to return the ID of models marked for
-            deletion.
 
     Returns:
         list(str|None). The auth IDs associated with each of the given user IDs,
@@ -297,8 +295,7 @@ def get_multi_auth_ids_from_user_ids(user_ids, include_deleted=False):
     """
     return [
         None if model is None else model.firebase_auth_id
-        for model in auth_models.UserAuthDetailsModel.get_multi(
-            user_ids, include_deleted=include_deleted)
+        for model in auth_models.UserAuthDetailsModel.get_multi(user_ids)
     ]
 
 
@@ -322,13 +319,11 @@ def get_user_id_from_auth_id(auth_id, include_deleted=False):
         assoc_by_auth_id_model.user_id)
 
 
-def get_multi_user_ids_from_auth_ids(auth_ids, include_deleted=False):
+def get_multi_user_ids_from_auth_ids(auth_ids):
     """Returns the user IDs associated with the given auth IDs.
 
     Args:
         auth_ids: list(str). The auth IDs.
-        include_deleted: bool. Whether to return the ID of models marked for
-            deletion.
 
     Returns:
         list(str|None). The user IDs associated with each of the given auth IDs,
@@ -336,8 +331,7 @@ def get_multi_user_ids_from_auth_ids(auth_ids, include_deleted=False):
     """
     return [
         None if model is None else model.user_id
-        for model in auth_models.UserIdByFirebaseAuthIdModel.get_multi(
-            auth_ids, include_deleted=include_deleted)
+        for model in auth_models.UserIdByFirebaseAuthIdModel.get_multi(auth_ids)
     ]
 
 

--- a/core/platform/auth/firebase_auth_services_test.py
+++ b/core/platform/auth/firebase_auth_services_test.py
@@ -1278,15 +1278,18 @@ class GenericAssociationTests(FirebaseAuthServicesTestBase):
         firebase_auth_services.associate_auth_id_with_user_id(
             auth_domain.AuthIdUserIdPair('aid', 'uid'))
 
-        self.assertIsNotNone(
-            auth_models.UserIdByFirebaseAuthIdModel.get('aid', strict=False))
-        self.assertFalse(firebase_admin.auth.get_user('aid').disabled)
+        self.assertEqual(
+            firebase_auth_services.get_user_id_from_auth_id('aid'), 'uid')
+        self.firebase_sdk_stub.assert_is_not_disabled('aid')
 
         firebase_auth_services.mark_user_for_deletion('uid')
 
         self.assertIsNone(
-            auth_models.UserIdByFirebaseAuthIdModel.get('aid', strict=False))
-        self.assertTrue(firebase_admin.auth.get_user('aid').disabled)
+            firebase_auth_services.get_user_id_from_auth_id('aid'))
+        self.assertIsNotNone(
+            firebase_auth_services.get_user_id_from_auth_id(
+                'aid', include_deleted=True))
+        self.firebase_sdk_stub.assert_is_disabled('aid')
 
     def test_disable_association_warns_when_firebase_fails_to_update_user(self):
         self.firebase_sdk_stub.create_user('aid')
@@ -1297,17 +1300,17 @@ class GenericAssociationTests(FirebaseAuthServicesTestBase):
             error=firebase_exceptions.UnknownError('could not update'))
         log_capturing_context = self.capture_logging()
 
-        self.assertIsNotNone(
-            auth_models.UserIdByFirebaseAuthIdModel.get('aid', strict=False))
-        self.assertFalse(firebase_admin.auth.get_user('aid').disabled)
+        self.assertEqual(
+            firebase_auth_services.get_user_id_from_auth_id('aid'), 'uid')
+        self.firebase_sdk_stub.assert_is_not_disabled('aid')
 
         with update_user_swap, log_capturing_context as logs:
             firebase_auth_services.mark_user_for_deletion('uid')
 
         self.assert_matches_regexps(logs, ['could not update'])
         self.assertIsNone(
-            auth_models.UserIdByFirebaseAuthIdModel.get('aid', strict=False))
-        self.assertFalse(firebase_admin.auth.get_user('aid').disabled)
+            firebase_auth_services.get_user_id_from_auth_id('aid'))
+        self.firebase_sdk_stub.assert_is_not_disabled('aid')
 
     def test_disable_association_gives_up_when_auth_assocs_do_not_exist(self):
         with self.capture_logging() as logs:
@@ -1367,6 +1370,7 @@ class DeleteAuthAssociationsTests(FirebaseAuthServicesTestBase):
         self.firebase_sdk_stub.create_user(self.AUTH_ID)
         user_settings = user_services.create_new_user(self.AUTH_ID, self.EMAIL)
         self.user_id = user_settings.user_id
+        firebase_auth_services.mark_user_for_deletion(self.user_id)
 
     def swap_get_user_to_always_fail(self):
         """Swaps the get_user function so that it always fails."""
@@ -1401,8 +1405,6 @@ class DeleteAuthAssociationsTests(FirebaseAuthServicesTestBase):
         with self.swap_delete_user_to_always_fail():
             firebase_auth_services.delete_external_auth_associations(
                 self.user_id)
-
-        self.firebase_sdk_stub.assert_is_user(self.AUTH_ID)
 
         self.assertFalse(
             firebase_auth_services

--- a/core/platform/auth/firebase_auth_services_test.py
+++ b/core/platform/auth/firebase_auth_services_test.py
@@ -1286,9 +1286,10 @@ class GenericAssociationTests(FirebaseAuthServicesTestBase):
 
         self.assertIsNone(
             firebase_auth_services.get_user_id_from_auth_id('aid'))
-        self.assertIsNotNone(
+        self.assertEqual(
             firebase_auth_services.get_user_id_from_auth_id(
-                'aid', include_deleted=True))
+                'aid', include_deleted=True),
+            'uid')
         self.firebase_sdk_stub.assert_is_disabled('aid')
 
     def test_disable_association_warns_when_firebase_fails_to_update_user(self):
@@ -1310,6 +1311,10 @@ class GenericAssociationTests(FirebaseAuthServicesTestBase):
         self.assert_matches_regexps(logs, ['could not update'])
         self.assertIsNone(
             firebase_auth_services.get_user_id_from_auth_id('aid'))
+        self.assertEqual(
+            firebase_auth_services.get_user_id_from_auth_id(
+                'aid', include_deleted=True),
+            'uid')
         self.firebase_sdk_stub.assert_is_not_disabled('aid')
 
     def test_disable_association_gives_up_when_auth_assocs_do_not_exist(self):
@@ -1405,6 +1410,8 @@ class DeleteAuthAssociationsTests(FirebaseAuthServicesTestBase):
         with self.swap_delete_user_to_always_fail():
             firebase_auth_services.delete_external_auth_associations(
                 self.user_id)
+
+        self.firebase_sdk_stub.assert_is_user(self.AUTH_ID)
 
         self.assertFalse(
             firebase_auth_services


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #11462 .
2. This PR does the following: Updates the logic for managing accounts marked for deletion to include checking models that have `deleted=True`. This is necessary because Firebase accounts and Oppia models need to be kept in sync regardless of the user's deletion status.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
