### PR TITLE
Fix package build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,7 @@ from __future__ import annotations
 import pkg_resources
 import setuptools
 
-# The third party library path is defined in common.py,
-# which is required to import typing_extensions.
-from scripts import common # isort:skip pylint: disable=unused-import
-# Since feconf imports typing_extensions, it should be
-# imported after common is imported.
-from core import feconf # isort:skip
+from core import feconf
 
 
 def main() -> None:

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,10 @@ The package is built by running 'python setup.py sdist' in the build.py.
 
 from __future__ import annotations
 
+from core import feconf
+
 import pkg_resources
 import setuptools
-
-from core import feconf
 
 
 def main() -> None:


### PR DESCRIPTION
## Overview

1. This PR fixes #N/A
2. This PR does the following: Fix package setup by removing an unnecessary dependency. 

We do not have psutil in [requirements.in](http://requirements.in/) (we have it in [requirements_dev.in](http://requirements_dev.in/)) and setup.py calls common.py which calls servers.py which imports psutil. 

Locally, we are able to build as [requirements_dev.in](http://requirements_dev.in/) is installed but on Apache Beam, we only install [requirements.in](http://requirements.in/) (this is correct behavior as on prod we also only install [requirements.in](http://requirements.in/)). This only surfaced now because Srijan PR introduced the import of servers.py into common.py.

There is of course a need for prevention too.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
