### PR TITLE
Relax Lighthouse uses-responsive-images assertion

### DIFF
--- a/.lighthouserc-1.js
+++ b/.lighthouserc-1.js
@@ -85,7 +85,7 @@ module.exports = {
             'uses-rel-preload': ['error', {'minScore': 1}],
             'deprecations': ['error', {'minScore': 1}],
             'redirects': ['error', {'minScore': 1}],
-            'uses-responsive-images': ['error', {'minScore': 1}]
+            'uses-responsive-images': ['error', {'minScore': 0.8}]
           }
         },
         {

--- a/.lighthouserc-2.js
+++ b/.lighthouserc-2.js
@@ -44,7 +44,7 @@ module.exports = {
             'uses-rel-preload': ['error', {'minScore': 0}],
             'deprecations': ['error', {'minScore': 1}],
             'redirects': ['error', {'minScore': 0}],
-            'uses-responsive-images': ['error', {'minScore': 1}]
+            'uses-responsive-images': ['error', {'minScore': 0.8}]
           }
         },
         {

--- a/.lighthouserc-base.js
+++ b/.lighthouserc-base.js
@@ -91,7 +91,7 @@ module.exports = {
     'uses-rel-preload': ['error', {'minScore': 1}],
     'deprecations': ['error', {'minScore': 1}],
     'redirects': ['error', {'minScore': 1}],
-    'uses-responsive-images': ['error', {'minScore': 1}],
+    'uses-responsive-images': ['error', {'minScore': 0.8}],
   },
   baseAccessibilityAssertions: {
     'categories:accessibility': ['error', {'minScore': 1}]


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following: The assertion is too strict. We don't think it's worthwhile to have multiple copies of images just to save a few kilobytes.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

Lighthouse performance test run log:

1. Pass: https://github.com/oppia/oppia/runs/6284705160?check_suite_focus=true and https://github.com/oppia/oppia/runs/6284705190?check_suite_focus=true
2. Pass: https://github.com/oppia/oppia/runs/6291694261?check_suite_focus=true and https://github.com/oppia/oppia/runs/6291694375?check_suite_focus=true
3. Pass: https://github.com/oppia/oppia/runs/6293290923?check_suite_focus=true and https://github.com/oppia/oppia/runs/6293291022?check_suite_focus=true
4. Pass: https://github.com/oppia/oppia/runs/6294222758?check_suite_focus=true and https://github.com/oppia/oppia/runs/6294222829?check_suite_focus=true
5. Pass: https://github.com/oppia/oppia/runs/6297881987?check_suite_focus=true and https://github.com/oppia/oppia/runs/6297882036?check_suite_focus=true

#### Proof of changes on desktop with slow/throttled network

Not Applicable

#### Proof of changes on mobile phone

Not Applicable

#### Proof of changes in Arabic language

Not Applicable

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
