### PR TITLE
Solved issue of explore tiles sticking in community library

### DIFF
--- a/core/templates/components/summary-tile/exploration-summary-tile.component.html
+++ b/core/templates/components/summary-tile/exploration-summary-tile.component.html
@@ -9,7 +9,7 @@
   </oppia-learner-dashboard-icons>
 
   <mat-card [ngClass]="{'oppia-activity-summary-tile-mobile': isCollectionPreviewTile, 'oppia-activity-summary-tile': !isCollectionPreviewTile, 'small-width': !isWindowLarge, 'oppia-activity-playlist-tile': isPlaylistTile}"
-          *ngIf="!isRefresherExploration" [style.padding]="0" class="oppia-exploration-dashboard-card e2e-test-exploration-dashboard-card" (mouseenter)="setHoverState(true)" (mouseleave)="setHoverState(false)">
+          *ngIf="!isRefresherExploration" [style.padding]="0" class="oppia-exploration-dashboard-card e2e-test-exploration-dashboard-card" (mouseenter)="setHoverState(true)" (mouseleave)="setHoverState(false)" [ngStyle]="{'margin': '5px'}">
     <a [href]="getExplorationLink()" target="{{ openInNewWindow ? '_blank' : '_self' }}">
       <div class="title-section" [ngStyle]="{'background-color': thumbnailBgColor}">
         <img class="thumbnail-image" [src]="thumbnailIcon" alt="{{ category }}">
@@ -81,7 +81,7 @@
   </button>
 </div>
 <div *ngIf="mobileCardToBeShown">
-  <mat-card class="mobile-activity-summary-card" *ngIf="!isRefresherExploration">
+  <mat-card class="mobile-activity-summary-card" *ngIf="!isRefresherExploration" [ngStyle]="{'margin': '5px'}">
     <a [href]="getExplorationLink()" target="{{ openInNewWindow ? '_blank' : '_self' }}">
       <div class="mobile-exploration-card-image-container" [ngStyle]="{'background-color': thumbnailBgColor}">
         <img class="mobile-exploration-card-image" [src]="thumbnailIcon" alt="{{ category }}">


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #16587 .
2. This PR does the following: Exploration tiles were sticking to each other in mobile view which has been corrected. Now it will always have a margin of 5px

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

https://user-images.githubusercontent.com/91470808/209176179-8fbaae82-13c9-4077-8211-1bb763c688ca.mp4





<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
