### PR TITLE
Fix #14944: Copy text in translation mode

### DIFF
--- a/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
+++ b/core/templates/pages/exploration-editor-page/translation-tab/state-translation/state-translation.component.html
@@ -71,7 +71,7 @@
       </angular-html-bind>
       <h3>Content</h3>
       <ul class="nav oppia-option-list nav-stacked nav-pills" role="tablist">
-        <li class="oppia-rule-block oppia-prevent-selection mt-0"
+        <li class="oppia-rule-block mt-0"
             ng-repeat="caContent in interactionCustomizationArgTranslatableContent track by $index"
             ng-class="{'active': activeCustomizationArgContentIndex === $index}">
           <a ng-click="changeActiveCustomizationArgContentIndex($index)"
@@ -114,7 +114,7 @@
     <div ng-if="isActive(TAB_ID_RULE_INPUTS)" class="translation-state-content">
       <div>
         <ul class="nav oppia-option-list nav-stacked nav-pills" role="tablist">
-          <li class="oppia-rule-block oppia-prevent-selection protractor-test-translation-feedback mt-0"
+          <li class="oppia-rule-block protractor-test-translation-feedback mt-0"
               ng-repeat="ruleContent in interactionRuleTranslatableContents track by $index"
               ng-class="{'active': activeRuleContentIndex === $index}">
             <a class="oppia-rule-tab protractor-test-feedback-<[$index]>"
@@ -139,7 +139,7 @@
     <div ng-if="isActive(TAB_ID_FEEDBACK)" class="translation-state-content">
       <div>
         <ul class="nav oppia-option-list nav-stacked nav-pills" role="tablist">
-          <li class="oppia-rule-block oppia-prevent-selection protractor-test-translation-feedback mt-0"
+          <li class="oppia-rule-block protractor-test-translation-feedback mt-0"
               ng-repeat="answerGroup in stateAnswerGroups track by $index"
               ng-class="{'active': activeAnswerGroupIndex === $index}">
             <a class="oppia-rule-tab protractor-test-feedback-<[$index]>"
@@ -217,7 +217,7 @@
     </div>
     <div ng-if="isActive(TAB_ID_HINTS)" class="translation-state-content">
       <ul class="nav oppia-option-list nav-stacked nav-pills" role="tablist">
-        <li class="oppia-rule-block oppia-prevent-selection protractor-test-translation-hint mt-0"
+        <li class="oppia-rule-block protractor-test-translation-hint mt-0"
             ng-repeat="hint in stateHints track by $index"
             ng-class="{'active': activeHintIndex === $index}">
           <a ng-click="changeActiveHintIndex($index)"


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #14944 .
2. This PR does the following: Allows all text to be copied in the translation tab.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://user-images.githubusercontent.com/73544247/156407565-fa83b0af-6b40-4216-bce1-50d150a58c7f.mp4


<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly. Please also include videos/screenshots of the developer tools browser console, so that we can be sure that there are no console errors.
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have a separate .rtl.css file for styling), make sure to add screenshots with the site language set to Arabic as well.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
