### PR TITLE
Fix wipeout on test and backup server

### DIFF
--- a/core/domain/wipeout_service.py
+++ b/core/domain/wipeout_service.py
@@ -226,7 +226,8 @@ def delete_users_pending_to_be_deleted():
         )
 
     email_subject = 'User Deletion job result'
-    email_manager.send_mail_to_admin(email_subject, email_message)
+    if not feconf.CAN_SEND_EMAILS:
+        email_manager.send_mail_to_admin(email_subject, email_message)
 
 
 def check_completion_of_user_deletion():
@@ -250,20 +251,18 @@ def check_completion_of_user_deletion():
         # or 'FAILURE'.
         completion_status = run_user_deletion_completion(
             pending_deletion_request)
-        email_message += '\n'
-        email_message += '-----------------------------------'
-        email_message += '\n'
-        email_message += (
-            'PendingDeletionRequestModel ID: %s'
-            'User ID: %s'
-            'Completion status: %s'
-        ) % (
-            request_model.id, pending_deletion_request.user_id,
-            completion_status
-        )
-
-        email_subject = 'Completion of User Deletion job result'
-        email_manager.send_mail_to_admin(email_subject, email_message)
+        if not feconf.CAN_SEND_EMAILS:
+            email_message += '\n-----------------------------------\n'
+            email_message += (
+                'PendingDeletionRequestModel ID: %s\n'
+                'User ID: %s\n'
+                'Completion status: %s\n'
+            ) % (
+                request_model.id, pending_deletion_request.user_id,
+                completion_status
+            )
+            email_subject = 'Completion of User Deletion job result'
+            email_manager.send_mail_to_admin(email_subject, email_message)
 
 
 def run_user_deletion(pending_deletion_request):
@@ -310,12 +309,18 @@ def run_user_deletion_completion(pending_deletion_request):
         if pending_deletion_request.normalized_long_term_username is not None:
             user_services.save_deleted_username(
                 pending_deletion_request.normalized_long_term_username)
-        email_manager.send_account_deleted_email(
-            pending_deletion_request.user_id, pending_deletion_request.email)
+            if not feconf.CAN_SEND_EMAILS:
+                email_manager.send_account_deleted_email(
+                    pending_deletion_request.user_id,
+                    pending_deletion_request.email
+                )
         return wipeout_domain.USER_VERIFICATION_SUCCESS
     else:
-        email_manager.send_account_deletion_failed_email(
-            pending_deletion_request.user_id, pending_deletion_request.email)
+        if not feconf.CAN_SEND_EMAILS:
+            email_manager.send_account_deletion_failed_email(
+                pending_deletion_request.user_id,
+                pending_deletion_request.email
+            )
         pending_deletion_request.deletion_complete = False
         save_pending_deletion_requests([pending_deletion_request])
         return wipeout_domain.USER_VERIFICATION_FAILURE

--- a/core/domain/wipeout_service.py
+++ b/core/domain/wipeout_service.py
@@ -213,20 +213,18 @@ def delete_users_pending_to_be_deleted():
             request_model.id)
         # The final status of the deletion. Either 'SUCCESS' or 'ALREADY DONE'.
         deletion_status = run_user_deletion(pending_deletion_request)
-        email_message += '\n'
-        email_message += '-----------------------------------'
-        email_message += '\n'
+        email_message += '\n-----------------------------------\n'
         email_message += (
-            'PendingDeletionRequestModel ID: %s'
-            'User ID: %s'
-            'Deletion status: %s'
+            'PendingDeletionRequestModel ID: %s\n'
+            'User ID: %s\n'
+            'Deletion status: %s\n'
         ) % (
             request_model.id, pending_deletion_request.user_id,
             deletion_status
         )
 
     email_subject = 'User Deletion job result'
-    if not feconf.CAN_SEND_EMAILS:
+    if feconf.CAN_SEND_EMAILS:
         email_manager.send_mail_to_admin(email_subject, email_message)
 
 
@@ -251,7 +249,7 @@ def check_completion_of_user_deletion():
         # or 'FAILURE'.
         completion_status = run_user_deletion_completion(
             pending_deletion_request)
