### PR TITLE
Fix part of #15753: End exploration interaction warning bug

### DIFF
--- a/extensions/interactions/EndExploration/directives/end-exploration-validation.service.spec.ts
+++ b/extensions/interactions/EndExploration/directives/end-exploration-validation.service.spec.ts
@@ -88,8 +88,6 @@ describe('EndExplorationValidationService', () => {
       [],
       null
     )];
-
-    errorMessageElement = document.createElement('span');
   });
 
   it('should not have warnings for no answer groups or no default outcome',

--- a/extensions/interactions/EndExploration/directives/end-exploration-validation.service.spec.ts
+++ b/extensions/interactions/EndExploration/directives/end-exploration-validation.service.spec.ts
@@ -94,11 +94,6 @@ describe('EndExplorationValidationService', () => {
 
   it('should not have warnings for no answer groups or no default outcome',
     () => {
-      // This makes sure that query selector for getting error message does
-      // not cause flake in the tests.
-      spyOn(document, 'querySelector').withArgs(
-        'oppia-interactive-end-exploration .oppia-error-message-text span')
-        .and.returnValue(errorMessageElement);
       var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, [], null);
       expect(warnings).toEqual([]);
@@ -106,11 +101,6 @@ describe('EndExplorationValidationService', () => {
 
   it('should have warnings for any answer groups or default outcome',
     () => {
-      // This makes sure that query selector for getting error message does
-      // not cause flake in the tests.
-      spyOn(document, 'querySelector').withArgs(
-        'oppia-interactive-end-exploration .oppia-error-message-text span')
-        .and.returnValue(errorMessageElement);
       var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, goodAnswerGroups, badOutcome);
       expect(warnings).toEqual([{
@@ -126,37 +116,25 @@ describe('EndExplorationValidationService', () => {
       }]);
     });
 
-  it('should have warnings if author recommended exploration ids are invalid',
+  it('should have warnings if a recommended exploration id is empty',
     () => {
-      let missingExpIds =
-        customizationArguments.recommendedExplorationIds.value;
-      let listOfIds = missingExpIds.join('", "');
-      let warningMessage = 'Warning: exploration(s) with the IDs "' +
-      listOfIds + '" will not be shown as recommendations because ' +
-      'they either do not exist, or are not publicly viewable.';
-      errorMessageElement.textContent = warningMessage;
-
+      let badCustomizationArguments = {
+        recommendedExplorationIds: {
+          value: ['ExpID0', '']
+        }
+      };
       let invalidExplorationIdsWarning = {
         type: WARNING_TYPES.ERROR,
-        message: warningMessage
+        message: 'Recommended exploration ID must be non-empty.'
       };
 
-      spyOn(document, 'querySelector').withArgs(
-        'oppia-interactive-end-exploration .oppia-error-message-text span')
-        .and.returnValue(errorMessageElement);
-
       var warnings = validatorService.getAllWarnings(
-        currentState, customizationArguments, [], null);
+        currentState, badCustomizationArguments, [], null);
+
       expect(warnings).toEqual([invalidExplorationIdsWarning]);
     });
 
-
   it('should throw for missing recommendations argument', () => {
-    // This makes sure that query selector for getting error message does
-    // not cause flake in the tests.
-    spyOn(document, 'querySelector').withArgs(
-      'oppia-interactive-end-exploration .oppia-error-message-text span')
-      .and.returnValue(errorMessageElement);
     expect(() => {
       // This throws "Argument of type '{}'. We need to suppress this error
       // because is not assignable to parameter of type
@@ -170,11 +148,6 @@ describe('EndExplorationValidationService', () => {
   });
 
   it('should not have warnings for 0 or 8 recommendations', () => {
-    // This makes sure that query selector for getting error message does
-    // not cause flake in the tests.
-    spyOn(document, 'querySelector').withArgs(
-      'oppia-interactive-end-exploration .oppia-error-message-text span')
-      .and.returnValue(errorMessageElement);
     customizationArguments.recommendedExplorationIds.value = [];
     var warnings = validatorService.getAllWarnings(
       currentState, customizationArguments, [], null);
@@ -191,11 +164,6 @@ describe('EndExplorationValidationService', () => {
 
   it('should catch non-string value for recommended exploration ID',
     () => {
-      // This makes sure that query selector for getting error message does
-      // not cause flake in the tests.
-      spyOn(document, 'querySelector').withArgs(
-        'oppia-interactive-end-exploration .oppia-error-message-text span')
-        .and.returnValue(errorMessageElement);
       // This throws "Type 'number'. We need to suppress this error because is
       // not assignable to type 'string'." Here we are assigning the wrong type
       // of value to "customizationArguments" in order to test validations.
@@ -211,11 +179,6 @@ describe('EndExplorationValidationService', () => {
 
   it('should have warnings for non-list format of recommended exploration IDs',
     () => {
-      // This makes sure that query selector for getting error message does
-      // not cause flake in the tests.
-      spyOn(document, 'querySelector').withArgs(
-        'oppia-interactive-end-exploration .oppia-error-message-text span')
-        .and.returnValue(errorMessageElement);
       // This throws "Type '"ExpID0"'. We need to suppress this error because is
       // not assignable to type 'string[]'." Here we are assigning the wrong
       // type of value to "customizationArguments" in order to test validations.

--- a/extensions/interactions/EndExploration/directives/end-exploration-validation.service.spec.ts
+++ b/extensions/interactions/EndExploration/directives/end-exploration-validation.service.spec.ts
@@ -89,7 +89,7 @@ describe('EndExplorationValidationService', () => {
     )];
   });
 
-  it('should not have warnings for no answer groups or no default outcome',
+  it('should not have warnings when the end exploration object is valid',
     () => {
       var warnings = validatorService.getAllWarnings(
         currentState, customizationArguments, [], null);

--- a/extensions/interactions/EndExploration/directives/end-exploration-validation.service.spec.ts
+++ b/extensions/interactions/EndExploration/directives/end-exploration-validation.service.spec.ts
@@ -89,12 +89,12 @@ describe('EndExplorationValidationService', () => {
     )];
   });
 
-  it('should not have warnings when the end exploration object is valid',
-    () => {
-      var warnings = validatorService.getAllWarnings(
-        currentState, customizationArguments, [], null);
-      expect(warnings).toEqual([]);
-    });
+  it('should not have warnings when the EndExploration object does not have ' +
+    'answer groups or a default outcome or empty recommended exp IDs', () => {
+    var warnings = validatorService.getAllWarnings(
+      currentState, customizationArguments, [], null);
+    expect(warnings).toEqual([]);
+  });
 
   it('should have warnings for any answer groups or default outcome',
     () => {

--- a/extensions/interactions/EndExploration/directives/end-exploration-validation.service.spec.ts
+++ b/extensions/interactions/EndExploration/directives/end-exploration-validation.service.spec.ts
@@ -34,7 +34,6 @@ describe('EndExplorationValidationService', () => {
   let validatorService: EndExplorationValidationService;
 
   let currentState: string;
-  let errorMessageElement: HTMLSpanElement;
   let badOutcome: Outcome;
   let goodAnswerGroups: AnswerGroup[];
   let customizationArguments: EndExplorationCustomizationArgs;

--- a/extensions/interactions/EndExploration/directives/end-exploration-validation.service.ts
+++ b/extensions/interactions/EndExploration/directives/end-exploration-validation.service.ts
@@ -61,7 +61,7 @@ export class EndExplorationValidationService {
         });
         break;
       }
-      if (recommendedExplorationIds[i].length == 0) {
+      if (recommendedExplorationIds[i].length === 0) {
         warningsList.push({
           type: AppConstants.WARNING_TYPES.ERROR,
           message: 'Recommended exploration ID must be non-empty.'

--- a/extensions/interactions/EndExploration/directives/end-exploration-validation.service.ts
+++ b/extensions/interactions/EndExploration/directives/end-exploration-validation.service.ts
@@ -59,22 +59,17 @@ export class EndExplorationValidationService {
           type: AppConstants.WARNING_TYPES.ERROR,
           message: 'Recommended exploration ID must be a string.'
         });
+        break;
       }
-    }
-    // Validate invalid exploration ids given in author recommended
-    // explorations ids.
-    let warningMessageElement = document.querySelector(
-      'oppia-interactive-end-exploration .oppia-error-message-text span'
-    );
-    if (warningMessageElement) {
-      let warningMessage = warningMessageElement.textContent;
-      if (warningMessage) {
+      if (recommendedExplorationIds[i].length == 0) {
         warningsList.push({
           type: AppConstants.WARNING_TYPES.ERROR,
-          message: warningMessage
+          message: 'Recommended exploration ID must be non-empty.'
         });
+        break;
       }
     }
+
     return warningsList;
   }
 


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #15753.
2. This PR does the following:

- tldr, to fix a bug, this PR removes logic from the warning code raised by the end exploration interaction.
- For recommended explorations attached to the end exploration interaction, some of them may be invalid (private explorations or deleted, for example). As the backend query to check if an exploration is published can take time, we choose to only check after-save; we do not block the save button when customizing the end exploration component. This led to a bug where the save button is permanently grayed out if there is an invalid recommended exploration.
- Note that we are choosing to allow invalid recommended exploration data in our backend storage so it is fine that the exploration editor does not raise a warning that there is an invalid recommended exploration like it previously did.


## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

**BEFORE (you'll see the bug in the video):**

https://user-images.githubusercontent.com/21316782/197372901-ccdc6fe1-d0a3-4e45-b7dc-584e97c6a936.mov

**AFTER:**

https://user-images.githubusercontent.com/21316782/197373041-80af3594-2477-4cee-8ebe-5cbd5fc226c4.mov

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
