### PR TITLE
Update branch protection rule prompt

### DIFF
--- a/scripts/release_scripts/cut_release_or_hotfix_branch.py
+++ b/scripts/release_scripts/cut_release_or_hotfix_branch.py
@@ -318,13 +318,8 @@ def execute_branch_cut(target_version, hotfix_number):
             'branch protection rule and doing all the cherrypicks.')
 
     common.ask_user_to_confirm(
-        'Ask Sean (or Ben, if Sean isn\'t available) to create '
-        'a new branch protection rule by:\n'
-        '1. Going to this page: https://github.com/oppia/oppia/'
-        'settings/branch_protection_rules/new.\n'
-        '2. Typing in the full branch name %s.\n'
-        '3. Checking the box: Restrict who can push to matching '
-        'branches (then add the oppia/release-coordinators team)\n' % (
+        'Confirm with Sean (or Ben, if Sean isn\'t available) that '
+        'a new branch protection rule is created for %s' % (
             new_branch_name))
 
     print('')


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of N/A.
2. This PR does the following: Updates branch cut script to confirm creation of a branch protection rule.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because this is not a user facing change.

