### PR TITLE
Make pre_push_hook_test.py assertRaisesRegex stricter

### DIFF
--- a/scripts/pre_push_hook_test.py
+++ b/scripts/pre_push_hook_test.py
@@ -140,7 +140,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
 
     def test_get_remote_name_with_error_in_obtaining_remote(self):
         def mock_communicate():
-            return (b'test', b'Error')
+            return (b'test', b'test_oppia_error')
         process = subprocess.Popen(
             [b'echo', b'test'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         process.communicate = mock_communicate
@@ -148,12 +148,12 @@ class PrePushHookTests(test_utils.GenericTestBase):
             return process
 
         popen_swap = self.swap(subprocess, 'Popen', mock_popen)
-        with popen_swap, self.assertRaisesRegex(ValueError, 'Error'):
+        with popen_swap, self.assertRaisesRegex(ValueError, 'test_oppia_error'):
             pre_push_hook.get_remote_name()
 
     def test_get_remote_name_with_error_in_obtaining_remote_url(self):
         def mock_communicate():
-            return ('test', 'Error')
+            return ('test', 'test_oppia_error')
         process_for_remote = subprocess.Popen(
             [b'echo', b'origin\nupstream'], stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
@@ -167,7 +167,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
                 return process_for_remote
 
         popen_swap = self.swap(subprocess, 'Popen', mock_popen)
-        with popen_swap, self.assertRaisesRegex(ValueError, 'Error'):
+        with popen_swap, self.assertRaisesRegex(ValueError, 'test_oppia_error'):
             pre_push_hook.get_remote_name()
 
     def test_get_remote_name_with_no_remote_set(self):
@@ -242,12 +242,14 @@ class PrePushHookTests(test_utils.GenericTestBase):
 
     def test_git_diff_name_status_with_error(self):
         def mock_start_subprocess_for_result(unused_cmd_tokens):
-            return ('M\tfile1\nA\tfile2', 'Error')
+            return ('M\tfile1\nA\tfile2', 'test_oppia_error')
         subprocess_swap = self.swap(
             pre_push_hook, 'start_subprocess_for_result',
             mock_start_subprocess_for_result)
 
-        with subprocess_swap, self.assertRaisesRegex(ValueError, 'Error'):
+        with subprocess_swap, self.assertRaisesRegex(
+            ValueError, 'test_oppia_error'
+        ):
             pre_push_hook.git_diff_name_status(
                 'left', 'right', diff_filter='filter')
 
@@ -451,7 +453,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
         def mock_exists(unused_file):
             return True
         def mock_start_subprocess_for_result(unused_cmd_tokens):
-            return ('Output', 'Error')
+            return ('Output', 'test_oppia_error')
 
         islink_swap = self.swap(os.path, 'islink', mock_islink)
         exists_swap = self.swap(os.path, 'exists', mock_exists)
@@ -460,7 +462,7 @@ class PrePushHookTests(test_utils.GenericTestBase):
             mock_start_subprocess_for_result)
 
         with islink_swap, exists_swap, subprocess_swap, self.print_swap:
-            with self.assertRaisesRegex(ValueError, 'Error'):
+            with self.assertRaisesRegex(ValueError, 'test_oppia_error'):
                 pre_push_hook.install_hook()
         self.assertTrue('Symlink already exists' in self.print_arr)
         self.assertFalse(


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following: Fixes a backend coverage flake whereby `pre_push_hook.py` was not completely covered on a per-file basis. For example: https://github.com/oppia/oppia/runs/7482170760?check_suite_focus=true#step:8:1809. More details in the associated [debugging doc](https://docs.google.com/document/d/1NSNzeROt6pB8061_Q-70YqiVRBmnQ2uvYXUkxGhAo4U/edit#). To quote from that document:

   > There are two nested if statements in the code that check for the presence of an error and raise ValueError if one is found. The outer check raises an exception if we fail to get the list of remotes. The inner check raises an exception if we fail to get a remote’s URL. When test_get_remote_name_with_error_in_obtaining_remote_url() ran, there could have been an error like the “[ev_epollex_linux](https://github.com/oppia/oppia/pull/15776)” flake when querying the list of remotes. That flake includes the “Error” string, so a value error would have been raised on line 144 instead of on line 142.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

Backend tests passed locally:

```
+------------------+
| SUMMARY OF TESTS |
+------------------+

SUCCESS   scripts.pre_push_hook_test: 48 tests (43.3 secs)
```

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
