### PR TITLE
Fix E2E Metrics Reporting and Reruns

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -68,9 +68,9 @@ language set to Arabic as well (we use Arabic as it is a language written from r
 
 ## PR Pointers
 
-- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
+- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
 - If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
-- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
+- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
 - Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
 - Never force push. If you do, your PR will be closed.
-- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
+- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).

--- a/.github/workflows/e2e_additional_editor_and_player.yml
+++ b/.github/workflows/e2e_additional_editor_and_player.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Install ffmpeg
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
         run: sudo apt install ffmpeg
+      - name: Build Webpack
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: python -m scripts.build --prod_env
       - name: Run Additional Editor E2E Test
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
-        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --suite="additionalEditorFeatures" --prod_env
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="additionalEditorFeatures" --prod_env
         env: 
           VIDEO_RECORDING_IS_ENABLED: 0
       - name: Run Additional Editor Modals E2E Test

--- a/.github/workflows/e2e_creator_learner_dashboard_and_editor_tabs.yml
+++ b/.github/workflows/e2e_creator_learner_dashboard_and_editor_tabs.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Install ffmpeg
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
         run: sudo apt install ffmpeg
+      - name: Build Webpack
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: python -m scripts.build --prod_env
       - name: Run Creator Dashboard E2E Test
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
-        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --suite="creatorDashboard" --prod_env
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="creatorDashboard" --prod_env
         env: 
           VIDEO_RECORDING_IS_ENABLED: 0
       - name: Run Improvements Tab E2E Test

--- a/.github/workflows/e2e_history_statistics_tabs_and_extensions.yml
+++ b/.github/workflows/e2e_history_statistics_tabs_and_extensions.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Install ffmpeg
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
         run: sudo apt install ffmpeg
+      - name: Build Webpack
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: python -m scripts.build --prod_env
       - name: Run History Tab E2E Test
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
-        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --suite="explorationHistoryTab" --prod_env
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationHistoryTab" --prod_env
         env: 
           VIDEO_RECORDING_IS_ENABLED: 0
       - name: Run Statistics Tab E2E Test

--- a/.github/workflows/e2e_learner_flow_skill_editor_and_embedding.yml
+++ b/.github/workflows/e2e_learner_flow_skill_editor_and_embedding.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Install ffmpeg
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
         run: sudo apt install ffmpeg
+      - name: Build Webpack
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: python -m scripts.build --prod_env
       - name: Run Learner Flow E2E Test
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
-        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --suite="learner" --prod_env
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="learner" --prod_env
         env: 
           VIDEO_RECORDING_IS_ENABLED: 0
       - name: Run Skill Editor E2E Test

--- a/.github/workflows/e2e_miscellaneous_tests.yml
+++ b/.github/workflows/e2e_miscellaneous_tests.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Install ffmpeg
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
         run: sudo apt install ffmpeg
+      - name: Build Webpack
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: python -m scripts.build --prod_env
       - name: Run e2e File Upload Features Test
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
-        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --suite="fileUploadFeatures" --prod_env
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-install --skip-build --suite="fileUploadFeatures" --prod_env
         env: 
           VIDEO_RECORDING_IS_ENABLED: 0
       - name: Run e2e Play Voiceovers Test

--- a/.github/workflows/e2e_other_tests.yml
+++ b/.github/workflows/e2e_other_tests.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Install ffmpeg
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
         run: sudo apt install ffmpeg
+      - name: Build Webpack
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: python -m scripts.build --prod_env
       - name: Run e2e Collections Test
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
-        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --suite="collections" --prod_env
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-install --skip-build --suite="collections" --prod_env
         env: 
           VIDEO_RECORDING_IS_ENABLED: 0
       - name: Run e2e Accessibility Test

--- a/.github/workflows/e2e_topic_tests.yml
+++ b/.github/workflows/e2e_topic_tests.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Install ffmpeg
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
         run: sudo apt install ffmpeg
+      - name: Build Webpack
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: python -m scripts.build --prod_env
       - name: Run Topics and Skills Dashboard E2E Test
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
-        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --suite="topicsAndSkillsDashboard" --prod_env
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="topicsAndSkillsDashboard" --prod_env
         env:
           VIDEO_RECORDING_IS_ENABLED: 0
       - name: Run Topic and Story Editor E2E Test

--- a/.github/workflows/e2e_translation_classroom_and_core_features.yml
+++ b/.github/workflows/e2e_translation_classroom_and_core_features.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Install ffmpeg
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
         run: sudo apt install ffmpeg
