### PR TITLE
Output backend test and installation messages as unicode instead of bytes

### DIFF
--- a/scripts/install_backend_python_libs.py
+++ b/scripts/install_backend_python_libs.py
@@ -482,7 +482,7 @@ def _run_pip_command(cmd_parts):
     stdout, stderr = process.communicate()
     if process.returncode == 0:
         python_utils.PRINT(stdout)
-    elif b'can\'t combine user with prefix' in stderr:
+    elif 'can\'t combine user with prefix' in stderr:
         python_utils.PRINT('Trying by setting --user and --prefix flags.')
         subprocess.check_call(
             command + ['--user', '--prefix=', '--system'])

--- a/scripts/install_backend_python_libs.py
+++ b/scripts/install_backend_python_libs.py
@@ -477,7 +477,8 @@ def _run_pip_command(cmd_parts):
     # compatible.
     command = [sys.executable, '-m', 'pip'] + cmd_parts
     process = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        encoding='utf-8')
     stdout, stderr = process.communicate()
     if process.returncode == 0:
         python_utils.PRINT(stdout)
@@ -486,8 +487,7 @@ def _run_pip_command(cmd_parts):
         subprocess.check_call(
             command + ['--user', '--prefix=', '--system'])
     else:
-        # Error output is in bytes, we need to decode the line to print it.
-        python_utils.PRINT(stderr.decode('utf-8'))
+        python_utils.PRINT(stderr)
         python_utils.PRINT(
             'Refer to https://github.com/oppia/oppia/wiki/Troubleshooting')
         raise Exception('Error installing package')

--- a/scripts/install_backend_python_libs_test.py
+++ b/scripts/install_backend_python_libs_test.py
@@ -138,10 +138,13 @@ class InstallBackendPythonLibsTests(test_utils.GenericTestBase):
 
             def communicate(self):
                 """Return required method."""
-                return b'', b'can\'t combine user with prefix'
+                return '', 'can\'t combine user with prefix'
 
-        def mock_check_call_error(cmd_tokens, **unsued_kwargs):  # pylint: disable=unused-argument
+        def mock_check_call_error(cmd_tokens, **kwargs):  # pylint: disable=unused-argument
             self.cmd_token_list.append(cmd_tokens[2:])
+            if kwargs.get('encoding') != 'utf-8':
+                raise AssertionError(
+                    'Popen should have been called with encoding="utf-8"')
             return MockErrorProcess()
 
         self.swap_Popen_error = self.swap(

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -402,8 +402,7 @@ def main(args=None):
 
         for task in tasks:
             if task.exception:
-                concurrent_task_utils.log(
-                    python_utils.convert_to_bytes(task.exception.args[0]))
+                concurrent_task_utils.log(task.exception.args[0])
 
     python_utils.PRINT('')
     python_utils.PRINT('+------------------+')
@@ -501,7 +500,7 @@ def main(args=None):
             [sys.executable, COVERAGE_MODULE_PATH, 'report',
              '--omit="%s*","third_party/*","/usr/share/*"'
              % common.OPPIA_TOOLS_DIR, '--show-missing'],
-            stdout=subprocess.PIPE)
+            stdout=subprocess.PIPE, encoding='utf-8')
 
         report_stdout, _ = process.communicate()
         python_utils.PRINT(report_stdout)

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -506,7 +506,7 @@ def main(args=None):
         python_utils.PRINT(report_stdout)
 
         coverage_result = re.search(
-            rb'TOTAL\s+(\d+)\s+(\d+)\s+(?P<total>\d+)%\s+', report_stdout)
+            r'TOTAL\s+(\d+)\s+(\d+)\s+(?P<total>\d+)%\s+', report_stdout)
         if (coverage_result.group('total') != '100'
                 and not parsed_args.ignore_coverage):
             raise Exception('Backend test coverage is not 100%')


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following: The data returned from subprocesses is represented as a `bytes` object, and we sometimes forget to decode it to a string. This leads to difficult-to-read test output since when a `bytes` object is printed, the result looks like this:

   ```text
   b'some\nmessage'
   ```

   We'd really prefer to have this:

   ```text
   some
   message
   ```

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

