### PR TITLE
Fix #14464  - Remove null as a possible option for interactionId

### DIFF
--- a/core/templates/domain/exploration/InteractionObjectFactory.ts
+++ b/core/templates/domain/exploration/InteractionObjectFactory.ts
@@ -399,12 +399,13 @@ export class InteractionObjectFactory {
   }
 
   convertFromCustomizationArgsBackendDict(
-      interactionId: string | null,
+      interactionId: string,
       caBackendDict: InteractionCustomizationArgsBackendDict
   ): InteractionCustomizationArgs {
-    if (interactionId === null) {
-      return {};
-    }
+    //This code is commented because interactionId can never be null 
+    // if (interactionId === null) {
+    //   return {};
+    // }
     switch (interactionId) {
       case 'AlgebraicExpressionInput':
         return (
@@ -486,7 +487,7 @@ export class InteractionObjectFactory {
 
   createAnswerGroupsFromBackendDict(
       answerGroupBackendDicts: readonly AnswerGroupBackendDict[],
-      interactionId: string | null
+      interactionId: string
   ): AnswerGroup[] {
     return answerGroupBackendDicts.map((
         answerGroupBackendDict) => {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #14464 .
2. This PR does the following: This commit updates the interactionId parameter in the InteractionObjectFactory class to be a string instead of being either a string or null. The corresponding tests were also updated to verify that the change does not break the functionality of the code.

This change is necessary to ensure that the interactionId parameter is always a string and never null, which was causing issues in the code. With this change, the code is now more robust and better-defined.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
No proof of changes needed because changed only a variable.This PR does not add any new Logic it only updates the parameters which are already tested.


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
