### PR TITLE
Add a waitFor to try and address "successful report" flake.

### DIFF
--- a/core/tests/protractor_utils/ExplorationPlayerPage.js
+++ b/core/tests/protractor_utils/ExplorationPlayerPage.js
@@ -136,6 +136,8 @@ var ExplorationPlayerPage = function() {
     let textArea = element(by.tagName('textarea'));
     await action.sendKeys('Text Area', textArea, 'Reporting this exploration');
     await action.click('Submit Button', submitButton);
+    await waitFor.visibilityOf(
+      flaggedSuccessElement, 'Successfully-flagged modal not showing up.');
     let afterSubmitText = await flaggedSuccessElement.getText();
     expect(afterSubmitText).toMatch(
       'Your report has been forwarded to the moderators for review.');


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Add a waitFor() to try and address the moderator flake here: https://github.com/oppia/oppia/runs/7484783723?check_suite_focus=true#step:12:488

Note that this might not fix the flake, but it shouldn't do any harm and it would give us more information if it does reoccur.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".
