### PR TITLE
Fix part of #14419: ANDROID_TEXT_SIZE and ANDROID_NETWORK_TYPE enums refactored

### DIFF
--- a/core/domain/app_feedback_report_constants.py
+++ b/core/domain/app_feedback_report_constants.py
@@ -119,30 +119,22 @@ class STATS_PARAMETER_NAMES(enum.Enum): # pylint: disable=invalid-name
     version_name = 'version_name' # pylint: disable=invalid-name
 
 
-# TODO(#14419): Change naming style of Enum class from SCREAMING_SNAKE_CASE
-# to PascalCase and its values to UPPER_CASE. Because we want to be consistent
-# throughout the codebase according to the coding style guide.
-# https://github.com/oppia/oppia/wiki/Coding-style-guide
-class ANDROID_TEXT_SIZE(enum.Enum): # pylint: disable=invalid-name
+class AndroidTextSize(enum.Enum):
     """Enum for android text sizes."""
 
-    text_size_unspecified = 'text_size_unspecified' # pylint: disable=invalid-name
-    small_text_size = 'small_text_size' # pylint: disable=invalid-name
-    medium_text_size = 'medium_text_size' # pylint: disable=invalid-name
-    large_text_size = 'large_text_size' # pylint: disable=invalid-name
-    extra_large_text_size = 'extra_large_text_size' # pylint: disable=invalid-name
+    TEXT_SIZE_UNSPECIFIED = 'text_size_unspecified'
+    SMALL_TEXT_SIZE = 'small_text_size'
+    MEDIUM_TEXT_SIZE = 'medium_text_size'
+    LARGE_TEXT_SIZE = 'large_text_size'
+    EXTRA_LARGE_TEXT_SIZE = 'extra_large_text_size'
 
 
-# TODO(#14419): Change naming style of Enum class from SCREAMING_SNAKE_CASE
-# to PascalCase and its values to UPPER_CASE. Because we want to be consistent
-# throughout the codebase according to the coding style guide.
-# https://github.com/oppia/oppia/wiki/Coding-style-guide
-class ANDROID_NETWORK_TYPE(enum.Enum): # pylint: disable=invalid-name
+class AndroidNetworkType(enum.Enum):
     """Enum for android network types."""
 
-    wifi = 'wifi' # pylint: disable=invalid-name
-    cellular = 'cellular' # pylint: disable=invalid-name
-    none = 'none' # pylint: disable=invalid-name
+    WIFI = 'wifi'
+    CELLULAR = 'cellular'
+    NONE = 'none'
 
 
 FILTER_FIELD_NAMES = app_feedback_report_models.FILTER_FIELD_NAMES
@@ -187,9 +179,9 @@ ALLOWED_FILTERS = [
     FILTER_FIELD_NAMES.audio_language_code, FILTER_FIELD_NAMES.platform_version,
     FILTER_FIELD_NAMES.android_device_country_locale_code]
 ALLOWED_ANDROID_NETWORK_TYPES = [
-    ANDROID_NETWORK_TYPE.wifi, ANDROID_NETWORK_TYPE.cellular,
-    ANDROID_NETWORK_TYPE.none]
+    AndroidNetworkType.WIFI, AndroidNetworkType.CELLULAR,
+    AndroidNetworkType.NONE]
 ALLOWED_ANDROID_TEXT_SIZES = [
-    ANDROID_TEXT_SIZE.text_size_unspecified, ANDROID_TEXT_SIZE.small_text_size,
-    ANDROID_TEXT_SIZE.medium_text_size, ANDROID_TEXT_SIZE.large_text_size,
-    ANDROID_TEXT_SIZE.extra_large_text_size]
+    AndroidTextSize.TEXT_SIZE_UNSPECIFIED, AndroidTextSize.SMALL_TEXT_SIZE,
+    AndroidTextSize.MEDIUM_TEXT_SIZE, AndroidTextSize.LARGE_TEXT_SIZE,
+    AndroidTextSize.EXTRA_LARGE_TEXT_SIZE]

--- a/core/domain/app_feedback_report_domain.py
+++ b/core/domain/app_feedback_report_domain.py
@@ -364,7 +364,7 @@ class AppFeedbackReport:
         """
         for text_size_type in (
             app_feedback_report_constants.ALLOWED_ANDROID_TEXT_SIZES):
-            if text_size_name == text_size_type.name:
+            if text_size_name == text_size_type.value:
                 return text_size_type
         raise utils.InvalidInputException(
             'The given Android app text size %s is invalid.' % text_size_name)
@@ -421,7 +421,7 @@ class AppFeedbackReport:
         """
         for network_type in (
             app_feedback_report_constants.ALLOWED_ANDROID_NETWORK_TYPES):
