### PR TITLE
Fix for 'Failed to load resource: net::ERR_UNKNOWN_URL_SCHEME' console error flake.

### DIFF
--- a/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.html
+++ b/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.html
@@ -8,7 +8,7 @@
 </ng-template>
 
 <div class="conversation-skin-learner-answer-container">
-  <img class="conversation-skin-user-avatar rounded-circle" [src]="profilePicture" alt="">
+  <img class="conversation-skin-user-avatar rounded-circle" [src]="decodedProfilePicture ? decodedProfilePicture : ''" alt="">
   <div *ngIf="!data.isHint">
     <div *ngIf="getShortAnswerHtml()"
          [ngbPopover]="popContent" triggers="manual" (click)="togglePopover()"

--- a/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.ts
@@ -42,6 +42,7 @@ export class InputResponsePairComponent {
   @Input() inputResponsePairId: string;
   @Input() isLastPair: boolean;
   OPPIA_AVATAR_LINK_URL: string;
+  decodedProfilePicture: string;
   @ViewChild('popover') popover: NgbPopover;
 
   constructor(
@@ -54,7 +55,7 @@ export class InputResponsePairComponent {
   ) {}
 
   ngOnInit(): void {
-    this.profilePicture = decodeURIComponent(this.profilePicture);
+    this.decodedProfilePicture = decodeURIComponent(this.profilePicture);
   }
 
   isVideoRteElementPresentInResponse(): boolean {


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: Fixes the flake introduced in #12853.

**What was the flake?**
After the completion of the suite, we check for errors in the console. Before the PR, there was no occurrence of the `'Failed to load resource: net::ERR_UNKNOWN_URL_SCHEME'` error but now the migrated component started throwing this error occasionally. 

**Let us understand the error:**
This error is thrown by the **browser** (not angular or our code).
Browser throws this error when we try to load encoded image data(as a security feature, encoded data can lead to security vulnerability e.g. phishing) using `<img src="imageData">`.
To avoid this error, we first decode the image data using **decodeURIComponent** (decoded data cannot cause vulnerabilites) and load it with the `img src` attribute.

**The problematic code**
`input-response-pair.component.ts`:
![image](https://user-images.githubusercontent.com/24855641/121411379-2eea4000-c981-11eb-99d2-2e3763bde886.png)

`input-response-pair.component.html`:
![image](https://user-images.githubusercontent.com/24855641/121411758-9902e500-c981-11eb-9db6-3dcc5790da91.png)

In the component, `profilePicture` data is passed by the parent component/directive in encoded format
i.e. it looks like this
![image](https://user-images.githubusercontent.com/24855641/121413292-2bf04f00-c983-11eb-89b8-0571c746fd7e.png)
notice the % with 2 hexadecimal numbers present in the data.

then it is decoded in the ngOnInit lifecycle method using decodeURIComponent() function.
It same data looks like this.
![image](https://user-images.githubusercontent.com/24855641/121413472-57733980-c983-11eb-8d7c-7df6bd4c31ee.png)
notice the percent symbol with 2 hexadecimal numbers is replaced with a character.

**What is problematic with this code?**
Here, the issue is `profilePicture` variable, first contains encoded image data, and then during ngOnInit, it is assigned the decoded data.
As angular compiles and renders the template before the triggering ngOnInit. So, during this duration, an encoded (error causing) image data is provided to `img src` tag, and quickly with the execution of ngOnInit, a decoded (safe) data replaces it.

**Why this is occasional (flake)?**

During the above process, there is a race between browser and angular.
As soon as the component's template is injected into the dom, the browser starts its checks and tries to find the encoded data in `img src` tag, and throws an error.

Whereas, angular tries to trigger ngOnInit.

So, in the cases where the browser wins the race and finds the encoded data before ngOnInit, an error is thrown to the console.
Otherwise, if ngOnInit is executed first, we don't get a console error.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct


https://user-images.githubusercontent.com/24855641/121410451-38bf7380-c980-11eb-82a3-91cc003095c4.mp4



## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
