### PR TITLE
Fix #16606: Make topological sort creation deterministic

### DIFF
--- a/scripts/create_topological_sort_of_all_services.py
+++ b/scripts/create_topological_sort_of_all_services.py
@@ -26,7 +26,7 @@ import os
 from core import utils
 
 import esprima
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Tuple
 
 
 DIRECTORY_NAMES = ['core/templates', 'extensions']
@@ -56,21 +56,21 @@ def dfs(
     topo_sort_stack.append(node)
 
 
-def make_graph() -> Tuple[Dict[str, List[str]], Set[str]]:
+def make_graph() -> Tuple[Dict[str, List[str]], List[str]]:
     """Creates an adjaceny list considering services as node and dependencies
     as edges.
 
     Returns:
-        tuple(dict, set(str)). Adjancency list of the graph formed with
-        services as nodes and dependencies as edges, set of all the services.
+        tuple(dict, list(str)). Adjancency list of the graph formed with
+        services as nodes and dependencies as edges, list of all the services.
     """
     adj_list = collections.defaultdict(list)
-    nodes_set = set()
+    nodes_list = []
     for dirname in DIRECTORY_NAMES:
         for root, _, filenames in os.walk(dirname):
             for filename in filenames:
                 if filename.endswith(SERVICE_FILES_SUFFICES):
-                    nodes_set.add(filename)
+                    nodes_list.append(filename)
                     filepath = os.path.join(root, filename)
                     with utils.open_file(filepath, 'r') as f:
                         file_lines = f.readlines()
@@ -124,18 +124,18 @@ def make_graph() -> Tuple[Dict[str, List[str]], Set[str]]:
                                 dep_name = os.path.basename(dep_path)
                                 adj_list[dep_name].append(filename)
 
-    return (adj_list, nodes_set)
+    return (adj_list, nodes_list)
 
 
 def main() -> None:
     """Prints the topological order of the services based on the
     dependencies.
     """
-    adj_list, nodes_set = make_graph()
+    adj_list, nodes_list = make_graph()
     visit_stack: List[str] = []
     topo_sort_stack: List[str] = []
 
-    for unchecked_node in nodes_set:
+    for unchecked_node in nodes_list:
         if unchecked_node not in visit_stack:
             dfs(unchecked_node, topo_sort_stack, adj_list, visit_stack)
 

--- a/scripts/create_topological_sort_of_all_services_test.py
+++ b/scripts/create_topological_sort_of_all_services_test.py
@@ -49,7 +49,7 @@ class TopologicalSortTests(test_utils.GenericTestBase):
         with self.swap(
             create_topological_sort_of_all_services, 'DIRECTORY_NAMES',
             MOCK_DIRECTORY_NAMES):
-            adj_list, node_set = (
+            adj_list, node_list = (
                 create_topological_sort_of_all_services.make_graph())
 
             expected_adj_list = {
@@ -71,7 +71,7 @@ class TopologicalSortTests(test_utils.GenericTestBase):
                 self.assertEqual(
                     sorted(adj_list[key]), sorted(expected_adj_list[key]))
 
-            self.assertEqual(node_set, expected_node_set)
+            self.assertEqual(set(node_list), expected_node_set)
 
     def test_complete_process(self) -> None:
         actual_output = []


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #16606.
2. This PR does the following: Makes the topological sort creation script deterministic.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
