### PR TITLE
Fix part of #14033: Added Mypy type annotations to `activity_services.py`

### DIFF
--- a/core/domain/activity_services.py
+++ b/core/domain/activity_services.py
@@ -34,9 +34,8 @@ if MYPY: # pragma: no cover
 (activity_models,) = models.Registry.import_models([models.NAMES.activity])
 
 
-def get_featured_activity_references() -> (
-    List[activity_domain.ActivityReference]
-):
+def get_featured_activity_references(
+) -> List[activity_domain.ActivityReference]:
     """Gets a list of ActivityReference domain models.
 
     Returns:

--- a/core/domain/activity_services.py
+++ b/core/domain/activity_services.py
@@ -33,10 +33,10 @@ if MYPY: # pragma: no cover
 
 (activity_models,) = models.Registry.import_models([models.NAMES.activity])
 
-ActivityReferenceList = List[activity_domain.ActivityReference]
 
-
-def get_featured_activity_references() -> ActivityReferenceList:
+def get_featured_activity_references() -> (
+    List[activity_domain.ActivityReference]
+):
     """Gets a list of ActivityReference domain models.
 
     Returns:
@@ -53,7 +53,7 @@ def get_featured_activity_references() -> ActivityReferenceList:
 
 
 def update_featured_activity_references(
-    featured_activity_references: ActivityReferenceList
+    featured_activity_references: List[activity_domain.ActivityReference]
 ) -> None:
     """Updates the current list of featured activity references.
 
@@ -126,7 +126,7 @@ def remove_featured_activities(
 
 
 def split_by_type(
-    activity_references: ActivityReferenceList
+    activity_references: List[activity_domain.ActivityReference]
 ) -> Tuple[List[str], List[str]]:
     """Given a list of activity references, returns two lists: the first list
     contains the exploration ids, and the second contains the collection ids.

--- a/core/domain/activity_services.py
+++ b/core/domain/activity_services.py
@@ -25,10 +25,18 @@ from core.constants import constants
 from core.domain import activity_domain
 from core.platform import models
 
+from typing import List, Tuple
+
+MYPY = False
+if MYPY: # pragma: no cover
+    from mypy_imports import activity_models
+
 (activity_models,) = models.Registry.import_models([models.NAMES.activity])
 
+ActivityReferenceList = List[activity_domain.ActivityReference]
 
-def get_featured_activity_references():
+
+def get_featured_activity_references() -> ActivityReferenceList:
     """Gets a list of ActivityReference domain models.
 
     Returns:
@@ -44,7 +52,9 @@ def get_featured_activity_references():
         for reference in featured_model_instance.activity_references]
 
 
-def update_featured_activity_references(featured_activity_references):
+def update_featured_activity_references(
+    featured_activity_references: ActivityReferenceList
+) -> None:
     """Updates the current list of featured activity references.
 
     Args:
@@ -74,7 +84,7 @@ def update_featured_activity_references(featured_activity_references):
     featured_model_instance.put()
 
 
-def remove_featured_activity(activity_type, activity_id):
+def remove_featured_activity(activity_type: str, activity_id: str) -> None:
     """Removes the specified activity reference from the list of featured
     activity references.
 
@@ -85,7 +95,10 @@ def remove_featured_activity(activity_type, activity_id):
     remove_featured_activities(activity_type, [activity_id])
 
 
-def remove_featured_activities(activity_type, activity_ids):
+def remove_featured_activities(
+    activity_type: str,
+    activity_ids: list[str]
+) -> None:
     """Removes the specified activity references from the list of featured
     activity references.
 
@@ -113,7 +126,9 @@ def remove_featured_activities(activity_type, activity_ids):
         update_featured_activity_references(new_activity_references)
 
 
