### PR TITLE
FIX #16908 : Submit button in Feedback dialogbox must have layout ind…

### DIFF
--- a/core/templates/pages/exploration-player-page/layout-directives/feedback-popup.component.html
+++ b/core/templates/pages/exploration-player-page/layout-directives/feedback-popup.component.html
@@ -18,7 +18,7 @@
     <button mat-button class="float-right oppia-exploration-feedback-submit-btn e2e-test-exploration-feedback-submit-btn"
             [ngClass]="{'oppia-feedback-popover-submit-btn-enabled': feedbackText}"
             (click)="saveFeedback()"
-            [disabled]="!feedbackText || feedbackText.length > MAX_REVIEW_MESSAGE_LENGTH">
+            [disabled]="!feedbackText || feedbackText.length > MAX_REVIEW_MESSAGE_LENGTH" type="button" class="btn btn-primary">
       {{ 'I18N_PLAYER_SUBMIT_BUTTON' | translate }}
     </button>
     <div class="checkbox oppia-checkbox" *ngIf="isLoggedIn">


### PR DESCRIPTION
### Overview

1.This PR fixes https://github.com/oppia/oppia/issues/16908.
2.This PR does the following: Adding CSS so that Submit button in Feedback dialogbox  have layout

### Essential Checklist

- [x] The PR title starts with "Fix#16908: Submit button in Feedback dialogbox must have layout indicating its a button #16908", followed by a short, clear summary of the changes:-
(https://github.com/oppia/oppia/compare/develop...princika-rai:oppia:develop)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
This lets reviewers restart your CircleCI tests for you.
- [x]  The PR is made from a branch that's not called "develop".

### Proof that changes are correct
![image](https://user-images.githubusercontent.com/78257712/212388515-e8d210d1-b888-469c-8466-3eef69256581.png)

https://user-images.githubusercontent.com/78257712/212460480-294312a1-d35c-428e-989d-c5bf48112e60.mp4

### PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).


