### PR TITLE
Feature 11434 computer aided translations in contributor dashboard

### DIFF
--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -5898,6 +5898,8 @@ export default {
     "\\u001b", "\\u001c", "\\u001d", "\\u001e", "\\u001f"
   ],
 
+  "ALLOWED_MACHINE_TRANSLATION_LANGUAGE_CODES": ["en", "es", "fr", "zh", "pt"],
+
   "DEFAULT_SKILL_DIFFICULTY": 0.6,
 
   "INLINE_RTE_COMPONENTS": ["link", "math", "skillreview"],

--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -5898,7 +5898,7 @@ export default {
     "\\u001b", "\\u001c", "\\u001d", "\\u001e", "\\u001f"
   ],
 
-  "ALLOWED_MACHINE_TRANSLATION_LANGUAGE_CODES": ["en", "es", "fr", "zh", "pt"],
+  "ALLOWED_MACHINE_TRANSLATION_LANGUAGE_CODES": ["en", "es", "fr", "pt", "zh"],
 
   "DEFAULT_SKILL_DIFFICULTY": 0.6,
 

--- a/core/platform/translate/cloud_translate_services.py
+++ b/core/platform/translate/cloud_translate_services.py
@@ -56,10 +56,14 @@ def translate_text(
     Returns:
         str. The translated text.
     """
-    if source_language not in constants.ALLOWED_MACHINE_TRANSLATION_LANGUAGE_CODES:
+    if source_language not in (
+        constants.ALLOWED_MACHINE_TRANSLATION_LANGUAGE_CODES):
         raise ValueError('Invalid source language code: %s' % source_language)
-    if target_language not in constants.ALLOWED_MACHINE_TRANSLATION_LANGUAGE_CODES:
+
+    if target_language not in (
+        constants.ALLOWED_MACHINE_TRANSLATION_LANGUAGE_CODES):
         raise ValueError('Invalid target language code: %s' % target_language)
+
     if source_language == target_language:
         return text
 

--- a/core/platform/translate/cloud_translate_services.py
+++ b/core/platform/translate/cloud_translate_services.py
@@ -32,9 +32,6 @@ CLIENT = translate.Client(
         auth.credentials.AnonymousCredentials()
         if constants.EMULATOR_MODE else auth.default()[0]))
 
-# List of languages with adequate Google Translate accuracy.
-LANGUAGE_CODE_ALLOWLIST = ('en', 'es', 'fr', 'zh', 'pt')
-
 
 def translate_text(
         text: str, source_language: str, target_language: str
@@ -59,9 +56,9 @@ def translate_text(
     Returns:
         str. The translated text.
     """
-    if source_language not in LANGUAGE_CODE_ALLOWLIST:
+    if source_language not in constants.ALLOWED_MACHINE_TRANSLATION_LANGUAGE_CODES:
         raise ValueError('Invalid source language code: %s' % source_language)
-    if target_language not in LANGUAGE_CODE_ALLOWLIST:
+    if target_language not in constants.ALLOWED_MACHINE_TRANSLATION_LANGUAGE_CODES:
         raise ValueError('Invalid target language code: %s' % target_language)
     if source_language == target_language:
         return text

--- a/core/platform/translate/dev_mode_translate_services.py
+++ b/core/platform/translate/dev_mode_translate_services.py
@@ -22,6 +22,7 @@ See cloud_translate_emulator.py for more details"""
 
 from __future__ import annotations
 
+from core.constants import constants
 from core.platform.translate import cloud_translate_emulator
 from core.platform.translate import cloud_translate_services
 
@@ -48,10 +49,14 @@ def translate_text(
     Returns:
         str. The translated text.
     """
-    if source_language not in cloud_translate_services.LANGUAGE_CODE_ALLOWLIST:
+    if source_language not in (
+        constants.ALLOWED_MACHINE_TRANSLATION_LANGUAGE_CODES):
         raise ValueError('Invalid source language code: %s' % source_language)
-    if target_language not in cloud_translate_services.LANGUAGE_CODE_ALLOWLIST:
+
+    if target_language not in (
+        constants.ALLOWED_MACHINE_TRANSLATION_LANGUAGE_CODES):
         raise ValueError('Invalid target language code: %s' % target_language)
+
     if source_language == target_language:
         return text
 

--- a/core/platform/translate/dev_mode_translate_services.py
+++ b/core/platform/translate/dev_mode_translate_services.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 from core.constants import constants
 from core.platform.translate import cloud_translate_emulator
-from core.platform.translate import cloud_translate_services
 
 CLIENT = cloud_translate_emulator.CloudTranslateEmulator()
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: [Explain here what your PR does and why]

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
