### PR TITLE
Make incomplete per-file coverage error clearer

### DIFF
--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -442,7 +442,7 @@ def check_test_results(
                 if (
                         spec.test_target not in coverage_exclusions
                         and float(coverage) != 100.0):
-                    print('INCOMPLETE COVERAGE (%s%%): %s' % (
+                    print('INCOMPLETE PER-FILE COVERAGE (%s%%): %s' % (
                         coverage, spec.test_target))
                     incomplete_coverage += 1
                     print(task.task_results[0].get_report()[-3])

--- a/scripts/run_backend_tests_test.py
+++ b/scripts/run_backend_tests_test.py
@@ -422,7 +422,8 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
                 tasks, task_to_taskspec, True)
 
         self.assertIn(
-            'INCOMPLETE COVERAGE (98%%): %s' % test_target, self.print_arr)
+            'INCOMPLETE PER-FILE COVERAGE (98%%): %s' %
+            test_target, self.print_arr)
 
     def test_successfull_test_run_message_is_printed_correctly(self) -> None:
         with self.swap_install_third_party_libs:
@@ -479,7 +480,8 @@ class RunBackendTestsTests(test_utils.GenericTestBase):
                 tasks, task_to_taskspec, True)
 
         self.assertNotIn(
-            'INCOMPLETE COVERAGE (98%%): %s' % test_target, self.print_arr)
+            'INCOMPLETE PER-FILE COVERAGE (98%%): %s' %
+            test_target, self.print_arr)
         self.assertIn(
             'SUCCESS   %s: 9 tests (1.2 secs)' % test_target,
             self.print_arr)


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #15231 ].
2. This PR does the following: Makes error message for incomplete per-file backend coverage state that the missing coverage is on a per-file basis.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because this change in error message is trivial.

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
