### PR TITLE
Fix #16751: [FE Flake] I18n service should reload the website if language direction changes when cookies acknowledged

### DIFF
--- a/core/templates/i18n/i18n.service.spec.ts
+++ b/core/templates/i18n/i18n.service.spec.ts
@@ -320,6 +320,12 @@ describe('I18n service', () => {
       I18nLanguageCodeService.prevLangCode = 'en';
       spyOn(windowRef.nativeWindow.location, 'reload');
       i18nService.initialize();
+      // In our code, we check if the dir cookie is set and use it to determine
+      // the window reload. If this test is run after a test that emits a rtl
+      // language in the end, we get a failed expectation. The failed expect is
+      // because we emit 'ar' which is also a 'rtl' language and hence we don't
+      // reload. To get around this in the short term we emit 'en' first and
+      // then 'ar' so that the dir value in cookie changes.
       mockI18nLanguageCodeServiceSubject.emit('en');
       expect(windowRef.nativeWindow.location.href).toBe('http://localhost:8181');
       mockI18nLanguageCodeServiceSubject.emit('ar');

--- a/core/templates/i18n/i18n.service.spec.ts
+++ b/core/templates/i18n/i18n.service.spec.ts
@@ -320,6 +320,7 @@ describe('I18n service', () => {
       I18nLanguageCodeService.prevLangCode = 'en';
       spyOn(windowRef.nativeWindow.location, 'reload');
       i18nService.initialize();
+      mockI18nLanguageCodeServiceSubject.emit('en');
       expect(windowRef.nativeWindow.location.href).toBe('http://localhost:8181');
       mockI18nLanguageCodeServiceSubject.emit('ar');
       I18nLanguageCodeService.prevLangCode = prevLangCode;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #16751.
2. This PR does the following: The test in some cases needs the cookies to initialised (not caught due to random test execution). Reveals an underlying issue in our testing module. That issue has been filed here: https://github.com/oppia/oppia/issues/16753

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
![Screenshot 2022-12-20 at 05 49 35](https://user-images.githubusercontent.com/23002114/208593415-a59bad22-04d4-4887-8c02-f776c27956bb.png)

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