-def split_by_type(activity_references):
+def split_by_type(
+    activity_references: ActivityReferenceList
+) -> Tuple[List[str], List[str]]:
     """Given a list of activity references, returns two lists: the first list
     contains the exploration ids, and the second contains the collection ids.
     The elements in each of the returned lists are in the same order as those

--- a/core/domain/activity_services.py
+++ b/core/domain/activity_services.py
@@ -96,8 +96,7 @@ def remove_featured_activity(activity_type: str, activity_id: str) -> None:
 
 
 def remove_featured_activities(
-    activity_type: str,
-    activity_ids: list[str]
+    activity_type: str, activity_ids: list[str]
 ) -> None:
     """Removes the specified activity references from the list of featured
     activity references.

--- a/core/domain/activity_services_test.py
+++ b/core/domain/activity_services_test.py
@@ -27,54 +27,69 @@ from core.domain import rights_manager
 from core.domain import user_services
 from core.tests import test_utils
 
+from typing import List
+from typing_extensions import Final
+
+ActivityReferenceList = List[activity_domain.ActivityReference]
+
 
 class ActivityServicesTests(test_utils.GenericTestBase):
     """Test the activity services module."""
 
-    EXP_ID_0 = 'EXP_ID_0'
-    EXP_ID_1 = 'EXP_ID_1'
-    COL_ID_2 = 'COL_ID_2'
+    EXP_ID_0: Final = 'EXP_ID_0'
+    EXP_ID_1: Final = 'EXP_ID_1'
+    COL_ID_2: Final = 'COL_ID_2'
 
-    def _create_exploration_reference(self, exploration_id):
+    def _create_exploration_reference(
+        self, exploration_id: str
+    ) -> activity_domain.ActivityReference:
         """Creates and returns the exploration reference corresponding to the
         given exploration id.
         """
         return activity_domain.ActivityReference(
             constants.ACTIVITY_TYPE_EXPLORATION, exploration_id)
 
-    def _create_collection_reference(self, collection_id):
+    def _create_collection_reference(
+        self, collection_id: str
+    ) -> activity_domain.ActivityReference:
         """Creates and returns the collection reference corresponding to the
         given collection id.
         """
         return activity_domain.ActivityReference(
             constants.ACTIVITY_TYPE_COLLECTION, collection_id)
 
-    def _compare_lists(self, reference_list_1, reference_list_2):
+    def _compare_lists(
+        self,
+        reference_list_1: ActivityReferenceList,
+        reference_list_2: ActivityReferenceList
+    ) -> None:
         """Compares the hashed values of the two given reference lists."""
         hashes_1 = [reference.get_hash() for reference in reference_list_1]
         hashes_2 = [reference.get_hash() for reference in reference_list_2]
         self.assertEqual(hashes_1, hashes_2)
 
-    def setUp(self):
+    def setUp(self) -> None:
         """Publish two explorations and one collection."""
         super(ActivityServicesTests, self).setUp()
 
         self.signup(self.OWNER_EMAIL, self.OWNER_USERNAME)
-        self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL)
+        self.owner_id = self.get_user_id_from_email(self.OWNER_EMAIL) # type: ignore[no-untyped-call]
         self.signup(self.MODERATOR_EMAIL, self.MODERATOR_USERNAME)
-        self.moderator_id = self.get_user_id_from_email(self.MODERATOR_EMAIL)
-        self.set_moderators([self.MODERATOR_USERNAME])
-        self.owner = user_services.get_user_actions_info(self.owner_id)
-        self.moderator = user_services.get_user_actions_info(self.moderator_id)
+        self.moderator_id = self.get_user_id_from_email(self.MODERATOR_EMAIL) # type: ignore[no-untyped-call]
+        self.set_moderators([self.MODERATOR_USERNAME]) # type: ignore[no-untyped-call]
+        self.owner = user_services.get_user_actions_info(self.owner_id) # type: ignore[no-untyped-call]
+        self.moderator = user_services.get_user_actions_info(self.moderator_id) # type: ignore[no-untyped-call]
 
