### PR TITLE
Add --disable-dev-shm-usage to lighthouse setup script

### DIFF
--- a/core/tests/puppeteer/lighthouse_setup.js
+++ b/core/tests/puppeteer/lighthouse_setup.js
@@ -294,7 +294,12 @@ const main = async function() {
   process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099';
   FirebaseAdmin.initializeApp({projectId: 'dev-project-id'});
   // Change headless to false to see the puppeteer actions.
-  const browser = await puppeteer.launch({headless: true});
+  // Use '--disable-dev-shm-usage' to try and prevent Chrome from crashing:
+  // https://developers.google.com/web/tools/puppeteer/troubleshooting#tips
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--disable-dev-shm-usage']
+  });
   const page = await browser.newPage();
   await page.setViewport({
     width: 1920,


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: This is a test PR to try and add a new config flag to Chrome when Lighthouse runs. That flag already exists for the frontend and e2e tests, so seeing if adding it here gives more stability.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because the Lighthouse tests will show whether this works.