### PR TITLE
Fix #16351: Fixed the overflow in audio header

### DIFF
--- a/core/templates/pages/exploration-player-page/layout-directives/audio-bar.component.html
+++ b/core/templates/pages/exploration-player-page/layout-directives/audio-bar.component.html
@@ -212,9 +212,9 @@
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
-    height: 44px;
+    height: auto;
     justify-content: center;
-    padding: 0 4px;
+    padding: 20px 4px;
     transition: margin-top 200ms linear;
     width: 100%;
   }
@@ -320,14 +320,10 @@
     .audio-collapse-button {
       top: 80px;
     }
-    .audio-controls {
-      height: 80px;
-    }
   }
 
   @media screen and (max-width: 550px) {
     .audio-controls {
-      height: auto;
       margin-top: -1px;
       padding: 20px 0;
       padding-right: 20px;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #16351.
2. This PR does the following: Changed the `height` to `auto` and `padding` to `20px 4px` of elements with `audio-controls` class.

I hope to get the review soon, thanks!

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop

<img width="960" alt="image" src="https://user-images.githubusercontent.com/79760854/209854587-11f8dd7e-0705-44ef-a72a-6cdd8251066e.png">

#### Proof of changes on mobile phone

<img width="236" alt="image" src="https://user-images.githubusercontent.com/79760854/209854741-9650f511-ed8f-40c7-b878-c874185c5ce5.png">


#### Proof of changes in Arabic language

<img width="955" alt="image" src="https://user-images.githubusercontent.com/79760854/209854927-66dad8ec-a911-4d47-8d97-40a991320872.png">

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