-        self.save_new_valid_exploration(self.EXP_ID_0, self.owner_id)
-        self.save_new_valid_exploration(self.EXP_ID_1, self.owner_id)
-        self.save_new_valid_collection(
+        self.save_new_valid_exploration(self.EXP_ID_0, self.owner_id) # type: ignore[no-untyped-call]
+        self.save_new_valid_exploration(self.EXP_ID_1, self.owner_id) # type: ignore[no-untyped-call]
+        self.save_new_valid_collection( # type: ignore[no-untyped-call]
             self.COL_ID_2, self.owner_id, exploration_id=self.EXP_ID_0)
 
-    def test_update_featured_refs_correctly_promotes_activities(self):
-        rights_manager.publish_exploration(self.owner, self.EXP_ID_0)
-        rights_manager.publish_collection(self.owner, self.COL_ID_2)
+    def test_update_featured_refs_correctly_promotes_activities(
+        self
+    ) -> None:
+        rights_manager.publish_exploration(self.owner, self.EXP_ID_0) # type: ignore[no-untyped-call]
+        rights_manager.publish_collection(self.owner, self.COL_ID_2) # type: ignore[no-untyped-call]
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
@@ -86,8 +101,10 @@ class ActivityServicesTests(test_utils.GenericTestBase):
                 self._create_exploration_reference(self.EXP_ID_0),
                 self._create_collection_reference(self.COL_ID_2)])
 
-    def test_update_featured_refs_clears_existing_featured_activities(self):
-        rights_manager.publish_exploration(self.owner, self.EXP_ID_0)
+    def test_update_featured_refs_clears_existing_featured_activities(
+        self
+    ) -> None:
+        rights_manager.publish_exploration(self.owner, self.EXP_ID_0) # type: ignore[no-untyped-call]
         activity_services.update_featured_activity_references([
             self._create_exploration_reference(self.EXP_ID_0)])
         self._compare_lists(
@@ -98,21 +115,25 @@ class ActivityServicesTests(test_utils.GenericTestBase):
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-    def test_updating_with_duplicate_refs_raises_exception(self):
-        rights_manager.publish_exploration(self.owner, self.EXP_ID_0)
-        rights_manager.publish_collection(self.owner, self.COL_ID_2)
+    def test_updating_with_duplicate_refs_raises_exception(
+        self
+    ) -> None:
+        rights_manager.publish_exploration(self.owner, self.EXP_ID_0) # type: ignore[no-untyped-call]
+        rights_manager.publish_collection(self.owner, self.COL_ID_2) # type: ignore[no-untyped-call]
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-        with self.assertRaisesRegex(Exception, 'should not have duplicates'):
+        with self.assertRaisesRegex(Exception, 'should not have duplicates'): # type: ignore[no-untyped-call]
             activity_services.update_featured_activity_references([
                 self._create_exploration_reference(self.EXP_ID_0),
                 self._create_exploration_reference(self.EXP_ID_0)])
 
-    def test_deleted_activity_is_removed_from_featured_list(self):
-        rights_manager.publish_exploration(self.owner, self.EXP_ID_0)
-        rights_manager.publish_exploration(self.owner, self.EXP_ID_1)
-        rights_manager.publish_collection(self.owner, self.COL_ID_2)
+    def test_deleted_activity_is_removed_from_featured_list(
+        self
+    ) -> None:
+        rights_manager.publish_exploration(self.owner, self.EXP_ID_0) # type: ignore[no-untyped-call]
+        rights_manager.publish_exploration(self.owner, self.EXP_ID_1) # type: ignore[no-untyped-call]
+        rights_manager.publish_collection(self.owner, self.COL_ID_2) # type: ignore[no-untyped-call]
         activity_services.update_featured_activity_references([
             self._create_exploration_reference(self.EXP_ID_0),
             self._create_collection_reference(self.COL_ID_2)])
@@ -123,24 +144,26 @@ class ActivityServicesTests(test_utils.GenericTestBase):
                 self._create_collection_reference(self.COL_ID_2)])
 
         # Deleting an unfeatured activity does not affect the featured list.
