### PR TITLE
Increase test coverage to 100% for file core.storage.skill.gae_models_test

### DIFF
--- a/core/storage/skill/gae_models_test.py
+++ b/core/storage/skill/gae_models_test.py
@@ -67,7 +67,12 @@ class SkillCommitLogEntryModelUnitTests(test_utils.GenericTestBase):
         self.assertFalse(
             skill_models.SkillCommitLogEntryModel
             .has_reference_to_user_id('x_id'))
-
+    
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            skill_models.SkillCommitLogEntryModel.get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+        )
 
 class SkillSummaryModelUnitTest(test_utils.GenericTestBase):
     """Test the SkillSummaryModel class."""
@@ -75,7 +80,8 @@ class SkillSummaryModelUnitTest(test_utils.GenericTestBase):
     def test_get_deletion_policy(self) -> None:
         self.assertEqual(
             skill_models.SkillSummaryModel.get_deletion_policy(),
-            base_models.DELETION_POLICY.NOT_APPLICABLE)
+            base_models.DELETION_POLICY.NOT_APPLICABLE
+        )
 
     def test_fetch_page(self) -> None:
         skill_models.SkillSummaryModel(

--- a/core/storage/skill/gae_models_test.py
+++ b/core/storage/skill/gae_models_test.py
@@ -23,6 +23,8 @@ import datetime
 from core.constants import constants
 from core.platform import models
 from core.tests import test_utils
+from core import feconf
+
 
 MYPY = False
 if MYPY: # pragma: no cover
@@ -40,6 +42,29 @@ class SkillSnapshotContentModelTests(test_utils.GenericTestBase):
             skill_models.SkillSnapshotContentModel.get_deletion_policy(),
             base_models.DELETION_POLICY.NOT_APPLICABLE)
 
+    def test_get_export_policy(self) -> None:
+        expected_export_policy_dict = {
+            'commit_cmds': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'commit_message': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'commit_type': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'post_commit_community_owned': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'post_commit_is_private': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'post_commit_status': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'skill_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'user_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'version': base_models.EXPORT_POLICY.NOT_APPLICABLE
+        }
+
+        self.assertEqual(
+            skill_models.SkillCommitLogEntryModel
+                .get_export_policy(),
+            expected_export_policy_dict
+        )
 
 class SkillModelUnitTest(test_utils.GenericTestBase):
     """Test the SkillModel class."""
@@ -74,6 +99,101 @@ class SkillCommitLogEntryModelUnitTests(test_utils.GenericTestBase):
             base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
         )
 
+    def test_get_export_policy(self) -> None:
+        expected_export_policy_dict = {
+            'commit_cmds': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'commit_message': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'commit_type': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'post_commit_community_owned': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'post_commit_is_private': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'post_commit_status': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'skill_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'user_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'version': base_models.EXPORT_POLICY.NOT_APPLICABLE
+        }
+        self.assertEqual(
+            skill_models.SkillCommitLogEntryModel
+                .get_export_policy(),
+            expected_export_policy_dict
+        )
+
+    def test_get_export_policy(self) -> None:
+        expected_export_policy_dict = {
+            'all_questions_merged': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'description': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'language_code': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'misconceptions': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'misconceptions_schema_version': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'next_misconception_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'prerequisite_skill_ids': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'rubric_schema_version': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'rubrics': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'skill_contents': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'skill_contents_schema_version': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'superseding_skill_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'version': base_models.EXPORT_POLICY.NOT_APPLICABLE
+
+        }
+        self.assertEqual(
+            skill_models.SkillModel
+                .get_export_policy(),
+            expected_export_policy_dict
+        )
+
+
+class SkillModelUnitTest(test_utils.GenericTestBase):
+    """Test the SkillModel class."""
+   
+    def test_get_deletion_policy(self) -> None:
+        self.assertEqual(
+            skill_models.SkillModel.get_deletion_policy(),
+            base_models.DELETION_POLICY.NOT_APPLICABLE
+        )
+
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            skill_models.SkillModel.get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+        )
+    def test_get_by_description(self) -> None:
+        committer_id = 'test_committer_id'
+        commit_message = 'test_commit_message'
+        commit_cmds = [{'cmd': 'test_command'}]
+
+        skill_instance = skill_models.SkillModel(
+            id = 'id',
+            description = 'description',
+            # misconceptions_schema_version = (feconf.CURRENT_MISCONCEPTIONS_SCHEMA_VERSION ),
+            # rubric_schema_version = (feconf.CURRENT_RUBRIC_SCHEMA_VERSION),
+            language_code = 'language_code')
+            # skill_contents_schema_version = (feconf.CURRENT_SKILL_CONTENTS_SCHEMA_VERSION),
+            # next_misconception_id = 0)
+            # all_questions_merged = 'all_questions_merged')
+
+        skill_instance.commit(committer_id, commit_message, commit_cmds)
+        skill_by_description = skill_models.SkillModel.test_get_by_description('description')
+        
+        assert skill_by_description is not None
+        self.assertEqual(skill_by_description.id, 'id')
+        # self.assertEqual(skill_by_description.misconceptions_schema_version, (feconf.CURRENT_MISCONCEPTIONS_SCHEMA_VERSION ))
+        # self.assertEqual(skill_by_description.rubric_schema_version, (feconf.CURRENT_RUBRIC_SCHEMA_VERSION))
+        self.assertEqual(skill_by_description.language_code, 'language_code')
+        # self.assertEqual(skill_by_description.skill_contents_schema_version, (feconf.CURRENT_SKILL_CONTENTS_SCHEMA_VERSION))
+        # self.assertEqual(skill_by_description.next_misconception_id , 'next_misconception_id')
+        # self.assertEqual(skill_by_description.all_questions_merged, 'all_questions_merged')
+
+
+
+        
+
 class SkillSummaryModelUnitTest(test_utils.GenericTestBase):
     """Test the SkillSummaryModel class."""
 
