### PR TITLE
Fix parts of #14219: Increasing backend test coverage of `core.storage.recommendations.gae_models_test` and `core.storage.subtopic.gae_models_test` to 100%

### DIFF
--- a/core/storage/recommendations/gae_models_test.py
+++ b/core/storage/recommendations/gae_models_test.py
@@ -41,6 +41,25 @@ class ExplorationRecommendationsModelUnitTests(test_utils.GenericTestBase):
             .get_deletion_policy(),
             base_models.DELETION_POLICY.NOT_APPLICABLE)
 
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            recommendations_models.ExplorationRecommendationsModel.
+                get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER)
+
+    def test_get_export_policy(self) -> None:
+        expected_export_policy_dict = {
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'recommended_exploration_ids': (
+                base_models.EXPORT_POLICY.NOT_APPLICABLE),
+        }
+        self.assertEqual(
+            recommendations_models.ExplorationRecommendationsModel
+            .get_export_policy(),
+            expected_export_policy_dict)
+
 
 class TopicSimilaritiesModelUnitTests(test_utils.GenericTestBase):
     """Tests the TopicSimilaritiesModel class."""
@@ -49,3 +68,20 @@ class TopicSimilaritiesModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             recommendations_models.TopicSimilaritiesModel.get_deletion_policy(),
             base_models.DELETION_POLICY.NOT_APPLICABLE)
+
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            recommendations_models.TopicSimilaritiesModel.
+                get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER)
+
+    def test_get_export_policy(self) -> None:
+        expected_export_policy_dict = {
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'content': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+        }
+        self.assertEqual(
+            recommendations_models.TopicSimilaritiesModel.get_export_policy(),
+            expected_export_policy_dict)

--- a/core/storage/subtopic/gae_models_test.py
+++ b/core/storage/subtopic/gae_models_test.py
@@ -47,6 +47,22 @@ class SubtopicPageModelUnitTest(test_utils.GenericTestBase):
 
     SUBTOPIC_PAGE_ID = 'subtopic_page_id'
 
+    def test_get_export_policy(self) -> None:
+        expected_export_policy_dict = {
+            'topic_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'page_contents': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'page_contents_schema_version': (
+                base_models.EXPORT_POLICY.NOT_APPLICABLE),
+            'language_code': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'version': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+        }
+        self.assertEqual(
+            subtopic_models.SubtopicPageModel.get_export_policy(),
+            expected_export_policy_dict)
+
     def test_get_deletion_policy(self) -> None:
         self.assertEqual(
             subtopic_models.SubtopicPageModel.get_deletion_policy(),
@@ -107,6 +123,34 @@ class SubtopicPageCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
         self.assertFalse(
             subtopic_models.SubtopicPageCommitLogEntryModel
             .has_reference_to_user_id('x_id'))
+
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            subtopic_models.SubtopicPageCommitLogEntryModel.
+                get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER)
+
+    def test_get_export_policy(self) -> None:
+        expected_export_policy_dict = {
+            'subtopic_page_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'commit_cmds': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'commit_message': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'commit_type': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'post_commit_community_owned': (
+                base_models.EXPORT_POLICY.NOT_APPLICABLE),
+            'post_commit_is_private': (
+                base_models.EXPORT_POLICY.NOT_APPLICABLE),
+            'post_commit_status': (
+                base_models.EXPORT_POLICY.NOT_APPLICABLE),
+            'user_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'version': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+        }
+        self.assertEqual(
+            subtopic_models.SubtopicPageCommitLogEntryModel.get_export_policy(),
+            expected_export_policy_dict)
 
     def test__get_instance_id(self) -> None:
         # Calling create() method calls _get_instance (a protected method)

--- a/scripts/backend_tests_incomplete_coverage.txt
+++ b/scripts/backend_tests_incomplete_coverage.txt
@@ -87,7 +87,6 @@ core.storage.story.gae_models_test
 core.storage.classifier.gae_models_test
 core.storage.blog.gae_models_test
 main_test
-core.storage.recommendations.gae_models_test
 core.storage.feedback.gae_models_test
 core.domain.user_domain_test
 core.storage.opportunity.gae_models_test

--- a/scripts/backend_tests_incomplete_coverage.txt
+++ b/scripts/backend_tests_incomplete_coverage.txt
@@ -89,7 +89,6 @@ core.storage.blog.gae_models_test
 main_test
 core.storage.recommendations.gae_models_test
 core.storage.feedback.gae_models_test
-core.storage.subtopic.gae_models_test
 core.domain.user_domain_test
 core.storage.opportunity.gae_models_test
 scripts.install_third_party_libs_test


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #14219 .
2. This PR does the following: [Added remaining tests]

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->
![Screenshot from 2022-01-11 13-07-19](https://user-images.githubusercontent.com/76519771/148900497-ba6a06da-b176-4fb8-a80d-dd7fe1b4e401.png)

![Screenshot from 2022-01-11 13-08-19](https://user-images.githubusercontent.com/76519771/148900583-fc985472-35ca-4d3b-b8de-f9912daea390.png)

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
