### PR TITLE
Fix #12013: Show latest exploration content in translation review modal

### DIFF
--- a/core/controllers/suggestion.py
+++ b/core/controllers/suggestion.py
@@ -27,7 +27,6 @@ from core.controllers import base
 from core.domain import exp_fetchers
 from core.domain import fs_services
 from core.domain import html_cleaner
-from core.domain import html_cleaner
 from core.domain import image_validation_services
 from core.domain import opportunity_services
 from core.domain import skill_fetchers

--- a/core/controllers/suggestion.py
+++ b/core/controllers/suggestion.py
@@ -24,7 +24,9 @@ import logging
 from constants import constants
 from core.controllers import acl_decorators
 from core.controllers import base
+from core.domain import exp_fetchers
 from core.domain import fs_services
+from core.domain import html_cleaner
 from core.domain import html_cleaner
 from core.domain import image_validation_services
 from core.domain import opportunity_services
@@ -223,7 +225,7 @@ class SuggestionsProviderHandler(base.BaseHandler):
             target_id_to_opportunity_dict = (
                 _get_target_id_to_exploration_opportunity_dict(suggestions))
             self.render_json({
-                'suggestions': [s.to_dict() for s in suggestions],
+                'suggestions': _construct_exploration_suggestions(suggestions),
                 'target_id_to_opportunity_dict':
                     target_id_to_opportunity_dict
             })
@@ -463,6 +465,29 @@ def _get_target_id_to_skill_opportunity_dict(suggestions):
                 rubric.to_dict() for rubric in skill.rubrics]
 
     return opportunity_id_to_opportunity_dict
+
+
+def _construct_exploration_suggestions(suggestions):
+    """Returns exploration suggestions with current exploration content.
+
+    Args:
+        suggestions: list(BaseSuggestion). A list of suggestions.
+
+    Returns:
+        list(dict). List of suggestion dicts with an additional
+        exploration_content_html field representing the target
+        exploration's current content.
+    """
+    suggestion_dicts = []
+    for suggestion in suggestions:
+        exploration = exp_fetchers.get_exploration_by_id(
+            suggestion.target_id)
+        content_html = exploration.get_content_html(
+            suggestion.change.state_name, suggestion.change.content_id)
+        suggestion_dict = suggestion.to_dict()
+        suggestion_dict['exploration_content_html'] = content_html
+        suggestion_dicts.append(suggestion_dict)
+    return suggestion_dicts
 
 
 def _upload_suggestion_images(request, suggestion, filenames):

--- a/core/domain/suggestion_registry.py
+++ b/core/domain/suggestion_registry.py
@@ -638,12 +638,6 @@ class SuggestionTranslateContent(BaseSuggestion):
         if self.change.state_name not in exploration.states:
             raise utils.ValidationError(
                 'Expected %s to be a valid state name' % self.change.state_name)