+      - name: Build Webpack
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: python -m scripts.build --prod_env
       - name: Run Exploration Translation Tab E2E Test
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
-        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --suite="explorationTranslationTab" --prod_env
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-build --skip-install --suite="explorationTranslationTab" --prod_env
         env: 
           VIDEO_RECORDING_IS_ENABLED: 0
       - name: Run Classroom Page E2E Test

--- a/.github/workflows/e2e_user_features_and_library.yml
+++ b/.github/workflows/e2e_user_features_and_library.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Install ffmpeg
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
         run: sudo apt install ffmpeg
+      - name: Build Webpack
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: python -m scripts.build --prod_env
       - name: Run Library E2E Test
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
-        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --suite="library" --prod_env
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-install --skip-build --suite="library" --prod_env
         env:
           VIDEO_RECORDING_IS_ENABLED: 0
       - name: Run e2e preferences test

--- a/.github/workflows/e2e_user_profile.yml
+++ b/.github/workflows/e2e_user_profile.yml
@@ -43,9 +43,12 @@ jobs:
       - name: Install ffmpeg
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
         run: sudo apt install ffmpeg
+      - name: Build Webpack
+        if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
+        run: python -m scripts.build --prod_env
       - name: Run e2e users test
         if: ${{ steps.check-risk.outputs.is-low-risk != 0 }}
-        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --suite="users" --prod_env
+        run: xvfb-run -a --server-args="-screen 0, 1285x1000x24" python -m scripts.run_e2e_tests --skip-install --skip-build --suite="users" --prod_env
         env: 
           VIDEO_RECORDING_IS_ENABLED: 0
       - name: Run e2e profileMenu test

--- a/scripts/flake_checker_test.py
+++ b/scripts/flake_checker_test.py
@@ -282,6 +282,7 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
                     'test': 'testName',
                     'flake_id': 'flake',
                 },
+                'rerun': 'rerun yes',
             }
             return MockResponse(True, response)
 
@@ -311,10 +312,9 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
             }])
 
         with getenv_swap, datetime_swap, post_swap:
-            flaky, rerun = flake_checker.is_test_output_flaky(
+            rerun = flake_checker.check_test_flakiness(
                 ['line1', 'line2'], 'suiteName')
-            self.assertTrue(flaky)
-            self.assertEqual(rerun, flake_checker.RERUN_UNKNOWN)
+            self.assertTrue(rerun)
 
     def test_successful_report_construct_url(self):
 
@@ -337,6 +337,7 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
                     'test': 'testName',
                     'flake_id': 'flake',
                 },
+                'rerun': 'rerun no',
             }
             return MockResponse(True, response)
 
@@ -366,10 +367,9 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
             }])
 
         with getenv_swap, datetime_swap, post_swap:
-            flaky, rerun = flake_checker.is_test_output_flaky(
+            rerun = flake_checker.check_test_flakiness(
                 ['line1', 'line2'], 'suiteName')
-            self.assertTrue(flaky)
-            self.assertEqual(rerun, flake_checker.RERUN_UNKNOWN)
+            self.assertFalse(rerun)
 
     def test_unsuccessful_report_exception(self):
 
@@ -411,10 +411,9 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
             }])
 
         with getenv_swap, datetime_swap, post_swap:
-            flaky, rerun = flake_checker.is_test_output_flaky(
+            rerun = flake_checker.check_test_flakiness(
                 ['line1', 'line2'], 'suiteName')
-            self.assertFalse(flaky)
-            self.assertEqual(rerun, flake_checker.RERUN_UNKNOWN)
+            self.assertFalse(rerun)
 
     def test_unsuccessful_report_not_ok(self):
 
@@ -456,10 +455,9 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
             }])
 
         with getenv_swap, datetime_swap, post_swap:
-            flaky, rerun = flake_checker.is_test_output_flaky(
+            rerun = flake_checker.check_test_flakiness(
                 ['line1', 'line2'], 'suiteName')
-            self.assertFalse(flaky)
-            self.assertEqual(rerun, flake_checker.RERUN_UNKNOWN)
+            self.assertFalse(rerun)
 
     def test_unsuccessful_report_bad_payload(self):
 
@@ -501,7 +499,6 @@ class IsTestOutputFlakyTests(test_utils.GenericTestBase):
             }])
 
         with getenv_swap, datetime_swap, post_swap:
