### PR TITLE
Fixes #17349 : Now Submit button or Clear button stable in our right position in music play exploration

### DIFF
--- a/extensions/interactions/MusicNotesInput/static/music_notes_input.css
+++ b/extensions/interactions/MusicNotesInput/static/music_notes_input.css
@@ -108,6 +108,7 @@
 
 .oppia-music-input-control-buttons {
   padding: 40% 0 5% 2%;
+  width: 340px;
 }
 
 .oppia-music-input-btn {


### PR DESCRIPTION
**Overview**
------------------------------------------------------------------------------------------------------------------------------------------
This PR fixes https://github.com/oppia/oppia/issues/17349 .
This PR does the following: Now Submit button or Clear button stable in our right position .


**Essential Checklist**
-------------------------------------------------------------------------------------------------------------------------------------------
- [x]  The PR title starts with "Fixes #17349   : ", followed by a short, clear summary of the changes. (https://github.com/oppia/oppia/blob/f0fa5752337ae3461e460fb86d98f60a06a36d27/extensions/interactions/MusicNotesInput/static/music_notes_input.css)
- [x]  The linter/Karma presubmit checks have passed locally on your machine.
- [x]  "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

  -  This lets reviewers restart your CircleCI tests for you.

- [x] The PR is made from a branch that's not called "develop".

**Proof that changes are correct**
------------------------------------------------------------------------------------------------------------------------------------------- 

![Screenshot 2023-02-14 035345](https://user-images.githubusercontent.com/102910229/218590834-1256e7ac-6717-4674-a28c-7e0211261394.png)
![Screenshot 2](https://user-images.githubusercontent.com/102910229/218590851-787ac99a-7042-446a-9d03-02868096c2b6.png)




**PR Pointers**
---------------------------------------------------------------------------------------------------------------------------------------

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).

- If you need a review or an answer to a question, and don't have permissions to assign people, leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.

- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).

- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.

- Never force push. If you do, your PR will be closed.

- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).