### PR TITLE
Support legacy translation command in the translation suggestion review edit flow

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
@@ -45,12 +45,12 @@
             </li>
           </ul>
           <schema-based-editor [schema]="getHtmlSchema.bind(this)"
-                               *ngIf="(startedEditing && isHtmlContent) || (isDeprecatedTranslationSuggestionCommand(translationHtml) && translationHtmlContainsTags(translationHtml))"
+                               *ngIf="startedEditing && (isHtmlContent || (isDeprecatedTranslationSuggestionCommand(translationHtml) && translationHtmlContainsTags(translationHtml)))"
                                [localValue]="editedContent.html"
                                (localValueChange)="updateHtml($event)">
           </schema-based-editor>
           <schema-based-editor [schema]="getUnicodeSchema.bind(this)"
-                               *ngIf="(startedEditing && isUnicodeContent) || (isDeprecatedTranslationSuggestionCommand(translationHtml) && !translationHtmlContainsTags(translationHtml))"
+                               *ngIf="startedEditing && (isUnicodeContent || (isDeprecatedTranslationSuggestionCommand(translationHtml) && !translationHtmlContainsTags(translationHtml)))"
                                [localValue]="editedContent.html"
                                (localValueChange)="updateHtml($event)">
           </schema-based-editor>

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
@@ -45,12 +45,12 @@
             </li>
           </ul>
           <schema-based-editor [schema]="getHtmlSchema.bind(this)"
-                               *ngIf="startedEditing && (isHtmlContent || (isDeprecatedTranslationSuggestionCommand(translationHtml) && translationHtmlContainsTags(translationHtml)))"
+                               *ngIf="startedEditing && (isHtmlContent || (isDeprecatedTranslationSuggestionCommand(translationHtml) && doesTranslationContainTags(translationHtml)))"
                                [localValue]="editedContent.html"
                                (localValueChange)="updateHtml($event)">
           </schema-based-editor>
           <schema-based-editor [schema]="getUnicodeSchema.bind(this)"
-                               *ngIf="startedEditing && (isUnicodeContent || (isDeprecatedTranslationSuggestionCommand(translationHtml) && !translationHtmlContainsTags(translationHtml)))"
+                               *ngIf="startedEditing && (isUnicodeContent || (isDeprecatedTranslationSuggestionCommand(translationHtml) && !doesTranslationContainTags(translationHtml)))"
                                [localValue]="editedContent.html"
                                (localValueChange)="updateHtml($event)">
           </schema-based-editor>

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
@@ -45,12 +45,12 @@
             </li>
           </ul>
           <schema-based-editor [schema]="getHtmlSchema.bind(this)"
-                               *ngIf="startedEditing && isHtmlContent"
+                               *ngIf="(startedEditing && isHtmlContent) || (isDeprecatedTranslationSuggestionCommand(translationHtml) && translationHtmlContainsTags(translationHtml))"
                                [localValue]="editedContent.html"
                                (localValueChange)="updateHtml($event)">
           </schema-based-editor>
           <schema-based-editor [schema]="getUnicodeSchema.bind(this)"
-                               *ngIf="startedEditing && isUnicodeContent"
+                               *ngIf="(startedEditing && isUnicodeContent) || (isDeprecatedTranslationSuggestionCommand(translationHtml) && !translationHtmlContainsTags(translationHtml))"
                                [localValue]="editedContent.html"
                                (localValueChange)="updateHtml($event)">
           </schema-based-editor>

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.spec.ts
@@ -710,5 +710,27 @@ describe('Translation Suggestion Review Modal Component', function() {
       expect(component.editedContent.html).toEqual('old');
       expect(changeDetectorRef.detectChanges).toHaveBeenCalledTimes(0);
     });
+
+    it('should check if the change cmd is deprecated', () => {
+      const deprecatedCmd = 'add_translation';
+      const validCmd = 'add_written_translation';
+
+      component.activeSuggestion.change.cmd = validCmd;
+      expect(component.isDeprecatedTranslationSuggestionCommand()).toBeFalse();
+
+      component.activeSuggestion.change.cmd = deprecatedCmd;
+      expect(component.isDeprecatedTranslationSuggestionCommand()).toBeTrue();
+    });
+
+    it('should check if translation contains HTML tags', () => {
+      const translationWithTags = '<p>translation with tags</p>';
+      const translationWithoutTags = 'translation without tags';
+
+      component.translationHtml = translationWithTags;
+      expect(component.doesTranslationContainTags()).toBeTrue();
+
+      component.translationHtml = translationWithoutTags;
+      expect(component.doesTranslationContainTags()).toBeFalse();
+    });
   });
 });

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.ts
@@ -392,6 +392,14 @@ export class TranslationSuggestionReviewModalComponent implements OnInit {
     this.translationHtml = this.preEditTranslationHtml;
   }
 
+  isDeprecatedTranslationSuggestionCommand(): boolean {
+    return this.activeSuggestion.change.cmd === 'add_translation';
+  }
+
+  translationHtmlContainsTags(): boolean {
+    return /<.*>/g.test(this.translationHtml);
+  }
+
   getHtmlSchema(): HTMLSchema {
     return this.HTML_SCHEMA;
   }

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.ts
@@ -396,7 +396,7 @@ export class TranslationSuggestionReviewModalComponent implements OnInit {
     return this.activeSuggestion.change.cmd === 'add_translation';
   }
 
-  translationHtmlContainsTags(): boolean {
+  doesTranslationContainTags(): boolean {
     return /<.*>/g.test(this.translationHtml);
   }
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #15287.
2. This PR does the following: Deprecated 'add_translation' command is supported in the backend for legacy purposes but was not allowed in the frontend, this PR makes changes such that it is allowed in the translation review edit flow in the frontend. Without these changes, the edit flow breaks for translations using the old command. 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes 
made in this PR work correctly. If this PR is for a developer-facing feature, 
provide the videos/screenshots of developer-facing interface. 

Please also include videos/screenshots of the developer tools 
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof 
for the changes then please leave a comment "No proof of changes needed because {{Reason}}" 
and remove all the sections below.
-->
Editing HTML
![html_edit](https://user-images.githubusercontent.com/11008603/163798980-fc57f106-684c-420b-a88a-bfaa177fdad6.png)

Editing Unicode
![unicode_ex](https://user-images.githubusercontent.com/11008603/163798983-bb5115cf-aca5-489f-8738-9b5f70d9b16a.png)


#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are 
no weird UI mistakes or other problems. Also, if there are any newly added fields, 
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below). 
There should be no performance or UI issues while the network is slow.

References: 
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to 
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have 
a separate .rtl.css file for styling), make sure to add screenshots with the site 
language set to Arabic as well (we use Arabic as it is a language written from right to left).  
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
