### PR TITLE
Fix part of #13467: Fix guppy test flakes 

### DIFF
--- a/core/templates/services/guppy-configuration.service.spec.ts
+++ b/core/templates/services/guppy-configuration.service.spec.ts
@@ -35,6 +35,9 @@ class MockGuppy {
   asciimath(): string {
     return 'Dummy value';
   }
+
+  'import_text'(value: string): void {}
+
   configure(name: string, val: Object): void {}
   static event(name: string, handler: Function): void {
     handler({focused: true});

--- a/core/templates/services/guppy-configuration.service.spec.ts
+++ b/core/templates/services/guppy-configuration.service.spec.ts
@@ -74,7 +74,7 @@ let guppyConfigurationService: GuppyConfigurationService;
 
 describe('GuppyConfigurationService', () => {
   beforeAll(() => {
-    guppyConfigurationService = TestBed.get(GuppyConfigurationService);
+    guppyConfigurationService = TestBed.inject(GuppyConfigurationService);
     window.Guppy = MockGuppy;
   });
 


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #13467 
2. This PR does the following: 
 -  the import_text function was called in a different service, which somehow triggered as part of the init. Because the mock didn't have it it threw an exception. Adding to the mock to mitigate this.
 - The testbed.get function is deprecated. It is likely that the get returned undefined which caused the log where init was called on undefined object. The testbed.inject function is guaranteed to be typesafe, which means it should return the correct object. 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

TODO: Run tests multiple times and update with screenshot

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
