### PR TITLE
Fix #13548: Enable solutions for item selection input interaction

### DIFF
--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.py
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.py
@@ -31,9 +31,7 @@ class ItemSelectionInput(base.BaseInteraction):
     _dependency_ids = []
     answer_type = 'SetOfTranslatableHtmlContentIds'
     can_have_solution = True
-    # ItemSelectionInput's submit button is dynamic and is handled
-    # separately.
-    show_generic_submit_button = False
+    show_generic_submit_button = True
 
     _customization_arg_specs = [{
         'name': 'minAllowableSelectionCount',

--- a/extensions/interactions/ItemSelectionInput/ItemSelectionInput.py
+++ b/extensions/interactions/ItemSelectionInput/ItemSelectionInput.py
@@ -30,9 +30,7 @@ class ItemSelectionInput(base.BaseInteraction):
     display_mode = base.DISPLAY_MODE_INLINE
     _dependency_ids = []
     answer_type = 'SetOfTranslatableHtmlContentIds'
-    # Radio buttons get unselected when specifying a solution. This needs to be
-    # fixed before solution feature can support this interaction.
-    can_have_solution = False
+    can_have_solution = True
     # ItemSelectionInput's submit button is dynamic and is handled
     # separately.
     show_generic_submit_button = False

--- a/extensions/interactions/ItemSelectionInput/directives/item-selection-input-short-response.component.html
+++ b/extensions/interactions/ItemSelectionInput/directives/item-selection-input-short-response.component.html
@@ -12,7 +12,7 @@
 <ul *ngIf="responses.length > 1">
   <li *ngFor="let response of responses; index as idx">
     <span>
-      <angular-html-bind-wrapper [htmlData]="responses">
+      <angular-html-bind-wrapper [htmlData]="response">
       </angular-html-bind-wrapper>
     </span>
   </li>

--- a/extensions/interactions/ItemSelectionInput/directives/oppia-response-item-selection-input.component.spec.ts
+++ b/extensions/interactions/ItemSelectionInput/directives/oppia-response-item-selection-input.component.spec.ts
@@ -65,4 +65,11 @@ describe('ResponseItemSelectionInput', () => {
 
     expect(component.responses).toEqual(['choice 1']);
   });
+  it('should set the answers and responses arrays to empty when no answer ' +
+    'is selected', () => {
+    component.answer = '""';
+    component.ngOnInit();
+
+    expect(component.responses).toEqual([]);
+  });
 });

