### PR TITLE
Fix #17832: Add Style to Help link in exploration editor page

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -1052,6 +1052,11 @@ textarea {
   text-align: center;
 }
 
+.oppia-exploration-tutorial-help-link {
+  font-weight: bold;
+  text-decoration: underline;
+}
+
 .oppia-exploration-ctrl {
   margin: 15px 0;
 }

--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -1052,11 +1052,6 @@ textarea {
   text-align: center;
 }
 
-.oppia-exploration-tutorial-help-link {
-  font-weight: bold;
-  text-decoration: underline;
-}
-
 .oppia-exploration-ctrl {
   margin: 15px 0;
 }

--- a/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.html
@@ -17,7 +17,7 @@
       </li>
       <li>
         Check out more resources in the
-        <a class="oppia-exploration-tutorial-help-link" href="https://oppia.github.io/#/" rel="noopener" target="_blank" >
+        <a class="oppia-exploration-tutorial-help-link" href="https://oppia.github.io/#/" rel="noopener" target="_blank">
           Help Center.
         </a>
       </li>
@@ -92,6 +92,10 @@
   }
   .exp-editor-overview-content {
     margin-top: 40px;
+  }
+  .oppia-exploration-tutorial-help-link {
+    font-weight: bold;
+    text-decoration: underline;
   }
   @media screen and (max-width: 768px) {
     .exp-editor-main-editor {

--- a/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.html
@@ -17,7 +17,7 @@
       </li>
       <li>
         Check out more resources in the
-        <a class="oppia-exploration-tutorial-help-link" href="https://oppia.github.io/#/" rel="noopener" target="_blank">
+        <a class="tutorial-help-link" href="https://oppia.github.io/#/" rel="noopener" target="_blank">
           Help Center.
         </a>
       </li>
@@ -93,7 +93,7 @@
   .exp-editor-overview-content {
     margin-top: 40px;
   }
-  .oppia-exploration-tutorial-help-link {
+  .tutorial-help-link {
     font-weight: bold;
     text-decoration: underline;
   }

--- a/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/exploration-editor-tab.component.html
@@ -17,7 +17,7 @@
       </li>
       <li>
         Check out more resources in the
-        <a href="https://oppia.github.io/#/" rel="noopener" target="_blank">
+        <a class="oppia-exploration-tutorial-help-link" href="https://oppia.github.io/#/" rel="noopener" target="_blank" >
           Help Center.
         </a>
       </li>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #17832.
2. This PR does the following: Add bold and underline style to `Help Center` link in exploration editor page to make it distinguishable 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

`screenshot`

<img width="1440" alt="228642454-2fe609d5-aa49-46ad-972c-8c9153741245" src="https://user-images.githubusercontent.com/75988952/229042206-8f064c37-97ec-4f7b-8a8e-ee3b6ccf96dc.png">


`video`

https://user-images.githubusercontent.com/75988952/229042681-43a4a79f-127f-4b23-8ead-4ca3f87a1757.mov

`Lint Test Results`

<img width="645" alt="Screenshot 2023-03-31 at 1 55 46 AM" src="https://user-images.githubusercontent.com/75988952/229042245-6c6ba1e1-0f07-485f-a8dc-efe6dc884363.png">

<img width="645" alt="Screenshot 2023-03-31 at 1 55 57 AM" src="https://user-images.githubusercontent.com/75988952/229042260-c49d2571-660a-42b8-8111-4889eb9a8e3e.png">



