### PR TITLE
Update branch protection rule prompt

### DIFF
--- a/scripts/release_scripts/cut_release_or_hotfix_branch.py
+++ b/scripts/release_scripts/cut_release_or_hotfix_branch.py
@@ -317,16 +317,6 @@ def execute_branch_cut(target_version, hotfix_number):
             'Note: It is fine to push the branch only after creating the '
             'branch protection rule and doing all the cherrypicks.')
 
-    common.ask_user_to_confirm(
-        'Ask Sean (or Ben, if Sean isn\'t available) to create '
-        'a new branch protection rule by:\n'
-        '1. Going to this page: https://github.com/oppia/oppia/'
-        'settings/branch_protection_rules/new.\n'
-        '2. Typing in the full branch name %s.\n'
-        '3. Checking the box: Restrict who can push to matching '
-        'branches (then add the oppia/release-coordinators team)\n' % (
-            new_branch_name))
-
     print('')
     print(
         'New %s branch successfully cut. You are now on branch %s' % (

--- a/scripts/release_scripts/cut_release_or_hotfix_branch_test.py
+++ b/scripts/release_scripts/cut_release_or_hotfix_branch_test.py
@@ -420,7 +420,7 @@ class CutReleaseOrHotfixBranchTests(test_utils.GenericTestBase):
                 with self.verify_target_branch_swap, self.run_cmd_swap:
                     with self.verify_target_version_swap, self.open_tab_swap:
                         with self.verify_hotfix_number_swap, self.input_swap:
-                            with self.ask_user_swap, get_branch_name_swap:
+                            with get_branch_name_swap:
                                 cut_release_or_hotfix_branch.execute_branch_cut(
                                     '1.2.3', 3)
         self.expected_check_function_calls[
@@ -448,7 +448,7 @@ class CutReleaseOrHotfixBranchTests(test_utils.GenericTestBase):
                 with self.verify_target_branch_swap, self.run_cmd_swap:
                     with self.verify_target_version_swap, self.open_tab_swap:
                         with self.verify_hotfix_number_swap, self.input_swap:
-                            with self.ask_user_swap, get_branch_name_swap:
+                            with get_branch_name_swap:
                                 cut_release_or_hotfix_branch.execute_branch_cut(
                                     '1.2.3', 1)
         self.expected_check_function_calls[

--- a/scripts/release_scripts/cut_release_or_hotfix_branch_test.py
+++ b/scripts/release_scripts/cut_release_or_hotfix_branch_test.py
@@ -49,8 +49,7 @@ class CutReleaseOrHotfixBranchTests(test_utils.GenericTestBase):
             (
                 'verify_hotfix_number_is_one_ahead_of_'
                 'previous_hotfix_number_is_called'): False,
-            'open_new_tab_in_browser_if_possible_is_called': False,
-            'ask_user_to_confirm_is_called': False
+            'open_new_tab_in_browser_if_possible_is_called': False
         }
         self.expected_check_function_calls = {
             'verify_local_repo_is_clean_is_called': True,
@@ -64,8 +63,7 @@ class CutReleaseOrHotfixBranchTests(test_utils.GenericTestBase):
             (
                 'verify_hotfix_number_is_one_ahead_of_'
                 'previous_hotfix_number_is_called'): True,
-            'open_new_tab_in_browser_if_possible_is_called': True,
-            'ask_user_to_confirm_is_called': True
+            'open_new_tab_in_browser_if_possible_is_called': True
         }
 
         class MockResponse:
@@ -110,8 +108,6 @@ class CutReleaseOrHotfixBranchTests(test_utils.GenericTestBase):
                 'open_new_tab_in_browser_if_possible_is_called'] = True
         def mock_input():
             return 'y'
-        def mock_ask_user_to_confirm(unused_msg):
-            self.check_function_calls['ask_user_to_confirm_is_called'] = True
 
         self.url_open_swap = self.swap(utils, 'url_open', mock_url_open)
         self.verify_local_repo_swap = self.swap(
@@ -140,8 +136,6 @@ class CutReleaseOrHotfixBranchTests(test_utils.GenericTestBase):
         self.open_tab_swap = self.swap(
             common, 'open_new_tab_in_browser_if_possible', mock_open_tab)
         self.input_swap = self.swap(builtins, 'input', mock_input)
-        self.ask_user_swap = self.swap(
-            common, 'ask_user_to_confirm', mock_ask_user_to_confirm)
 
     def test_exception_is_raised_if_target_branch_exists(self):
         def mock_check_output(unused_cmd_tokens):
@@ -393,8 +387,6 @@ class CutReleaseOrHotfixBranchTests(test_utils.GenericTestBase):
         self.expected_check_function_calls[
             'verify_target_version_compatible_with_'
             'latest_released_version_is_called'] = False
-        self.expected_check_function_calls[
-            'ask_user_to_confirm_is_called'] = False
         self.assertEqual(
             self.check_function_calls, self.expected_check_function_calls)
 
@@ -403,7 +395,7 @@ class CutReleaseOrHotfixBranchTests(test_utils.GenericTestBase):
             with self.get_remote_alias_swap, self.check_call_swap:
                 with self.verify_target_branch_swap:
                     with self.verify_target_version_swap, self.open_tab_swap:
-                        with self.input_swap, self.ask_user_swap:
+                        with self.input_swap:
                             cut_release_or_hotfix_branch.execute_branch_cut(
                                 '1.2.3', 0)
         self.expected_check_function_calls[


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of N/A.
2. This PR does the following: Updates branch cut script to remove additional check for creation of a branch protection rule.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because this is not a user facing change.

