### PR TITLE
Fix #17338: Replace htmllint-cli dependency SSH URL with HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.0.3",
     "htmllint": "^0.8.0",
-    "htmllint-cli": "github:oppia/htmllint-cli#01a8b74",
+    "htmllint-cli": "git+https://github.com/oppia/htmllint-cli#01a8b74",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jasmine-core": "^3.5.0",
     "jasmine-spec-reporter": "^7.0.0",


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->
This PR fixes the error during starting of the server, in package.json
which is caused by use of SSH git URL in "htmllint-cli": "github:oppia/htmllint-cli#01a8b74".
## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

##Before:
showing the error "Could not read from remote repository." 
![image](https://user-images.githubusercontent.com/95924468/218320774-05edbda8-bd6f-4468-b8a5-8a39b227a72d.png)
##After:
I am able to run the server locally.


