### PR TITLE
Fix #14019: Save topic draft without commit message

### DIFF
--- a/core/domain/topic_services.py
+++ b/core/domain/topic_services.py
@@ -435,7 +435,8 @@ def update_topic_and_subtopic_pages(
     Raises:
         ValueError. Current user does not have enough rights to edit a topic.
     """
-    if not commit_message:
+    topic_rights = topic_fetchers.get_topic_rights(topic_id, strict=False)
+    if topic_rights.topic_is_published and not commit_message:
         raise ValueError(
             'Expected a commit message, received none.')
 

--- a/core/domain/topic_services_test.py
+++ b/core/domain/topic_services_test.py
@@ -1539,6 +1539,18 @@ class TopicServicesUnitTests(test_utils.GenericTestBase):
 
     def test_cannot_update_topic_and_subtopic_pages_with_empty_commit_message(
             self):
+        changelist = [topic_domain.TopicChange({
+            'cmd': topic_domain.CMD_MOVE_SKILL_ID_TO_SUBTOPIC,
+            'old_subtopic_id': None,
+            'new_subtopic_id': self.subtopic_id,
+            'skill_id': 'skill_1'
+        })]
+        # Test can have an empty commit message when not published.
+        topic_services.update_topic_and_subtopic_pages(
+            self.user_id_admin, self.TOPIC_ID, changelist,
+            None)
+        topic_services.publish_topic(self.TOPIC_ID, self.user_id_admin)
+        # Test must have a commit message when published.
         with self.assertRaisesRegexp(
             Exception, 'Expected a commit message, received none.'):
             topic_services.update_topic_and_subtopic_pages(

--- a/core/templates/pages/topic-editor-page/modal-templates/topic-editor-save-modal.template.html
+++ b/core/templates/pages/topic-editor-page/modal-templates/topic-editor-save-modal.template.html
@@ -6,6 +6,7 @@
 </div>
 <div class="modal-body oppia-long-text">
   <p>
+    <span ng-if="!isTopicPublished">(Optional)</span>
     Please enter a brief description of what you have changed:
     <textarea rows="3" cols="50" maxlength="<[MAX_COMMIT_MESSAGE_LENGTH]>" ng-model="commitMessage" focus-on="saveChangesModalOpened" class="protractor-test-commit-message-input" autofocus></textarea>
   </p>


### PR DESCRIPTION
## Overview
1. This PR fixes #14019.
2. This PR does the following: Allows user to submit an empty commit message on save when the topic is in draft mode (it is not published). <-- this is the expected behavior.

**Behavior in this PR:**
Empty commit message is allowed when saving a topic if the topic has not been published.
Commit message must be non-empty when saving a topic that is already published.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://user-images.githubusercontent.com/21316782/137836092-8a9ce208-52a2-4059-8dbe-69e29e8f0dd3.mp4

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
