### PR TITLE
Fix #14084: Allow resize image to 200%; Surface exp role editor error

### DIFF
--- a/core/templates/pages/exploration-editor-page/services/exploration-rights.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/exploration-rights.service.ts
@@ -112,6 +112,8 @@ export class ExplorationRightsService {
           response.rights.voice_artist_names, response.rights.viewer_names,
           response.rights.status, response.rights.cloned_from,
           response.rights.community_owned, response.rights.viewable_if_private);
+      }, (response) => {
+        this.alertsService.addWarning(response.error.error);
       });
   }
 

--- a/extensions/objects/templates/image-editor.component.ts
+++ b/extensions/objects/templates/image-editor.component.ts
@@ -815,10 +815,11 @@ export class ImageEditorComponent implements OnInit, OnChanges {
   }
 
   increaseResizePercent(amount: number): void {
-    // Do not allow to increase size above 100% (only downsize allowed).
+    // Do not allow to increase size above 200% (only downsize allowed).
     this.imageResizeRatio = Math.min(
-      1, this.imageResizeRatio + amount / 100);
+      2, this.imageResizeRatio + amount / 100);
     this.updateValidationWithLatestDimensions();
+    this.cancelCropImage();
   }
 
   private updateValidationWithLatestDimensions(): void {

--- a/extensions/objects/templates/image-editor.component.ts
+++ b/extensions/objects/templates/image-editor.component.ts
@@ -815,9 +815,17 @@ export class ImageEditorComponent implements OnInit, OnChanges {
   }
 
   increaseResizePercent(amount: number): void {
-    // Do not allow to increase size above 200% (only downsize allowed).
+    const imageDataURI = (
+      this.imgData || this.data.metadata.uploadedImageData as string);
+    const mimeType = imageDataURI.split(';')[0];
+    const maxImageRatio = (mimeType === 'data:image/svg+xml') ? 2 : 1;
+    // Do not allow the user to increase size beyond 100% for non-SVG images
+    // and 200% for SVG images. Users may downsize the image if required.
+    // SVG images can be resized to 200% because certain SVGs may not contain a
+    // default height/width, this results in a browser-specific default, which
+    // may be too small to work with.
     this.imageResizeRatio = Math.min(
-      2, this.imageResizeRatio + amount / 100);
+      maxImageRatio, this.imageResizeRatio + amount / 100);
     this.updateValidationWithLatestDimensions();
     this.cancelCropImage();
   }

--- a/extensions/objects/templates/svg-editor.component.spec.ts
+++ b/extensions/objects/templates/svg-editor.component.spec.ts
@@ -69,6 +69,11 @@ describe('SvgEditor', () => {
   let fixture: ComponentFixture<SvgEditorComponent>;
   var component: SvgEditorComponent;
   let svgSanitizerService: SvgSanitizerService;
+  const mockilss = {
+    getRawImageData: (filename) => {
+      return dataUrl;
+    }
+  };
   // This sample SVG is generated using different tools present
   // in the SVG editor.
   var samplesvg = (
@@ -210,7 +215,7 @@ describe('SvgEditor', () => {
         },
         {
           provide: ImageLocalStorageService,
-          useValue: {}
+          useValue: mockilss
         },
         {
           provide: ImagePreloaderService,
@@ -710,6 +715,8 @@ describe('SvgEditor', () => {
 describe('SvgEditor initialized with value attribute', () => {
   var component: SvgEditorComponent;
   var contextService: ContextService;
+  let svgSanitizerService: SvgSanitizerService;
+  let imageLocalStorageService: ImageLocalStorageService;
   var samplesvg = (
     '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.or' +
       'g/1999/xlink" version="1.1" width="494" height="367" viewBox="0 0 494' +
@@ -748,6 +755,8 @@ describe('SvgEditor initialized with value attribute', () => {
       SvgEditorComponent).componentInstance;
     component.value = 'svgimageFilename1.svg';
     contextService = TestBed.inject(ContextService);
+    svgSanitizerService = TestBed.inject(SvgSanitizerService);
+    imageLocalStorageService = TestBed.inject(ImageLocalStorageService);
     const svgFileFetcherBackendApiService: SvgFileFetcherBackendApiService = (
       TestBed.inject(SvgFileFetcherBackendApiService));
     spyOn(svgFileFetcherBackendApiService, 'fetchSvg').and.returnValue(
@@ -763,6 +772,23 @@ describe('SvgEditor initialized with value attribute', () => {
     expect(component.diagramStatus).toBe('saved');
     expect(component.savedSvgDiagram).toBe(samplesvg);
   })));
+
+  it('should handle previously uploaded svg diagram correctly',
+    waitForAsync(fakeAsync(() => {
+      spyOn(svgSanitizerService, 'getTrustedSvgResourceUrl');
+      spyOn(contextService, 'getImageSaveDestination').and.returnValue(
+        AppConstants.IMAGE_SAVE_DESTINATION_LOCAL_STORAGE);
+      let dataUrl = (
+        'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcv');
+      spyOn(imageLocalStorageService, 'getRawImageData').and.returnValue(
+        dataUrl);
+      component.value = 'svgimageFilename1.svg';
+      component.ngOnInit();
+      tick(10);
+      expect(
+        svgSanitizerService.getTrustedSvgResourceUrl
+      ).toHaveBeenCalledWith(dataUrl);
+    })));
 }
 );
 

--- a/extensions/objects/templates/svg-editor.component.ts
+++ b/extensions/objects/templates/svg-editor.component.ts
@@ -293,13 +293,27 @@ export class SvgEditorComponent implements OnInit {
       };
       this.diagramWidth = dimensions.width;
       this.diagramHeight = dimensions.height;
-      this.svgFileFetcherBackendApiService.fetchSvg(
-        this.data.savedSvgUrl as string
-      ).subscribe(
-        response => {
-          this.savedSvgDiagram = response;
-        }
-      );
+      let svgDataUrl = this.imageLocalStorageService.getRawImageData(
+        this.data.savedSvgFileName);
+      if (
+        this.imageSaveDestination ===
+        AppConstants.IMAGE_SAVE_DESTINATION_LOCAL_STORAGE && svgDataUrl
+      ) {
+        this.uploadedSvgDataUrl = {
+          safeUrl: this.svgSanitizerService.getTrustedSvgResourceUrl(
+            svgDataUrl as string),
+          unsafeUrl: svgDataUrl as string
+        };
+        this.savedSvgDiagram = atob(svgDataUrl.split(',')[1]);
+      } else {
+        this.svgFileFetcherBackendApiService.fetchSvg(
+          this.data.savedSvgUrl as string
+        ).subscribe(
+          response => {
+            this.savedSvgDiagram = response;
+          }
+        );
+      }
     }
   }
 


### PR DESCRIPTION

## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #14084.
2. This PR does the following:

- Fix #14084: Editing a copied image in the CD.
- Allow resizing of image to 200%. This is because certain images default to browser defined dimensions which might be too small to be useful.
- Show an error when an exploration role is assigned to an invalid user.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

https://user-images.githubusercontent.com/11008603/148314888-0abe6390-d6c1-4984-87e2-5486ad04d6a9.mp4


https://user-images.githubusercontent.com/11008603/148314887-ecf8f1c5-e639-43a8-80b3-590fa335990b.mp4


https://user-images.githubusercontent.com/11008603/148314883-69a22789-3264-4350-9bc9-f6c1a8c1491f.mp4






## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