-        content_html = exploration.get_content_html(
-            self.change.state_name, self.change.content_id)
-        if content_html != self.change.content_html:
-            raise utils.ValidationError(
-                'The Exploration content has changed since this translation '
-                'was submitted.')
 
     def accept(self, commit_message):
         """Accepts the suggestion.

--- a/core/domain/suggestion_registry_test.py
+++ b/core/domain/suggestion_registry_test.py
@@ -1417,46 +1417,6 @@ class SuggestionTranslateContentUnitTests(test_utils.GenericTestBase):
         ):
             suggestion.pre_accept_validate()
 
-    def test_pre_accept_validate_content_html(self):
-        self.save_new_default_exploration('exp1', self.author_id)
-        expected_suggestion_dict = self.suggestion_dict
-        suggestion = suggestion_registry.SuggestionTranslateContent(
-            expected_suggestion_dict['suggestion_id'],
-            expected_suggestion_dict['target_id'],
-            expected_suggestion_dict['target_version_at_submission'],
-            expected_suggestion_dict['status'], self.author_id,
-            self.reviewer_id, expected_suggestion_dict['change'],
-            expected_suggestion_dict['score_category'],
-            expected_suggestion_dict['language_code'], False, self.fake_date)
-
-        exp_services.update_exploration(
-            self.author_id, 'exp1', [
-                exp_domain.ExplorationChange({
-                    'cmd': exp_domain.CMD_ADD_STATE,
-                    'state_name': 'State A',
-                }),
-                exp_domain.ExplorationChange({
-                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                    'property_name': exp_domain.STATE_PROPERTY_CONTENT,
-                    'new_value': {
-                        'content_id': 'content',
-                        'html': '<p>This is a content.</p>'
-                    },
-                    'state_name': 'State A',
-                })
-            ], 'Added state')
-        suggestion.change.state_name = 'State A'
-
-        suggestion.pre_accept_validate()
-
-        suggestion.change.content_html = 'invalid content_html'
-        with self.assertRaisesRegexp(
-            utils.ValidationError,
-            'The Exploration content has changed since this translation '
-            'was submitted.'
-        ):
-            suggestion.pre_accept_validate()
-
     def test_accept_suggestion_adds_translation_in_exploration(self):
         self.save_new_default_exploration('exp1', self.author_id)
         exploration = exp_fetchers.get_exploration_by_id('exp1')

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.controller.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.controller.spec.ts
@@ -372,6 +372,7 @@ describe('Translation Suggestion Review Modal Controller', function() {
         translation_html: 'Tradução',
         state_name: 'StateName'
       },
+      exploration_content_html: ['Translation1', 'Translation2'],
       status: 'rejected'
     };
     const suggestion2 = {
@@ -383,7 +384,8 @@ describe('Translation Suggestion Review Modal Controller', function() {
         content_html: 'Translation',
         translation_html: 'Tradução',
         state_name: 'StateName'
-      }
+      },
+      exploration_content_html: 'Translation'
     };
 
     const contribution1 = {
@@ -428,6 +430,9 @@ describe('Translation Suggestion Review Modal Controller', function() {
         expect($scope.activeSuggestion).toEqual(suggestion1);
         expect($scope.reviewable).toBe(reviewable);
         expect($scope.subheading).toBe('subheading_title');
+        // Suggestion 1's exploration_content_html does not match its
+        // content_html.
+        expect($scope.hasExplorationContentChanged()).toBe(true);
 
         var messages = [{
           author_username: '',

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.controller.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.controller.spec.ts
@@ -368,11 +368,11 @@ describe('Translation Suggestion Review Modal Controller', function() {
       suggestion_type: 'translate_content',
       change: {
         content_id: 'hint_1',
-        content_html: 'Translation',
+        content_html: ['Translation1', 'Translation2'],
         translation_html: 'Tradução',
         state_name: 'StateName'
       },
-      exploration_content_html: ['Translation1', 'Translation2'],
+      exploration_content_html: ['Translation1', 'Translation2 CHANGED'],
       status: 'rejected'
     };
     const suggestion2 = {

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.controller.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.controller.spec.ts
@@ -60,7 +60,8 @@ describe('Translation Suggestion Review Modal Controller', function() {
         content_html: 'Translation',
         translation_html: 'Tradução',
         state_name: 'StateName'
-      }
+      },
+      exploration_content_html: 'Translation'
     };
     const suggestion2 = {
       suggestion_id: 'suggestion_2',
@@ -71,7 +72,8 @@ describe('Translation Suggestion Review Modal Controller', function() {
         content_html: 'Translation',
         translation_html: 'Tradução',
         state_name: 'StateName'
-      }
+      },
+      exploration_content_html: 'Translation CHANGED'
     };
 
     const contribution1 = {
@@ -122,7 +124,7 @@ describe('Translation Suggestion Review Modal Controller', function() {
       $scope.init();
     }));
 
-    it('should user service at initialization.',
+    it('should call user service at initialization.',
       function() {
         $scope.$apply();
         expect(userInfoSpy).toHaveBeenCalled();
@@ -169,6 +171,8 @@ describe('Translation Suggestion Review Modal Controller', function() {
       expect($scope.activeSuggestion).toEqual(suggestion1);
       expect($scope.reviewable).toBe(reviewable);
       expect($scope.reviewMessage).toBe('');
+      // Suggestion 1's exploration_content_html matches its content_html.
+      expect($scope.hasExplorationContentChanged()).toBe(false);
 
       spyOn(
         SiteAnalyticsService,
@@ -188,6 +192,9 @@ describe('Translation Suggestion Review Modal Controller', function() {
       expect($scope.activeSuggestion).toEqual(suggestion2);
       expect($scope.reviewable).toBe(reviewable);
       expect($scope.reviewMessage).toBe('');
+      // Suggestion 2's exploration_content_html does not match its
+      // content_html.
+      expect($scope.hasExplorationContentChanged()).toBe(true);
       expect(
         SiteAnalyticsService.registerContributorDashboardAcceptSuggestion)
         .toHaveBeenCalledWith('Translation');

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.controller.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.controller.ts
@@ -143,6 +143,8 @@ angular.module('oppia').controller(
         $scope.status = $scope.activeSuggestion.status;
         $scope.contentHtml = (
           $scope.activeSuggestion.change.content_html);
+        $scope.explorationContentHtml = (
+          $scope.activeSuggestion.exploration_content_html);
         $scope.isHtmlContent = (
           $scope.activeSuggestion.change.data_format === 'html'
         );
@@ -227,6 +229,21 @@ angular.module('oppia').controller(
             ACTION_REJECT_SUGGESTION, reviewMessage || $scope.reviewMessage,
             generateCommitMessage(), $scope.showNextItemToReview);
         }
+      };
+
+      $scope.hasExplorationContentChanged = function() {
+        if (
+          Array.isArray($scope.contentHtml) ||
+          Array.isArray($scope.explorationContentHtml)) {
+          // Check equality of all array elements.
+          return (
+            $scope.contentHtml.length !==
+              $scope.explorationContentHtml.length ||
+            $scope.contentHtml.some(
+              (val, index) => val !== $scope.explorationContentHtml[index])
+          );
+        }
+        return $scope.contentHtml !== $scope.explorationContentHtml;
       };
 
       $scope.editSuggestion = function() {

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review.directive.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review.directive.html
@@ -110,8 +110,8 @@
   .oppia-suggestion-review-panel {
     border: 1px solid #ccc;
     height: 88%;
-    padding-top: 10px;
     padding-left: 10px;
+    padding-top: 10px;
   }
   .oppia-suggestion-review-message {
     margin-left: 10px;

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review.directive.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review.directive.html
@@ -28,6 +28,19 @@
         <angular-html-bind ng-if="!isSetOfStringsContent"
                            html-data="contentHtml">
         </angular-html-bind>
+        <div ng-if="hasExplorationContentChanged()">
+          <p class="oppia-suggestion-review-panel-exploration-change-note">
+            <strong>NOTE: The content has been modified since this translation has been submitted. Please edit the translation as necessary. The current content is:</strong>
+          </p>
+          <ul ng-if="isSetOfStringsContent">
+            <li ng-repeat="item in explorationContentHtml track by $index">
+              <[item]>
+            </li>
+          </ul>
+          <angular-html-bind ng-if="!isSetOfStringsContent"
+                             html-data="explorationContentHtml">
+          </angular-html-bind>
+        </div>
       </div>
     </div>
     <div class="oppia-suggestion-review-panel-container float-right">
@@ -98,6 +111,7 @@
     border: 1px solid #ccc;
     height: 88%;
     padding-top: 10px;
+    padding-left: 10px;
   }
   .oppia-suggestion-review-message {
     margin-left: 10px;
@@ -108,6 +122,9 @@
   }
   .oppia-suggestion-review-panel-header-container {
     height: 12%;
+  }
+  .oppia-suggestion-review-panel-exploration-change-note {
+    margin-top: 18px;
   }
   .oppia-translation-review-edit-buttons {
     margin-left: 10px;

--- a/core/templates/pages/contributor-dashboard-page/services/translate-text.service.ts
+++ b/core/templates/pages/contributor-dashboard-page/services/translate-text.service.ts
@@ -202,21 +202,21 @@ export class TranslateTextService {
   }
 
   getTextToTranslate(): TranslatableItem {
+    const text = this._getNextText();
     const {
       status = this.PENDING,
       translation = ''
     } = { ...this.stateAndContent[this.activeIndex] };
-    const text = this._getNextText();
     return this._getUpdatedTextToTranslate(
       text, this._isMoreTextAvailableForTranslation(), status, translation);
   }
 
   getPreviousTextToTranslate(): TranslatableItem {
+    const text = this._getPreviousText();
     const {
       status = this.PENDING,
       translation = ''
     } = { ...this.stateAndContent[this.activeIndex] };
-    const text = this._getPreviousText();
     return this._getUpdatedTextToTranslate(
       text, this._isPreviousTextAvailableForTranslation(), status, translation);
   }


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #12013.
2. This PR does the following: Shows the latest exploration content in the translation review modal so that reviewers can edit the translation accordingly. Also fixes #13940 by updating internal state in core/templates/pages/contributor-dashboard-page/services/translate-text.service.ts after fetching the next/previous translation. 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

![Screen Shot 2021-09-27 at 7 24 05 PM](https://user-images.githubusercontent.com/9004726/135177858-22285a77-d51e-40b1-ad9d-9940ceae865c.png)


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
