### PR TITLE
Fix #13725: Added space after checkbox

### DIFF
--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -866,7 +866,7 @@
     "I18N_SIDEBAR_VOLUNTEER_DESCRIPTION": "Join our global team to create and improve lessons.",
     "I18N_SIGNIN_LOADING": "Signing in",
     "I18N_SIGNIN_PAGE_TITLE": "Sign in",
-    "I18N_SIGNUP_AGREE_LICENSE_DESCRIPTION": "&nbsp;By checking the box to the left of this text, you acknowledge, agree, and accept to be bound by the <[sitename]> Terms of Use, found <a href=\"/terms\" target=\"_blank\">here</a>.",
+    "I18N_SIGNUP_AGREE_LICENSE_DESCRIPTION": "By checking the box to the left of this text, you acknowledge, agree, and accept to be bound by the <[sitename]> Terms of Use, found <a href=\"/terms\" target=\"_blank\">here</a>.",
     "I18N_SIGNUP_BUTTON_SUBMIT": "Submit and start contributing",
     "I18N_SIGNUP_CC_TITLE": "Creative Commons License",
     "I18N_SIGNUP_CLOSE_BUTTON": "Close",

--- a/assets/i18n/en.json
+++ b/assets/i18n/en.json
@@ -866,7 +866,7 @@
     "I18N_SIDEBAR_VOLUNTEER_DESCRIPTION": "Join our global team to create and improve lessons.",
     "I18N_SIGNIN_LOADING": "Signing in",
     "I18N_SIGNIN_PAGE_TITLE": "Sign in",
-    "I18N_SIGNUP_AGREE_LICENSE_DESCRIPTION": "By checking the box to the left of this text, you acknowledge, agree, and accept to be bound by the <[sitename]> Terms of Use, found <a href=\"/terms\" target=\"_blank\">here</a>.",
+    "I18N_SIGNUP_AGREE_LICENSE_DESCRIPTION": "&nbsp;By checking the box to the left of this text, you acknowledge, agree, and accept to be bound by the <[sitename]> Terms of Use, found <a href=\"/terms\" target=\"_blank\">here</a>.",
     "I18N_SIGNUP_BUTTON_SUBMIT": "Submit and start contributing",
     "I18N_SIGNUP_CC_TITLE": "Creative Commons License",
     "I18N_SIGNUP_CLOSE_BUTTON": "Close",

--- a/core/templates/pages/signup-page/signup-page.component.html
+++ b/core/templates/pages/signup-page/signup-page.component.html
@@ -119,7 +119,7 @@ link before completing the signup process, they will be logged out.
           <input type="checkbox"
                  [(ngModel)]="hasAgreedToLatestTerms"
                  [ngModelOptions]="{standalone: true}"
-                 class="protractor-test-agree-to-terms-checkbox"
+                 class="protractor-test-agree-to-terms-checkbox oppia-checkbox-margin"
                  id="terms-checkbox">
           <span innerHTML="{{ 'I18N_SIGNUP_AGREE_LICENSE_DESCRIPTION' | translate: { sitename: siteName } }}">
           </span>
@@ -162,7 +162,7 @@ link before completing the signup process, they will be logged out.
   .oppia-signup-site-description-text {
     font-size: 1em;
   }
-  .protractor-test-agree-to-terms-checkbox {
+  .oppia-checkbox-margin {
     margin-right: 6px;
   }
 </style>

--- a/core/templates/pages/signup-page/signup-page.component.html
+++ b/core/templates/pages/signup-page/signup-page.component.html
@@ -119,7 +119,7 @@ link before completing the signup process, they will be logged out.
           <input type="checkbox"
                  [(ngModel)]="hasAgreedToLatestTerms"
                  [ngModelOptions]="{standalone: true}"
-                 class="protractor-test-agree-to-terms-checkbox oppia-checkbox-margin"
+                 class="oppia-checkbox-margin protractor-test-agree-to-terms-checkbox"
                  id="terms-checkbox">
           <span innerHTML="{{ 'I18N_SIGNUP_AGREE_LICENSE_DESCRIPTION' | translate: { sitename: siteName } }}">
           </span>

--- a/core/templates/pages/signup-page/signup-page.component.html
+++ b/core/templates/pages/signup-page/signup-page.component.html
@@ -162,4 +162,7 @@ link before completing the signup process, they will be logged out.
   .oppia-signup-site-description-text {
     font-size: 1em;
   }
+  .protractor-test-agree-to-terms-checkbox{
+    margin-right: 6px;
+  }
 </style>

--- a/core/templates/pages/signup-page/signup-page.component.html
+++ b/core/templates/pages/signup-page/signup-page.component.html
@@ -162,7 +162,7 @@ link before completing the signup process, they will be logged out.
   .oppia-signup-site-description-text {
     font-size: 1em;
   }
-  .protractor-test-agree-to-terms-checkbox{
+  .protractor-test-agree-to-terms-checkbox {
     margin-right: 6px;
   }
 </style>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #13725.
2. This PR does the following: added the appropriate right margin to the checkbox on the signup page.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: 15469".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
![image](https://user-images.githubusercontent.com/63997049/168449242-3df72ba4-c3a1-4014-acf9-1cb9a8ce60b1.png)

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
![image](https://user-images.githubusercontent.com/63997049/168449288-a45c5166-cf13-4974-acff-e0c8488a7209.png)

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have
a separate .rtl.css file for styling), make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
