### PR TITLE
Fix issue #16612 : Back to Topics dashboard link is not bold and  aligned properly in skill editor page

### DIFF
--- a/core/templates/pages/skill-editor-page/editor-tab/skill-editor-main-tab.component.html
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-editor-main-tab.component.html
@@ -87,7 +87,7 @@
   }
 
   .skill-editor .skill-editor-info-container {
-    margin-top: 30px;
+    margin-top: 4%;
     width: 31%;
   }
 
@@ -108,11 +108,14 @@
   }
 
   .skill-editor .topic-dashboard-link {
-    font-weight: bold;
+    font-size: 15px;
+    margin-top: 3%;
+    margin-bottom: 5%;
+    margin-left: -24%;
   }
 
   .skill-editor .topic-dashboard-link a {
-    margin-left: 1%;
+    color: #015f9c;
     text-decoration: none;
   }
 

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-editor-main-tab.component.html
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-editor-main-tab.component.html
@@ -109,8 +109,8 @@
 
   .skill-editor .topic-dashboard-link {
     font-size: 15px;
-    margin-top: 3%;
     margin-bottom: 5%;
+    margin-top: 3%;
     margin-left: -24%;
   }
 

--- a/core/templates/pages/skill-editor-page/editor-tab/skill-editor-main-tab.component.html
+++ b/core/templates/pages/skill-editor-page/editor-tab/skill-editor-main-tab.component.html
@@ -110,8 +110,8 @@
   .skill-editor .topic-dashboard-link {
     font-size: 15px;
     margin-bottom: 5%;
-    margin-top: 3%;
     margin-left: -24%;
+    margin-top: 3%;
   }
 
   .skill-editor .topic-dashboard-link a {


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #16612 .
2. This PR does the following: Back to Topics dashboard link is not bold and  aligned properly in skill editor page by changing the proper css. 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
After change : 
![Topic_dashboard_link](https://user-images.githubusercontent.com/100484672/205133055-a1b25f2d-0311-4d09-9a78-1b43e5a5cde6.png)













.