### PR TITLE
Fix #14085: Added validation to restrict usage of unsupported math functions.

### DIFF
--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -6130,6 +6130,9 @@ export default {
     "arcsin", "arccos", "arctan", "sinh", "cosh", "tanh"
   ],
 
+  // Supported functions for math interactions.
+  "SUPPORTED_FUNCTION_NAMES": ["sqrt", "abs"],
+
   "OSK_MAIN_TAB": "mainTab",
   "OSK_FUNCTIONS_TAB": "functionsTab",
   "OSK_LETTERS_TAB": "lettersTab",

--- a/core/templates/services/math-interactions.service.spec.ts
+++ b/core/templates/services/math-interactions.service.spec.ts
@@ -643,4 +643,23 @@ describe('MathInteractionsService', () => {
       expressionWithPlaceholders,
       'x/(x+1) + y/8', ['alpha', 'beta'])).toBeFalse();
   });
+
+  it('should correctly check for unsupported functions', function() {
+    // Currently, the supported functions are 'sqrt' and 'abs', so any
+    // other function usages should raise a validation error which
+    // should be caught using the checkUnsupportedFunctions function.
+    expect(mathInteractionsService.checkUnsupportedFunctions(
+      'a + sqrt(b) + abs(3)')).toEqual([]);
+    expect(mathInteractionsService.checkUnsupportedFunctions(
+      'a + b')).toEqual([]);
+    expect(mathInteractionsService.checkUnsupportedFunctions(
+      'a + x * (y)')).toEqual([]);
+    expect(mathInteractionsService.checkUnsupportedFunctions(
+      'a*b*(c)')).toEqual([]);
+
+    expect(mathInteractionsService.checkUnsupportedFunctions(
+      'a + log(b) + abs(3)')).toEqual(['log']);
+    expect(mathInteractionsService.checkUnsupportedFunctions(
+      'a - tan(b)*cos(c)')).toEqual(['tan', 'cos']);
+  });
 });

--- a/core/templates/services/math-interactions.service.ts
+++ b/core/templates/services/math-interactions.service.ts
@@ -29,6 +29,7 @@ import { AppConstants } from 'app.constants';
 export class MathInteractionsService {
   private warningText = '';
   private mathFunctionNames = AppConstants.MATH_FUNCTION_NAMES;
+  private supportedFunctionNames = AppConstants.SUPPORTED_FUNCTION_NAMES;
 
   private cleanErrorMessage(
       errorMessage: string, expressionString: string): string {
@@ -637,6 +638,25 @@ export class MathInteractionsService {
   containsAtLeastOneVariable(expressionString: string): boolean {
     let variablesList = nerdamer(expressionString).variables();
     return variablesList.length > 0;
+  }
+
+  checkUnsupportedFunctions(expressionString: string): string[] {
+    let matches = expressionString.match(/[a-zA-Z]+\(/g) || [];
+    let unsupportedFunctions = [];
+    for (let match of matches) {
+      match = match.slice(0, -1); // Removing the "(".
+      let matchIsSupported = false;
+      for (let functionName of this.supportedFunctionNames) {
+        if (functionName === match) {
+          matchIsSupported = true;
+          break;
+        }
+      }
+      if (!matchIsSupported) {
+        unsupportedFunctions.push(match);
+      }
+    }
+    return unsupportedFunctions;
   }
 }
 

--- a/extensions/interactions/AlgebraicExpressionInput/directives/algebraic-expression-input-validation.service.spec.ts
+++ b/extensions/interactions/AlgebraicExpressionInput/directives/algebraic-expression-input-validation.service.spec.ts
@@ -238,4 +238,31 @@ describe('AlgebraicExpressionInputValidationService', () => {
       message: 'The number of custom letters cannot be more than 10.'
     }]);
   });
+
+  it('should warn if there are inputs with unsupported functions', function() {
+    answerGroups[0].rules = [
+      rof.createFromBackendDict({
+        rule_type: 'IsEquivalentTo',
+        inputs: {
+          x: 'x+log(y)'
+        }
+      }, 'AlgebraicExpressionInput')
+    ];
+    customizationArgs = {
+      useFractionForDivision: false,
+      allowedVariables: {
+        value: ['y', 'x']
+      }
+    };
+
+    warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups, goodDefaultOutcome);
+
+    expect(warnings).toEqual([{
+      type: AppConstants.WARNING_TYPES.ERROR,
+      message: (
+        'Input for rule 1 from answer group 1 uses these function(s) that ' +
+        'aren\'t supported: [log] The supported functions are: [sqrt,abs]')
+    }]);
+  });
 });

