### PR TITLE
Fix 'ExplorationTitleInput is not visible' flake in the exploration editor.

### DIFF
--- a/core/templates/pages/exploration-editor-page/editor-tab/state-name-editor/state-name-editor.component.ts
+++ b/core/templates/pages/exploration-editor-page/editor-tab/state-name-editor/state-name-editor.component.ts
@@ -104,6 +104,7 @@ angular.module('oppia').component('stateNameEditor', {
           RouterService.navigateToMainTab(normalizedStateName);
         }
       };
+
       ctrl.$onInit = function() {
         ctrl.directiveSubscriptions.add(
           ExternalSaveService.onExternalSave.subscribe(

--- a/core/templates/pages/exploration-editor-page/services/router.service.ts
+++ b/core/templates/pages/exploration-editor-page/services/router.service.ts
@@ -153,7 +153,12 @@ export class RouterService {
             clearInterval(waitForStatesToLoad);
             if (this.explorationStatesService.hasState(putativeStateName)) {
               this.stateEditorService.setActiveStateName(putativeStateName);
-              if (pathType === this.SLUG_GUI) {
+              // We need to check this._activeTabName because the user may have
+              // navigated to a different tab before the states finish loading.
+              // In such a case, we should not switch back to the editor main
+              // tab.
+              if (pathType === this.SLUG_GUI &&
+                  this._activeTabName === this.TABS.MAIN.name) {
                 this.windowRef.nativeWindow.location.hash = path;
                 this.stateEditorRefreshService.onRefreshStateEditor.emit();
                 // Fire an event to center the Graph in the Editor.

--- a/core/tests/protractor.conf.js
+++ b/core/tests/protractor.conf.js
@@ -335,8 +335,7 @@ exports.config = {
           }
         },
       });
-    }
-    else {
+    } else {
       console.log(
         'Videos will not be recorded for this suite either because videos' +
         ' have been disabled for it (using environment variables) or' +

--- a/core/tests/protractor_utils/waitFor.js
+++ b/core/tests/protractor_utils/waitFor.js
@@ -33,8 +33,9 @@ var loadingMessage = element(by.css('.e2e-test-loading-message'));
 
 var alertToBePresent = async function() {
   await browser.wait(
-    until.alertIsPresent(), DEFAULT_WAIT_TIME_MSECS,
-    'Alert box took too long to appear.');
+    until.alertIsPresent(),
+    DEFAULT_WAIT_TIME_MSECS,
+    'Alert box took too long to appear.\n' + new Error().stack + '\n');
 };
 
 /**
@@ -43,7 +44,9 @@ var alertToBePresent = async function() {
  */
 var elementToBeClickable = async function(element, errorMessage) {
   await browser.wait(
-    until.elementToBeClickable(element), DEFAULT_WAIT_TIME_MSECS, errorMessage);
+    until.elementToBeClickable(element),
+    DEFAULT_WAIT_TIME_MSECS,
+    errorMessage + '\n' + new Error().stack + '\n');
 };
 
 /**
@@ -54,7 +57,8 @@ var elementToBeClickable = async function(element, errorMessage) {
 var invisibilityOf = async function(element, errorMessage) {
   await browser.wait(
     await until.invisibilityOf(element),
-    DEFAULT_WAIT_TIME_MSECS, errorMessage);
+    DEFAULT_WAIT_TIME_MSECS,
+    errorMessage + '\n' + new Error().stack + '\n');
 };
 
 /**
@@ -67,8 +71,9 @@ var pageToFullyLoad = async function() {
   // https://github.com/angular/protractor/issues/2954.
   var loadingMessage = element(by.css('.e2e-test-loading-fullpage'));
   await browser.driver.wait(
-    until.invisibilityOf(loadingMessage), 15000,
-    'Page takes more than 15 secs to load');
+    until.invisibilityOf(loadingMessage),
+    15000,
+    'Page takes more than 15 secs to load\n' + new Error().stack + '\n');
 };
 
 /**
@@ -79,8 +84,9 @@ var pageToFullyLoad = async function() {
  */
 var textToBePresentInElement = async function(element, text, errorMessage) {
   await browser.wait(
-    until.textToBePresentInElement(element, text), DEFAULT_WAIT_TIME_MSECS,
-    errorMessage);
+    until.textToBePresentInElement(element, text),
+    DEFAULT_WAIT_TIME_MSECS,
+    errorMessage + '\n' + new Error().stack + '\n');
 };
 
 /**
@@ -91,7 +97,8 @@ var textToBePresentInElement = async function(element, text, errorMessage) {
 var presenceOf = async function(element, errorMessage) {
   await browser.wait(
     await until.presenceOf(element),
-    DEFAULT_WAIT_TIME_MSECS, errorMessage);
+    DEFAULT_WAIT_TIME_MSECS,
+    errorMessage + '\n' + new Error().stack + '\n');
 };
 
 /**
@@ -102,7 +109,8 @@ var presenceOf = async function(element, errorMessage) {
 var visibilityOf = async function(element, errorMessage) {
   await browser.wait(
     await until.visibilityOf(element),
-    DEFAULT_WAIT_TIME_MSECS, errorMessage);
+    DEFAULT_WAIT_TIME_MSECS,
+    errorMessage + '\n' + new Error().stack + '\n');
 };
 
 /**
@@ -115,23 +123,29 @@ var visibilityOf = async function(element, errorMessage) {
 var elementAttributeToBe = async function(
     element, attribute, value, errorMessage
 ) {
-  await browser.wait(async function() {
-    return await element.getAttribute(attribute) === value;
-  }, DEFAULT_WAIT_TIME_MSECS, errorMessage);
+  await browser.wait(
+    async function() {
+      return await element.getAttribute(attribute) === value;
+    },
+    DEFAULT_WAIT_TIME_MSECS,
+    errorMessage + '\n' + new Error().stack + '\n');
 };
 
 /**
 * Wait for new tab is opened
 */
 var newTabToBeCreated = async function(errorMessage, urlToMatch) {
-  await browser.wait(async function() {
-    var handles = await browser.driver.getAllWindowHandles();
-    await browser.waitForAngularEnabled(false);
-    await browser.switchTo().window(await handles.pop());
-    var url = await browser.getCurrentUrl();
-    await browser.waitForAngularEnabled(true);
-    return await url.match(urlToMatch);
-  }, DEFAULT_WAIT_TIME_MSECS_FOR_NEW_TAB, errorMessage);
+  await browser.wait(
+    async function() {
+      var handles = await browser.driver.getAllWindowHandles();
+      await browser.waitForAngularEnabled(false);
+      await browser.switchTo().window(await handles.pop());
+      var url = await browser.getCurrentUrl();
+      await browser.waitForAngularEnabled(true);
+      return await url.match(urlToMatch);
+    },
+    DEFAULT_WAIT_TIME_MSECS_FOR_NEW_TAB,
+    errorMessage + '\n' + new Error().stack + '\n');
 };
 
 /**
@@ -140,7 +154,9 @@ var newTabToBeCreated = async function(errorMessage, urlToMatch) {
 var urlRedirection = async function(url) {
   // Checks that the current URL matches the expected text.
   await browser.wait(
-    until.urlIs(url), DEFAULT_WAIT_TIME_MSECS, 'URL redirection took too long');
+    until.urlIs(url),
+    DEFAULT_WAIT_TIME_MSECS,
+    'URL redirection took too long\n' + new Error().stack + '\n');
 };
 
 var visibilityOfInfoToast = async function(errorMessage) {
@@ -161,9 +177,12 @@ var visibilityOfSuccessToast = async function(errorMessage) {
 
 var fadeInToComplete = async function(element, errorMessage) {
   await visibilityOf(element, 'Editor taking too long to appear');
-  await browser.driver.wait(async function() {
-    return await element.getCssValue('opacity') === '1';
-  }, DEFAULT_WAIT_TIME_MSECS, errorMessage);
+  await browser.driver.wait(
+    async function() {
+      return await element.getCssValue('opacity') === '1';
+    },
+    DEFAULT_WAIT_TIME_MSECS,
+    errorMessage + '\n' + new Error().stack + '\n');
 };
 
 var modalPopupToAppear = async function() {
@@ -178,7 +197,9 @@ var fileToBeDownloaded = async function(filename) {
   var name = Constants.DOWNLOAD_PATH + '/' + filename;
   await browser.driver.wait(function() {
     return fs.existsSync(name);
-  }, DEFAULT_WAIT_TIME_MSECS, 'File was not downloaded!');
+  },
+  DEFAULT_WAIT_TIME_MSECS,
+  'File was not downloaded!\n' + new Error().stack + '\n');
 };
 
 var clientSideRedirection = async function(


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: The following flake has been occurring recently in many PRs: "ExplorationTitleInput is not visible". This PR identifies the root cause and fixes it. It also adds more detailed logging for waitFor() errors so that the stack trace is more complete.

See https://docs.google.com/document/d/1I0gAcIo3SRCoc6VQH8tAykp4g6Uw3sxXvhR446JMNlw/edit# for the debugging doc.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

I ran the e2e tests 3 times locally and all the runs passed. Prior to that, local runs were failing 5 times out of 6, so I am fairly confident that this PR fixes the issue.
