### PR TITLE
Fix #15883: fix html select component logic

### DIFF
--- a/core/templates/components/forms/custom-forms-directives/html-select.component.html
+++ b/core/templates/components/forms/custom-forms-directives/html-select.component.html
@@ -1,11 +1,11 @@
 <mat-form-field class="oppia-html-select" appearance="fill">
   <mat-label>Parameter:</mat-label>
   <mat-select class="e2e-test-main-html-select-selector"
-              [(value)]="selectionAsString"
+              [(value)]="selection"
               disableRipple>
     <mat-option class="e2e-test-html-select-selector"
                 *ngFor="let choice of options; index as index"
-                value="{{(choice.id)}}"
+                [value]="choice.id"
                 (click)="updatedSelection()">
       <oppia-rte-output-display class="oppia-html-select-option"
                                 [rteString]="choice.val">

--- a/core/templates/components/forms/custom-forms-directives/html-select.component.spec.ts
+++ b/core/templates/components/forms/custom-forms-directives/html-select.component.spec.ts
@@ -44,7 +44,7 @@ describe('HTML Select Component', () => {
   });
 
   it('should update Selection', () => {
-    component.selection = "1";
+    component.selection = '1';
     spyOn(component.onSelectionChange, 'emit');
 
     component.updatedSelection();

--- a/core/templates/components/forms/custom-forms-directives/html-select.component.spec.ts
+++ b/core/templates/components/forms/custom-forms-directives/html-select.component.spec.ts
@@ -44,11 +44,11 @@ describe('HTML Select Component', () => {
   });
 
   it('should update Selection', () => {
-    component.selection = 1;
-    component.selectionAsString = '2';
+    component.selection = "1";
+    spyOn(component.onSelectionChange, 'emit');
 
     component.updatedSelection();
 
-    expect(component.selection).toBe(2);
+    expect(component.onSelectionChange.emit).toHaveBeenCalledWith('1');
   });
 });

--- a/core/templates/components/forms/custom-forms-directives/html-select.component.ts
+++ b/core/templates/components/forms/custom-forms-directives/html-select.component.ts
@@ -27,19 +27,16 @@ export class HtmlSelectComponent implements OnInit {
   // and we need to do non-null assertion. For more information, see
   // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
   @Input() options!: { id: string; val: string }[];
-  @Input() selection!: number;
-  selectionAsString!: string;
+  @Input() selection!: string;
   @Output() onSelectionChange = new EventEmitter();
 
   ngOnInit(): void {
-    this.selectionAsString = String(this.selection);
-    if (this.selection === null || this.selection === undefined) {
-      this.selection = Number(this.options[0].id);
+    if (!this.selection) {
+      this.selection = this.options[0].id;
     }
   }
 
   updatedSelection(): void {
-    this.selection = Number(this.selectionAsString);
     this.onSelectionChange.emit(this.selection);
   }
 }


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #15883
2. This PR does the following: Use the value of option id as-is when updating "selection" in the html-select component. Unlike the previous implementation "selection" here represents the single source of truth for the selected value.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->


https://user-images.githubusercontent.com/11008603/188024007-c3d83776-2f84-4492-a085-78194be2e768.mp4


#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->
Rule editor is not visible on loading of the page, so this section is not relevant for the PR.

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
