### PR TITLE
Fix 11248

### DIFF
--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
@@ -18,7 +18,7 @@
 
 import { Component, ElementRef, Input, Output, EventEmitter, ViewChild } from '@angular/core';
 import { downgradeComponent } from '@angular/upgrade/static';
-//import { PassThrough } from 'node:stream';
+// Timport { PassThrough } from 'node:stream';
 import { WindowRef } from 'services/contextual/window-ref.service';
 import { IdGenerationService } from 'services/id-generation.service';
 
@@ -97,7 +97,7 @@ export class ImageUploaderComponent {
       /(\\|\/)/g).pop();
     this.errorMessage = this.validateUploadedFile(file, filename);
     let fchng = this.fileChanged;
-    let newFile: File = new File(["asd"], 'so.txt', { type: 'text/plain' });
+    let newFile: File = new File(['asd'], 'so.txt', { type: 'text/plain' });
     if (!this.errorMessage) {
       // Only fir this event if validation pass.
       const HUNDRED_KB_IN_BYTES: number = 100 * 1024;

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
@@ -18,6 +18,7 @@
 
 import { Component, ElementRef, Input, Output, EventEmitter, ViewChild } from '@angular/core';
 import { downgradeComponent } from '@angular/upgrade/static';
+import { PassThrough } from 'node:stream';
 import { WindowRef } from 'services/contextual/window-ref.service';
 import { IdGenerationService } from 'services/id-generation.service';
 
@@ -95,9 +96,53 @@ export class ImageUploaderComponent {
     let filename: string = this.imageInputRef.nativeElement.value.split(
       /(\\|\/)/g).pop();
     this.errorMessage = this.validateUploadedFile(file, filename);
+    let fchng = this.fileChanged;
+    let newFile: File = new File(["asd".repeat(34134)], "so.txt", { type: "text/plain" });
     if (!this.errorMessage) {
       // Only fir this event if validation pass.
-      this.fileChanged.emit(file);
+      const HUNDRED_KB_IN_BYTES: number = 100 * 1024;
+
+      if (file.size > HUNDRED_KB_IN_BYTES) {
+        let width: number = 171;
+        let stop: boolean = false;
+          const reader: FileReader = new FileReader();
+          reader.readAsDataURL(file);
+
+          reader.onload = function (event) {
+            let imgElement: HTMLImageElement = document.createElement("img");
+            imgElement.src = reader.result;
+            imgElement.onload = function (e) {
+              const canvas = document.createElement("canvas");
+              let scale: number = e.target.height / e.target.width;
+              width = Math.sqrt((100 * 1024) / (3.5 * scale));
+
+              const MAX_WIDTH = width;
+              if (imgElement.width > imgElement.height) {
+                const scaleSize = MAX_WIDTH / e.target.width;
+                canvas.width = MAX_WIDTH;
+                canvas.height = e.target.height * scaleSize;
+              }
+              else {
+                const scaleSize = MAX_WIDTH / e.target.height;
+                canvas.height = MAX_WIDTH;
+                canvas.width = e.target.width * scaleSize;
+              }
+              
+              const ctx = canvas.getContext("2d");
+              ctx.drawImage(imgElement, 0, 0, canvas.width, canvas.height);
+              
+              canvas.toBlob(function (blob) {
+                newFile = new File([blob], file.name, {type: file.type} );
+                fchng.emit(newFile);
+              });
+            };
+
+          };
+
+      }
+      else {
+        this.fileChanged.emit(file);
+      }
     }
   }
 
@@ -153,14 +198,6 @@ export class ImageUploaderComponent {
       return 'This image format is not supported';
     }
 
-    const HUNDRED_KB_IN_BYTES: number = 100 * 1024;
-    if (file.size > HUNDRED_KB_IN_BYTES) {
-      let currentSizeInKb: string = (
-        (file.size * 100 / HUNDRED_KB_IN_BYTES).toFixed(1) + ' KB'
-      );
-      return 'The maximum allowed file size is 100 KB' +
-        ' (' + currentSizeInKb + ' given).';
-    }
     return null;
   }
 }

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
@@ -97,22 +97,22 @@ export class ImageUploaderComponent {
       /(\\|\/)/g).pop();
     this.errorMessage = this.validateUploadedFile(file, filename);
     let fchng = this.fileChanged;