### Installation messages from pip

Before:

```text
Checking if pip is installed on the local machine
b'Requirement already satisfied: enum34==1.1.10 in /.pyenv/versions/3.7.10/envs/oppia3/lib/python3.7/site-packages (1.1.10)\n'
Checking if protobuf is installed
```

After:

```text
Checking if pip is installed on the local machine
Requirement already satisfied: enum34==1.1.10 in /.pyenv/versions/3.7.10/envs/oppia3/lib/python3.7/site-packages (1.1.10)

Checking if protobuf is installed.
```

### Test error output

Before:

```text
18:17:54 ERROR scripts.linters.pylint_extensions_test: 5.2 secs
b'Error 1\ntest_finds_backslash_continuation (scripts.linters.pylint_extensions_test.BackslashContinuationCheckerTests) ... ok\ntest_extra_empty_lines_below_fileoverview (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok\ntest_extra_empty_lines_below_fileoverview_with_unicode_characters (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok\ntest_file_overview_at_end_of_file (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok\ntest_file_with_no_file_overview (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok\ntest_no_empty_line_below_fileoverview (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok\ntest_no_empty_line_below_fileoverview_with_unicode_characters (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok\ntest_single_new_line_below_file_overview (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok\ntest_correct_metaclass_usage_raises_no_error (scripts.linters.pylint_extensions_test.DisallowDunderMetaclassCheckerTests) ... ok\ntest_no_metaclass_usage_raises_no_error (scripts.linters.pylint_extensions_test.DisallowDunderMetaclassCheckerTests) ... ok\ntest_wrong_metaclass_usage_raises_error (scripts.linters.pylint_extensions_test.DisallowDunderMetaclassCheckerTests) ... ok\ntest_handlers_with_valid_schema_do_not_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests) ... ok\ntest_list_of_non_schema_handlers_do_not_raise_errors (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests)\nHandler class name in list of ... ok\ntest_schema_handler_with_basehandler_as_an_ancestor_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests)\nHandlers which are child classes of BaseHandler must have schema ... ok\ntest_schema_handlers_without_request_args_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests) ... ok\ntest_schema_handlers_without_url_path_args_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests) ... ok\ntest_wrong_data_type_in_handler_args_schema_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests)\nChecks whether the schemas in URL_PATH_ARGS_SCHEMAS must be of ... ok\ntest_wrong_data_type_in_url_path_args_schema_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests)\nChecks whether the schemas in URL_PATH_ARGS_SCHEMAS must be of ... ok\ntest_disallowed_removals_regex (scripts.linters.pylint_extensions_test.DisallowedFunctionsCheckerTests) ... ok\ntest_disallowed_removals_str (scripts.linters.pylint_extensions_test.DisallowedFunctionsCheckerTests) ... ok\ntest_disallowed_replacements_regex (scripts.linters.pylint_extensions_test.DisallowedFunctionsCheckerTests) ... ok\ntest_disallowed_replacements_str (scripts.linters.pylint_extensions_test.DisallowedFunctionsCheckerTests) ... ok\ntest_importing_text_from_typing_in_multi_line_raises_error (scripts.linters.pylint_extensions_test.DisallowedImportsCheckerTests) ... ok\ntest_importing_text_from_typing_in_single_line_raises_error (scripts.linters.pylint_extensions_test.DisallowedImportsCheckerTests) ... ok\ntest_non_import_of_text_from_typing_does_not_raise_error (scripts.linters.pylint_extensions_test.DisallowedImportsCheckerTests) ... ok\ntest_division_operator_with_spaces (scripts.linters.pylint_extensions_test.DivisionOperatorCheckerTests) ... ok\ntest_division_operator_without_spaces (scripts.linters.pylint_extensions_test.DivisionOperatorCheckerTests) ... ok\ntest_checks_args_formatting_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_class_with_no_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_correct_args_formatting_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_empty_line_before_end_of_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_excessive_newline_above_args (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_excessive_newline_below_class_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_finds_docstring_parameter (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_function_with_no_args (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_inline_comment_after_class_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_invalid_description_indentation_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_invalid_parameter_indentation_in_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_malformed_args_argument (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_malformed_args_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_malformed_parameter_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_malformed_raises_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_malformed_returns_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_malformed_yields_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_multiline_class_argument_with_correct_style (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_multiline_class_argument_with_incorrect_style (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_newline_before_docstring_with_correct_style (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_newline_before_docstring_with_incorrect_style (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_no_newline_above_args (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_no_newline_above_raises (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_no_newline_above_return (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_no_newline_at_end_of_multi_line_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_no_newline_below_class_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_no_period_at_end (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_no_period_at_end_of_a_multiline_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_return_in_comment (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_single_line_docstring_span_two_lines (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_single_newline_below_class_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_space_after_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_two_lines_empty_docstring_raise_correct_message (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_varying_combination_of_newline_above_args (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_visit_raise_warns_unknown_style (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_well_formated_args_argument (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_well_formated_args_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_well_formated_returns_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_well_formated_yields_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_well_formed_multi_line_description_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_well_formed_multi_line_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_well_formed_single_line_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_well_placed_newline (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok\ntest_checker_skips_object_call_when_noncallable_object_is_called (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok\ntest_constructor_call_with_keyword_arguments (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok\ntest_correct_use_of_keyword_args (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok\ntest_finds_arg_name_for_non_keyword_arg (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok\ntest_finds_non_explicit_keyword_args (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok\ntest_function_with_args_and_kwargs (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok\ntest_register (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok\ntest_finds_function_def (scripts.linters.pylint_extensions_test.FunctionArgsOrderCheckerTests) ... ok\ntest_break_after_hanging_indentation (scripts.linters.pylint_extensions_test.HangingIndentCheckerTests) ... ok\ntest_hanging_indentation_with_a_comment_after_bracket (scripts.linters.pylint_extensions_test.HangingIndentCheckerTests) ... ok\ntest_hanging_indentation_with_a_comment_after_two_or_more_bracket (scripts.linters.pylint_extensions_test.HangingIndentCheckerTests) ... ok\ntest_no_break_after_hanging_indentation (scripts.linters.pylint_extensions_test.HangingIndentCheckerTests) ... ok\ntest_no_break_after_hanging_indentation_with_comment (scripts.linters.pylint_extensions_test.HangingIndentCheckerTests) ... ok\ntest_finds_hello_world (scripts.linters.pylint_extensions_test.HelloWorldASTTests) ... ok\ntest_finds_hello_world_assignment (scripts.linters.pylint_extensions_test.HelloWorldTokenCheckerTests) ... FAIL\ntest_finds_import_from (scripts.linters.pylint_extensions_test.ImportOnlyModulesCheckerTests) ... ok\ntest_importing_internals_from_allowed_modules_does_not_raise_message (scripts.linters.pylint_extensions_test.ImportOnlyModulesCheckerTests) ... ok\ntest_inequality_op_on_none_adds_message (scripts.linters.pylint_extensions_test.InequalityWithNoneCheckerTests) ... ok\ntest_inequality_op_on_none_with_wrapped_none_adds_message (scripts.linters.pylint_extensions_test.InequalityWithNoneCheckerTests) ... ok\ntest_usage_of_is_not_on_none_does_not_add_message (scripts.linters.pylint_extensions_test.InequalityWithNoneCheckerTests) ... ok\ntest_function_def_for_non_test_file_with_test_only_adds_msg (scripts.linters.pylint_extensions_test.NonTestFilesFunctionNameCheckerTests) ... ok\ntest_function_def_for_non_test_file_without_test_only_adds_no_msg (scripts.linters.pylint_extensions_test.NonTestFilesFunctionNameCheckerTests) ... ok\ntest_function_def_for_test_file_with_test_only_adds_no_msg (scripts.linters.pylint_extensions_test.NonTestFilesFunctionNameCheckerTests) ... ok\ntest_function_def_for_test_file_without_test_only_adds_no_msg (scripts.linters.pylint_extensions_test.NonTestFilesFunctionNameCheckerTests) ... ok\ntest_allow_domain_from_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_allow_domain_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_allow_platform_from_import_in_domain_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_allow_platform_from_import_in_storage_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_allow_platform_import_in_domain_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_allow_platform_import_in_storage_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_forbid_controllers_from_import_in_domain_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_forbid_controllers_import_in_domain_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_forbid_domain_from_import_in_storage_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_forbid_domain_import_in_storage_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_forbid_platform_from_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_forbid_platform_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_forbid_storage_from_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_forbid_storage_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok\ntest_checks_single_char_and_newline_eof (scripts.linters.pylint_extensions_test.SingleCharAndNewlineAtEOFCheckerTests) ... ok\ntest_comment_inside_docstring (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_comment_with_excluded_phrase (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_comment_with_version_info (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_data_type_in_comment (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_inline_comment_with_allowed_pragma_raises_no_error (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_inline_comment_with_invalid_pragma_raises_error (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_inline_comment_with_multiple_allowed_pragmas_raises_no_error (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_invalid_punctuation (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_no_capital_letter_at_beginning (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_no_space_at_beginning (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_variable_name_in_comment (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_well_formed_comment (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok\ntest_enable_single_line_pragma_for_multiline (scripts.linters.pylint_extensions_test.SingleLinePragmaCheckerTests) ... ok\ntest_enable_single_line_pragma_with_invalid_name (scripts.linters.pylint_extensions_test.SingleLinePragmaCheckerTests) ... ok\ntest_no_and_extra_space_before_pylint (scripts.linters.pylint_extensions_test.SingleLinePragmaCheckerTests) ... ok\ntest_pragma_for_multiline (scripts.linters.pylint_extensions_test.SingleLinePragmaCheckerTests) ... ok\ntest_single_line_pylint_pragma (scripts.linters.pylint_extensions_test.SingleLinePragmaCheckerTests) ... ok\ntest_multiple_spaces_after_keyword (scripts.linters.pylint_extensions_test.SingleSpaceAfterKeyWordCheckerTests) ... ok\ntest_no_space_after_keyword (scripts.linters.pylint_extensions_test.SingleSpaceAfterKeyWordCheckerTests) ... ok\ntest_single_space_after_keyword (scripts.linters.pylint_extensions_test.SingleSpaceAfterKeyWordCheckerTests) ... ok\n\n======================================================================\nFAIL: test_finds_hello_world_assignment (scripts.linters.pylint_extensions_test.HelloWorldTokenCheckerTests)\n----------------------------------------------------------------------\nTraceback (most recent call last):\n  File "/oppia/scripts/linters/pylint_extensions_test.py", line 104, in test_finds_hello_world_assignment\n    temp_file.close()\n  File "/.pyenv/versions/3.7.10/lib/python3.7/contextlib.py", line 119, in __exit__\n    next(self.gen)\n  File "/oppia_tools/pylint-2.8.3/pylint/testutils/checker_test_case.py", line 48, in assertAddsMessages\n    assert got == list(messages), msg\nAssertionError: Expected messages did not match actual.\n\nExpected:\nMessage(msg_id=\'no-hello-world-token\', line=1, node=None, args=None, confidence=None)\n\nGot:\nMessage(msg_id=\'hello-world-token\', line=1, node=None, args=None, confidence=Confidence(name=\'UNDEFINED\', description=\'Warning without any associated confidence level.\'))\n\n\n----------------------------------------------------------------------\nRan 129 tests in 0.999s\n\nFAILED (failures=1)\nTraceback (most recent call last):\n  File "/oppia/core/tests/gae_suite.py", line 126, in <module>\n    main()\n  File "/oppia/core/tests/gae_suite.py", line 122, in main\n    result.testsRun, len(result.errors), len(result.failures)))\nException: Test suite failed: 129 tests run, 0 errors, 1 failures.\n'
```