-        if not feconf.CAN_SEND_EMAILS:
+        if feconf.CAN_SEND_EMAILS:
             email_message += '\n-----------------------------------\n'
             email_message += (
                 'PendingDeletionRequestModel ID: %s\n'
@@ -309,14 +307,14 @@ def run_user_deletion_completion(pending_deletion_request):
         if pending_deletion_request.normalized_long_term_username is not None:
             user_services.save_deleted_username(
                 pending_deletion_request.normalized_long_term_username)
-            if not feconf.CAN_SEND_EMAILS:
+            if feconf.CAN_SEND_EMAILS:
                 email_manager.send_account_deleted_email(
                     pending_deletion_request.user_id,
                     pending_deletion_request.email
                 )
         return wipeout_domain.USER_VERIFICATION_SUCCESS
     else:
-        if not feconf.CAN_SEND_EMAILS:
+        if feconf.CAN_SEND_EMAILS:
             email_manager.send_account_deletion_failed_email(
                 pending_deletion_request.user_id,
                 pending_deletion_request.email

--- a/core/domain/wipeout_service.py
+++ b/core/domain/wipeout_service.py
@@ -307,11 +307,11 @@ def run_user_deletion_completion(pending_deletion_request):
         if pending_deletion_request.normalized_long_term_username is not None:
             user_services.save_deleted_username(
                 pending_deletion_request.normalized_long_term_username)
-            if feconf.CAN_SEND_EMAILS:
-                email_manager.send_account_deleted_email(
-                    pending_deletion_request.user_id,
-                    pending_deletion_request.email
-                )
+        if feconf.CAN_SEND_EMAILS:
+            email_manager.send_account_deleted_email(
+                pending_deletion_request.user_id,
+                pending_deletion_request.email
+            )
         return wipeout_domain.USER_VERIFICATION_SUCCESS
     else:
         if feconf.CAN_SEND_EMAILS:

--- a/core/domain/wipeout_service_test.py
+++ b/core/domain/wipeout_service_test.py
@@ -570,7 +570,8 @@ class WipeoutServiceRunFunctionsTests(test_utils.GenericTestBase):
             auth_services.verify_external_auth_associations_are_deleted(
                 self.user_1_id))
 
-    def test_run_user_deletion_completion_with_user_wrongly_deleted(self):
+    def test_run_user_deletion_completion_user_wrongly_deleted_emails_enabled(
+            self):
         wipeout_service.run_user_deletion(self.pending_deletion_request)
 
         user_models.CompletedActivitiesModel(
@@ -589,7 +590,29 @@ class WipeoutServiceRunFunctionsTests(test_utils.GenericTestBase):
             expected_args=[('WIPEOUT: Account deletion failed', email_content)]
         )
 
-        with send_email_swap:
+        with send_email_swap, self.swap(feconf, 'CAN_SEND_EMAILS', True):
+            self.assertEqual(
+                wipeout_service.run_user_deletion_completion(
+                    self.pending_deletion_request),
+                wipeout_domain.USER_VERIFICATION_FAILURE)
+
+        self.assertIsNotNone(
+            user_models.UserSettingsModel.get_by_id(self.user_1_id))
+        self.assertIsNotNone(
+            auth_models.UserAuthDetailsModel.get_by_id(self.user_1_id))
+        self.assertIsNotNone(
+            user_models.PendingDeletionRequestModel.get_by_id(self.user_1_id))
+
+    def test_run_user_deletion_completion_user_wrongly_deleted_emails_disabled(
+            self):
+        wipeout_service.run_user_deletion(self.pending_deletion_request)
+
+        user_models.CompletedActivitiesModel(
+            id=self.user_1_id, exploration_ids=[], collection_ids=[],
+            story_ids=[], learnt_topic_ids=[]
+        ).put()
+
+        with self.swap(feconf, 'CAN_SEND_EMAILS', False):
             self.assertEqual(
                 wipeout_service.run_user_deletion_completion(
                     self.pending_deletion_request),
@@ -4935,9 +4958,13 @@ class PendingUserDeletionTaskServiceTests(test_utils.GenericTestBase):
 
         self.send_mail_to_admin_swap = self.swap(
             email_manager, 'send_mail_to_admin', _mock_send_mail_to_admin)
+        self.can_send_email_swap = self.swap(
+            feconf, 'CAN_SEND_EMAILS', True)
+        self.cannot_send_email_swap = self.swap(
+            feconf, 'CAN_SEND_EMAILS', False)
 
-    def test_repeated_deletion_is_successful(self):
-        with self.send_mail_to_admin_swap:
+    def test_repeated_deletion_is_successful_when_emails_enabled(self):
+        with self.send_mail_to_admin_swap, self.can_send_email_swap:
             wipeout_service.delete_users_pending_to_be_deleted()
             self.assertIn('SUCCESS', self.email_bodies[0])
             self.assertIn(self.user_1_id, self.email_bodies[0])
@@ -4945,8 +4972,15 @@ class PendingUserDeletionTaskServiceTests(test_utils.GenericTestBase):
             self.assertIn('ALREADY DONE', self.email_bodies[1])
             self.assertIn(self.user_1_id, self.email_bodies[1])
 
+    def test_repeated_deletion_is_successful_when_emails_disabled(self):
+        with self.send_mail_to_admin_swap, self.cannot_send_email_swap:
+            wipeout_service.delete_users_pending_to_be_deleted()
+            self.assertEqual(len(self.email_bodies), 0)
+            wipeout_service.delete_users_pending_to_be_deleted()
+            self.assertEqual(len(self.email_bodies), 0)
+
     def test_regular_deletion_is_successful(self):
-        with self.send_mail_to_admin_swap:
+        with self.send_mail_to_admin_swap, self.can_send_email_swap:
             wipeout_service.delete_users_pending_to_be_deleted()
         self.assertIn('SUCCESS', self.email_bodies[0])
         self.assertIn(self.user_1_id, self.email_bodies[0])
@@ -5008,12 +5042,21 @@ class CheckCompletionOfUserDeletionTaskServiceTests(
 
         self.send_mail_to_admin_swap = self.swap(
             email_manager, 'send_mail_to_admin', _mock_send_mail_to_admin)
+        self.can_send_email_swap = self.swap(
+            feconf, 'CAN_SEND_EMAILS', True)
+        self.cannot_send_email_swap = self.swap(
+            feconf, 'CAN_SEND_EMAILS', False)
 
-    def test_verification_when_user_is_not_deleted(self):
-        with self.send_mail_to_admin_swap:
+    def test_verification_when_user_is_not_deleted_emails_enabled(self):
+        with self.send_mail_to_admin_swap, self.can_send_email_swap:
             wipeout_service.check_completion_of_user_deletion()
         self.assertIn('NOT DELETED', self.email_bodies[0])
         self.assertIn(self.user_1_id, self.email_bodies[0])
+
+    def test_verification_when_user_is_not_deleted_emails_disabled(self):
+        with self.send_mail_to_admin_swap, self.cannot_send_email_swap:
+            wipeout_service.check_completion_of_user_deletion()
+        self.assertEqual(len(self.email_bodies), 0)
 
     def test_verification_when_user_is_deleted_is_successful(self):
         pending_deletion_request = (
@@ -5023,7 +5066,7 @@ class CheckCompletionOfUserDeletionTaskServiceTests(
         wipeout_service.save_pending_deletion_requests(
             [pending_deletion_request])
 
-        with self.send_mail_to_admin_swap:
+        with self.send_mail_to_admin_swap, self.can_send_email_swap:
             wipeout_service.check_completion_of_user_deletion()
         self.assertIn('SUCCESS', self.email_bodies[0])
         self.assertIn(self.user_1_id, self.email_bodies[0])
@@ -5044,7 +5087,7 @@ class CheckCompletionOfUserDeletionTaskServiceTests(
             story_ids=[], learnt_topic_ids=[]
         ).put()
 
-        with self.send_mail_to_admin_swap:
+        with self.send_mail_to_admin_swap, self.can_send_email_swap:
             wipeout_service.check_completion_of_user_deletion()
         self.assertIn('FAILURE', self.email_bodies[-1])
         self.assertIn(self.user_1_id, self.email_bodies[-1])


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Add if statements that verify if we can send emails, before any attempt to send email, this is done in order to fix the wipeout on test and backup server. These statements will be removed after we introduce some kind of email handling to the backup and test server.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
No proof of changes needed because I have verified that this approach fixes the wipeout on backup server.

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