-            flaky, rerun = flake_checker.is_test_output_flaky(
+            rerun = flake_checker.check_test_flakiness(
                 ['line1', 'line2'], 'suiteName')
-            self.assertFalse(flaky)
-            self.assertEqual(rerun, flake_checker.RERUN_UNKNOWN)
+            self.assertFalse(rerun)

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -358,20 +358,12 @@ def main(args=None):
 
             # Check whether we should rerun based on the instructions from the
             # flake checker server.
-            _, rerun_override = flake_checker.is_test_output_flaky(
+            rerun = flake_checker.check_test_flakiness(
                 output, parsed_args.suite)
-            if rerun_override == flake_checker.RERUN_YES:
-                print(
-                    'Rerunning as per instructions from logging '
-                    'server.')
-            elif rerun_override == flake_checker.RERUN_NO:
-                print(
-                    'Not rerunning as per instructions from '
-                    'logging server.')
-                break
+            if rerun:
+                print('Rerunning.')
             else:
-                print(
-                    'Not rerunning since no instructions from logging server.')
+                print('Not rerunning.')
                 break
 
     sys.exit(return_code)

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -358,7 +358,7 @@ def main(args=None):
 
             # Check whether we should rerun based on the instructions from the
             # flake checker server.
-            test_is_flaky, rerun_override = flake_checker.is_test_output_flaky(
+            _, rerun_override = flake_checker.is_test_output_flaky(
                 output, parsed_args.suite)
             if rerun_override == flake_checker.RERUN_YES:
                 print(

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -98,58 +98,6 @@ _PARSER.add_argument(
     help='Build webpack with source maps.',
     action='store_true')
 
-# Never rerun failing tests, even when they match a known flake.
-RERUN_POLICY_NEVER = 'never'
-# Only rerun failing tests when they match a known flake.
-RERUN_POLICY_KNOWN_FLAKES = 'known flakes'
-# Always rerun failing tests, even when they don't match a known flake.
-RERUN_POLICY_ALWAYS = 'always'
-
-RERUN_POLICIES = {
-    'accessibility': RERUN_POLICY_NEVER,
-    'additionaleditorfeatures': RERUN_POLICY_KNOWN_FLAKES,
-    'additionaleditorfeaturesmodals': RERUN_POLICY_ALWAYS,
-    'additionalplayerfeatures': RERUN_POLICY_NEVER,
-    'adminpage': RERUN_POLICY_NEVER,
-    'blogdashboard': RERUN_POLICY_NEVER,
-    'classroompage': RERUN_POLICY_NEVER,
-    'classroompagefileuploadfeatures': RERUN_POLICY_NEVER,
-    'collections': RERUN_POLICY_NEVER,
-    'contributordashboard': RERUN_POLICY_KNOWN_FLAKES,
-    'coreeditorandplayerfeatures': RERUN_POLICY_KNOWN_FLAKES,
-    'creatordashboard': RERUN_POLICY_KNOWN_FLAKES,
-    'embedding': RERUN_POLICY_KNOWN_FLAKES,
-    'explorationfeedbacktab': RERUN_POLICY_NEVER,
-    'explorationhistorytab': RERUN_POLICY_KNOWN_FLAKES,
-    'explorationimprovementstab': RERUN_POLICY_ALWAYS,
-    'explorationstatisticstab': RERUN_POLICY_KNOWN_FLAKES,
-    'explorationtranslationtab': RERUN_POLICY_KNOWN_FLAKES,
-    'extensions': RERUN_POLICY_NEVER,
-    'featuregating': RERUN_POLICY_ALWAYS,
-    'fileuploadextensions': RERUN_POLICY_NEVER,
-    'fileuploadfeatures': RERUN_POLICY_KNOWN_FLAKES,
-    'learner': RERUN_POLICY_NEVER,
-    'learnerdashboard': RERUN_POLICY_NEVER,
-    'library': RERUN_POLICY_NEVER,
-    'navigation': RERUN_POLICY_KNOWN_FLAKES,
-    'playvoiceovers': RERUN_POLICY_NEVER,
-    'preferences': RERUN_POLICY_NEVER,
-    'profilefeatures': RERUN_POLICY_NEVER,
-    'profilemenu': RERUN_POLICY_NEVER,
-    'publication': RERUN_POLICY_NEVER,
-    'releasecoordinatorpagefeatures': RERUN_POLICY_NEVER,
-    'skilleditor': RERUN_POLICY_KNOWN_FLAKES,
-    'subscriptions': RERUN_POLICY_NEVER,
-    'topicandstoryeditor': RERUN_POLICY_NEVER,
-    'topicandstoryeditorfileuploadfeatures': RERUN_POLICY_NEVER,
-    'topicandstoryviewer': RERUN_POLICY_NEVER,
-    'topicsandskillsdashboard': RERUN_POLICY_NEVER,
-    'users': RERUN_POLICY_NEVER,
-    'wipeout': RERUN_POLICY_NEVER,
-    # The suite name is `full` when no --suite argument is passed. This
-    # indicates that all the tests should be run.
-    'full': RERUN_POLICY_NEVER,
-}
 
 SUITES_MIGRATED_TO_WEBDRIVERIO = [
     'collections',
@@ -392,7 +340,6 @@ def run_tests(args):
 def main(args=None):
     """Run tests, rerunning at most MAX_RETRY_COUNT times if they flake."""
     parsed_args = _PARSER.parse_args(args=args)
-    policy = RERUN_POLICIES[parsed_args.suite.lower()]
 
     with servers.managed_portserver():
         for attempt_num in range(1, MAX_RETRY_COUNT + 1):
@@ -409,8 +356,8 @@ def main(args=None):
                 flake_checker.report_pass(parsed_args.suite)
                 break
 
-            # Check whether we should rerun based on this suite's policy
-            # and override instructions from the flake checker server.
+            # Check whether we should rerun based on the instructions from the
+            # flake checker server.
             test_is_flaky, rerun_override = flake_checker.is_test_output_flaky(
                 output, parsed_args.suite)
             if rerun_override == flake_checker.RERUN_YES:
@@ -422,21 +369,10 @@ def main(args=None):
                     'Not rerunning as per instructions from '
                     'logging server.')
                 break
-            # No rerun override, so follow rerun policies.
-            elif policy == RERUN_POLICY_NEVER:
+            else:
                 print(
-                    'Not rerunning because the policy is to never '
-                    'rerun the {} suite'.format(parsed_args.suite))
+                    'Not rerunning since no instructions from logging server.')
                 break
-            elif policy == RERUN_POLICY_KNOWN_FLAKES and not test_is_flaky:
-                print((
-                    'Not rerunning because the policy is to only '
-                    'rerun the %s suite on known flakes, and this '
-                    'failure did not match any known flakes')
-                    % parsed_args.suite)
-                break
-            # Else rerun policy is either always or we had a known flake
-            # with a known flakes rerun policy, so rerun.
 
     sys.exit(return_code)
 

--- a/scripts/run_e2e_tests_test.py
+++ b/scripts/run_e2e_tests_test.py
@@ -393,16 +393,16 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
     def test_rerun_when_tests_fail_with_rerun_yes(self):
         def mock_run_tests(unused_args):
             return 'sample\noutput', 1
-        def mock_is_test_output_flaky(*_):
-            return True, flake_checker.RERUN_YES
+        def mock_check_test_flakiness(*_):
+            return True
 
         self.exit_stack.enter_context(self.swap_with_checks(
             servers, 'managed_portserver', mock_managed_process))
         self.exit_stack.enter_context(self.swap(
             run_e2e_tests, 'run_tests', mock_run_tests))
         self.exit_stack.enter_context(self.swap_with_checks(
-            flake_checker, 'is_test_output_flaky',
-            mock_is_test_output_flaky, expected_args=[
+            flake_checker, 'check_test_flakiness',
+            mock_check_test_flakiness, expected_args=[
                 ('sample\noutput', 'navigation'),
                 ('sample\noutput', 'navigation'),
                 ('sample\noutput', 'navigation'),
@@ -417,14 +417,14 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
     def test_no_rerun_when_tests_flake_with_rerun_no(self):
         def mock_run_tests(unused_args):
             return 'sample\noutput', 1
-        def mock_is_test_output_flaky(*_):
-            return True, flake_checker.RERUN_NO
+        def mock_check_test_flakiness(*_):
+            return False
 
         self.exit_stack.enter_context(self.swap(
             run_e2e_tests, 'run_tests', mock_run_tests))
         self.exit_stack.enter_context(self.swap_with_checks(
-            flake_checker, 'is_test_output_flaky',
-            mock_is_test_output_flaky, expected_args=[
+            flake_checker, 'check_test_flakiness',
+            mock_check_test_flakiness, expected_args=[
                 ('sample\noutput', 'navigation'),
             ]))
         self.exit_stack.enter_context(self.swap(
@@ -439,14 +439,14 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
     def test_no_rerun_when_tests_flake_with_rerun_unknown(self):
         def mock_run_tests(unused_args):
             return 'sample\noutput', 1
-        def mock_is_test_output_flaky(*_):
-            return True, flake_checker.RERUN_UNKNOWN
+        def mock_check_test_flakiness(*_):
+            return False
 
         self.exit_stack.enter_context(self.swap(
             run_e2e_tests, 'run_tests', mock_run_tests))
         self.exit_stack.enter_context(self.swap_with_checks(
-            flake_checker, 'is_test_output_flaky',
-            mock_is_test_output_flaky, expected_args=[
+            flake_checker, 'check_test_flakiness',
+            mock_check_test_flakiness, expected_args=[
                 ('sample\noutput', 'navigation'),
             ]))
         self.exit_stack.enter_context(self.swap(
@@ -462,7 +462,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         def mock_run_tests(unused_args):
             return 'sample\noutput', 1
 
-        def mock_is_test_output_flaky(unused_output, unused_suite_name):
+        def mock_check_test_flakiness(unused_output, unused_suite_name):
             raise AssertionError('Tried to Check Flakiness.')
 
         self.exit_stack.enter_context(self.swap_with_checks(
@@ -470,7 +470,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         self.exit_stack.enter_context(self.swap(
             run_e2e_tests, 'run_tests', mock_run_tests))
         self.exit_stack.enter_context(self.swap(
-            flake_checker, 'is_test_output_flaky', mock_is_test_output_flaky))
+            flake_checker, 'check_test_flakiness', mock_check_test_flakiness))
         self.exit_stack.enter_context(self.swap(
             flake_checker, 'check_if_on_ci', lambda: False))
         self.exit_stack.enter_context(self.swap_with_checks(

--- a/scripts/run_e2e_tests_test.py
+++ b/scripts/run_e2e_tests_test.py
@@ -33,11 +33,6 @@ from scripts import scripts_test_utils
 from scripts import servers
 
 CHROME_DRIVER_VERSION = '77.0.3865.40'
-MOCK_RERUN_POLICIES = {
-    'always': run_e2e_tests.RERUN_POLICY_ALWAYS,
-    'known_flakes': run_e2e_tests.RERUN_POLICY_KNOWN_FLAKES,
-    'never': run_e2e_tests.RERUN_POLICY_NEVER,
-}
 TOTAL_E2E_SUITES = [
     'accessibility',
     'additionalEditorFeatures',
@@ -395,11 +390,11 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
             ['sample', u'✓', 'output']
         )
 
-    def test_rerun_when_tests_fail_with_always_policy(self):
+    def test_rerun_when_tests_fail_with_rerun_yes(self):
         def mock_run_tests(unused_args):
             return 'sample\noutput', 1
         def mock_is_test_output_flaky(*_):
-            return True, flake_checker.RERUN_UNKNOWN
+            return True, flake_checker.RERUN_YES
 
         self.exit_stack.enter_context(self.swap_with_checks(
             servers, 'managed_portserver', mock_managed_process))
@@ -408,94 +403,18 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         self.exit_stack.enter_context(self.swap_with_checks(
             flake_checker, 'is_test_output_flaky',
             mock_is_test_output_flaky, expected_args=[
-                ('sample\noutput', 'always'),
-                ('sample\noutput', 'always'),
-                ('sample\noutput', 'always'),
+                ('sample\noutput', 'navigation'),
+                ('sample\noutput', 'navigation'),
+                ('sample\noutput', 'navigation'),
             ]))
         self.exit_stack.enter_context(self.swap(
             flake_checker, 'check_if_on_ci', lambda: True))
         self.exit_stack.enter_context(self.swap_with_checks(
             sys, 'exit', lambda _: None, expected_args=[(1,)]))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
 
-        run_e2e_tests.main(args=['--suite', 'always'])
+        run_e2e_tests.main(args=['--suite', 'navigation'])
 
-    def test_do_not_rerun_when_tests_fail_with_known_flakes_policy(self):
-        def mock_run_tests(unused_args):
-            return 'sample\noutput', 1
-        def mock_is_test_output_flaky(*_):
-            return False, flake_checker.RERUN_UNKNOWN
-
-        self.exit_stack.enter_context(self.swap_with_checks(
-            servers, 'managed_portserver', mock_managed_process))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'run_tests', mock_run_tests))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            flake_checker, 'is_test_output_flaky',
-            mock_is_test_output_flaky, expected_args=[
-                ('sample\noutput', 'known_flakes'),
-            ]))
-        self.exit_stack.enter_context(self.swap(
-            flake_checker, 'check_if_on_ci', lambda: True))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            sys, 'exit', lambda _: None, expected_args=[(1,)]))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
-
-        run_e2e_tests.main(args=['--suite', 'known_flakes'])
-
-    def test_do_not_rerun_when_tests_fail_with_never_policy(self):
-        def mock_run_tests(unused_args):
-            return 'sample\noutput', 1
-        def mock_is_test_output_flaky(*_):
-            return False, flake_checker.RERUN_UNKNOWN
-
-        self.exit_stack.enter_context(self.swap_with_checks(
-            servers, 'managed_portserver', mock_managed_process))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'run_tests', mock_run_tests))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            flake_checker, 'is_test_output_flaky',
-            mock_is_test_output_flaky, expected_args=[
-                ('sample\noutput', 'never'),
-            ]))
-        self.exit_stack.enter_context(self.swap(
-            flake_checker, 'check_if_on_ci', lambda: True))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            sys, 'exit', lambda _: None, expected_args=[(1,)]))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
-
-        run_e2e_tests.main(args=['--suite', 'never'])
-
-    def test_rerun_when_tests_flake_with_always_policy(self):
-        def mock_run_tests(unused_args):
-            return 'sample\noutput', 1
-        def mock_is_test_output_flaky(*_):
-            return True, flake_checker.RERUN_UNKNOWN
-
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'run_tests', mock_run_tests))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            flake_checker, 'is_test_output_flaky',
-            mock_is_test_output_flaky, expected_args=[
-                ('sample\noutput', 'always'),
-                ('sample\noutput', 'always'),
-                ('sample\noutput', 'always'),
-            ]))
-        self.exit_stack.enter_context(self.swap(
-            flake_checker, 'check_if_on_ci', lambda: True))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            sys, 'exit', lambda _: None, expected_args=[(1,)]))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            servers, 'managed_portserver', mock_managed_process))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
-
-        run_e2e_tests.main(args=['--suite', 'always'])
-
-    def test_rerun_when_tests_flake_always_policy_override_no(self):
+    def test_no_rerun_when_tests_flake_with_rerun_no(self):
         def mock_run_tests(unused_args):
             return 'sample\noutput', 1
         def mock_is_test_output_flaky(*_):
