### PR TITLE
Fix #16168: Fix Context service flake in stats-reporting.service.spec.ts

### DIFF
--- a/core/templates/pages/exploration-player-page/services/stats-reporting.service.spec.ts
+++ b/core/templates/pages/exploration-player-page/services/stats-reporting.service.spec.ts
@@ -119,6 +119,10 @@ describe('Stats reporting service ', () => {
     let recordExplorationStartedSpy = spyOn(
       statsReportingBackendApiService, 'recordExpStartedAsync')
       .and.returnValue(Promise.resolve({}));
+    spyOn(statsReportingBackendApiService, 'recordStateHitAsync')
+      .and.returnValue(Promise.resolve({}));
+    spyOn(statsReportingBackendApiService, 'postsStatsAsync')
+      .and.returnValue(Promise.resolve({}));
 
     let sampleStats = {
       total_answers_count: 1,
@@ -132,10 +136,12 @@ describe('Stats reporting service ', () => {
       sampleStats);
 
     expect(statsReportingService.explorationStarted).toBe(false);
+
     statsReportingService.recordExplorationStarted('firstState', {});
 
     expect(statsReportingService.explorationStarted).toBe(true);
     expect(recordExplorationStartedSpy).toHaveBeenCalled();
+    expect(statsReportingBackendApiService.postsStatsAsync).toHaveBeenCalled();
   });
 
   it('should not again record exploration\'s stats when ' +
@@ -144,6 +150,7 @@ describe('Stats reporting service ', () => {
       statsReportingBackendApiService, 'recordExpStartedAsync')
       .and.returnValue(Promise.resolve({}));
     statsReportingService.explorationStarted = true;
+
     statsReportingService.recordExplorationStarted('firstState', {});
 
     expect(recordExplorationStartedSpy).not.toHaveBeenCalled();
@@ -153,10 +160,19 @@ describe('Stats reporting service ', () => {
     'it is about to start and already recorded', () => {
     let postStatsSpy = spyOn(statsReportingBackendApiService, 'postsStatsAsync')
       .and.returnValue(Promise.resolve({}));
+    spyOn(statsReportingBackendApiService, 'recordExpStartedAsync')
+      .and.returnValue(Promise.resolve({}));
+    spyOn(statsReportingBackendApiService, 'recordStateHitAsync')
+      .and.returnValue(Promise.resolve({}));
     statsReportingService.explorationIsComplete = true;
+
     statsReportingService.recordExplorationStarted('firstState', {});
 
     expect(postStatsSpy).not.toHaveBeenCalled();
+    expect(statsReportingBackendApiService.recordExpStartedAsync)
+      .toHaveBeenCalled();
+    expect(statsReportingBackendApiService.recordStateHitAsync)
+      .toHaveBeenCalled();
   });
 
   it('should record exploration\'s stats when it is actually started', () => {
@@ -241,20 +257,28 @@ describe('Stats reporting service ', () => {
     let recordExplorationCompletedSpy = spyOn(
       statsReportingBackendApiService, 'recordExplorationCompletedAsync')
       .and.returnValue(Promise.resolve({}));
+    spyOn(statsReportingBackendApiService, 'postsStatsAsync')
+      .and.returnValue(Promise.resolve({}));
     expect(statsReportingService.explorationIsComplete).toBe(false);
+
     statsReportingService.recordExplorationCompleted('firstState', {});
 
     expect(recordExplorationCompletedSpy).toHaveBeenCalled();
     expect(statsReportingService.explorationIsComplete).toBe(true);
+    expect(statsReportingBackendApiService.postsStatsAsync).toHaveBeenCalled();
   });
 
   it('should record stats when a leave event is triggered', () => {
     let recordMaybeLeaveEventSpy = spyOn(
       statsReportingBackendApiService, 'recordMaybeLeaveEventAsync')
       .and.returnValue(Promise.resolve({}));
+    spyOn(statsReportingBackendApiService, 'postsStatsAsync')
+      .and.returnValue(Promise.resolve({}));
+
     statsReportingService.recordMaybeLeaveEvent('firstState', {});
 
     expect(recordMaybeLeaveEventSpy).toHaveBeenCalled();
+    expect(statsReportingBackendApiService.postsStatsAsync).toHaveBeenCalled();
   });
 
   it('should record stats when an answer submit button is clicked', () => {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #16168.
2. This PR does the following:

The functions (`recordStateHitAsync`, `recordExpStartedAsync` and `postsStatsAsync`) in `statsReportingBackendApiService` call `getFullStatsUrl` which in turn calls `urlInterpolationService.interpolateUrl`. This throws an error which results in `contextService.getExplorationId()` being called. To fix this, we're spying on `recordStateHitAsync`, `recordExpStartedAsync` and `postsStatsAsync` since we only need to ensure that the functions are called since no action is performed with the returned promise.
https://github.com/oppia/oppia/blob/84d35d266e0a82fceeb525468bdceff4afcb4226/core/templates/pages/exploration-player-page/services/stats-reporting.service.ts#L132-L134

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
https://github.com/gp201/frontend-tests-flake-check-oppia/actions/runs/3163961006
<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
