### PR TITLE
Fix part of #15968: Replace material icons with FA icons

### DIFF
--- a/core/templates/components/summary-tile/collection-summary-tile.component.html
+++ b/core/templates/components/summary-tile/collection-summary-tile.component.html
@@ -71,7 +71,7 @@
             </li>
             <li>
               <span>
-                <i class="material-icons md-12 bullet-separator">&#xef4a;</i>
+                <i class="fas fa-circle bullet-separator"></i>
               </span>
             </li>
             <li>

--- a/core/templates/components/summary-tile/exploration-summary-tile.component.html
+++ b/core/templates/components/summary-tile/exploration-summary-tile.component.html
@@ -102,7 +102,7 @@
             </li>
             <li>
               <span>
-                <i class="material-icons md-12 bullet-separator">&#xef4a;</i>
+                <i class="fas fa-circle bullet-separator"></i>
               </span>
             </li>
             <li>

--- a/core/templates/components/summary-tile/story-summary-tile.component.css
+++ b/core/templates/components/summary-tile/story-summary-tile.component.css
@@ -320,4 +320,3 @@ oppia-story-summary-tile .down-caret-position {
 oppia-story-summary-tile .up-caret-position {
   width: 24px;
 }
-

--- a/core/templates/components/summary-tile/story-summary-tile.component.css
+++ b/core/templates/components/summary-tile/story-summary-tile.component.css
@@ -41,6 +41,8 @@ oppia-story-summary-tile .completed-icon {
   color: #00645c;
   float: left;
   margin-right: 6px;
+  width: 24px;
+  font-size: 20px;
 }
 
 oppia-story-summary-tile .view-button {
@@ -309,3 +311,13 @@ oppia-story-summary-tile .stories-can-play {
 oppia-story-summary-tile .oppia-topic-viewer-container .background-banner-position {
   position: inherit;
 }
+
+oppia-story-summary-tile .down-caret-position {
+  width: 24px;
+  vertical-align: middle;
+}
+
+oppia-story-summary-tile .up-caret-position {
+  width: 24px;
+}
+

--- a/core/templates/components/summary-tile/story-summary-tile.component.css
+++ b/core/templates/components/summary-tile/story-summary-tile.component.css
@@ -40,9 +40,9 @@ oppia-story-summary-tile .oppia-story-title {
 oppia-story-summary-tile .completed-icon {
   color: #00645c;
   float: left;
+  font-size: 20px;
   margin-right: 6px;
   width: 24px;
-  font-size: 20px;
 }
 
 oppia-story-summary-tile .view-button {
@@ -313,8 +313,8 @@ oppia-story-summary-tile .oppia-topic-viewer-container .background-banner-positi
 }
 
 oppia-story-summary-tile .down-caret-position {
-  width: 24px;
   vertical-align: middle;
+  width: 24px;
 }
 
 oppia-story-summary-tile .up-caret-position {

--- a/core/templates/components/summary-tile/story-summary-tile.component.html
+++ b/core/templates/components/summary-tile/story-summary-tile.component.html
@@ -93,12 +93,12 @@
       <div (click)="showAllChapters()"
            *ngIf="showButton && (chaptersDisplayed < nodeCount)"
            class="view-button">
-      <span class="fas fa-caret-down down-caret-position"></span>
+        <span class="fas fa-caret-down down-caret-position"></span>
       </div>
       <div (click)="hideExtraChapters()"
            *ngIf="showButton && (chaptersDisplayed === nodeCount)"
            class="view-button">
-      <span class="fas fa-caret-up up-caret-position"></span>
+        <span class="fas fa-caret-up up-caret-position"></span>
       </div>
     </div>
     <div class="chapters-container-box chapter-container" *ngIf="checkTabletView()">

--- a/core/templates/components/summary-tile/story-summary-tile.component.html
+++ b/core/templates/components/summary-tile/story-summary-tile.component.html
@@ -93,12 +93,12 @@
       <div (click)="showAllChapters()"
            *ngIf="showButton && (chaptersDisplayed < nodeCount)"
            class="view-button">
-        <span class="material-icons"> arrow_drop_down </span>
+           <span class="fas fa-caret-down down-caret-position"></span>
       </div>
       <div (click)="hideExtraChapters()"
            *ngIf="showButton && (chaptersDisplayed === nodeCount)"
            class="view-button">
-        <span class="material-icons"> arrow_drop_up </span>
+           <span class="fas fa-caret-up up-caret-position"></span>
       </div>
     </div>
     <div class="chapters-container-box chapter-container" *ngIf="checkTabletView()">
@@ -123,8 +123,7 @@
     <div class="chapter-details" *ngIf="!checkTabletView()">
       <div class="chapter-title"
            *ngFor="let title of nodeTitles;let idx = index">
-        <div *ngIf="storySummary.isNodeCompleted(title)" class="material-icons completed-icon">
-          done
+        <div *ngIf="storySummary.isNodeCompleted(title)" class="fas fa-check completed-icon">
         </div>
         <div [ngClass]="{'border-bottom': idx < chaptersDisplayed, 'pending-chapter': !storySummary.isNodeCompleted(title) && isPreviousChapterCompleted(idx), 'incomplete-chapter': !storySummary.isNodeCompleted(title), 'complete-chapter': storySummary.isNodeCompleted(title)}"
              *ngIf="idx < chaptersDisplayed">
@@ -141,13 +140,13 @@
            *ngIf="showButton && (chaptersDisplayed < nodeCount)"
            class="view-button">
         <span [innerHTML]="'I18N_TOPIC_VIEWER_VIEW_ALL' | translate"></span>
-        <span class="material-icons"> arrow_drop_down </span>
+        <span class="fas fa-caret-down down-caret-position"></span>
       </div>
       <div (click)="hideExtraChapters()"
            *ngIf="showButton && (chaptersDisplayed === nodeCount)"
            class="view-button">
         <span [innerHTML]="'I18N_TOPIC_VIEWER_VIEW_LESS' | translate"></span>
-        <span class="material-icons"> arrow_drop_up </span>
+        <span class="fas fa-caret-up up-caret-position"></span>
       </div>
     </div>
   </div>

--- a/core/templates/components/summary-tile/story-summary-tile.component.html
+++ b/core/templates/components/summary-tile/story-summary-tile.component.html
@@ -93,12 +93,12 @@
       <div (click)="showAllChapters()"
            *ngIf="showButton && (chaptersDisplayed < nodeCount)"
            class="view-button">
-           <span class="fas fa-caret-down down-caret-position"></span>
+      <span class="fas fa-caret-down down-caret-position"></span>
       </div>
       <div (click)="hideExtraChapters()"
            *ngIf="showButton && (chaptersDisplayed === nodeCount)"
            class="view-button">
-           <span class="fas fa-caret-up up-caret-position"></span>
+      <span class="fas fa-caret-up up-caret-position"></span>
       </div>
     </div>
     <div class="chapters-container-box chapter-container" *ngIf="checkTabletView()">

--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -3280,9 +3280,10 @@ oppia-noninteractive-link {
 }
 
 .bullet-separator {
-  font-size: 10px;
+  font-size: 9px;
   margin: -3px 13px 0 16px;
   opacity: 30%;
+  vertical-align: middle;
 }
 
 .mobile-activity-card-summary-elements li::marker {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #15968.
2. This PR does the following: In this PR the material icons have been replaced with their respective Font Awesome icons for the following files:
- oppia/core/templates/components/summary-tile/collection-summary-tile.component.html
- oppia/core/templates/components/summary-tile/exploration-summary-tile.component.html
- oppia/core/templates/components/summary-tile/story-summary-tile.component.html




## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

- oppia/core/templates/components/summary-tile/collection-summary-tile.component.html
1. Bullet separator:
Before:
![collection_summary_before_cropped](https://user-images.githubusercontent.com/20265098/194376371-9da26c7a-f2c5-4420-b68c-dd865a8f60b2.png)
After:
![collection_summary_after_cropped](https://user-images.githubusercontent.com/20265098/194376422-5e5acd4c-1646-4ff0-8e84-91302bd64545.png)


- oppia/core/templates/components/summary-tile/exploration-summary-tile.component.html
1. Bullet separator:
Before:
![exploration_summary_before_cropped](https://user-images.githubusercontent.com/20265098/194376643-78eed6b2-cee8-46e0-ae2d-0da7e54d3ddb.png)
After:
![exploration_summary_after_cropped](https://user-images.githubusercontent.com/20265098/194376670-759a440a-d20d-44d8-9a09-54a8c51788ad.png)


- oppia/core/templates/components/summary-tile/story-summary-tile.component.html
1. Up arrow
Before:
![story_summary_up_before_cropped](https://user-images.githubusercontent.com/20265098/194376964-c77ecd50-12f4-43e8-8ede-8c61be2679f1.png)
After:
![story_summary_up_after_cropped](https://user-images.githubusercontent.com/20265098/194377112-41f7cd3b-19f9-459c-a3bd-c654e341f404.png)

2. Down arrow
Before:
![story_summary_down_before_cropped](https://user-images.githubusercontent.com/20265098/194377193-fc0e8945-a77d-4d2d-bf00-308ad4c3f6f0.png)
After:
![story_summary_down_after_cropped](https://user-images.githubusercontent.com/20265098/194377231-bd08f0ff-0920-468b-92aa-8afcef89e511.png)

3. Done
Before:
![story_summary_done_before_cropped](https://user-images.githubusercontent.com/20265098/194377333-988126bd-f9c3-4bcd-a718-5ebbc2ab1f59.png)
After:
![story_summary_done_after_cropped](https://user-images.githubusercontent.com/20265098/194377365-ae1447ca-ad99-40f5-85e9-fa0216a5540c.png)

4. Up arrow (mobile view)
Before:
![story_summary_up_mobile_before_cropped](https://user-images.githubusercontent.com/20265098/194377442-10628b44-6907-473c-b6d9-8a1f7ca5f6a1.png)
After:
![story_summary_up_mobile_after_cropped](https://user-images.githubusercontent.com/20265098/194377472-7d0e0d95-c53f-4a8c-b2d3-b0bbeab6fe88.png)

5. Down arrow (mobile view)
Before:
![story_summary_down_mobile_before_cropped](https://user-images.githubusercontent.com/20265098/194377561-7cc1d804-ae18-4052-8b0a-8bf70ad5c444.png)
After:
![story_summary_down_mobile_after_cropped](https://user-images.githubusercontent.com/20265098/194377609-bf9fae33-01d2-4eb1-ba2d-7c9c3fa39b01.png)

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
