### PR TITLE
updated "noImplicitUseStrict": true, to ignore deprecations:5.0 as it is no longer functional in newer versions.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "downlevelIteration": true,
     "lib": ["es2017", "dom", "webworker"],
     "module": "es2020",
-    "noImplicitUseStrict": true,
+    "ignoreDeprecations": "5.0",
     "outDir": "local_compiled_js_for_test",
     "rootDir": ".",
     "target": "es6",


### PR DESCRIPTION
In tsconfig.json file, 
"noImplicitUseStrict": true, was deprecated in typescript 5.5. So, it was updated to "ignoreDeprecations": "5.0".
Also, I am a noob in contributing to larger open-source projects, so please give your valuable feedbacks on my work.