### PR TITLE
Pin pylint-quotes version

### DIFF
--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -15,7 +15,7 @@ protobuf==3.13.0
 psutil==5.8.0
 pycodestyle==2.8.0
 pylint==2.11.1
-git+https://github.com/oppia/pylint-quotes.git
+git+https://github.com/oppia/pylint-quotes.git@0.2.4
 pyyaml==6.0
 six==1.16.0
 typing-extensions==4.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -56,7 +56,7 @@ pylint==2.11.1
     # via
     #   -r requirements_dev.in
     #   pylint-quotes
-pylint-quotes @ git+https://github.com/oppia/pylint-quotes.git
+pylint-quotes @ git+https://github.com/oppia/pylint-quotes.git@0.2.4
     # via -r requirements_dev.in
 pynacl==1.5.0
     # via pygithub


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #N/A
2. This PR does the following: Pins the pylint-quotes version, similar to our other dependencies.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because this PR just adds the latest tag to the dependency (and I was able to push it successfully, which means that the pre-push checks which depend on this code run fine).