### PR TITLE
Fix #16634: Fix Draft migration error

### DIFF
--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -498,13 +498,16 @@ class DraftUpgradeUtil:
                         'feedback': (
                             answer_group_dict['outcome']['feedback']),
                         'labelled_as_correct': (
-                            answer_group_dict['outcome']['labelled_as_correct']),
+                            answer_group_dict
+                                ['outcome']['labelled_as_correct']),
                         'param_changes': (
                             answer_group_dict['outcome']['param_changes']),
                         'refresher_exploration_id': (
-                            answer_group_dict['outcome']['refresher_exploration_id']),
+                            answer_group_dict
+                                ['outcome']['refresher_exploration_id']),
                         'missing_prerequisite_skill_id': (
-                            answer_group_dict['outcome']['missing_prerequisite_skill_id'])
+                            answer_group_dict['outcome']
+                                ['missing_prerequisite_skill_id'])
                     })
                     answer_group_dicts.append({
                         'rule_specs': answer_group_dict['rule_specs'],
@@ -519,7 +522,7 @@ class DraftUpgradeUtil:
                     'state_name': change.state_name,
                     'new_value': answer_group_dicts
                 })
-            elif (change.property_name ==
+            if (change.property_name ==
                   exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME and
                   change.cmd == exp_domain.CMD_EDIT_STATE_PROPERTY):
                 # Here we use cast because this 'elif' condition forces change
@@ -542,7 +545,8 @@ class DraftUpgradeUtil:
                     'refresher_exploration_id': (
                         new_default_outcome_dict['refresher_exploration_id']),
                     'missing_prerequisite_skill_id': (
-                        new_default_outcome_dict['missing_prerequisite_skill_id'])
+                        new_default_outcome_dict
+                            ['missing_prerequisite_skill_id'])
                 })
                 draft_change_list[i] = exp_domain.ExplorationChange({
                     'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,

--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -466,7 +466,9 @@ class DraftUpgradeUtil:
     def _convert_states_v50_dict_to_v51_dict(
         cls, draft_change_list: List[exp_domain.ExplorationChange]
     ) -> List[exp_domain.ExplorationChange]:
-        """Converts draft change list from state version 50 to 51.
+        """Converts draft change list from state version 50 to 51. Adds
+        a new field dest_if_really_stuck to Outcome class to direct the
+        learner to a custom revision state.
 
         Args:
             draft_change_list: list(ExplorationChange). The list of
@@ -490,15 +492,19 @@ class DraftUpgradeUtil:
                 )
                 answer_group_dicts: List[state_domain.AnswerGroupDict] = []
                 for answer_group_dict in new_answer_groups_dicts:
-                    outcome_dict: state_domain.OutcomeDict = []
-                    outcome_dict = ({
+                    outcome_dict: state_domain.OutcomeDict = ({
                         'dest': answer_group_dict['outcome']['dest'],
                         'dest_if_really_stuck': None,
-                        'feedback': answer_group_dict['outcome']['feedback'],
-                        'labelled_as_correct': answer_group_dict['outcome']['labelled_as_correct'],
-                        'param_changes': answer_group_dict['outcome']['param_changes'],
-                        'refresher_exploration_id': answer_group_dict['outcome']['refresher_exploration_id'],
-                        'missing_prerequisite_skill_id': answer_group_dict['outcome']['missing_prerequisite_skill_id']
+                        'feedback': (
+                            answer_group_dict['outcome']['feedback']),
+                        'labelled_as_correct': (
+                            answer_group_dict['outcome']['labelled_as_correct']),
+                        'param_changes': (
+                            answer_group_dict['outcome']['param_changes']),
+                        'refresher_exploration_id': (
+                            answer_group_dict['outcome']['refresher_exploration_id']),
+                        'missing_prerequisite_skill_id': (
+                            answer_group_dict['outcome']['missing_prerequisite_skill_id'])
                     })
                     answer_group_dicts.append({
                         'rule_specs': answer_group_dict['rule_specs'],
@@ -525,15 +531,18 @@ class DraftUpgradeUtil:
                 new_default_outcome_dict = (
                     edit_interaction_default_outcome_cmd.new_value
                 )
-                default_outcome_dict: state_domain.OutcomeDict = []
-                default_outcome_dict = ({
+                default_outcome_dict: state_domain.OutcomeDict = ({
                     'dest': new_default_outcome_dict['dest'],
                     'dest_if_really_stuck': None,
                     'feedback': new_default_outcome_dict['feedback'],
-                    'labelled_as_correct': new_default_outcome_dict['labelled_as_correct'],
-                    'param_changes': new_default_outcome_dict['param_changes'],
-                    'refresher_exploration_id': new_default_outcome_dict['refresher_exploration_id'],
-                    'missing_prerequisite_skill_id': new_default_outcome_dict['missing_prerequisite_skill_id']
+                    'labelled_as_correct': (
+                        new_default_outcome_dict['labelled_as_correct']),
+                    'param_changes': (
+                        new_default_outcome_dict['param_changes']),
+                    'refresher_exploration_id': (
+                        new_default_outcome_dict['refresher_exploration_id']),
+                    'missing_prerequisite_skill_id': (
+                        new_default_outcome_dict['missing_prerequisite_skill_id'])
                 })
                 draft_change_list[i] = exp_domain.ExplorationChange({
                     'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,

--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -522,7 +522,7 @@ class DraftUpgradeUtil:
                     'state_name': change.state_name,
                     'new_value': answer_group_dicts
                 })
-            if (change.property_name ==
+            elif (change.property_name ==
                   exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME and
                   change.cmd == exp_domain.CMD_EDIT_STATE_PROPERTY):
                 # Here we use cast because this 'elif' condition forces change

--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -492,13 +492,13 @@ class DraftUpgradeUtil:
                 for answer_group_dict in new_answer_groups_dicts:
                     outcome_dict: List[state_domain.OutcomeDict] = []
                     outcome_dict.append({
-                        'dest': outcome_dict['dest'],
+                        'dest': answer_group_dict['outcome']['dest'],
                         'dest_if_really_stuck': None,
-                        'feedback': outcome_dict['feedback'],
-                        'labelled_as_correct': outcome_dict['labelled_as_correct'],
-                        'param_changes': outcome_dict['param_changes'],
-                        'refresher_exploration_id': outcome_dict['refresher_exploration_id'],
-                        'missing_prerequisite_skill_id': outcome_dict['missing_prerequisite_skill_id']
+                        'feedback': answer_group_dict['outcome']['feedback'],
+                        'labelled_as_correct': answer_group_dict['outcome']['labelled_as_correct'],
+                        'param_changes': answer_group_dict['outcome']['param_changes'],
+                        'refresher_exploration_id': answer_group_dict['outcome']['refresher_exploration_id'],
+                        'missing_prerequisite_skill_id': answer_group_dict['outcome']['missing_prerequisite_skill_id']
                     })
                     answer_group_dicts.append({
                         'rule_specs': answer_group_dict['rule_specs'],

--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -490,8 +490,8 @@ class DraftUpgradeUtil:
                 )
                 answer_group_dicts: List[state_domain.AnswerGroupDict] = []
                 for answer_group_dict in new_answer_groups_dicts:
-                    outcome_dict: List[state_domain.OutcomeDict] = []
-                    outcome_dict.append({
+                    outcome_dict: state_domain.OutcomeDict = []
+                    outcome_dict = ({
                         'dest': answer_group_dict['outcome']['dest'],
                         'dest_if_really_stuck': None,
                         'feedback': answer_group_dict['outcome']['feedback'],
@@ -513,7 +513,7 @@ class DraftUpgradeUtil:
                     'state_name': change.state_name,
                     'new_value': answer_group_dicts
                 })
-            if (change.property_name ==
+            elif (change.property_name ==
                   exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME and
                   change.cmd == exp_domain.CMD_EDIT_STATE_PROPERTY):
                 # Here we use cast because this 'elif' condition forces change
@@ -522,26 +522,25 @@ class DraftUpgradeUtil:
                     exp_domain.EditExpStatePropertyInteractionDefaultOutcomeCmd,
                     change
                 )
-                new_default_outcome_dicts = (
+                new_default_outcome_dict = (
                     edit_interaction_default_outcome_cmd.new_value
                 )
-                default_outcome_dicts: List[state_domain.OutcomeDict] = []
-                for default_outcome_dict in new_default_outcome_dicts:
-                    default_outcome_dicts.append({
-                        'dest': default_outcome_dict['dest'],
-                        'dest_if_really_stuck': None,
-                        'feedback': default_outcome_dict['feedback'],
-                        'labelled_as_correct': default_outcome_dict['labelled_as_correct'],
-                        'param_changes': default_outcome_dict['param_changes'],
-                        'refresher_exploration_id': default_outcome_dict['refresher_exploration_id'],
-                        'missing_prerequisite_skill_id': default_outcome_dict['missing_prerequisite_skill_id']
-                    })
+                default_outcome_dict: state_domain.OutcomeDict = []
+                default_outcome_dict = ({
+                    'dest': new_default_outcome_dict['dest'],
+                    'dest_if_really_stuck': None,
+                    'feedback': new_default_outcome_dict['feedback'],
+                    'labelled_as_correct': new_default_outcome_dict['labelled_as_correct'],
+                    'param_changes': new_default_outcome_dict['param_changes'],
+                    'refresher_exploration_id': new_default_outcome_dict['refresher_exploration_id'],
+                    'missing_prerequisite_skill_id': new_default_outcome_dict['missing_prerequisite_skill_id']
+                })
                 draft_change_list[i] = exp_domain.ExplorationChange({
                     'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
                     'property_name': (
                         exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME),
                     'state_name': change.state_name,
-                    'new_value': default_outcome_dicts
+                    'new_value': default_outcome_dict
                 })
         return draft_change_list
 

--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -466,11 +466,7 @@ class DraftUpgradeUtil:
     def _convert_states_v50_dict_to_v51_dict(
         cls, draft_change_list: List[exp_domain.ExplorationChange]
     ) -> List[exp_domain.ExplorationChange]:
-        """Converts from version 50 to 51. Version 51 adds a new
-        dest_if_really_stuck field to Outcome class to redirect learners
-        to a state for strengthening concepts when they get really stuck. As
-        this is a new property and therefore doesn't affect any pre-existing
-        drafts, there should be no changes to drafts.
+        """Converts draft change list from state version 50 to 51.
 
         Args:
             draft_change_list: list(ExplorationChange). The list of
@@ -479,6 +475,66 @@ class DraftUpgradeUtil:
         Returns:
             list(ExplorationChange). The converted draft_change_list.
         """
+        for i, change in enumerate(draft_change_list):
+            # if (change.cmd == exp_domain.CMD_EDIT_STATE_PROPERTY and
+            #         change.property_name ==
+            #         exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS):
+            #     # Here we use cast because this 'if' condition forces change to
+            #     # have type EditExpStatePropertyInteractionAnswerGroupsCmd.
+            #     edit_interaction_answer_groups_cmd = cast(
+            #         exp_domain.EditExpStatePropertyInteractionAnswerGroupsCmd,
+            #         change
+            #     )
+            #     new_answer_groups_dicts = (
+            #         edit_interaction_answer_groups_cmd.new_value
+            #     )
+            #     answer_group_dicts: List[state_domain.AnswerGroupDict] = []
+            #     for answer_group_dict in new_answer_groups_dicts:
+            #         outcome_dict: List[state_domain.OutcomeDict] = answer_group_dict['outcome']
+            #         outcome_dict['dest_if_really_stuck'] = None
+            #         answer_group_dicts.append({
+            #             'rule_specs': answer_group_dict['rule_specs'],
+            #             'outcome': outcome_dict,
+            #             'training_data': answer_group_dict['training_data'],
+            #             'tagged_skill_misconception_id': None
+            #         })
+            #     draft_change_list[i] = exp_domain.ExplorationChange({
+            #         'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+            #         'property_name': (
+            #             exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS),
+            #         'state_name': change.state_name,
+            #         'new_value': answer_group_dicts
+            #     })
+            if (change.property_name ==
+                  exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME and
+                  change.cmd == exp_domain.CMD_EDIT_STATE_PROPERTY):
+                # Here we use cast because this 'elif' condition forces change
+                # to have type EditExpStatePropertyInteractionDefaultOutcomeCmd.
+                edit_interaction_default_outcome_cmd = cast(
+                    exp_domain.EditExpStatePropertyInteractionDefaultOutcomeCmd,
+                    change
+                )
+                new_default_outcome_dicts = (
+                    edit_interaction_default_outcome_cmd.new_value
+                )
+                default_outcome_dicts: List[state_domain.OutcomeDict] = []
+                for default_outcome_dict in new_default_outcome_dicts:
+                    default_outcome_dicts.append({
+                        'dest': default_outcome_dict['dest'],
+                        'dest_if_really_stuck': None,
+                        'feedback': default_outcome_dict['feedback'],
+                        'labelled_as_correct': default_outcome_dict['labelled_as_correct'],
+                        'param_changes': default_outcome_dict['param_changes'],
+                        'refresher_exploration_id': default_outcome_dict['refresher_exploration_id'],
+                        'missing_prerequisite_skill_id': default_outcome_dict['missing_prerequisite_skill_id']
+                    })
+                draft_change_list[i] = exp_domain.ExplorationChange({
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'property_name': (
+                        exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME),
+                    'state_name': change.state_name,
+                    'new_value': default_outcome_dicts
+                })
         return draft_change_list
 
     @classmethod

--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -476,35 +476,35 @@ class DraftUpgradeUtil:
             list(ExplorationChange). The converted draft_change_list.
         """
         for i, change in enumerate(draft_change_list):
-            # if (change.cmd == exp_domain.CMD_EDIT_STATE_PROPERTY and
-            #         change.property_name ==
-            #         exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS):
-            #     # Here we use cast because this 'if' condition forces change to
-            #     # have type EditExpStatePropertyInteractionAnswerGroupsCmd.
-            #     edit_interaction_answer_groups_cmd = cast(
-            #         exp_domain.EditExpStatePropertyInteractionAnswerGroupsCmd,
-            #         change
-            #     )
-            #     new_answer_groups_dicts = (
-            #         edit_interaction_answer_groups_cmd.new_value
-            #     )
-            #     answer_group_dicts: List[state_domain.AnswerGroupDict] = []
-            #     for answer_group_dict in new_answer_groups_dicts:
-            #         outcome_dict: List[state_domain.OutcomeDict] = answer_group_dict['outcome']
-            #         outcome_dict['dest_if_really_stuck'] = None
-            #         answer_group_dicts.append({
-            #             'rule_specs': answer_group_dict['rule_specs'],
-            #             'outcome': outcome_dict,
-            #             'training_data': answer_group_dict['training_data'],
-            #             'tagged_skill_misconception_id': None
-            #         })
-            #     draft_change_list[i] = exp_domain.ExplorationChange({
-            #         'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-            #         'property_name': (
-            #             exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS),
-            #         'state_name': change.state_name,
-            #         'new_value': answer_group_dicts
-            #     })
+            if (change.cmd == exp_domain.CMD_EDIT_STATE_PROPERTY and
+                    change.property_name ==
+                    exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS):
+                # Here we use cast because this 'if' condition forces change to
+                # have type EditExpStatePropertyInteractionAnswerGroupsCmd.
+                edit_interaction_answer_groups_cmd = cast(
+                    exp_domain.EditExpStatePropertyInteractionAnswerGroupsCmd,
+                    change
+                )
+                new_answer_groups_dicts = (
+                    edit_interaction_answer_groups_cmd.new_value
+                )
+                answer_group_dicts: List[state_domain.AnswerGroupDict] = []
+                for answer_group_dict in new_answer_groups_dicts:
+                    outcome_dict: List[state_domain.OutcomeDict] = answer_group_dict['outcome']
+                    outcome_dict['dest_if_really_stuck'] = None
+                    answer_group_dicts.append({
+                        'rule_specs': answer_group_dict['rule_specs'],
+                        'outcome': outcome_dict,
+                        'training_data': answer_group_dict['training_data'],
+                        'tagged_skill_misconception_id': None
+                    })
+                draft_change_list[i] = exp_domain.ExplorationChange({
+                    'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                    'property_name': (
+                        exp_domain.STATE_PROPERTY_INTERACTION_ANSWER_GROUPS),
+                    'state_name': change.state_name,
+                    'new_value': answer_group_dicts
+                })
             if (change.property_name ==
                   exp_domain.STATE_PROPERTY_INTERACTION_DEFAULT_OUTCOME and
                   change.cmd == exp_domain.CMD_EDIT_STATE_PROPERTY):

--- a/core/domain/draft_upgrade_services.py
+++ b/core/domain/draft_upgrade_services.py
@@ -490,8 +490,16 @@ class DraftUpgradeUtil:
                 )
                 answer_group_dicts: List[state_domain.AnswerGroupDict] = []
                 for answer_group_dict in new_answer_groups_dicts:
-                    outcome_dict: List[state_domain.OutcomeDict] = answer_group_dict['outcome']
-                    outcome_dict['dest_if_really_stuck'] = None
+                    outcome_dict: List[state_domain.OutcomeDict] = []
+                    outcome_dict.append({
+                        'dest': outcome_dict['dest'],
+                        'dest_if_really_stuck': None,
+                        'feedback': outcome_dict['feedback'],
+                        'labelled_as_correct': outcome_dict['labelled_as_correct'],
+                        'param_changes': outcome_dict['param_changes'],
+                        'refresher_exploration_id': outcome_dict['refresher_exploration_id'],
+                        'missing_prerequisite_skill_id': outcome_dict['missing_prerequisite_skill_id']
+                    })
                     answer_group_dicts.append({
                         'rule_specs': answer_group_dict['rule_specs'],
                         'outcome': outcome_dict,

--- a/core/domain/draft_upgrade_services_test.py
+++ b/core/domain/draft_upgrade_services_test.py
@@ -456,31 +456,92 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
         draft_change_list_v50 = [
             exp_domain.ExplorationChange({
                 'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
-                'state_name': 'Intro',
-                'property_name': 'content',
-                'new_value': 'new value'
+                'property_name': 'answer_groups',
+                'state_name': 'State 1',
+                'new_value': [{
+                    'rule_specs': [{
+                        'rule_type': 'Equals',
+                        'inputs': {'x': [
+                            '<p>This is value1 for ItemSelection</p>'
+                        ]}
+                    }, {
+                        'rule_type': 'Equals',
+                        'inputs': {'x': [
+                            '<p>This is value2 for ItemSelection</p>'
+                        ]}
+                    }],
+                    'outcome': {
+                        'dest': 'Introduction',
+                        'feedback': {
+                            'content_id': 'feedback',
+                            'html': '<p>Outcome for state1</p>'
+                        },
+                        'param_changes': [],
+                        'labelled_as_correct': False,
+                        'refresher_exploration_id': None,
+                        'missing_prerequisite_skill_id': None
+                    },
+                    'training_data': [],
+                    'tagged_misconception_id': None
+                }]
             })
         ]
-        # Migrate exploration to state schema version 51.
+        # Version 30 replaces the tagged_misconception_id in version 29
+        # with tagged_skill_misconception_id.
+        expected_draft_change_list_v51 = [
+            exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'property_name': 'answer_groups',
+                'state_name': 'State 1',
+                'new_value': [{
+                    'rule_specs': [{
+                        'rule_type': 'Equals',
+                        'inputs': {'x': [
+                            '<p>This is value1 for ItemSelection</p>'
+                        ]}
+                    }, {
+                        'rule_type': 'Equals',
+                        'inputs': {'x': [
+                            '<p>This is value2 for ItemSelection</p>'
+                        ]}
+                    }],
+                    'outcome': {
+                        'dest': 'Introduction',
+                        'dest_if_really_stuck': None,
+                        'feedback': {
+                            'content_id': 'feedback',
+                            'html': '<p>Outcome for state1</p>'
+                        },
+                        'param_changes': [],
+                        'labelled_as_correct': False,
+                        'refresher_exploration_id': None,
+                        'missing_prerequisite_skill_id': None
+                    },
+                    'training_data': [],
+                    'tagged_skill_misconception_id': None
+                }]
+            })
+        ]
+        # Migrate exploration to state schema version 30.
         self.create_and_migrate_new_exploration('50', '51')
+        # Migrate the draft change list's state schema to the migrated
+        # exploration's schema.
         migrated_draft_change_list_v51 = (
             draft_upgrade_services.try_upgrading_draft_to_exp_version(
                 draft_change_list_v50, 1, 2, self.EXP_ID)
         )
-        # Change draft change lists into a list of dicts so that it is
-        # easy to compare the whole draft change list.
         # Ruling out the possibility of None for mypy type checking.
         assert migrated_draft_change_list_v51 is not None
-        draft_change_list_v50_dict_list = [
-            change.to_dict() for change in draft_change_list_v50
+        # Change draft change lists into a list of dicts so that it is
+        # easy to compare the whole draft change list.
+        expected_draft_change_list_v51_dict_list = [
+            change.to_dict() for change in expected_draft_change_list_v51
         ]
-
         migrated_draft_change_list_v51_dict_list = [
             change.to_dict() for change in migrated_draft_change_list_v51
         ]
-
         self.assertEqual(
-            draft_change_list_v50_dict_list,
+            expected_draft_change_list_v51_dict_list,
             migrated_draft_change_list_v51_dict_list)
 
     def test_convert_states_v49_dict_to_v50_dict(self) -> None:

--- a/core/domain/draft_upgrade_services_test.py
+++ b/core/domain/draft_upgrade_services_test.py
@@ -486,8 +486,7 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                 }]
             })
         ]
-        # Version 30 replaces the tagged_misconception_id in version 29
-        # with tagged_skill_misconception_id.
+        # Version 51 adds the dest_if_really_stuck field.
         expected_draft_change_list_v51 = [
             exp_domain.ExplorationChange({
                 'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
@@ -522,7 +521,7 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                 }]
             })
         ]
-        # Migrate exploration to state schema version 30.
+        # Migrate exploration to state schema version 51.
         self.create_and_migrate_new_exploration('50', '51')
         # Migrate the draft change list's state schema to the migrated
         # exploration's schema.
@@ -543,6 +542,60 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             expected_draft_change_list_v51_dict_list,
             migrated_draft_change_list_v51_dict_list)
+
+        draft_change_list_v50_2 = [
+            exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'state_name': 'Intro',
+                'property_name': 'default_outcome',
+                'new_value': {
+                    'param_changes': [],
+                    'feedback': {},
+                    'dest': 'Introduction',
+                    'refresher_exploration_id': None,
+                    'missing_prerequisite_skill_id': None,
+                    'labelled_as_correct': False
+                }
+            })
+        ]
+        # Version 51 adds the dest_if_really_stuck field.
+        expected_draft_change_list_v51_2 = [
+            exp_domain.ExplorationChange({
+                'cmd': exp_domain.CMD_EDIT_STATE_PROPERTY,
+                'state_name': 'Intro',
+                'property_name': 'default_outcome',
+                'new_value': {
+                    'param_changes': [],
+                    'feedback': {},
+                    'dest': 'Introduction',
+                    'dest_if_really_stuck': None,
+                    'refresher_exploration_id': None,
+                    'missing_prerequisite_skill_id': None,
+                    'labelled_as_correct': False
+                }
+            })
+        ]
+        # Migrate exploration to state schema version 51.
+        self.create_and_migrate_new_exploration('50', '51')
+        # Migrate the draft change list's state schema to the migrated
+        # exploration's schema.
+        migrated_draft_change_list_v51_2 = (
+            draft_upgrade_services.try_upgrading_draft_to_exp_version(
+                draft_change_list_v50_2, 1, 2, self.EXP_ID)
+        )
+        # Ruling out the possibility of None for mypy type checking.
+        assert migrated_draft_change_list_v51_2 is not None
+        # Change draft change lists into a list of dicts so that it is
+        # easy to compare the whole draft change list.
+        expected_draft_change_list_v51_dict_list_2 = [
+            change.to_dict() for change in expected_draft_change_list_v51_2
+        ]
+        migrated_draft_change_list_v51_dict_list_2 = [
+            change.to_dict() for change in migrated_draft_change_list_v51_2
+        ]
+        self.assertEqual(
+            expected_draft_change_list_v51_dict_list_2,
+            migrated_draft_change_list_v51_dict_list_2)
 
     def test_convert_states_v49_dict_to_v50_dict(self) -> None:
         draft_change_list_v49 = [

--- a/core/domain/draft_upgrade_services_test.py
+++ b/core/domain/draft_upgrade_services_test.py
@@ -550,7 +550,10 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                 'property_name': 'default_outcome',
                 'new_value': {
                     'param_changes': [],
-                    'feedback': {},
+                    'feedback': {
+                        'content_id': 'feedback',
+                        'html': '<p>Content</p>'
+                    },
                     'dest': 'Introduction',
                     'refresher_exploration_id': None,
                     'missing_prerequisite_skill_id': None,
@@ -566,7 +569,10 @@ class DraftUpgradeUtilUnitTests(test_utils.GenericTestBase):
                 'property_name': 'default_outcome',
                 'new_value': {
                     'param_changes': [],
-                    'feedback': {},
+                    'feedback': {
+                        'content_id': 'feedback',
+                        'html': '<p>Content</p>'
+                    },
                     'dest': 'Introduction',
                     'dest_if_really_stuck': None,
                     'refresher_exploration_id': None,

--- a/scripts/backend_tests_incomplete_coverage.txt
+++ b/scripts/backend_tests_incomplete_coverage.txt
@@ -33,7 +33,6 @@ core.domain.collection_domain_test
 core.domain.change_domain_test
 core.domain.collection_services_test
 core.domain.config_domain_test
-core.domain.draft_upgrade_services_test
 core.domain.email_manager_test
 core.domain.event_services_test
 core.domain.exp_domain_test

--- a/scripts/backend_tests_incomplete_coverage.txt
+++ b/scripts/backend_tests_incomplete_coverage.txt
@@ -33,6 +33,7 @@ core.domain.collection_domain_test
 core.domain.change_domain_test
 core.domain.collection_services_test
 core.domain.config_domain_test
+core.domain.draft_upgrade_services_test
 core.domain.email_manager_test
 core.domain.event_services_test
 core.domain.exp_domain_test


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #16634 .
2. This PR does the following: Fixes the draft migration function for the field dest_if_really_stuck
## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

https://user-images.githubusercontent.com/76519771/204125571-0a4bddce-d297-4b89-bce7-ba6be7792a8d.mp4




https://user-images.githubusercontent.com/76519771/204125575-db4d9b05-1622-4f0b-b947-311b0d477a36.mp4



#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
