### PR TITLE
Fix failing mypy checks of `core.domain.rights_domain_test`

### DIFF
--- a/core/domain/rights_domain_test.py
+++ b/core/domain/rights_domain_test.py
@@ -291,7 +291,7 @@ class ActivityRightsTests(test_utils.GenericTestBase):
 
         self.activity_rights.assign_new_role(
             '123456', rights_domain.ROLE_VOICE_ARTIST)
-        with self.assertRaisesRegexp( # type: ignore[no-untyped-call]
+        with self.assertRaisesRegex( # type: ignore[no-untyped-call]
             Exception, 'This user already can voiceover this exploration.'):
             self.activity_rights.assign_new_role(
                 '123456', rights_domain.ROLE_VOICE_ARTIST)
@@ -299,7 +299,7 @@ class ActivityRightsTests(test_utils.GenericTestBase):
         self.activity_rights.status = rights_domain.ACTIVITY_STATUS_PRIVATE
         self.activity_rights.assign_new_role(
                 '123456', rights_domain.ROLE_VIEWER)
-        with self.assertRaisesRegexp( # type: ignore[no-untyped-call]
+        with self.assertRaisesRegex( # type: ignore[no-untyped-call]
             Exception, 'This user already can view this exploration.'):
             self.activity_rights.assign_new_role(
                 '123456', rights_domain.ROLE_VIEWER)


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of NA.
2. This PR does the following: The PR #14578  aimed to increase the backend coverage of `core.domain.rights_domain_test` to 100% but it used `assertRaisesRegexp()`, a deprecated python method which was strictly checked after merging of the PR #14506. As a result mypy checks started failing in all the PRs which were recently merged from develop. 

  This PR replaces the deprecated `assertRaisesRegexp` with `assertRaisesRegex` as a followup on PR #14506 

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
On running `python -m scripts.run_mypy_checks` - 
![Screenshot from 2022-01-14 17-31-18](https://user-images.githubusercontent.com/89375125/149512530-4a5db600-a87f-4567-8714-181480a0fa97.png)

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
