### PR TITLE
Fix #12841: Exploration player i18n bug fixes

### DIFF
--- a/core/templates/pages/exploration-player-page/services/content-translation-manager.service.ts
+++ b/core/templates/pages/exploration-player-page/services/content-translation-manager.service.ts
@@ -19,6 +19,7 @@
 import { downgradeInjectable } from '@angular/upgrade/static';
 import { EventEmitter, Injectable } from '@angular/core';
 import cloneDeep from 'lodash/cloneDeep';
+import isObject from 'lodash/isObject';
 
 import { BaseTranslatableObject, InteractionRuleInputs } from
   'interactions/rule-input-defs';
@@ -144,7 +145,8 @@ export class ContentTranslationManagerService {
 
     const contentTranslation = writtenTranslations.translationsMapping[
       card.contentId][languageCode];
-    const contentTranslationText = contentTranslation.getTranslation();
+    const contentTranslationText = (
+      contentTranslation && contentTranslation.getTranslation());
 
     // The isString() check is needed for the TypeScript compiler to narrow the
     // type down from string|string[] to string. See "Using type predicates" at
@@ -269,7 +271,7 @@ export class ContentTranslationManagerService {
   _isTranslatableObject(
       ruleInputValue: InteractionRuleInputs):
       ruleInputValue is BaseTranslatableObject {
-    return 'contentId' in ruleInputValue;
+    return isObject(ruleInputValue) && 'contentId' in ruleInputValue;
   }
 
   _isString(translation: string|string[]): translation is string {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #12841.
2. This PR does the following:
- Fixes #12841. Usage of "in" operator is not valid for all ruleInput values. Some values may not be objects (e.g. NumericInput rules). Fix is to check if the value is an object before doing the "in" operation.
- Fixes a bug related to missing translated text. If a card is added post-publish and it has not been translated, the player page for that card would error and block the user. Fix was to add a guard check for this case. 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
Before fix (issue 1).
![error-1](https://user-images.githubusercontent.com/11008603/118737071-ba305400-b861-11eb-9343-9d50b0ca3278.gif)

After fix (issue 1).
![error-1-fix](https://user-images.githubusercontent.com/11008603/118737080-bdc3db00-b861-11eb-9cda-14469657c692.gif)


Before fix (issue 2).
![error](https://user-images.githubusercontent.com/11008603/118736717-e0092900-b860-11eb-9ac9-25dd3ecc91dd.gif)

After fix (issue 2).
![not-blocked](https://user-images.githubusercontent.com/11008603/118736720-e1d2ec80-b860-11eb-9675-35c59e201105.gif)

-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
