### PR TITLE
Enable ts strict mode

### DIFF
--- a/core/templates/components/skill-selector/select-skill-modal.component.spec.ts
+++ b/core/templates/components/skill-selector/select-skill-modal.component.spec.ts
@@ -28,6 +28,7 @@ import { SkillsCategorizedByTopics } from 'pages/topics-and-skills-dashboard-pag
 import { ShortSkillSummary, ShortSkillSummaryBackendDict } from 'domain/skill/short-skill-summary.model';
 import { SkillSummaryBackendDict } from 'domain/skill/skill-summary.model';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { SkillSummary } from '../../domain/skill/skill-summary.model';
 
 
 describe('Select Skill Modal', () => {
@@ -94,7 +95,10 @@ describe('Select Skill Modal', () => {
   it('should close modal on confirm', () => {
     spyOn(ngbActiveModal, 'close');
     componentInstance.selectedSkillId = '2';
-    let totalSkills = [];
+    let totalSkills: 
+    (ShortSkillSummary | 
+      SkillSummaryBackendDict | 
+      SkillSummary)[] = [];
     if (componentInstance.skillSummaries) {
       totalSkills = [...componentInstance.skillSummaries];
     }

--- a/core/templates/components/skill-selector/select-skill-modal.component.spec.ts
+++ b/core/templates/components/skill-selector/select-skill-modal.component.spec.ts
@@ -96,8 +96,7 @@ describe('Select Skill Modal', () => {
     spyOn(ngbActiveModal, 'close');
     componentInstance.selectedSkillId = '2';
     let totalSkills:
-    (ShortSkillSummary |SkillSummaryBackendDict | SkillSummary)[]
-    = [];
+    (ShortSkillSummary |SkillSummaryBackendDict | SkillSummary)[] = [];
     if (componentInstance.skillSummaries) {
       totalSkills = [...componentInstance.skillSummaries];
     }

--- a/core/templates/components/skill-selector/select-skill-modal.component.spec.ts
+++ b/core/templates/components/skill-selector/select-skill-modal.component.spec.ts
@@ -95,10 +95,9 @@ describe('Select Skill Modal', () => {
   it('should close modal on confirm', () => {
     spyOn(ngbActiveModal, 'close');
     componentInstance.selectedSkillId = '2';
-    let totalSkills: 
-    (ShortSkillSummary | 
-      SkillSummaryBackendDict | 
-      SkillSummary)[] = [];
+    let totalSkills:
+    (ShortSkillSummary |SkillSummaryBackendDict | SkillSummary)[]
+    = [];
     if (componentInstance.skillSummaries) {
       totalSkills = [...componentInstance.skillSummaries];
     }

--- a/core/templates/components/skill-selector/select-skill-modal.component.ts
+++ b/core/templates/components/skill-selector/select-skill-modal.component.ts
@@ -19,7 +19,7 @@ import { Component } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { ConfirmOrCancelModal } from 'components/common-layout-directives/common-elements/confirm-or-cancel-modal.component';
 import { ShortSkillSummary } from 'domain/skill/short-skill-summary.model';
-import { SkillSummaryBackendDict } from 'domain/skill/skill-summary.model';
+import { SkillSummary, SkillSummaryBackendDict } from 'domain/skill/skill-summary.model';
 import { SkillsCategorizedByTopics } from 'pages/topics-and-skills-dashboard-page/skills-list/skills-list.component';
 
 @Component({
@@ -27,12 +27,12 @@ import { SkillsCategorizedByTopics } from 'pages/topics-and-skills-dashboard-pag
   templateUrl: './select-skill-modal.component.html',
 })
 export class SelectSkillModalComponent extends ConfirmOrCancelModal {
-  categorizedSkills: SkillsCategorizedByTopics;
-  skillsInSameTopicCount: number;
-  skillSummaries: SkillSummaryBackendDict[];
-  untriagedSkillSummaries: ShortSkillSummary[];
-  allowSkillsFromOtherTopics: boolean;
-  selectedSkillId: string = null;
+  categorizedSkills!: SkillsCategorizedByTopics;
+  skillsInSameTopicCount!: number;
+  skillSummaries!: SkillSummaryBackendDict[];
+  untriagedSkillSummaries!: ShortSkillSummary[];
+  allowSkillsFromOtherTopics!: boolean;
+  selectedSkillId: string | null = null;
 
   constructor(
     private ngbActiveModal: NgbActiveModal
@@ -41,7 +41,10 @@ export class SelectSkillModalComponent extends ConfirmOrCancelModal {
   }
 
   confirm(): void {
-    let totalSkills = [];
+    let totalSkills: 
+    (ShortSkillSummary | 
+      SkillSummaryBackendDict | 
+      SkillSummary)[] = [];
     if (this.skillSummaries) {
       totalSkills = [...this.skillSummaries];
     }

--- a/core/templates/components/skill-selector/select-skill-modal.component.ts
+++ b/core/templates/components/skill-selector/select-skill-modal.component.ts
@@ -41,10 +41,9 @@ export class SelectSkillModalComponent extends ConfirmOrCancelModal {
   }
 
   confirm(): void {
-    let totalSkills: 
-    (ShortSkillSummary | 
-      SkillSummaryBackendDict | 
-      SkillSummary)[] = [];
+    let totalSkills:
+    (ShortSkillSummary | SkillSummaryBackendDict | SkillSummary)[]
+     = [];
     if (this.skillSummaries) {
       totalSkills = [...this.skillSummaries];
     }

--- a/core/templates/components/skill-selector/select-skill-modal.component.ts
+++ b/core/templates/components/skill-selector/select-skill-modal.component.ts
@@ -42,7 +42,7 @@ export class SelectSkillModalComponent extends ConfirmOrCancelModal {
 
   confirm(): void {
     let totalSkills:
-    (ShortSkillSummary | SkillSummaryBackendDict | SkillSummary)[]= [];
+    (ShortSkillSummary | SkillSummaryBackendDict | SkillSummary)[] = [];
     if (this.skillSummaries) {
       totalSkills = [...this.skillSummaries];
     }

--- a/core/templates/components/skill-selector/select-skill-modal.component.ts
+++ b/core/templates/components/skill-selector/select-skill-modal.component.ts
@@ -42,8 +42,7 @@ export class SelectSkillModalComponent extends ConfirmOrCancelModal {
 
   confirm(): void {
     let totalSkills:
-    (ShortSkillSummary | SkillSummaryBackendDict | SkillSummary)[]
-     = [];
+    (ShortSkillSummary | SkillSummaryBackendDict | SkillSummary)[]= [];
     if (this.skillSummaries) {
       totalSkills = [...this.skillSummaries];
     }

--- a/core/templates/domain/skill/skill-summary.model.ts
+++ b/core/templates/domain/skill/skill-summary.model.ts
@@ -21,8 +21,8 @@ export interface SkillSummaryBackendDict {
   'description': string;
   'language_code': string;
   'version': number;
-  'misconception_count': number;
-  'worked_examples_count': number;
+  'misconception_count': number | null;
+  'worked_examples_count': number | null;
   'skill_model_created_on': number;
   'skill_model_last_updated': number;
 }
@@ -33,8 +33,8 @@ export class SkillSummary {
     public description: string,
     public languageCode: string,
     public version: number,
-    public misconceptionCount: number,
-    public workedExamplesCount: number,
+    public misconceptionCount: number | null,
+    public workedExamplesCount: number | null,
     public skillModelCreatedOn: number,
     public skillModelLastUpdated: number) {}
 

--- a/tsconfig-strict.json
+++ b/tsconfig-strict.json
@@ -101,6 +101,8 @@
     "core/templates/components/question-directives/question-player/services/question-player-state.service.spec.ts",
     "core/templates/components/skill-selector/merge-skill-modal.component.ts",
     "core/templates/components/skill-selector/merge-skill-modal.component.spec.ts",
+    "core/templates/components/skill-selector/select-skill-modal.component.ts",
+    "core/templates/components/skill-selector/select-skill-modal.component.spec.ts",
     "core/templates/components/skills-mastery-list/skills-mastery-list.constants.ts",
     "core/templates/components/state-directives/answer-group-editor/summary-list-header.component.ts",
     "core/templates/components/state-directives/outcome-editor/outcome-feedback-editor.component.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "downlevelIteration": true,
     "lib": ["es2017", "dom", "webworker"],
     "module": "es2020",
-    "noImplicitUseStrict": true,
+    "strict": true,
     "outDir": "local_compiled_js_for_test",
     "rootDir": ".",
     "target": "es6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "downlevelIteration": true,
     "lib": ["es2017", "dom", "webworker"],
     "module": "es2020",
-    "strict": true,
+    "noImplicitUseStrict": true,
     "outDir": "local_compiled_js_for_test",
     "rootDir": ".",
     "target": "es6",


### PR DESCRIPTION
1. This PR fixes or fixes part of #10474.
2. This PR does the following: Enabled typescript strict checks on two files: `select-skill-modal.component.ts` and `select-skill-modal.component.spec.ts` and added the paths to the files to `files` in the `tsconfig-strict.json` file

