### PR TITLE
Fix #17838: Able to select interactions with keyboard now.

### DIFF
--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/customize-interaction-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/customize-interaction-modal.component.html
@@ -114,10 +114,10 @@
 </div>
 
 <style>
-  .oppia-interaction-card{
-    border: 0px;
-    margin: 0px 0px;
-    padding: 0px 0px;
+  .oppia-interaction-card {
+    border: 0;
+    margin: 0 0;
+    padding: 0 0;
   }
 
   .modal-footer {

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/customize-interaction-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/customize-interaction-modal.component.html
@@ -32,10 +32,12 @@
                  [ngbPopover]="getDescription(interactionId)"
                  placement="bottom"
                  triggers="mouseenter:mouseleave">
-              <img [src]="getInteractionThumbnailImageUrl(interactionId)">
-              <div class="oppia-interaction-tile-name fx-row fx-main-center fx-cross-center">
-                {{ getTitle(interactionId) }}
-              </div>
+              <button class="oppia-interaction-card">
+                <img [src]="getInteractionThumbnailImageUrl(interactionId)">
+                <div class="oppia-interaction-tile-name fx-row fx-main-center fx-cross-center">
+                  {{ getTitle(interactionId) }}
+                </div>
+              </button>
             </div>
           </div>
         </ng-template>
@@ -112,6 +114,12 @@
 </div>
 
 <style>
+  .oppia-interaction-card{
+    border: 0px;
+    margin: 0px 0px;
+    padding: 0px 0px;
+  }
+
   .modal-footer {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #17838 
2. This PR does the following: Able to select interactions with keyboard now.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

[Screencast from 03-29-2023 01:57:32 PM.webm](https://user-images.githubusercontent.com/118007662/228475885-2747dec0-8034-4d87-a731-767cc4fb0d2c.webm)

#### Proof of changes on mobile view

[Screencast from 03-30-2023 09:01:15 AM.webm](https://user-images.githubusercontent.com/118007662/228721707-23d51ffb-5e6f-4bc5-b17a-6245da4bceb2.webm)


<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->




## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
