### PR TITLE
Fix part of #14419: ENTRY_POINT refactored to EntryPoint and values changed to UPPERCASE

### DIFF
--- a/core/domain/app_feedback_report_constants.py
+++ b/core/domain/app_feedback_report_constants.py
@@ -89,17 +89,13 @@ class CATEGORY(enum.Enum): # pylint: disable=invalid-name
     other_crash = 'other_crash' # pylint: disable=invalid-name
 
 
-# TODO(#14419): Change naming style of Enum class from SCREAMING_SNAKE_CASE
-# to PascalCase and its values to UPPER_CASE. Because we want to be consistent
-# throughout the codebase according to the coding style guide.
-# https://github.com/oppia/oppia/wiki/Coding-style-guide
-class ENTRY_POINT(enum.Enum): # pylint: disable=invalid-name
+class EntryPoint(enum.Enum): 
     """Enum for entry points."""
 
-    navigation_drawer = 'navigation_drawer' # pylint: disable=invalid-name
-    lesson_player = 'lesson_player' # pylint: disable=invalid-name
-    revision_card = 'revision_card' # pylint: disable=invalid-name
-    crash = 'crash' # pylint: disable=invalid-name
+    NAVIGATION_DRAWER = 'navigation_drawer' 
+    LESSON_PLAYER = 'lesson_player' 
+    REVISION_CARD = 'revision_card'
+    CRASH = 'crash'
 
 
 # TODO(#14419): Change naming style of Enum class from SCREAMING_SNAKE_CASE
