### PR TITLE
Fix issue #17747: Navigation with keyboard on suggest question window in contributor dashboard.

### DIFF
--- a/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
+++ b/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
@@ -2,14 +2,16 @@
   <div class="oppia-editor-card-with-avatar oppia-mobile-collapsible-card">
     <div class="oppia-editor-card-body">
       <div class="state-responses-header-container oppia-mobile-collapsible-card-header">
-        <div class="state-responses-header" (click)="toggleResponseCard()">
+        <div class="state-responses-header" (click)="toggleResponseCard()" (keydown.enter)="toggleResponseCard()">
           <h3 class="oppia-exp-answer-card-header">Learner's Answers and Oppia's Responses</h3>
           <i class="fa fa-caret-down"
              *ngIf="!responseCardIsShown"
+             tabindex="0"
              aria-hidden="true">
           </i>
           <i class="fa fa-caret-up"
              *ngIf="responseCardIsShown"
+             tabindex="0"
              aria-hidden="true">
           </i>
         </div>

--- a/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
+++ b/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
@@ -75,7 +75,9 @@
                     </oppia-answer-group-editor>
                   </div>
                   <div *ngIf="editabilityService.isEditable()">
-                    <button type="button" class="btn btn-danger oppia-delete-response e2e-test-delete-response" (click)="deleteAnswerGroup($event, index)">
+                    <button type="button"
+                            class="btn btn-danger oppia-delete-response e2e-test-delete-response"
+                            (click)="deleteAnswerGroup($event, index)">
                       Delete Response
                     </button>
                   </div>
@@ -138,7 +140,9 @@
         </div>
         <div class="oppia-add-response-button-container">
           <div *ngIf="editabilityService.isEditableOutsideTutorialMode() && !isCurrentInteractionLinear() && editabilityService.isEditable()">
-            <button type="button" class="btn btn-secondary oppia-add-response-button e2e-test-open-add-response-modal" (click)="openAddAnswerGroupModal()">
+            <button type="button"
+                    class="btn btn-secondary oppia-add-response-button e2e-test-open-add-response-modal"
+                    (click)="openAddAnswerGroupModal()">
               + ADD RESPONSE
             </button>
           </div>

--- a/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
+++ b/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
@@ -2,7 +2,9 @@
   <div class="oppia-editor-card-with-avatar oppia-mobile-collapsible-card">
     <div class="oppia-editor-card-body">
       <div class="state-responses-header-container oppia-mobile-collapsible-card-header">
-        <div class="state-responses-header" (click)="toggleResponseCard()" (keydown.enter)="toggleResponseCard()">
+        <div class="state-responses-header"
+             (click)="toggleResponseCard()"
+             (keydown.enter)="toggleResponseCard()">
           <h3 class="oppia-exp-answer-card-header">Learner's Answers and Oppia's Responses</h3>
           <i class="fa fa-caret-down"
              *ngIf="!responseCardIsShown"

--- a/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
+++ b/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
@@ -73,7 +73,7 @@
                     </oppia-answer-group-editor>
                   </div>
                   <div *ngIf="editabilityService.isEditable()">
-                    <button type="button" class="btn btn-danger oppia-delete-response e2e-test-delete-response" (click)="deleteAnswerGroup($event, index)">  
+                    <button type="button" class="btn btn-danger oppia-delete-response e2e-test-delete-response" (click)="deleteAnswerGroup($event, index)">
                       Delete Response
                     </button>
                   </div>

--- a/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
+++ b/core/templates/components/state-editor/state-responses-editor/state-responses.component.html
@@ -72,10 +72,10 @@
                                                [addState]="addState">
                     </oppia-answer-group-editor>
                   </div>
-                  <div class="btn btn-danger oppia-delete-response e2e-test-delete-response"
-                       *ngIf="editabilityService.isEditable()"
-                       (click)="deleteAnswerGroup($event, index)">
-                    Delete Response
+                  <div *ngIf="editabilityService.isEditable()">
+                    <button type="button" class="btn btn-danger oppia-delete-response e2e-test-delete-response" (click)="deleteAnswerGroup($event, index)">  
+                      Delete Response
+                    </button>
                   </div>
                 </div>
               </div>

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-or-update-solution-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-or-update-solution-modal.component.html
@@ -24,8 +24,6 @@
       <button class="md-button oppia-learner-confirm-button oppia-learner-submit-answer-button e2e-test-submit-answer-button"
               (click)="onSubmitFromSubmitButton()"
               *ngIf="data.correctAnswer === undefined && shouldAdditionalSubmitButtonBeShown()"
-              onblur="this.style.border = 'none';"
-              onfocus="this.style.border = '2px solid black';"
               [disabled]="isSubmitButtonDisabled()">
           Submit
       </button>
@@ -53,3 +51,9 @@
     Check and Save Solution
   </button>
 </div>
+
+<style>
+  .oppia-learner-submit-answer-button:focus {
+    border: 2px solid #000;
+  }
+</style>

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-or-update-solution-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-or-update-solution-modal.component.html
@@ -24,6 +24,8 @@
       <button class="md-button oppia-learner-confirm-button oppia-learner-submit-answer-button e2e-test-submit-answer-button"
               (click)="onSubmitFromSubmitButton()"
               *ngIf="data.correctAnswer === undefined && shouldAdditionalSubmitButtonBeShown()"
+              onblur="this.style.border = 'none';"
+              onfocus="this.style.border = '2px solid black';"
               [disabled]="isSubmitButtonDisabled()">
           Submit
       </button>

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/customize-interaction-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/customize-interaction-modal.component.html
@@ -28,9 +28,11 @@
           <div>
             <div *ngFor="let interactionId of category.interaction_ids"
                  (click)="onChangeInteractionId(interactionId)"
+                 (keydown.enter)="onChangeInteractionId(interactionId)"
                  class="oppia-interaction-tile e2e-test-interaction-tile-{{ interactionId }}"
                  [ngbPopover]="getDescription(interactionId)"
                  placement="bottom"
+                 tabindex="0"
                  triggers="mouseenter:mouseleave">
               <img [src]="getInteractionThumbnailImageUrl(interactionId)">
               <div class="oppia-interaction-tile-name fx-row fx-main-center fx-cross-center">


### PR DESCRIPTION
## Overview

1. This PR fixes #17747
2. There were some problems in the navigation with keyboard on suggest quesiton window in contributor dashboard, we are changing things in order to fix those problems. What I did was add tabindex and keydown.enter in the <div> sections that weren't being targeted by tab for the 1st two problems. For the 3rd I added a button inside the div section and for the 4th I added a onblur and onfocus atribute so it would pop when targeted.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. 
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
   - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's not called "develop".

## Proof that changes are correct

https://user-images.githubusercontent.com/97408647/229379376-ca469322-70de-42d2-87b7-c2bf0538bd96.mp4

## PR Pointers
 - Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
 - If you need a review or an answer to a question, and don't have permissions to assign people, leave a comment like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
 - For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
 - Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
 - Never force push. If you do, your PR will be closed.
 - Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).