### PR TITLE
Fix #15413: ViewDestroyedError Frontend flake and other flakes also present.

### DIFF
--- a/core/templates/pages/blog-dashboard-page/modal-templates/upload-blog-post-thumbnail.component.spec.ts
+++ b/core/templates/pages/blog-dashboard-page/modal-templates/upload-blog-post-thumbnail.component.spec.ts
@@ -26,7 +26,7 @@ import { ImageUploaderComponent } from 'components/forms/custom-forms-directives
 import { WindowDimensionsService } from 'services/contextual/window-dimensions.service';
 import { of } from 'rxjs';
 
-describe('Upload Blog Post Thumbnail Modal Component', () => {
+describe('Upload Blog Post Thumbnail Component', () => {
   let fixture: ComponentFixture<UploadBlogPostThumbnailComponent>;
   let componentInstance: UploadBlogPostThumbnailComponent;
   let windowDimensionsService: WindowDimensionsService;

--- a/core/templates/pages/blog-dashboard-page/modal-templates/upload-blog-post-thumbnail.component.ts
+++ b/core/templates/pages/blog-dashboard-page/modal-templates/upload-blog-post-thumbnail.component.ts
@@ -94,8 +94,15 @@ export class UploadBlogPostThumbnailComponent implements OnInit {
         this.uploadedImage = decodeURIComponent(
           (e.target as FileReader).result as string);
       }
-      this.changeDetectorRef.detectChanges();
-      this.initializeCropper();
+      try {
+        this.changeDetectorRef.detectChanges();
+        this.initializeCropper();
+      } catch (viewDestroyedError) {
+        // This try catch block handles the following error in FE tests:
+        // ViewDestroyedError:
+        //   Attempt to use a destroyed view: detectChanges thrown.
+        // No further action is needed.
+      }
     };
     reader.readAsDataURL(file);
   }

--- a/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.spec.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.spec.ts
@@ -163,6 +163,11 @@ describe('Contributor dashboard page', () => {
       fakeAsync(() => {
         getTranslatableTopicNamesAsyncSpy.and.returnValue(
           Promise.resolve([]));
+        // The `topicName` is set to undefined below since ngOnInit() does not
+        // initialize the variable as undefined. This means that if another
+        // frontend test is run before this test, the topicName will be set to
+        // the value of the previous test.
+        component.topicName = undefined;
 
         component.ngOnInit();
         tick();

--- a/core/templates/pages/exploration-editor-page/preview-tab/preview-tab.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/preview-tab/preview-tab.component.spec.ts
@@ -37,6 +37,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ExplorationDataService } from '../services/exploration-data.service';
 import { ExplorationBackendDict } from 'domain/exploration/ExplorationObjectFactory';
 import { NumberAttemptsService } from 'pages/exploration-player-page/services/number-attempts.service';
+import { RouterService } from '../services/router.service';
 
 
 class MockNgbModalRef {
@@ -67,6 +68,7 @@ describe('Preview Tab Component', () => {
   let explorationParamChangesService: ExplorationParamChangesService;
   let explorationStatesService: ExplorationStatesService;
   let graphDataService: GraphDataService;
+  let routerService: RouterService;
   let stateEditorService: StateEditorService;
   let stateObjectFactory: StateObjectFactory;
   let paramChangeObjectFactory: ParamChangeObjectFactory;
@@ -129,6 +131,7 @@ describe('Preview Tab Component', () => {
     fixture = TestBed.createComponent(PreviewTabComponent);
     component = fixture.componentInstance;
     numberAttemptsService = TestBed.inject(NumberAttemptsService);
+    routerService = TestBed.inject(RouterService);
     paramChangeObjectFactory = TestBed.inject(ParamChangeObjectFactory);
     stateObjectFactory = TestBed.inject(StateObjectFactory);
     explorationEngineService = TestBed.inject(ExplorationEngineService);
@@ -236,6 +239,7 @@ describe('Preview Tab Component', () => {
     fakeAsync(() => {
       spyOn(explorationFeaturesService, 'areParametersEnabled')
         .and.returnValue(false);
+      spyOn(routerService, 'navigateToMainTab');
       component.allParams = {};
 
       expect(component.showParameterSummary()).toBe(false);
@@ -255,6 +259,7 @@ describe('Preview Tab Component', () => {
       flushMicrotasks();
 
       expect(ngbModal.open).toHaveBeenCalled();
+      expect(routerService.navigateToMainTab).toHaveBeenCalled();
     }));
 
   it('should getManualParamChanges', fakeAsync(() => {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #15413.
2. This PR does the following:

- Fixes the `ViewDestroyedError` in `Upload Blog Post Thumbnail` component. A similar error occurred previously and was fixed in PR: #14088
- Fixes 
```
Chrome Headless 104.0.5112.101 (Linux x86_64) Contributor dashboard page when user is logged in should not set active topic name when no topics are returned FAILED
	Error: Expected 'Topic 1' to be undefined.
	    at <Jasmine>
	    at UserContext.<anonymous> (core/templates/combined-tests.spec.js:91035:41)
	    at UserContext.<anonymous> (core/templates/combined-tests.spec.js:704014:34)
	    at ./node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke (core/templates/combined-tests.spec.js:705243:30)
	Error: Expected spy setActiveTopicName not to have been called.
	    at <Jasmine>
	    at UserContext.<anonymous> (core/templates/combined-tests.spec.js:91037:22)
	    at UserContext.<anonymous> (core/templates/combined-tests.spec.js:704014:34)
	    at ./node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke (core/templates/combined-tests.spec.js:705243:30)
```
- Fixes 
```
Chrome Headless 105.0.5195.102 (Linux x86_64) Preview Tab Component should initialize open ngbModal and naviage to mainTab FAILED
	Error: 1 periodic timer(s) still in the queue.
	    at UserContext.<anonymous> (core/templates/combined-tests.spec.js:706138:31)
	    at ./node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke (core/templates/combined-tests.spec.js:707360:30)
	    at ./node_modules/zone.js/dist/proxy.js.ProxyZoneSpec.onInvoke (core/templates/combined-tests.spec.js:706845:43)
	    at ./node_modules/zone.js/dist/zone.js.ZoneDelegate.invoke (core/templates/combined-tests.spec.js:707359:36)
	    at ./node_modules/zone.js/dist/zone.js.Zone.run (core/templates/combined-tests.spec.js:707117:47)
	    at runInTestZone (core/templates/combined-tests.spec.js:706400:38)
	    at UserContext.<anonymous> (core/templates/combined-tests.spec.js:706415:24)
	    at <Jasmine>
```

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://github.com/gp201/frontend-tests-flake-check-oppia/actions/runs/3026617509/attempts/1

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
