### PR TITLE
Add WordCount Plugin to CKEditor

### DIFF
--- a/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
+++ b/core/templates/components/ck-editor-helpers/ck-editor-4-rte.component.ts
@@ -355,6 +355,15 @@ export class CkEditor4RteComponent implements AfterViewInit, OnChanges,
     CKEDITOR.plugins.addExternal(
       'pre', '/extensions/ckeditor_plugins/pre/', 'plugin.js');
 
+    // CKEDITOR.plugins.addExternal(
+    //   'wordCount',
+    //   // '/third_party/static/ckeditor-4.12.1/plugins/wordcount/',
+    //   // '/third_party/static/ckeditor-bootstrapck-1.0.0/plugins/wordcount/',
+    //   '/extensions/ckeditor_plugins/wordcount/',
+    //   'plugin.js'
+    // );
+
+
     const sharedSpaces = {
       top: (
         this.elementRef.nativeElement.children[0].children[0] as HTMLElement)
@@ -469,7 +478,8 @@ export class CkEditor4RteComponent implements AfterViewInit, OnChanges,
       if (ck.getData() === this.value) {
         return;
       }
-
+      // This console.log gives error, with wordCount not found
+      // console.log(CKEDITOR.instances.editor1.wordCount.wordCount);
       // TODO(#12882): Remove the use of jQuery.
       var elt = $('<div>' + ck.getData() + '</div>');
       var textElt = elt[0].childNodes;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #16728 
2. This PR does the following: Integrates CKEditor plugin

I am getting stuck while integrating the **WordCount and CharCount Plugin** for counting the number of characters in the CKEditor.
I have tried following the procedure given in https://ckeditor.com/cke4/addon/wordcount, and added the required changes in the third_party/static/ckeditor-4.12.1/config.js file (it was git ignored so could not commit), and tried querying the wordcount, as given in the doc, in the commented line 482 of the committed file, which gave an error.

Thereafter I also tried adding the plugin in a similar manner to the **plugin 'pre'**, as you can see in lines 358 to 366 of the committed file, still the query to wordcount was unsuccessful.

Please guide me if I am missing out any step.


## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
