### PR TITLE
Fix Part of #11496: Lint Check for Nested Awaits When Calling `browser.switchTo().activeElement()`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -116,6 +116,7 @@
     "oppia/test-message-style": "error",
     "oppia/dependency-checks": "error",
     "oppia/no-test-blockers": "error",
+    "oppia/e2e-browser-nested-awaits": "error",
     "angular/di": [
       "error",
       "array"

--- a/core/tests/protractor_utils/ExplorationEditorMainTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorMainTab.js
@@ -532,7 +532,7 @@ var ExplorationEditorMainTab = function() {
       addHintModal, 'Add hint modal takes too long to appear');
     await element(by.css('.protractor-test-hint-text')).all(by.tagName('p'))
       .last().click();
-    await browser.switchTo().activeElement().sendKeys(hint);
+    await (await browser.switchTo().activeElement()).sendKeys(hint);
 
     await waitFor.elementToBeClickable(
       saveHintButton,
@@ -556,7 +556,9 @@ var ExplorationEditorMainTab = function() {
       solution.correctAnswer);
     await element(by.css('.protractor-test-explanation-textarea'))
       .all(by.tagName('p')).first().click();
-    await browser.switchTo().activeElement().sendKeys(solution.explanation);
+    await (
+      await browser.switchTo().activeElement()
+    ).sendKeys(solution.explanation);
     var submitSolutionButton = element(
       by.css('.protractor-test-submit-solution-button'));
     await waitFor.elementToBeClickable(

--- a/core/tests/protractor_utils/SkillEditorPage.js
+++ b/core/tests/protractor_utils/SkillEditorPage.js
@@ -282,10 +282,10 @@ var SkillEditorPage = function() {
       'Add Worked Example Modal takes too long to appear');
 
     await workedExampleQuestion.click();
-    await browser.switchTo().activeElement().sendKeys(question);
+    await (await browser.switchTo().activeElement()).sendKeys(question);
 
     await workedExampleExplanation.click();
-    await browser.switchTo().activeElement().sendKeys(explanation);
+    await (await browser.switchTo().activeElement()).sendKeys(explanation);
 
     await action.click(
       'Save worked example', saveWorkedExampleButton);
@@ -349,13 +349,13 @@ var SkillEditorPage = function() {
       'Add Misconception Modal takes too long to appear');
 
     await misconceptionNameField.click();
-    await browser.switchTo().activeElement().sendKeys(name);
+    await (await browser.switchTo().activeElement()).sendKeys(name);
 
     await misconceptionNotesField.click();
-    await browser.switchTo().activeElement().sendKeys(notes);
+    await (await browser.switchTo().activeElement()).sendKeys(notes);
 
     await misconceptionFeedbackField.click();
-    await browser.switchTo().activeElement().sendKeys(feedback);
+    await (await browser.switchTo().activeElement()).sendKeys(feedback);
 
     await action.click('Confirm add misconception', confirmAddMisconception);
 

--- a/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.js
+++ b/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.js
@@ -40,8 +40,8 @@ module.exports = {
   },
 
   create: function(context) {
-    // Checks if this expression is syntactically the same as:
-    // `await browser.switchTo().activeElement().sendKeys(<ARGS>)`
+    /* Checks if this expression is syntactically the same as:
+       `await browser.switchTo().activeElement().sendKeys(<ARGS>)` */
     var checkExprNode = function(node) {
       node = node.expression;
       if (node.type !== 'AwaitExpression' ||

--- a/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.js
+++ b/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.js
@@ -1,0 +1,92 @@
+// Copyright 2020 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Lint to ensure that e2e tests have nested awaits for
+   `await (await browser.switchTo().activeElement()).sendKeys(explanation)`
+ */
+
+'use strict';
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: (
+        '`browser.switchTo().activeElement()` ' +
+        'should be wrapped in an `await` ' +
+        'expression before calling `sendKeys()`'),
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noNestedAwaits: (
+        'should have a nested `await` for ' +
+        '`browser.switchTo().activeElement()`')
+    },
+  },
+
+  create: function(context) {
+    // Checks if this expression is syntactically the same as:
+    // `await browser.switchTo().activeElement().sendKeys(<ARGS>)`
+    var checkExprNode = function(node) {
+      node = node.expression;
+      if (node.type !== "AwaitExpression" ||
+        node.argument.type !== "CallExpression") {
+        return false;
+      }
+
+      node = node.argument.callee;
+      if (node.type !== "MemberExpression" ||
+        node.property.type !== "Identifier" ||
+        node.property.name !== "sendKeys" ||
+        node.object.type != "CallExpression") {
+        return false;
+      }
+
+      node = node.object.callee;
+      if (node.type !== "MemberExpression" ||
+        node.property.type !== "Identifier" ||
+        node.property.name !== "activeElement" ||
+        node.object.type !== "CallExpression") {
+        return false;
+      }
+
+      node = node.object.callee;
+      if (node.type !== "MemberExpression" ||
+        node.property.type !== "Identifier" ||
+        node.property.name !== "switchTo" ||
+        node.object.type !== "Identifier" ||
+        node.object.name !== "browser") {
+        return false;
+      }
+
+      return true;
+    }
+
+    return {
+      ExpressionStatement: function(node) {
+        if (checkExprNode(node)) {
+          context.report({
+            node,
+            loc: node.loc,
+            messageId: 'noNestedAwaits'
+          });
+        }
+      }
+    };
+  }
+};

--- a/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.js
+++ b/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.js
@@ -44,38 +44,38 @@ module.exports = {
     // `await browser.switchTo().activeElement().sendKeys(<ARGS>)`
     var checkExprNode = function(node) {
       node = node.expression;
-      if (node.type !== "AwaitExpression" ||
-        node.argument.type !== "CallExpression") {
+      if (node.type !== 'AwaitExpression' ||
+        node.argument.type !== 'CallExpression') {
         return false;
       }
 
       node = node.argument.callee;
-      if (node.type !== "MemberExpression" ||
-        node.property.type !== "Identifier" ||
-        node.property.name !== "sendKeys" ||
-        node.object.type != "CallExpression") {
+      if (node.type !== 'MemberExpression' ||
+        node.property.type !== 'Identifier' ||
+        node.property.name !== 'sendKeys' ||
+        node.object.type !== 'CallExpression') {
         return false;
       }
 
       node = node.object.callee;
-      if (node.type !== "MemberExpression" ||
-        node.property.type !== "Identifier" ||
-        node.property.name !== "activeElement" ||
-        node.object.type !== "CallExpression") {
+      if (node.type !== 'MemberExpression' ||
+        node.property.type !== 'Identifier' ||
+        node.property.name !== 'activeElement' ||
+        node.object.type !== 'CallExpression') {
         return false;
       }
 
       node = node.object.callee;
-      if (node.type !== "MemberExpression" ||
-        node.property.type !== "Identifier" ||
-        node.property.name !== "switchTo" ||
-        node.object.type !== "Identifier" ||
-        node.object.name !== "browser") {
+      if (node.type !== 'MemberExpression' ||
+        node.property.type !== 'Identifier' ||
+        node.property.name !== 'switchTo' ||
+        node.object.type !== 'Identifier' ||
+        node.object.name !== 'browser') {
         return false;
       }
 
       return true;
-    }
+    };
 
     return {
       ExpressionStatement: function(node) {

--- a/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.js
+++ b/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.js
@@ -39,10 +39,10 @@ module.exports = {
   },
 
   create: function(context) {
-    /*  Checks if CallExpression `expr` contains:
+    /*  Checks if CallExpression `expr` is syntactically the same as:
      *  `browser.switchTo().activeElement()`.
      *
-     *  If it does, checks to see whether `expr` is wrapped
+     *  If it is, checks to see whether `expr` is wrapped
      *  in an `await` expression.
      */
     var checkExprNode = function(expr) {

--- a/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.spec.js
+++ b/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.spec.js
@@ -1,0 +1,71 @@
+// Copyright 2021 The Oppia Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS-IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Tests for the e2e-browser-nested-awaits.js file.
+ */
+
+'use strict';
+
+var rule = require('./e2e-browser-nested-awaits');
+var RuleTester = require('eslint').RuleTester;
+
+// Note: parser options added in order to parse
+// `async` and `await` in the test code snippets
+var ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2017
+  }
+});
+
+ruleTester.run('e2e-browser-nested-awaits', rule, {
+  valid: [
+  {
+    code: `
+        async function def() {
+            await page;
+            await getPage().sendKeys(solution.explanation);
+            await page.frame().activeElement().sendKeys();
+            await(await browser.switchTo().activeElement()).sendKeys(solution.explanation);
+        }
+        `
+  }],
+  invalid: [
+  {
+    code: `
+        async function def() {
+            await browser.switchTo().activeElement().sendKeys(solution.explanation);
+        }
+        `,
+    errors: [
+    {
+      message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
+    }]
+  },
+  {
+    code: `
+        async function def() {
+            await browser.switchTo().activeElement().sendKeys();
+            await browser.switchTo().activeElement().sendKeys(array[0].attr);
+        }
+        `,
+    errors: [
+    {
+      message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
+    },
+    {
+      message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
+    }]
+  }]
+});

--- a/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.spec.js
+++ b/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.spec.js
@@ -31,41 +31,41 @@ var ruleTester = new RuleTester({
 
 ruleTester.run('e2e-browser-nested-awaits', rule, {
   valid: [
-  {
-    code: `
-        async function def() {
-            await page;
-            await getPage().sendKeys(solution.explanation);
-            await page.frame().activeElement().sendKeys();
-            await(await browser.switchTo().activeElement()).sendKeys(solution.explanation);
-        }
-        `
-  }],
+    {
+      code: `
+          async function def() {
+              await page;
+              await getPage().sendKeys(solution.explanation);
+              await page.frame().activeElement().sendKeys();
+              await(await browser.switchTo().activeElement()).sendKeys(solution.explanation);
+          }
+          `
+    }],
   invalid: [
-  {
-    code: `
-        async function def() {
-            await browser.switchTo().activeElement().sendKeys(solution.explanation);
-        }
-        `,
-    errors: [
     {
-      message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
-    }]
-  },
-  {
-    code: `
-        async function def() {
-            await browser.switchTo().activeElement().sendKeys();
-            await browser.switchTo().activeElement().sendKeys(array[0].attr);
-        }
-        `,
-    errors: [
-    {
-      message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
+      code: `
+          async function def() {
+              await browser.switchTo().activeElement().sendKeys(solution.explanation);
+          }
+          `,
+      errors: [
+      {
+        message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
+      }]
     },
     {
-      message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
+      code: `
+          async function def() {
+              await browser.switchTo().activeElement().sendKeys();
+              await browser.switchTo().activeElement().sendKeys(array[0].attr);
+          }
+          `,
+      errors: [
+      {
+        message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
+      },
+      {
+        message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
+      }]
     }]
-  }]
 });

--- a/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.spec.js
+++ b/scripts/linters/custom_eslint_checks/rules/e2e-browser-nested-awaits.spec.js
@@ -21,8 +21,8 @@
 var rule = require('./e2e-browser-nested-awaits');
 var RuleTester = require('eslint').RuleTester;
 
-// Note: parser options added in order to parse
-// `async` and `await` in the test code snippets
+/* Note: parser options added in order to parse
+   `async` and `await` in the test code snippets */
 var ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 2017
@@ -37,7 +37,9 @@ ruleTester.run('e2e-browser-nested-awaits', rule, {
               await page;
               await getPage().sendKeys(solution.explanation);
               await page.frame().activeElement().sendKeys();
-              await(await browser.switchTo().activeElement()).sendKeys(solution.explanation);
+              await(
+                await browser.switchTo().activeElement()
+              ).sendKeys(solution.explanation);
           }
           `
     }],
@@ -45,27 +47,31 @@ ruleTester.run('e2e-browser-nested-awaits', rule, {
     {
       code: `
           async function def() {
-              await browser.switchTo().activeElement().sendKeys(solution.explanation);
+              await browser.switchTo().activeElement().sendKeys(
+                solution.explanation);
           }
           `,
       errors: [
-      {
-        message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
-      }]
+        {
+          message: 'should have a nested `await` for ' +
+                   '`browser.switchTo().activeElement()`'
+        }]
     },
     {
       code: `
           async function def() {
               await browser.switchTo().activeElement().sendKeys();
-              await browser.switchTo().activeElement().sendKeys(array[0].attr);
+              await browser.switchTo().activeElement().sendKeys(arr[0].attr);
           }
           `,
       errors: [
-      {
-        message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
-      },
-      {
-        message: 'should have a nested `await` for `browser.switchTo().activeElement()`'
-      }]
+        {
+          message: 'should have a nested `await` for ' +
+                   '`browser.switchTo().activeElement()`'
+        },
+        {
+          message: 'should have a nested `await` for ' +
+                   '`browser.switchTo().activeElement()`'
+        }]
     }]
 });


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #11496.
2. This PR does the following: Adds a lint check to ensure `browser.switchTo().activeElement()` is wrapped in an `await` statement

## Essential Checklist

- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The linter/Karma presubmit checks have passed locally on your machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [X] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

I checked that my tests pass locally and does not break anything (linter tests run fine, server runs fine, backend/frontend tests run fine).

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