--- a/extensions/interactions/ItemSelectionInput/directives/oppia-response-item-selection-input.component.spec.ts
+++ b/extensions/interactions/ItemSelectionInput/directives/oppia-response-item-selection-input.component.spec.ts
@@ -67,6 +67,8 @@ describe('ResponseItemSelectionInput', () => {
   });
   it('should set the answers and responses arrays to empty when no answer ' +
     'is selected', () => {
+    expect(component.responses).toBe(undefined);
+
     component.answer = '""';
     component.ngOnInit();
 

--- a/extensions/interactions/ItemSelectionInput/directives/oppia-response-item-selection-input.component.ts
+++ b/extensions/interactions/ItemSelectionInput/directives/oppia-response-item-selection-input.component.ts
@@ -40,16 +40,20 @@ export class ResponseItemSelectionInputComponent implements OnInit {
   constructor(private htmlEscaperService: HtmlEscaperService) {}
 
   ngOnInit(): void {
-    const answer = this.htmlEscaperService.escapedJsonToObj(
+    let answer = this.htmlEscaperService.escapedJsonToObj(
       this.answer
     ) as string[];
+    if (!answer) {
+      answer = [];
+    }
     const choices = this.htmlEscaperService.escapedJsonToObj(
       this.choices
     ) as { _html: string; _contentId: string }[];
 
     const choicesContentIds = choices.map(choice => choice._contentId);
-    this.responses = answer.map(
-      contentId => choices[choicesContentIds.indexOf(contentId)]._html);
+    this.responses = [];
+    answer.forEach(contentId => this.responses.push(
+      choices[choicesContentIds.indexOf(contentId)]._html));
   }
 }
 

--- a/extensions/interactions/ItemSelectionInput/directives/oppia-response-item-selection-input.component.ts
+++ b/extensions/interactions/ItemSelectionInput/directives/oppia-response-item-selection-input.component.ts
@@ -51,9 +51,8 @@ export class ResponseItemSelectionInputComponent implements OnInit {
     ) as { _html: string; _contentId: string }[];
 
     const choicesContentIds = choices.map(choice => choice._contentId);
-    this.responses = [];
-    answer.forEach(contentId => this.responses.push(
-      choices[choicesContentIds.indexOf(contentId)]._html));
+    this.responses = answer.map(
+      contentId => choices[choicesContentIds.indexOf(contentId)]._html);
   }
 }
 

--- a/extensions/interactions/ItemSelectionInput/directives/oppia-short-response-item-selection-input.component.spec.ts
+++ b/extensions/interactions/ItemSelectionInput/directives/oppia-short-response-item-selection-input.component.spec.ts
@@ -48,21 +48,12 @@ describe('ShortResponseItemSelectionInput', () => {
     fixture = TestBed.createComponent(ShortResponseItemSelectionInputComponent);
     component = fixture.componentInstance;
     component.answer = '["ca_choices_1"]';
-    component.choices = '[{' +
-      '"_html": "choice 1",' +
-      '"_contentId": "ca_choices_1"' +
-    '}, {' +
-      '"_html": "choice 2",' +
-      '"_contentId": "ca_choices_2"' +
-    '}, {' +
-      '"_html": "choice 3",' +
-      '"_contentId": "ca_choices_3"' +
-    '}]';
+    component.choices = '["choice 1","choice 2","choice 3"]';
   });
 
   it('should initialise component when user submits answer', () => {
     component.ngOnInit();
 
-    expect(component.responses).toEqual(['choice 1']);
+    expect(component.responses).toEqual(['choice 2']);
   });
 });

--- a/extensions/interactions/ItemSelectionInput/directives/oppia-short-response-item-selection-input.component.ts
+++ b/extensions/interactions/ItemSelectionInput/directives/oppia-short-response-item-selection-input.component.ts
@@ -45,11 +45,10 @@ export class ShortResponseItemSelectionInputComponent implements OnInit {
     ) as string[];
     const choices = this.htmlEscaperService.escapedJsonToObj(
       this.choices
-    ) as { _html: string; _contentId: string }[];
+    ) as string[];
 
-    const choicesContentIds = choices.map(choice => choice._contentId);
     this.responses = answer.map(
-      contentId => choices[choicesContentIds.indexOf(contentId)]._html);
+      contentId => choices[parseInt(contentId.split('_')[2])]);
   }
 }
 

--- a/extensions/interactions/interaction_specs.json
+++ b/extensions/interactions/interaction_specs.json
@@ -200,8 +200,8 @@
     }
   },
   "ItemSelectionInput": {
-    "can_have_solution": false,
-    "show_generic_submit_button": false,
+    "can_have_solution": true,
+    "show_generic_submit_button": true,
     "instructions": null,
     "is_trainable": false,
     "narrow_instructions": null,


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #13548 .
2. This PR does the following: Enables solutions for states with interaction type "Item selection input". Fixes Item selection input indexing via contentID.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
Adding a solution when max_selections_allowed is set to 1:

https://user-images.githubusercontent.com/78612244/158175568-2b4b5110-2438-49e2-9d4a-e4fcbc09f78e.mp4

Viewing a solution when max_selections_allowed is set to 1:

https://user-images.githubusercontent.com/78612244/158175710-953c9380-a86e-48a9-b29a-be312260b463.mp4

Adding a solution when max_selections_allowed is set to a value greater than 1:

https://user-images.githubusercontent.com/78612244/158175732-fd89b14e-0b4e-41ad-a2fe-79aed5a9b4b3.mp4

Viewing a solution when max_selections_allowed is set to a value greater than 1:

https://user-images.githubusercontent.com/78612244/158175748-b15fc140-becd-4af9-a9ef-ea9f6a787e90.mp4



## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