@@ -140,8 +136,8 @@ class AndroidNetworkType(enum.Enum):
 FILTER_FIELD_NAMES = app_feedback_report_models.FILTER_FIELD_NAMES
 
 ANDROID_ENTRY_POINT = [
-    ENTRY_POINT.navigation_drawer, ENTRY_POINT.lesson_player,
-    ENTRY_POINT.revision_card, ENTRY_POINT.crash]
+    EntryPoint.NAVIGATION_DRAWER, EntryPoint.LESSON_PLAYER,
+    EntryPoint.REVISION_CARD, EntryPoint.CRASH]
 ALLOWED_REPORT_TYPES = [
     REPORT_TYPE.suggestion, REPORT_TYPE.issue, REPORT_TYPE.crash]
 ALLOWED_CATEGORIES = [

--- a/core/domain/app_feedback_report_constants.py
+++ b/core/domain/app_feedback_report_constants.py
@@ -92,8 +92,8 @@ class CATEGORY(enum.Enum): # pylint: disable=invalid-name
 class EntryPoint(enum.Enum): 
     """Enum for entry points."""
 
-    NAVIGATION_DRAWER = 'navigation_drawer' 
-    LESSON_PLAYER = 'lesson_player' 
+    NAVIGATION_DRAWER = 'navigation_drawer'
+    LESSON_PLAYER = 'lesson_player'
     REVISION_CARD = 'revision_card'
     CRASH = 'crash'
 

--- a/core/domain/app_feedback_report_constants.py
+++ b/core/domain/app_feedback_report_constants.py
@@ -89,7 +89,7 @@ class CATEGORY(enum.Enum): # pylint: disable=invalid-name
     other_crash = 'other_crash' # pylint: disable=invalid-name
 
 
-class EntryPoint(enum.Enum): 
+class EntryPoint(enum.Enum):
     """Enum for entry points."""
 
     NAVIGATION_DRAWER = 'navigation_drawer'

--- a/core/domain/app_feedback_report_domain.py
+++ b/core/domain/app_feedback_report_domain.py
@@ -387,21 +387,21 @@ class AppFeedbackReport:
         """
         entry_point_name = entry_point_json['entry_point_name']
         if entry_point_name == (
-            app_feedback_report_constants.ENTRY_POINT.navigation_drawer.name):
+            app_feedback_report_constants.EntryPoint.NAVIGATION_DRAWER.name):
             return NavigationDrawerEntryPoint()
         elif entry_point_name == (
-            app_feedback_report_constants.ENTRY_POINT.lesson_player.name):
+            app_feedback_report_constants.EntryPoint.LESSON_PLAYER.name):
             return LessonPlayerEntryPoint(
                 entry_point_json['entry_point_topic_id'],
                 entry_point_json['entry_point_story_id'],
                 entry_point_json['entry_point_exploration_id'])
         elif entry_point_name == (
-            app_feedback_report_constants.ENTRY_POINT.revision_card.name):
+            app_feedback_report_constants.EntryPoint.REVISION_CARD.name):
             return RevisionCardEntryPoint(
                 entry_point_json['entry_point_topic_id'],
                 entry_point_json['entry_point_subtopic_id'])
         elif entry_point_name == (
-            app_feedback_report_constants.ENTRY_POINT.crash.name):
+            app_feedback_report_constants.EntryPoint.CRASH.name):
             return CrashEntryPoint()
         else:
             raise utils.InvalidInputException(
@@ -1096,7 +1096,7 @@ class EntryPoint:
 
     def __init__(
         self,
-        entry_point: app_feedback_report_constants.ENTRY_POINT,
+        entry_point: app_feedback_report_constants.EntryPoint,
         topic_id: Optional[str] = None,
         story_id: Optional[str] = None,
         exploration_id: Optional[str] = None,
@@ -1148,7 +1148,7 @@ class EntryPoint:
     def require_valid_entry_point_name(
         cls,
         actual_name: str,
-        expected_entry_point: app_feedback_report_constants.ENTRY_POINT
+        expected_entry_point: app_feedback_report_constants.EntryPoint
     ) -> None:
         """Validates this EntryPoint name.
 
@@ -1206,7 +1206,7 @@ class NavigationDrawerEntryPoint(EntryPoint):
     def __init__(self) -> None:
         """Constructs an NavigationDrawerEntryPoint domain object."""
         super(NavigationDrawerEntryPoint, self).__init__(
-            app_feedback_report_constants.ENTRY_POINT.navigation_drawer, None,
+            app_feedback_report_constants.EntryPoint.NAVIGATION_DRAWER, None,
             None, None, None)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -1230,7 +1230,7 @@ class NavigationDrawerEntryPoint(EntryPoint):
         """
         self.require_valid_entry_point_name(
             self.entry_point_name,
-            app_feedback_report_constants.ENTRY_POINT.navigation_drawer)
+            app_feedback_report_constants.EntryPoint.NAVIGATION_DRAWER)
 
 
 class LessonPlayerEntryPoint(EntryPoint):
@@ -1250,7 +1250,7 @@ class LessonPlayerEntryPoint(EntryPoint):
                 user is playing when intiating the report.
         """
         super(LessonPlayerEntryPoint, self).__init__(
-            app_feedback_report_constants.ENTRY_POINT.lesson_player,
+            app_feedback_report_constants.EntryPoint.LESSON_PLAYER,
             topic_id=topic_id, story_id=story_id, exploration_id=exploration_id)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -1276,7 +1276,7 @@ class LessonPlayerEntryPoint(EntryPoint):
         """
         self.require_valid_entry_point_name(
             self.entry_point_name,
-            app_feedback_report_constants.ENTRY_POINT.lesson_player)
+            app_feedback_report_constants.EntryPoint.LESSON_PLAYER)
         topic_domain.Topic.require_valid_topic_id(self.topic_id)
         story_domain.Story.require_valid_story_id(self.story_id) # type: ignore[no-untyped-call]
         self.require_valid_entry_point_exploration(
@@ -1296,7 +1296,7 @@ class RevisionCardEntryPoint(EntryPoint):
                 reviewing when intiating the report.
         """
         super(RevisionCardEntryPoint, self).__init__(
-            app_feedback_report_constants.ENTRY_POINT.revision_card,
+            app_feedback_report_constants.EntryPoint.REVISION_CARD,
             topic_id, None, None, subtopic_id)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -1322,7 +1322,7 @@ class RevisionCardEntryPoint(EntryPoint):
         """
         self.require_valid_entry_point_name(
             self.entry_point_name,
-            app_feedback_report_constants.ENTRY_POINT.revision_card)
+            app_feedback_report_constants.EntryPoint.REVISION_CARD)
         topic_domain.Topic.require_valid_topic_id(self.topic_id)
         if not isinstance(self.subtopic_id, int):
             raise utils.ValidationError(
@@ -1337,7 +1337,7 @@ class CrashEntryPoint(EntryPoint):
         """Constructs an CrashEntryPoint domain object."""
         super(
             CrashEntryPoint, self).__init__(
-                app_feedback_report_constants.ENTRY_POINT.crash, None, None,
+                app_feedback_report_constants.EntryPoint.CRASH, None, None,
                 None, None)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -1360,7 +1360,7 @@ class CrashEntryPoint(EntryPoint):
         """
         self.require_valid_entry_point_name(
             self.entry_point_name,
-            app_feedback_report_constants.ENTRY_POINT.crash)
+            app_feedback_report_constants.EntryPoint.CRASH)
 
 
 class AppFeedbackReportTicket:

