### PR TITLE
Fix part of #13822: backend validation for exp title

### DIFF
--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -808,6 +808,10 @@ class Exploration:
         utils.require_valid_name(
             self.title, 'the exploration title', allow_empty=True)
 
+        if len(self.title) > 36:
+            raise utils.ValidationError(
+                'Title length should not exceed 36 characters')
+
         if not isinstance(self.category, str):
             raise utils.ValidationError(
                 'Expected category to be a string, received %s'

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -2331,6 +2331,17 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             exp_domain.Exploration.deserialize(
                 exploration.serialize()).to_dict())
 
+    def test_validate_exploration_title_length(self):
+        """Checks the title length of a default exploration,
+        whether it exceeds the max title length or not.
+        """
+        exploration = exp_domain.Exploration.create_default_exploration('eid')
+        exploration.title = 'titleeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+        with self.assertRaisesRegex(
+            utils.ValidationError, (
+                'Title length should not exceed 36 characters')):
+            exploration.validate()
+
 
 class ExplorationSummaryTests(test_utils.GenericTestBase):
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #13822.
2. This PR does the following: Ensures that the exploration title length doesn't exceed max title character length.

#14748 created the Beam Job to test that no explorations in Oppia's current data storage violate this backend validation. The Beam Job listed a few explorations that violate this backend validation.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
No proof of changes required as we already have a frontend validation for this cause.
<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly. Please also include videos/screenshots of the developer tools browser console, so that we can be sure that there are no console errors.
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have a separate .rtl.css file for styling), make sure to add screenshots with the site language set to Arabic as well.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
