### PR TITLE
Fix #13421: Run backend tests in core/tests

### DIFF
--- a/core/tests/build_sources/extensions/models_test.py
+++ b/core/tests/build_sources/extensions/models_test.py
@@ -29,7 +29,11 @@ class BaseCalculationUnitTests(test_utils.GenericTestBase):
     """Test cases for BaseCalculation."""
 
     def test_requires_override_for_calculation(self):
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaisesRegexp(
+            NotImplementedError,
+            r'Subclasses of BaseCalculation should implement the '
+            r'calculate_from_state_answers_dict\(state_answers_dict\) '
+            r'method.'):
             answer_models.BaseCalculation().calculate_from_state_answers_dict(
                 state_answers_dict={})
 

--- a/core/tests/gae_suite_test.py
+++ b/core/tests/gae_suite_test.py
@@ -21,6 +21,7 @@ import unittest
 
 from core.tests import gae_suite
 from core.tests import test_utils
+from scripts import common
 
 
 class GaeSuiteTests(test_utils.GenericTestBase):
@@ -38,7 +39,7 @@ class GaeSuiteTests(test_utils.GenericTestBase):
 
     def test_cannot_add_directory_with_invalid_path(self):
         dir_to_add_swap = self.swap(
-            gae_suite, 'DIRS_TO_ADD_TO_SYS_PATH', ['invalid_path'])
+            common, 'DIRS_TO_ADD_TO_SYS_PATH', ['invalid_path'])
         assert_raises_regexp_context_manager = self.assertRaisesRegexp(
             Exception, 'Directory invalid_path does not exist.')
         with assert_raises_regexp_context_manager, dir_to_add_swap:

--- a/scripts/backend_test_shards.json
+++ b/scripts/backend_test_shards.json
@@ -155,8 +155,6 @@
         "jobs.blog_validation_errors_test",
         "jobs.blog_validation_jobs_test",
         "jobs.transforms.blog_validation_test",
-        "core.tests.build_sources.extensions.base_test",
-        "core.tests.build_sources.extensions.models_test",
         "core.tests.load_tests.feedback_thread_summaries_test",
         "core.tests.test_utils_test",
         "core.tests.gae_suite_test"

--- a/scripts/backend_test_shards.json
+++ b/scripts/backend_test_shards.json
@@ -155,7 +155,11 @@
         "jobs.blog_validation_errors_test",
         "jobs.blog_validation_jobs_test",
         "jobs.transforms.blog_validation_test",
-        "core.tests"
+        "core.tests.build_sources.extensions.base_test",
+        "core.tests.build_sources.extensions.models_test",
+        "core.tests.load_tests.feedback_thread_summaries_test",
+        "core.tests.test_utils_test",
+        "core.tests.gae_suite_test"
     ],
     "6": [
         "core.domain.object_registry_test",

--- a/scripts/backend_test_shards.json
+++ b/scripts/backend_test_shards.json
@@ -154,7 +154,8 @@
         "core.platform.email.dev_mode_email_services_test",
         "jobs.blog_validation_errors_test",
         "jobs.blog_validation_jobs_test",
-        "jobs.transforms.blog_validation_test"
+        "jobs.transforms.blog_validation_test",
+        "core.tests"
     ],
     "6": [
         "core.domain.object_registry_test",

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -212,7 +212,8 @@ def _get_all_test_targets_from_path(test_path=None, include_load_tests=True):
     base_path = os.path.join(os.getcwd(), test_path or '')
     result = []
     excluded_dirs = [
-        '.git', 'third_party', 'node_modules', 'venv', 'core/tests/data']
+        '.git', 'third_party', 'node_modules', 'venv',
+        'core/tests/data', 'core/tests/build_sources']
     for root in os.listdir(base_path):
         if any([s in root for s in excluded_dirs]):
             continue
@@ -220,14 +221,10 @@ def _get_all_test_targets_from_path(test_path=None, include_load_tests=True):
             result = result + (
                 _get_test_target_classes(os.path.join(base_path, root)))
         for subroot, _, files in os.walk(os.path.join(base_path, root)):
-            if any([s in subroot for s in excluded_dirs]):
+            if any(s in subroot for s in excluded_dirs):
                 continue
-            if _LOAD_TESTS_DIR in subroot and include_load_tests:
-                for f in files:
-                    if f.endswith('_test.py'):
-                        result = result + (
-                            _get_test_target_classes(os.path.join(subroot, f)))
-
+            if _LOAD_TESTS_DIR in subroot and not include_load_tests:
+                continue
             for f in files:
                 if f.endswith('_test.py'):
                     result = result + (

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -212,7 +212,7 @@ def _get_all_test_targets_from_path(test_path=None, include_load_tests=True):
     base_path = os.path.join(os.getcwd(), test_path or '')
     result = []
     excluded_dirs = [
-        '.git', 'third_party', 'core/tests', 'node_modules', 'venv']
+        '.git', 'third_party', 'node_modules', 'venv', 'core/tests/data']
     for root in os.listdir(base_path):
         if any([s in root for s in excluded_dirs]):
             continue
