### PR TITLE
Fix #15214: audioFinishedCallback is now being called after voiceover playback

### DIFF
--- a/core/templates/services/speech-synthesis-chunker.service.spec.ts
+++ b/core/templates/services/speech-synthesis-chunker.service.spec.ts
@@ -152,13 +152,9 @@ describe('Speech Synthesis Chunker Service', () => {
     const MockSpeechSynthesisUtteranceConstructor = (
       SpeechSynthesisUtterance);
     const mockSpeechSynthesisUtteran = {
-      _callback: null,
-      speak: () => {
-        this._callback();
-      },
+      speak: () => {},
       onend: () => {},
-      addEventListener: function(_, cb) {
-        this._callback = cb;
+      addEventListener: function(_: string, cb: () => void) {
         this.onend = cb;
       }
     };
@@ -166,7 +162,7 @@ describe('Speech Synthesis Chunker Service', () => {
     beforeEach(() => {
       spyOn(window, 'SpeechSynthesisUtterance').and.returnValues(
         // This throws "Argument of type '{ speak: () => void; onend:
-        // () => void; }' is not assignable to parameter of type
+        // () => void; ...}' is not assignable to parameter of type
         // 'SpeechSynthesisUtterance'.". We need to suppress this error because
         // 'SpeechSynthesisUtterance' has around 10 more properties. We have
         // only defined the properties we need in 'mockSpeechSynthesisUtteran'.
@@ -177,8 +173,14 @@ describe('Speech Synthesis Chunker Service', () => {
 
     it('should not speak when chunk is too short', () => {
       const speakSpy = spyOn(window.speechSynthesis, 'speak').and
-        .callFake(function(utterance: SpeechSynthesisUtterance) {
-          utterance.onend(null);
+        .callFake(function(utterance) {
+        // This throws "Argument of type '{ speak: () => void; onend:
+        // () => void; ...}' is not assignable to parameter of type
+        // 'SpeechSynthesisUtterance'.". We need to suppress this error because
+        // 'SpeechSynthesisUtterance' has around 10 more properties. We have
+        // only defined the properties we need in 'mockSpeechSynthesisUtteran'.
+        // @ts-expect-error
+          utterance.onend();
         });
       const speechSynthesisUtterance = (
         new MockSpeechSynthesisUtteranceConstructor('a'));
@@ -193,7 +195,13 @@ describe('Speech Synthesis Chunker Service', () => {
     it('should not speak when chunk is a falsy value', () => {
       const speakSpy = spyOn(window.speechSynthesis, 'speak').and
         .callFake(function(utterance: SpeechSynthesisUtterance) {
-          utterance.onend(null);
+        // This throws "Argument of type '{ speak: () => void; onend:
+        // () => void; ...}' is not assignable to parameter of type
+        // 'SpeechSynthesisUtterance'.". We need to suppress this error because
+        // 'SpeechSynthesisUtterance' has around 10 more properties. We have
+        // only defined the properties we need in 'mockSpeechSynthesisUtteran'.
+        // @ts-expect-error
+          utterance.onend();
         });
       const speechSynthesisUtterance = (
         new MockSpeechSynthesisUtteranceConstructor(''));
@@ -208,7 +216,13 @@ describe('Speech Synthesis Chunker Service', () => {
     it('should speak two phrases at a time', fakeAsync(() => {
       const speakSpy = spyOn(window.speechSynthesis, 'speak').and
         .callFake(function(utterance: SpeechSynthesisUtterance) {
-          utterance.onend(null);
+        // This throws "Argument of type '{ speak: () => void; onend:
+        // () => void; ...}' is not assignable to parameter of type
+        // 'SpeechSynthesisUtterance'.". We need to suppress this error because
+        // 'SpeechSynthesisUtterance' has around 10 more properties. We have
+        // only defined the properties we need in 'mockSpeechSynthesisUtteran'.
+        // @ts-expect-error
+          utterance.onend();
         });
 
       const speechSynthesisUtterance = (
@@ -231,7 +245,14 @@ describe('Speech Synthesis Chunker Service', () => {
       fakeAsync(() => {
         const speakSpy = spyOn(window.speechSynthesis, 'speak').and
           .callFake(function(utterance: SpeechSynthesisUtterance) {
-            utterance.onend(null);
+          // This throws "Argument of type '{ speak: () => void; onend:
+          // () => void; ...}' is not assignable to parameter of type
+          // 'SpeechSynthesisUtterance'.". We need to suppress this error
+          // because 'SpeechSynthesisUtterance' has around 10 more properties.
+          // We have only defined the properties we need in
+          // 'mockSpeechSynthesisUtteran'.
+          // @ts-expect-error
+            utterance.onend();
           });
         const speechSynthesisUtterance = (
           new MockSpeechSynthesisUtteranceConstructor(

--- a/core/templates/services/speech-synthesis-chunker.service.ts
+++ b/core/templates/services/speech-synthesis-chunker.service.ts
@@ -113,18 +113,15 @@ export class SpeechSynthesisChunkerService {
         );
       }
     }
-    Object.defineProperty(
-      newUtterance, 'onend', {
-        value: () => {
-          if (this.cancelRequested) {
-            this.cancelRequested = false;
-            return;
-          }
-          offset += chunk.length;
-          this._speechUtteranceChunker(utterance, offset, callback);
-        }
+    newUtterance.addEventListener('end', () => {
+      if (this.cancelRequested) {
+        this.cancelRequested = false;
+        return;
       }
-    );
+      offset += chunk.length;
+      this._speechUtteranceChunker(utterance, offset, callback);
+    });
+
 
     // IMPORTANT!! Do not remove: Logging the object out fixes some onend
     // firing issues. Placing the speak invocation inside a callback

--- a/core/templates/services/speech-synthesis-chunker.service.ts
+++ b/core/templates/services/speech-synthesis-chunker.service.ts
@@ -105,7 +105,7 @@ export class SpeechSynthesisChunkerService {
     // excluding the text being spoken.
     for (var property in utterance) {
       const _property = property as keyof SpeechSynthesisUtterance;
-      if (_property !== 'text') {
+      if (_property !== 'text' && _property !== 'addEventListener') {
         Object.defineProperty(
           newUtterance, _property, {
             value: utterance[_property]


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #15214.
2. This PR does the following: The callback audioFinishedCallback() was not being called in core/templates/services/autogenerated-audio-player.service.ts when the audio has finished playing (as it should). This is because the /core/templates/services/speech-synthesis-chunker.service.ts was not calling the callback in the _speechUtteranceChunker() function. Turns out that the browser does not like the previous way of adding the onend callback, so I changed it to a way that worked: adding the callback with addEventListener instead of setting onend.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

![Screen Shot 2022-03-31 at 4 52 02 PM](https://user-images.githubusercontent.com/2841740/161167849-aa9ed9cf-e2d9-4e10-9541-9ec11a2a7fa9.png)

Note the console.log message. Done after adding:
[autogenerated-audio-player.service.ts:60](https://github.com/oppia/oppia/blob/46ee2fa3747afdba675cb26790aca1cbfc923468/core/templates/services/autogenerated-audio-player.service.ts#L60)
<img width="682" alt="Screen Shot 2022-03-25 at 12 53 42 AM" src="https://user-images.githubusercontent.com/2841740/160078516-3a003655-1033-4126-bcb1-a0b28f27ab7e.png">

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