--- a/core/domain/app_feedback_report_domain_test.py
+++ b/core/domain/app_feedback_report_domain_test.py
@@ -330,7 +330,7 @@ class AppFeedbackReportDomainTests(test_utils.GenericTestBase):
         }
 
         entry_point_json['entry_point_name'] = (
-            app_feedback_report_constants.ENTRY_POINT.navigation_drawer.name)
+            app_feedback_report_constants.EntryPoint.NAVIGATION_DRAWER.name)
         navigation_drawer_obj = (
             feedback_report.get_entry_point_from_json(
                 entry_point_json))
@@ -340,7 +340,7 @@ class AppFeedbackReportDomainTests(test_utils.GenericTestBase):
                 app_feedback_report_domain.NavigationDrawerEntryPoint))
 
         entry_point_json['entry_point_name'] = (
-            app_feedback_report_constants.ENTRY_POINT.lesson_player.name)
+            app_feedback_report_constants.EntryPoint.LESSON_PLAYER.name)
         lesson_player_obj = (
             feedback_report.get_entry_point_from_json(
                 entry_point_json))
@@ -350,7 +350,7 @@ class AppFeedbackReportDomainTests(test_utils.GenericTestBase):
                 app_feedback_report_domain.LessonPlayerEntryPoint))
 
         entry_point_json['entry_point_name'] = (
-            app_feedback_report_constants.ENTRY_POINT.revision_card.name)
+            app_feedback_report_constants.EntryPoint.REVISION_CARD.name)
         revision_card_obj = (
             feedback_report.get_entry_point_from_json(
                 entry_point_json))
@@ -360,7 +360,7 @@ class AppFeedbackReportDomainTests(test_utils.GenericTestBase):
                 app_feedback_report_domain.RevisionCardEntryPoint))
 
         entry_point_json['entry_point_name'] = (
-            app_feedback_report_constants.ENTRY_POINT.crash.name)
+            app_feedback_report_constants.EntryPoint.CRASH.name)
         crash_obj = (
             feedback_report.get_entry_point_from_json(
                 entry_point_json))
@@ -739,7 +739,7 @@ class EntryPointDomainTests(test_utils.GenericTestBase):
         super(EntryPointDomainTests, self).setUp()
         self.entry_point = (
             app_feedback_report_domain.EntryPoint(
-                app_feedback_report_constants.ENTRY_POINT.navigation_drawer,
+                app_feedback_report_constants.EntryPoint.NAVIGATION_DRAWER,
                 'topic_id', 'story_id', 'exploration_id', 'subtopic_id'))
 
     def test_to_dict_raises_exception(self) -> None:
@@ -765,7 +765,7 @@ class NavigationDrawerEntryPointDomainTests(test_utils.GenericTestBase):
     def test_to_dict(self) -> None:
         expected_dict = {
             'entry_point_name': (
-                app_feedback_report_constants.ENTRY_POINT.navigation_drawer.name) # pylint: disable=line-too-long
+                app_feedback_report_constants.EntryPoint.NAVIGATION_DRAWER.name) # pylint: disable=line-too-long
         }
         self.assertDictEqual(
             expected_dict, self.entry_point.to_dict())
@@ -793,7 +793,7 @@ class NavigationDrawerEntryPointDomainTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex( # type: ignore[no-untyped-call]
             utils.ValidationError,
             'Expected entry point name %s' % (
-                app_feedback_report_constants.ENTRY_POINT.navigation_drawer.name)): # pylint: disable=line-too-long
+                app_feedback_report_constants.EntryPoint.NAVIGATION_DRAWER.name)): # pylint: disable=line-too-long
             self.entry_point.validate()
 
 
