### PR TITLE
Fix the notify GH Action

### DIFF
--- a/.github/workflows/develop_commit_notification.yml
+++ b/.github/workflows/develop_commit_notification.yml
@@ -5,7 +5,9 @@ on:
       - develop
 
 jobs:
-  send_notifications:
+  send_notification:
+    name: Send notification
+    runs-on: ubuntu-22.04
     if: github.repository == 'oppia/oppia'
     steps:
     - name: Repository Dispatch

--- a/.github/workflows/develop_commit_notification.yml
+++ b/.github/workflows/develop_commit_notification.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   send_notifications:
+    if: github.repository == 'oppia/oppia'
+    steps:
     - name: Repository Dispatch
       uses: peter-evans/repository-dispatch@v2
       with:

--- a/.github/workflows/develop_commit_notification.yml
+++ b/.github/workflows/develop_commit_notification.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   send_notifications:
-    name: Repository Dispatch
-    uses: peter-evans/repository-dispatch@v2
-    with:
-      token: ${{ secrets.REPO_ACCESS_TOKEN }}
-      repository: oppia/release-scripts
-      event-type: develop-commit
-      client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        repository: oppia/release-scripts
+        event-type: develop-commit
+        client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of https://github.com/oppia/release-scripts/issues/85
2. This PR does the following: Fix the notify GH Action

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

Not possible, needs to be merged to test this.


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
