### PR TITLE
Fix #15484: Minor changes to convertAnswerToLocalFormat implementation

### DIFF
--- a/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.spec.ts
@@ -289,9 +289,9 @@ describe('InputResponsePairComponent', () => {
 
   it('should determine if a string is a number', ()=>{
     let number = '-12.4';
-    expect(component.isNumber(number)).toEqual(true);
+    expect(component.isStringifiedNumber(number)).toEqual(true);
     number = 'ab12';
-    expect(component.isNumber(number)).toEqual(false);
+    expect(component.isStringifiedNumber(number)).toEqual(false);
   });
 
   it('should convert answer to a local format if it is a number', ()=>{

--- a/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.ts
@@ -32,8 +32,9 @@ import { PlayerTranscriptService } from '../services/player-transcript.service';
 import { I18nLanguageCodeService } from 'services/i18n-language-code.service';
 import { Interaction } from 'domain/exploration/InteractionObjectFactory';
 import { NumberConversionService } from 'services/number-conversion.service';
-import { InteractionAnswer } from 'interactions/answer-defs';
-import { isNumber, isString} from 'lodash';
+import isNumber from 'lodash/isNumber';
+import isString from 'lodash/isString';
+
 
 @Component({
   selector: 'oppia-input-response-pair',

--- a/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.ts
@@ -32,6 +32,8 @@ import { PlayerTranscriptService } from '../services/player-transcript.service';
 import { I18nLanguageCodeService } from 'services/i18n-language-code.service';
 import { Interaction } from 'domain/exploration/InteractionObjectFactory';
 import { NumberConversionService } from 'services/number-conversion.service';
+import { InteractionAnswer } from 'interactions/answer-defs';
+import { isNumber, isString} from 'lodash';
 
 @Component({
   selector: 'oppia-input-response-pair',
@@ -82,7 +84,7 @@ export class InputResponsePairComponent {
     return this.i18nLanguageCodeService.isCurrentLanguageRTL();
   }
 
-  isNumber(value: string): boolean {
+  isStringifiedNumber(value: string): boolean {
     const validRegex = /.*[^0-9.\-].*/g;
     if (validRegex.test(value)) {
       return false;
@@ -92,7 +94,7 @@ export class InputResponsePairComponent {
 
   convertAnswerToLocalFormat(data: string): string {
     // We need to use the numberConversionService, only if the data is number.
-    if (!this.isNumber(data)) {
+    if (isString(data) ? !this.isStringifiedNumber(data) : !isNumber(data)) {
       return data;
     }
 

--- a/core/templates/services/exploration-html-formatter.service.ts
+++ b/core/templates/services/exploration-html-formatter.service.ts
@@ -160,7 +160,7 @@ export class ExplorationHtmlFormatterService {
   }
 
   getAnswerHtml(
-      answer: string,
+      answer: InteractionAnswer,
       interactionId: string | null,
       interactionCustomizationArgs: InteractionCustomizationArgs
   ): string {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #15484.
2. This PR does the following: Minor changes to convertAnswerToLocalFormat implementation. Previously, the isNumber check would implicitly convert the passed value to string to check if it were an number, now the check is made more explicit so that string values are checked usin regex while other data type uses the loadash isNumber check.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

![numberwithunits](https://user-images.githubusercontent.com/11008603/169425178-a67fd6a0-2ee3-4278-a08f-22d945583cdf.png)
