### PR TITLE
Fix part of #8423: Add pylint check to prohibit inline comments

### DIFF
--- a/scripts/linters/pylint_extensions.py
+++ b/scripts/linters/pylint_extensions.py
@@ -1756,7 +1756,8 @@ class SingleLineCommentChecker(checkers.BaseChecker):
             line_num: int. Line number of the current comment.
         """
         # Extract comment from line.
-        _, trail_comment = line.split('#')
+        split_line = line.split('#')
+        trail_comment = split_line[1]
         # Check for pylint pragma.
         if (re.search('pylint:', trail_comment) or
                 re.search('isort:', trail_comment)):

--- a/scripts/linters/pylint_extensions_test.py
+++ b/scripts/linters/pylint_extensions_test.py
@@ -2488,6 +2488,79 @@ class SingleLineCommentCheckerTests(unittest.TestCase):
         with self.checker_test_object.assertNoMessages():
             temp_file.close()
 
+    def test_invalid_trailing_comment(self):
+        node_invalid_trailing_comment = astroid.scoped_nodes.Module(
+            name='test',
+            doc='Custom test')
+        temp_file = tempfile.NamedTemporaryFile()
+        filename = temp_file.name
+
+        with python_utils.open_file(filename, 'w') as tmp:
+            tmp.write(
+                u"""# coding: utf-8
+
+                    import sys   # invalid trailing comment
+                """)
+        node_invalid_trailing_comment.file = filename
+        node_invalid_trailing_comment.path = filename
+
+        self.checker_test_object.checker.process_tokens(
+            utils.tokenize_module(node_invalid_trailing_comment))
+
+        message = testutils.Message(
+            msg_id='invalid-trailing-comment',
+            line=3)
+
+        with self.checker_test_object.assertAddsMessages(message):
+            temp_file.close()
+
+    def test_no_space_before_pylint_pragma(self):
+        node_no_space_before_pylint_pragma = astroid.scoped_nodes.Module(
+            name='test', doc='Custom test')
+        temp_file = tempfile.NamedTemporaryFile()
+        filename = temp_file.name
+
+        with python_utils.open_file(filename, 'w') as tmp:
+            tmp.write(
+                u"""# coding: utf-8
+
+                    import sys   #pylint: no space
+                """)
+        node_no_space_before_pylint_pragma.file = filename
+        node_no_space_before_pylint_pragma.path = filename
+
+        self.checker_test_object.checker.process_tokens(
+            utils.tokenize_module(node_no_space_before_pylint_pragma))
+
+        message = testutils.Message(
+            msg_id='no-space-before-pylint-pragma',
+            line=3)
+
+        with self.checker_test_object.assertAddsMessages(message):
+            temp_file.close()
+
+    def test_valid_pylint_pragma(self):
+        node_valid_pylint_pragma = astroid.scoped_nodes.Module(
+            name='test',
+            doc='Custom test')
+        temp_file = tempfile.NamedTemporaryFile()
+        filename = temp_file.name
+
+        with python_utils.open_file(filename, 'w') as tmp:
+            tmp.write(
+                u"""# coding: utf-8
+
+                    import sys   # pylint: this is fine
+                """)
+        node_valid_pylint_pragma.file = filename
+        node_valid_pylint_pragma.path = filename
+
+        self.checker_test_object.checker.process_tokens(
+            utils.tokenize_module(node_valid_pylint_pragma))
+
+        with self.checker_test_object.assertNoMessages():
+            temp_file.close()
+
 
 class BlankLineBelowFileOverviewCheckerTests(unittest.TestCase):
 

--- a/scripts/linters/test_files/invalid_trailing_comments.py
+++ b/scripts/linters/test_files/invalid_trailing_comments.py
@@ -1,0 +1,43 @@
+# coding: utf-8
+#
+# Copyright 2020 The Oppia Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Python file with invalid syntax, used by scripts/linters/
+python_linter_test. This file uses inline / trailing comments, which go against
+Oppia's style guidelines.  Note that the pylint pragmas are allowed.
+"""
+
+from __future__ import absolute_import  # pylint: disable=import-only-modules
+from __future__ import unicode_literals  # pylint: disable=import-only-modules
+
+import python_utils
+
+
+class FakeClass(python_utils.OBJECT):
+    """This is a fake docstring for invalid syntax purposes."""
+
+    def __init__(self, fake_arg):
+        self.fake_arg = fake_arg  # pylint: allowed
+
+    def fake_method(self, name):  # This is an inline comment that is useless
+        """This doesn't do anything.
+
+        Args:
+            name: str. Means nothing.
+
+        Yields:
+            tuple(str, str). The argument passed in but twice in a tuple.
+        """
+        yield (name, name)  # Another illegal inline comment


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #8423 .
2. This PR does the following: Adds a lint check that prohibits the use of trailing or inline comments, while still allowing the use of pylint pragmas.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

After adding the new lint check and 3 test cases to pylint_extensions_test.py, all of the lint tests passed successfully:
<img width="556" alt="Screen Shot 2021-05-07 at 10 19 26 PM" src="https://user-images.githubusercontent.com/38113604/117522587-4b5e1b80-af82-11eb-98c2-cf137314f686.png">


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