-        exp_services.delete_exploration(self.owner_id, self.EXP_ID_1)
+        exp_services.delete_exploration(self.owner_id, self.EXP_ID_1) # type: ignore[no-untyped-call]
         self._compare_lists(
             activity_services.get_featured_activity_references(), [
                 self._create_exploration_reference(self.EXP_ID_0),
                 self._create_collection_reference(self.COL_ID_2)])
 
         # Deleting a featured activity removes it from the featured list.
-        collection_services.delete_collection(self.owner_id, self.COL_ID_2)
+        collection_services.delete_collection(self.owner_id, self.COL_ID_2) # type: ignore[no-untyped-call]
         self._compare_lists(
             activity_services.get_featured_activity_references(), [
                 self._create_exploration_reference(self.EXP_ID_0)])
-        exp_services.delete_exploration(self.owner_id, self.EXP_ID_0)
+        exp_services.delete_exploration(self.owner_id, self.EXP_ID_0) # type: ignore[no-untyped-call]
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-    def test_deleted_activity_is_removed_from_featured_list_multiple(self):
-        rights_manager.publish_exploration(self.owner, self.EXP_ID_0)
-        rights_manager.publish_exploration(self.owner, self.EXP_ID_1)
+    def test_deleted_activity_is_removed_from_featured_list_multiple(
+        self
+    ) -> None:
+        rights_manager.publish_exploration(self.owner, self.EXP_ID_0) # type: ignore[no-untyped-call]
+        rights_manager.publish_exploration(self.owner, self.EXP_ID_1) # type: ignore[no-untyped-call]
         exploration_references = [
             self._create_exploration_reference(self.EXP_ID_0),
             self._create_exploration_reference(self.EXP_ID_1)]
@@ -151,15 +174,17 @@ class ActivityServicesTests(test_utils.GenericTestBase):
             activity_services.get_featured_activity_references(),
             exploration_references)
 
-        exp_services.delete_explorations(
+        exp_services.delete_explorations( # type: ignore[no-untyped-call]
             self.owner_id, [self.EXP_ID_0, self.EXP_ID_1])
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-    def test_unpublished_activity_is_removed_from_featured_list(self):
-        rights_manager.publish_exploration(self.owner, self.EXP_ID_0)
-        rights_manager.publish_exploration(self.owner, self.EXP_ID_1)
-        rights_manager.publish_collection(self.owner, self.COL_ID_2)
+    def test_unpublished_activity_is_removed_from_featured_list(
+        self
+    ) -> None:
+        rights_manager.publish_exploration(self.owner, self.EXP_ID_0) # type: ignore[no-untyped-call]
+        rights_manager.publish_exploration(self.owner, self.EXP_ID_1) # type: ignore[no-untyped-call]
+        rights_manager.publish_collection(self.owner, self.COL_ID_2) # type: ignore[no-untyped-call]
         activity_services.update_featured_activity_references([
             self._create_exploration_reference(self.EXP_ID_0),
             self._create_collection_reference(self.COL_ID_2)])
@@ -171,35 +196,39 @@ class ActivityServicesTests(test_utils.GenericTestBase):
 
         # Unpublishing an unfeatured activity does not affect the featured
         # list.
-        rights_manager.unpublish_exploration(self.moderator, self.EXP_ID_1)
+        rights_manager.unpublish_exploration(self.moderator, self.EXP_ID_1) # type: ignore[no-untyped-call]
         self._compare_lists(
             activity_services.get_featured_activity_references(), [
                 self._create_exploration_reference(self.EXP_ID_0),
                 self._create_collection_reference(self.COL_ID_2)])
 
         # Unpublishing a featured activity removes it from the featured list.
-        rights_manager.unpublish_collection(self.moderator, self.COL_ID_2)
+        rights_manager.unpublish_collection(self.moderator, self.COL_ID_2) # type: ignore[no-untyped-call]
         self._compare_lists(
             activity_services.get_featured_activity_references(), [
                 self._create_exploration_reference(self.EXP_ID_0)])
 
-        rights_manager.unpublish_exploration(self.moderator, self.EXP_ID_0)
+        rights_manager.unpublish_exploration(self.moderator, self.EXP_ID_0) # type: ignore[no-untyped-call]
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-    def test_publish_activity_does_not_affect_featured_list(self):
+    def test_publish_activity_does_not_affect_featured_list(
+        self
+    ) -> None:
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-        rights_manager.publish_exploration(self.owner, self.EXP_ID_0)
+        rights_manager.publish_exploration(self.owner, self.EXP_ID_0) # type: ignore[no-untyped-call]
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-        rights_manager.publish_collection(self.owner, self.COL_ID_2)
+        rights_manager.publish_collection(self.owner, self.COL_ID_2) # type: ignore[no-untyped-call]
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-    def test_split_by_type(self):
+    def test_split_by_type(
+        self
+    ) -> None:
         self.assertEqual(
             activity_services.split_by_type([]), ([], []))
 
@@ -219,9 +248,11 @@ class ActivityServicesTests(test_utils.GenericTestBase):
                 exploration_123, collection_def, exploration_ab]),
             (['123', 'ab'], ['def']))
 
