### PR TITLE
Fix #13624: Limit number of characters that can be entered in the skill description text field

### DIFF
--- a/core/templates/pages/skill-editor-page/editor-tab/skill-description-editor/skill-description-editor.component.html
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-description-editor/skill-description-editor.component.html
@@ -8,7 +8,7 @@
     <p [ngClass]="{'has-error': !tmpSkillDescription.length > 0}">
       <input type="text" aria-label="Skill Description" class="form-control protractor-test-skill-description-field" *ngIf="canEditSkillDescription()"
              [(ngModel)]="tmpSkillDescription" (change)="resetErrorMsg()" (blur)="saveSkillDescription(tmpSkillDescription)"
-             maxlength="MAX_CHARS_IN_SKILL_DESCRIPTION" ng-trim="false">
+             [attr.maxlength]="MAX_CHARS_IN_SKILL_DESCRIPTION" ng-trim="false">
       <span class="oppia-input-box-subtitle">
         <i>
           Skill description should be at most {{ MAX_CHARS_IN_SKILL_DESCRIPTION }} characters.


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #13624 .
2. This PR does the following: Fix attribute binding to limit number of characters that can be entered in the text field.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly. Please also include videos/screenshots of the developer tools browser console, so that we can be sure that there are no console errors.
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have a separate .rtl.css file for styling), make sure to add screenshots with the site language set to Arabic as well.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->
(The field already has a 100 characters and '2' is being held down.)
Before:

https://user-images.githubusercontent.com/78612244/154079388-380c5a79-6c7f-47e8-8d3f-8db491cf03bb.mp4

After:

https://user-images.githubusercontent.com/78612244/154079519-1acf4bf7-e395-4a29-9b6d-a93b1051536e.mp4

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
