### PR TITLE
Fix #17886: Change style of save button in exploration for sufficient color contrast

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -1390,8 +1390,8 @@ span.sort-explorations-select .sort-order {
 .oppia-save-draft-button.btn-success,
 .oppia-save-changes-button.btn-success,
 .oppia-editor-publish-button.btn-success {
-  background-color: #28a745;
-  border-color: #28a745;
+  background-color: #24883e;
+  border-color: #24883e;
   color: #fff;
 }
 .oppia-save-draft-button.btn-success:hover,

--- a/core/templates/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.component.html
+++ b/core/templates/pages/exploration-editor-page/exploration-save-and-publish-buttons/exploration-save-and-publish-buttons.component.html
@@ -98,7 +98,6 @@
   }
   .oppia-num-changes-text {
     margin-left: 2px;
-    opacity: 0.5;
   }
   .oppia-num-changes-count-text {
     opacity: 0.5;


### PR DESCRIPTION
## Overview
1. This PR fixes #17886.
2. This PR does the following: Fix the `insufficient color contrast` of saving button in exploration editor page by removing `opacity: 0.5;` and changing background color from `#28a745` to `#24883e`.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
`output`

https://user-images.githubusercontent.com/75988952/229376215-f010ccbb-baeb-44c3-be51-1c17297c4055.mov



`Lint Test Results`
<img width="645" alt="Screenshot 2023-04-02 at 3 29 09 PM" src="https://user-images.githubusercontent.com/75988952/229376188-6e47d8e4-f1a5-458a-ae7a-e0adc0a9d05b.png">

<img width="645" alt="Screenshot 2023-04-02 at 3 26 52 PM" src="https://user-images.githubusercontent.com/75988952/229376189-f8e422ce-02aa-4c65-9b26-a381097bc40c.png">
