### PR TITLE
Revert "Add CLA Check using Github Action"

### DIFF
--- a/.github/workflows/oppiabot.yml
+++ b/.github/workflows/oppiabot.yml
@@ -4,21 +4,13 @@ on:
   issues:
     types:
       - labeled
-  pull_request_target:
-    branches:
-      - develop
-      - release-*
 
 jobs:
   oppiabot:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Github Actions from Oppiabot
-        uses: oppia/oppiabot@1.3.0
+      - name: Ensure that appropriate labels are added to issues
+        uses: oppia/oppiabot@1.1.0
         with:
           repo-token: ${{secrets.GITHUB_TOKEN}}
-        env:
-          SHEETS_TOKEN: ${{ secrets.SHEETS_TOKEN }}
-          SHEETS_CRED: ${{ secrets.SHEETS_CRED }}
-          SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}


### PR DESCRIPTION
Reverts oppia/oppia#13141. I opened this just in case #13141 causes failures on develop, since I merged it when it had the STALE BUILD label on.