### PR TITLE
Attempt to suppress ev_epollex_linux error

### DIFF
--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -181,7 +181,17 @@ class TestingTaskSpec:
         else:
             exc_list = [sys.executable, TEST_RUNNER_PATH, test_target_flag]
 
-        result = run_shell_cmd(exc_list, env=env)
+        try:
+            result = run_shell_cmd(exc_list, env=env)
+        except Exception as e:
+            # Occasionally, tests fail spuriously because of an issue in grpc
+            # (see e.g. https://github.com/oppia/oppia/runs/7462764522) that
+            # causes a random polling error to be surfaced. Since this doesn't
+            # represent a 'real' test failure, we do a single extra run if we
+            # see that.
+            if 'ev_epollex_linux.cc' in str(e):
+                result = run_shell_cmd(exc_list, env=env)
+
         messages = [result]
 
         if self.generate_coverage_report:


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #N/A
2. This PR does the following: Occasionally, backend tests flake because of an ev_epollex_linux.cc poller error surfaced by grpc (see examples [here](https://github.com/oppia/oppia/runs/7362408872?check_suite_focus=true) and [here](https://github.com/oppia/oppia/runs/7462764522)). This PR attempts a single rerun in such cases in order to try and avoid such errors from breaking the build. 

(Note: [This](https://github.com/grpc/grpc/issues/19161) might be relevant more generally but I can't find where the DEFAULT_POLL_INTERVAL is set. It seems like we only access grpc/grpcio through dependencies and not directly.)

Edit: I saw the following in the setup scripts; this is probably where the use of grpc is coming from -- it is likely through the dependency on the datastore emulator. Leaving this info here for posterity.

```
[datastore] If you are using a library that supports the DATASTORE_EMULATOR_HOST environment variable, run:
[datastore] 
[datastore]   export DATASTORE_EMULATOR_HOST=localhost:8089
[datastore] 
[datastore] Dev App Server is now running.
[datastore] 
[datastore] The previous line was printed for backwards compatibility only.
[datastore] If your tests rely on it to confirm emulator startup,
[datastore] please migrate to the emulator health check endpoint (/). Thank you!
Starting new Redis Server: /../oppia_tools/redis-cli-6.2.4/src/redis-server redis.conf
[datastore] The health check endpoint for this emulator instance is http://localhost:8089/Jul 22, 2022 12:52:50 AM io.gapi.emulators.grpc.GrpcServer$3 operationComplete
```

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

I tested this manually by adding code to extensions/domain_test.py that raises an exception containing the ev_epollex_linux string, and confirmed that the test runner entered the exception clause and thereafter followed whatever behaviour was in the exception clause.

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
