### PR TITLE
Fix #12062 Sends email notification to contributors when they are added to the submit question allowlist 

### DIFF
--- a/core/controllers/contributor_dashboard_admin.py
+++ b/core/controllers/contributor_dashboard_admin.py
@@ -174,7 +174,7 @@ class ContributionRightsHandler(
                         username))
             user_services.allow_user_to_submit_question(user_id)
             email_manager.send_email_to_new_contribution_submit_questions(
-                user_id, category, language_code=language_code)
+                user_id, category)
 
         if category in [
                 constants.CONTRIBUTION_RIGHT_CATEGORY_REVIEW_TRANSLATION,

--- a/core/controllers/contributor_dashboard_admin.py
+++ b/core/controllers/contributor_dashboard_admin.py
@@ -173,6 +173,8 @@ class ContributionRightsHandler(
                     'User %s already has rights to submit question.' % (
                         username))
             user_services.allow_user_to_submit_question(user_id)
+            email_manager.send_email_to_new_contribution_submit_questions(
+                user_id, category, language_code=language_code)
 
         if category in [
                 constants.CONTRIBUTION_RIGHT_CATEGORY_REVIEW_TRANSLATION,

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -2157,7 +2157,7 @@ def send_email_to_new_contribution_submit_questions(
 
     Args:
         recipient_id: str. The ID of the user.
-        review_category: str. submit_question.
+        review_category: str. Submit questions.
 
     Raises:
         Exception. The review category is not valid.

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -2157,7 +2157,7 @@ def send_email_to_new_contribution_submit_questions(
 
     Args:
         recipient_id: str. The ID of the user.
-        review_category: str. submit_question.        
+        review_category: str. submit_question.
 
     Raises:
         Exception. The review category is not valid.
@@ -2168,7 +2168,6 @@ def send_email_to_new_contribution_submit_questions(
     review_category_data = NEW_REVIEWER_EMAIL_DATA[review_category]
     email_subject = 'You have been invited at Oppia to %s' % (
         review_category_data['description'])
-
 
     email_body_template = (
         'Hi %s,<br><br>'

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -79,10 +79,10 @@ NEW_REVIEWER_EMAIL_DATA: Dict[str, Dict[str, str]] = {
         'description': 'questions',
         'rights_message': 'review question suggestions made by contributors'
     },
-    constants.CONTRIBUTION_RIGHT_CATEGORY_SUBMIT_QUESTIONS:{
-        'review_category' : 'submit_question',
-        'description':'submit questions',
-        'right_message':'contributors submit questions'
+    constants.CONTRIBUTION_RIGHT_CATEGORY_SUBMIT_QUESTIONS: {
+        'review_category': 'submit_question',
+        'description': 'submit questions',
+        'right_message': 'contributors submit questions'
 
     }
 }
@@ -2152,14 +2152,12 @@ def send_email_to_new_contribution_reviewer(
 def send_email_to_new_contribution_submit_questions(
     recipient_id: str,
     review_category: str,
-    language_code: Optional[str] = None
 ) -> None:
     """Sends an email to user who is assigned to submit questions.
 
     Args:
         recipient_id: str. The ID of the user.
-        review_category: str. submit_question.
-        
+        review_category: str. submit_question.        
 
     Raises:
         Exception. The review category is not valid.

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -78,6 +78,12 @@ NEW_REVIEWER_EMAIL_DATA: Dict[str, Dict[str, str]] = {
         'to_check': 'question suggestions',
         'description': 'questions',
         'rights_message': 'review question suggestions made by contributors'
+    },
+    constants.CONTRIBUTION_RIGHT_CATEGORY_SUBMIT_QUESTIONS:{
+        'review_category' : 'submit_question',
+        'description':'submit questions',
+        'right_message':'contributors submit questions'
+
     }
 }
 
@@ -2137,6 +2143,58 @@ def send_email_to_new_contribution_reviewer(
         email_body = email_body_template % (
             recipient_username, review_category_description,
             reviewer_rights_message, to_review)
+        _send_email(
+            recipient_id, feconf.SYSTEM_COMMITTER_ID,
+            feconf.EMAIL_INTENT_ONBOARD_REVIEWER, email_subject, email_body,
+            feconf.NOREPLY_EMAIL_ADDRESS)
+
+
+def send_email_to_new_contribution_submit_questions(
+    recipient_id: str,
+    review_category: str,
+    language_code: Optional[str] = None
+) -> None:
+    """Sends an email to user who is assigned to submit questions.
+
+    Args:
+        recipient_id: str. The ID of the user.
+        review_category: str. submit_question.
+        
+
+    Raises:
+        Exception. The review category is not valid.
+    """
+    if review_category not in NEW_REVIEWER_EMAIL_DATA:
+        raise Exception('Invalid review_category: %s' % review_category)
+
+    review_category_data = NEW_REVIEWER_EMAIL_DATA[review_category]
+    email_subject = 'You have been invited at Oppia to %s' % (
+        review_category_data['description'])
+
+
+    email_body_template = (
+        'Hi %s,<br><br>'
+        'This is to let you know that the Oppia team has granted you '
+        'the rights to  %s.<br><br>'
+        'Link to the '
+        '<a href="https://www.oppia.org/contributor-dashboard">'
+        'Contributor Dashboard</a>.<br><br>'
+        'Thanks, and happy contributing!<br><br>'
+        'Best wishes,<br>'
+        'The Oppia Community')
+
+    if not feconf.CAN_SEND_EMAILS:
+        logging.error('This app cannot send emails to users.')
+        return
+
+    recipient_username = user_services.get_username(recipient_id)
+    can_user_receive_email = user_services.get_email_preferences(
+        recipient_id).can_receive_email_updates
+
+    # Send email only if recipient wants to receive.
+    if can_user_receive_email:
+        email_body = email_body_template % (
+            recipient_username, review_category_data['description'])
         _send_email(
             recipient_id, feconf.SYSTEM_COMMITTER_ID,
             feconf.EMAIL_INTENT_ONBOARD_REVIEWER, email_subject, email_body,

--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -79,7 +79,7 @@ NEW_REVIEWER_EMAIL_DATA: Dict[str, Dict[str, str]] = {
         'description': 'questions',
         'rights_message': 'review question suggestions made by contributors'
     },
-    constants.CONTRIBUTION_RIGHT_CATEGORY_SUBMIT_QUESTIONS: {
+    constants.CONTRIBUTION_RIGHT_CATEGORY_SUBMIT_QUESTION: {
         'review_category': 'submit_question',
         'description': 'submit questions',
         'right_message': 'contributors submit questions'


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[12062].
2. This PR does the following: [send an email notification when contributors are granted rights to submit questions in the contributor dashboard.]

## Essential Checklist

- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The linter/Karma presubmit checks have passed locally on your machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [X] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
i have added temporary print statements to check if the function encounters any errors in the mid way. output on the terminal window shows that the function ran perfectly i have also printed the email body data in the terminal for debugging purpose

NOTE :  1)i  have used this tedious approach of adding print statements for debugging because i didn't have the access to the email where i could see the inbox to see the actual mail received 
2)I had temporary made CAN_SEND_EMAILS = True inside feconf.py
![image](https://user-images.githubusercontent.com/86470881/217596529-b95216e8-de81-43ab-998c-18a82a32a5dc.png)
![image](https://user-images.githubusercontent.com/86470881/217597060-99407b04-d6c6-49c9-8163-3c957b0e20b1.png)
![image](https://user-images.githubusercontent.com/86470881/217597177-5c26985f-88a5-4526-ad08-90d43ec86532.png)


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
