### PR TITLE
Allow bigger JobRunResult 

### DIFF
--- a/core/jobs/io/job_io_test.py
+++ b/core/jobs/io/job_io_test.py
@@ -53,7 +53,7 @@ class PutResultsTests(job_test_utils.PipelinedTestBase):
             job_run_result.JobRunResult(stdout='ghi', stderr='789'),
         ]
 
-        with self.swap(job_run_result, 'MAX_OUTPUT_BYTES', 11):
+        with self.swap(job_run_result, 'MAX_OUTPUT_CHARACTERS', 8):
             self.assert_pcoll_empty(
                 self.pipeline
                 | beam.Create(messages)

--- a/core/jobs/types/job_run_result.py
+++ b/core/jobs/types/job_run_result.py
@@ -133,7 +133,7 @@ class JobRunResult:
             padding = 2 if next_smallest.stdout and next_smallest.stderr else 1
 
             overall_size = latest_batch_size + padding + result_size
-            if overall_size < 2 * MAX_OUTPUT_CHARACTERS:
+            if overall_size <= MAX_OUTPUT_CHARACTERS:
                 latest_batch_size += padding + result_size
                 batches[-1].append(next_smallest)
             else:

--- a/core/jobs/types/job_run_result.py
+++ b/core/jobs/types/job_run_result.py
@@ -29,6 +29,7 @@ from typing import Any, List, Tuple # isort: skip
 MAX_OUTPUT_CHARACTERS = 5000
 TRUNCATED_MARK = '[TRUNCATED]'
 
+
 class JobRunResult:
     """Encapsulates the result of a job run.
 

--- a/core/jobs/types/job_run_result.py
+++ b/core/jobs/types/job_run_result.py
@@ -24,8 +24,10 @@ from core import utils
 
 from typing import Any, List, Tuple # isort: skip
 
-MAX_OUTPUT_BYTES = 1500
-
+# This is just to make sure that the output of the job have some reasonable
+# length. The maximum that model can hold is around 1 MB and this is much lower.
+MAX_OUTPUT_CHARACTERS = 5000
+TRUNCATED_MARK = '[TRUNCATED]'
 
 class JobRunResult:
     """Encapsulates the result of a job run.
@@ -52,9 +54,14 @@ class JobRunResult:
 
         self.stdout, self.stderr = stdout, stderr
 
-        if self.len_in_bytes() > MAX_OUTPUT_BYTES:
-            raise ValueError(
-                'JobRunResult must not exceed %d bytes' % MAX_OUTPUT_BYTES)
+        if len(self.stdout) > MAX_OUTPUT_CHARACTERS:
+            self.stdout = '%s%s' % (
+                self.stdout[:MAX_OUTPUT_CHARACTERS], TRUNCATED_MARK
+            )
+        if len(self.stderr) > MAX_OUTPUT_CHARACTERS:
+            self.stderr = '%s%s' % (
+                self.stderr[:MAX_OUTPUT_CHARACTERS], TRUNCATED_MARK
+            )
 
     @classmethod
     def as_stdout(cls, value: Any, use_repr: bool = False) -> JobRunResult:
@@ -107,7 +114,10 @@ class JobRunResult:
         for i, result in enumerate(results):
             # Use i as a tie-breaker so that results, which don't implement the
             # comparison operators, don't get compared with one another.
-            heapq.heappush(results_heap, (result.len_in_bytes(), i, result))
+            heapq.heappush(
+                results_heap,
+                (len(result.stdout) + len(result.stderr), i, result)
+            )
 
         batches = []
         latest_batch_size, _, smallest = heapq.heappop(results_heap)
@@ -121,7 +131,8 @@ class JobRunResult:
             # them is empty).
             padding = 2 if next_smallest.stdout and next_smallest.stderr else 1
 
-            if latest_batch_size + padding + result_size < MAX_OUTPUT_BYTES:
+            overall_size = latest_batch_size + padding + result_size
+            if overall_size < 2 * MAX_OUTPUT_CHARACTERS:
                 latest_batch_size += padding + result_size
                 batches[-1].append(next_smallest)
             else:
@@ -134,15 +145,6 @@ class JobRunResult:
             stderr = '\n'.join(r.stderr for r in batch if r.stderr)
             batched_results.append(JobRunResult(stdout=stdout, stderr=stderr))
         return batched_results
-
-    def len_in_bytes(self) -> int:
-        """Returns the number of bytes encoded by the JobRunResult instance.
-
-        Returns:
-            int. The number of bytes encoded by the JobRunResult instance.
-        """
-        output_bytes = (s.encode('utf-8') for s in (self.stdout, self.stderr))
-        return sum(len(output) for output in output_bytes)
 
     def __repr__(self) -> str:
         return '%s(stdout=%s, stderr=%s)' % (


### PR DESCRIPTION
## Overview

1. This PR fixes #15407
2. This PR does the following: Add higher limit for the size of the job output and only truncate if it exceeds the limit.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI in any of the files listed in rtl_css.py (i.e, those that have
a separate .rtl.css file for styling), make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
