### PR TITLE
Fix part of #16600: Add debugging information when byte decoding fails

### DIFF
--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -150,8 +150,21 @@ def run_shell_cmd(
     last_stdout_bytes, last_stderr_bytes = p.communicate()
     # Standard and error output is in bytes, we need to decode them to be
     # compatible with rest of the code.
-    last_stdout_str = last_stdout_bytes.decode('utf-8')
-    last_stderr_str = last_stderr_bytes.decode('utf-8')
+    try:
+        last_stdout_str = last_stdout_bytes.decode('utf-8')
+        last_stderr_str = last_stderr_bytes.decode('utf-8')
+    except UnicodeDecodeError as e:
+        # We sometimes get a UnicodeDecodeError with an "invalid continuation
+        # byte" or "invalid start byte" message, and this can sometimes happen
+        # when trying to read a non-unicode file. To help debug this issue,
+        # print some more information before failing. See #16600 for details.
+        print(
+            '[Debug invalid start/continuation byte flake] STDOUT:',
+            last_stdout_bytes)
+        print(
+            '[Debug invalid start/continuation byte flake] STDERR:',
+            last_stderr_bytes)
+        raise e
     last_stdout = last_stdout_str.split('\n')
 
     if LOG_LINE_PREFIX in last_stdout_str:

--- a/scripts/run_backend_tests.py
+++ b/scripts/run_backend_tests.py
@@ -153,7 +153,7 @@ def run_shell_cmd(
     try:
         last_stdout_str = last_stdout_bytes.decode('utf-8')
         last_stderr_str = last_stderr_bytes.decode('utf-8')
-    except UnicodeDecodeError as e:
+    except UnicodeDecodeError as e:  # pragma: no cover
         # We sometimes get a UnicodeDecodeError with an "invalid continuation
         # byte" or "invalid start byte" message, and this can sometimes happen
         # when trying to read a non-unicode file. To help debug this issue,


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #16600.
2. This PR does the following: Adds debugging information for when byte decoding fails when running backend tests.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because this flake is not easily reproducible.

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
