### PR TITLE
Fix #17874: The focus now goes to the "upload a file" button in creator dashboard

### DIFF
--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
@@ -1,4 +1,4 @@
-<div class="image-uploader-drop-area" 
+<div class="image-uploader-drop-area"
      [ngClass]="{'image-uploader-is-active': backgroundWhileUploading, 'image-uploader-is-narrow': blogDashboardPageService.imageUploaderIsNarrow}"
      #dropArea>
   <div class="image-uploader-text" *ngIf="!isBlogPostThumbnailUploader">{{ 'I18N_DIRECTIVES_DRAG_IMAGE_HERE' | translate }}</div>

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
@@ -9,7 +9,7 @@
   </span>
   <span class="image-uploader-license-warning" *ngIf="!isBlogPostThumbnailUploader">
     Before uploading images, please ensure that they are<br>
-    compatible with the <a href="/license" [smartRouterLink]="'/' + licenseUrl" target="_blank" rel="noopener">license terms</a> of the site.<br>
+    compatible with the <a class="license-term-link" href="/license" [smartRouterLink]="'/' + licenseUrl" target="_blank" rel="noopener">license terms</a> of the site.<br>
     Please do not upload watermarked images.
   </span>
   <label for="image-file-input" class="image-uploader-upload-label-button" *ngIf="!isBlogPostThumbnailUploader" tabindex="0">{{ 'I18N_DIRECTIVES_UPLOAD_A_FILE' | translate }}</label>

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
@@ -12,7 +12,7 @@
     compatible with the <a class="license-term-link" href="/license" [smartRouterLink]="'/' + licenseUrl" target="_blank" rel="noopener">license terms</a> of the site.<br>
     Please do not upload watermarked images.
   </span>
-  <label for="image-file-input" class="image-uploader-upload-label-button" *ngIf="!isBlogPostThumbnailUploader">{{ 'I18N_DIRECTIVES_UPLOAD_A_FILE' | translate }}</label>
+  <button for="image-file-input" class="image-uploader-upload-label-button" *ngIf="!isBlogPostThumbnailUploader">{{ 'I18N_DIRECTIVES_UPLOAD_A_FILE' | translate }}</button>
   <!-- The onclick="this.imageInputRef.nativeElement.value=null" attribute resets the value of the input so that uploading the same image twice in a row works. This fix is only needed for chrome. Reference: stackoverflow.com/q/12030686 -->
   <input type="file" id="image-file-input" (click)="this.imageInputRef.nativeElement.value = null"
          (change)="handleFile()"
@@ -87,7 +87,7 @@
     text-decoration-color: #0859aa;
   }
 
-  label.image-uploader-upload-label-button {
+  button.image-uploader-upload-label-button {
     background: grey;
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #f2f2f2), color-stop(1, #bfbfbf));
     background-image: -o-linear-gradient(bottom, #f2f2f2 0%, #bfbfbf 100%);

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
@@ -80,11 +80,11 @@
     width: 0.1px;
     z-index: -1;
   }
-  
-  .license-term-link {	
-    color: #0859aa;	
-    text-decoration: underline;	
-    text-decoration-color: #0859aa;	
+
+  .license-term-link {
+    color: #0859aa;
+    text-decoration: underline;
+    text-decoration-color: #0859aa;
   }
 
   label.image-uploader-upload-label-button {

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
@@ -9,10 +9,10 @@
   </span>
   <span class="image-uploader-license-warning" *ngIf="!isBlogPostThumbnailUploader">
     Before uploading images, please ensure that they are<br>
-    compatible with the <a class="license-term-link" href="/license" [smartRouterLink]="'/' + licenseUrl" target="_blank" rel="noopener">license terms</a> of the site.<br>
+    compatible with the <a href="/license" [smartRouterLink]="'/' + licenseUrl" target="_blank" rel="noopener">license terms</a> of the site.<br>
     Please do not upload watermarked images.
   </span>
-  <button for="image-file-input" class="image-uploader-upload-label-button" *ngIf="!isBlogPostThumbnailUploader">{{ 'I18N_DIRECTIVES_UPLOAD_A_FILE' | translate }}</button>
+  <label for="image-file-input" class="image-uploader-upload-label-button" *ngIf="!isBlogPostThumbnailUploader" tabindex="0">{{ 'I18N_DIRECTIVES_UPLOAD_A_FILE' | translate }}</label>
   <!-- The onclick="this.imageInputRef.nativeElement.value=null" attribute resets the value of the input so that uploading the same image twice in a row works. This fix is only needed for chrome. Reference: stackoverflow.com/q/12030686 -->
   <input type="file" id="image-file-input" (click)="this.imageInputRef.nativeElement.value = null"
          (change)="handleFile()"
@@ -81,13 +81,7 @@
     z-index: -1;
   }
 
-  .license-term-link {
-    color: #0859aa;
-    text-decoration: underline;
-    text-decoration-color: #0859aa;
-  }
-
-  button.image-uploader-upload-label-button {
+  label.image-uploader-upload-label-button {
     background: grey;
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #f2f2f2), color-stop(1, #bfbfbf));
     background-image: -o-linear-gradient(bottom, #f2f2f2 0%, #bfbfbf 100%);

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
@@ -80,6 +80,12 @@
     width: 0.1px;
     z-index: -1;
   }
+  
+  .license-term-link {	
+    color: #0859aa;	
+    text-decoration: underline;	
+    text-decoration-color: #0859aa;	
+  }
 
   label.image-uploader-upload-label-button {
     background: grey;

--- a/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
+++ b/core/templates/components/forms/custom-forms-directives/image-uploader.component.html
@@ -1,4 +1,4 @@
-<div class="image-uploader-drop-area"
+<div class="image-uploader-drop-area" 
      [ngClass]="{'image-uploader-is-active': backgroundWhileUploading, 'image-uploader-is-narrow': blogDashboardPageService.imageUploaderIsNarrow}"
      #dropArea>
   <div class="image-uploader-text" *ngIf="!isBlogPostThumbnailUploader">{{ 'I18N_DIRECTIVES_DRAG_IMAGE_HERE' | translate }}</div>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #17874 
2. This PR does the following: The focus now goes to the "upload a file" button in creator dashboard

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

[Screencast from 03-30-2023 05:09:03 PM.webm](https://user-images.githubusercontent.com/118007662/228824851-69e826c4-210b-4cd3-a0eb-6198b0a84357.webm)


<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

[Screencast from 03-30-2023 05:09:25 PM.webm](https://user-images.githubusercontent.com/118007662/228824891-2327f839-8cfc-4a3e-ae27-f745445718fa.webm)


<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->



<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
