### PR TITLE
Fix #17351: Assigned user a review rights with contributor_dashboard_debug flag

### DIFF
--- a/scripts/contributor_dashboard_debug.py
+++ b/scripts/contributor_dashboard_debug.py
@@ -213,7 +213,9 @@ class ContributorDashboardDebugInitializer:
         self._make_request(
             'POST', '/contributionrightshandler/submit_question', params=params)
 
-    def _add_review_question_rights(self, username: str) -> None:
+    def _add_review_question_rights(
+        self, username: str
+    ) -> None:
         """Adds review question rights to the user with the given username."""
         params = {
             'payload': json.dumps({'username': username}),
@@ -223,7 +225,9 @@ class ContributorDashboardDebugInitializer:
         self._make_request(
             'POST', '/contributionrightshandler/question', params=params)
 
-    def _add_review_translation_rights(self, username: str) -> None: 
+    def _add_review_translation_rights(
+        self, username: str
+    ) -> None: 
         """Adds review translation rights to the user with the given username."""
         params = {
             'payload': json.dumps({'username': username, 'language_code': 'ak'}),

--- a/scripts/contributor_dashboard_debug.py
+++ b/scripts/contributor_dashboard_debug.py
@@ -92,6 +92,8 @@ class ContributorDashboardDebugInitializer:
         self.csrf_token = self._get_csrf_token()
         self._assign_admin_roles(SUPER_ADMIN_ROLES, SUPER_ADMIN_USERNAME)
         self._add_submit_question_rights(CONTRIBUTOR_USERNAME)
+        self._add_review_question_rights(SUPER_ADMIN_USERNAME)
+        self._add_review_translation_rights(SUPER_ADMIN_USERNAME)
         self._generate_sample_new_structures_data()
         self._add_topics_to_classroom(CLASSROOM_NAME, CLASSROOM_URL_FRAGMENT)
 
@@ -210,6 +212,26 @@ class ContributorDashboardDebugInitializer:
 
         self._make_request(
             'POST', '/contributionrightshandler/submit_question', params=params)
+
+    def _add_review_question_rights(self, username: str) -> None:
+        """Adds review question rights to the user with the given username."""
+        params = {
+            'payload': json.dumps({'username': username}),
+            'csrf_token': self.csrf_token
+        }
+
+        self._make_request(
+            'POST', '/contributionrightshandler/question', params=params)
+
+    def _add_review_translation_rights(self, username: str) -> None: 
+        """Adds review translation rights to the user with the given username."""
+        params = {
+            'payload': json.dumps({'username': username, 'language_code': 'ak'}),
+            'csrf_token': self.csrf_token
+        }
+
+        self._make_request(
+            'POST', '/contributionrightshandler/translation', params=params)
 
     def _generate_sample_new_structures_data(self) -> None:
         """Generates sample new structures data."""

--- a/scripts/contributor_dashboard_debug.py
+++ b/scripts/contributor_dashboard_debug.py
@@ -216,7 +216,7 @@ class ContributorDashboardDebugInitializer:
     def _add_review_question_rights(
         self, username: str
     ) -> None:
-        """Adds review question rights to the user with the given username."""
+        """Adds review question rights to the user."""
         params = {
             'payload': json.dumps({'username': username}),
             'csrf_token': self.csrf_token
@@ -227,8 +227,8 @@ class ContributorDashboardDebugInitializer:
 
     def _add_review_translation_rights(
         self, username: str
-    ) -> None: 
-        """Adds review translation rights to the user with the given username."""
+    ) -> None:
+        """Adds review translation rights to the user."""
         params = {
             'payload': json.dumps({'username': username, 'language_code': 'ak'}),
             'csrf_token': self.csrf_token

--- a/scripts/contributor_dashboard_debug.py
+++ b/scripts/contributor_dashboard_debug.py
@@ -230,7 +230,8 @@ class ContributorDashboardDebugInitializer:
     ) -> None:
         """Adds review translation rights to the user."""
         params = {
-            'payload': json.dumps({'username': username, 'language_code': 'ak'}),
+            'payload': json.dumps({
+                'username': username, 'language_code': 'ak'}),
             'csrf_token': self.csrf_token
         }
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #17351.
2. This PR does the following: The functions _add_review_translation_rights and _add_review_question_rights grants the user 'a' the required review rights to translation of the Akan language and review rights to submitted questions, so that we don't have to manually do so.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
![Screenshot from 2023-03-14 23-17-48](https://user-images.githubusercontent.com/65906166/225100374-af8c072c-acea-47e6-b4d7-fd232f838ae5.png)
![Screenshot from 2023-03-14 23-18-10](https://user-images.githubusercontent.com/65906166/225100387-8ede541e-1abe-4c43-9881-0853ea0beb50.png)


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