After:

```text
18:22:06 ERROR scripts.linters.pylint_extensions_test: 4.3 secs
Error 1
test_finds_backslash_continuation (scripts.linters.pylint_extensions_test.BackslashContinuationCheckerTests) ... ok
test_extra_empty_lines_below_fileoverview (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok
test_extra_empty_lines_below_fileoverview_with_unicode_characters (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok
test_file_overview_at_end_of_file (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok
test_file_with_no_file_overview (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok
test_no_empty_line_below_fileoverview (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok
test_no_empty_line_below_fileoverview_with_unicode_characters (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok
test_single_new_line_below_file_overview (scripts.linters.pylint_extensions_test.BlankLineBelowFileOverviewCheckerTests) ... ok
test_correct_metaclass_usage_raises_no_error (scripts.linters.pylint_extensions_test.DisallowDunderMetaclassCheckerTests) ... ok
test_no_metaclass_usage_raises_no_error (scripts.linters.pylint_extensions_test.DisallowDunderMetaclassCheckerTests) ... ok
test_wrong_metaclass_usage_raises_error (scripts.linters.pylint_extensions_test.DisallowDunderMetaclassCheckerTests) ... ok
test_handlers_with_valid_schema_do_not_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests) ... ok
test_list_of_non_schema_handlers_do_not_raise_errors (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests)
Handler class name in list of ... ok
test_schema_handler_with_basehandler_as_an_ancestor_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests)
Handlers which are child classes of BaseHandler must have schema ... ok
test_schema_handlers_without_request_args_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests) ... ok
test_schema_handlers_without_url_path_args_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests) ... ok
test_wrong_data_type_in_handler_args_schema_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests)
Checks whether the schemas in URL_PATH_ARGS_SCHEMAS must be of ... ok
test_wrong_data_type_in_url_path_args_schema_raise_error (scripts.linters.pylint_extensions_test.DisallowHandlerWithoutSchemaTests)
Checks whether the schemas in URL_PATH_ARGS_SCHEMAS must be of ... ok
test_disallowed_removals_regex (scripts.linters.pylint_extensions_test.DisallowedFunctionsCheckerTests) ... ok
test_disallowed_removals_str (scripts.linters.pylint_extensions_test.DisallowedFunctionsCheckerTests) ... ok
test_disallowed_replacements_regex (scripts.linters.pylint_extensions_test.DisallowedFunctionsCheckerTests) ... ok
test_disallowed_replacements_str (scripts.linters.pylint_extensions_test.DisallowedFunctionsCheckerTests) ... ok
test_importing_text_from_typing_in_multi_line_raises_error (scripts.linters.pylint_extensions_test.DisallowedImportsCheckerTests) ... ok
test_importing_text_from_typing_in_single_line_raises_error (scripts.linters.pylint_extensions_test.DisallowedImportsCheckerTests) ... ok
test_non_import_of_text_from_typing_does_not_raise_error (scripts.linters.pylint_extensions_test.DisallowedImportsCheckerTests) ... ok
test_division_operator_with_spaces (scripts.linters.pylint_extensions_test.DivisionOperatorCheckerTests) ... ok
test_division_operator_without_spaces (scripts.linters.pylint_extensions_test.DivisionOperatorCheckerTests) ... ok
test_checks_args_formatting_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_class_with_no_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_correct_args_formatting_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_empty_line_before_end_of_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_excessive_newline_above_args (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_excessive_newline_below_class_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_finds_docstring_parameter (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_function_with_no_args (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_inline_comment_after_class_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_invalid_description_indentation_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_invalid_parameter_indentation_in_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_malformed_args_argument (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_malformed_args_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_malformed_parameter_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_malformed_raises_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_malformed_returns_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_malformed_yields_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_multiline_class_argument_with_correct_style (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_multiline_class_argument_with_incorrect_style (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_newline_before_docstring_with_correct_style (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_newline_before_docstring_with_incorrect_style (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_no_newline_above_args (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_no_newline_above_raises (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_no_newline_above_return (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_no_newline_at_end_of_multi_line_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_no_newline_below_class_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_no_period_at_end (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_no_period_at_end_of_a_multiline_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_return_in_comment (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_single_line_docstring_span_two_lines (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_single_newline_below_class_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_space_after_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_two_lines_empty_docstring_raise_correct_message (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_varying_combination_of_newline_above_args (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_visit_raise_warns_unknown_style (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_well_formated_args_argument (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_well_formated_args_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_well_formated_returns_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_well_formated_yields_section (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_well_formed_multi_line_description_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_well_formed_multi_line_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_well_formed_single_line_docstring (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_well_placed_newline (scripts.linters.pylint_extensions_test.DocstringParameterCheckerTests) ... ok
test_checker_skips_object_call_when_noncallable_object_is_called (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok
test_constructor_call_with_keyword_arguments (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok
test_correct_use_of_keyword_args (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok
test_finds_arg_name_for_non_keyword_arg (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok
test_finds_non_explicit_keyword_args (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok
test_function_with_args_and_kwargs (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok
test_register (scripts.linters.pylint_extensions_test.ExplicitKeywordArgsCheckerTests) ... ok
test_finds_function_def (scripts.linters.pylint_extensions_test.FunctionArgsOrderCheckerTests) ... ok
test_break_after_hanging_indentation (scripts.linters.pylint_extensions_test.HangingIndentCheckerTests) ... ok
test_hanging_indentation_with_a_comment_after_bracket (scripts.linters.pylint_extensions_test.HangingIndentCheckerTests) ... ok
test_hanging_indentation_with_a_comment_after_two_or_more_bracket (scripts.linters.pylint_extensions_test.HangingIndentCheckerTests) ... ok
test_no_break_after_hanging_indentation (scripts.linters.pylint_extensions_test.HangingIndentCheckerTests) ... ok
test_no_break_after_hanging_indentation_with_comment (scripts.linters.pylint_extensions_test.HangingIndentCheckerTests) ... ok
test_finds_hello_world (scripts.linters.pylint_extensions_test.HelloWorldASTTests) ... ok
test_finds_hello_world_assignment (scripts.linters.pylint_extensions_test.HelloWorldTokenCheckerTests) ... ok
test_finds_hello_world_func_call (scripts.linters.pylint_extensions_test.HelloWorldTokenCheckerTests) ... FAIL
test_finds_import_from (scripts.linters.pylint_extensions_test.ImportOnlyModulesCheckerTests) ... ok
test_importing_internals_from_allowed_modules_does_not_raise_message (scripts.linters.pylint_extensions_test.ImportOnlyModulesCheckerTests) ... ok
test_inequality_op_on_none_adds_message (scripts.linters.pylint_extensions_test.InequalityWithNoneCheckerTests) ... ok
test_inequality_op_on_none_with_wrapped_none_adds_message (scripts.linters.pylint_extensions_test.InequalityWithNoneCheckerTests) ... ok
test_usage_of_is_not_on_none_does_not_add_message (scripts.linters.pylint_extensions_test.InequalityWithNoneCheckerTests) ... ok
test_function_def_for_non_test_file_with_test_only_adds_msg (scripts.linters.pylint_extensions_test.NonTestFilesFunctionNameCheckerTests) ... ok
test_function_def_for_non_test_file_without_test_only_adds_no_msg (scripts.linters.pylint_extensions_test.NonTestFilesFunctionNameCheckerTests) ... ok
test_function_def_for_test_file_with_test_only_adds_no_msg (scripts.linters.pylint_extensions_test.NonTestFilesFunctionNameCheckerTests) ... ok
test_function_def_for_test_file_without_test_only_adds_no_msg (scripts.linters.pylint_extensions_test.NonTestFilesFunctionNameCheckerTests) ... ok
test_allow_domain_from_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_allow_domain_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_allow_platform_from_import_in_domain_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_allow_platform_from_import_in_storage_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_allow_platform_import_in_domain_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_allow_platform_import_in_storage_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_forbid_controllers_from_import_in_domain_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_forbid_controllers_import_in_domain_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_forbid_domain_from_import_in_storage_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_forbid_domain_import_in_storage_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_forbid_platform_from_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_forbid_platform_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_forbid_storage_from_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_forbid_storage_import_in_controllers_module (scripts.linters.pylint_extensions_test.RestrictedImportCheckerTests) ... ok
test_checks_single_char_and_newline_eof (scripts.linters.pylint_extensions_test.SingleCharAndNewlineAtEOFCheckerTests) ... ok
test_comment_inside_docstring (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_comment_with_excluded_phrase (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_comment_with_version_info (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_data_type_in_comment (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_inline_comment_with_allowed_pragma_raises_no_error (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_inline_comment_with_invalid_pragma_raises_error (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_inline_comment_with_multiple_allowed_pragmas_raises_no_error (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_invalid_punctuation (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_no_capital_letter_at_beginning (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_no_space_at_beginning (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_variable_name_in_comment (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_well_formed_comment (scripts.linters.pylint_extensions_test.SingleLineCommentCheckerTests) ... ok
test_enable_single_line_pragma_for_multiline (scripts.linters.pylint_extensions_test.SingleLinePragmaCheckerTests) ... ok
test_enable_single_line_pragma_with_invalid_name (scripts.linters.pylint_extensions_test.SingleLinePragmaCheckerTests) ... ok
test_no_and_extra_space_before_pylint (scripts.linters.pylint_extensions_test.SingleLinePragmaCheckerTests) ... ok
test_pragma_for_multiline (scripts.linters.pylint_extensions_test.SingleLinePragmaCheckerTests) ... ok
test_single_line_pylint_pragma (scripts.linters.pylint_extensions_test.SingleLinePragmaCheckerTests) ... ok
test_multiple_spaces_after_keyword (scripts.linters.pylint_extensions_test.SingleSpaceAfterKeyWordCheckerTests) ... ok
test_no_space_after_keyword (scripts.linters.pylint_extensions_test.SingleSpaceAfterKeyWordCheckerTests) ... ok
test_single_space_after_keyword (scripts.linters.pylint_extensions_test.SingleSpaceAfterKeyWordCheckerTests) ... ok

======================================================================
FAIL: test_finds_hello_world_func_call (scripts.linters.pylint_extensions_test.HelloWorldTokenCheckerTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/oppia/scripts/linters/pylint_extensions_test.py", line 124, in test_finds_hello_world_func_call
    temp_file.close()
  File "/.pyenv/versions/3.7.10/lib/python3.7/contextlib.py", line 119, in __exit__
    next(self.gen)
  File "/oppia_tools/pylint-2.8.3/pylint/testutils/checker_test_case.py", line 48, in assertAddsMessages
    assert got == list(messages), msg
AssertionError: Expected messages did not match actual.

Expected:
Message(msg_id='nohello-world-token', line=1, node=None, args=None, confidence=None)

Got:
Message(msg_id='hello-world-token', line=1, node=None, args=None, confidence=Confidence(name='UNDEFINED', description='Warning without any associated confidence level.'))


----------------------------------------------------------------------
Ran 130 tests in 0.636s
```

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