-    let newFile: File = new File(["asd".repeat(34134)], "so.txt", { type: "text/plain" });
+    let newFile: File = new File(["asd".repeat(34134)], 'so.txt', 
+                        { type: 'text/plain' });
     if (!this.errorMessage) {
       // Only fir this event if validation pass.
       const HUNDRED_KB_IN_BYTES: number = 100 * 1024;
 
       if (file.size > HUNDRED_KB_IN_BYTES) {
         let width: number = 171;
-        let stop: boolean = false;
         const reader: FileReader = new FileReader();
         reader.readAsDataURL(file);
 
-        reader.onload = function (event) {
-          let imgElement: HTMLImageElement = document.createElement("img");
+        reader.onload = function(event) {
+          let imgElement: HTMLImageElement = document.createElement('img');
           imgElement.src = reader.result;
-          imgElement.onload = function (e) {
-            const canvas = document.createElement("canvas");
+          imgElement.onload = function(e) {
+            const canvas = document.createElement('canvas');
             let scale: number = e.target.height / e.target.width;
             width = Math.sqrt((100 * 1024) / (3.5 * scale));
 
@@ -121,24 +121,21 @@ export class ImageUploaderComponent {
               const scaleSize = MAX_WIDTH / e.target.width;
               canvas.width = MAX_WIDTH;
               canvas.height = e.target.height * scaleSize;
-            }
-            else {
+            } else {
               const scaleSize = MAX_WIDTH / e.target.height;
               canvas.height = MAX_WIDTH;
               canvas.width = e.target.width * scaleSize;
             }
 
-            const ctx = canvas.getContext("2d");
+            const ctx = canvas.getContext('2d');
             ctx.drawImage(imgElement, 0, 0, canvas.width, canvas.height);
 
-            canvas.toBlob(function (blob) {
+            canvas.toBlob(function(blob) {
               newFile = new File([blob], file.name, { type: file.type });
               fchng.emit(newFile);
             });
           };
-
         };
-
       }
       else {
         this.fileChanged.emit(file);

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
@@ -107,29 +107,29 @@ export class ImageUploaderComponent {
         const reader: FileReader = new FileReader();
         reader.readAsDataURL(file);
 
-        reader.onload = function(event) {
+        reader.onload = function (event) {
           let imgElement: HTMLImageElement = document.createElement('img');
-          imgElement.src = reader.result;
-          imgElement.onload = function(e) {
+          imgElement.src = reader.result.toString();
+          imgElement.onload = function (e) {
             const canvas = document.createElement('canvas');
-            let scale: number = e.target.height / e.target.width;
+            let scale: number = imgElement.height / imgElement.width;
             width = Math.sqrt((100 * 1024) / (3.5 * scale));
 
             const MAX_WIDTH = width;
             if (imgElement.width > imgElement.height) {
-              const scaleSize = MAX_WIDTH / e.target.width;
+              const scaleSize = MAX_WIDTH / imgElement.width;
               canvas.width = MAX_WIDTH;
-              canvas.height = e.target.height * scaleSize;
+              canvas.height = imgElement.height * scaleSize;
             } else {
-              const scaleSize = MAX_WIDTH / e.target.height;
+              const scaleSize = MAX_WIDTH / imgElement.height;
               canvas.height = MAX_WIDTH;
-              canvas.width = e.target.width * scaleSize;
+              canvas.width = imgElement.width * scaleSize;
             }
 
             const ctx = canvas.getContext('2d');
             ctx.drawImage(imgElement, 0, 0, canvas.width, canvas.height);
 
-            canvas.toBlob(function(blob) {
+            canvas.toBlob(function (blob) {
               newFile = new File([blob], file.name, { type: file.type });
               fchng.emit(newFile);
             });

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
@@ -105,39 +105,39 @@ export class ImageUploaderComponent {
       if (file.size > HUNDRED_KB_IN_BYTES) {
         let width: number = 171;
         let stop: boolean = false;
-          const reader: FileReader = new FileReader();
-          reader.readAsDataURL(file);
+        const reader: FileReader = new FileReader();
+        reader.readAsDataURL(file);
 
-          reader.onload = function (event) {
-            let imgElement: HTMLImageElement = document.createElement("img");
-            imgElement.src = reader.result;
-            imgElement.onload = function (e) {
-              const canvas = document.createElement("canvas");
-              let scale: number = e.target.height / e.target.width;
-              width = Math.sqrt((100 * 1024) / (3.5 * scale));
+        reader.onload = function (event) {
+          let imgElement: HTMLImageElement = document.createElement("img");
+          imgElement.src = reader.result;
+          imgElement.onload = function (e) {
+            const canvas = document.createElement("canvas");
+            let scale: number = e.target.height / e.target.width;
+            width = Math.sqrt((100 * 1024) / (3.5 * scale));
 
-              const MAX_WIDTH = width;
-              if (imgElement.width > imgElement.height) {
-                const scaleSize = MAX_WIDTH / e.target.width;
-                canvas.width = MAX_WIDTH;
-                canvas.height = e.target.height * scaleSize;
-              }
-              else {
-                const scaleSize = MAX_WIDTH / e.target.height;
-                canvas.height = MAX_WIDTH;
-                canvas.width = e.target.width * scaleSize;
-              }
-              
-              const ctx = canvas.getContext("2d");
-              ctx.drawImage(imgElement, 0, 0, canvas.width, canvas.height);
-              
-              canvas.toBlob(function (blob) {
-                newFile = new File([blob], file.name, {type: file.type} );
-                fchng.emit(newFile);
-              });
-            };
+            const MAX_WIDTH = width;
+            if (imgElement.width > imgElement.height) {
+              const scaleSize = MAX_WIDTH / e.target.width;
+              canvas.width = MAX_WIDTH;
+              canvas.height = e.target.height * scaleSize;
+            }
+            else {
+              const scaleSize = MAX_WIDTH / e.target.height;
+              canvas.height = MAX_WIDTH;
+              canvas.width = e.target.width * scaleSize;
+            }
 
+            const ctx = canvas.getContext("2d");
+            ctx.drawImage(imgElement, 0, 0, canvas.width, canvas.height);
+
+            canvas.toBlob(function (blob) {
+              newFile = new File([blob], file.name, { type: file.type });
+              fchng.emit(newFile);
+            });
           };
+
+        };
 
       }
       else {

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
@@ -18,7 +18,7 @@
 
 import { Component, ElementRef, Input, Output, EventEmitter, ViewChild } from '@angular/core';
 import { downgradeComponent } from '@angular/upgrade/static';
-import { PassThrough } from 'node:stream';
+//import { PassThrough } from 'node:stream';
 import { WindowRef } from 'services/contextual/window-ref.service';
 import { IdGenerationService } from 'services/id-generation.service';
 
@@ -97,8 +97,7 @@ export class ImageUploaderComponent {
       /(\\|\/)/g).pop();
     this.errorMessage = this.validateUploadedFile(file, filename);
     let fchng = this.fileChanged;
-    let newFile: File = new File(["asd".repeat(34134)], 'so.txt', 
-                        { type: 'text/plain' });
+    let newFile: File = new File(["asd"], 'so.txt', { type: 'text/plain' });
     if (!this.errorMessage) {
       // Only fir this event if validation pass.
       const HUNDRED_KB_IN_BYTES: number = 100 * 1024;
@@ -136,8 +135,7 @@ export class ImageUploaderComponent {
             });
           };
         };
-      }
-      else {
+      } else {
         this.fileChanged.emit(file);
       }
     }

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.ts
@@ -107,10 +107,10 @@ export class ImageUploaderComponent {
         const reader: FileReader = new FileReader();
         reader.readAsDataURL(file);
 
-        reader.onload = function (event) {
+        reader.onload = function(event) {
           let imgElement: HTMLImageElement = document.createElement('img');
           imgElement.src = reader.result.toString();
-          imgElement.onload = function (e) {
+          imgElement.onload = function(e) {
             const canvas = document.createElement('canvas');
             let scale: number = imgElement.height / imgElement.width;
             width = Math.sqrt((100 * 1024) / (3.5 * scale));
@@ -129,7 +129,7 @@ export class ImageUploaderComponent {
             const ctx = canvas.getContext('2d');
             ctx.drawImage(imgElement, 0, 0, canvas.width, canvas.height);
 
-            canvas.toBlob(function (blob) {
+            canvas.toBlob(function(blob) {
               newFile = new File([blob], file.name, { type: file.type });
               fchng.emit(newFile);
             });


### PR DESCRIPTION
## Overview
Fix #11248 using HTML canvas to compress images that are too large

1. This PR fixes #11248.
2. This PR does the following: Uses HTML canvas object to create a compressed version of an image if the file uploaded by the user is too large