@@ -506,7 +425,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         self.exit_stack.enter_context(self.swap_with_checks(
             flake_checker, 'is_test_output_flaky',
             mock_is_test_output_flaky, expected_args=[
-                ('sample\noutput', 'always'),
+                ('sample\noutput', 'navigation'),
             ]))
         self.exit_stack.enter_context(self.swap(
             flake_checker, 'check_if_on_ci', lambda: True))
@@ -514,12 +433,10 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
             sys, 'exit', lambda _: None, expected_args=[(1,)]))
         self.exit_stack.enter_context(self.swap_with_checks(
             servers, 'managed_portserver', mock_managed_process))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
 
-        run_e2e_tests.main(args=['--suite', 'always'])
+        run_e2e_tests.main(args=['--suite', 'navigation'])
 
-    def test_rerun_when_tests_flake_with_known_flakes_policy(self):
+    def test_no_rerun_when_tests_flake_with_rerun_unknown(self):
         def mock_run_tests(unused_args):
             return 'sample\noutput', 1
         def mock_is_test_output_flaky(*_):
@@ -530,9 +447,7 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
         self.exit_stack.enter_context(self.swap_with_checks(
             flake_checker, 'is_test_output_flaky',
             mock_is_test_output_flaky, expected_args=[
-                ('sample\noutput', 'known_flakes'),
-                ('sample\noutput', 'known_flakes'),
-                ('sample\noutput', 'known_flakes'),
+                ('sample\noutput', 'navigation'),
             ]))
         self.exit_stack.enter_context(self.swap(
             flake_checker, 'check_if_on_ci', lambda: True))
