### PR TITLE
Fix part of issue #14419: SERVER_MODES enum class changed to ServerModes

### DIFF
--- a/core/controllers/platform_feature_test.py
+++ b/core/controllers/platform_feature_test.py
@@ -70,7 +70,7 @@ class PlatformFeaturesEvaluationHandlerTest(test_utils.GenericTestBase):
                         {
                             'type': 'server_mode',
                             'conditions': [
-                                ['=', param_domain.SERVER_MODES.dev.value]
+                                ['=', param_domain.ServerModes.dev.value]
                             ]
                         }
                     ],
@@ -229,7 +229,7 @@ class PlatformFeatureDummyHandlerTest(test_utils.GenericTestBase):
 
         with dev_mode_ctx, dummy_feature_dev_stage_context:
             self._set_dummy_feature_status_for_mode(
-                True, param_domain.SERVER_MODES.dev
+                True, param_domain.ServerModes.dev
             )
 
             result = self.get_json(
@@ -244,7 +244,7 @@ class PlatformFeatureDummyHandlerTest(test_utils.GenericTestBase):
 
         with dev_mode_ctx, dummy_feature_dev_stage_context:
             self._set_dummy_feature_status_for_mode(
-                False, param_domain.SERVER_MODES.dev
+                False, param_domain.ServerModes.dev
             )
             self.get_json(
                 '/platform_feature_dummy_handler',
@@ -258,7 +258,7 @@ class PlatformFeatureDummyHandlerTest(test_utils.GenericTestBase):
 
         with dev_mode_ctx, dummy_feature_prod_stage_context:
             self._set_dummy_feature_status_for_mode(
-                True, param_domain.SERVER_MODES.prod
+                True, param_domain.ServerModes.prod
             )
 
             result = self.get_json(
@@ -273,7 +273,7 @@ class PlatformFeatureDummyHandlerTest(test_utils.GenericTestBase):
 
         with dev_mode_ctx, dummy_feature_prod_stage_context:
             self._set_dummy_feature_status_for_mode(
-                False, param_domain.SERVER_MODES.prod
+                False, param_domain.ServerModes.prod
             )
             self.get_json(
                 '/platform_feature_dummy_handler',

--- a/core/domain/platform_feature_services.py
+++ b/core/domain/platform_feature_services.py
@@ -148,9 +148,9 @@ def _get_server_mode():
         in development mode, prod if in production mode.
     """
     return (
-        platform_parameter_domain.SERVER_MODES.dev
+        platform_parameter_domain.ServerModes.dev
         if constants.DEV_MODE
-        else platform_parameter_domain.SERVER_MODES.prod
+        else platform_parameter_domain.ServerModes.prod
     )
 
 

--- a/core/domain/platform_feature_services_test.py
+++ b/core/domain/platform_feature_services_test.py
@@ -36,7 +36,7 @@ class ParamNames(enum.Enum):
     FEATURE_B = 'feature_b'
 
 
-SERVER_MODES = platform_parameter_domain.SERVER_MODES # pylint: disable=invalid-name
+SERVER_MODES = platform_parameter_domain.ServerModes # pylint: disable=invalid-name
 FEATURE_STAGES = platform_parameter_domain.FEATURE_STAGES # pylint: disable=invalid-name
 
 

--- a/core/domain/platform_parameter_domain.py
+++ b/core/domain/platform_parameter_domain.py
@@ -33,7 +33,7 @@ from core.domain import change_domain
 # to PascalCase and its values to UPPER_CASE. Because we want to be consistent
 # throughout the codebase according to the coding style guide.
 # https://github.com/oppia/oppia/wiki/Coding-style-guide
-class SERVER_MODES(enum.Enum): # pylint: disable=invalid-name
+class ServerModes(enum.Enum): # pylint: disable=invalid-name
     """Enum for server modes."""
 
     dev = 'dev' # pylint: disable=invalid-name
@@ -41,7 +41,7 @@ class SERVER_MODES(enum.Enum): # pylint: disable=invalid-name
     prod = 'prod' # pylint: disable=invalid-name
 
 
-FEATURE_STAGES = SERVER_MODES # pylint: disable=invalid-name
+FEATURE_STAGES = ServerModes # pylint: disable=invalid-name
 
 
 # TODO(#14419): Change naming style of Enum class from SCREAMING_SNAKE_CASE
@@ -57,7 +57,7 @@ class DATA_TYPES(enum.Enum): # pylint: disable=invalid-name
 
 
 ALLOWED_SERVER_MODES = [
-    SERVER_MODES.dev.value, SERVER_MODES.test.value, SERVER_MODES.prod.value]
+    ServerModes.dev.value, ServerModes.test.value, ServerModes.prod.value]
 ALLOWED_FEATURE_STAGES = [
     FEATURE_STAGES.dev.value,
     FEATURE_STAGES.test.value,
@@ -769,13 +769,13 @@ class PlatformParameter:
                     value for _, value in server_mode_filter.conditions]
                 if self._feature_stage == FEATURE_STAGES.dev.value:
                     if (
-                            SERVER_MODES.test.value in server_modes or
-                            SERVER_MODES.prod.value in server_modes):
+                            ServerModes.test.value in server_modes or
+                            ServerModes.prod.value in server_modes):
                         raise utils.ValidationError(
                             'Feature in dev stage cannot be enabled in test or'
                             ' production environments.')
                 elif self._feature_stage == FEATURE_STAGES.test.value:
-                    if SERVER_MODES.prod.value in server_modes:
+                    if ServerModes.prod.value in server_modes:
                         raise utils.ValidationError(
                             'Feature in test stage cannot be enabled in '
                             'production environment.')

--- a/core/domain/platform_parameter_domain_test.py
+++ b/core/domain/platform_parameter_domain_test.py
@@ -25,7 +25,7 @@ from core import utils
 from core.domain import platform_parameter_domain as parameter_domain
 from core.tests import test_utils
 
-SERVER_MODES = parameter_domain.SERVER_MODES # pylint: disable=invalid-name
+SERVER_MODES = parameter_domain.ServerModes # pylint: disable=invalid-name
 
 
 class PlatformParameterChangeTests(test_utils.GenericTestBase):


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #14419
2. This PR does the following: Refactored SERVER_MODES enum class to make it consistent with PascalCase throughout the code base.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because this PR does not introduce any new logic in the code base; it just update the parameters which are already tested.
## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
