### PR TITLE
Fix #14390: Concept cards have line breaks before and above them

### DIFF
--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
@@ -234,9 +234,9 @@ export class CkEditor4RteComponent implements AfterViewInit, OnChanges,
       return html;
     }
     return html.replace(this.componentRe, (match, p1, p2, p3) => {
-      // Here we remove the "ckeditor" part of the string p3 to get the name
+      // Here we remove the 'ckeditor' part of the string p3 to get the name
       // of the RTE Component.
-      let rteComponentName = p3.split("-")[1];
+      let rteComponentName = p3.split('-')[1];
 
       if (this.rteHelperService.isInlineComponent(rteComponentName)) {
         return `<span type="oppia-noninteractive-${p3}">${match}</span>`;

--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
@@ -234,7 +234,11 @@ export class CkEditor4RteComponent implements AfterViewInit, OnChanges,
       return html;
     }
     return html.replace(this.componentRe, (match, p1, p2, p3) => {
-      if (this.rteHelperService.isInlineComponent(p3)) {
+      // Here we remove the "ckeditor" part of the string p3 to get the name
+      // of the RTE Component.
+      let rteComponentName = p3.split("-")[1];
+
+      if (this.rteHelperService.isInlineComponent(rteComponentName)) {
         return `<span type="oppia-noninteractive-${p3}">${match}</span>`;
       } else {
         return (


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #14390 
2. This PR does the following: Fixes if-condition to check if RTE Component is inline.

## What caused the error?
In PR #14263, `<oppia-noninteractive-` was replaced with `<oppia-noninteractive-ckeditor-` ([why?](https://github.com/oppia/oppia/blob/3dba46a33e7a0a05028261c97d52c8905e05dffa/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts#L113-L121)).

[Here](https://github.com/oppia/oppia/blob/3dba46a33e7a0a05028261c97d52c8905e05dffa/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts#L237), the check for an inline component failed as the RteHelper Service expected the RTE Component name (`skillreview`) instead of `ckeditor-skillreview`.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://user-images.githubusercontent.com/26626415/146271082-639625aa-25dc-4088-aa8d-4d653e77fe41.mov


<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
