### PR TITLE
[Contributor Dashboard] Use supported languages list when computing incomplete translation languages on opportunity update

### DIFF
--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -1609,7 +1609,6 @@ class Exploration(python_utils.OBJECT):
         """
         content_count = self.get_content_count()
         language_code_list = []
-        # TODO(#13903): Think of ways of reducing this runtime.
         for language_code, count in self.get_translation_counts().items():
             if count == content_count:
                 language_code_list.append(language_code)

--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -1609,6 +1609,7 @@ class Exploration(python_utils.OBJECT):
         """
         content_count = self.get_content_count()
         language_code_list = []
+        # TODO(#13903): Think of ways of reducing this runtime.
         for language_code, count in self.get_translation_counts().items():
             if count == content_count:
                 language_code_list.append(language_code)

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -149,6 +149,7 @@ def _create_exploration_opportunity_summary(topic, story, exploration):
     # languages.
     complete_translation_language_list = (
         exploration.get_languages_with_complete_translation())
+    # TODO(#13912): Revisit voiceover language logic.
     language_codes_needing_voice_artists = set(
         complete_translation_language_list)
     incomplete_translation_language_codes = (

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -247,6 +247,8 @@ def update_opportunity_with_updated_exploration(exp_id):
     updated_exploration = exp_fetchers.get_exploration_by_id(exp_id)
     content_count = updated_exploration.get_content_count()
     translation_counts = updated_exploration.get_translation_counts()
+    # TODO(#13903): Potentially reduce runtime of computing the complete
+    # languages.
     complete_translation_language_list = (
         updated_exploration.get_languages_with_complete_translation())
     model = opportunity_models.ExplorationOpportunitySummaryModel.get(exp_id)

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -182,7 +182,8 @@ def _compute_exploration_incomplete_translation_languages(exploration):
             incomplete translation languages.
 
     Returns:
-        list(str). List of incomplete translation language codes.
+        list(str). List of incomplete translation language codes sorted
+        alphabetically.
     """
     audio_language_codes = set(
         language['id'] for language in constants.SUPPORTED_AUDIO_LANGUAGES)
@@ -193,7 +194,7 @@ def _compute_exploration_incomplete_translation_languages(exploration):
     # Remove exploration language from incomplete translation languages list
     # as an exploration does not need a translation in its own language.
     incomplete_translation_language_codes.discard(exploration.language_code)
-    return list(incomplete_translation_language_codes)
+    return list(incomplete_translation_language_codes).sort()
 
 
 def add_new_exploration_opportunities(story_id, exp_ids):

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -145,10 +145,13 @@ def _create_exploration_opportunity_summary(topic, story, exploration):
         ExplorationOpportunitySummary. The exploration opportunity summary
         object.
     """
-    language_codes_needing_voice_artists = set(
+    complete_translation_language_list = (
         exploration.get_languages_with_complete_translation())
+    language_codes_needing_voice_artists = set(
+        complete_translation_language_list)
     incomplete_translation_language_codes = (
-        _compute_exploration_incomplete_translation_languages(exploration))
+        _compute_exploration_incomplete_translation_languages(
+            exploration.language_code, complete_translation_language_list))
     if exploration.language_code in incomplete_translation_language_codes:
         # Add exploration language to voiceover required languages list as an
         # exploration can be voiceovered in its own language.
@@ -174,12 +177,14 @@ def _create_exploration_opportunity_summary(topic, story, exploration):
     return exploration_opportunity_summary
 
 
-def _compute_exploration_incomplete_translation_languages(exploration):
+def _compute_exploration_incomplete_translation_languages(
+        exploration_language_code, complete_translation_languages):
     """Computes all languages that are not 100% translated in an exploration.
 
     Args:
-        exploration: Exploration. The exploration for which to compute
-            incomplete translation languages.
+        exploration_language_code: str. The exploration language code.
+        complete_translation_languages: list(str). List of complete translation
+            language codes in the exploration.
 
     Returns:
         list(str). List of incomplete translation language codes sorted
@@ -187,13 +192,11 @@ def _compute_exploration_incomplete_translation_languages(exploration):
     """
     audio_language_codes = set(
         language['id'] for language in constants.SUPPORTED_AUDIO_LANGUAGES)
-    complete_translation_languages = set(
-        exploration.get_languages_with_complete_translation())
     incomplete_translation_language_codes = (
         audio_language_codes - complete_translation_languages)
     # Remove exploration language from incomplete translation languages list
     # as an exploration does not need a translation in its own language.
-    incomplete_translation_language_codes.discard(exploration.language_code)
+    incomplete_translation_language_codes.discard(exploration_language_code)
     return list(incomplete_translation_language_codes).sort()
 
 
@@ -254,7 +257,8 @@ def update_opportunity_with_updated_exploration(exp_id):
     exploration_opportunity_summary.translation_counts = translation_counts
     exploration_opportunity_summary.incomplete_translation_language_codes = (
         _compute_exploration_incomplete_translation_languages(
-            updated_exploration))
+            updated_exploration.language_code,
+            complete_translation_language_list))
 
     new_languages_for_voiceover = set(complete_translation_language_list) - set(
         exploration_opportunity_summary.

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -145,6 +145,8 @@ def _create_exploration_opportunity_summary(topic, story, exploration):
         ExplorationOpportunitySummary. The exploration opportunity summary
         object.
     """
+    # TODO(#13903): Find a way to reduce runtime of computing the complete
+    # languages.
     complete_translation_language_list = (
         exploration.get_languages_with_complete_translation())
     language_codes_needing_voice_artists = set(
@@ -247,7 +249,7 @@ def update_opportunity_with_updated_exploration(exp_id):
     updated_exploration = exp_fetchers.get_exploration_by_id(exp_id)
     content_count = updated_exploration.get_content_count()
     translation_counts = updated_exploration.get_translation_counts()
-    # TODO(#13903): Potentially reduce runtime of computing the complete
+    # TODO(#13903): Find a way to reduce runtime of computing the complete
     # languages.
     complete_translation_language_list = (
         updated_exploration.get_languages_with_complete_translation())

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -147,9 +147,12 @@ def _create_exploration_opportunity_summary(topic, story, exploration):
     """
     language_codes_needing_voice_artists = set(
         exploration.get_languages_with_complete_translation())
-    # Add exploration language to voiceover required languages list as an
-    # exploration can be voiceovered in its own language.
-    language_codes_needing_voice_artists.add(exploration.language_code)
+    incomplete_translation_language_codes = (
+        _compute_exploration_incomplete_translation_languages(exploration))
+    if exploration.language_code in incomplete_translation_language_codes:
+        # Add exploration language to voiceover required languages list as an
+        # exploration can be voiceovered in its own language.
+        language_codes_needing_voice_artists.add(exploration.language_code)
 
     content_count = exploration.get_content_count()
     translation_counts = exploration.get_translation_counts()
@@ -165,7 +168,7 @@ def _create_exploration_opportunity_summary(topic, story, exploration):
         opportunity_domain.ExplorationOpportunitySummary(
             exploration.id, topic.id, topic.name, story.id, story.title,
             story_node.title, content_count,
-            _compute_exploration_incomplete_translation_languages(exploration),
+            incomplete_translation_language_codes,
             translation_counts, list(language_codes_needing_voice_artists), []))
 
     return exploration_opportunity_summary

