### PR TITLE
Fix #13723: Do not redirect partially-logged-in users from /logout

### DIFF
--- a/core/controllers/base.py
+++ b/core/controllers/base.py
@@ -251,9 +251,10 @@ class BaseHandler(webapp2.RequestHandler):
             Exception. The CSRF token is missing.
             UnauthorizedUserException. The CSRF token is invalid.
         """
+        request_split = python_utils.url_split(self.request.uri)
         # If the request is to the old demo server, redirect it permanently to
         # the new demo server.
-        if self.request.uri.startswith('https://oppiaserver.appspot.com'):
+        if request_split.netloc == 'oppiaserver.appspot.com':
             self.redirect('https://oppiatestserver.appspot.com', permanent=True)
             return
 
@@ -267,7 +268,7 @@ class BaseHandler(webapp2.RequestHandler):
                 '/logout?redirect_url=%s' % feconf.PENDING_ACCOUNT_DELETION_URL)
             return
 
-        if self.partially_logged_in:
+        if self.partially_logged_in and request_split.path != '/logout':
             self.redirect('/logout?redirect_url=%s' % self.request.uri)
             return
 

--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -99,6 +99,7 @@ class BaseHandlerTests(test_utils.GenericTestBase):
     TEST_EDITOR_USERNAME = 'testeditoruser'
     DELETED_USER_EMAIL = 'deleted.user@example.com'
     DELETED_USER_USERNAME = 'deleteduser'
+    PARTIALLY_LOGGED_IN_USER_EMAIL = 'partial@example.com'
 
     class MockHandlerWithInvalidReturnType(base.BaseHandler):
         GET_HANDLER_ERROR_RETURN_TYPE = 'invalid_type'
@@ -161,6 +162,11 @@ class BaseHandlerTests(test_utils.GenericTestBase):
         deleted_user_model.deleted = True
         deleted_user_model.update_timestamps()
         deleted_user_model.put()
+
+        # Create a new user but do not submit their registration form.
+        user_services.create_new_user(
+            self.get_auth_id_from_email(self.PARTIALLY_LOGGED_IN_USER_EMAIL),
+            self.PARTIALLY_LOGGED_IN_USER_EMAIL)
 
     def test_that_no_get_results_in_500_error(self):
         """Test that no GET request results in a 500 error."""
@@ -343,6 +349,25 @@ class BaseHandlerTests(test_utils.GenericTestBase):
         # Tests that the old '/splash' URL is redirected to '/'.
         response = self.get_html_response('/splash', expected_status_int=302)
         self.assertEqual('http://localhost/', response.headers['location'])
+
+    def test_partially_logged_in_redirect(self):
+        login_context = self.login_context(
+            self.PARTIALLY_LOGGED_IN_USER_EMAIL)
+
+        with login_context:
+            response = self.get_html_response(
+                '/splash', expected_status_int=302)
+            self.assertEqual(
+                response.location,
+                'http://localhost/logout?redirect_url=http://localhost/splash')
+
+    def test_no_partially_logged_in_redirect_from_logout(self):
+        login_context = self.login_context(
+            self.PARTIALLY_LOGGED_IN_USER_EMAIL)
+
+        with login_context:
+            response = self.get_html_response(
+                '/logout', expected_status_int=200)
 
     def test_unauthorized_user_exception_raised_when_session_is_stale(self):
         with python_utils.ExitStack() as exit_stack:


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #13723.
2. This PR does the following: Avoids redirecting partially-logged-in users when the request was for /logout. We normally redirect partially-logged-in users to /logout, but if we redirect partially-logged-in users from /logout to /logout, we create an infinite loop of redirections.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://user-images.githubusercontent.com/19878639/130549959-0125a55e-9320-46eb-9d24-31f3813e08c1.mov

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
