### PR TITLE
Fix #15225: Skip pylint cyclic import check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04]
-        shard: ['1', 'other']
+        shard: ['other']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.pylintrc
+++ b/.pylintrc
@@ -133,7 +133,11 @@ disable=abstract-method,
         unnecessary-pass,
         consider-using-f-string,
 # TODO(#14322): Reinstate this.
-        missing-type-doc
+        missing-type-doc,
+        # Pylint considers imports to be cyclic even when the cycle is
+        # broken by putting imports inside functions so they aren't
+        # executed upon module import.
+        cyclic-import,
 
 [REPORTS]
 

--- a/scripts/linters/pre_commit_linter.py
+++ b/scripts/linters/pre_commit_linter.py
@@ -83,9 +83,9 @@ OTHER_SHARD_NAME = 'other'
 # Shards are specified by a mapping from shard name to a list of the
 # paths in that shard. For exaple, `'1': ['core/domain/']` will create a
 # shard named `'1'` that contains all the files under core/domain/. A
-# shard value of `None` includes all files not under another shard.
-# Currently we are not sharding the lint checks, so the only shard is
-# the `other` shard that contains all files.
+# shard name matching OTHER_SHARD_NAME includes all files not under
+# another shard.  Currently we are not sharding the lint checks, so the
+# only shard is the `other` shard that contains all files.
 SHARDS = {
     'other': None,
 }

--- a/scripts/linters/pre_commit_linter.py
+++ b/scripts/linters/pre_commit_linter.py
@@ -80,16 +80,13 @@ from .. import install_third_party_libs
 
 OTHER_SHARD_NAME = 'other'
 
+# Shards are specified by a mapping from shard name to a list of the
+# paths in that shard. For exaple, `'1': ['core/domain/']` will create a
+# shard named `'1'` that contains all the files under core/domain/. A
+# shard value of `None` includes all files not under another shard.
+# Currently we are not sharding the lint checks, so the only shard is
+# the `other` shard that contains all files.
 SHARDS = {
-    '1': [
-        'core/templates/',
-        'extensions/',
-        'core/tests/',
-        'core/storage/',
-        'core/controllers/',
-        'core/platform',
-        'core/jobs/',
-    ],
     'other': None,
 }
 

--- a/scripts/linters/pre_commit_linter_test.py
+++ b/scripts/linters/pre_commit_linter_test.py
@@ -120,19 +120,29 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
             ['No files to check'], self.linter_stdout)
 
     def test_main_with_non_other_shard(self):
+        mock_shards = {
+            '1': [
+                'a/',
+                'b/',
+            ],
+        }
+
         def mock_get_filepaths_from_path(path, namespace):  # pylint: disable=unused-argument
-            if path == pre_commit_linter.SHARDS['1'][0]:
+            if path == mock_shards['1'][0]:
                 return [VALID_PY_FILEPATH]
             return []
+
+        shards_swap = self.swap(
+            pre_commit_linter, 'SHARDS', mock_shards)
 
         get_filenames_from_path_swap = self.swap_with_checks(
             pre_commit_linter, '_get_filepaths_from_path',
             mock_get_filepaths_from_path, expected_args=[
                 (prefix,)
-                for prefix in pre_commit_linter.SHARDS['1']
+                for prefix in mock_shards['1']
             ])
 
-        with self.print_swap, self.sys_swap:
+        with self.print_swap, self.sys_swap, shards_swap:
             with self.install_swap:
                 with get_filenames_from_path_swap:
                     pre_commit_linter.main(args=['--shard', '1'])
@@ -146,17 +156,27 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
             raise AssertionError(
                 'Third party libs should not be installed.')
 
+        mock_shards = {
+            '1': [
+                'a/',
+            ],
+        }
+
+        shards_swap = self.swap(
+            pre_commit_linter, 'SHARDS', mock_shards)
+
         get_filenames_from_path_swap = self.swap_with_checks(
             pre_commit_linter, '_get_filepaths_from_path',
-            mock_get_filepaths_from_path, expected_args=[
+            mock_get_filepaths_from_path,
+            expected_args=[
                 (prefix,)
-                for prefix in pre_commit_linter.SHARDS['1']
+                for prefix in mock_shards['1']
             ])
         install_swap = self.swap(
             install_third_party_libs, 'main',
             mock_install_third_party_main)
 
-        with self.print_swap, self.sys_swap, install_swap:
+        with self.print_swap, self.sys_swap, install_swap, shards_swap:
             with get_filenames_from_path_swap:
                 with self.assertRaisesRegex(
                     RuntimeError, 'mock_file in multiple shards'
@@ -172,9 +192,21 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
             else:
                 return []
 
+        mock_shards = {
+            '1': [
+                'a/',
+            ],
+            'other': [
+                'b/',
+            ],
+        }
+
+        shards_swap = self.swap(
+            pre_commit_linter, 'SHARDS', mock_shards)
+
         filenames_from_path_expected_args = [(os.getcwd(),)] + [
             (prefix,)
-            for prefix in pre_commit_linter.SHARDS['1']
+            for prefix in mock_shards['1']
         ]
 
         get_filenames_from_path_swap = self.swap_with_checks(
@@ -182,7 +214,7 @@ class PreCommitLinterTests(test_utils.LinterTestBase):
             mock_get_filepaths_from_path,
             expected_args=filenames_from_path_expected_args)
 
-        with self.print_swap, self.sys_swap:
+        with self.print_swap, self.sys_swap, shards_swap:
             with self.install_swap:
                 with get_filenames_from_path_swap:
                     pre_commit_linter.main(


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #15225.
2. This PR does the following:

   1. Pylint's cyclic import check does not account for the fact that apparent import cycles can often be avoided by putting one import inside a code block that does not execute on import. We use this strategy frequently, so Pylint's cyclic import check produces false positives. This PR disables the cyclic import check.
   2. While investigating this problem, @Hudda noted that sharding the lint checks can actually result in false negatives because some problems only surface when multiple files are checked simultaneously. This PR also eliminates sharding (specifically, it consolidates the shards into one shard) to avoid this issue in the future. This is acceptable since our shards currently each run in under 15 minutes.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface in various display sizes (mainly phone, tablet, and desktop display size) to demonstrate that the changes made in this PR work correctly. Please also include videos/screenshots of the developer tools browser console, so that we can be sure that there are no console errors.
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have a separate .rtl.css file for styling), make sure to add screenshots with the site language set to Arabic as well.
If the changes in your PRs are autogenerated via a script and you cannot provide proof for the changes then please leave a comment "No proof of changes needed because {{Reason}}".
-->

Lint checks passed locally:

```
---------------------------
All Checks Passed.
---------------------------
```

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