-            if network_type_name == network_type.name:
+            if network_type_name == network_type.value:
                 return network_type
         raise utils.InvalidInputException(
             'The given Android network type %s is invalid.' % network_type_name)
@@ -698,7 +698,7 @@ class AndroidDeviceSystemContext(DeviceSystemContext):
             'device_model': self.device_model,
             'sdk_version': self.sdk_version,
             'build_fingerprint': self.build_fingerprint,
-            'network_type': self.network_type.name
+            'network_type': self.network_type.value
         }
 
     def validate(self) -> None:
@@ -977,7 +977,7 @@ class AndroidAppContext(AppContext):
             'entry_point': self.entry_point.to_dict(),
             'text_language_code': self.text_language_code,
             'audio_language_code': self.audio_language_code,
-            'text_size': self.text_size.name,
+            'text_size': self.text_size.value,
             'only_allows_wifi_download_and_update': (
                 self.only_allows_wifi_download_and_update
             ),

--- a/core/domain/app_feedback_report_domain.py
+++ b/core/domain/app_feedback_report_domain.py
@@ -353,14 +353,14 @@ class AppFeedbackReport:
     @classmethod
     def get_android_text_size_from_string(
         cls, text_size_name: str
-    ) -> app_feedback_report_constants.ANDROID_TEXT_SIZE:
+    ) -> app_feedback_report_constants.AndroidTextSize:
         """Determines the app text size based on the JSON value.
 
         Args:
             text_size_name: str. The name of the app's text size set.
 
         Returns:
-            ANDROID_TEXT_SIZE. The enum representing the text size.
+            AndroidTextSize. The enum representing the text size.
         """
         for text_size_type in (
             app_feedback_report_constants.ALLOWED_ANDROID_TEXT_SIZES):
@@ -410,14 +410,14 @@ class AppFeedbackReport:
     @classmethod
     def get_android_network_type_from_string(
         cls, network_type_name: str
-    ) -> app_feedback_report_constants.ANDROID_NETWORK_TYPE:
+    ) -> app_feedback_report_constants.AndroidNetworkType:
         """Determines the network type based on the JSON value.
 
         Args:
             network_type_name: str. The name of the network type.
 
         Returns:
-            ANDROID_NETWORK_TYPE. The enum representing the network type.
+            AndroidNetworkType. The enum representing the network type.
         """
         for network_type in (
             app_feedback_report_constants.ALLOWED_ANDROID_NETWORK_TYPES):
@@ -651,7 +651,7 @@ class AndroidDeviceSystemContext(DeviceSystemContext):
         device_model: str,
         sdk_version: int,
         build_fingerprint: str,
