### PR TITLE
Fix cannot read properties of undefined (reading 'is_linear') e2e flake

### DIFF
--- a/core/templates/components/state-directives/outcome-editor/outcome-editor.component.ts
+++ b/core/templates/components/state-directives/outcome-editor/outcome-editor.component.ts
@@ -71,8 +71,8 @@ export class OutcomeEditorComponent implements OnInit {
 
   isCurrentInteractionLinear(): boolean {
     let interactionId = this.getCurrentInteractionId();
-    return interactionId !== null && INTERACTION_SPECS[
-      interactionId as InteractionSpecsKey]?.is_linear;
+    return Boolean(interactionId) && INTERACTION_SPECS[
+      interactionId as InteractionSpecsKey].is_linear;
   }
 
   onExternalSave(): void {

--- a/core/templates/components/state-directives/response-header/response-header.component.ts
+++ b/core/templates/components/state-directives/response-header/response-header.component.ts
@@ -76,8 +76,8 @@ export class ResponseHeaderComponent {
 
   isCurrentInteractionLinear(): boolean {
     let interactionId = this.getCurrentInteractionId();
-    return interactionId !== null && INTERACTION_SPECS[
-      interactionId as InteractionSpecsKey]?.is_linear;
+    return Boolean(interactionId) && INTERACTION_SPECS[
+      interactionId as InteractionSpecsKey].is_linear;
   }
 
   isCorrect(): boolean {

--- a/core/templates/components/state-editor/state-hints-editor/state-hints-editor.component.ts
+++ b/core/templates/components/state-editor/state-hints-editor/state-hints-editor.component.ts
@@ -129,7 +129,7 @@ export class StateHintsEditorComponent implements OnInit {
   isCurrentInteractionLinear(): boolean {
     const interactionId = this.stateInteractionIdService.savedMemento;
     if (interactionId) {
-      return INTERACTION_SPECS[interactionId as InteractionSpecsKey]?.is_linear;
+      return INTERACTION_SPECS[interactionId as InteractionSpecsKey].is_linear;
     }
     return false;
   }

--- a/core/templates/components/state-editor/state-solution-editor/state-solution-editor.component.ts
+++ b/core/templates/components/state-editor/state-solution-editor/state-solution-editor.component.ts
@@ -154,8 +154,8 @@ export class StateSolutionEditorComponent implements OnInit {
   // This returns false if the current interaction ID is null.
   isCurrentInteractionLinear(): boolean {
     let savedMemento = this.stateInteractionIdService.savedMemento;
-    return (savedMemento !== null && INTERACTION_SPECS[
-      savedMemento as InteractionSpecsKey]?.is_linear);
+    return (Boolean(savedMemento) && INTERACTION_SPECS[
+      savedMemento as InteractionSpecsKey].is_linear);
   }
 
   onSaveSolution(value: Solution | null): void {

--- a/core/templates/domain/state/StateObjectFactory.ts
+++ b/core/templates/domain/state/StateObjectFactory.ts
@@ -138,7 +138,7 @@ export class State {
     // checking status of a state.
     if (
       !interactionId ||
-      INTERACTION_SPECS[interactionId as InteractionSpecsKey]?.is_linear ||
+      INTERACTION_SPECS[interactionId as InteractionSpecsKey].is_linear ||
       INTERACTION_SPECS[interactionId as InteractionSpecsKey].is_terminal
     ) {
       allContentIds.forEach(contentId => {

--- a/core/templates/domain/state_card/state-card.model.ts
+++ b/core/templates/domain/state_card/state-card.model.ts
@@ -137,7 +137,7 @@ export class StateCard {
         !InteractionSpecsConstants.INTERACTION_SPECS[
           interactionId as InteractionSpecsKey].is_terminal &&
         !InteractionSpecsConstants.INTERACTION_SPECS[
-          interactionId as InteractionSpecsKey]?.is_linear
+          interactionId as InteractionSpecsKey].is_linear
       );
     }
     return false;


### PR DESCRIPTION
## Overview

1. This PR fixes NA
2. This PR does the following: Fix cannot read properties of undefined (reading 'is_linear') e2e flake

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
