### PR TITLE
Revert "Allow marking translations as stale in the editor"

### DIFF
--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation-editor/state-translation-editor.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation-editor/state-translation-editor.component.html
@@ -1,6 +1,6 @@
 <div class="oppia-translated-content-header">Translated content</div>
 <div class="oppia-state-translation-editor-section oppia-editor-card-section">
-  <div ng-if="!translationEditorIsOpen" class="clearfix">
+  <div ng-if="!translationEditorIsOpen">
     <button class="btn oppia-translation-needs-update-button" ng-if="activeWrittenTranslation.needsUpdate">
       <i class="material-icons md-18"
          uib-tooltip="Translation needs update"
@@ -41,12 +41,6 @@
       <div class="oppia-translation-editable-mask oppia-editable-section-mask">
       </div>
     </div>
-    <button ng-if="activeWrittenTranslation.needsUpdate === false"
-            type="button"
-            class="btn btn-secondary mt-4 float-right"
-            ng-click="markAsNeedingUpdate()">
-      Mark translation as needing update
-    </button>
   </div>
 
   <div ng-if="translationEditorIsOpen" class="protractor-test-state-translation-editor">

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation-editor/state-translation-editor.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation-editor/state-translation-editor.component.spec.ts
@@ -445,21 +445,6 @@ describe('State Translation Editor Component', function() {
         writtenTranslationObjectFactory.createNew('set_of_unicode_string'));
     });
 
-    it('should mark translation as needing update', function() {
-      spyOn(
-        explorationStatesService, 'markWrittenTranslationsAsNeedingUpdate');
-      $scope.activeWrittenTranslation = (
-        writtenTranslationObjectFactory.createNew('set_of_unicode_string'));
-      expect($scope.activeWrittenTranslation.needsUpdate).toBeFalse();
-
-      $scope.markAsNeedingUpdate();
-
-      expect(
-        explorationStatesService.markWrittenTranslationsAsNeedingUpdate
-      ).toHaveBeenCalled();
-      expect($scope.activeWrittenTranslation.needsUpdate).toBeTrue();
-    });
-
     it('should add written translation html when clicking on save' +
       ' translation button', function() {
       $scope.openTranslationEditor();

--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation-editor/state-translation-editor.component.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation-editor/state-translation-editor.component.ts
@@ -214,17 +214,6 @@ angular.module('oppia').component('stateTranslationEditor', {
             }
           }));
       };
-
-      $scope.markAsNeedingUpdate = function() {
-        let contentId = (
-          TranslationTabActiveContentIdService.getActiveContentId());
-        let stateName = StateEditorService.getActiveStateName();
-        $scope.activeWrittenTranslation.needsUpdate = true;
-        ExplorationStatesService.markWrittenTranslationsAsNeedingUpdate(
-          contentId, stateName);
-        TranslationStatusService.refresh();
-      };
-
       ctrl.$onDestroy = function() {
         ctrl.directiveSubscriptions.unsubscribe();
       };


### PR DESCRIPTION
Reverts oppia/oppia#13584

This was implemented incorrectly. Marking content as stale in the translation editor should only mark the content as stale in the selected language. The current implementation seems to mark as stale in all languages.