@@ -808,7 +808,7 @@ class LessonPlayerEntryPointDomainTests(test_utils.GenericTestBase):
     def test_to_dict(self) -> None:
         expected_dict = {
             'entry_point_name': (
-                app_feedback_report_constants.ENTRY_POINT.lesson_player.name),
+                app_feedback_report_constants.EntryPoint.LESSON_PLAYER.name),
             'topic_id': 'topic_id',
             'story_id': 'story_id',
             'exploration_id': 'exploration_id'
@@ -837,7 +837,7 @@ class LessonPlayerEntryPointDomainTests(test_utils.GenericTestBase):
         self._assert_validation_error(
             self.entry_point,
             'Expected entry point name %s' % (
-                app_feedback_report_constants.ENTRY_POINT.lesson_player.name))
+                app_feedback_report_constants.EntryPoint.LESSON_PLAYER.name))
 
     def test_validation_invalid_topic_id_fails(self) -> None:
         self.entry_point.topic_id = 'invalid_topic_id'
@@ -897,7 +897,7 @@ class RevisionCardEntryPointDomainTests(test_utils.GenericTestBase):
     def test_to_dict(self) -> None:
         expected_dict = {
             'entry_point_name': (
-                app_feedback_report_constants.ENTRY_POINT.revision_card.name),
+                app_feedback_report_constants.EntryPoint.REVISION_CARD.name),
             'topic_id': 'topic_id',
             'subtopic_id': 'subtopic_id'
         }
@@ -925,7 +925,7 @@ class RevisionCardEntryPointDomainTests(test_utils.GenericTestBase):
         self._assert_validation_error(
             self.entry_point,
             'Expected entry point name %s' % (
-                app_feedback_report_constants.ENTRY_POINT.revision_card.name))
+                app_feedback_report_constants.EntryPoint.REVISION_CARD.name))
 
     def test_validation_invalid_topic_id_fails(self) -> None:
         self.entry_point.topic_id = 'invalid_topic_id'
@@ -967,7 +967,7 @@ class CrashEntryPointDomainTests(test_utils.GenericTestBase):
     def test_to_dict(self) -> None:
         expected_dict = {
             'entry_point_name': (
-                app_feedback_report_constants.ENTRY_POINT.crash.name)
+                app_feedback_report_constants.EntryPoint.CRASH.name)
         }
         self.assertDictEqual(
             expected_dict, self.entry_point.to_dict())
@@ -995,7 +995,7 @@ class CrashEntryPointDomainTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex( # type: ignore[no-untyped-call]
             utils.ValidationError,
             'Expected entry point name %s' % (
-                app_feedback_report_constants.ENTRY_POINT.crash.name)):
+                app_feedback_report_constants.EntryPoint.CRASH.name)):
             self.entry_point.validate()
 
 
@@ -1014,7 +1014,7 @@ class AppContextDomainTests(test_utils.GenericTestBase):
         expected_dict = {
             'entry_point': {
                 'entry_point_name': (
-                    app_feedback_report_constants.ENTRY_POINT.navigation_drawer.name), # pylint: disable=line-too-long
+                    app_feedback_report_constants.EntryPoint.NAVIGATION_DRAWER.name), # pylint: disable=line-too-long
             },
             'text_language_code': LANGUAGE_LOCALE_CODE_ENGLISH,
             'audio_language_code': LANGUAGE_LOCALE_CODE_ENGLISH
@@ -1045,7 +1045,7 @@ class AndroidAppContextDomainTests(test_utils.GenericTestBase):
         expected_dict = {
             'entry_point': {
                 'entry_point_name': (
-                    app_feedback_report_constants.ENTRY_POINT.navigation_drawer.name), # pylint: disable=line-too-long
+                    app_feedback_report_constants.EntryPoint.NAVIGATION_DRAWER.name), # pylint: disable=line-too-long
             },
             'text_language_code': LANGUAGE_LOCALE_CODE_ENGLISH,
             'audio_language_code': LANGUAGE_LOCALE_CODE_ENGLISH,

