### PR TITLE
Fixes backend flake introduced by #15626

### DIFF
--- a/core/domain/subtopic_page_services.py
+++ b/core/domain/subtopic_page_services.py
@@ -329,7 +329,8 @@ def delete_subtopic_page(
 def get_topic_ids_from_subtopic_page_ids(
     subtopic_page_ids: List[str]
 ) -> List[str]:
-    """Returns the topic ids corresponding to the given set of subtopic page ids.
+    """Returns the topic ids corresponding to the given set of subtopic page
+    ids.
 
     Args:
         subtopic_page_ids: list(str). The ids of the subtopic pages.

--- a/core/domain/subtopic_page_services.py
+++ b/core/domain/subtopic_page_services.py
@@ -329,18 +329,20 @@ def delete_subtopic_page(
 def get_topic_ids_from_subtopic_page_ids(
     subtopic_page_ids: List[str]
 ) -> List[str]:
-    """Returns the topic ids corresponding to the given subtopic page ids.
+    """Returns the topic ids corresponding to the given set of subtopic page ids.
 
     Args:
         subtopic_page_ids: list(str). The ids of the subtopic pages.
 
     Returns:
         list(str). The topic ids corresponding to the given subtopic page ids.
+        The returned list of topic ids is deduplicated and ordered
+        alphabetically.
     """
-    return list(dict.fromkeys([
+    return sorted(list({
         subtopic_page_id.split(':')[0] for subtopic_page_id in
-        subtopic_page_ids]
-    ))
+        subtopic_page_ids
+    }))
 
 
 def get_multi_users_subtopic_pages_progress(

--- a/core/domain/subtopic_page_services.py
+++ b/core/domain/subtopic_page_services.py
@@ -337,10 +337,10 @@ def get_topic_ids_from_subtopic_page_ids(
     Returns:
         list(str). The topic ids corresponding to the given subtopic page ids.
     """
-    return list({
+    return list(dict.fromkeys([
         subtopic_page_id.split(':')[0] for subtopic_page_id in
-        subtopic_page_ids
-    })
+        subtopic_page_ids]
+    ))
 
 
 def get_multi_users_subtopic_pages_progress(


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of N/A
2. This PR does the following: This PR fixes a backend flake introduced by #15626

Flake:
```
    return list({
        subtopic_page_id.split(':')[0] for subtopic_page_id in
        subtopic_page_ids
    })
```
The above code attempts to return a list without duplicates. However, this does not preserve the order of the list.

Fix:
```
return list(dict.fromkeys([
        subtopic_page_id.split(':')[0] for subtopic_page_id in
        subtopic_page_ids]
    ))
```
The above code takes advantage of the feature that dictionaries are ordered (source: https://stackoverflow.com/a/17016257/15100413).

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
