### PR TITLE
Fix SVG image edit bug

### DIFF
--- a/extensions/objects/templates/svg-editor.component.ts
+++ b/extensions/objects/templates/svg-editor.component.ts
@@ -459,21 +459,17 @@ export class SvgEditorComponent implements OnInit {
       obj: fabric.Object,
       groupedObjects: fabric.Object[][]
   ): fabric.Object[][] {
-    // Checks if the id starts with 'group' to identify whether the
-    // svg objects are grouped together.
-    if (objId.startsWith('group')) {
-      // The objId is of the form "group" + number.
-      const GROUP_ID_PREFIX_LENGTH = 5;
-      const groupId = parseInt(objId.slice(GROUP_ID_PREFIX_LENGTH));
-      // Checks whether the object belongs to an already existing group
-      // or not.
-      if (groupedObjects.length <= groupId) {
-        groupedObjects.push([]);
-      }
-      obj.toSVG = this.createCustomToSVG(
-        obj.toSVG, obj.type, (obj as unknown as {id: string}).id, obj);
-      groupedObjects[groupId].push(obj);
+    // The objId is of the form "group" + number.
+    const GROUP_ID_PREFIX_LENGTH = 5;
+    const groupId = parseInt(objId.slice(GROUP_ID_PREFIX_LENGTH));
+    // Checks whether the object belongs to an already existing group
+    // or not.
+    if (groupedObjects.length <= groupId) {
+      groupedObjects.push([]);
     }
+    obj.toSVG = this.createCustomToSVG(
+      obj.toSVG, obj.type, (obj as unknown as {id: string}).id, obj);
+    groupedObjects[groupId].push(obj);
     return groupedObjects;
   }
 
@@ -573,7 +569,9 @@ export class SvgEditorComponent implements OnInit {
           let groupedObjects = [];
           objects.forEach((obj, index) => {
             const objId = elements[index].id;
-            if (objId !== '') {
+            // Checks if the id starts with 'group' to identify whether the
+            // svg objects are grouped together.
+            if (objId.startsWith('group')) {
               groupedObjects = this.loadGroupedObject(
                 objId, obj, groupedObjects);
             } else {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[NA].
2. This PR does the following: Previously, when an SVG was loaded from string, we assumed that any tag with an id will imply it is grouped but inside the "loadGroupedObject" method we simply check if it it starts with "group", if so we add it to the list of grouped objects (which will eventually get rendered) or else we just skip it. Certain SVGs may contain ids for tags that don't start with "group" and they would not get added to the canvas. The fix moves the "starts with group" logic before the method is called so that "non group" SVGs get added to the canvas correctly.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://user-images.githubusercontent.com/11008603/136755212-570fc1f4-9217-4121-8eea-99821191e891.mp4



<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
