### PR TITLE
Fix part of #14219: Increasing backend test coverage of `core.controllers.library_test` to 100%

### DIFF
--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -572,7 +572,8 @@ class CategoryConfigTests(test_utils.GenericTestBase):
 
 
 class LibraryRedirectPageTest(test_utils.GenericTestBase):
-    """Test for redirecting the old 'gallery' page URL to the library index page."""
+    """Test for redirecting the old 'gallery' page URL to the
+    library index page."""
 
     def test_old_gallery_page_url(self):
         """Test to validate that the old gallery page url redirects

--- a/core/controllers/library_test.py
+++ b/core/controllers/library_test.py
@@ -571,6 +571,18 @@ class CategoryConfigTests(test_utils.GenericTestBase):
             '%s.svg' % constants.DEFAULT_THUMBNAIL_ICON))
 
 
+class LibraryRedirectPageTest(test_utils.GenericTestBase):
+    """Test for redirecting the old 'gallery' page URL to the library index page."""
+
+    def test_old_gallery_page_url(self):
+        """Test to validate that the old gallery page url redirects
+        to the library index page.
+        """
+        response = self.get_html_response('/gallery', expected_status_int=302)
+        self.assertEqual(
+            'http://localhost/community-library', response.headers['location'])
+
+
 class ExplorationSummariesHandlerTests(test_utils.GenericTestBase):
 
     PRIVATE_EXP_ID_EDITOR = 'eid0'

--- a/scripts/backend_tests_incomplete_coverage.txt
+++ b/scripts/backend_tests_incomplete_coverage.txt
@@ -7,7 +7,6 @@ core.controllers.profile_test
 core.controllers.story_editor_test
 core.controllers.questions_list_test
 core.constants_test
-core.controllers.library_test
 core.controllers.reader_test
 core.controllers.skill_editor_test
 core.controllers.tasks_test


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #14219 .
2. This PR does the following: Adds the remaining test to check that the old gallery page url redirects to the library index page.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
On running `python -m scripts.run_backend_tests --test_target core.controllers.library_test --generate_coverage_report` -
Before any change to the file -
![Backend3_Before](https://user-images.githubusercontent.com/89375125/148114560-a17a74ea-5e89-497b-ad57-204efab84057.png)

After adding test - 
![Backend3_After](https://user-images.githubusercontent.com/89375125/148114616-14a01183-52e8-4121-84ef-cf1873b2f9b1.png)
<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