--- a/extensions/interactions/AlgebraicExpressionInput/directives/algebraic-expression-input-validation.service.ts
+++ b/extensions/interactions/AlgebraicExpressionInput/directives/algebraic-expression-input-validation.service.ts
@@ -39,6 +39,8 @@ import { NumericExpressionInputRulesService } from 'interactions/NumericExpressi
   providedIn: 'root'
 })
 export class AlgebraicExpressionInputValidationService {
+  private supportedFunctionNames = AppConstants.SUPPORTED_FUNCTION_NAMES;
+
   constructor(
       private baseInteractionValidationServiceInstance:
         baseInteractionValidationService) {}
@@ -95,6 +97,22 @@ export class AlgebraicExpressionInputValidationService {
         // Explicitly inserting '*' signs wherever necessary.
         currentInput = mathInteractionsService.insertMultiplicationSigns(
           currentInput);
+
+        let unsupportedFunctions = (
+          mathInteractionsService.checkUnsupportedFunctions(currentInput));
+        if (unsupportedFunctions.length > 0) {
+          warningsList.push({
+            type: AppConstants.WARNING_TYPES.ERROR,
+            message: (
+              'Input for rule ' + (j + 1) + ' from answer group ' + (i + 1) +
+              ' uses these function(s) that aren\'t supported: ' +
+              '[' + unsupportedFunctions + ']' +
+              ' The supported functions are: ' +
+              '[' + this.supportedFunctionNames + ']'
+            )
+          });
+        }
+
         let currentRuleType = rules[j].type as string;
 
         for (let variable of nerdamer(currentInput).variables()) {

--- a/extensions/interactions/MathEquationInput/directives/math-equation-input-validation.service.spec.ts
+++ b/extensions/interactions/MathEquationInput/directives/math-equation-input-validation.service.spec.ts
@@ -241,4 +241,31 @@ describe('MathEquationInputValidationService', () => {
       message: 'The number of custom letters cannot be more than 10.'
     }]);
   });
+
+  it('should warn if there are inputs with unsupported functions', function() {
+    answerGroups[0].rules = [
+      rof.createFromBackendDict({
+        rule_type: 'IsEquivalentTo',
+        inputs: {
+          x: 'x+log(y)=tan(x) - sqrt(y)'
+        }
+      }, 'MathEquationInput')
+    ];
+    customizationArgs = {
+      useFractionForDivision: false,
+      allowedVariables: {
+        value: ['x', 'y']
+      }
+    };
+
+    warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups, goodDefaultOutcome);
+
+    expect(warnings).toEqual([{
+      type: AppConstants.WARNING_TYPES.ERROR,
+      message: (
+        'Input for rule 1 from answer group 1 uses these function(s) that ' +
+        'aren\'t supported: [log,tan] The supported functions are: [sqrt,abs]')
+    }]);
+  });
 });