@@ -540,60 +455,8 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
             sys, 'exit', lambda _: None, expected_args=[(1,)]))
         self.exit_stack.enter_context(self.swap_with_checks(
             servers, 'managed_portserver', mock_managed_process))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
 
-        run_e2e_tests.main(args=['--suite', 'known_flakes'])
-
-    def test_do_not_rerun_when_tests_flake_with_never_policy(self):
-        def mock_run_tests(unused_args):
-            return 'sample\noutput', 1
-        def mock_is_test_output_flaky(*_):
-            return True, flake_checker.RERUN_UNKNOWN
-
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'run_tests', mock_run_tests))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            flake_checker, 'is_test_output_flaky',
-            mock_is_test_output_flaky, expected_args=[
-                ('sample\noutput', 'never'),
-            ]))
-        self.exit_stack.enter_context(self.swap(
-            flake_checker, 'check_if_on_ci', lambda: True))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            sys, 'exit', lambda _: None, expected_args=[(1,)]))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            servers, 'managed_portserver', mock_managed_process))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
-
-        run_e2e_tests.main(args=['--suite', 'never'])
-
-    def test_do_not_rerun_when_tests_flake_never_policy_override_yes(self):
-        def mock_run_tests(unused_args):
-            return 'sample\noutput', 1
-        def mock_is_test_output_flaky(*_):
-            return True, flake_checker.RERUN_YES
-
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'run_tests', mock_run_tests))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            flake_checker, 'is_test_output_flaky',
-            mock_is_test_output_flaky, expected_args=[
-                ('sample\noutput', 'never'),
-                ('sample\noutput', 'never'),
-                ('sample\noutput', 'never'),
-            ]))
-        self.exit_stack.enter_context(self.swap(
-            flake_checker, 'check_if_on_ci', lambda: True))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            sys, 'exit', lambda _: None, expected_args=[(1,)]))
-        self.exit_stack.enter_context(self.swap_with_checks(
-            servers, 'managed_portserver', mock_managed_process))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
-
-        run_e2e_tests.main(args=['--suite', 'never'])
+        run_e2e_tests.main(args=['--suite', 'navigation'])
 
     def test_no_reruns_off_ci_fail(self):
         def mock_run_tests(unused_args):
