### PR TITLE
Fix part of #14219: Increase backend test coverage of core.domain.learner_group_domain to 100%

### DIFF
--- a/core/domain/learner_group_domain_test.py
+++ b/core/domain/learner_group_domain_test.py
@@ -18,6 +18,8 @@
 
 from __future__ import annotations
 
+from core import utils
+
 from core.domain import learner_group_domain
 from core.tests import test_utils
 
@@ -25,14 +27,16 @@ from core.tests import test_utils
 class LearnerGroupTest(test_utils.GenericTestBase):
     """Tests for LearnerGroup domain object."""
 
-    def test_initialization(self) -> None:
-        learner_group = learner_group_domain.LearnerGroup(
+    VALID_LEARNER_GROUP = learner_group_domain.LearnerGroup(
             '3232', 'title', 'description',
             ['user_1'],
             ['user_2', 'user_3', 'user_4'],
             ['user_5', 'user_6'],
             ['subtopic_1', 'subtopic_2'],
             ['story_1', 'story_2'])
+
+    def test_initialization(self) -> None:
+        learner_group = self.VALID_LEARNER_GROUP
 
         expected_learner_group_dict = {
             'group_id': '3232',
@@ -63,13 +67,7 @@ class LearnerGroupTest(test_utils.GenericTestBase):
             expected_learner_group_dict)
 
     def test_to_dict(self) -> None:
-        learner_group = learner_group_domain.LearnerGroup(
-            '3232', 'title', 'description',
-            ['user_1'],
-            ['user_2', 'user_3', 'user_4'],
-            ['user_5', 'user_6'],
-            ['subtopic_1', 'subtopic_2'],
-            ['story_1', 'story_2'])
+        learner_group = self.VALID_LEARNER_GROUP
 
         expected_learner_group_dict = {
             'group_id': '3232',
@@ -126,3 +124,11 @@ class LearnerGroupTest(test_utils.GenericTestBase):
                 ['subtopic_1', 'subtopic_2'],
                 ['story_1', 'story_2']),
             'Learner group facilitator cannot be invited to join the group.')
+
+        try:
+            # Test that valid learner group does not raise error
+            learner_group = self.VALID_LEARNER_GROUP
+            learner_group.validate()
+        except Exception as error:
+            raise utils.ValidationError(
+                'Unexpected validation error.') from error

--- a/core/domain/learner_group_domain_test.py
+++ b/core/domain/learner_group_domain_test.py
@@ -126,7 +126,7 @@ class LearnerGroupTest(test_utils.GenericTestBase):
             'Learner group facilitator cannot be invited to join the group.')
 
         try:
-            # Test that valid learner group does not raise error
+            # Test that valid learner group does not raise error.
             learner_group = self.VALID_LEARNER_GROUP
             learner_group.validate()
         except Exception as error:

--- a/core/domain/learner_group_domain_test.py
+++ b/core/domain/learner_group_domain_test.py
@@ -18,8 +18,6 @@
 
 from __future__ import annotations
 
-from core import utils
-
 from core.domain import learner_group_domain
 from core.tests import test_utils
 
@@ -37,7 +35,6 @@ class LearnerGroupTest(test_utils.GenericTestBase):
 
     def test_initialization(self) -> None:
         learner_group = self.VALID_LEARNER_GROUP
-
         expected_learner_group_dict = {
             'group_id': '3232',
             'title': 'title',
@@ -68,7 +65,6 @@ class LearnerGroupTest(test_utils.GenericTestBase):
 
     def test_to_dict(self) -> None:
         learner_group = self.VALID_LEARNER_GROUP
-
         expected_learner_group_dict = {
             'group_id': '3232',
             'title': 'title',
@@ -125,10 +121,6 @@ class LearnerGroupTest(test_utils.GenericTestBase):
                 ['story_1', 'story_2']),
             'Learner group facilitator cannot be invited to join the group.')
 
-        try:
-            # Test that valid learner group does not raise error.
-            learner_group = self.VALID_LEARNER_GROUP
-            learner_group.validate()
-        except Exception as error:
-            raise utils.ValidationError(
-                'Unexpected validation error.') from error
+        # Valid object should not raise exception during validation.
+        learner_group = self.VALID_LEARNER_GROUP
+        learner_group.validate()

--- a/core/domain/learner_group_domain_test.py
+++ b/core/domain/learner_group_domain_test.py
@@ -26,12 +26,12 @@ class LearnerGroupTest(test_utils.GenericTestBase):
     """Tests for LearnerGroup domain object."""
 
     VALID_LEARNER_GROUP = learner_group_domain.LearnerGroup(
-            '3232', 'title', 'description',
-            ['user_1'],
-            ['user_2', 'user_3', 'user_4'],
-            ['user_5', 'user_6'],
-            ['subtopic_1', 'subtopic_2'],
-            ['story_1', 'story_2'])
+        '3232', 'title', 'description',
+        ['user_1'],
+        ['user_2', 'user_3', 'user_4'],
+        ['user_5', 'user_6'],
+        ['subtopic_1', 'subtopic_2'],
+        ['story_1', 'story_2'])
 
     def test_initialization(self) -> None:
         learner_group = self.VALID_LEARNER_GROUP

--- a/scripts/backend_tests_incomplete_coverage.txt
+++ b/scripts/backend_tests_incomplete_coverage.txt
@@ -46,7 +46,6 @@ core.domain.html_validation_service_test
 core.domain.image_validation_services_test
 core.domain.interaction_registry_test
 core.domain.learner_goals_services_test
-core.domain.learner_group_domain_test
 core.domain.learner_group_fetchers_test
 core.domain.learner_group_services_test
 core.domain.learner_playlist_services_test


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #14219.
2. This PR does the following: Add missing test case validating `valid` learner group object to achieve 100% test coverage.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
#### Before any changes to the file:

<img width="925" alt="Skärmavbild 2022-11-30 kl  09 48 02" src="https://user-images.githubusercontent.com/48027815/204764305-5aaf9b2c-0244-4d1a-a712-aa5527ceba07.png">

#### After changes:

<img width="585" alt="Skärmavbild 2022-11-30 kl  10 34 32" src="https://user-images.githubusercontent.com/48027815/204764421-d21f19b7-29f1-4fa0-b530-cf04737835d6.png">


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->


<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->


<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
