### PR TITLE
Fix #14621: Change concept-card modal's z-index so it stacks correctly over other modals

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -4473,6 +4473,19 @@ div.oppia-issues-learner-action {
   z-index: 1035 !important;
 }
 
+/*
+  The .forced-modal-stack-over and .forced-modal-backdrop-stack-over styles may be
+  removed once rte-helper-service is migrated to Angular. Currently, these styles
+  are used for correctly stacking AngularJS modals on top of Angular modals.
+*/
+.forced-modal-stack-over {
+  z-index: 1060 !important;
+}
+
+.forced-modal-backdrop-stack-over {
+  z-index: 1055 !important;
+}
+
 .oppia-profile-h1 {
   color: #fff;
   display: inline;

--- a/core/templates/services/rte-helper.service.ts
+++ b/core/templates/services/rte-helper.service.ts
@@ -94,6 +94,12 @@ angular.module('oppia').factory('RteHelperService', [
             'components/ck-editor-helpers/' +
             'customize-rte-component-modal.template.html'),
           backdrop: 'static',
+          // The 'windowClass' & 'backdropClass' options may be removed once
+          // this service is migrated to Angular and NgbModal is used instead of
+          // uibModal. Currently, these custom classes are used for correctly
+          // stacking AngularJS modals on top of Angular modals.
+          windowClass: 'forced-modal-stack-over',
+          backdropClass: 'forced-modal-backdrop-stack-over',
           resolve: {
             customizationArgSpecs: function() {
               return customizationArgSpecs;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #14621.
2. This PR does the following: Adds custom classes to manually set the z-indices of the modal and the modal-backdrop, ensuring they are stacked correctly.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->
![image 1](https://user-images.githubusercontent.com/78612244/149655804-c34d2e25-efcc-4e50-b12e-3898b13c29ab.png)

![image 2](https://user-images.githubusercontent.com/78612244/149655808-23c856f4-3391-4d7c-8a65-e62cdd2e462c.png)

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