@@ -220,6 +220,8 @@ def _get_all_test_targets_from_path(test_path=None, include_load_tests=True):
             result = result + (
                 _get_test_target_classes(os.path.join(base_path, root)))
         for subroot, _, files in os.walk(os.path.join(base_path, root)):
+            if any([s in subroot for s in excluded_dirs]):
+                continue
             if _LOAD_TESTS_DIR in subroot and include_load_tests:
                 for f in files:
                     if f.endswith('_test.py'):
@@ -227,8 +229,7 @@ def _get_all_test_targets_from_path(test_path=None, include_load_tests=True):
                             _get_test_target_classes(os.path.join(subroot, f)))
 
             for f in files:
-                if (f.endswith('_test.py') and
-                        os.path.join('core', 'tests') not in subroot):
+                if f.endswith('_test.py'):
                     result = result + (
                         _get_test_target_classes(os.path.join(subroot, f)))
 

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -356,7 +356,7 @@ def main(args=None):
             all_test_targets = [parsed_args.test_target + '_test']
     elif parsed_args.test_shard:
         validation_error = _check_shards_match_tests(
-            include_load_tests=False)
+            include_load_tests=True)
         if validation_error:
             raise Exception(validation_error)
         all_test_targets = _get_all_test_targets_from_shard(


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #13421.
2. This PR does the following: Since 19a5b3c5d8cab06f7aff4fe7d1bd0598c2dad848, we have excluded tests in `core/tests` from being executed:

   https://github.com/oppia/oppia/blob/4fdf3f73348487e9a1673ff16de6006a6c41c00d/scripts/run_backend_tests.py#L214-L215

   This PR adds these tests back since they don't seem to cause any problems when run.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

Proof that the backend tests in `core/tests` pass:

```console
$ python -m scripts.run_backend_tests --test_path core/tests
...
+------------------+
| SUMMARY OF TESTS |
+------------------+

SUCCESS   core.tests.build_sources.extensions.base_test.ActionUnitTests: 3 tests (1.0 secs)
SUCCESS   core.tests.build_sources.extensions.models_test.AnswerFrequenciesUnitTestCase: 2 tests (0.9 secs)
SUCCESS   core.tests.build_sources.extensions.models_test.BaseCalculationUnitTests: 1 tests (0.6 secs)
SUCCESS   core.tests.build_sources.extensions.models_test.CalculationUnitTestBase: 0 tests (0.0 secs)
SUCCESS   core.tests.build_sources.extensions.models_test.FrequencyCommonlySubmittedElementsUnitTestCase: 2 tests (1.0 secs)
SUCCESS   core.tests.build_sources.extensions.models_test.Top10AnswerFrequenciesUnitTestCase: 2 tests (0.9 secs)
SUCCESS   core.tests.build_sources.extensions.models_test.Top5AnswerFrequenciesUnitTestCase: 2 tests (1.0 secs)
SUCCESS   core.tests.build_sources.extensions.models_test.TopAnswersByCategorizationUnitTestCase: 3 tests (1.3 secs)
SUCCESS   core.tests.build_sources.extensions.models_test.TopNUnresolvedAnswersByFrequency: 2 tests (1.0 secs)
SUCCESS   core.tests.load_tests.feedback_thread_summaries_test.FeedbackThreadSummariesLoadTests: 1 tests (44.6 secs)
SUCCESS   core.tests.load_tests.feedback_thread_summaries_test.FeedbackThreadSummariesLoadTests: 1 tests (44.8 secs)
SUCCESS   core.tests.test_utils_test.AuthServicesStubTests: 13 tests (5.6 secs)
SUCCESS   core.tests.test_utils_test.CallCounterTests: 1 tests (0.7 secs)
SUCCESS   core.tests.test_utils_test.EmailMockTests: 2 tests (0.9 secs)
SUCCESS   core.tests.test_utils_test.FailingFunctionTests: 2 tests (1.7 secs)
SUCCESS   core.tests.test_utils_test.FunctionWrapperTests: 6 tests (4.0 secs)
SUCCESS   core.tests.test_utils_test.TestUtilsTests: 26 tests (13.6 secs)
SUCCESS   core.tests.gae_suite_test.GaeSuiteTests: 1 tests (0.4 secs)

Ran 70 tests in 18 test classes.
All tests passed.

Done!
```

Proof that the modules added to the shards match the modules now available to the test runner:

```console
$ python -m scripts.run_backend_tests --test_shard 1
...
Number of unstarted tasks: 50
```

Notice that the tests start running instead of an exception being raised.

Proof of 100% code coverage ([ci run](https://github.com/oppia/oppia/pull/13470/checks?check_run_id=3146788037)):

![Proof of 100% code coverage](https://user-images.githubusercontent.com/19878639/126836984-762d5ac5-1a1a-4a92-a6cb-e1f0d1888603.png)

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
