### PR TITLE
Fix part of #14960: Remove extra margin from beneath the lesson completion card

### DIFF
--- a/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.html
+++ b/core/templates/pages/exploration-player-page/learner-experience/conversation-skin.component.html
@@ -136,7 +136,7 @@ otherwise they will interfere with the iframed conversation skin directive.
 
   .conversation-skin-tutor-card-container {
     flex-shrink: 10000;
-    margin-bottom: 150px;
+    margin-bottom: 24px;
     max-width: 650px;
     /* NOTE TO DEVELOPERS: If min-width is changed, max-width in media query
        below should be changed to match. */

--- a/core/templates/pages/exploration-player-page/learner-experience/ratings-and-recommendations.component.html
+++ b/core/templates/pages/exploration-player-page/learner-experience/ratings-and-recommendations.component.html
@@ -46,15 +46,6 @@
     </div>
   </div>
 
-  <div *ngIf="inStoryMode" class="conversation-skin-back-to-collection-container">
-    <a [href]="storyViewerUrl" class="conversation-skin-back-to-collection" translate="I18N_PLAYER_RETURN_TO_STORY"></a>
-  </div>
-  <div *ngIf="!collectionSummary && !isRefresherExploration && !inStoryMode" class="conversation-skin-back-to-collection-container">
-    <a href="/community-library" class="conversation-skin-back-to-collection" translate="I18N_PLAYER_RETURN_TO_LIBRARY"></a>
-  </div>
-  <div *ngIf="collectionSummary && !isRefresherExploration" class="conversation-skin-back-to-collection-container">
-    <a [href]="'/collection/' + collectionId" class="conversation-skin-back-to-collection" translate="I18N_PLAYER_BACK_TO_COLLECTION"></a>
-  </div>
   <div *ngIf="inStoryMode && !userIsLoggedIn" class="conversation-skin-login-container">
     <div class="conversation-skin-congratulations-text" translate="I18N_CHAPTER_COMPLETION"></div>
     <span class="conversation-skin-login-text text-secondary" translate="I18N_SAVE_PROGRESS"></span>
@@ -67,9 +58,31 @@
       </button>
     </div>
   </div>
+
+  <div *ngIf="inStoryMode" class="conversation-skin-back-to-collection-container">
+    <a [href]="storyViewerUrl" class="conversation-skin-back-to-collection" translate="I18N_PLAYER_RETURN_TO_STORY"></a>
+  </div>
+  <div *ngIf="!collectionSummary && !isRefresherExploration && !inStoryMode" class="conversation-skin-back-to-collection-container">
+    <a href="/community-library" class="conversation-skin-back-to-collection" translate="I18N_PLAYER_RETURN_TO_LIBRARY"></a>
+  </div>
+  <div *ngIf="collectionSummary && !isRefresherExploration" class="conversation-skin-back-to-collection-container">
+    <a [href]="'/collection/' + collectionId" class="conversation-skin-back-to-collection" translate="I18N_PLAYER_BACK_TO_COLLECTION"></a>
+  </div>
 </div>
 
 <style>
+.oppia-login-button {
+  background-color: #00645c;
+  font-size: 1em;
+  min-width: max-content;
+  width: 30%;
+}
+.oppia-sign-up-button {
+  background-color: #00609c;
+  font-size: 1em;
+  min-width: max-content;
+  width: 30%;
+}
   .conversation-skin-final-summary {
     margin-bottom: 25px;
     margin-top: 20px;

--- a/core/templates/pages/exploration-player-page/learner-experience/ratings-and-recommendations.component.html
+++ b/core/templates/pages/exploration-player-page/learner-experience/ratings-and-recommendations.component.html
@@ -50,10 +50,10 @@
     <div class="conversation-skin-congratulations-text" translate="I18N_CHAPTER_COMPLETION"></div>
     <span class="conversation-skin-login-text text-secondary" translate="I18N_SAVE_PROGRESS"></span>
     <div class="mt-2">
-      <button mat-button class="md-raised oppia-login-button text-light protractor-test-login-button" (click)="signIn()">
+      <button mat-button class="md-raised oppia-login-button text-light protractor-test-login-button m-2" (click)="signIn()">
         LOGIN
       </button>
-      <button mat-button class="md-raised oppia-sign-up-button text-light" (click)="signIn()">
+      <button mat-button class="md-raised oppia-sign-up-button text-light m-2" (click)="signIn()">
         SIGN UP
       </button>
     </div>
@@ -71,18 +71,19 @@
 </div>
 
 <style>
-.oppia-login-button {
-  background-color: #00645c;
-  font-size: 1em;
-  min-width: max-content;
-  width: 30%;
-}
-.oppia-sign-up-button {
-  background-color: #00609c;
-  font-size: 1em;
-  min-width: max-content;
-  width: 30%;
-}
+  .oppia-login-button {
+    background-color: #00645c;
+    font-size: 1em;
+    min-width: max-content;
+    width: 154px;
+  }
+
+  .oppia-sign-up-button {
+    background-color: #00609c;
+    font-size: 1em;
+    min-width: max-content;
+    width: 154px;
+  }
   .conversation-skin-final-summary {
     margin-bottom: 25px;
     margin-top: 20px;
@@ -122,7 +123,7 @@
 
   .conversation-skin-back-to-collection-container {
     margin-bottom: 92px;
-    margin-top: 25px;
+    margin-top: 24px;
     text-align: center;
   }
 
@@ -133,7 +134,8 @@
 
   .conversation-skin-login-container {
     background-color: #fff;
-    margin: -52px auto 92px;
+    margin-bottom: 24px;
+    margin-top: 24px;
     padding: 1.5em 2em;
     text-align: center;
     width: 100%;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #14960.
2. This PR does the following: Implements the fix for the 1st checkpoint of PR #14960 by removing extra sapce from beneath the lesson completion page.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly. Please also include videos/screenshots of the developer tools browser console, so that we can be sure that there are no console errors.
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have a separate .rtl.css file for styling), make sure to add screenshots with the site language set to Arabic as well.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->
<img width="960" alt="1" src="https://user-images.githubusercontent.com/73544247/154678558-1b1bbf08-ceff-4e35-96c9-470fc02c04e6.png">
<img width="960" alt="2" src="https://user-images.githubusercontent.com/73544247/154678563-b5d7285d-cd93-4404-baf5-389ad310db1e.png">
<img width="960" alt="3" src="https://user-images.githubusercontent.com/73544247/154678567-9dbc39cb-e8f0-440a-a110-09a21ffbde43.png">
<img width="755" alt="4" src="https://user-images.githubusercontent.com/73544247/154678568-d071cce8-1f7e-4ab3-a3ee-143d3311c25f.png">


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