@@ -81,6 +201,31 @@ class SkillSummaryModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(
             skill_models.SkillSummaryModel.get_deletion_policy(),
             base_models.DELETION_POLICY.NOT_APPLICABLE
+        )
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            skill_models.SkillSummaryModel.get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+        )
+    
+    def test_get_export_policy(self) -> None:
+        expected_export_policy_dict = {
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'description': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'misconception_count': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'worked_examples_count': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'language_code': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'skill_model_last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'skill_model_created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'version': base_models.EXPORT_POLICY.NOT_APPLICABLE
+        }
+
+        self.assertEqual(
+            skill_models.SkillSummaryModel
+                .get_export_policy(),
+            expected_export_policy_dict
         )
 
     def test_fetch_page(self) -> None:
@@ -137,3 +282,6 @@ class SkillSummaryModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(skill_summaries[0].id, 'skill_id1')
         self.assertEqual(skill_summaries[1].id, 'skill_id2')
         self.assertFalse(more)
+
+
+    

--- a/scripts/backend_tests_incomplete_coverage.txt
+++ b/scripts/backend_tests_incomplete_coverage.txt
@@ -26,7 +26,6 @@ core.utils_test
 scripts.install_backend_python_libs_test
 core.domain.subtopic_page_domain_test
 core.domain.user_services_test
-core.storage.skill.gae_models_test
 core.storage.topic.gae_models_test
 core.domain.app_feedback_report_domain_test
 core.domain.collection_services_test


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[14219].
2. This PR does the following: [Increase test coverage to 100% for file core.storage.skill.gae_models_test]

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes 
made in this PR work correctly. If this PR is for a developer-facing feature, 
provide the videos/screenshots of developer-facing interface. 

Please also include videos/screenshots of the developer tools 
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof 
for the changes then please leave a comment "No proof of changes needed because {{Reason}}" 
and remove all the sections below.
-->
Before changes:
<img width="622" alt="img07" src="https://user-images.githubusercontent.com/50207701/163697171-ffcfbc99-f927-4b83-994a-b95c0c680dbf.png">

After change:
<img width="915" alt="Screen Shot 2022-04-16 at 05 57 52" src="https://user-images.githubusercontent.com/50207701/163697179-be6dc731-60fa-4c9e-ac58-23ad7da9ebf3.png">
<!--
#### Proof of changes on desktop with slow/throttled network
-->
<!--
Make sure to properly verify that everything works correctly, and that there are 
no weird UI mistakes or other problems. Also, if there are any newly added fields, 
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below). 
There should be no performance or UI issues while the network is slow.

References: 
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->
<!--
#### Proof of changes on mobile phone
-->
<!--
In some cases this is not needed (e.g. for pages that we do not expect to 
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->
<!--
#### Proof of changes in Arabic language
-->
<!--
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have 
a separate .rtl.css file for styling), make sure to add screenshots with the site 
language set to Arabic as well (we use Arabic as it is a language written from right to left).  
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