-        network_type: app_feedback_report_constants.ANDROID_NETWORK_TYPE
+        network_type: app_feedback_report_constants.AndroidNetworkType
     ) -> None:
         """Constructs an AndroidDeviceSystemContext domain object.
 
@@ -670,7 +670,7 @@ class AndroidDeviceSystemContext(DeviceSystemContext):
             sdk_version: int. The Android SDK version running on the device.
             build_fingerprint: str. The unique build fingerprint of this app
                 version.
-            network_type: ANDROID_NETWORK_TYPE. The enum for the network type
+            network_type: AndroidNetworkType. The enum for the network type
                 the device was connected to.
         """
         super(AndroidDeviceSystemContext, self).__init__(
@@ -843,12 +843,12 @@ class AndroidDeviceSystemContext(DeviceSystemContext):
 
     @classmethod
     def require_valid_network_type(
-        cls, network_type: app_feedback_report_constants.ANDROID_NETWORK_TYPE
+        cls, network_type: app_feedback_report_constants.AndroidNetworkType
     ) -> None:
         """Checks that the Android device's network type is valid.
 
         Args:
-            network_type: ANDROID_NETWORK_TYPE. The network type the device
+            network_type: AndroidNetworkType. The network type the device
                 was connected to when sending the report, as an enum.
 
         Raises:
@@ -923,7 +923,7 @@ class AndroidAppContext(AppContext):
         entry_point: EntryPoint,
         text_language_code: str,
         audio_language_code: str,
-        text_size: app_feedback_report_constants.ANDROID_TEXT_SIZE,
+        text_size: app_feedback_report_constants.AndroidTextSize,
         only_allows_wifi_download_and_update: bool,
         automatically_update_topics: bool,
         account_is_profile_admin: bool,
@@ -939,7 +939,7 @@ class AndroidAppContext(AppContext):
                 in the app.
             audio_language_code: str. The ISO-639 code for the audio language
                 set in the app.
-            text_size: ANDROID_TEXT_SIZE. The enum type for text size set by
+            text_size: AndroidTextSize. The enum type for text size set by
                 the user in the app.
             only_allows_wifi_download_and_update: bool. True if the user only
                 allows downloads and updates when connected to wifi.
@@ -1067,13 +1067,13 @@ class AndroidAppContext(AppContext):
 
     @classmethod
     def require_valid_text_size(
-        cls, text_size: app_feedback_report_constants.ANDROID_TEXT_SIZE
+        cls, text_size: app_feedback_report_constants.AndroidTextSize
     ) -> None:
         """Checks whether the package version code is a valid string code for
         Oppia Android.
 
         Args:
-            text_size: ANDROID_TEXT_SIZE. The enum type for the text size set by
+            text_size: AndroidTextSize. The enum type for the text size set by
                 the user in the app.
 
         Raises:

--- a/core/domain/app_feedback_report_domain_test.py
+++ b/core/domain/app_feedback_report_domain_test.py
@@ -80,12 +80,12 @@ ANDROID_REPORT_INFO = {
     'logcat_logs': ['logcat1', 'logcat2'],
     'package_version_code': ANDROID_PACKAGE_VERSION_CODE,
     'build_fingerprint': ANDROID_BUILD_FINGERPRINT,
-    'network_type': NETWORK_WIFI.name,
+    'network_type': NETWORK_WIFI.value,
     'android_device_language_locale_code': LANGUAGE_LOCALE_CODE_ENGLISH,
     'entry_point_info': {
         'entry_point_name': ENTRY_POINT_NAVIGATION_DRAWER,
     },
-    'text_size': ANDROID_TEXT_SIZE.name,
+    'text_size': ANDROID_TEXT_SIZE.value,
     'only_allows_wifi_download_and_update': True,
     'automatically_update_topics': False,
     'account_is_profile_admin': False
@@ -173,7 +173,7 @@ class AppFeedbackReportDomainTests(test_utils.GenericTestBase):
                 'device_model': ANDROID_DEVICE_MODEL,
                 'sdk_version': ANDROID_SDK_VERSION,
                 'build_fingerprint': ANDROID_BUILD_FINGERPRINT,
-                'network_type': NETWORK_WIFI.name
+                'network_type': NETWORK_WIFI.value
             },
             'app_context': {
                 'entry_point': {
@@ -181,7 +181,7 @@ class AppFeedbackReportDomainTests(test_utils.GenericTestBase):
                 },
                 'text_language_code': LANGUAGE_LOCALE_CODE_ENGLISH,
                 'audio_language_code': LANGUAGE_LOCALE_CODE_ENGLISH,
-                'text_size': ANDROID_TEXT_SIZE.name,
+                'text_size': ANDROID_TEXT_SIZE.value,
                 'only_allows_wifi_download_and_update': True,
                 'automatically_update_topics': False,
                 'account_is_profile_admin': False,
@@ -305,7 +305,7 @@ class AppFeedbackReportDomainTests(test_utils.GenericTestBase):
             app_feedback_report_constants.ALLOWED_ANDROID_TEXT_SIZES):
             self.assertEqual(
                 feedback_report.get_android_text_size_from_string(
-                    text_size.name), text_size)
+                    text_size.value), text_size)
 
     def test_get_android_text_size_from_string_with_invalid_string_raises_error(
             self) -> None:
@@ -387,7 +387,7 @@ class AppFeedbackReportDomainTests(test_utils.GenericTestBase):
         for network_type in app_feedback_report_constants.AndroidNetworkType:
             self.assertEqual(
                 feedback_report.get_android_network_type_from_string(
-                    network_type.name), network_type)
+                    network_type.value), network_type)
 
     def test_get_android_network_type_from_string_invalid_string_raises_error(
             self) -> None:
@@ -590,7 +590,7 @@ class AndroidDeviceSystemContextTests(test_utils.GenericTestBase):
             'device_model': ANDROID_DEVICE_MODEL,
             'sdk_version': ANDROID_SDK_VERSION,
             'build_fingerprint': ANDROID_BUILD_FINGERPRINT,
