### PR TITLE
Fix part of #11776. Adding/Updating 'Args' and 'Return' in docstrings

### DIFF
--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -56,18 +56,18 @@ _PARSER.add_argument(
 def create_test_suites(
     test_target: Optional[str] = None
 ) -> List[unittest.TestSuite]:
-    """Creates test suites. If test_dir is None, runs all tests.
+        """Creates test suites. If test_dir is None, runs all tests.
 
-    Args:
-        test_target: str. The name of the test script.
-        Defaults to None
+        Args:
+            test_target: str. The name of the test script.
+            Defaults to None
 
-    Returns:
-        master_test_suite: list. A list of tests within the test script
+        Returns:
+            master_test_suite: list. A list of tests within the test script
 
-    Raises:
-        Exception. The delimiter in test_target should be a dot (.)
-    """
+        Raises:
+            Exception. The delimiter in test_target should be a dot (.)
+        """
 
     if test_target and '/' in test_target:
         raise Exception('The delimiter in test_target should be a dot (.)')

--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -60,14 +60,13 @@ def create_test_suites(
 
     Args:
         test_target: str. The name of the test script.
-        Default to None if not specified.
+            Default to None if not specified.
 
     Returns:
-        master_test_suite: list. A list of tests within the test script.
+        list. A list of tests within the test script.
 
     Raises:
         Exception. The delimeter in the test_target should be a dot (.)
-
     """
 
     if test_target and '/' in test_target:
@@ -90,11 +89,7 @@ def main(args: Optional[List[str]] = None) -> None:
     """Runs the tests.
 
     Args:
-        args: list(str).
-        Defaults to None.
-
-    Returns:
-        None.
+        args: list. A list of.
 
     Raises:
         Exception. Directory invalid_path does not exist.

--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -56,18 +56,19 @@ _PARSER.add_argument(
 def create_test_suites(
     test_target: Optional[str] = None
 ) -> List[unittest.TestSuite]:
-        """Creates test suites. If test_dir is None, runs all tests.
+    """Creates test suites. If test_target is None, runs all tests.
 
-        Args:
-            test_target: str. The name of the test script.
-            Defaults to None
+    Args:
+        test_target: str. The name of the test script.
+        Default to None if not specified.
 
-        Returns:
-            master_test_suite: list. A list of tests within the test script
+    Returns:
+        master_test_suite: list. A list of tests within the test script.
 
-        Raises:
-            Exception. The delimiter in test_target should be a dot (.)
-        """
+    Raises:
+        Exception. The delimeter in the test_target should be a dot (.)
+
+    """
 
     if test_target and '/' in test_target:
         raise Exception('The delimiter in test_target should be a dot (.)')

--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -89,7 +89,7 @@ def main(args: Optional[List[str]] = None) -> None:
     """Runs the tests.
 
     Args:
-        args: list. A list of.
+        args: list. A list of arguments to parse
 
     Raises:
         Exception. Directory invalid_path does not exist.

--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -89,7 +89,7 @@ def main(args: Optional[List[str]] = None) -> None:
     """Runs the tests.
 
     Args:
-        args: list. A list of arguments to parse
+        args: list. A list of arguments to parse.
 
     Raises:
         Exception. Directory invalid_path does not exist.

--- a/core/tests/gae_suite.py
+++ b/core/tests/gae_suite.py
@@ -56,7 +56,19 @@ _PARSER.add_argument(
 def create_test_suites(
     test_target: Optional[str] = None
 ) -> List[unittest.TestSuite]:
-    """Creates test suites. If test_dir is None, runs all tests."""
+    """Creates test suites. If test_dir is None, runs all tests.
+
+    Args:
+        test_target: str. The name of the test script.
+        Defaults to None
+
+    Returns:
+        master_test_suite: list. A list of tests within the test script
+
+    Raises:
+        Exception. The delimiter in test_target should be a dot (.)
+    """
+
     if test_target and '/' in test_target:
         raise Exception('The delimiter in test_target should be a dot (.)')
 
@@ -70,14 +82,24 @@ def create_test_suites(
             top_level_dir=CURR_DIR
         )
     )
-
     return [master_test_suite]
 
 
 def main(args: Optional[List[str]] = None) -> None:
-    """Runs the tests."""
-    parsed_args = _PARSER.parse_args(args=args)
+    """Runs the tests.
 
+    Args:
+        args: list(str).
+        Defaults to None.
+
+    Returns:
+        None.
+
+    Raises:
+        Exception. Directory invalid_path does not exist.
+    """
+
+    parsed_args = _PARSER.parse_args(args=args)
     for directory in common.DIRS_TO_ADD_TO_SYS_PATH:
         if not os.path.exists(os.path.dirname(directory)):
             raise Exception('Directory %s does not exist.' % directory)

--- a/core/tests/gae_suite_test.py
+++ b/core/tests/gae_suite_test.py
@@ -26,21 +26,28 @@ from typing import List
 
 
 class GaeSuiteTests(test_utils.GenericTestBase):
+    """Test the methods for creating test suites"""
 
     def test_cannot_create_test_suites_with_invalid_test_target_format(
         self
     ) -> None:
+        """Creates target_test with invalid name."""
+
         with self.assertRaisesRegex(
             Exception, 'The delimiter in test_target should be a dot (.)'):
             gae_suite.create_test_suites(test_target='core/controllers')
 
     def test_create_test_suites(self) -> None:
+        """Creates target_test with valid name."""
+
         test_suite = gae_suite.create_test_suites(
             test_target='core.tests.gae_suite_test')
         self.assertEqual(len(test_suite), 1)
         self.assertEqual(type(test_suite[0]), unittest.suite.TestSuite)
 
     def test_cannot_add_directory_with_invalid_path(self) -> None:
+        """Creates invalid path."""
+
         dir_to_add_swap = self.swap(
             common, 'DIRS_TO_ADD_TO_SYS_PATH', ['invalid_path'])
         assert_raises_regexp_context_manager = self.assertRaisesRegex(

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -1250,6 +1250,12 @@ class TestBase(unittest.TestCase):
     def get_static_asset_url(self, asset_suffix: str) -> str:
         """Returns the relative path for the asset, appending it to the
         corresponding cache slug. asset_suffix should have a leading slash.
+
+        Args:
+            asset_suffix: str. The asset suffix to append to the cache slug.
+
+        Returns:
+            str. The relative path for the asset.
         """
         return '/assets%s%s' % (utils.get_asset_dir_prefix(), asset_suffix)
 
@@ -3039,7 +3045,18 @@ title: Title
         csrf_token: Optional[str] = None,
         expected_status_int: int = 200
     ) -> Dict[str, Any]:
-        """PUT an object to the server with JSON and return the response."""
+        """PUT an object to the server with JSON and return the response.
+
+        Args:
+            url: str. The url of where to put the object.
+            payload: dict. The dictionary to be sent over to the handler
+            csrf_token: str. The csrf token to use.
+            expected_status_int: int. The integer status code to expect. Will be
+            200 if not specified.
+
+        Returns:
+            response: dict. A json dict response from the server.
+        """
         params = {'payload': json.dumps(payload)}
         if csrf_token:
             params['csrf_token'] = csrf_token

--- a/core/tests/test_utils.py
+++ b/core/tests/test_utils.py
@@ -3049,13 +3049,13 @@ title: Title
 
         Args:
             url: str. The url of where to put the object.
-            payload: dict. The dictionary to be sent over to the handler
+            payload: dict. The dictionary to be sent over to the handler.
             csrf_token: str. The csrf token to use.
             expected_status_int: int. The integer status code to expect. Will be
-            200 if not specified.
+                200 if not specified.
 
         Returns:
-            response: dict. A json dict response from the server.
+            dict. A json dict response from the server.
         """
         params = {'payload': json.dumps(payload)}
         if csrf_token:

--- a/core/tests/test_utils_test.py
+++ b/core/tests/test_utils_test.py
@@ -147,6 +147,7 @@ class FunctionWrapperTests(test_utils.GenericTestBase):
             self.assertEqual(data.get('value'), 'foobar')
 
     def test_wrapper_calls_passed_lambdas(self) -> None:
+        """Tests that FunctionWrapper also works for lambdas."""
         data = {}
 
         def mock_function_with_side_effect(string: str) -> str:
@@ -161,6 +162,7 @@ class FunctionWrapperTests(test_utils.GenericTestBase):
 
 
 class AuthServicesStubTests(test_utils.GenericTestBase):
+    """Test the methods for AuthServices."""
 
     EMAIL: Final = 'user@test.com'
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #11776 
3. This PR does the following: Added/updated args, return and raises in docstrings

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
