### PR TITLE
Fix gunicorn workers not properly exiting

### DIFF
--- a/app_dev.yaml
+++ b/app_dev.yaml
@@ -3,6 +3,7 @@ instance_class: F2
 # The "version" line is added here so that MR jobs can run locally (see issue
 # #6534 on oppia/oppia).
 version: default
+entrypoint: gunicorn -b :$PORT main:app
 
 inbound_services:
 - warmup

--- a/requirements.in
+++ b/requirements.in
@@ -11,6 +11,7 @@ callbacks==0.3.0
 contextlib2==0.6.0.post1
 firebase-admin==5.0.0
 future==0.18.2
+gunicorn==20.1.0
 google-cloud-storage==1.37.1
 GoogleAppEnginePipeline==1.9.22.1
 Graphy==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -174,6 +174,8 @@ grpcio==1.32.0
     #   googleapis-common-protos
     #   grpc-google-iam-v1
     #   grpcio-gcp
+gunicorn==20.1.0
+    # via -r requirements.in
 hdfs==2.6.0
     # via apache-beam
 html5lib==1.0.1

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -116,7 +116,7 @@ def managed_process(
 def managed_dev_appserver(
         app_yaml_path, env=None, log_level='info',
         host='0.0.0.0', port=8080, admin_host='0.0.0.0', admin_port=8000,
-        enable_host_checking=True, automatic_restart=True,
+        enable_host_checking=True, automatic_restart=False,
         skip_sdk_update_check=False):
     """Returns a context manager to start up and shut down a GAE dev appserver.
 


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #13686.
2. This PR does the following: Manually add entrypoint to app.yaml (it is exactly the same as the default one but it seems to work bit differently) and also disable auto restart as a default option for the tests server, that way it is disabled in e2e tests.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

When running the e2e tests it seems to properly register when parent process have changed:
![image](https://user-images.githubusercontent.com/10142938/130869340-15915be8-e45b-4f3e-bf2b-1ad24be876a9.png)
and also when the auto restart is disabled the parent process do not even seem to change:
![image](https://user-images.githubusercontent.com/10142938/130869446-5ab3a740-e4b8-45b1-9ae7-e1322b0b0a2d.png)

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