-            'network_type': NETWORK_WIFI.name
+            'network_type': NETWORK_WIFI.value
         }
         self.assertDictEqual(
             expected_dict, self.device_system_context.to_dict())
@@ -1049,7 +1049,7 @@ class AndroidAppContextDomainTests(test_utils.GenericTestBase):
             },
             'text_language_code': LANGUAGE_LOCALE_CODE_ENGLISH,
             'audio_language_code': LANGUAGE_LOCALE_CODE_ENGLISH,
-            'text_size': ANDROID_TEXT_SIZE.name,
+            'text_size': ANDROID_TEXT_SIZE.value,
             'only_allows_wifi_download_and_update': True,
             'automatically_update_topics': False,
             'account_is_profile_admin': False,

--- a/core/domain/app_feedback_report_domain_test.py
+++ b/core/domain/app_feedback_report_domain_test.py
@@ -65,9 +65,9 @@ ENTRY_POINT_CRASH = 'crash'
 ENTRY_POINT_NAVIGATION_DRAWER = 'navigation_drawer'
 LANGUAGE_LOCALE_CODE_ENGLISH = 'en'
 ANDROID_PACKAGE_VERSION_CODE = 1
-NETWORK_WIFI = app_feedback_report_constants.ANDROID_NETWORK_TYPE.wifi
+NETWORK_WIFI = app_feedback_report_constants.AndroidNetworkType.WIFI
 ANDROID_TEXT_SIZE = (
-    app_feedback_report_constants.ANDROID_TEXT_SIZE.medium_text_size)
+    app_feedback_report_constants.AndroidTextSize.MEDIUM_TEXT_SIZE)
 ANDROID_BUILD_FINGERPRINT = 'example_fingerprint_id'
 EVENT_LOGS = ['event1', 'event2']
 LOGCAT_LOGS = ['logcat1', 'logcat2']
@@ -384,7 +384,7 @@ class AppFeedbackReportDomainTests(test_utils.GenericTestBase):
     def test_get_android_network_type_from_string_returns_expected_network_type(
             self) -> None:
         feedback_report = app_feedback_report_domain.AppFeedbackReport
-        for network_type in app_feedback_report_constants.ANDROID_NETWORK_TYPE:
+        for network_type in app_feedback_report_constants.AndroidNetworkType:
             self.assertEqual(
                 feedback_report.get_android_network_type_from_string(
                     network_type.name), network_type)

--- a/core/domain/app_feedback_report_services.py
+++ b/core/domain/app_feedback_report_services.py
@@ -516,8 +516,8 @@ def save_feedback_report_to_storage(
         'android_device_language_locale_code': (
             device_system_context.device_language_locale_code),
         'build_fingerprint': device_system_context.build_fingerprint,
-        'network_type': device_system_context.network_type.name,
-        'text_size': app_context.text_size.name,
+        'network_type': device_system_context.network_type.value,
+        'text_size': app_context.text_size.value,
         'only_allows_wifi_download_and_update': str(
             app_context.only_allows_wifi_download_and_update),
         'automatically_update_topics': str(

--- a/core/domain/app_feedback_report_services_test.py
+++ b/core/domain/app_feedback_report_services_test.py
@@ -305,7 +305,7 @@ class AppFeedbackReportServicesUnitTests(test_utils.GenericTestBase):
             self.android_report_model.android_report_info[
                 'build_fingerprint'])
         self.assertEqual(
-            device_system_context.network_type.name,
+            device_system_context.network_type.value,
             self.android_report_model.android_report_info[
                 'network_type'])
 
@@ -326,7 +326,7 @@ class AppFeedbackReportServicesUnitTests(test_utils.GenericTestBase):
             app_context.audio_language_code,
             self.android_report_model.audio_language_code)
         self.assertEqual(
-            app_context.text_size.name,
+            app_context.text_size.value,
             self.android_report_model.android_report_info['text_size'])
         self.assertEqual(
             app_context.only_allows_wifi_download_and_update,


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #14419 
2. This PR does the following: Refactored ANDROID_TEXT_SIZE and ANDROID_NETWORK_TYPE to conform to the Oppia style guide.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
No proof of changes needed because only naming style convention of already tested classes is changed.
<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly. Please also include videos/screenshots of the developer tools browser console, so that we can be sure that there are no console errors.
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have a separate .rtl.css file for styling), make sure to add screenshots with the site language set to Arabic as well.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
