### PR TITLE
Fix skill delete issue

### DIFF
--- a/core/templates/components/state-editor/state-editor-properties-services/state-skill.service.ts
+++ b/core/templates/components/state-editor/state-editor-properties-services/state-skill.service.ts
@@ -28,9 +28,9 @@ import { UtilsService } from 'services/utils.service';
   providedIn: 'root'
 })
 export class StateLinkedSkillIdService
-    // Until a skill is selected, the state attribute is undefined. Also used to
+    // Until a skill is selected, the state attribute is null. Also used to
     // avoid circular dependencies.
-    extends StatePropertyService<string | undefined> {
+    extends StatePropertyService<string | null> {
   constructor(alertsService: AlertsService, utilsService: UtilsService) {
     super(alertsService, utilsService);
     this.setterMethodKey = 'saveLinkedSkillId';

--- a/core/templates/components/state-editor/state-skill-editor/state-skill-editor.component.spec.ts
+++ b/core/templates/components/state-editor/state-skill-editor/state-skill-editor.component.spec.ts
@@ -269,7 +269,7 @@ describe('State Skill Editor Component', () => {
 
   it('should throw error on call getSkillEditorUrl when there is no skill' +
     'is selected', () => {
-    stateLinkedSkillIdService.displayed = undefined;
+    stateLinkedSkillIdService.displayed = null;
     expect(() => {
       componentInstance.getSkillEditorUrl();
     }).toThrowError('Expected a skill id to be displayed');

--- a/core/templates/components/state-editor/state-skill-editor/state-skill-editor.component.ts
+++ b/core/templates/components/state-editor/state-skill-editor/state-skill-editor.component.ts
@@ -40,8 +40,8 @@ import { ShortSkillSummary } from 'domain/skill/short-skill-summary.model';
   templateUrl: './state-skill-editor.component.html'
 })
 export class StateSkillEditorComponent implements OnInit {
-  @Output() onSaveLinkedSkillId: EventEmitter<string> = (
-    new EventEmitter<string>());
+  @Output() onSaveLinkedSkillId: EventEmitter<string | null> = (
+    new EventEmitter<string | null>());
 
   @Output() onSaveStateContent: EventEmitter<string> = (
     new EventEmitter<string>());

--- a/core/templates/components/state-editor/state-skill-editor/state-skill-editor.component.ts
+++ b/core/templates/components/state-editor/state-skill-editor/state-skill-editor.component.ts
@@ -127,7 +127,7 @@ export class StateSkillEditorComponent implements OnInit {
       DeleteStateSkillModalComponent, {
         backdrop: true,
       }).result.then(() => {
-      this.stateLinkedSkillIdService.displayed = undefined;
+      this.stateLinkedSkillIdService.displayed = null;
       this.stateLinkedSkillIdService.saveDisplayedValue();
       this.onSaveLinkedSkillId.emit(this.stateLinkedSkillIdService.displayed);
     }, () => {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[NA].
2. This PR does the following: Removing a linked skill in an exploration errored because the changelist submitted to the backend was invalid -- it did not contain a new_value. This happened because we set new_value to be undefined, which meant the dict sent to the backend would not have the key. I've fixed this by setting the value to null instead -- this is what we do for other state properties.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://user-images.githubusercontent.com/11008603/184533797-3c4d76c9-fab9-4444-ae88-ea06d093d05c.mp4


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
