### PR TITLE
Refactoring of filter_skills_by_mastery for Python Migration

### DIFF
--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -1071,7 +1071,7 @@ def filtered_skills_with_none_type_keys(degrees_of_mastery):
     id.
 
     Args:
-        degrees_of_mastery: dict. (skill_ids, float|None)
+        degrees_of_mastery: dict. The dict of type (skill_ids, float|None)
 
     Returns:
         list. Sorted list of skill ids.

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -1065,6 +1065,34 @@ def skill_has_associated_questions(skill_id):
     return len(question_ids) > 0
 
 
+def filtered_skills_with_none_type_keys(degrees_of_mastery):
+    """Given a dict of skills id's with there corresponding
+    mastery. It first split the dict and then returns a list of skill
+    id.
+    
+    Args:
+        degrees_of_mastery: dict. (skill_ids, float|None)
+    
+    Returns:
+        sorted list of skill ids."""
+
+    skill_dict_with_float_value = {skill_id: degree 
+        for skill_id,degree in degrees_of_mastery.items() if degree is not None}
+
+    sorted_skill_ids_with_float_value = sorted(
+        skill_dict_with_float_value, key=skill_dict_with_float_value.get)
+
+    skill_ids_with_none_value = [skill_id 
+        for skill_id,degree in degrees_of_mastery.items() if degree is None]
+    
+    if feconf.MAX_NUMBER_OF_SKILL_IDS <= len(skill_ids_with_none_value):
+        return skill_ids_with_none_value[:feconf.MAX_NUMBER_OF_SKILL_IDS]
+    else:
+        return (skill_ids_with_none_value + sorted_skill_ids_with_float_value[:(
+            feconf.MAX_NUMBER_OF_SKILL_IDS - len(skill_ids_with_none_value))])
+
+    
+
 def filter_skills_by_mastery(user_id, skill_ids):
     """Given a list of skill_ids, it returns a list of
     feconf.MAX_NUMBER_OF_SKILL_IDS skill_ids in which the user has
@@ -1078,12 +1106,9 @@ def filter_skills_by_mastery(user_id, skill_ids):
     Returns:
         list(str). A list of the filtered skill_ids.
     """
-    degrees_of_mastery = get_multi_user_skill_mastery(user_id, skill_ids)
+    degrees_of_mastery = get_multi_user_skill_mastery(user_id, skill_ids)    
 
-    sorted_skill_ids = sorted(
-        degrees_of_mastery, key=degrees_of_mastery.get)
-
-    filtered_skill_ids = sorted_skill_ids[:feconf.MAX_NUMBER_OF_SKILL_IDS]
+    filtered_skill_ids = filtered_skills_with_none_type_keys(degrees_of_mastery)
 
     # Arranges the skill_ids in the order as it was received.
     arranged_filtered_skill_ids = []

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -1069,29 +1069,29 @@ def filtered_skills_with_none_type_keys(degrees_of_mastery):
     """Given a dict of skills id's with there corresponding
     mastery. It first split the dict and then returns a list of skill
     id.
-    
+
     Args:
         degrees_of_mastery: dict. (skill_ids, float|None)
-    
-    Returns:
-        sorted list of skill ids."""
 
-    skill_dict_with_float_value = {skill_id: degree 
-        for skill_id,degree in degrees_of_mastery.items() if degree is not None}
+    Returns:
+        list. Sorted list of skill ids."""
+
+    skill_dict_with_float_value = {
+        skill_id: degree for skill_id, degree in degrees_of_mastery.items()
+            if degree is not None}
 
     sorted_skill_ids_with_float_value = sorted(
         skill_dict_with_float_value, key=skill_dict_with_float_value.get)
 
     skill_ids_with_none_value = [skill_id 
-        for skill_id,degree in degrees_of_mastery.items() if degree is None]
-    
+        for skill_id, degree in degrees_of_mastery.items() if degree is None]
+
     if feconf.MAX_NUMBER_OF_SKILL_IDS <= len(skill_ids_with_none_value):
         return skill_ids_with_none_value[:feconf.MAX_NUMBER_OF_SKILL_IDS]
     else:
         return (skill_ids_with_none_value + sorted_skill_ids_with_float_value[:(
             feconf.MAX_NUMBER_OF_SKILL_IDS - len(skill_ids_with_none_value))])
 
-    
 
 def filter_skills_by_mastery(user_id, skill_ids):
     """Given a list of skill_ids, it returns a list of

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -1066,15 +1066,14 @@ def skill_has_associated_questions(skill_id):
 
 
 def filtered_skills_with_none_type_keys(degrees_of_mastery):
