### PR TITLE
Fixes #16903 : Brings the 'share' and 'feedback' buttons into the tab order so that they can be accessed using the keyboard.

### DIFF
--- a/core/templates/pages/exploration-player-page/layout-directives/learner-local-nav.component.html
+++ b/core/templates/pages/exploration-player-page/layout-directives/learner-local-nav.component.html
@@ -3,7 +3,7 @@
 </ng-template>
 <ul class="nav navbar-nav oppia-navbar-nav float-right mr-0">
   <li class="nav-item">
-    <span class="nav-link" ngbTooltip="Share"
+    <span tabindex="0" class="nav-link" ngbTooltip="Share"
           placement="bottom" (click)="toggleAttributionModal()">
       <i class="fas fa-share-alt exploration-player-navbar-icons"></i>
       <span class="oppia-icon-accessibility-label">Share</span>
@@ -12,7 +12,7 @@
   <li *ngIf="feedbackOptionIsShown" placement="bottom-right"
       [ngbPopover]="popContent" triggers="manual" (click)="togglePopover()"
       class="nav-item" #feedbackPopOver="ngbPopover" [autoClose]="false">
-    <div class="nav-link e2e-test-exploration-feedback-popup-link"
+    <div tabindex="0" class="nav-link e2e-test-exploration-feedback-popup-link"
        ngbTooltip="{{ 'I18N_PLAYER_FEEDBACK_TOOLTIP' | translate }}" placement="bottom">
       <i class="fas fa-comment-alt exploration-player-navbar-icons"></i>
       <span class="oppia-icon-accessibility-label">{{ 'I18N_PLAYER_FEEDBACK_TOOLTIP' | translate }}</span>


### PR DESCRIPTION
**Overview**
------------------------------------------------------------------------------------------------------------------------------------------
This PR fixes https://github.com/oppia/oppia/issues/16903 .
This PR does the following: Brings the 'share' and 'feedback' buttons into the tab order so that they can be accessed using the keyboard .


**Essential Checklist**
-------------------------------------------------------------------------------------------------------------------------------------------
- [x]  The PR title starts with "Fixes #16903 : ", followed by a short, clear summary of the changes. (https://github.com/oppia/oppia/blob/dfd35dce891d82441a343ccae333a236a5905747/core/templates/pages/exploration-player-page/layout-directives/learner-local-nav.component.html)
- [x]  The linter/Karma presubmit checks have passed locally on your machine.
- [x]  "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

  -  This lets reviewers restart your CircleCI tests for you.

- [x] The PR is made from a branch that's not called "develop".

**Proof that changes are correct**
------------------------------------------------------------------------------------------------------------------------------------------- 
![Screenshot 2023-01-14 005736](https://user-images.githubusercontent.com/102910229/212405921-d10b9d61-6ad4-4aa9-85e1-7e1342e99678.jpg)
![Screenshot 2023-01-14 005759](https://user-images.githubusercontent.com/102910229/212405936-9982b379-9f7f-46e8-9680-2ef1b2bccc59.jpg)

**PR Pointers**
---------------------------------------------------------------------------------------------------------------------------------------

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- If you need a review or an answer to a question, and don't have permissions to assign people, leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.

- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).

- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.

- Never force push. If you do, your PR will be closed.

- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).