### PR TITLE
Fix part of #14219: Increase interaction_registry test coverage to 100%

### DIFF
--- a/core/domain/interaction_registry_test.py
+++ b/core/domain/interaction_registry_test.py
@@ -28,7 +28,6 @@ from core.domain import exp_services
 from core.domain import interaction_registry
 from core.tests import test_utils
 from extensions.interactions import base
-from mock import patch
 
 EXPECTED_TERMINAL_INTERACTIONS_COUNT = 1
 
@@ -88,15 +87,21 @@ class InteractionRegistryUnitTests(test_utils.GenericTestBase):
 
     def test_interaction_registry(self):
         """Do some sanity checks on the interaction registry."""
-        with patch(
-                'core.domain.interaction_registry.Registry._interactions', {}):
-            interaction_registry.Registry.get_all_interactions()
         self.assertEqual(
             {
                 type(i).__name__
                 for i in interaction_registry.Registry.get_all_interactions()
             },
             set(interaction_registry.Registry.get_all_interaction_ids()))
+
+        with self.swap(interaction_registry.Registry, '_interactions', {}):
+            self.assertEqual(
+                {
+                    type(i).__name__
+                    for i in
+                    interaction_registry.Registry.get_all_interactions()
+                },
+                set(interaction_registry.Registry.get_all_interaction_ids()))
 
     def test_get_all_specs(self):
         """Test the get_all_specs() method."""

--- a/core/domain/interaction_registry_test.py
+++ b/core/domain/interaction_registry_test.py
@@ -28,6 +28,7 @@ from core.domain import exp_services
 from core.domain import interaction_registry
 from core.tests import test_utils
 from extensions.interactions import base
+from mock import patch
 
 EXPECTED_TERMINAL_INTERACTIONS_COUNT = 1
 
@@ -87,6 +88,9 @@ class InteractionRegistryUnitTests(test_utils.GenericTestBase):
 
     def test_interaction_registry(self):
         """Do some sanity checks on the interaction registry."""
+        with patch("core.domain.interaction_registry.Registry._interactions",
+            {}):
+            interaction_registry.Registry.get_all_interactions()
         self.assertEqual(
             {
                 type(i).__name__

--- a/core/domain/interaction_registry_test.py
+++ b/core/domain/interaction_registry_test.py
@@ -89,7 +89,7 @@ class InteractionRegistryUnitTests(test_utils.GenericTestBase):
     def test_interaction_registry(self):
         """Do some sanity checks on the interaction registry."""
         with patch(
-                "core.domain.interaction_registry.Registry._interactions", {}):
+                'core.domain.interaction_registry.Registry._interactions', {}):
             interaction_registry.Registry.get_all_interactions()
         self.assertEqual(
             {

--- a/core/domain/interaction_registry_test.py
+++ b/core/domain/interaction_registry_test.py
@@ -88,8 +88,8 @@ class InteractionRegistryUnitTests(test_utils.GenericTestBase):
 
     def test_interaction_registry(self):
         """Do some sanity checks on the interaction registry."""
-        with patch("core.domain.interaction_registry.Registry._interactions",
-            {}):
+        with patch(
+                "core.domain.interaction_registry.Registry._interactions", {}):
             interaction_registry.Registry.get_all_interactions()
         self.assertEqual(
             {

--- a/scripts/backend_tests_incomplete_coverage.txt
+++ b/scripts/backend_tests_incomplete_coverage.txt
@@ -12,7 +12,6 @@ core.domain.rights_manager_test
 core.domain.story_domain_test
 core.domain.stats_services_test
 core.domain.value_generators_domain_test
-core.domain.interaction_registry_test
 core.domain.auth_services_test
 core.domain.opportunity_services_test
 core.domain.feedback_domain_test


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #14219.
2. This PR does the following: Increases backend test coverage of  core.domain.interaction_registry_test.py to 100%

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
<img width="836" alt="Screen Shot 2022-04-18 at 11 49 43 PM" src="https://user-images.githubusercontent.com/55938712/163920315-cbe85e28-577a-4b3a-8f54-68889eb88024.png">
<!--

#### Proof of changes on desktop with slow/throttled network
N/A

#### Proof of changes on mobile phone
N/A

#### Proof of changes in Arabic language
N/A