### PR TITLE
Fix #12264: Disproportionate topic thumbnail upload image

### DIFF
--- a/core/templates/components/forms/custom-forms-directives/thumbnail-uploader.directive.html
+++ b/core/templates/components/forms/custom-forms-directives/thumbnail-uploader.directive.html
@@ -12,12 +12,14 @@
       <oppia-thumbnail-display ng-show="!thumbnailIsLoading"
                                [img-src]="editableThumbnailDataUrl"
                                [classes]="['img-thumbnail', 'protractor-test-custom-photo']"
-                               [background]="getBgColor()">
+                               [background]="getBgColor()"
+                               [aspectRatio]="4:3">
       </oppia-thumbnail-display>
       <oppia-thumbnail-display ng-if="useLocalStorage && newThumbnailDataUrl"
                                [img-src]="newThumbnailDataUrl"
                                [classes]="['img-thumbnail', 'protractor-test-custom-photo']"
-                               [background]="localStorageBgcolor">
+                               [background]="localStorageBgcolor"
+                               [aspectRatio]="4:3">
       </oppia-thumbnail-display>
     </div>
   </div>
@@ -25,13 +27,13 @@
 
 <style>
   thumbnail-uploader .thumbnail-editor {
-    height: 100px;
+    height: 200px;
   }
 
   thumbnail-uploader .oppia-editable-section {
     border-radius: 0.25rem;
     display: table-cell;
-    height: 100px;
+    height: 190px;
     text-align: center;
     vertical-align: middle;
     width: 180px;

--- a/core/templates/components/forms/custom-forms-directives/thumbnail-uploader.directive.html
+++ b/core/templates/components/forms/custom-forms-directives/thumbnail-uploader.directive.html
@@ -13,13 +13,13 @@
                                [img-src]="editableThumbnailDataUrl"
                                [classes]="['img-thumbnail', 'protractor-test-custom-photo']"
                                [background]="getBgColor()"
-                               [aspectRatio]="4:3">
+                               [aspect-ratio]="'4:3'">
       </oppia-thumbnail-display>
       <oppia-thumbnail-display ng-if="useLocalStorage && newThumbnailDataUrl"
                                [img-src]="newThumbnailDataUrl"
                                [classes]="['img-thumbnail', 'protractor-test-custom-photo']"
                                [background]="localStorageBgcolor"
-                               [aspectRatio]="4:3">
+                               [aspect-ratio]="'4:3'">
       </oppia-thumbnail-display>
     </div>
   </div>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #12264.
2. This PR does the following: Now the thumbnail looks perfect and the ratio in which the image uploaded is 4:3.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

![Screenshot from 2021-05-26 12-52-21](https://user-images.githubusercontent.com/44300735/119693092-97a5c880-be69-11eb-95b2-326492447e75.png)

![Screenshot from 2021-05-26 12-52-14](https://user-images.githubusercontent.com/44300735/119693189-ad1af280-be69-11eb-8385-13dfb7890e31.png)


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
