### PR TITLE
Fix #14354, #14328 and #57 (on release-scripts): Multiple Release script fixes

### DIFF
--- a/assets/release_constants.json
+++ b/assets/release_constants.json
@@ -1,7 +1,6 @@
 {
     "APP_DEV_YAML_PATH": "app_dev.yaml",
     "APP_YAML_PATH": "app.yaml",
-    "BLOCKING_BUG_MILESTONE_NUMBER": 39,
     "BRANCH_TYPE_HOTFIX": "hotfix",
     "BRANCH_TYPE_RELEASE": "release",
     "BUILD_MODULE_TARGET": "scripts.build",
@@ -35,7 +34,6 @@
     "RELEASE_DRIVE_URL": "https://drive.google.com/drive/folders/0B9KSjiibL_WDNjJyYlEtbTNvY3c",
     "RELEASE_NOTES_EXAMPLE_URL": "https://docs.google.com/document/d/1OUwgMPNORABJAz7DS0iuDUr5A2FxcXg4Y5-qUEdgo-M",
     "RELEASE_NOTES_TEMPLATE_URL": "https://docs.google.com/document/d/1VBa3pdRLnvobNlfmZB6-uRYJHBz_Gc-6eN_ilSoVlhE",
-    "RELEASE_NOTES_URL": "https://docs.google.com/document/d/1pmcDNfM2KtmkZeYipuInC48RE5JfkSJWQYdIQAkD0hQ",
     "RELEASE_ROTA_URL": "https://github.com/oppia/oppia/wiki/Release-schedule-and-other-information#release-coordinators-and-qa-coordinators-for-upcoming-releases",
     "RELEASE_SUMMARY_FILEPATH": "../release_summary.md",
     "REMOTE_URL": "git@github.com:oppia/oppia.git",

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -343,6 +343,11 @@ def get_current_branch_name():
     # Standard output is in bytes, we need to decode the line to print it.
     return git_status_first_line[len(branch_message_prefix):]
 
+def update_branch_with_upstream():
+    """Updates the current branch with upstream."""
+    current_branch_name = get_current_branch_name()
+    run_cmd(['git', 'pull', 'upstream', current_branch_name])
+
 
 def get_current_release_version_number(release_branch_name):
     """Gets the release version given a release branch name.

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -343,6 +343,7 @@ def get_current_branch_name():
     # Standard output is in bytes, we need to decode the line to print it.
     return git_status_first_line[len(branch_message_prefix):]
 
+
 def update_branch_with_upstream():
     """Updates the current branch with upstream."""
     current_branch_name = get_current_branch_name()

--- a/scripts/release_scripts/cut_release_or_hotfix_branch.py
+++ b/scripts/release_scripts/cut_release_or_hotfix_branch.py
@@ -257,6 +257,7 @@ def execute_branch_cut(target_version, hotfix_number):
     common.require_cwd_to_be_oppia()
     common.verify_local_repo_is_clean()
     common.verify_current_branch_name('develop')
+    common.update_branch_with_upstream()
 
     # Update the local repo.
     remote_alias = common.get_remote_alias(

--- a/scripts/release_scripts/repo_specific_changes_fetcher.py
+++ b/scripts/release_scripts/repo_specific_changes_fetcher.py
@@ -28,7 +28,7 @@ from core import python_utils
 from scripts import common
 
 GIT_CMD_DIFF_NAMES_ONLY_FORMAT_STRING = 'git diff --name-only %s %s'
-GIT_CMD_SHOW_FORMAT_STRING = 'git show %s:feconf.py'
+GIT_CMD_SHOW_FORMAT_STRING = 'git show %s:core/feconf.py'
 VERSION_RE_FORMAT_STRING = r'%s\s*=\s*(\d+|\.)+'
 FECONF_SCHEMA_VERSION_CONSTANT_NAMES = [
     'CURRENT_STATE_SCHEMA_VERSION', 'CURRENT_COLLECTION_SCHEMA_VERSION']

--- a/scripts/release_scripts/update_changelog_and_credits.py
+++ b/scripts/release_scripts/update_changelog_and_credits.py
@@ -45,10 +45,12 @@ CHANGELOG_FILEPATH = os.path.join('', 'CHANGELOG')
 CONTRIBUTORS_FILEPATH = os.path.join('', 'CONTRIBUTORS')
 PACKAGE_JSON_FILEPATH = os.path.join('', 'package.json')
 SETUP_PY_FILEPATH = os.path.join('', 'setup.py')
+FECONF_PY_FILEPATH = os.path.join('core', 'feconf.py')
 LIST_OF_FILEPATHS_TO_MODIFY = (
     CHANGELOG_FILEPATH,
     AUTHORS_FILEPATH,
     CONTRIBUTORS_FILEPATH,
+    FECONF_PY_FILEPATH,
     ABOUT_PAGE_CONSTANTS_FILEPATH,
     PACKAGE_JSON_FILEPATH
 )
@@ -397,7 +399,7 @@ def create_branch(
     """
     print(
         'Creating new branch with updates to AUTHORS, CONTRIBUTORS, '
-        'CHANGELOG, about-page, and package.json...')
+        'CHANGELOG, feconf.py, about-page, and package.json...')
     sb = repo.get_branch('develop')
     repo_fork.create_git_ref(
         ref='refs/heads/%s' % target_branch, sha=sb.commit.sha)


### PR DESCRIPTION
## Overview

1. This PR fixes #14354, #14328 and # 57 (on release scripts).
2. This PR does the following: 
Remove references to 2 unused constants. Fixes path of feconf.py in the release scripts, pull from upstream before cutting hotfix branch, and fix feconf not getting committed in automatic PR creation. 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
No proof of changes needed because this is changes to later parts of deployment that can't be tested directly.

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
