### PR TITLE
Fix a part of #14278 : Exploration rights Service  small important change in code

### DIFF
--- a/core/templates/pages/exploration-editor-page/services/exploration-rights-backend-api.service.spec.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-rights-backend-api.service.spec.ts
@@ -45,11 +45,11 @@ describe('Exploration Rights Backend Api Service', () => {
     () => {
       let requestData = {
         version: 3,
-        make_communityOwned: true
+        make_community_owned: true
       };
 
       service.makeCommunityOwnedPutData(
-        'oppia12345', requestData.version, requestData.make_communityOwned
+        'oppia12345', requestData.version, requestData.make_community_owned
       ).then(successHandler, failHandler);
 
       let req = httpTestingController.expectOne(

--- a/core/templates/pages/exploration-editor-page/services/exploration-rights-backend-api.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-rights-backend-api.service.ts
@@ -48,7 +48,7 @@ export class ExplorationRightsBackendApiService {
 
     return this.http.put<ExplorationRightsBackendData>(requestUrl, {
       version: version,
-      make_communityOwned: makeCommunityOwned
+      make_community_owned: makeCommunityOwned
     }).toPromise();
   }
 


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #14278.
2. This PR does the following: in file `exploration-rights-backend-api.service.ts` on line number 51 by mistake I have written `make_communityOwned` on that place right word should be `make_community_owned` which leads to failing in HTTP request

## Essential Checklist

- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The linter/Karma presubmit checks have passed locally on your machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [X] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://user-images.githubusercontent.com/77006897/145278398-faa88f2a-f40d-468b-b1d3-1e1f333ad4f2.mp4


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
