### PR TITLE
Re-add rtl css to develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "protractor-jasmine2-screenshot-reporter": "^0.5.0",
     "puppeteer": "^13.0.0",
     "reflect-metadata": "^0.1.12",
+    "rtlcss": "^3.5.0",
     "sourcemapped-stacktrace": "^1.1.11",
     "style-loader": "^2.0.0",
     "stylelint": "^14.1.0",


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of N/A.
2. This PR does the following: Re-add rtlcss to dependencies on develop (It was removed specifically for release).

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because it just adds back an existing dependency.

