### PR TITLE
Removed who link from OPPIA avatar

### DIFF
--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -6220,9 +6220,6 @@ export default {
 
   "ENABLE_EXP_FEEDBACK_FOR_LOGGED_OUT_USERS": true,
 
-  // Link to open when the Oppia avatar is clicked on any page.
-  "OPPIA_AVATAR_LINK_URL": null,
-
   // Maximum allowed length of a username.
   "MAX_USERNAME_LENGTH": 30,
 

--- a/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
@@ -111,8 +111,7 @@
           <div class="oppia-outer-container">
             <div class="oppia-mascot-container">
               <div class="oppia-mascot-avatar-container">
-                <a [ngClass]="{'oppia-disabled-image-link': (OPPIA_AVATAR_LINK_URL === null)}"
-                   [href]="OPPIA_AVATAR_LINK_URL"
+                <a [ngClass]=""
                    rel="noopener"
                    target="_blank">
                   <img class="oppia-mascot-avatar"

--- a/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.ts
@@ -38,7 +38,6 @@ import { WindowRef } from 'services/contextual/window-ref.service';
 })
 export class ContributorDashboardPageComponent
   implements OnInit {
-  OPPIA_AVATAR_LINK_URL: string | null = AppConstants.OPPIA_AVATAR_LINK_URL;
   // These properties are initialized using Angular lifecycle hooks
   // and we need to do non-null assertion. For more information, see
   // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1

--- a/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.html
+++ b/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.html
@@ -1,7 +1,6 @@
 <div class="oppia-login-required-message-container">
   <div class="oppia-mascot-avatar-container">
-    <a [ngClass]="{'oppia-disabled-image-link': OPPIA_AVATAR_LINK_URL === null}"
-       [href]="OPPIA_AVATAR_LINK_URL"
+    <a [ngClass]=""
        rel="noopener"
        target="_blank">
       <img class="oppia-mascot-avatar"

--- a/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/login-required-message/login-required-message.component.ts
@@ -22,7 +22,7 @@ import { UserService } from 'services/user.service';
 import { WindowRef } from 'services/contextual/window-ref.service';
 import { Component } from '@angular/core';
 import { downgradeComponent } from '@angular/upgrade/static';
-import { AppConstants } from 'app.constants';
+// Import { AppConstants } from 'app.constants';
 
 @Component({
   selector: 'login-required-message',
@@ -34,8 +34,6 @@ export class LoginRequiredMessageComponent {
   // and we need to do non-null assertion. For more information, see
   // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
   OPPIA_AVATAR_IMAGE_URL!: string;
-  // This constant is defined as null at AppConstants.
-  OPPIA_AVATAR_LINK_URL!: string | null;
 
   constructor(
     private readonly siteAnalyticsService: SiteAnalyticsService,
@@ -44,7 +42,6 @@ export class LoginRequiredMessageComponent {
     private readonly windowRef: WindowRef) {}
 
   ngOnInit(): void {
-    this.OPPIA_AVATAR_LINK_URL = AppConstants.OPPIA_AVATAR_LINK_URL;
     this.OPPIA_AVATAR_IMAGE_URL = (
       this.urlInterpolationService.getStaticImageUrl(
         '/avatar/oppia_avatar_100px.svg'));

--- a/core/templates/pages/contributor-dashboard-page/translation-opportunities/translation-opportunities.component.html
+++ b/core/templates/pages/contributor-dashboard-page/translation-opportunities/translation-opportunities.component.html
@@ -8,8 +8,7 @@
 </div>
 <div *ngIf="!languageSelected" class="oppia-language-required-message-container">
   <div class="oppia-mascot-avatar-container">
-    <a [ngClass]="{'oppia-disabled-image-link': OPPIA_AVATAR_LINK_URL === null}"
-       [href]="OPPIA_AVATAR_LINK_URL"
+    <a [ngClass]=""
        rel="noopener"
        target="_blank">
       <img class="oppia-mascot-avatar"

--- a/core/templates/pages/contributor-dashboard-page/translation-opportunities/translation-opportunities.component.html
+++ b/core/templates/pages/contributor-dashboard-page/translation-opportunities/translation-opportunities.component.html
@@ -23,7 +23,7 @@
 </div>
 
 <style>
-  .oppia-language-required-message-container {
+  .oppia-language-required-message-container { 
     align-items: center;
     background-color: white;
     display: flex;

--- a/core/templates/pages/contributor-dashboard-page/translation-opportunities/translation-opportunities.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/translation-opportunities/translation-opportunities.component.ts
@@ -28,7 +28,7 @@ import { UserService } from 'services/user.service';
 import { TranslationModalComponent, TranslationOpportunity } from '../modal-templates/translation-modal.component';
 import { ContributionOpportunitiesService, ExplorationOpportunitiesDict } from '../services/contribution-opportunities.service';
 import { TranslateTextService } from '../services/translate-text.service';
-import { AppConstants } from 'app.constants';
+// Import { AppConstants } from 'app.constants';
 
 @Component({
   selector: 'oppia-translation-opportunities',
@@ -40,7 +40,6 @@ export class TranslationOpportunitiesComponent {
   // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
   OPPIA_AVATAR_IMAGE_URL!: string;
   // This constant is defined as null at AppConstants.
-  OPPIA_AVATAR_LINK_URL!: string | null;
 
   allOpportunities: {[id: string]: TranslationOpportunity} = {};
   userIsLoggedIn = false;
@@ -133,7 +132,6 @@ export class TranslationOpportunitiesComponent {
     if (this.translationLanguageService.getActiveLanguageCode()) {
       this.languageSelected = true;
     } else {
-      this.OPPIA_AVATAR_LINK_URL = AppConstants.OPPIA_AVATAR_LINK_URL;
       this.OPPIA_AVATAR_IMAGE_URL = (
         this.urlInterpolationService.getStaticImageUrl(
           '/avatar/oppia_avatar_100px.svg'));

--- a/core/templates/pages/contributor-dashboard-page/translation-opportunities/translation-opportunities.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/translation-opportunities/translation-opportunities.component.ts
@@ -32,7 +32,7 @@ import { TranslateTextService } from '../services/translate-text.service';
 
 @Component({
   selector: 'oppia-translation-opportunities',
-  templateUrl: './translation-opportunities.component.html',
+  templateUrl: './translation-opportunities.component.html', 
 })
 export class TranslationOpportunitiesComponent {
   // These properties are initialized using Angular lifecycle hooks

--- a/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.html
+++ b/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.html
@@ -32,8 +32,7 @@
 </div>
 
 <div class="conversation-skin-oppia-feedback-container" *ngIf="data.oppiaResponse !== '' && feedbackIsEnabled">
-  <a [ngClass]="{'oppia-disabled-image-link': (OPPIA_AVATAR_LINK_URL === null)}"
-     [href]="OPPIA_AVATAR_LINK_URL"
+  <a [ngClass]=""
      target="_blank"
      rel="noopener">
     <img class="conversation-skin-oppia-avatar rounded-circle"

--- a/core/templates/pages/exploration-player-page/learner-experience/supplemental-card.component.html
+++ b/core/templates/pages/exploration-player-page/learner-experience/supplemental-card.component.html
@@ -3,8 +3,7 @@
        class="conversation-skin-help-card help-card-standard e2e-test-conversation-skin-help-card"
        [ngStyle]="!isHelpCardTall() ? {'top': helpCardBottomPosition + 'px'} : {}"
        #helpCard>
-    <a [ngClass]="{'oppia-disabled-image-link': (OPPIA_AVATAR_LINK_URL === null)}"
-       [href]="OPPIA_AVATAR_LINK_URL"
+    <a [ngClass]=""
        target="_blank"
        rel="noopener">
       <img class="conversation-skin-oppia-avatar"

--- a/core/templates/pages/exploration-player-page/learner-experience/supplemental-card.component.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/supplemental-card.component.ts
@@ -18,7 +18,7 @@
 
 import { Component, Output, EventEmitter, Input, OnInit, OnDestroy, ElementRef, ViewChild, ChangeDetectorRef, SimpleChanges } from '@angular/core';
 import { downgradeComponent } from '@angular/upgrade/static';
-import { AppConstants } from 'app.constants';
+// Import { AppConstants } from 'app.constants';
 import { StateCard } from 'domain/state_card/state-card.model';
 import { UrlInterpolationService } from 'domain/utilities/url-interpolation.service';
 import { Subscription } from 'rxjs';
@@ -58,7 +58,6 @@ export class SupplementalCardComponent implements OnInit, OnDestroy {
   lastAnswer: string | null = null;
   maxHelpCardHeightSeen: number = 0;
   helpCardHasContinueButton: boolean = false;
-  OPPIA_AVATAR_LINK_URL = AppConstants.OPPIA_AVATAR_LINK_URL;
   CONTINUE_BUTTON_FOCUS_LABEL: string = (
     ExplorationPlayerConstants.CONTINUE_BUTTON_FOCUS_LABEL);
 

--- a/core/templates/pages/exploration-player-page/learner-experience/tutor-card.component.html
+++ b/core/templates/pages/exploration-player-page/learner-experience/tutor-card.component.html
@@ -12,8 +12,7 @@
        [ngClass]="{'learner-view-card-transition-class': isOnTerminalCard(), 'card-content-hidden': !checkMarkHidden}">
     <div class="oppia-learner-view-card-top-section">
       <oppia-content-language-selector></oppia-content-language-selector>
-      <a [ngClass]="{'oppia-disabled-image-link': (OPPIA_AVATAR_LINK_URL === null)}"
-         [href]="OPPIA_AVATAR_LINK_URL"
+      <a [ngClass]=""
          target="_blank"
          rel="noopener">
         <img class="conversation-skin-oppia-avatar"

--- a/core/templates/pages/exploration-player-page/learner-experience/tutor-card.component.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/tutor-card.component.ts
@@ -129,7 +129,6 @@ export class TutorCardComponent {
   isIframed!: boolean;
   getCanAskLearnerForAnswerInfo!: () => boolean;
   OPPIA_AVATAR_IMAGE_URL!: string;
-  OPPIA_AVATAR_LINK_URL!: string | null;
   profilePicture!: string;
   directiveSubscriptions = new Subscription();
   arePreviousResponsesShown: boolean = false;
@@ -171,7 +170,6 @@ export class TutorCardComponent {
     this.OPPIA_AVATAR_IMAGE_URL = (
       this.urlInterpolationService
         .getStaticImageUrl('/avatar/oppia_avatar_100px.svg'));
-    this.OPPIA_AVATAR_LINK_URL = AppConstants.OPPIA_AVATAR_LINK_URL;
 
     this.profilePicture = this.urlInterpolationService
       .getStaticImageUrl('/avatar/user_blue_72px.png');


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #16294 
2. This PR does the following: removes the WHO link fromOPPIA Avatar

https://user-images.githubusercontent.com/118007662/212941455-44f5f18b-ce06-4b80-b3e6-ea24c8b618cc.mp4



## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
Earlier when we use to click in the OPPIA avatar link it redirects to the WHO page  but now the I have removed that link and
the issue has been resolved proof has been indicated in the overview section. I have recreated that exploration on my local device that's why it is looking like this when you will remove that link from your server it will look like this

https://user-images.githubusercontent.com/118007662/212943769-918dc4a3-10aa-44ca-8a16-1a8cd6152f20.mp4



References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->


<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
