### PR TITLE
Add promise rejection handler for CSRF initializeToken fetch() call.

### DIFF
--- a/core/templates/services/csrf-token.service.spec.ts
+++ b/core/templates/services/csrf-token.service.spec.ts
@@ -66,7 +66,7 @@ describe('Csrf Token Service', function() {
         csrfTokenService.initializeToken();
       } catch (e) {
         expect(e).toEqual(new Error(
-          'THere has been a problem with the fetch operation: Test Error'));
+          'There has been a problem with the fetch operation: Test Error'));
       }
     });
   });

--- a/core/templates/services/csrf-token.service.ts
+++ b/core/templates/services/csrf-token.service.ts
@@ -39,6 +39,9 @@ export class CsrfTokenService {
       return response.text();
     }).then((responseText: string) => {
       return JSON.parse(responseText.substring(5)).token;
+    }).catch((error: Error) => {
+      throw new Error(
+        'There has been a problem with the fetch operation: ' + error.message);
     });
   }
 


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Adds a promise rejection handler for the fetch() call in CSRF initializeToken, to hopefully get better error messages than "Failed to fetch" in cases like [this](https://github.com/oppia/oppia/runs/7513357802?check_suite_focus=true) and [this](https://github.com/oppia/oppia/runs/7512018422?check_suite_focus=true).

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

This PR just adds a catch() to the existing fetch() handler. I've added a frontend test for this change, which passes.