### PR TITLE
Fix frontend test failures: undefined message mismatch and failure to set URL

### DIFF
--- a/core/templates/domain/topic/topic-update.service.spec.ts
+++ b/core/templates/domain/topic/topic-update.service.spec.ts
@@ -943,7 +943,8 @@ describe('Topic update service', function() {
     expect(() => {
       topicUpdateService.moveSkillToSubtopic(
         _sampleTopic, 1, 2, _secondSkillSummary);
-    }).toThrowError('Cannot read property \'addSkill\' of null');
+    }).toThrowError(
+      'Cannot read properties of null (reading \'addSkill\')');
     expect(undoRedoService.getCommittableChangeList()).toEqual([]);
   });
 

--- a/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.directive.spec.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.directive.spec.ts
@@ -2423,7 +2423,8 @@ describe('Conversation skin directive', function() {
       expect(() => {
         $scope.recommendedExplorationSummaries[0].parentExplorationIds;
       }).toThrowError(
-        'Cannot read property \'parentExplorationIds\' of undefined');
+        'Cannot read properties of undefined (reading \'parentExplorationIds\')'
+      );
     }));
 
     it('should fetch recommeded summary dicts ' +

--- a/core/templates/pages/exploration-player-page/services/exploration-engine.service.spec.ts
+++ b/core/templates/pages/exploration-player-page/services/exploration-engine.service.spec.ts
@@ -403,7 +403,7 @@ describe('Exploration engine service ', () => {
     expect(explorationEngineService.isInPreviewMode()).toBe(false);
     expect(() => {
       explorationEngineService.getExplorationTitle();
-    }).toThrowError('Cannot read property \'title\' of undefined');
+    }).toThrowError('Cannot read properties of undefined (reading \'title\')');
 
     explorationEngineService.init(
       explorationDict, 1, null, true, ['en'], initSuccessCb);
@@ -432,7 +432,7 @@ describe('Exploration engine service ', () => {
     expect(explorationEngineService.isInPreviewMode()).toBe(true);
     expect(() => {
       explorationEngineService.getExplorationTitle();
-    }).toThrowError('Cannot read property \'title\' of undefined');
+    }).toThrowError('Cannot read properties of undefined (reading \'title\')');
 
     explorationEngineService.initSettingsFromEditor('Start', [paramChanges]);
     explorationEngineService.init(
@@ -690,7 +690,7 @@ describe('Exploration engine service ', () => {
 
     expect(() => {
       explorationEngineService.getExplorationTitle();
-    }).toThrowError('Cannot read property \'title\' of undefined');
+    }).toThrowError('Cannot read properties of undefined (reading \'title\')');
 
     explorationEngineService.init(
       explorationDict, 1, null, true, ['en'], initSuccessCb);
@@ -724,7 +724,8 @@ describe('Exploration engine service ', () => {
     expect(() => {
       explorationEngineService.getAuthorRecommendedExpIds();
     }).toThrowError(
-      'Cannot read property \'getAuthorRecommendedExpIds\' of undefined');
+      'Cannot read properties of undefined ' +
+      '(reading \'getAuthorRecommendedExpIds\')');
 
     explorationEngineService.init(
       explorationDict, 1, null, true, ['en'], initSuccessCb);
@@ -810,7 +811,8 @@ describe('Exploration engine service ', () => {
 
     expect(() => {
       explorationEngineService.isCurrentStateInitial();
-    }).toThrowError('Cannot read property \'initStateName\' of undefined');
+    }).toThrowError(
+      'Cannot read properties of undefined (reading \'initStateName\')');
 
     explorationEngineService.init(
       explorationDict, 1, null, true, ['en'], initSuccessCb);
@@ -825,7 +827,8 @@ describe('Exploration engine service ', () => {
 
     expect(() => {
       explorationEngineService.getState();
-    }).toThrowError('Cannot read property \'getState\' of undefined');
+    }).toThrowError(
+      'Cannot read properties of undefined (reading \'getState\')');
 
     explorationEngineService.init(
       explorationDict, 1, null, true, ['en'], initSuccessCb);
@@ -857,7 +860,8 @@ describe('Exploration engine service ', () => {
 
     expect(() => {
       explorationEngineService.getLanguageCode();
-    }).toThrowError('Cannot read property \'getLanguageCode\' of undefined');
+    }).toThrowError(
+      'Cannot read properties of undefined (reading \'getLanguageCode\')');
 
     // First exploration has language code 'en'.
     explorationEngineService.init(

--- a/core/templates/pages/exploration-player-page/services/question-player-engine.service.spec.ts
+++ b/core/templates/pages/exploration-player-page/services/question-player-engine.service.spec.ts
@@ -496,7 +496,8 @@ describe('Question player engine service ', () => {
 
     expect(() => {
       questionPlayerEngineService.getCurrentQuestionId();
-    }).toThrowError('Cannot read property \'getId\' of undefined');
+    }).toThrowError(
+      'Cannot read properties of undefined (reading \'getId\')');
 
     questionPlayerEngineService.init(
       multipleQuestionsBackendDict, initSuccessCb, initErrorCb);

--- a/core/templates/pages/library-page/search-bar/search-bar.component.spec.ts
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.spec.ts
@@ -282,7 +282,7 @@ describe('Search bar component', () => {
     windowRef.nativeWindow.location = new URL('http://localhost/not/search/find');
     component.onSearchQueryChangeExec();
     expect(windowRef.nativeWindow.location.href).toEqual(
-      '/search/find?q=search_query');
+      'http://localhost/search/find?q=search_query');
   });
 
   it('should update search fields based on url query', () => {

--- a/core/templates/pages/library-page/search-bar/search-bar.component.ts
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.ts
@@ -191,8 +191,10 @@ export class SearchBarComponent implements OnInit, OnDestroy {
           url.search = '?q=' + searchUrlQueryString;
           this.windowRef.nativeWindow.history.pushState({}, '', url.toString());
         } else {
-          this.windowRef.nativeWindow.location.href = '/search/find?q=' +
-            searchUrlQueryString;
+          let url = new URL(this.windowRef.nativeWindow.location.toString());
+          url.pathname = '/search/find';
+          url.search = '?q=' + searchUrlQueryString;
+          this.windowRef.nativeWindow.location.href = url.toString();
         }
       });
   }

--- a/core/templates/services/math-interactions.service.ts
+++ b/core/templates/services/math-interactions.service.ts
@@ -79,7 +79,10 @@ export class MathInteractionsService {
         '" and "' + symbol2 + '".');
     }
     if (
-      errorMessage === 'Cannot read property \'column\' of undefined.') {
+      errorMessage === 'Cannot read property \'column\' of undefined.' ||
+      errorMessage === 'Cannot read properties of undefined ' +
+        '(reading \'column\').'
+    ) {
       let emptyFunctionNames = [];
       for (let functionName of this.mathFunctionNames) {
         if (expressionString.includes(functionName + '()')) {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following:

   * Fixes frontend test failures that resulted from a change in how Chrome formats error messages from trying to access a property of an `undefined` or `null` object ([debugging doc](https://docs.google.com/document/d/1JuViL7a9FZ_3SNE_7jfrviYr1clvFF08sOJaZlWcXB8/edit))
   * In fixing the above, I discovered another frontend failure that occurred when trying to set `this.windowRef.nativeWindow.location.href` to a path (e.g. `/search/find`) instead of a full URL (e.g. `http://localhost/search/find`). This PR also fixes that issue by computing a full URL.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because this PR fixes a frontend test failure. Note that this was a true failure, not a flake, so any pass of the frontend tests on CI is proof of correctness. There are still some frontend flakes that this PR does not fix.

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