-    """Given a dict of skills id's with there corresponding
-    mastery. It first split the dict and then returns a list of skill
-    id.
+    """Sort the dict based on the mastery value.
 
     Args:
-        degrees_of_mastery: dict. The dict of type (skill_ids, float|None)
+        degrees_of_mastery: dict(str, float|None). Dict mapping
+        skill ids to mastery level.
 
     Returns:
-        list. Sorted list of skill ids.
+        list. List of the initial skill id's based on the mastery level.
     """
 
     skill_dict_with_float_value = {
@@ -1088,11 +1087,10 @@ def filtered_skills_with_none_type_keys(degrees_of_mastery):
         skill_id for skill_id, degree in degrees_of_mastery.items()
         if degree is None]
 
-    if feconf.MAX_NUMBER_OF_SKILL_IDS <= len(skill_ids_with_none_value):
-        return skill_ids_with_none_value[:feconf.MAX_NUMBER_OF_SKILL_IDS]
-    else:
-        return (skill_ids_with_none_value + sorted_skill_ids_with_float_value[:(
-            feconf.MAX_NUMBER_OF_SKILL_IDS - len(skill_ids_with_none_value))])
+    sorted_skill_ids = (
+        skill_ids_with_none_value + sorted_skill_ids_with_float_value)
+
+    return sorted_skill_ids[:feconf.MAX_NUMBER_OF_SKILL_IDS]
 
 
 def filter_skills_by_mastery(user_id, skill_ids):

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -1065,31 +1065,29 @@ def skill_has_associated_questions(skill_id):
     return len(question_ids) > 0
 
 
-def filtered_skills_with_none_type_keys(degrees_of_mastery):
+def get_sorted_skill_ids(degrees_of_mastery):
     """Sort the dict based on the mastery value.
 
     Args:
         degrees_of_mastery: dict(str, float|None). Dict mapping
-            skill ids to mastery level.
+            skill ids to mastery level. The mastery level can be
+            float or None.
 
     Returns:
         list. List of the initial skill id's based on the mastery level.
     """
-
     skill_dict_with_float_value = {
         skill_id: degree for skill_id, degree in degrees_of_mastery.items()
         if degree is not None}
 
     sorted_skill_ids_with_float_value = sorted(
         skill_dict_with_float_value, key=skill_dict_with_float_value.get)
-
     skill_ids_with_none_value = [
         skill_id for skill_id, degree in degrees_of_mastery.items()
         if degree is None]
 
     sorted_skill_ids = (
         skill_ids_with_none_value + sorted_skill_ids_with_float_value)
-
     return sorted_skill_ids[:feconf.MAX_NUMBER_OF_SKILL_IDS]
 
 
@@ -1108,7 +1106,7 @@ def filter_skills_by_mastery(user_id, skill_ids):
     """
     degrees_of_mastery = get_multi_user_skill_mastery(user_id, skill_ids)
 
-    filtered_skill_ids = filtered_skills_with_none_type_keys(degrees_of_mastery)
+    filtered_skill_ids = get_sorted_skill_ids(degrees_of_mastery)
 
     # Arranges the skill_ids in the order as it was received.
     arranged_filtered_skill_ids = []

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -1070,7 +1070,7 @@ def filtered_skills_with_none_type_keys(degrees_of_mastery):
 
     Args:
         degrees_of_mastery: dict(str, float|None). Dict mapping
-        skill ids to mastery level.
+            skill ids to mastery level.
 
     Returns:
         list. List of the initial skill id's based on the mastery level.

--- a/core/domain/skill_services.py
+++ b/core/domain/skill_services.py
@@ -1074,17 +1074,19 @@ def filtered_skills_with_none_type_keys(degrees_of_mastery):
         degrees_of_mastery: dict. (skill_ids, float|None)
 
     Returns:
-        list. Sorted list of skill ids."""
+        list. Sorted list of skill ids.
+    """
 
     skill_dict_with_float_value = {
         skill_id: degree for skill_id, degree in degrees_of_mastery.items()
-            if degree is not None}
+        if degree is not None}
 
     sorted_skill_ids_with_float_value = sorted(
         skill_dict_with_float_value, key=skill_dict_with_float_value.get)
 
