### PR TITLE
Fix part of #11329: oppia-interactive-music-notes-input.directive (remove addClass)

### DIFF
--- a/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
+++ b/extensions/interactions/MusicNotesInput/directives/oppia-interactive-music-notes-input.component.ts
@@ -289,12 +289,12 @@ export class MusicNotesInputComponent
     let validNoteArea = $(this.elementRef.nativeElement.querySelectorAll(
       '.oppia-music-input-valid-note-area'));
     for (let i = 0; i < this.NOTE_TYPES.length; i++) {
-      let innerDiv = $('<div></div>').data('noteType', this.NOTE_TYPES[i]);
-      let addedClass = null;
-      if ($(innerDiv).data('noteType') === this.NOTE_TYPE_NATURAL) {
+      var addedClass = null;
+      if (this.NOTE_TYPES[i] === this.NOTE_TYPE_NATURAL) {
         addedClass = 'oppia-music-input-natural-note';
-        $(innerDiv).addClass(addedClass);
       }
+      var innerDiv = $(`<div class="${addedClass}"></div>`)
+        .data('noteType', this.NOTE_TYPES[i]);
       if (this.interactionIsActive) {
         innerDiv.draggable({
           // Keeps note from being placed on top of the clef.
@@ -350,11 +350,11 @@ export class MusicNotesInputComponent
     let validNoteArea = $(this.elementRef.nativeElement.querySelectorAll(
       '.oppia-music-input-valid-note-area'));
     for (let i = 0; i < this.noteSequence.length; i++) {
-      let innerDiv = $('<div></div>')
+      var innerDiv = $(
+        '<div class="oppia-music-input-natural-note' +
+      ' oppia-music-input-on-staff"></div>')
         .data('noteType', this.NOTE_TYPE_NATURAL)
         .data('noteId', this.noteSequence[i].note.noteId)
-        .addClass('oppia-music-input-natural-note')
-        .addClass('oppia-music-input-on-staff')
         // Position notes horizontally by their noteStart positions and
         // vertically by the midi value they hold.
         .css({
@@ -399,8 +399,8 @@ export class MusicNotesInputComponent
   buildDroppableStaff(): void {
     let lineValues = Object.keys(this.NOTE_NAMES_TO_MIDI_VALUES);
     for (let i = 0; i < lineValues.length; i++) {
-      let staffLineDiv = $('<div></div>')
-        .addClass('oppia-music-staff-position')
+      var staffLineDiv = $(
+        '<div class="oppia-music-staff-position"></div>')
         .css('height', this.VERTICAL_GRID_SPACING)
         .data('lineValue', lineValues[i])
         .droppable({
@@ -533,11 +533,10 @@ export class MusicNotesInputComponent
       // line.
       if (this.NOTES_ON_LINES.indexOf(noteName) !== -1) {
         staffLineDiv.append(
-          $('<div></div>')
+          $('<div class="oppia-music-staff-line"></div>')
             // Positions and centers the staff line directly on top of its
             // associated droppable.
             .css('margin-top', this.VERTICAL_GRID_SPACING / 2.5)
-            .addClass('oppia-music-staff-line')
         );
       }
     }
@@ -649,9 +648,9 @@ export class MusicNotesInputComponent
 
   // TODO(#14340): Remove some usages of jQuery from the codebase.
   drawLedgerLine(topPos: number, leftPos: number): void {
-    let ledgerLineDiv = $('<div></div>')
-      .addClass(
-        'oppia-music-input-ledger-line oppia-music-input-natural-note')
+    var ledgerLineDiv = $(
+      '<div class"oppia-music-input-ledger-line ' +
+    'oppia-music-input-natural-note"></div>')
       .droppable({
         accept: '.oppia-music-input-note-choices div',
         // When a ledgerLine note is moved out of its droppable,


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #11329.
2. This PR does the following: Removes 5 calls to the jQuery-style addClass() function in the oppia-interactive-music-notes-input.directive.ts file, making sure that functionality is maintained. There is an additional, and last, addClass() that was not removed as it is part of the draggable functionality from jQuery, so it would require a significant refactor of the file where all the drag-and-drop functionality is rebuilt with Angular, and with possibly the inclusion of an angular drag-and-drop library such as [angular-dragdrop](http://angular-dragdrop.github.io/angular-dragdrop/), or [@angular/cdk/drag-drop](https://material.angular.io/cdk/drag-drop/overview).

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
![Screen Shot 2022-03-17 at 6 36 09 PM](https://user-images.githubusercontent.com/2841740/158950567-7e738dd8-24b0-4e0c-883f-6b98ea5a30b0.png)

<img width="1505" alt="Screen Shot 2022-03-17 at 11 43 26 PM" src="https://user-images.githubusercontent.com/2841740/158950830-d51df86a-4611-49b8-ba64-809ee556b40e.png">


<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly. Please also include videos/screenshots of the developer tools browser console, so that we can be sure that there are no console errors.
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have a separate .rtl.css file for styling), make sure to add screenshots with the site language set to Arabic as well.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
