### PR TITLE
Fix: #15968 Replaced Material Icons with Font Awesomne 

### DIFF
--- a/core/templates/pages/release-coordinator-page/navbar/release-coordinator-navbar.component.html
+++ b/core/templates/pages/release-coordinator-page/navbar/release-coordinator-navbar.component.html
@@ -119,7 +119,7 @@
                          alt="">
                   </span>
                   <div *ngIf="!profilePictureDataUrl" class="dropdown-toggle">
-                    <i class="fas fa-user-circle md-40 oppia-dropdown-toggle-icon">&#xE853;</i>
+                    <i class="fas fa-user-circle md-40 oppia-dropdown-toggle-icon"></i>
                   </div>
                 </a>
                 <ul ngbDropdownMenu class="dropdown-menu dropdown-menu oppia-navbar-dropdown"

--- a/core/templates/pages/release-coordinator-page/navbar/release-coordinator-navbar.component.html
+++ b/core/templates/pages/release-coordinator-page/navbar/release-coordinator-navbar.component.html
@@ -119,7 +119,7 @@
                          alt="">
                   </span>
                   <div *ngIf="!profilePictureDataUrl" class="dropdown-toggle">
-                    <i class="material-icons md-40 oppia-dropdown-toggle-icon">&#xE853;</i>
+                    <i class="fas fa-user-circle md-40 oppia-dropdown-toggle-icon">&#xE853;</i>
                   </div>
                 </a>
                 <ul ngbDropdownMenu class="dropdown-menu dropdown-menu oppia-navbar-dropdown"

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-concept-card-editor/worked-example-editor.component.html
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-concept-card-editor/worked-example-editor.component.html
@@ -8,8 +8,8 @@
       <div class="oppia-rule-preview">
         <div class="oppia-click-to-start-editing" (click)="openQuestionEditor()">
           <i *ngIf="isEditable"
-             class="material-icons oppia-editor-edit-icon float-right"
-             title="Edit Worked Example">&#xE254;
+             class="fas fa-pencil-alt oppia-editor-edit-icon float-right"
+             title="Edit Worked Example">
           </i>
         </div>
 
@@ -60,8 +60,8 @@
       <div class="oppia-rule-preview">
         <div class="oppia-click-to-start-editing" (click)="openExplanationEditor()">
           <i *ngIf="isEditable"
-             class="material-icons oppia-editor-edit-icon float-right"
-             title="Edit Worked Example">&#xE254;
+             class="fas fa-pencil-alt oppia-editor-edit-icon float-right"
+             title="Edit Worked Example">
           </i>
         </div>
 

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-misconceptions-editor/misconception-editor.component.html
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-misconceptions-editor/misconception-editor.component.html
@@ -15,7 +15,7 @@
         <div class="oppia-rule-preview">
           <div class="oppia-click-to-start-editing" (click)="openNameEditor()">
             <i *ngIf="isEditable"
-               class="material-icons oppia-editor-edit-icon float-right"
+               class="fas fa-pencil-alt oppia-editor-edit-icon float-right"
                title="Edit Misconception Name">&#xE254;
             </i>
           </div>
@@ -65,7 +65,7 @@
         <div class="oppia-rule-preview">
           <div class="oppia-click-to-start-editing" (click)="openNotesEditor()">
             <i *ngIf="isEditable"
-               class="material-icons oppia-editor-edit-icon float-right"
+               class="fas fa-pencil-alt oppia-editor-edit-icon float-right"
                title="Edit Misconception Notes">&#xE254;
             </i>
           </div>
@@ -118,7 +118,7 @@
         <div class="oppia-rule-preview">
           <div class="oppia-click-to-start-editing" (click)="openFeedbackEditor()">
             <i *ngIf="isEditable"
-               class="material-icons oppia-editor-edit-icon float-right"
+               class="fas fa-pencil-alt  oppia-editor-edit-icon float-right"
                title="Edit Misconception Feedback">&#xE254;
             </i>
           </div>

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-misconceptions-editor/misconception-editor.component.html
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-misconceptions-editor/misconception-editor.component.html
@@ -16,7 +16,7 @@
           <div class="oppia-click-to-start-editing" (click)="openNameEditor()">
             <i *ngIf="isEditable"
                class="fas fa-pencil-alt oppia-editor-edit-icon float-right"
-               title="Edit Misconception Name">&#xE254;
+               title="Edit Misconception Name">
             </i>
           </div>
 
@@ -66,7 +66,7 @@
           <div class="oppia-click-to-start-editing" (click)="openNotesEditor()">
             <i *ngIf="isEditable"
                class="fas fa-pencil-alt oppia-editor-edit-icon float-right"
-               title="Edit Misconception Notes">&#xE254;
+               title="Edit Misconception Notes">
             </i>
           </div>
 
@@ -119,7 +119,7 @@
           <div class="oppia-click-to-start-editing" (click)="openFeedbackEditor()">
             <i *ngIf="isEditable"
                class="fas fa-pencil-alt  oppia-editor-edit-icon float-right"
-               title="Edit Misconception Feedback">&#xE254;
+               title="Edit Misconception Feedback">
             </i>
           </div>
 


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #15968 .
2. This PR does the following: Replaced Material Icons with Font Awesome Icons

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

- Changed user circle in `oppia/core/templates/pages/release-coordinator-page/navbar/release-coordinator-navbar.component.html `
**Before**
![Screenshot from 2022-10-11 21-48-01](https://user-images.githubusercontent.com/96713176/195157869-5c69a1e9-e368-4b11-9a54-9802479999c4.png)
**After**
![Screenshot from 2022-10-11 21-50-52](https://user-images.githubusercontent.com/96713176/195158055-0c45381f-2a15-4963-9095-2cd9bfc247ae.png)

- Changed pencil icons in `oppia/core/templates/pages/skill-editor-page/editor-tab/skill-concept-card-editor/worked-example-editor.component.html`
**Before**
![before](https://user-images.githubusercontent.com/96713176/195158463-ba414bc0-a75e-4727-9498-535aefe083e6.png)
**After**
![after](https://user-images.githubusercontent.com/96713176/195158516-6d6bed7c-e3fe-4d19-bb14-28ba545ac451.png)

-Changed the pencil icons in `oppia/core/templates/pages/skill-editor-page/editor-tab/skill-misconceptions-editor/misconception-editor.component.html`
**Before**
![before](https://user-images.githubusercontent.com/96713176/195158976-b631e786-05ca-4027-a125-9c2f026c2f2a.png)
**After**
![after](https://user-images.githubusercontent.com/96713176/195159031-2bb75894-f7be-4b2b-a1fc-bc27ea05146c.png)



## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