-    skill_ids_with_none_value = [skill_id 
-        for skill_id, degree in degrees_of_mastery.items() if degree is None]
+    skill_ids_with_none_value = [
+        skill_id for skill_id, degree in degrees_of_mastery.items()
+        if degree is None]
 
     if feconf.MAX_NUMBER_OF_SKILL_IDS <= len(skill_ids_with_none_value):
         return skill_ids_with_none_value[:feconf.MAX_NUMBER_OF_SKILL_IDS]
@@ -1106,7 +1108,7 @@ def filter_skills_by_mastery(user_id, skill_ids):
     Returns:
         list(str). A list of the filtered skill_ids.
     """
-    degrees_of_mastery = get_multi_user_skill_mastery(user_id, skill_ids)    
+    degrees_of_mastery = get_multi_user_skill_mastery(user_id, skill_ids)
 
     filtered_skill_ids = filtered_skills_with_none_type_keys(degrees_of_mastery)
 

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -1289,6 +1289,31 @@ class SkillMasteryServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             degrees_of_mastery, {skill_id_4: 0.3, skill_id_5: 0.5})
 
+    def test_get_sorted_skill_ids(self):
+        masteries = [self.DEGREE_OF_MASTERY_1, self.DEGREE_OF_MASTERY_2, None]
+
+        for _ in python_utils.RANGE(feconf.MAX_NUMBER_OF_SKILL_IDS):
+            skill_id = skill_services.get_new_skill_id()
+            mastery = random.random()
+            masteries.append(mastery)
+            skill_services.create_user_skill_mastery(
+                self.USER_ID, skill_id, mastery)
+            self.SKILL_IDS.append(skill_id)
+        
+        masteries.sort()
+        degrees_of_masteries = skill_services.get_multi_user_skill_mastery(
+            self.USER_ID, self.SKILL_IDS)
+        arranged_filtered_skill_ids = skill_services.filter_skills_by_mastery(
+            self.USER_ID, self.SKILL_IDS)
+
+        self.assertEqual(
+            len(arranged_filtered_skill_ids), feconf.MAX_NUMBER_OF_SKILL_IDS)
+
+        for i in python_utils.RANGE(feconf.MAX_NUMBER_OF_SKILL_IDS):
+            self.assertIn(
+                degrees_of_masteries[arranged_filtered_skill_ids[i]],
+                masteries[:feconf.MAX_NUMBER_OF_SKILL_IDS])
+
     def test_filter_skills_by_mastery(self):
         # Create feconf.MAX_NUMBER_OF_SKILL_IDS + 3 skill_ids
         # to test two things:

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -1299,7 +1299,7 @@ class SkillMasteryServicesUnitTests(test_utils.GenericTestBase):
             skill_services.create_user_skill_mastery(
                 self.USER_ID, skill_id, mastery)
             self.SKILL_IDS.append(skill_id)
-        
+
         masteries.sort()
         degrees_of_masteries = skill_services.get_multi_user_skill_mastery(
             self.USER_ID, self.SKILL_IDS)


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of N/A.
2. This PR does the following: The PR creates a new function which handle the sorting of the dict with None keys.  

## Implementation
The dict will be divided into two parts. first will be a list of skill id's which have None mastery value and second will be the dict of unsorted skill_ids, The dict with float value will be sorted as per the builtin function(sorted) and a list will be created with sorting based on the float values. In the end the required number of elements from both the list will be returned.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
Note I have taken the `MAX_NUMBER_OF_SKILL_IDS` to be 3 for demo purpose.
result for original code:
![Screenshot from 2021-05-12 20-25-21](https://user-images.githubusercontent.com/46648172/117997416-900dfc00-b360-11eb-96c4-98f6730be13b.png)
result for python 2.7 modified code:
![Screenshot from 2021-05-12 20-26-36](https://user-images.githubusercontent.com/46648172/117997411-8e443880-b360-11eb-9e86-0cbe9be77d17.png)
result for python3.8 for modified code
![Screenshot from 2021-05-12 20-27-16](https://user-images.githubusercontent.com/46648172/117997402-8c7a7500-b360-11eb-8da5-4b182ee505b0.png)



<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
