### PR TITLE
Fix #bug1 when use pip mirrors

### DIFF
--- a/scripts/install_backend_python_libs.py
+++ b/scripts/install_backend_python_libs.py
@@ -133,7 +133,7 @@ def _get_requirements_file_contents():
         common.COMPILED_REQUIREMENTS_FILE_PATH, 'r') as f:
         trimmed_lines = (line.strip() for line in f.readlines())
         for line_num, line in enumerate(trimmed_lines, start=1):
-            if not line or line.startswith('#'):
+            if not line or line.startswith('#') or line.startswith('--'):
                 continue
 
             elif line.startswith('git'):


### PR DESCRIPTION
1. This PR fixes or fixes part of #[1].
2. This PR does the following: when use pip mirrors, the requirements.txt generate by the script will contains such as --global-url, --trusted-host