### PR TITLE
fix #17699 Tooltip for Close button in interaction pane is supposed to display 'Delete interaction'

### DIFF
--- a/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.component.html
+++ b/core/templates/components/state-editor/state-interaction-editor/state-interaction-editor.component.html
@@ -62,7 +62,7 @@
                     class="e2e-test-delete-interaction oppia-delete-interaction-button oppia-transition-200"
                     (click)="deleteInteraction()"
                     *ngIf="editabilityService.isEditable()">
-              <i class="fas fa-times oppia-delete-interaction-icon"></i>
+              <i class="fas fa-times oppia-delete-interaction-icon" title="Delete interaction"></i>
             </button>
           </div>
         </div>


### PR DESCRIPTION
**Overview:**
This PR fixes : https://github.com/oppia/oppia/issues/17699#issue-1620924783
This PR does the following: the tooltip for the close button displays "Delete interaction".

**Essential Checklist**
 

- [x]  The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)

- [x] The linter/Karma presubmit checks have passed locally on your machine.

- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.) 

- [x] This lets reviewers restart your CircleCI tests for you.

- [x] The PR is made from a branch that's not called "develop".

**Previous:**
https://user-images.githubusercontent.com/102851742/225744210-bc92bf6b-c20a-4e47-b456-f5d59b701d9d.mov


**after**
**proof that changes are correct:**

https://user-images.githubusercontent.com/102851742/225717409-b4b17f9e-4c78-4ccf-a12c-f5213a2e1b5b.mov

