### PR TITLE
Fixed customization arg rename migration issue.

### DIFF
--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -144,6 +144,10 @@ MATH_INTERACTION_TYPES = [
     TYPE_VALID_NUMERIC_EXPRESSION,
     TYPE_VALID_MATH_EQUATION
 ]
+ALGEBRAIC_MATH_INTERACTIONS = [
+    TYPE_VALID_ALGEBRAIC_EXPRESSION,
+    TYPE_VALID_MATH_EQUATION
+]
 MATH_INTERACTION_DEPRECATED_RULES = [
     'ContainsSomeOf', 'OmitsSomeOf', 'MatchesWithGeneralForm']
 
@@ -2280,10 +2284,10 @@ class Exploration(translation_domain.BaseTranslatableObject):
                     'interaction']['answer_groups'] = filtered_answer_groups
 
                 # Renaming cust arg.
-                customization_args = state_dict[
-                    'interaction']['customization_args']
-                customization_args['allowedVariables'] = []
-                if 'customOskLetters' in customization_args:
+                if state_dict[
+                        'interaction']['id'] in ALGEBRAIC_MATH_INTERACTIONS:
+                    customization_args = state_dict[
+                        'interaction']['customization_args']
                     customization_args['allowedVariables'] = copy.deepcopy(
                         customization_args['customOskLetters'])
                     del customization_args['customOskLetters']

--- a/core/domain/question_domain.py
+++ b/core/domain/question_domain.py
@@ -1234,13 +1234,13 @@ class Question(translation_domain.BaseTranslatableObject):
                 'interaction']['answer_groups'] = filtered_answer_groups
 
             # Renaming cust arg.
+        if question_state_dict[
+                'interaction']['id'] in exp_domain.ALGEBRAIC_MATH_INTERACTIONS:
             customization_args = question_state_dict[
                 'interaction']['customization_args']
-            customization_args['allowedVariables'] = []
-            if 'customOskLetters' in customization_args:
-                customization_args['allowedVariables'] = copy.deepcopy(
-                    customization_args['customOskLetters'])
-                del customization_args['customOskLetters']
+            customization_args['allowedVariables'] = copy.deepcopy(
+                customization_args['customOskLetters'])
+            del customization_args['customOskLetters']
 
         return question_state_dict
 

--- a/core/domain/question_domain_test.py
+++ b/core/domain/question_domain_test.py
@@ -1772,7 +1772,9 @@ class QuestionDomainTest(test_utils.GenericTestBase):
 
         question_data['interaction']['id'] = 'AlgebraicExpressionInput'
         question_data['interaction']['customization_args'] = {
-            'customOskLetters': ['a', 'b', 'c']
+            'customOskLetters': {
+                'value': ['a', 'b', 'c']
+            }
         }
         question_data['interaction']['answer_groups'] = [{
             'outcome': {
@@ -1818,7 +1820,9 @@ class QuestionDomainTest(test_utils.GenericTestBase):
         self.assertEqual(rule_specs[0]['rule_type'], 'MatchesExactlyWith')
         self.assertEqual(
             test_value['state']['interaction']['customization_args'], {
-                'allowedVariables': ['a', 'b', 'c']
+                'allowedVariables': {
+                    'value': ['a', 'b', 'c']
+                }
             }
         )
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

~1. This PR fixes or fixes part of #[fill_in_number_here].~
2. This PR does the following:
  - The migration from state version 49 to 50 introduced an issue with the type of the customization arg. [This PR](https://github.com/oppia/oppia/pull/15271/) introduced the typing issue where the customization arg was set to an empty list by default instead of a dict. ([code change](https://github.com/iamprayush/oppia/blob/6b278e422cbf613108119438c5693b911182075a/core/domain/exp_domain.py#L2083))

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
N/A
<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
