### PR TITLE
Fix bug #17023 | It adds h1 tag to main heading and h2 to subheading

### DIFF
--- a/core/templates/pages/preferences-page/preferences-page.component.html
+++ b/core/templates/pages/preferences-page/preferences-page.component.html
@@ -1,11 +1,13 @@
 <background-banner></background-banner>
 <div class="oppia-dashboard-container ng-scope">
-  <h2 class="oppia-preferences-page-heading e2e-test-preferences-title">
+  <h1 class="oppia-preferences-page-heading e2e-test-preferences-title">
       {{ 'I18N_PREFERENCES_HEADING' | translate }}
-  </h2>
+  </h1>
   <em>
-    <div class="oppia-preferences-page-heading-subtext">
-      {{ 'I18N_PREFERENCES_HEADING_SUBTEXT' | translate }}
+    <div>
+      <h2 class="oppia-preferences-page-heading-subtext">
+        {{ 'I18N_PREFERENCES_HEADING_SUBTEXT' | translate }}
+      </h2>
     </div>
   </em>
   <mat-card class="oppia-page-card">


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #17023 
2. This PR does the following: 
- **Replaced** `h2` tag at **line 3** with `h1` ( as it is the main heading ).
- **Added** `h2` tag to the sub-heading at **line 8**.
- Removed the class -"oppia-preferences-page-heading-subtext", from the div present at line 7 which is containing the h2 tag.
- Added class -"oppia-preferences-page-heading-subtext", to the `h2` tag.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".


