### PR TITLE
Fail noisily if a process crashes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ yarn-error.log
 .lighthouseci
 .direnv/*
 .envrc
+portserver.socket
 
 # Oppia uses cache slugs for various resources and we need separate resource
 # directories for dev and prod. Resource directories for prod are generated

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1322,7 +1322,7 @@ def generate_build_directory(hashes):
 def generate_python_package():
     """Generates Python package using setup.py."""
     print('Building Oppia package...')
-    subprocess.check_call('python setup.py sdist -d build', shell=True)
+    subprocess.check_call('python setup.py -q sdist -d build', shell=True)
     print('Oppia package build completed.')
 
 

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -116,7 +116,9 @@ def managed_process(
                 'Failed to stop %s gracefully!' % get_proc_info(popen_proc))
 
         exit_code = popen_proc.returncode
-        if exit_code != 0:
+        # Note that negative values indicate termination by a signal:  SIGTERM,
+        # SIGINT, etc.
+        if exit_code > 0:
             raise Exception(
                 'Process %s exited unexpectedly with exit code %s' %
                 (proc_name, exit_code))

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -34,7 +34,7 @@ from scripts import common
 @contextlib.contextmanager
 def managed_process(
         command_args, human_readable_name='Process', shell=False,
-        timeout_secs=60, **popen_kwargs):
+        timeout_secs=60, expected_exit_codes=None, **popen_kwargs):
     """Context manager for starting and stopping a process gracefully.
 
     Args:
@@ -53,6 +53,9 @@ def managed_process(
         timeout_secs: int. The time allotted for the managed process and its
             descendants to terminate themselves. After the timeout, any
             remaining processes will be killed abruptly.
+        expected_exit_codes: list(int)|None. If provided, a list of return
+            codes that can be silently ignored. For other non-signal return
+            codes, an error will be thrown.
         **popen_kwargs: dict(str: *). Same kwargs as `subprocess.Popen`.
 
     Yields:
@@ -65,6 +68,9 @@ def managed_process(
     if common.PSUTIL_DIR not in sys.path:
         sys.path.insert(1, common.PSUTIL_DIR)
     import psutil
+
+    if expected_exit_codes is None:
+        expected_exit_codes = []
 
     get_proc_info = lambda p: (
         '%s(name="%s", pid=%d)' % (human_readable_name, p.name(), p.pid)
@@ -118,7 +124,8 @@ def managed_process(
         exit_code = popen_proc.returncode
         # Note that negative values indicate termination by a signal:  SIGTERM,
         # SIGINT, etc.
-        if exit_code > 0:
+        if exit_code is not None and exit_code > 0 and (
+                exit_code not in expected_exit_codes):
             raise Exception(
                 'Process %s exited unexpectedly with exit code %s' %
                 (proc_name, exit_code))
@@ -598,10 +605,16 @@ def managed_webdriver_server(chrome_version=None):
 
         # OK to use shell=True here because we are passing string literals and
         # constants, so there is no risk of a shell-injection attack.
-        proc = exit_stack.enter_context(managed_process([
-            common.NODE_BIN_PATH, common.WEBDRIVER_MANAGER_BIN_PATH, 'start',
-            '--versions.chrome', chrome_version, '--quiet', '--standalone',
-        ], human_readable_name='Webdriver manager', shell=True))
+        # Additionally, we accept the exit code 143 because Webdriver-manager
+        # seems to emit that when terminated externally.
+        proc = exit_stack.enter_context(managed_process(
+            [
+                common.NODE_BIN_PATH, common.WEBDRIVER_MANAGER_BIN_PATH,
+                'start', '--versions.chrome', chrome_version, '--quiet',
+                '--standalone',
+            ],
+            human_readable_name='Webdriver Manager', shell=True,
+            expected_exit_codes=[143]))
 
         common.wait_for_port_to_be_in_use(4444)
 

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -84,7 +84,6 @@ def managed_process(
     finally:
         proc_name = get_proc_info(popen_proc)
         print('Stopping %s...' % proc_name)
-        exit_code = popen_proc.wait()
         procs_still_alive = [popen_proc]
 
         try:
@@ -116,6 +115,7 @@ def managed_process(
             logging.exception(
                 'Failed to stop %s gracefully!' % get_proc_info(popen_proc))
 
+        exit_code = popen_proc.returncode
         if exit_code != 0:
             raise Exception(
                 'Process %s exited unexpectedly with exit code %s' %

--- a/scripts/servers_test.py
+++ b/scripts/servers_test.py
@@ -227,7 +227,10 @@ class ManagedProcessTests(test_utils.TestBase):
 
         proc = self.exit_stack.enter_context(servers.managed_process(
             ['a'], timeout_secs=10))
-        self.exit_stack.close()
+        with self.assertRaisesRegex(
+                Exception,
+                'Process .* exited unexpectedly with exit code 1'):
+            self.exit_stack.close()
 
         self.assert_proc_was_managed_as_expected(
             logs, proc.pid,
@@ -255,7 +258,9 @@ class ManagedProcessTests(test_utils.TestBase):
         proc = self.exit_stack.enter_context(servers.managed_process(
             ['a'], timeout_secs=10))
         pids = [c.pid for c in proc.children()] + [proc.pid]
-        self.exit_stack.close()
+        with self.assertRaisesRegex(
+                Exception, 'Process .* exited unexpectedly with exit code 1'):
+            self.exit_stack.close()
 
         self.assertEqual(len(set(pids)), 4)
         for pid in pids:
@@ -273,7 +278,9 @@ class ManagedProcessTests(test_utils.TestBase):
         time.sleep(1)
         proc.kill()
         proc.wait()
-        self.exit_stack.close()
+        with self.assertRaisesRegex(
+                Exception, 'Process .* exited unexpectedly with exit code 1'):
+            self.exit_stack.close()
 
         self.assert_proc_was_managed_as_expected(
             logs, proc.pid,
@@ -304,7 +311,7 @@ class ManagedProcessTests(test_utils.TestBase):
             manager_should_have_sent_terminate_signal=True,
             manager_should_have_sent_kill_signal=False)
 
-    def test_does_not_raise_when_exit_fails(self):
+    def test_raise_when_process_errors(self):
         self.exit_stack.enter_context(self.swap_popen())
         self.exit_stack.enter_context(self.swap_to_always_raise(
             psutil, 'wait_procs', error=Exception('uh-oh')))
@@ -312,8 +319,9 @@ class ManagedProcessTests(test_utils.TestBase):
             min_level=logging.ERROR))
 
         self.exit_stack.enter_context(servers.managed_process(['a', 'bc']))
-        # Should not raise.
-        self.exit_stack.close()
+        with self.assertRaisesRegex(
+                Exception, 'Process .* exited unexpectedly with exit code 1'):
+            self.exit_stack.close()
 
         self.assert_matches_regexps(logs, [
             r'Failed to stop Process\(pid=1\) gracefully!\n'
@@ -612,7 +620,10 @@ class ManagedProcessTests(test_utils.TestBase):
         popen_calls = self.exit_stack.enter_context(self.swap_popen())
 
         proc = self.exit_stack.enter_context(servers.managed_portserver())
-        self.exit_stack.close()
+        with self.assertRaisesRegex(
+                Exception,
+                'Process Portserver.* exited unexpectedly with exit code 1'):
+            self.exit_stack.close()
 
         self.assertEqual(len(popen_calls), 1)
         self.assertEqual(
@@ -647,7 +658,10 @@ class ManagedProcessTests(test_utils.TestBase):
             os, 'remove', mock_os_remove))
 
         proc = self.exit_stack.enter_context(servers.managed_portserver())
-        self.exit_stack.close()
+        with self.assertRaisesRegex(
+                Exception,
+                'Process Portserver.* exited unexpectedly with exit code 1'):
+            self.exit_stack.close()
 
         self.assertEqual(len(popen_calls), 1)
         self.assertEqual(
@@ -682,7 +696,10 @@ class ManagedProcessTests(test_utils.TestBase):
 
         proc = self.exit_stack.enter_context(servers.managed_portserver())
         proc.unresponsive = True
-        self.exit_stack.close()
+        with self.assertRaisesRegex(
+                Exception,
+                'Process Portserver.* exited unexpectedly with exit code 1'):
+            self.exit_stack.close()
 
         self.assertEqual(len(popen_calls), 1)
         self.assertEqual(


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Raises an exception if a process crashes unexpectedly.

Context: We ran into an issue where, when running the build script, webpack failed due to an OOM error -- but the build continued anyway, using the wrong files from a previous build, and the error messages were lost among the subsequent server logs, so the developer didn't realize that the process had failed. This PR causes a managed process exception to be regarded as fatal, so that the parent process stops and the developer is clearly notified of the failure.

More context: [Vojta's debugging doc](https://docs.google.com/document/d/1K-oJqJktc9UqS4YB44SatHDwOZoWYMKU1Cxz5P6OL9o/edit#)

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

I ran the script:

```
python -m scripts.build --prod_env --deploy_mode --source_maps
```

with max_old_space_size=2, so that the script would fail. Then I ran the same script with the usual max_old_space_size and by modifying webpack.common.config.ts to only build oppia_root, so that the script would definitely pass.

In the first case, the script terminated after throwing the exception, as expected:

```
$ python -m scripts.build --prod_env --deploy_mode --source_maps
Building third party libs at third_party/generated/
Minifying and creating sourcemap for third_party/generated/js/third_party.js
Computing hashes for files in /opensource/oppia/assets/
Computing hashes for files in /opensource/oppia/extensions/
Computing hashes for files in /opensource/oppia/core/templates/
Computing hashes for files in /opensource/oppia/third_party/generated/
Building Oppia package...
warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md

warning: check: missing required meta-data: url

warning: check: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) must be supplied

Oppia package build completed.
Building webpack
Starting new Webpack Compiler: /opensource/oppia/../oppia_tools/node-16.13.0/bin/node --max-old-space-size=2 /opensource/oppia/node_modules/webpack/bin/webpack.js --config webpack.prod.sourcemap.config.ts

<--- Last few GCs --->


<--- JS stacktrace --->


#
# Fatal javascript OOM in GC during deserialization
#

Trace/breakpoint trap (core dumped)
Stopping Webpack Compiler(pid=647616)...
Traceback (most recent call last):
  File "/.pyenv/versions/3.7.10/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/.pyenv/versions/3.7.10/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/opensource/oppia/scripts/build.py", line 1374, in <module>
    main()
  File "/opensource/oppia/scripts/build.py", line 1361, in main
    build_using_webpack(WEBPACK_PROD_SOURCE_MAPS_CONFIG)
  File "/opensource/oppia/scripts/build.py", line 659, in build_using_webpack
    p.wait()
  File "/.pyenv/versions/3.7.10/lib/python3.7/contextlib.py", line 119, in __exit__
    next(self.gen)
  File "/opensource/oppia/scripts/servers.py", line 445, in managed_webpack_compiler
    yield proc
  File "/.pyenv/versions/3.7.10/lib/python3.7/contextlib.py", line 524, in __exit__
    raise exc_details[1]
  File "/.pyenv/versions/3.7.10/lib/python3.7/contextlib.py", line 509, in __exit__
    if cb(*exc_details):
  File "/.pyenv/versions/3.7.10/lib/python3.7/contextlib.py", line 377, in _exit_wrapper
    return cm_exit(cm, exc_type, exc, tb)
  File "/.pyenv/versions/3.7.10/lib/python3.7/contextlib.py", line 119, in __exit__
    next(self.gen)
  File "/opensource/oppia/scripts/servers.py", line 122, in managed_process
    (proc_name, exit_code))
Exception: Process Webpack Compiler(pid=647616) exited unexpectedly with exit code 133

```

In the second case, the script ran to completion, as expected.


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
