### PR TITLE
#16351 issue fixed : Text and header overlap issue has been solved

### DIFF
--- a/core/templates/pages/exploration-player-page/layout-directives/audio-bar.component.html
+++ b/core/templates/pages/exploration-player-page/layout-directives/audio-bar.component.html
@@ -1,5 +1,5 @@
 <div class="audio-header" *ngIf="isAudioBarAvailable()"
-     [ngClass]="{'audio-header-margin': explorationPlayerModeIsActive}" headroom>
+  [ngClass]="{'audio-header-margin': explorationPlayerModeIsActive}" headroom>
   <div *ngIf="audioBarIsExpanded" class="audio-bar-expanded" headroom>
     <div class="audio-controls" [ngClass]="{'audio-controls-margin': progressBarIsShown}">
       <div class="oppia-audio-header-control-buttons fx-row fx-main-center fx-cross-center">
@@ -11,10 +11,10 @@
             </span>
           </a>
           <a (click)="onPlayButtonClicked()"
-             [ngbTooltip]="!isAudioAvailableInCurrentLanguage() ? ('I18N_PLAYER_AUDIO_NOT_AVAILABLE_IN' | translate:{languageDescription:getCurrentAudioLanguageDescription()}) : ''"
-             placement="right">
+            [ngbTooltip]="!isAudioAvailableInCurrentLanguage() ? ('I18N_PLAYER_AUDIO_NOT_AVAILABLE_IN' | translate:{languageDescription:getCurrentAudioLanguageDescription()}) : ''"
+            placement="right">
             <i class="fas oppia-audio-controls-button-icon" tabindex="0"
-               [ngClass]="{'fa-ellipsis-h': audioLoadingIndicatorIsShown, 'fa-play-circle e2e-test-play-circle': !isAudioPlaying(), 'fa-pause-circle e2e-test-pause-circle': isAudioPlaying(), 'audio-controls-audio-not-available': !isAudioAvailableInCurrentLanguage() || audioIsLoading}">
+              [ngClass]="{'fa-ellipsis-h': audioLoadingIndicatorIsShown, 'fa-play-circle e2e-test-play-circle': !isAudioPlaying(), 'fa-pause-circle e2e-test-pause-circle': isAudioPlaying(), 'audio-controls-audio-not-available': !isAudioAvailableInCurrentLanguage() || audioIsLoading}">
             </i>
           </a>
           <a (click)="onForwardButtonClicked()">
@@ -30,43 +30,36 @@
           </div>
           <div *ngIf="!audioLoadingIndicatorIsShown">
             <oppia-audio-slider [value]="audioPlayerService.getCurrentTime()"
-                                [max]="audioPlayerService.getAudioDuration()"
-                                (valueChange)="setProgress($event)"
-                                aria-label="audio-slider">
+              [max]="audioPlayerService.getAudioDuration()" (valueChange)="setProgress($event)"
+              aria-label="audio-slider">
             </oppia-audio-slider>
           </div>
           <span *ngIf="audioLoadingIndicatorIsShown && !doesCurrentAudioTranslationNeedUpdate()"
-                class="audio-controls-message">
+            class="audio-controls-message">
             {{ 'I18N_PLAYER_AUDIO_LOADING_AUDIO' | translate }}
           </span>
           <span *ngIf="isAudioAvailableInCurrentLanguage() && doesCurrentAudioTranslationNeedUpdate()"
-                class="audio-controls-message">
+            class="audio-controls-message">
             {{ 'I18N_PLAYER_AUDIO_MIGHT_NOT_MATCH_TEXT' | translate }}
           </span>
           <!--Filler space for message-->
           <span class="audio-controls-message">&zwnj;</span>
         </div>
         <div class="oppia-audio-header-select">
-          <select class="audio-language-select e2e-test-audio-lang-select"
-                  [(ngModel)]="selectedLanguage.value"
-                  (change)="onNewLanguageSelected()">
+          <select class="audio-language-select e2e-test-audio-lang-select" [(ngModel)]="selectedLanguage.value"
+            (change)="onNewLanguageSelected()">
             <option *ngFor="let opt of languagesInExploration" [value]="opt.value">{{ opt.displayed }}</option>
           </select>
         </div>
       </div>
     </div>
