### PR TITLE
Fix part of #15753: Fix frontend validation for numeric input

### DIFF
--- a/extensions/interactions/NumericInput/directives/numeric-input-validation.service.spec.ts
+++ b/extensions/interactions/NumericInput/directives/numeric-input-validation.service.spec.ts
@@ -47,7 +47,8 @@ describe('NumericInputValidationService', () => {
     lessThanOrEqualToOneRuleLessThanZero: Rule,
     greaterThanOrEqualToNegativeOneRule: Rule,
     zeroWithinToleranceOfOneRule: Rule,
-    zeroWithinToleranceOfOneRuleLessThanZero: Rule;
+    zeroWithinToleranceOfOneRuleLessThanZero: Rule,
+    nonPositiveToleranceRule: Rule;
   let oof: OutcomeObjectFactory, agof: AnswerGroupObjectFactory,
     rof: RuleObjectFactory;
 
@@ -140,6 +141,14 @@ describe('NumericInputValidationService', () => {
           tol: 1
         }
       }, 'NumericInput');
+    nonPositiveToleranceRule =
+      rof.createFromBackendDict({
+        rule_type: 'IsWithinTolerance',
+        inputs: {
+          x: 2,
+          tol: -1
+        }
+      }, 'NumericInput');
     lessThanOneRuleLessThanZero = rof.createFromBackendDict({
       rule_type: 'IsLessThan',
       inputs: {
@@ -175,6 +184,17 @@ describe('NumericInputValidationService', () => {
       ' or equal to zero.'
     }]);
   });
+
+  it('should show warning if tolerance is not positive for IsWithinTolerance',
+    () => {
+      answerGroups[0].rules = [nonPositiveToleranceRule];
+      var warnings = validatorService.getAllWarnings(
+        currentState, customizationArgs, answerGroups, goodDefaultOutcome);
+      expect(warnings).toEqual([{
+        type: WARNING_TYPES.ERROR,
+        message: 'Rule 1 tolerance must be a positive value.'
+      }]);
+    });
 
   it('should show warning if input less than zero for IsWithinTolerance',
     () => {

--- a/extensions/interactions/NumericInput/directives/numeric-input-validation.service.spec.ts
+++ b/extensions/interactions/NumericInput/directives/numeric-input-validation.service.spec.ts
@@ -41,8 +41,8 @@ describe('NumericInputValidationService', () => {
     customizationArgs: NumericInputCustomizationArgs;
   let equalsZeroRule: Rule, equalsZeroRuleLessThanZero: Rule,
     betweenNegativeOneAndOneRule: Rule,
-    betweenFourAndTwoRule: Rule, lessThanOneRule: Rule,
-    lessThanOneRuleLessThanZero: Rule,
+    betweenOneAndOneRule: Rule, betweenFourAndTwoRule: Rule,
+    lessThanOneRule: Rule, lessThanOneRuleLessThanZero: Rule,
     greaterThanNegativeOneRule: Rule, lessThanOrEqualToOneRule: Rule,
     lessThanOrEqualToOneRuleLessThanZero: Rule,
     greaterThanOrEqualToNegativeOneRule: Rule,
@@ -92,6 +92,13 @@ describe('NumericInputValidationService', () => {
       rule_type: 'IsInclusivelyBetween',
       inputs: {
         a: -1,
+        b: 1
+      }
+    }, 'NumericInput');
+    betweenOneAndOneRule = rof.createFromBackendDict({
+      rule_type: 'IsInclusivelyBetween',
+      inputs: {
+        a: 1,
         b: 1
       }
     }, 'NumericInput');
@@ -188,8 +195,10 @@ describe('NumericInputValidationService', () => {
   it('should show warning if tolerance is not positive for IsWithinTolerance',
     () => {
       answerGroups[0].rules = [nonPositiveToleranceRule];
+
       var warnings = validatorService.getAllWarnings(
         currentState, customizationArgs, answerGroups, goodDefaultOutcome);
+
       expect(warnings).toEqual([{
         type: WARNING_TYPES.ERROR,
         message: 'Rule 1 tolerance must be a positive value.'
@@ -246,13 +255,19 @@ describe('NumericInputValidationService', () => {
   it('should raise warning for IsInclusivelyBetween rule ' +
   'caused by incorrect range',
   () => {
-    answerGroups[0].rules = [betweenFourAndTwoRule];
+    answerGroups[0].rules = [betweenOneAndOneRule, betweenFourAndTwoRule];
+
     var warnings = validatorService.getAllWarnings(
       currentState, customizationArgs, answerGroups, goodDefaultOutcome);
+
     expect(warnings).toEqual([{
       type: WARNING_TYPES.ERROR,
       message: 'In Rule 1 from answer group 1, Please ensure ' +
-      'that the second number ' + 'is greater than the first number.'
+      'that the second number is greater than the first number.'
+    }, {
+      type: WARNING_TYPES.ERROR,
+      message: 'In Rule 2 from answer group 1, Please ensure ' +
+      'that the second number is greater than the first number.'
     }]);
   });
 

--- a/extensions/interactions/NumericInput/directives/numeric-input-validation.service.ts
+++ b/extensions/interactions/NumericInput/directives/numeric-input-validation.service.ts
@@ -131,7 +131,7 @@ export class NumericInputValidationService {
           case 'IsInclusivelyBetween':
             var a = rule.inputs.a as number;
             var b = rule.inputs.b as number;
-            if (a > b) {
+            if (a >= b) {
               raiseWarningForRuleIsInclusivelyBetween(j, i);
             }
             setLowerAndUpperBounds(range, a, b, true, true);
@@ -169,6 +169,13 @@ export class NumericInputValidationService {
             var x = rule.inputs.x as number;
             var tol = rule.inputs.tol as number;
             setLowerAndUpperBounds(range, x - tol, x + tol, true, true);
+            if (tol <= 0) {
+              warningsList.push({
+                type: AppConstants.WARNING_TYPES.ERROR,
+                message: (
+                  'Rule ' + (j + 1) + ' tolerance must be a positive value.')
+              });
+            }
             if (
               (x + tol) < 0 &&
               customizationArgs.requireNonnegativeInput.value


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #15753.
2. This PR does the following: Restricts the tolerance value for `IsWithinTolerance` rule for `NumericInput` to be positive.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

Skipping this since the change is very minor!

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
