### PR TITLE
Fix part of #10616: Introduced 'typescript-eslint/quotes' rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -328,11 +328,7 @@
       "never"
     ],
     "quotes": [
-      "error",
-      "single",
-      {
-        "avoidEscape": true
-      }
+      "off"
     ],
     "quote-props": [
       "error",
@@ -460,6 +456,13 @@
       "always",
       {
         "exceptAfterSingleLine": true
+      }
+    ],
+    "@typescript-eslint/quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true
       }
     ],
     "no-dupe-class-members": "off",

--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -3,7 +3,7 @@
 // "eslint disable next line" for each of them.
 /* eslint-disable oppia/no-multiline-disable */
 /* eslint-disable quote-props */
-/* eslint-disable quotes */
+/* eslint-disable  @typescript-eslint/quotes */
 /* Don't modify anything outside the {} brackets.
  * Insides of the {} brackets should be formatted as a JSON object.
  * JSON rules:

--- a/core/templates/components/ck-editor-helpers/ck-editor-copy-content.service.spec.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-copy-content.service.spec.ts
@@ -92,7 +92,7 @@ describe('Ck editor copy content service', () => {
     service.toggleCopyMode();
     expect(service.copyModeActive).toBe(true);
 
-    // eslint-disable-next-line quotes
+    // eslint-disable-next-line  @typescript-eslint/quotes
     let listHtml = `<ul><li>Parent bullet<ul><li>Child bullet<ul>\
 <li>Grandchild bullet</li></ul></li></ul></li></ul>`;
     const listElement = generateContent(listHtml);


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #10616 .
2. This PR does the following: added typescript rules for `@typescript-eslint/quotes`, updates `assets/constants.ts` and `core/templates/components/ck-editor-helpers/ck-editor-copy-content.service.spec.ts` to disable rule as it was disabled before

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
No new errors are thrown after adding the rule:
![image](https://user-images.githubusercontent.com/76408777/206791651-1a22f092-53c7-476b-959d-661056b0eb7f.png)

Frontend tests pass:
![image](https://user-images.githubusercontent.com/76408777/206796887-c59a7b2c-6e6a-4b03-bfb1-90088a187c7f.png)


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
