### PR TITLE
Fix #15425: Increase max_old_space_size for webpack

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -683,7 +683,7 @@ def build_using_webpack(config_path: str) -> None:
 
     print('Building webpack')
     managed_webpack_compiler = servers.managed_webpack_compiler(
-        config_path=config_path, max_old_space_size=4096)
+        config_path=config_path, max_old_space_size=6144)
     with managed_webpack_compiler as p:
         p.wait()
     assert get_file_count('backend_prod_files/webpack_bundles/') > 0, (

--- a/scripts/build_test.py
+++ b/scripts/build_test.py
@@ -1189,7 +1189,7 @@ class BuildTests(test_utils.GenericTestBase):
             max_old_space_size: int
         ) -> Iterator[scripts_test_utils.PopenStub]:
             self.assertEqual(config_path, build.WEBPACK_PROD_CONFIG)
-            self.assertEqual(max_old_space_size, 4096)
+            self.assertEqual(max_old_space_size, 6144)
             yield scripts_test_utils.PopenStub()
 
         def mock_get_file_count(unused_path: str) -> int:
@@ -1213,7 +1213,7 @@ class BuildTests(test_utils.GenericTestBase):
             config_path: str, max_old_space_size: int
         ) -> Iterator[scripts_test_utils.PopenStub]:
             self.assertEqual(config_path, build.WEBPACK_PROD_CONFIG)
-            self.assertEqual(max_old_space_size, 4096)
+            self.assertEqual(max_old_space_size, 6144)
             yield scripts_test_utils.PopenStub()
 
         def mock_get_file_count(unused_path: str) -> int:


### PR DESCRIPTION
## Overview

1. This PR fixes #15425.
2. This PR does the following: The `max_old_space_size` needs to be increased because otherwise, the webpack compilation is impossible on some devices.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

I successfully deployed to the backup server with this change.

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
