### PR TITLE
Fix #17023: Adds h1 to main heading and h2 to subheading in preferences.

### DIFF
--- a/core/templates/pages/preferences-page/preferences-page.component.html
+++ b/core/templates/pages/preferences-page/preferences-page.component.html
@@ -1,11 +1,13 @@
 <background-banner></background-banner>
 <div class="oppia-dashboard-container ng-scope">
-  <h2 class="oppia-preferences-page-heading e2e-test-preferences-title">
+  <h1 class="oppia-preferences-page-heading e2e-test-preferences-title">
       {{ 'I18N_PREFERENCES_HEADING' | translate }}
-  </h2>
+  </h1>
   <em>
-    <div class="oppia-preferences-page-heading-subtext">
-      {{ 'I18N_PREFERENCES_HEADING_SUBTEXT' | translate }}
+    <div>
+      <h2 class="oppia-preferences-page-heading-subtext">
+        {{ 'I18N_PREFERENCES_HEADING_SUBTEXT' | translate }}
+      </h2>
     </div>
   </em>
   <mat-card class="oppia-page-card">


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #17023 
2. This PR does the following: 
- Main heading was not having h1 tag and subheading was not having h2 tag.
- **Replaced** `h2` tag at **line 3** with `h1` ( as it is the main heading ).
- **Added** `h2` tag to the sub-heading at **line 8**.
- Removed the class -"oppia-preferences-page-heading-subtext", from the div present at line 7 which is containing the h2 tag.
- Added class -"oppia-preferences-page-heading-subtext", to the `h2` tag.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
<img width="960" alt="Screenshot_20230119_155213" src="https://user-images.githubusercontent.com/96219910/213419147-38a450de-0624-4e56-adc1-43389b58ec61.png">


<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
<img width="959" alt="Screenshot_20230119_155733" src="https://user-images.githubusercontent.com/96219910/213419263-d89de55d-2fd6-4552-aec1-57b52a3f5eea.png">

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language
<img width="960" alt="Screenshot_20230119_155532" src="https://user-images.githubusercontent.com/96219910/213419342-fbbd3732-507e-438c-bf1f-2a5068e5bcf5.png">

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
