### PR TITLE
Learner Group UI improvements

### DIFF
--- a/core/templates/pages/learner-group-pages/edit-group/learner-group-learner-specific-progress.component.css
+++ b/core/templates/pages/learner-group-pages/edit-group/learner-group-learner-specific-progress.component.css
@@ -327,6 +327,16 @@
   font-size: 14px;
 }
 
+.oppia-learner-group-learner-specific-progress .drop-icon svg {
+  transform: rotate(0deg);
+  transition: transform 0.3s ease-in-out;
+}
+
+.oppia-learner-group-learner-specific-progress .mat-expanded .drop-icon svg {
+  transform: rotate(180deg);
+  transition: transform 0.3s ease-in-out;
+}
+
 @media screen and (max-width: 940px) {
   .oppia-learner-group-learner-specific-progress {
     width: 90%;

--- a/core/templates/pages/learner-group-pages/edit-group/learner-group-learner-specific-progress.component.html
+++ b/core/templates/pages/learner-group-pages/edit-group/learner-group-learner-specific-progress.component.html
@@ -19,7 +19,7 @@
           <div *ngIf="learnerProgress" class="all-subtopics-progress">
             <div *ngFor="let topicName of topicNames" class="progress-dropdown">
               <mat-accordion>
-                <mat-expansion-panel hideToggle>
+                <mat-expansion-panel hideToggle expanded>
                   <mat-expansion-panel-header>
                     <mat-panel-title>
                       <div class="story-info-summary-container">
@@ -72,7 +72,7 @@
         <div *ngIf="learnerProgress" class="all-stories-progress">
           <div *ngFor="let storyProgress of learnerProgress.storiesProgress; let storyIndex = index" class="progress-dropdown story-progress-dropdown">
             <mat-accordion>
-              <mat-expansion-panel hideToggle>
+              <mat-expansion-panel hideToggle expanded>
                 <mat-expansion-panel-header>
                   <mat-panel-title>
                     <div class="story-info-summary-container">


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR does the following: Expands collapsible panels for showing learners' progress by default and rotate caret icon upon expanding and collapsing

## Essential Checklist

- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

https://user-images.githubusercontent.com/42764756/199375244-8d5d2a55-5e46-469b-a91f-7a86ba2484d0.mp4


#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

https://user-images.githubusercontent.com/42764756/199375689-eb561ce5-70b7-49da-86d4-ecc4848fe714.mp4


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
