### PR TITLE
Fix export policy docstring for BaseCommitLogEntryModel to use the correct rationale.

### DIFF
--- a/core/storage/base_model/gae_models.py
+++ b/core/storage/base_model/gae_models.py
@@ -690,10 +690,9 @@ class BaseCommitLogEntryModel(BaseModel):
 
     @classmethod
     def get_export_policy(cls) -> Dict[str, EXPORT_POLICY]:
-        """Model contains data corresponding to a user,
-        but this isn't exported because the history of commits is not
-        relevant to a user for the purposes of Takeout, since commits do not
-        contain any personal user data.
+        """Model contains data corresponding to a user, but this isn't exported
+        because all user-related data for a commit is already being exported
+        as part of the corresponding SnapshotMetadataModel.
         """
         return dict(BaseModel.get_export_policy(), **{
             'user_id': EXPORT_POLICY.NOT_APPLICABLE,

--- a/core/storage/exploration/gae_models.py
+++ b/core/storage/exploration/gae_models.py
@@ -1214,7 +1214,7 @@ class ExpSummaryModel(base_models.BaseModel):
     @classmethod
     def get_export_policy(cls) -> Dict[str, base_models.EXPORT_POLICY]:
         """Model contains data corresponding to a user, but this isn't exported
-        because because noteworthy details that belong to this model have
+        because noteworthy details that belong to this model have
         already been exported as a part of the ExplorationModel.
         """
         return dict(super(cls, cls).get_export_policy(), **{


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Fix docstring for export method in BaseCommitLogEntryModel.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because this is only a single comment change.