--- a/extensions/interactions/MathEquationInput/directives/math-equation-input-validation.service.ts
+++ b/extensions/interactions/MathEquationInput/directives/math-equation-input-validation.service.ts
@@ -40,6 +40,8 @@ import { NumericExpressionInputRulesService } from 'interactions/NumericExpressi
   providedIn: 'root'
 })
 export class MathEquationInputValidationService {
+  private supportedFunctionNames = AppConstants.SUPPORTED_FUNCTION_NAMES;
+
   constructor(
       private baseInteractionValidationServiceInstance:
         baseInteractionValidationService) {}
@@ -115,6 +117,28 @@ export class MathEquationInputValidationService {
           if (seenVariables.indexOf(variable) === -1) {
             seenVariables.push(variable);
           }
+        }
+
+        let unsupportedFunctions = (
+          mathInteractionsService.checkUnsupportedFunctions(
+            splitInput[0]
+          ).concat(
+            mathInteractionsService.checkUnsupportedFunctions(
+              splitInput[1]
+            )
+          )
+        );
+        if (unsupportedFunctions.length > 0) {
+          warningsList.push({
+            type: AppConstants.WARNING_TYPES.ERROR,
+            message: (
+              'Input for rule ' + (j + 1) + ' from answer group ' + (i + 1) +
+              ' uses these function(s) that aren\'t supported: ' +
+              '[' + unsupportedFunctions + ']' +
+              ' The supported functions are: ' +
+              '[' + this.supportedFunctionNames + ']'
+            )
+          });
         }
 
         for (let seenRule of seenRules) {

--- a/extensions/interactions/NumericExpressionInput/directives/numeric-expression-input-validation.service.spec.ts
+++ b/extensions/interactions/NumericExpressionInput/directives/numeric-expression-input-validation.service.spec.ts
@@ -191,4 +191,25 @@ describe('NumericExpressionInputValidationService', () => {
       currentState, customizationArgs, answerGroups, goodDefaultOutcome);
     expect(warnings).toEqual([]);
   });
+
+  it('should warn if there are inputs with unsupported functions', function() {
+    answerGroups[0].rules = [
+      rof.createFromBackendDict({
+        rule_type: 'IsEquivalentTo',
+        inputs: {
+          x: '2+log(3)'
+        }
+      }, 'NumericExpressionInput')
+    ];
+
+    warnings = validatorService.getAllWarnings(
+      currentState, customizationArgs, answerGroups, goodDefaultOutcome);
+
+    expect(warnings).toEqual([{
+      type: AppConstants.WARNING_TYPES.ERROR,
+      message: (
+        'Input for rule 1 from answer group 1 uses these function(s) that ' +
+        'aren\'t supported: [log] The supported functions are: [sqrt,abs]')
+    }]);
+  });
 });

--- a/extensions/interactions/NumericExpressionInput/directives/numeric-expression-input-validation.service.ts
+++ b/extensions/interactions/NumericExpressionInput/directives/numeric-expression-input-validation.service.ts
@@ -23,6 +23,7 @@ import { AnswerGroup } from
   'domain/exploration/AnswerGroupObjectFactory';
 import { Warning, baseInteractionValidationService } from
   'interactions/base-interaction-validation.service';
+import { MathInteractionsService } from 'services/math-interactions.service';
 import { NumericExpressionInputCustomizationArgs } from
   'extensions/interactions/customization-args-defs';
 import { NumericExpressionInputRulesService } from
@@ -35,6 +36,8 @@ import { AppConstants } from 'app.constants';
   providedIn: 'root'
 })
 export class NumericExpressionInputValidationService {
+  private supportedFunctionNames = AppConstants.SUPPORTED_FUNCTION_NAMES;
+
   constructor(
       private baseInteractionValidationServiceInstance:
         baseInteractionValidationService) {}
@@ -51,6 +54,7 @@ export class NumericExpressionInputValidationService {
     let warningsList: Warning[] = [];
     let algebraicRulesService = (
       new NumericExpressionInputRulesService());
+    let mathInteractionsService = new MathInteractionsService();
 
     warningsList = warningsList.concat(
       this.getCustomizationArgsWarnings(customizationArgs));
@@ -73,6 +77,21 @@ export class NumericExpressionInputValidationService {
       for (let j = 0; j < rules.length; j++) {
         let currentInput = rules[j].inputs.x as string;
         let currentRuleType = rules[j].type as string;
+
+        let unsupportedFunctions = (
+          mathInteractionsService.checkUnsupportedFunctions(currentInput));
+        if (unsupportedFunctions.length > 0) {
+          warningsList.push({
+            type: AppConstants.WARNING_TYPES.ERROR,
+            message: (
+              'Input for rule ' + (j + 1) + ' from answer group ' + (i + 1) +
+              ' uses these function(s) that aren\'t supported: ' +
+              '[' + unsupportedFunctions + ']' +
+              ' The supported functions are: ' +
+              '[' + this.supportedFunctionNames + ']'
+            )
+          });
+        }
 
         for (let seenRule of seenRules) {
           let seenInput = seenRule.inputs.x as string;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of https://github.com/oppia/oppia/issues/14085.
2. This PR does the following: Adds an exploration validation to the math interactions in order to restrict usage of math functions. This is required for parity between web and android since android only supports usage of sqrt and abs functions for the math interactions.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
N/A
<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
