### PR TITLE
Fix #14227: Disable "Add Thumbnail" button when user has not uploaded new thumbnail

### DIFF
--- a/core/templates/components/forms/custom-forms-directives/edit-thumbnail-modal.component.html
+++ b/core/templates/components/forms/custom-forms-directives/edit-thumbnail-modal.component.html
@@ -80,7 +80,7 @@
     <button class="btn btn-secondary" (click)="cancel()" [innerHTML]="'I18N_MODAL_CANCEL_BUTTON' | translate"></button>
     <button class="btn btn-success protractor-test-photo-upload-submit"
             (click)="confirm()"
-            [disabled]="!uploadedImage">
+            [disabled]="!uploadedImage || !thumbnailHasChanged">
       Add Thumbnail
     </button>
   </div>

--- a/core/templates/components/forms/custom-forms-directives/edit-thumbnail-modal.component.spec.ts
+++ b/core/templates/components/forms/custom-forms-directives/edit-thumbnail-modal.component.spec.ts
@@ -44,6 +44,7 @@ describe('Edit Thumbnail Modal Component', () => {
   let component: EditThumbnailModalComponent;
   let fixture: ComponentFixture<EditThumbnailModalComponent>;
   let ngbActiveModal: NgbActiveModal;
+  let svgSanitizerService: SvgSanitizerService;
   let closeSpy: jasmine.Spy;
   let dismissSpy: jasmine.Spy;
 
@@ -102,6 +103,7 @@ describe('Edit Thumbnail Modal Component', () => {
     fixture = TestBed.createComponent(EditThumbnailModalComponent);
     component = fixture.componentInstance;
     ngbActiveModal = TestBed.inject(NgbActiveModal);
+    svgSanitizerService = TestBed.inject(SvgSanitizerService);
     closeSpy = spyOn(ngbActiveModal, 'close').and.callThrough();
     dismissSpy = spyOn(ngbActiveModal, 'dismiss').and.callThrough();
     // This throws "Argument of type 'mockImageObject' is not assignable to
@@ -257,5 +259,27 @@ describe('Edit Thumbnail Modal Component', () => {
   it('should close the modal on clicking cancel button', () => {
     component.cancel();
     expect(dismissSpy).toHaveBeenCalled();
+  });
+
+  it('should disable \'Add Thumbnail\' button unless a new image is' +
+    ' uploaded', () => {
+    spyOn(component, 'isUploadedImageSvg').and.returnValue(true);
+    spyOn(component, 'isValidFilename').and.returnValue(true);
+    spyOn(
+      svgSanitizerService, 'getInvalidSvgTagsAndAttrsFromDataUri'
+    ).and.callFake(() => {
+      return { tags: [], attrs: [] };
+    });
+    const safeSvg = (
+      'data:image/svg+xml;base64,PHN2ZyBpZD0ic291cmNlIiB2ZXJzaW9uPSIxLjEiIGJhc2' +
+      'VQcm9maWxlPSJmdWxsIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogID' +
+      'xwb2x5Z29uIGlkPSJ0cmlhbmdsZSIgcG9pbnRzPSIwLDAgMCw1MCA1MCwwIiBmaWxsPSIjMD' +
+      'A5OTAwIiBzdHJva2U9IiMwMDQ0MDAiPjwvcG9seWdvbj4KPC9zdmc+'
+    );
+    let file = new File([safeSvg], 'triangle.svg', {type: 'image/svg'});
+    component.uploadedImageMimeType = 'image/svg+xml';
+    expect(component.thumbnailHasChanged).toBeFalse();
+    component.onFileChanged(file);
+    expect(component.thumbnailHasChanged).toBeTrue();
   });
 });

--- a/core/templates/components/forms/custom-forms-directives/edit-thumbnail-modal.component.spec.ts
+++ b/core/templates/components/forms/custom-forms-directives/edit-thumbnail-modal.component.spec.ts
@@ -81,6 +81,12 @@ describe('Edit Thumbnail Modal Component', () => {
     },
   };
 
+  const fileContent = (
+    'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjA' +
+    'wMC9zdmciICB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCI+PGNpcmNsZSBjeD0iNTAiIGN5' +
+    'PSI1MCIgcj0iNDAiIHN0cm9rZT0iZ3JlZW4iIHN0cm9rZS13aWR0aD0iNCIgZmlsbD0ie' +
+    'WVsbG93IiAvPjwvc3ZnPg==');
+
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -127,11 +133,6 @@ describe('Edit Thumbnail Modal Component', () => {
     spyOn(component, 'isUploadedImageSvg').and.returnValue(true);
     spyOn(component, 'isValidFilename').and.returnValue(true);
     const resetSpy = spyOn(component, 'reset').and.callThrough();
-    let fileContent = (
-      'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjA' +
-      'wMC9zdmciICB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCI+PGNpcmNsZSBjeD0iNTAiIGN5' +
-      'PSI1MCIgcj0iNDAiIHN0cm9rZT0iZ3JlZW4iIHN0cm9rZS13aWR0aD0iNCIgZmlsbD0ie' +
-      'WVsbG93IiAvPjwvc3ZnPg==');
     let file = new File([fileContent], 'circle.svg', {type: 'image/svg'});
     component.invalidImageWarningIsShown = false;
     component.invalidFilenameWarningIsShown = false;
@@ -270,13 +271,7 @@ describe('Edit Thumbnail Modal Component', () => {
     ).and.callFake(() => {
       return { tags: [], attrs: [] };
     });
-    const safeSvg = (
-      'data:image/svg+xml;base64,PHN2ZyBpZD0ic291cmNlIiB2ZXJzaW9uPSIxLjEiIGJhc2' +
-      'VQcm9maWxlPSJmdWxsIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgogID' +
-      'xwb2x5Z29uIGlkPSJ0cmlhbmdsZSIgcG9pbnRzPSIwLDAgMCw1MCA1MCwwIiBmaWxsPSIjMD' +
-      'A5OTAwIiBzdHJva2U9IiMwMDQ0MDAiPjwvcG9seWdvbj4KPC9zdmc+'
-    );
-    let file = new File([safeSvg], 'triangle.svg', {type: 'image/svg'});
+    let file = new File([fileContent], 'triangle.svg', {type: 'image/svg'});
     component.uploadedImageMimeType = 'image/svg+xml';
     expect(component.thumbnailHasChanged).toBeFalse();
     component.onFileChanged(file);

--- a/core/templates/components/forms/custom-forms-directives/edit-thumbnail-modal.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/edit-thumbnail-modal.component.ts
@@ -69,6 +69,7 @@ export class EditThumbnailModalComponent implements OnInit {
 
   invalidImageWarningIsShown = false;
   invalidFilenameWarningIsShown = false;
+  thumbnailHasChanged = false;
   allowedImageFormats = ['svg'];
 
   constructor(
@@ -125,6 +126,8 @@ export class EditThumbnailModalComponent implements OnInit {
       this.attrs = this.invalidTagsAndAttributes.attrs;
       if (this.tags.length > 0 || this.attrs.length > 0) {
         this.reset();
+      } else {
+        this.thumbnailHasChanged = true;
       }
     };
     reader.readAsDataURL(file);

--- a/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.directive.ts
+++ b/core/templates/pages/topic-editor-page/editor-tab/topic-editor-tab.directive.ts
@@ -288,6 +288,7 @@ angular.module('oppia').directive('topicEditorTab', [
             }
             TopicUpdateService.setTopicThumbnailFilename(
               $scope.topic, newThumbnailFilename);
+            $scope.$applyAsync();
           };
 
           $scope.updateTopicThumbnailBgColor = function(newThumbnailBgColor) {


### PR DESCRIPTION
## Overview
1. This PR fixes #14227.
2. This PR does the following: Do not allow the user to click "Add Thumbnail" when they have not uploaded a new thumbnail. This avoids the server error in the issue.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://user-images.githubusercontent.com/21316782/142978614-b1a7d9b6-9dd6-4af3-bfb7-d59c3180a894.mp4

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
