### PR TITLE
Fix part of #14537: Refactored rights domain file

### DIFF
--- a/core/domain/rights_domain.py
+++ b/core/domain/rights_domain.py
@@ -22,9 +22,6 @@ from core.constants import constants
 from core.domain import change_domain
 
 from typing import List, Optional
-from typing_extensions import TypedDict
-
-from core.domain import user_services  # pylint: disable=invalid-import-from # isort:skip
 
 # TODO(#14537): Refactor this file and remove imports marked
 # with 'invalid-import-from'.
@@ -54,19 +51,6 @@ ASSIGN_ROLE_COMMIT_MESSAGE_TEMPLATE = 'Changed role of %s from %s to %s'
 ASSIGN_ROLE_COMMIT_MESSAGE_REGEX = '^Changed role of (.*) from (.*) to (.*)$'
 DEASSIGN_ROLE_COMMIT_MESSAGE_TEMPLATE = 'Remove %s from role %s'
 DEASSIGN_ROLE_COMMIT_MESSAGE_REGEX = '^Remove (.*) from role (.*)$'
-
-
-class ActivityRightsDict(TypedDict):
-    """A dict version of ActivityRights suitable for use by the frontend."""
-
-    cloned_from: Optional[str]
-    status: str
-    community_owned: bool
-    owner_names: List[str]
-    editor_names: List[str]
-    voice_artist_names: List[str]
-    viewer_names: List[str]
-    viewable_if_private: bool
 
 
 class ActivityRights:
@@ -155,40 +139,6 @@ class ActivityRights:
         if not self.community_owned and len(self.owner_ids) == 0:
             raise utils.ValidationError(
                 'Activity should have atleast one owner.')
-
-    def to_dict(self) -> ActivityRightsDict:
-        """Returns a dict suitable for use by the frontend.
-
-        Returns:
-            dict. A dict version of ActivityRights suitable for use by the
-            frontend.
-        """
-        if self.community_owned:
-            return {
-                'cloned_from': self.cloned_from,
-                'status': self.status,
-                'community_owned': True,
-                'owner_names': [],
-                'editor_names': [],
-                'voice_artist_names': [],
-                'viewer_names': [],
-                'viewable_if_private': self.viewable_if_private,
-            }
-        else:
-            return {
-                'cloned_from': self.cloned_from,
-                'status': self.status,
-                'community_owned': False,
-                'owner_names': user_services.get_human_readable_user_ids(# type: ignore[no-untyped-call]
-                    self.owner_ids),
-                'editor_names': user_services.get_human_readable_user_ids(# type: ignore[no-untyped-call]
-                    self.editor_ids),
-                'voice_artist_names': user_services.get_human_readable_user_ids(# type: ignore[no-untyped-call]
-                    self.voice_artist_ids),
-                'viewer_names': user_services.get_human_readable_user_ids(# type: ignore[no-untyped-call]
-                    self.viewer_ids),
-                'viewable_if_private': self.viewable_if_private,
-            }
 
     def is_owner(self, user_id: str) -> bool:
         """Checks whether given user is owner of activity.

--- a/core/domain/rights_domain_test.py
+++ b/core/domain/rights_domain_test.py
@@ -209,28 +209,6 @@ class ActivityRightsTests(test_utils.GenericTestBase):
             'Activity should have atleast one owner.'):
             self.activity_rights.validate()
 
-    def test_to_dict(self) -> None:
-        sample_activity_rights_dict: rights_domain.ActivityRightsDict = {
-            'cloned_from': None,
-            'status': rights_domain.ACTIVITY_STATUS_PUBLIC,
-            'community_owned': False,
-            'owner_names': ['owner'],
-            'editor_names': [],
-            'voice_artist_names': [],
-            'viewer_names': [],
-            'viewable_if_private': False,
-        }
-        self.assertEqual(
-            self.activity_rights.to_dict(), sample_activity_rights_dict
-        )
-
-        self.activity_rights.community_owned = True
-        sample_activity_rights_dict['community_owned'] = True
-        sample_activity_rights_dict['owner_names'] = []
-        self.assertEqual(
-            self.activity_rights.to_dict(), sample_activity_rights_dict
-        )
-
     def test_is_editor(self) -> None:
         self.activity_rights.editor_ids = ['123456']
         self.assertTrue(self.activity_rights.is_editor('123456'))
@@ -475,19 +453,6 @@ class ExplorationRightsChangeTests(test_utils.GenericTestBase):
             exploration_rights_change_object.new_status,
             rights_domain.ACTIVITY_STATUS_PUBLIC)
 
-    def test_to_dict(self) -> None:
-        exploration_rights_change_dict = {
-            'cmd': 'change_private_viewability',
-            'old_viewable_if_private': 'old_viewable_if_private',
-            'new_viewable_if_private': 'new_viewable_if_private'
-        }
-        exploration_rights_change_object = (
-            rights_domain.ExplorationRightsChange(
-                exploration_rights_change_dict))
-        self.assertEqual(
-            exploration_rights_change_object.to_dict(),
-            exploration_rights_change_dict)
-
 
 class CollectionRightsChangeTests(test_utils.GenericTestBase):
 
@@ -637,15 +602,3 @@ class CollectionRightsChangeTests(test_utils.GenericTestBase):
         self.assertEqual(
             collection_rights_change_object.new_status,
             rights_domain.ACTIVITY_STATUS_PUBLIC)
-
-    def test_to_dict(self) -> None:
-        collection_rights_change_dict = {
-            'cmd': 'change_private_viewability',
-            'old_viewable_if_private': 'old_viewable_if_private',
-            'new_viewable_if_private': 'new_viewable_if_private'
-        }
-        collection_rights_change_object = rights_domain.CollectionRightsChange(
-            collection_rights_change_dict)
-        self.assertEqual(
-            collection_rights_change_object.to_dict(),
-            collection_rights_change_dict)


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #14537.
2. This PR does the following: Make sure that domain object files do not import services
## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
<img width="1422" alt="Screenshot 2022-01-10 at 3 17 17 PM" src="https://user-images.githubusercontent.com/63154588/156938650-9eb1db8c-3366-4950-8357-c48b9873bdf9.png">

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
