### PR TITLE
Fixes an e2e flake in AdditionalEditorFeatures

### DIFF
--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -2143,6 +2143,11 @@ def compute_models_to_put_when_saving_new_exp_version(
             'Commit messages for non-suggestions may not start with \'%s\'' %
             feconf.COMMIT_MESSAGE_ACCEPTED_SUGGESTION_PREFIX)
 
+    caching_services.delete_multi(
+        caching_services.CACHE_NAMESPACE_EXPLORATION,
+        None,
+        [exploration_id]
+    )
     updated_exploration = apply_change_list(exploration_id, change_list)
     if get_story_id_linked_to_exploration(exploration_id) is not None:
         validate_exploration_for_story(updated_exploration, True)

--- a/core/domain/exp_services.py
+++ b/core/domain/exp_services.py
@@ -2067,6 +2067,12 @@ def update_exploration(
     datastore_services.update_timestamps_multi(models_to_put)
     datastore_services.put_multi(models_to_put)
     index_explorations_given_ids([exploration_id])
+    # Explicitly clear the cache for explorations after putting the new
+    # version.
+    caching_services.delete_multi(
+        caching_services.CACHE_NAMESPACE_EXPLORATION, None,
+        [exploration_id]
+    )
 
 
 def compute_models_to_put_when_saving_new_exp_version(

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -55,7 +55,6 @@ from typing import Dict, Final, List, Optional, Sequence, Tuple, Type, Union
 
 MYPY = False
 if MYPY:  # pragma: no cover
-    from mypy_imports import datastore_services
     from mypy_imports import exp_models
     from mypy_imports import feedback_models
     from mypy_imports import opportunity_models
@@ -80,7 +79,6 @@ if MYPY:  # pragma: no cover
 ])
 
 search_services = models.Registry.import_search_services()
-datastore_services = models.Registry.import_datastore_services()
 
 # TODO(msl): Test ExpSummaryModel changes if explorations are updated,
 # reverted, deleted, created, rights changed.
@@ -6770,7 +6768,7 @@ title: Old Title
         exploration.version = 2
 
         def _mock_apply_change_list(
-            *args: str, **kwargs: str
+            *unused_args: str, **unused_kwargs: str
         ) -> exp_domain.Exploration:
             """Mocks exp_fetchers.get_exploration_by_id()."""
             return exploration

--- a/core/domain/exp_services_test.py
+++ b/core/domain/exp_services_test.py
@@ -6771,7 +6771,7 @@ title: Old Title
 
         def _mock_apply_change_list(
             *args: str, **kwargs: str
-        ) -> None:
+        ) -> exp_domain.Exploration:
             """Mocks exp_fetchers.get_exploration_by_id()."""
             return exploration
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes an e2e flake in AdditionalEditorFeatures.
2. This PR does the following: PR #16352 seems to have resulted in an e2e flake (https://github.com/oppia/oppia/actions/runs/3373946075/jobs/5599042787). This PR attempts to the flake by explicitly clearing the exploration specific cache entry after updating the model. It also clears the exploration specific cache before computing the updated exploration version.
 

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

![image](https://user-images.githubusercontent.com/11008603/200139068-d0ca02ad-e9e4-4c0d-91ee-1f378eaa3604.png)


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