@@ -612,10 +475,8 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
             flake_checker, 'check_if_on_ci', lambda: False))
         self.exit_stack.enter_context(self.swap_with_checks(
             sys, 'exit', lambda _: None, expected_args=[(1,)]))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
 
-        run_e2e_tests.main(args=['--suite', 'always'])
+        run_e2e_tests.main(args=['--suite', 'navigation'])
 
     def test_no_reruns_off_ci_pass(self):
         def mock_run_tests(unused_args):
@@ -634,10 +495,8 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
             flake_checker, 'check_if_on_ci', lambda: False))
         self.exit_stack.enter_context(self.swap_with_checks(
             sys, 'exit', lambda _: None, expected_args=[(0,)]))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
 
-        run_e2e_tests.main(args=['--suite', 'always'])
+        run_e2e_tests.main(args=['--suite', 'navigation'])
 
     def test_start_tests_skip_build(self):
         self.exit_stack.enter_context(self.swap_with_checks(
@@ -926,8 +785,6 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
             servers, 'managed_cloud_datastore_emulator', mock_managed_process))
         self.exit_stack.enter_context(self.swap(
             flake_checker, 'check_if_on_ci', lambda: True))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
 
         with self.assertRaisesRegex(SystemExit, '1'):
             run_e2e_tests.main(args=['--suite', 'never'])
