### PR TITLE
Fix #13139: Remove mapreduce handler comments.

### DIFF
--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -1128,12 +1128,7 @@ class CheckAllHandlersHaveDecoratorTests(test_utils.GenericTestBase):
         handlers_checked = []
 
         for route in main.URLS:
-            # URLS = MAPREDUCE_HANDLERS + other handlers. MAPREDUCE_HANDLERS
-            # are tuples. So, below check is to handle them.
-            if isinstance(route, tuple):
-                continue
-            else:
-                handler = route.handler
+            handler = route.handler
 
             if handler.__name__ in self.UNDECORATED_HANDLERS:
                 continue
@@ -1556,9 +1551,7 @@ class SchemaValidationIntegrationTests(test_utils.GenericTestBase):
         Returns:
             list(RedirectRoute). A list of RedirectRoute objects.
         """
-        # TODO(#13139): Remove if condition from the list comprehension,
-        # once all the MAPREDUCE_HANDLERS are removed from the codebase.
-        return [route for route in main.URLS if not isinstance(route, tuple)]
+        return [route for route in main.URLS]
 
     def test_every_handler_class_has_schema(self) -> None:
         """This test ensures that every child class of BaseHandler


### PR DESCRIPTION
## Overview
1. This PR fixes #13139.
2. This PR does the following: Remove obsolete instances of MAPREDUCE_HANDLERS in comments, and simplify the code accordingly.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

The changes are only to a test file, so the CI run should provide adequate proof of changes.