### PR TITLE
Fix for flaky exp_domain's backend test.

### DIFF
--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -2087,9 +2087,11 @@ class Exploration(translation_domain.BaseTranslatableObject):
         if len(self.states) != len(processed_queue):
             dead_end_states = list(
                 set(self.states.keys()) - set(processed_queue))
+            sorted_dead_end_states = sorted(dead_end_states)
             raise utils.ValidationError(
                 'It is impossible to complete the exploration from the '
-                'following states: %s' % ', '.join(dead_end_states))
+                'following states: %s' % ', '.join(sorted_dead_end_states)
+            )
 
     def get_content_html(self, state_name: str, content_id: str) -> str:
         """Return the content for a given content id of a state.

--- a/core/domain/exp_domain_test.py
+++ b/core/domain/exp_domain_test.py
@@ -4202,7 +4202,7 @@ class ExplorationDomainUnitTests(test_utils.GenericTestBase):
             'Please fix the following issues before saving this exploration: '
             '1. The following states are not reachable from the initial state: '
             'End 2. It is impossible to complete the exploration from the '
-            'following states: Stuck State, Introduction'):
+            'following states: Introduction, Stuck State'):
             exploration.validate(strict=True)
 
     def test_update_init_state_name_with_invalid_state(self) -> None:


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of N/A
2. This PR does the following: This PR fix backend flaky test.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

### Proof where test failed ( or reported ).

[LINK1](https://github.com/oppia/oppia/actions/runs/3479017894/jobs/5818600933#step:8:1908) -- flake occurred on PR.

[LINK2](https://github.com/oppia/oppia/actions/runs/3476372502/jobs/5811542387#step:8:1897) -- flake occurred on develop

[LINK3](https://github.com/oppia/oppia/issues/13162#issuecomment-1314571241) -- flake reported by someone.

### Reason

In [code](https://github.com/oppia/oppia/blob/cc1376ab305ef647b2c8f7a817c5f1e595ed0661/core/domain/exp_domain.py#L2092), the set is directly used while joining the string values, since set does not keep the order of entities ( or values ), so values are joined in random order and become backend flake.


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