--- a/core/domain/app_feedback_report_services_test.py
+++ b/core/domain/app_feedback_report_services_test.py
@@ -69,7 +69,7 @@ class AppFeedbackReportServicesUnitTests(test_utils.GenericTestBase):
     ANDROID_DEVICE_MODEL = 'Pixel 4a'
     ANDROID_SDK_VERSION = 23
     ENTRY_POINT_NAVIGATION_DRAWER = (
-        app_feedback_report_constants.ENTRY_POINT.navigation_drawer)
+        app_feedback_report_constants.EntryPoint.NAVIGATION_DRAWER)
     TEXT_LANGUAGE_CODE_ENGLISH = 'en'
     AUDIO_LANGUAGE_CODE_ENGLISH = 'en'
     ANDROID_REPORT_INFO = {

--- a/core/domain/app_feedback_report_services_test.py
+++ b/core/domain/app_feedback_report_services_test.py
@@ -101,7 +101,7 @@ class AppFeedbackReportServicesUnitTests(test_utils.GenericTestBase):
         'android_report_info_schema_version': 1,
         'app_context': {
             'entry_point': {
-                'entry_point_name': 'navigation_drawer',
+                'entry_point_name': 'NAVIGATION_DRAWER',
                 'entry_point_exploration_id': None,
                 'entry_point_story_id': None,
                 'entry_point_topic_id': None,

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -57,7 +57,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(
             collection_models.CollectionModel.get_deletion_policy(),
             base_models.DELETION_POLICY.NOT_APPLICABLE)
-    
+
     def test_get_model_association_to_user(self) -> None:
         self.assertEqual(
             collection_models.CollectionModel.get_model_association_to_user(),
@@ -65,10 +65,17 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
 
     def test_get_export_policy(self) -> None:
         results = collection_models.CollectionModel.get_export_policy()
-        result_list = [results['title'], results['category'], results['objective'], results['language_code'], results['tags'], results['schema_version'], results['collection_contents']]
+        result_list = [
+            results['title'],results['category'],
+            results['objective'],
+            results['language_code'],
+            results['tags'],
+            results['schema_version'],
+            results['collection_contents']
+        ]
         correct_list = [base_models.EXPORT_POLICY.NOT_APPLICABLE] * 7
         self.assertListEqual(result_list, correct_list)
-    
+
     def test_get_collection_count(self) -> None:
         collection = collection_domain.Collection.create_default_collection( # type: ignore[no-untyped-call]
             'id', title='A title',
@@ -233,13 +240,15 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
             collection_models.CollectionRightsModel.get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
-    
+
     def test_get_model_association_to_user(self) -> None:
         self.assertEqual(
-            collection_models.CollectionRightsModel.get_model_association_to_user(),
-            base_models.MODEL_ASSOCIATION_TO_USER.ONE_INSTANCE_SHARED_ACROSS_USERS
+            collection_models.CollectionRightsModel
+            .get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER
+            .ONE_INSTANCE_SHARED_ACROSS_USERS
         )
-    
+
     def test_get_field_name_mapping_to_takeout_keys(self) -> None:
         result = {
             'owner_ids': 'owned_collection_ids',
@@ -248,7 +257,8 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
             'viewer_ids': 'viewable_collection_ids'
         }
         self.assertEqual(
-            collection_models.CollectionRightsModel.get_field_name_mapping_to_takeout_keys(),
+            collection_models.CollectionRightsModel
+            .get_field_name_mapping_to_takeout_keys(),
             result
         )
 
@@ -267,10 +277,6 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
         correct_list = [base_models.EXPORT_POLICY.EXPORTED] * 4
         correct_list.extend([base_models.EXPORT_POLICY.NOT_APPLICABLE] * 4)
         self.assertListEqual(result_list, correct_list)
-        # self.assertEqual(
-        #     results['title'],
-        #     base_models.EXPORT_POLICY.NOT_APPLICABLE
-        # )
 
     def test_has_reference_to_user_id(self) -> None:
         with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
@@ -545,18 +551,18 @@ class CollectionCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
             .get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
-    
+
     def test_get_model_association_to_user(self) -> None:
         self.assertEqual(
             collection_models.CollectionCommitLogEntryModel
             .get_model_association_to_user(),
             base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
         )
-    
+
     def test_get_export_policy(self) -> None:
-        results = collection_models.CollectionCommitLogEntryModel.get_export_policy()
+        rs = collection_models.CollectionCommitLogEntryModel.get_export_policy()
         self.assertEqual(
-            results['collection_id'],
+            rs['collection_id'],
             base_models.EXPORT_POLICY.NOT_APPLICABLE
         )
 
@@ -663,17 +669,18 @@ class CollectionSummaryModelUnitTest(test_utils.GenericTestBase):
             collection_models.CollectionSummaryModel.get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
-    
+
     def test_get_model_association_to_user(self) -> None:
         self.assertEqual(
-            collection_models.CollectionSummaryModel.get_model_association_to_user(),
+            collection_models.CollectionSummaryModel
+            .get_model_association_to_user(),
             base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
         )
-    
+
     def test_get_export_policy(self) -> None:
         results = collection_models.CollectionSummaryModel.get_export_policy()
         result_list = [
-            results['title'], 
+            results['title'],
             results['category'],
             results['objective'],
             results['language_code'],

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -78,7 +78,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertListEqual(result_list, correct_list)
 
     def test_get_collection_count(self) -> None:
-        collection = collection_domain.Collection.create_default_collection( 
+        collection = collection_domain.Collection.create_default_collection(
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]
@@ -88,7 +88,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(num_collections, 1)
 
     def test_reconstitute(self) -> None:
-        collection = collection_domain.Collection.create_default_collection( 
+        collection = collection_domain.Collection.create_default_collection(
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -78,7 +78,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertListEqual(result_list, correct_list)
 
     def test_get_collection_count(self) -> None:
-        collection = collection_domain.Collection.create_default_collection( # type: ignore[no-untyped-call]
+        collection = collection_domain.Collection.create_default_collection( 
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]
@@ -88,7 +88,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(num_collections, 1)
 
     def test_reconstitute(self) -> None:
-        collection = collection_domain.Collection.create_default_collection( # type: ignore[no-untyped-call]
+        collection = collection_domain.Collection.create_default_collection( 
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -57,9 +57,20 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(
             collection_models.CollectionModel.get_deletion_policy(),
             base_models.DELETION_POLICY.NOT_APPLICABLE)
+    
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            collection_models.CollectionModel.get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER)
 
+    def test_get_export_policy(self) -> None:
+        results = collection_models.CollectionModel.get_export_policy()
+        result_list = [results['title'], results['category'], results['objective'], results['language_code'], results['tags'], results['schema_version'], results['collection_contents']]
+        correct_list = [base_models.EXPORT_POLICY.NOT_APPLICABLE] * 7
+        self.assertListEqual(result_list, correct_list)
+    
     def test_get_collection_count(self) -> None:
-        collection = collection_domain.Collection.create_default_collection(
+        collection = collection_domain.Collection.create_default_collection( # type: ignore[no-untyped-call]
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]
@@ -69,7 +80,7 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
         self.assertEqual(num_collections, 1)
 
     def test_reconstitute(self) -> None:
-        collection = collection_domain.Collection.create_default_collection(
+        collection = collection_domain.Collection.create_default_collection( # type: ignore[no-untyped-call]
             'id', title='A title',
             category='A Category', objective='An Objective')
         collection_services.save_new_collection('id', collection) # type: ignore[no-untyped-call]
@@ -222,6 +233,44 @@ class CollectionRightsModelUnitTest(test_utils.GenericTestBase):
             collection_models.CollectionRightsModel.get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
+    
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            collection_models.CollectionRightsModel.get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.ONE_INSTANCE_SHARED_ACROSS_USERS
+        )
+    
+    def test_get_field_name_mapping_to_takeout_keys(self) -> None:
+        result = {
+            'owner_ids': 'owned_collection_ids',
+            'editor_ids': 'editable_collection_ids',
+            'voice_artist_ids': 'voiced_collection_ids',
+            'viewer_ids': 'viewable_collection_ids'
+        }
+        self.assertEqual(
+            collection_models.CollectionRightsModel.get_field_name_mapping_to_takeout_keys(),
+            result
+        )
+
+    def test_get_export_policy(self) -> None:
+        results = collection_models.CollectionRightsModel.get_export_policy()
+        result_list = [
+            results['owner_ids'],
+            results['editor_ids'],
+            results['voice_artist_ids'],
+            results['viewer_ids'],
+            results['community_owned'],
+            results['viewable_if_private'],
+            results['status'],
+            results['first_published_msec']
+        ]
+        correct_list = [base_models.EXPORT_POLICY.EXPORTED] * 4
+        correct_list.extend([base_models.EXPORT_POLICY.NOT_APPLICABLE] * 4)
+        self.assertListEqual(result_list, correct_list)
+        # self.assertEqual(
+        #     results['title'],
+        #     base_models.EXPORT_POLICY.NOT_APPLICABLE
+        # )
 
     def test_has_reference_to_user_id(self) -> None:
         with self.swap(base_models, 'FETCH_BATCH_SIZE', 1):
@@ -496,6 +545,20 @@ class CollectionCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
             .get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
+    
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            collection_models.CollectionCommitLogEntryModel
+            .get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+        )
+    
+    def test_get_export_policy(self) -> None:
+        results = collection_models.CollectionCommitLogEntryModel.get_export_policy()
+        self.assertEqual(
+            results['collection_id'],
+            base_models.EXPORT_POLICY.NOT_APPLICABLE
+        )
 
     def test_has_reference_to_user_id(self) -> None:
         commit = collection_models.CollectionCommitLogEntryModel.create(
@@ -600,6 +663,36 @@ class CollectionSummaryModelUnitTest(test_utils.GenericTestBase):
             collection_models.CollectionSummaryModel.get_deletion_policy(),
             base_models.DELETION_POLICY.PSEUDONYMIZE_IF_PUBLIC_DELETE_IF_PRIVATE
         )
+    
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            collection_models.CollectionSummaryModel.get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER
+        )
+    
+    def test_get_export_policy(self) -> None:
+        results = collection_models.CollectionSummaryModel.get_export_policy()
+        result_list = [
+            results['title'], 
+            results['category'],
+            results['objective'],
+            results['language_code'],
+            results['tags'],
+            results['ratings'],
+            results['collection_model_last_updated'],
+            results['collection_model_created_on'],
+            results['status'],
+            results['community_owned'],
+            results['owner_ids'],
+            results['editor_ids'],
+            results['viewer_ids'],
+            results['contributor_ids'],
+            results['contributors_summary'],
+            results['version'],
+            results['node_count'],
+        ]
+        correct_list = [base_models.EXPORT_POLICY.NOT_APPLICABLE] * 17
+        self.assertListEqual(result_list, correct_list)
 
     def test_has_reference_to_user_id(self) -> None:
         collection_models.CollectionSummaryModel(

--- a/core/storage/collection/gae_models_test.py
+++ b/core/storage/collection/gae_models_test.py
@@ -66,7 +66,8 @@ class CollectionModelUnitTest(test_utils.GenericTestBase):
     def test_get_export_policy(self) -> None:
         results = collection_models.CollectionModel.get_export_policy()
         result_list = [
-            results['title'],results['category'],
+            results['title'],
+            results['category'],
             results['objective'],
             results['language_code'],
             results['tags'],


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #14419 .
2. This PR does the following: Changed naming style of ENTRY_POINT Enum class in app_feedback_report_constants.py from SCREAMING_SNAKE_CASE to PascalCase and its values to UPPER_CASE because we want to be consistent throughout the code base according to the coding style guide.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No new functionality was added to the codebase as the changes were purely stylistic in nature.

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes 
made in this PR work correctly. If this PR is for a developer-facing feature, 
provide the videos/screenshots of developer-facing interface. 

Please also include videos/screenshots of the developer tools 
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof 
for the changes then please leave a comment "No proof of changes needed because {{Reason}}" 
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are 
no weird UI mistakes or other problems. Also, if there are any newly added fields, 
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below). 
There should be no performance or UI issues while the network is slow.

References: 
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- Oppiabot will notify you when you don't add a PR_CHANGELOG label. If you are unable to do so, please @-mention a code owner (who will be in the Reviewers list), or ask on [Gitter](https://gitter.im/oppia/oppia-chat).
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Oppiabot can assign anyone for review/help if you leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL"
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
