### PR TITLE
change material icon with fontawesome icons #15968

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/opportunities-list/opportunities-list.component.html
+++ b/core/templates/pages/contributor-dashboard-page/opportunities-list/opportunities-list.component.html
@@ -18,13 +18,13 @@
             class="oppia-pagination-button"
             (click)="gotoPage(activePageNumber - 1)"
             [disabled]="activePageNumber == 1">
-      <span class="material-icons">navigate_before</span>Previous
+            <i class="fa-solid fa-angle-left"></i>
     </button>
     <button type="button"
             class="oppia-pagination-button"
             (click)="gotoPage(activePageNumber + 1)"
             [disabled]="loadingOpportunityData || userIsOnLastPage">
-      Next<span class="material-icons">navigate_next</span>
+      Next<i class="fa-solid fa-angle-right"></i>
     </button>
   </div>
   <div class="oppia-end-availability" [hidden]="!(visibleOpportunities.length === 0 && !loadingOpportunityData)">
@@ -92,3 +92,4 @@
     }
   }
 </style>
+<script src="https://kit.fontawesome.com/f1e162f77d.js" crossorigin="anonymous"></script>

--- a/core/templates/pages/contributor-dashboard-page/translation-language-selector/translation-language-selector.component.html
+++ b/core/templates/pages/contributor-dashboard-page/translation-language-selector/translation-language-selector.component.html
@@ -20,9 +20,8 @@
            [(ngModel)]="optionsFilter"
            (input)="filterOptions()"
            autofocus>
-    <div class="material-icons oppia-translation-language-selector-inner-container-arrow" (click)="toggleDropdown()">
-      arrow_drop_down
-    </div>
+           <i class="fa-solid fa-caret-down oppia-translation-language-selector-inner-container-arrow" (click)="toggleDropdown()"></i>
+     
 
     <div class="oppia-translation-language-selector-dropdown-options-container">
       <div *ngIf="featuredLanguages.length > 0" class="e2e-test-featured-language-container">
@@ -32,12 +31,12 @@
                *ngIf="languageIdToDescription[featuredOption.languageCode]"
                (click)="selectOption(featuredOption.languageCode)"
                [ngClass]="{'oppia-translation-language-selector-dropdown-option-selected' : featuredOption.languageCode === activeLanguageCode}">
-            <span class="material-icons oppia-translation-language-selector-info-icon e2e-test-featured-language-tooltip"
+               <i class="fa-solid fa-circle-info oppia-translation-language-selector-info-icon e2e-test-featured-language-tooltip">
                   *ngIf="featuredOption.explanation"
                   (mouseenter)="showExplanationPopup(i)"
                   (mouseleave)="hideExplanationPopup()">
-              info
-            </span>
+              
+            </i>
             {{languageIdToDescription[featuredOption.languageCode]}}
           </div>
         </div>
@@ -172,3 +171,4 @@
     width: calc(100% - 32px);
   }
 </style>
+<script src="https://kit.fontawesome.com/f1e162f77d.js" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of oppia/core/templates/pages/contributor-dashboard-page/opportunities-list/opportunities-list.component.html
oppia/core/templates/pages/contributor-dashboard-page/translation-language-selector/translation-language-selector.component.html
oppia/core/templates/pages/exploration-editor-page/exploration-editor-page.component.html
3. This PR changes the material icon in the file with the font awesome icons.

## Proof that changes are correct

Icons I have changes are
![Screenshot (181)](https://user-images.githubusercontent.com/98754072/213520700-d8458a1f-1ba6-44cb-a8b0-5c484e70eecb.png)
![Screenshot (186)](https://user-images.githubusercontent.com/98754072/213520777-9451c199-2f59-4963-ac2c-1bf09641e3e0.png)
![Screenshot (188)](https://u
![Screenshot (190)](https://user-images.githubusercontent.com/98754072/213520833-835e933e-0036-403c-bb36-689052322ba3.png)
ser-images.githubusercontent.com/98754072/213520820-ad2f42e5-acc1-4ad5-a5a0-761a335a2ae6.png)
Icons which I have changed to

![Screenshot (185)](https://user-images.githubusercontent.com/98754072/213520914-22de6213-4e0a-45b3-9a9e-f4fd1da07e11
![Screenshot (191)](https://user-images.githubusercontent.com/98754072/213520954-36237220-3c6c-4901-87b6-5d98c25ebfbc.png)

![Screenshot (189)](https://user-images.githubusercontent.com/98754072/213520942-45011daf-8eb1-4022-8a2d-7834b1f7a562.png)
.png)
![Screenshot (187)](https://user-images.githubusercontent.com/98754072/213520932-f68c6fc2-da02-4a0c-b4c3-33eca138cf78.png)
