### PR TITLE
Initialise Carousel after library page data has loaded

### DIFF
--- a/core/templates/pages/library-page/library-page.component.ts
+++ b/core/templates/pages/library-page/library-page.component.ts
@@ -258,8 +258,8 @@ export class LibraryPageComponent {
         this.groupHeaderI18nId = response.header_i18n_id;
         this.i18nLanguageCodeService.onPreferredLanguageCodesLoaded.emit(
           response.preferred_language_codes);
-
         this.loaderService.hideLoadingScreen();
+        this.initCarousels();
       });
     } else {
       this.libraryPageBackendApiService.fetchLibraryIndexDataAsync()
@@ -311,19 +311,17 @@ export class LibraryPageComponent {
                     });
                   });
                   this.loaderService.hideLoadingScreen();
+                  this.initCarousels();
                 });
             } else {
               this.loaderService.hideLoadingScreen();
+              this.initCarousels();
             }
           });
 
           this.i18nLanguageCodeService.onPreferredLanguageCodesLoaded.emit(
             response.preferred_language_codes);
 
-
-          // Initialize the carousel(s) on the library index page.
-          // Pause is necessary to ensure all elements have loaded.
-          setTimeout(this.initCarousels.bind(this), 390);
           this.keyboardShortcutService.bindLibraryPageShortcuts();
 
           // Check if actual and expected widths are the same.


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #13635.
2. This PR does the following: #13635 was happening due to a race condition in the initialisation of the carousels. Previously, `ngOnInit` called `initCarousels` inside a setTimeout with an arbitrary wait time so that the carousels get initialised after the page contents have loaded -- this is a prerequisite. However, this was not ideal because in slower networks, the library page data calls may take longer to complete and the carousels would get initialised before the page contents have loaded. This PR moves the `initCarousels` call such that it is called only after the page contents have initialised.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

### After
![after-lib](https://user-images.githubusercontent.com/11008603/131048439-fd44dcb5-c48a-422a-ae97-3d95ccc03452.gif)


### Before
![before-lib](https://user-images.githubusercontent.com/11008603/131048445-3a460922-21da-4730-bb26-3d38ff226148.gif)



## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
