### PR TITLE
Unhandled promise flake test

### DIFF
--- a/.github/workflows/e2e_creator_learner_dashboard_and_editor_tabs.yml
+++ b/.github/workflows/e2e_creator_learner_dashboard_and_editor_tabs.yml
@@ -63,6 +63,51 @@ jobs:
         run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env
         env: 
           VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Learner Dashboard E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env
+        env: 
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Learner Dashboard E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env
+        env: 
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Learner Dashboard E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env
+        env: 
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Learner Dashboard E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env
+        env: 
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Learner Dashboard E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env
+        env: 
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Learner Dashboard E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env
+        env: 
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Learner Dashboard E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env
+        env: 
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Learner Dashboard E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env
+        env: 
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Learner Dashboard E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learnerDashboard" --prod_env
+        env: 
+          VIDEO_RECORDING_IS_ENABLED: 0
       - name: Uploading protractor-video as Artifacts
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 && always() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/e2e_topic_tests.yml
+++ b/.github/workflows/e2e_topic_tests.yml
@@ -63,6 +63,51 @@ jobs:
         run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryViewer" --prod_env
         env:
           VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Topic and Story Viewer E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryViewer" --prod_env
+        env:
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Topic and Story Viewer E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryViewer" --prod_env
+        env:
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Topic and Story Viewer E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryViewer" --prod_env
+        env:
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Topic and Story Viewer E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryViewer" --prod_env
+        env:
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Topic and Story Viewer E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryViewer" --prod_env
+        env:
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Topic and Story Viewer E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryViewer" --prod_env
+        env:
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Topic and Story Viewer E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryViewer" --prod_env
+        env:
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Topic and Story Viewer E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryViewer" --prod_env
+        env:
+          VIDEO_RECORDING_IS_ENABLED: 0
+      - name: Run Topic and Story Viewer E2E Test
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicAndStoryViewer" --prod_env
+        env:
+          VIDEO_RECORDING_IS_ENABLED: 0
       - name: Uploading protractor-video as Artifacts
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 && always() }}
         uses: actions/upload-artifact@v2

--- a/core/tests/wdio.conf.js
+++ b/core/tests/wdio.conf.js
@@ -129,7 +129,7 @@ exports.config = {
   // Define all options that are relevant for the WebdriverIO instance here
   //
   // Level of logging verbosity: trace | debug | info | warn | error | silent.
-  logLevel: 'warn',
+  logLevel: 'info',
 
   // Set a base URL in order to shorten url command calls. If your `url`
   // parameter starts with `/`, the base url gets prepended, not including

--- a/core/tests/webdriverio_utils/waitFor.js
+++ b/core/tests/webdriverio_utils/waitFor.js
@@ -17,6 +17,9 @@
  * wdio-wait-for.
  */
 
+var loadingPageSelector = function() {
+    return $('.e2e-test-loading-fullpage');
+};
 var until = require('wdio-wait-for');
 var fs = require('fs');
 var Constants = require('./WebdriverioConstants');
@@ -76,8 +79,7 @@ var invisibilityOf = async function(element, errorMessage) {
  * Consider adding this method after each browser.url() call.
  */
 var pageToFullyLoad = async function() {
-  var loadingMessage = await $('.e2e-test-loading-fullpage');
-  await loadingMessage.waitForDisplayed({
+  await loadingPageSelector().waitForDisplayed({
     timeout: 15000,
     reverse: true,
     timeoutMsg: 'Pages takes more than 15 sec to load\n' +


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: [Explain here what your PR does and why]

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
