### PR TITLE
Fixes Enum bug

### DIFF
--- a/python_utils.py
+++ b/python_utils.py
@@ -512,7 +512,8 @@ def create_enum(*sequential):
     enum_values = dict(ZIP(sequential, sequential))
     try:
         from enum import Enum # pylint: disable=import-only-modules
-        return Enum(str('Enum'), enum_values)
+        # The type() of argument 1 in Enum must be str, not unicode
+        return Enum(str('Enum'), enum_values) # pylint: disable=disallowed-function-calls
     except ImportError:
         _enums = {}
         for name, value in enum_values.items():

--- a/python_utils.py
+++ b/python_utils.py
@@ -512,7 +512,7 @@ def create_enum(*sequential):
     enum_values = dict(ZIP(sequential, sequential))
     try:
         from enum import Enum # pylint: disable=import-only-modules
-        # The type() of argument 1 in Enum must be str, not unicode
+        # The type() of argument 1 in Enum must be str, not unicode.
         return Enum(str('Enum'), enum_values) # pylint: disable=disallowed-function-calls
     except ImportError:
         _enums = {}

--- a/python_utils.py
+++ b/python_utils.py
@@ -512,7 +512,7 @@ def create_enum(*sequential):
     enum_values = dict(ZIP(sequential, sequential))
     try:
         from enum import Enum # pylint: disable=import-only-modules
-        return Enum('Enum', enum_values)
+        return Enum(str('Enum'), enum_values)
     except ImportError:
         _enums = {}
         for name, value in enum_values.items():


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: Fixes the enum bug that throws `TypeError: type() argument 1 must be string, not unicode`

**Stack Trace**
```
File "/base/data/home/apps/s~oppiaserver-backup-migration/test-roles.435133718326155695/python_utils.py", line 514, in create_enum
return Enum('Enum', enum_values)
File "/base/alloc/tmpfs/dynamic_runtimes/python27g/64b1229e467d7bc0/python27/python27_lib/versions/third_party/enum-0.9.23/enum/__init__.py", line 325, in __call__
return cls._create_(value, names, module=module, type=type)
File "/base/alloc/tmpfs/dynamic_runtimes/python27g/64b1229e467d7bc0/python27/python27_lib/versions/third_party/enum-0.9.23/enum/__init__.py", line 433, in _create_
enum_class = metacls.__new__(metacls, class_name, bases, classdict)
File "/base/alloc/tmpfs/dynamic_runtimes/python27g/64b1229e467d7bc0/python27/python27_lib/versions/third_party/enum-0.9.23/enum/__init__.py", line 190, in __new__
enum_class = super(EnumMeta, metacls).__new__(metacls, cls, bases, classdict)
TypeError: type() argument 1 must be string, not unicode
```

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
Proof that changes are correct is not required since its a backend bug fix.

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
