### PR TITLE
Alert when E2E or Lighthouse tests fail on develop

### DIFF
--- a/.github/workflows/e2e_additional_editor_and_player.yml
+++ b/.github/workflows/e2e_additional_editor_and_player.yml
@@ -79,3 +79,9 @@ jobs:
         with:
           name: webpack-bundles
           path: /home/runner/work/oppia/oppia/build
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "An E2E test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/e2e_creator_learner_dashboard_and_editor_tabs.yml
+++ b/.github/workflows/e2e_creator_learner_dashboard_and_editor_tabs.yml
@@ -96,3 +96,9 @@ jobs:
         with:
           name: webpack-bundles
           path: /home/runner/work/oppia/oppia/build
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "An E2E test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/e2e_history_statistics_tabs_and_extensions.yml
+++ b/.github/workflows/e2e_history_statistics_tabs_and_extensions.yml
@@ -79,3 +79,9 @@ jobs:
         with:
           name: webpack-bundles
           path: /home/runner/work/oppia/oppia/build
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "An E2E test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/e2e_learner_flow_skill_editor_and_embedding.yml
+++ b/.github/workflows/e2e_learner_flow_skill_editor_and_embedding.yml
@@ -91,3 +91,9 @@ jobs:
         with:
           name: webpack-bundles
           path: /home/runner/work/oppia/oppia/build
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "An E2E test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/e2e_miscellaneous_tests.yml
+++ b/.github/workflows/e2e_miscellaneous_tests.yml
@@ -111,3 +111,9 @@ jobs:
         with:
           name: webpack-bundles
           path: /home/runner/work/oppia/oppia/build
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "An E2E test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/e2e_other_tests.yml
+++ b/.github/workflows/e2e_other_tests.yml
@@ -101,3 +101,9 @@ jobs:
         with:
           name: webpack-bundles
           path: /home/runner/work/oppia/oppia/build
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "An E2E test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/e2e_topic_tests.yml
+++ b/.github/workflows/e2e_topic_tests.yml
@@ -84,3 +84,9 @@ jobs:
         with:
           name: webpack-bundles
           path: /home/runner/work/oppia/oppia/build
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "An E2E test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/e2e_translation_classroom_and_core_features.yml
+++ b/.github/workflows/e2e_translation_classroom_and_core_features.yml
@@ -79,3 +79,9 @@ jobs:
         with:
           name: webpack-bundles
           path: /home/runner/work/oppia/oppia/build
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "An E2E test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/e2e_user_features_and_library.yml
+++ b/.github/workflows/e2e_user_features_and_library.yml
@@ -96,3 +96,9 @@ jobs:
         with:
           name: webpack-bundles
           path: /home/runner/work/oppia/oppia/build
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "An E2E test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/e2e_user_profile.yml
+++ b/.github/workflows/e2e_user_profile.yml
@@ -79,3 +79,9 @@ jobs:
         with:
           name: webpack-bundles
           path: /home/runner/work/oppia/oppia/build
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "An E2E test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/lighthouse_accessibility.yml
+++ b/.github/workflows/lighthouse_accessibility.yml
@@ -63,3 +63,9 @@ jobs:
       - name: Run Lighthouse accessibility checks shard
         if: startsWith(github.head_ref, 'update-changelog-for-release') == false
         run: python -m scripts.run_lighthouse_tests --mode accessibility --shard ${{ matrix.shard }}
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "A Lighthouse test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/.github/workflows/lighthouse_performance.yml
+++ b/.github/workflows/lighthouse_performance.yml
@@ -41,3 +41,9 @@ jobs:
       - name: Run Lighthouse performance checks shard
         if: startsWith(github.head_ref, 'update-changelog-for-release') == false
         run: python -m scripts.run_lighthouse_tests --mode performance --shard ${{ matrix.shard }}
+      - name: Report failure if failed on oppia/oppia develop branch
+        if: ${{ failure() && github.event_name == 'push' && github.repository == 'oppia/oppia' && github.ref == 'refs/heads/develop'}}
+        uses: ./.github/actions/send-webhook-notification
+        with:
+          message: "A Lighthouse test failed on the upstream develop branch."
+          webhook-url: ${{ secrets.BUILD_FAILURE_ROOM_WEBHOOK_URL }}

--- a/core/tests/webdriverio_utils/BlogDashboardPage.js
+++ b/core/tests/webdriverio_utils/BlogDashboardPage.js
@@ -162,6 +162,8 @@ var BlogDashboardPage = function() {
       'Confirm Publish Blog Post button', confirmButton);
     await waitFor.visibilityOfSuccessToast(
       'Blog Post Saved and Published Succesfully.');
+    await waitFor.invisibilityOfSuccessToast(
+      'Blog Post Saved and Published Succesfully.');
   };
 
   this.publishDraftBlogPost = async function(tags) {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following: Sends alerts whenever E2E or lighthouse tests fail on develop.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because this cannot be tested. We'll have to wait for a failure to happen. However, this same approach works for other CI workflows, so we are pretty confident it will work.

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
