### PR TITLE
Add new flag "download_combined_frontend_spec_file" to frontend test execution file

### DIFF
--- a/scripts/run_frontend_tests.py
+++ b/scripts/run_frontend_tests.py
@@ -72,7 +72,7 @@ _PARSER.add_argument(
     action='store_true'
 )
 _PARSER.add_argument(
-    '--download_combined_frontend_file',
+    '--download_combined_frontend_spec_file',
     help='optional; if specifided, downloads the combined frontend file',
     action='store_true'
 )
@@ -146,7 +146,7 @@ def main(args: Optional[Sequence[str]] = None) -> None:
     # the `stdout=subprocess.PIPE` argument to `Popen`.
     assert task.stdout is not None
     # Prevents the wget command from running multiple times.
-    combined_test_spec_downloaded = False
+    combined_spec_file_started_downloading = False
     # This variable will be used to define the wget command to download
     # the combined-test.spec.js file.
     download_task = None
@@ -164,22 +164,22 @@ def main(args: Optional[Sequence[str]] = None) -> None:
             output_lines.append(line)
         # Download the combined-tests.js file from the web-server.
         if ('Executed' in line.decode('utf-8') and
-            not combined_test_spec_downloaded and
-            parsed_args.download_combined_frontend_file):
+            not combined_spec_file_started_downloading and
+            parsed_args.download_combined_frontend_spec_file):
             download_task = subprocess.Popen(
                 ['wget',
                 'http://localhost:9876/base/core/templates/' +
                 'combined-tests.spec.js',
                 '-P',
                 os.path.join('../karma_coverage_reports')])
-            combined_test_spec_downloaded = True
+            # Wait for the wget command to download the combined-tests.spec.js
+            # file to complete.
+            download_task.wait()
+            combined_spec_file_started_downloading = True
     # Standard output is in bytes, we need to decode the line to print it.
     concatenated_output = ''.join(
         line.decode('utf-8') for line in output_lines)
     if download_task:
-        # Wait for the wget command to download the combined-tests.spec.js
-        # file to complete.
-        download_task.wait()
         # The result of the download is printed at the end for
         # easy access to it.
         if download_task.returncode:

--- a/scripts/run_frontend_tests.py
+++ b/scripts/run_frontend_tests.py
@@ -68,7 +68,12 @@ _PARSER.add_argument(
     action='store_true')
 _PARSER.add_argument(
     '--check_coverage',
-    help='option; if specified, checks frontend test coverage',
+    help='optional; if specified, checks frontend test coverage',
+    action='store_true'
+)
+_PARSER.add_argument(
+    '--download_combined_frontend_file',
+    help='optional; if specifided, downloads the combined frontend file',
     action='store_true'
 )
 
@@ -140,6 +145,11 @@ def main(args: Optional[Sequence[str]] = None) -> None:
     # The value of `process.stdout` should not be None since we passed
     # the `stdout=subprocess.PIPE` argument to `Popen`.
     assert task.stdout is not None
+    # Prevents the wget command from running multiple times.
+    combined_test_spec_downloaded = False
+    # This variable will be used to define the wget command to download
+    # the combined-test.spec.js file.
+    download_task = None
     # Reads and prints realtime output from the subprocess until it terminates.
     while True:
         line = task.stdout.readline()
@@ -152,10 +162,32 @@ def main(args: Optional[Sequence[str]] = None) -> None:
             # the line to print it.
             print(line.decode('utf-8'), end='')
             output_lines.append(line)
+        # Download the combined-tests.js file from the web-server.
+        if ('Executed' in line.decode('utf-8') and
+            not combined_test_spec_downloaded and
+            parsed_args.download_combined_frontend_file):
+            download_task = subprocess.Popen(
+                ['wget',
+                'http://localhost:9876/base/core/templates/' +
+                'combined-tests.spec.js',
+                '-P',
+                os.path.join('../karma_coverage_reports')])
+            combined_test_spec_downloaded = True
     # Standard output is in bytes, we need to decode the line to print it.
     concatenated_output = ''.join(
         line.decode('utf-8') for line in output_lines)
-
+    if download_task:
+        # Wait for the wget command to download the combined-tests.spec.js
+        # file to complete.
+        download_task.wait()
+        # The result of the download is printed at the end for
+        # easy access to it.
+        if download_task.returncode:
+            print('Failed to download the combined-tests.spec.js file.')
+        else:
+            print(
+                'Downloaded the combined-tests.spec.js file and stored'
+                'in ../karma_coverage_reports')
     print('Done!')
 
     if 'Trying to get the Angular injector' in concatenated_output:


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of N/A.
2. This PR does the following: A new flag `download_combined_frontend_file` is added to allow developers to download the `combined-tests.spec.js` to allow easier debugging.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
![image](https://user-images.githubusercontent.com/30050862/175797214-ab35f8b9-118c-4e89-b819-c2a3296489de.png)

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have
a separate .rtl.css file for styling), make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
