### PR TITLE
Fix site-analytics-service frontend flake

### DIFF
--- a/core/templates/services/site-analytics.service.spec.ts
+++ b/core/templates/services/site-analytics.service.spec.ts
@@ -20,19 +20,34 @@ import { TestBed } from '@angular/core/testing';
 import { SiteAnalyticsService } from 'services/site-analytics.service';
 import { WindowRef } from 'services/contextual/window-ref.service';
 
+class MockWindowRef {
+  nativeWindow = {
+    location: {
+      pathname: '/context.html'
+    },
+    gtag: function() {}
+  };
+}
+
 describe('Site Analytics Service', () => {
   let sas: SiteAnalyticsService;
-  let ws: WindowRef;
+  let ws: MockWindowRef;
   let gtagSpy: jasmine.Spy;
 
   beforeEach(() => {
+    ws = new MockWindowRef();
+    gtagSpy = spyOn(ws.nativeWindow, 'gtag').and.stub();
+
+    TestBed.configureTestingModule({
+      providers: [
+        SiteAnalyticsService,
+        { provide: WindowRef, useValue: ws },
+      ],
+    });
+
     sas = TestBed.get(SiteAnalyticsService);
-    ws = TestBed.get(WindowRef);
     spyOnProperty(sas, 'CAN_SEND_ANALYTICS_EVENTS', 'get')
       .and.returnValue(true);
-
-    ws.nativeWindow.gtag = function() {};
-    gtagSpy = spyOn(ws.nativeWindow, 'gtag').and.stub();
   });
 
   it('should register start login event', () => {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #13709.
2. This PR does the following: The spec relied on the global `window` object having the correct values. Instead, we should be mocking the object to ensure we control the values tested.

**Reminder: Check off the associated item in #13467 once this PR merges.**

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

Tests passed locally:

![Screen Shot 2021-08-24 at 10 56 00](https://user-images.githubusercontent.com/19878639/130639784-69db8215-1c01-4b25-9cf1-ed9871ebc012.png)

Reran tests on CI:

1. Frontend tests [failed](https://github.com/oppia/oppia/pull/13731/checks?check_run_id=3412445167) with the other common flake right now: `this.explorationDataService.autosaveChangeListAsync is not a function`. The site analytics service tests passed.
2. Frontend tests [passed](https://github.com/oppia/oppia/pull/13731/checks?check_run_id=3412624988).
3. Frontend tests [passed](https://github.com/oppia/oppia/pull/13731/checks?check_run_id=3413064308).
4. Frontend tests [passed](https://github.com/oppia/oppia/pull/13731/checks?check_run_id=3413451091).
5. Frontend tests [passed](https://github.com/oppia/oppia/pull/13731/checks?check_run_id=3413700087).

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
