### PR TITLE
Fix part of #14219-Increase Backend Test coverage to 92% for core.storage.collection.gae_models_test

### DIFF
--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -57,7 +57,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(
             collection_models.CollectionModel.get_deletion_policy(),
             base_models.DELETION_POLICY.NOT_APPLICABLE)
-    
+
     def test_get_model_association_to_user(self) -> None:
         self.assertEqual(
             collection_models.CollectionModel.get_model_association_to_user(),
@@ -65,10 +65,17 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
 
     def test_get_export_policy(self) -> None:
         results = collection_models.CollectionModel.get_export_policy()
-        result_list = [results['title'], results['category'], results['objective'], results['language_code'], results['tags'], results['schema_version'], results['collection_contents']]
+        result_list = [
+            results['title'],results['category'],
+            results['objective'],
+            results['language_code'],
+            results['tags'],
+            results['schema_version'],
+            results['collection_contents']
+        ]
         correct_list = [base_models.EXPORT_POLICY.NOT_APPLICABLE] * 7
         self.assertListEqual(result_list, correct_list)
-    
+
     def test_get_collection_count(self) -> None:
         collection = collection_domain.Collection.create_default_collection( # type: ignore[no-untyped-call]
             'id', title='A title',
@@ -233,13 +240,15 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
             collection_models.CollectionRightsModel.get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
-    
+
     def test_get_model_association_to_user(self) -> None:
         self.assertEqual(
-            collection_models.CollectionRightsModel.get_model_association_to_user(),
-            base_models.MODEL_ASSOCIATION_TO_USER.ONE_INSTANCE_SHARED_ACROSS_USERS
+            collection_models.CollectionRightsModel
+            .get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER
+            .ONE_INSTANCE_SHARED_ACROSS_USERS
         )
-    
+
     def test_get_field_name_mapping_to_takeout_keys(self) -> None:
         result = {
             'owner_ids': 'owned_collection_ids',
@@ -248,7 +257,8 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
             'viewer_ids': 'viewable_collection_ids'
         }
         self.assertEqual(
-            collection_models.CollectionRightsModel.get_field_name_mapping_to_takeout_keys(),
+            collection_models.CollectionRightsModel
+            .get_field_name_mapping_to_takeout_keys(),
             result
         )
 
@@ -267,10 +277,6 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
         correct_list = [base_models.EXPORT_POLICY.EXPORTED] * 4
         correct_list.extend([base_models.EXPORT_POLICY.NOT_APPLICABLE] * 4)
         self.assertListEqual(result_list, correct_list)
-        # self.assertEqual(
-        #     results['title'],
-        #     base_models.EXPORT_POLICY.NOT_APPLICABLE
-        # )
 
     def test_has_reference_to_user_id(self) -> None:
         with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
@@ -545,18 +551,18 @@ class CollectionCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
             .get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
-    
+
     def test_get_model_association_to_user(self) -> None:
         self.assertEqual(
             collection_models.CollectionCommitLogEntryModel
             .get_model_association_to_user(),
             base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
         )
-    
+
     def test_get_export_policy(self) -> None:
-        results = collection_models.CollectionCommitLogEntryModel.get_export_policy()
+        rs = collection_models.CollectionCommitLogEntryModel.get_export_policy()
         self.assertEqual(
-            results['collection_id'],
+            rs['collection_id'],
             base_models.EXPORT_POLICY.NOT_APPLICABLE
         )
 
@@ -663,17 +669,18 @@ class CollectionSummaryModelUnitTest(test_utils.GenericTestBase):
             collection_models.CollectionSummaryModel.get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
-    
+
     def test_get_model_association_to_user(self) -> None:
         self.assertEqual(
-            collection_models.CollectionSummaryModel.get_model_association_to_user(),
+            collection_models.CollectionSummaryModel
+            .get_model_association_to_user(),
             base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
         )
-    
+
     def test_get_export_policy(self) -> None:
         results = collection_models.CollectionSummaryModel.get_export_policy()
         result_list = [
-            results['title'], 
+            results['title'],
             results['category'],
             results['objective'],
             results['language_code'],

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -78,7 +78,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertListEqual(result_list, correct_list)
 
     def test_get_collection_count(self) -> None:
-        collection = collection_domain.Collection.create_default_collection( 
+        collection = collection_domain.Collection.create_default_collection(
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]
@@ -88,7 +88,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(num_collections, 1)
 
     def test_reconstitute(self) -> None:
-        collection = collection_domain.Collection.create_default_collection( 
+        collection = collection_domain.Collection.create_default_collection(
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -78,7 +78,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertListEqual(result_list, correct_list)
 
     def test_get_collection_count(self) -> None:
-        collection = collection_domain.Collection.create_default_collection( # type: ignore[no-untyped-call]
+        collection = collection_domain.Collection.create_default_collection( 
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]
@@ -88,7 +88,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(num_collections, 1)
 
     def test_reconstitute(self) -> None:
-        collection = collection_domain.Collection.create_default_collection( # type: ignore[no-untyped-call]
+        collection = collection_domain.Collection.create_default_collection( 
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -57,9 +57,20 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(
             collection_models.CollectionModel.get_deletion_policy(),
             base_models.DELETION_POLICY.NOT_APPLICABLE)
+    
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            collection_models.CollectionModel.get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER)
 
+    def test_get_export_policy(self) -> None:
+        results = collection_models.CollectionModel.get_export_policy()
+        result_list = [results['title'], results['category'], results['objective'], results['language_code'], results['tags'], results['schema_version'], results['collection_contents']]
+        correct_list = [base_models.EXPORT_POLICY.NOT_APPLICABLE] * 7
+        self.assertListEqual(result_list, correct_list)
+    
     def test_get_collection_count(self) -> None:
-        collection = collection_domain.Collection.create_default_collection(
+        collection = collection_domain.Collection.create_default_collection( # type: ignore[no-untyped-call]
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]
@@ -69,7 +80,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(num_collections, 1)
 
     def test_reconstitute(self) -> None:
-        collection = collection_domain.Collection.create_default_collection(
+        collection = collection_domain.Collection.create_default_collection( # type: ignore[no-untyped-call]
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]
@@ -222,6 +233,44 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
             collection_models.CollectionRightsModel.get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
+    
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            collection_models.CollectionRightsModel.get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.ONE_INSTANCE_SHARED_ACROSS_USERS
+        )
+    
+    def test_get_field_name_mapping_to_takeout_keys(self) -> None:
+        result = {
+            'owner_ids': 'owned_collection_ids',
+            'editor_ids': 'editable_collection_ids',
+            'voice_artist_ids': 'voiced_collection_ids',
+            'viewer_ids': 'viewable_collection_ids'
+        }
+        self.assertEqual(
+            collection_models.CollectionRightsModel.get_field_name_mapping_to_takeout_keys(),
+            result
+        )
+
+    def test_get_export_policy(self) -> None:
+        results = collection_models.CollectionRightsModel.get_export_policy()
+        result_list = [
+            results['owner_ids'],
+            results['editor_ids'],
+            results['voice_artist_ids'],
+            results['viewer_ids'],
+            results['community_owned'],
+            results['viewable_if_private'],
+            results['status'],
+            results['first_published_msec']
+        ]
+        correct_list = [base_models.EXPORT_POLICY.EXPORTED] * 4
+        correct_list.extend([base_models.EXPORT_POLICY.NOT_APPLICABLE] * 4)
+        self.assertListEqual(result_list, correct_list)
+        # self.assertEqual(
+        #     results['title'],
+        #     base_models.EXPORT_POLICY.NOT_APPLICABLE
+        # )
 
     def test_has_reference_to_user_id(self) -> None:
         with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
@@ -496,6 +545,20 @@ class CollectionCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
             .get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
+    
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            collection_models.CollectionCommitLogEntryModel
+            .get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+        )
+    
+    def test_get_export_policy(self) -> None:
+        results = collection_models.CollectionCommitLogEntryModel.get_export_policy()
+        self.assertEqual(
+            results['collection_id'],
+            base_models.EXPORT_POLICY.NOT_APPLICABLE
+        )
 
     def test_has_reference_to_user_id(self) -> None:
         commit = collection_models.CollectionCommitLogEntryModel.create(
@@ -600,6 +663,36 @@ class CollectionSummaryModelUnitTest(test_utils.GenericTestBase):
             collection_models.CollectionSummaryModel.get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
+    
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            collection_models.CollectionSummaryModel.get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+        )
+    
+    def test_get_export_policy(self) -> None:
+        results = collection_models.CollectionSummaryModel.get_export_policy()
+        result_list = [
+            results['title'], 
+            results['category'],
+            results['objective'],
+            results['language_code'],
+            results['tags'],
+            results['ratings'],
+            results['collection_model_last_updated'],
+            results['collection_model_created_on'],
+            results['status'],
+            results['community_owned'],
+            results['owner_ids'],
+            results['editor_ids'],
+            results['viewer_ids'],
+            results['contributor_ids'],
+            results['contributors_summary'],
+            results['version'],
+            results['node_count'],
+        ]
+        correct_list = [base_models.EXPORT_POLICY.NOT_APPLICABLE] * 17
+        self.assertListEqual(result_list, correct_list)
 
     def test_has_reference_to_user_id(self) -> None:
         collection_models.CollectionSummaryModel(

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -66,7 +66,8 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
     def test_get_export_policy(self) -> None:
         results = collection_models.CollectionModel.get_export_policy()
         result_list = [
-            results['title'],results['category'],
+            results['title'],
+            results['category'],
             results['objective'],
             results['language_code'],
             results['tags'],


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #14219 .
2. This PR does the following: Increases the backend test file coverage to 92% for core.storage.collection.gae_models_test

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
![Screenshot 2022-04-20 032127](https://user-images.githubusercontent.com/34915273/164327845-f81d8c27-c8c3-4d67-94d0-f8f0798462b4.jpg)
![Screenshot 2022-04-20 032048](https://user-images.githubusercontent.com/34915273/164327847-38746fe1-34b7-43cf-aaa8-ff6bf89c5ad4.jpg)
![Screenshot 2022-04-20 030957](https://user-images.githubusercontent.com/34915273/164328110-7791d8cc-76cc-4ed0-8b85-e6d4f6c341da.jpg)

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes 
made in this PR work correctly. If this PR is for a developer-facing feature, 
provide the videos/screenshots of developer-facing interface. 

Please also include videos/screenshots of the developer tools 
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof 
for the changes then please leave a comment "No proof of changes needed because {{Reason}}" 
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are 
no weird UI mistakes or other problems. Also, if there are any newly added fields, 
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below). 
There should be no performance or UI issues while the network is slow.

References: 
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to 
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
