### PR TITLE
 Replace Material Icons with Font Awesome icons #15968 

### DIFF
--- a/core/templates/components/question-directives/questions-list/questions-list.component.html
+++ b/core/templates/components/question-directives/questions-list/questions-list.component.html
@@ -30,7 +30,7 @@
       <mat-card class="question-skill-id" *ngFor="let skill of associatedSkillSummaries">
         <div class="skill-description-card">
           <span (click)="removeSkill(skill.getId())" aria-hidden="true">
-            <i class="material-icons oppia-cross-icon md-18">&#xE14C;</i>
+            <i class="fas fa-times oppia-cross-icon md-18">&#xE14C;</i>
           </span>
           <a [attr.href]="getSkillEditorUrl(skill.getId())" target="_blank" rel="noopener">
             {{skill.getDescription()}}


### PR DESCRIPTION
![Screenshot from 2022-12-17 19-31-36](https://user-images.githubusercontent.com/86769921/208250755-e1c6e9e8-54e7-4f52-a136-3de0d066e2cd.png)

I changed the material icon to font awesome icons

![Screenshot from 2022-12-17 19-36-12](https://user-images.githubusercontent.com/86769921/208250765-4197f980-d90f-4c0f-8eb9-08892837861e.png)
