### PR TITLE
#17074 - Issue Resolved , Expand/collapse does not work when interact…

### DIFF
--- a/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.component.html
+++ b/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.component.html
@@ -6,14 +6,10 @@
       <h3 class="oppia-exp-interaction-card-header">
         Interaction <span *ngIf="getCurrentInteractionName()">( {{getCurrentInteractionName()}} )</span>
       </h3>
-      <i class="fa fa-caret-down"
-         *ngIf="!interactionEditorIsShown"
-         aria-hidden="true">
-      </i>
-      <i class="fa fa-caret-up"
-         *ngIf="interactionEditorIsShown"
-         aria-hidden="true">
-      </i>
+      <div *ngIf="getCurrentInteractionName().length > 0">
+        <i class="fa fa-caret-{{ interactionEditorIsShown ? 'up' : 'down' }}" aria-hidden="true"></i>
+      </div>
+      
     </div>
     <div class="oppia-add-interaction-button-container"
          *ngIf="!interactionId">


### PR DESCRIPTION
Here, I refactored an HTML code block that displayed an icon to indicate whether an interaction editor was shown or hidden. The original code had two <i> elements to display the up and down arrows separately. We simplified the code by combining the two <i> elements into one, using a ternary operator to conditionally set the fa-caret class to either up or down based on the value of interactionEditorIsShown. We also made a few small changes to improve the readability of the code.