### PR TITLE
Remove unnecessary state-editor-content code in e2e test.

### DIFF
--- a/core/templates/components/entity-creation-services/exploration-creation.service.ts
+++ b/core/templates/components/entity-creation-services/exploration-creation.service.ts
@@ -60,12 +60,13 @@ export class ExplorationCreationService {
         this.siteAnalyticsService.registerCreateNewExplorationEvent(
           response.explorationId);
         setTimeout(() => {
-          this.windowRef.nativeWindow.location.href =
-        this.urlInterpolationService.interpolateUrl(
-          this.CREATE_NEW_EXPLORATION_URL_TEMPLATE, {
-            exploration_id: response.explorationId
-          }
-        );
+          this.windowRef.nativeWindow.location.href = (
+            this.urlInterpolationService.interpolateUrl(
+              this.CREATE_NEW_EXPLORATION_URL_TEMPLATE, {
+                exploration_id: response.explorationId
+              }
+            )
+          );
         }, 150);
         return false;
       }, () => {

--- a/core/tests/protractor_utils/ExplorationEditorMainTab.js
+++ b/core/tests/protractor_utils/ExplorationEditorMainTab.js
@@ -90,8 +90,6 @@ var ExplorationEditorMainTab = function() {
   var stateNameInput = element(
     by.css('.e2e-test-state-name-input'));
   var ruleDetails = element(by.css('.e2e-test-rule-details'));
-  var stateContentEditorLocator = by.css(
-    '.e2e-test-state-content-editor');
   var addOrUpdateSolutionModal = element(
     by.css('.e2e-test-add-or-update-solution-modal'));
   var answerDescriptionFragment = element.all(
@@ -512,11 +510,7 @@ var ExplorationEditorMainTab = function() {
     await action.click('stateEditButton', stateEditButton);
     await waitFor.visibilityOf(
       stateEditorTag, 'State editor tag not showing up');
-    var stateContentEditor = stateEditorTag.element(stateContentEditorLocator);
-    await waitFor.visibilityOf(
-      stateContentEditor,
-      'stateContentEditor taking too long to appear to set content');
-    var richTextEditor = await forms.RichTextEditor(stateContentEditor);
+    var richTextEditor = await forms.RichTextEditor(stateEditorTag);
     await richTextEditor.clear();
     await richTextInstructions(richTextEditor);
     await action.click('Save State Content Button', saveStateContentButton);

--- a/core/tests/webdriverio_utils/ExplorationEditorMainTab.js
+++ b/core/tests/webdriverio_utils/ExplorationEditorMainTab.js
@@ -80,7 +80,6 @@ var ExplorationEditorMainTab = function() {
   };
   var ruleDetails = $('.e2e-test-rule-details');
   var stateContentDisplay = $('.e2e-test-state-content-display');
-  var stateContentEditorLocator = '.e2e-test-state-content-editor';
   var stateEditButton = $('.e2e-test-edit-content-pencil-button');
   var stateEditorTag = $('.e2e-test-state-content-editor');
   var stateNameContainer = $('.e2e-test-state-name-container');
@@ -468,11 +467,7 @@ var ExplorationEditorMainTab = function() {
     await action.click('stateEditButton', stateEditButton);
     await waitFor.visibilityOf(
       stateEditorTag, 'State editor tag not showing up');
-    var stateContentEditor = stateEditorTag.$(stateContentEditorLocator);
-    await waitFor.visibilityOf(
-      stateContentEditor,
-      'stateContentEditor taking too long to appear to set content');
-    var richTextEditor = await forms.RichTextEditor(stateContentEditor);
+    var richTextEditor = await forms.RichTextEditor(stateEditorTag);
     await richTextEditor.clear();
     await richTextInstructions(richTextEditor);
     await action.click('Save State Content Button', saveStateContentButton);


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Removes state-editor-content code that doesn't seem necessary in e2e files and that _might_ be leading to flakes. (Note that the removed code is a duplicate of the selector stateEditorTag that seems to be defined in exactly the same way.)

Debugging doc:
https://docs.google.com/document/d/14SYySyGoGuL3k9BiG2RndqAtR_CFEQzrNz4duXTABwI/edit#

Recent instances of this flake (in both webdriverio and protractor):
- https://github.com/oppia/oppia/runs/7525079139?check_suite_focus=true
- https://github.com/oppia/oppia/runs/7525078654?check_suite_focus=true
- https://github.com/oppia/oppia/runs/7529979612?check_suite_focus=true
- https://github.com/oppia/oppia/runs/7525078697?check_suite_focus=true

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

The tests at least pass, though it's not certain that they fully fix the flake. The fix in this PR shouldn't do any harm, though.