-    def test_split_by_type_raises_error_if_given_invalid_activity_ref(self):
+    def test_split_by_type_raises_error_if_given_invalid_activity_ref(
+        self
+    ) -> None:
         exploration_123 = self._create_exploration_reference('123')
-        with self.assertRaisesRegex(Exception, 'Invalid activity reference'):
+        with self.assertRaisesRegex(Exception, 'Invalid activity reference'): # type: ignore[no-untyped-call]
             activity_services.split_by_type([
                 exploration_123,
                 activity_domain.ActivityReference('invalid_type', 'bbb')

--- a/core/domain/activity_services_test.py
+++ b/core/domain/activity_services_test.py
@@ -27,6 +27,7 @@ from core.domain import rights_manager
 from core.domain import user_services
 from core.tests import test_utils
 
+from typing import List
 from typing_extensions import Final
 
 
@@ -57,8 +58,8 @@ class ActivityServicesTests(test_utils.GenericTestBase):
 
     def _compare_lists(
         self,
-        reference_list_1: activity_services.ActivityReferenceList,
-        reference_list_2: activity_services.ActivityReferenceList,
+        reference_list_1: List[activity_domain.ActivityReference],
+        reference_list_2: List[activity_domain.ActivityReference],
     ) -> None:
         """Compares the hashed values of the two given reference lists."""
         hashes_1 = [reference.get_hash() for reference in reference_list_1]

--- a/core/domain/activity_services_test.py
+++ b/core/domain/activity_services_test.py
@@ -27,10 +27,7 @@ from core.domain import rights_manager
 from core.domain import user_services
 from core.tests import test_utils
 
-from typing import List
 from typing_extensions import Final
-
-ActivityReferenceList = List[activity_domain.ActivityReference]
 
 
 class ActivityServicesTests(test_utils.GenericTestBase):
@@ -60,8 +57,8 @@ class ActivityServicesTests(test_utils.GenericTestBase):
 
     def _compare_lists(
         self,
-        reference_list_1: ActivityReferenceList,
-        reference_list_2: ActivityReferenceList
+        reference_list_1: activity_services.ActivityReferenceList,
+        reference_list_2: activity_services.ActivityReferenceList,
     ) -> None:
         """Compares the hashed values of the two given reference lists."""
         hashes_1 = [reference.get_hash() for reference in reference_list_1]
@@ -85,9 +82,7 @@ class ActivityServicesTests(test_utils.GenericTestBase):
         self.save_new_valid_collection( # type: ignore[no-untyped-call]
             self.COL_ID_2, self.owner_id, exploration_id=self.EXP_ID_0)
 
-    def test_update_featured_refs_correctly_promotes_activities(
-        self
-    ) -> None:
+    def test_update_featured_refs_correctly_promotes_activities(self) -> None:
         rights_manager.publish_exploration(self.owner, self.EXP_ID_0) # type: ignore[no-untyped-call]
         rights_manager.publish_collection(self.owner, self.COL_ID_2) # type: ignore[no-untyped-call]
         self._compare_lists(
@@ -115,9 +110,7 @@ class ActivityServicesTests(test_utils.GenericTestBase):
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-    def test_updating_with_duplicate_refs_raises_exception(
-        self
-    ) -> None:
+    def test_updating_with_duplicate_refs_raises_exception(self) -> None:
         rights_manager.publish_exploration(self.owner, self.EXP_ID_0) # type: ignore[no-untyped-call]
         rights_manager.publish_collection(self.owner, self.COL_ID_2) # type: ignore[no-untyped-call]
         self._compare_lists(
@@ -128,9 +121,7 @@ class ActivityServicesTests(test_utils.GenericTestBase):
                 self._create_exploration_reference(self.EXP_ID_0),
                 self._create_exploration_reference(self.EXP_ID_0)])
 
-    def test_deleted_activity_is_removed_from_featured_list(
-        self
-    ) -> None:
+    def test_deleted_activity_is_removed_from_featured_list(self) -> None:
         rights_manager.publish_exploration(self.owner, self.EXP_ID_0) # type: ignore[no-untyped-call]
         rights_manager.publish_exploration(self.owner, self.EXP_ID_1) # type: ignore[no-untyped-call]
         rights_manager.publish_collection(self.owner, self.COL_ID_2) # type: ignore[no-untyped-call]
@@ -179,9 +170,7 @@ class ActivityServicesTests(test_utils.GenericTestBase):
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-    def test_unpublished_activity_is_removed_from_featured_list(
-        self
-    ) -> None:
+    def test_unpublished_activity_is_removed_from_featured_list(self) -> None:
         rights_manager.publish_exploration(self.owner, self.EXP_ID_0) # type: ignore[no-untyped-call]
         rights_manager.publish_exploration(self.owner, self.EXP_ID_1) # type: ignore[no-untyped-call]
         rights_manager.publish_collection(self.owner, self.COL_ID_2) # type: ignore[no-untyped-call]
@@ -212,9 +201,7 @@ class ActivityServicesTests(test_utils.GenericTestBase):
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-    def test_publish_activity_does_not_affect_featured_list(
-        self
-    ) -> None:
+    def test_publish_activity_does_not_affect_featured_list(self) -> None:
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
@@ -226,9 +213,7 @@ class ActivityServicesTests(test_utils.GenericTestBase):
         self._compare_lists(
             activity_services.get_featured_activity_references(), [])
 
-    def test_split_by_type(
-        self
-    ) -> None:
+    def test_split_by_type(self) -> None:
         self.assertEqual(
             activity_services.split_by_type([]), ([], []))
 

--- a/scripts/run_mypy_checks.py
+++ b/scripts/run_mypy_checks.py
@@ -41,8 +41,6 @@ NOT_FULLY_COVERED_FILES = [
     'core/controllers/',
     'core/domain/action_registry.py',
     'core/domain/action_registry_test.py',
-    'core/domain/activity_services.py',
-    'core/domain/activity_services_test.py',
     'core/domain/auth_services.py',
     'core/domain/auth_services_test.py',
     'core/domain/blog_services.py',


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #14033 .
2. This PR does the following: added annotations to `activity_services.py` and it's test file.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
No proof of changes needed because following tests passed on local machine.
- lint checks.
- mypy type checks


<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly. Please also include videos/screenshots of the developer tools browser console, so that we can be sure that there are no console errors.
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have a separate .rtl.css file for styling), make sure to add screenshots with the site language set to Arabic as well.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