-    <div class="audio-collapse-button audio-toggle-button"
-         *ngIf="audioBarIsExpanded"
-         (click)="collapseAudioBar()"
-         aria-label="Audio menu collapse"
-         [ngClass]="{'audio-controls-margin': progressBarIsShown}">
+    <div class="audio-collapse-button audio-toggle-button" *ngIf="audioBarIsExpanded" (click)="collapseAudioBar()"
+      aria-label="Audio menu collapse" [ngClass]="{'audio-controls-margin': progressBarIsShown}">
       <i class="fas fa-sort-up"></i>
     </div>
   </div>
-  <div class="audio-expand-button audio-toggle-button"
-       *ngIf="!audioBarIsExpanded"
-       (click)="expandAudioBar()"
-       aria-label="Audio menu expand">
+  <div class="audio-expand-button audio-toggle-button" *ngIf="!audioBarIsExpanded" (click)="expandAudioBar()"
+    aria-label="Audio menu expand">
     <div class="container e2e-test-audio-bar">
       <div class="row">
         <div class="col-lg-6 px-0 mt-1 ml-2">
@@ -107,7 +100,8 @@
     border-color: #009688;
   }
 
-  .audio-header .fa-sort-up, .audio-header .fa-sort-down {
+  .audio-header .fa-sort-up,
+  .audio-header .fa-sort-down {
     transform: translateY(-2px);
   }
 
@@ -121,6 +115,7 @@
       height: 32px;
       width: 90px;
     }
+
     .audio-expand-button-text {
       display: none;
     }
@@ -157,12 +152,14 @@
     text-align: right;
     vertical-align: middle;
   }
+
   .oppia-audio-header-control-buttons {
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
     width: 700px;
   }
+
   .oppia-replay-white-circle {
     display: inline-block;
     font-size: 1.4em;
@@ -172,6 +169,7 @@
     vertical-align: middle;
     width: 36px;
   }
+
   .audio-undo-icon {
     color: #fff;
     left: 50%;
@@ -180,12 +178,15 @@
     top: 7px;
     transform: translateX(-43%);
   }
+
   .audio-undo-icon-forward {
     transform: scaleX(-1) translateX(43%);
   }
+
   .oppia-audio-header-select {
     transform: translateY(5px);
   }
+
   .oppia-five-icon {
     bottom: 7px;
     color: #fff;
@@ -194,9 +195,11 @@
     left: 3px;
     position: relative;
   }
+
   .oppia-five-icon-forward {
     left: 0;
   }
+
   .audio-controls-button-image {
     height: 21px;
     width: 21px;
@@ -274,6 +277,7 @@
       top: 0;
     }
   }
+
   .audio-language-select {
     border-radius: 9px;
     font-size: 15px;
@@ -299,30 +303,52 @@
     .oppia-audio-header-control-buttons {
       justify-content: space-evenly;
     }
+
     .oppia-replay-white-circle {
       padding: 5px;
       width: 26px;
     }
+
     .oppia-audio-header-select select {
       width: 100%;
     }
+
     .audio-header-control-icons {
       order: 2;
     }
+
     .slider-section {
       order: 1;
       width: 90%;
     }
+
+    
+    .slider-section ng-star-inserted {
+      align-items: center;
+      margin-top: -20px;
+      display: flex;
+    }
+
     .oppia-audio-header-select {
       order: 3;
       width: 50%;
     }
+
     .audio-collapse-button {
       top: 80px;
     }
+
     .audio-controls {
       height: 80px;
     }
+
+    .audio-controls audio-control-margin {
+      height: 100px;
+    }
+
+    
+
+
   }
 
   @media screen and (max-width: 550px) {
@@ -332,17 +358,21 @@
       padding: 20px 0;
       padding-right: 20px;
     }
+
     .slider-section {
       transform: translateY(4px);
     }
+
     .audio-collapse-button {
       top: 98px;
     }
+
     .audio-header-control-icons {
       display: flex;
       flex-wrap: wrap;
       justify-content: space-between;
     }
+
     .oppia-audio-controls-button-icon {
       font-size: 1.1em;
       margin: 0 20px;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: [Explain here what your PR does and why]

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
