### PR TITLE
Fix part of #16641: Remove secret logging from acl_decorators.py

### DIFF
--- a/core/controllers/acl_decorators.py
+++ b/core/controllers/acl_decorators.py
@@ -144,8 +144,7 @@ def is_source_mailchimp(
             *. The return value of the decorated function.
         """
         if not email_manager.verify_mailchimp_secret(secret):
-            logging.error(
-                'Invalid Mailchimp webhook request received with secret')
+            logging.error('Received invalid Mailchimp webhook secret')
             raise self.PageNotFoundException
 
         return handler(self, secret, **kwargs)

--- a/core/controllers/acl_decorators.py
+++ b/core/controllers/acl_decorators.py
@@ -145,8 +145,7 @@ def is_source_mailchimp(
         """
         if not email_manager.verify_mailchimp_secret(secret):
             logging.error(
-                'Invalid Mailchimp webhook request received with secret: %s'
-                % secret)
+                'Invalid Mailchimp webhook request received with secret')
             raise self.PageNotFoundException
 
         return handler(self, secret, **kwargs)

--- a/core/controllers/profile_test.py
+++ b/core/controllers/profile_test.py
@@ -1162,8 +1162,7 @@ class BulkEmailWebhookEndpointTests(test_utils.GenericTestBase):
                         'type': 'subscribe'
                     }, use_payload=False, expected_status_int=404)
                 self.assertIn(
-                    'Invalid Mailchimp webhook request received with secret: '
-                    'invalid_secret', captured_logs)
+                    'Received invalid Mailchimp webhook secret', captured_logs)
 
     def test_post(self) -> None:
         with self.swap_secret, self.swap_audience_id:


### PR DESCRIPTION
## Overview

1. This PR fixes part of #16641
2. This PR does the following: Remove logging of API key.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No need as this is just a logging change.

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