--- a/core/domain/opportunity_services.py
+++ b/core/domain/opportunity_services.py
@@ -28,7 +28,6 @@ from core.domain import question_fetchers
 from core.domain import story_fetchers
 from core.domain import topic_fetchers
 from core.platform import models
-import utils
 
 (opportunity_models,) = models.Registry.import_models(
     [models.NAMES.opportunity])

--- a/core/domain/opportunity_services_test.py
+++ b/core/domain/opportunity_services_test.py
@@ -477,6 +477,21 @@ class OpportunityServicesIntegrationTest(test_utils.GenericTestBase):
             opportunity_services.get_translation_opportunities('hi', None))
         self.assertEqual(len(translation_opportunities), 0)
 
+        # The translation opportunity should be returned after marking a
+        # translation as stale.
+        translation_needs_update_change_list = [exp_domain.ExplorationChange({
+            'cmd': exp_domain.CMD_MARK_WRITTEN_TRANSLATION_AS_NEEDING_UPDATE,
+            'state_name': 'Introduction',
+            'content_id': 'content',
+            'language_code': 'hi'
+        })]
+        exp_services.update_exploration(
+            self.owner_id, '0', translation_needs_update_change_list,
+            'commit message')
+        translation_opportunities, _, _ = (
+            opportunity_services.get_translation_opportunities('hi', None))
+        self.assertEqual(len(translation_opportunities), 1)
+
     def test_create_new_skill_creates_new_skill_opportunity(self):
         skill_opportunities, _, _ = (
             opportunity_services.get_skill_opportunities(None))


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here]. NA
2. This PR does the following: Upon translation opportunity update, the opportunity's incomplete translation languages are recomputed. Previously, the logic used the set difference of incomplete languages - complete languages. This does not work when a language marked as complete later has a translation marked as stale. We make sure to recompute the incomplete translation languages from scratch instead.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
