### PR TITLE
Fix #14280: Try to fix blog page flake: "Cannot read property 'getDirection' of undefined"

### DIFF
--- a/core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.ts
+++ b/core/templates/pages/blog-dashboard-page/blog-post-editor/blog-post-editor.component.ts
@@ -64,7 +64,7 @@ export class BlogPostEditorComponent implements OnInit {
   dateTimeLastSaved: string = '';
   authorUsername: string = '';
   windowIsNarrow: boolean = false;
-  contentEditorIsActive: boolean = true;
+  contentEditorIsActive: boolean = false;
   invalidImageWarningIsShown: boolean = false;
   newChangesAreMade: boolean = false;
   lastChangesWerePublished: boolean = false;
@@ -131,9 +131,8 @@ export class BlogPostEditorComponent implements OnInit {
           this.title = this.blogPostData.title;
           this.dateTimeLastSaved = this.getDateStringInWords(
             this.blogPostData.lastUpdated);
-          if (this.blogPostData.content.length > 0) {
-            this.contentEditorIsActive = false;
-          }
+          this.contentEditorIsActive = Boolean(
+            this.blogPostData.content.length === 0);
           if (this.blogPostData.thumbnailFilename) {
             this.thumbnailDataUrl = this.assetsBackendApiService
               .getThumbnailUrlForPreview(


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of  #14280
2. This PR does the following: Fixes (hopefully) the blog post flake "Cannot read property 'getDirection' of undefined". Analysis and debugging doc here: https://docs.google.com/document/d/1AwlIOxisTS47Kf-4ROg5GAQG8eexWsbFROYG92IQNCE/edit#

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

I've run this 5 times locally and it passes every time. This is not a foolproof guarantee of correctness, but Chris and I will monitor the e2e flakes after this PR is merged as well to see if the flake reoccurs.