### PR TITLE
Fix #14419 Refactor PARAM_NAMES enum class to Pascal case and values to uppercase

### DIFF
--- a/core/domain/platform_parameter_list.py
+++ b/core/domain/platform_parameter_list.py
@@ -25,28 +25,23 @@ from core.domain import platform_parameter_registry as registry
 
 Registry = registry.Registry
 
-
-# TODO(#14419): Change naming style of Enum class from SCREAMING_SNAKE_CASE
-# to PascalCase and its values to UPPER_CASE. Because we want to be consistent
-# throughout the codebase according to the coding style guide.
-# https://github.com/oppia/oppia/wiki/Coding-style-guide
-class PARAM_NAMES(enum.Enum): # pylint: disable=invalid-name
+class ParamNames(enum.Enum): # pylint: disable=invalid-name
     """Enum for parameter names."""
 
-    dummy_feature = 'dummy_feature' # pylint: disable=invalid-name
-    dummy_parameter = 'dummy_parameter' # pylint: disable=invalid-name
+    DUMMY_FEATURE = 'DUMMY_FEATURE' # pylint: disable=invalid-name
+    DUMMY_PARAMETER = 'DUMMY_PARAMETER' # pylint: disable=invalid-name
 
 
 # Platform parameters should all be defined below.
 
 Registry.create_feature_flag(
-    PARAM_NAMES.dummy_feature,
+    ParamNames.DUMMY_FEATURE,
     'This is a dummy feature flag.',
     platform_parameter_domain.FeatureStages.DEV,
 )
 
 Registry.create_platform_parameter(
-    PARAM_NAMES.dummy_parameter,
+    ParamNames.DUMMY_PARAMETER,
     'This is a dummy platform parameter.',
     platform_parameter_domain.DataTypes.STRING
 )


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[14419].
2. This PR does the following: [Refactor PARAM_NAMES platform_parameter_list.py Enum class to Pascal case and values to UPPERCASE]

## Essential Checklist

- [ x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x ] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly. Please also include videos/screenshots of the developer tools browser console, so that we can be sure that there are no console errors.
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have a separate .rtl.css file for styling), make sure to add screenshots with the site language set to Arabic as well.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