@@ -955,8 +812,6 @@ class RunE2ETestsTests(test_utils.GenericTestBase):
             servers, 'managed_cloud_datastore_emulator', mock_managed_process))
         self.exit_stack.enter_context(self.swap(
             flake_checker, 'check_if_on_ci', lambda: True))
-        self.exit_stack.enter_context(self.swap(
-            run_e2e_tests, 'RERUN_POLICIES', MOCK_RERUN_POLICIES))
 
         with self.assertRaisesRegex(SystemExit, '1'):
             run_e2e_tests.main(args=['--suite', 'never'])

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -35,7 +35,7 @@ import psutil
 @contextlib.contextmanager
 def managed_process(
         command_args, human_readable_name='Process', shell=False,
-        timeout_secs=60, **popen_kwargs):
+        timeout_secs=60, raise_on_nonzero_exit=True, **popen_kwargs):
     """Context manager for starting and stopping a process gracefully.
 
     Args:
@@ -54,13 +54,17 @@ def managed_process(
         timeout_secs: int. The time allotted for the managed process and its
             descendants to terminate themselves. After the timeout, any
             remaining processes will be killed abruptly.
+        raise_on_nonzero_exit: bool. If True, raise an Exception when the
+            managed process has a nonzero exit code. If False, no Exception is
+            raised, and it is the caller's responsibility to handle the error.
         **popen_kwargs: dict(str: *). Same kwargs as `subprocess.Popen`.
 
     Yields:
         psutil.Process. The process managed by the context manager.
 
     Raises:
-        Exception. The process exited unexpectedly.
+        Exception. The process exited unexpectedly (only raised if
+        raise_on_nonzero_exit is True).
     """
     get_proc_info = lambda p: (
         '%s(name="%s", pid=%d)' % (human_readable_name, p.name(), p.pid)
@@ -115,7 +119,10 @@ def managed_process(
         # Note that negative values indicate termination by a signal: SIGTERM,
         # SIGINT, etc. Also, exit code 143 indicates that the process received
         # a SIGTERM from the OS, and it succeeded in gracefully terminating.
-        if exit_code is not None and exit_code > 0 and exit_code != 143:
+        if (
+            exit_code is not None and exit_code > 0 and exit_code != 143
+            and raise_on_nonzero_exit
+        ):
             raise Exception(
                 'Process %s exited unexpectedly with exit code %s' %
                 (proc_name, exit_code))
@@ -655,7 +662,7 @@ def managed_protractor_server(
     # constants, so there is no risk of a shell-injection attack.
     managed_protractor_proc = managed_process(
         protractor_args, human_readable_name='Protractor Server', shell=True,
-        **kwargs)
+        raise_on_nonzero_exit=False, **kwargs)
     with managed_protractor_proc as proc:
         yield proc
 
@@ -722,7 +729,7 @@ def managed_webdriverio_server(
     # constants, so there is no risk of a shell-injection attack.
     managed_webdriverio_proc = managed_process(
         webdriverio_args, human_readable_name='WebdriverIO Server', shell=True,
-        **kwargs)
+        raise_on_nonzero_exit=False, **kwargs)
 
     with managed_webdriverio_proc as proc:
         yield proc

--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -64,7 +64,7 @@ def managed_process(
 
     Raises:
         Exception. The process exited unexpectedly (only raised if
-        raise_on_nonzero_exit is True).
+            raise_on_nonzero_exit is True).
     """
     get_proc_info = lambda p: (
         '%s(name="%s", pid=%d)' % (human_readable_name, p.name(), p.pid)

--- a/scripts/servers_test.py
+++ b/scripts/servers_test.py
@@ -220,7 +220,7 @@ class ManagedProcessTests(test_utils.TestBase):
         self.assertEqual(
             popen_calls, [self.POPEN_CALL(['a', '1'], {'shell': False})])
 
-    def test_reports_killed_processes_as_warnings(self):
+    def test_killing_process_raises_exception(self):
         self.exit_stack.enter_context(self.swap_popen(
             unresponsive=True))
         logs = self.exit_stack.enter_context(self.capture_logging())
@@ -231,6 +231,21 @@ class ManagedProcessTests(test_utils.TestBase):
                 Exception,
                 'Process .* exited unexpectedly with exit code 1'):
             self.exit_stack.close()
+
+        self.assert_proc_was_managed_as_expected(
+            logs, proc.pid,
+            manager_should_have_sent_terminate_signal=True,
+            manager_should_have_sent_kill_signal=True)
+
+    def test_killing_process_raises_no_exception_if_disabled(self):
+        self.exit_stack.enter_context(self.swap_popen(
+            unresponsive=True))
+        logs = self.exit_stack.enter_context(self.capture_logging())
+
+        proc = self.exit_stack.enter_context(servers.managed_process(
+            ['a'], timeout_secs=10, raise_on_nonzero_exit=False))
+        # Should not raise an exception.
+        self.exit_stack.close()
 
         self.assert_proc_was_managed_as_expected(
             logs, proc.pid,


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following: #15250 caused an exception to be raised when a managed process exited with a nonzero exit code. This unintentionally broke our E2E metric reporting and rerun logic by aborting the `run_e2e_tests.py` script before the test result could be reported. This PR fixes this problem and also removes the rerun policies, which are now managed by the logging server.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

Here is an example workflow run on this PR that failed: https://github.com/oppia/oppia/runs/7583295280?check_suite_focus=true. In the console output for that workflow, we can see that the failure was reported to the metrics server:

![Screen Shot 2022-07-29 at 11 20 11](https://user-images.githubusercontent.com/19878639/181820798-6a652eed-1548-47a1-9f92-1a9449dbafca.png)

In the database, we can see that the request was recorded, which wasn't working before:

```pgsql
> SELECT time_occurred FROM request;
         time_occurred         
-------------------------------
 2022-07-29 18:00:21.318685+00
 2022-07-29 18:08:25.356771+00
(2 rows)
```

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Contributing-code-to-Oppia#instructions-for-making-a-code-change).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia%27s-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-your-build-fails).
