### PR TITLE
Fix #17912: Aligning drag and drop interaction elements

### DIFF
--- a/extensions/interactions/DragAndDropSortInput/directives/drag-and-drop-sort-input-interaction.component.html
+++ b/extensions/interactions/DragAndDropSortInput/directives/drag-and-drop-sort-input-interaction.component.html
@@ -69,7 +69,7 @@
     height: 540px;
     margin: 16px;
     overflow-y: auto;
-    padding: 10px 10px 25px 80px;
+    padding: 10px 10px 10px 10px;
     touch-action: manipulation;
   }
 
@@ -95,8 +95,7 @@
   }
 
   .child-dnd {
-    display: inline-block;
-    margin: -10px 0 0 0;
+    margin: 0 auto;
     max-width: 100%;
     position: relative;
     vertical-align: top;
@@ -104,8 +103,7 @@
   }
 
   .child-dnd-single-item {
-    display: inline-block;
-    margin: 80px 0 0 0;
+    margin: 0 auto;
     max-width: 100%;
     position: relative;
     vertical-align: top;
@@ -128,7 +126,6 @@
     border-radius: 4px;
     border-top: solid 1px #ccc;
     display: block;
-    margin-top: 20px;
     overflow: hidden;
     padding-bottom: 25px;
   }


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #17912.
2. This PR does the following: This PR changes the CSS of the drag and drop interaction to align the elements correctly for both single item in the same position and multiple items in the same position.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->
### Single item in same position
![image](https://user-images.githubusercontent.com/66096388/231001614-50005df0-06dc-47c1-a6f3-cb16747f32d9.png)
![image](https://user-images.githubusercontent.com/66096388/231001686-95a3ac7b-a1f1-4300-b77f-5b4b9af61e52.png)

### Multiple items in same position
![image](https://user-images.githubusercontent.com/66096388/231001778-6e7d1456-cf2e-4537-b74e-e34ca5f07f3f.png)
![image](https://user-images.githubusercontent.com/66096388/231001814-dfca7604-060c-4f3d-bca8-d826c73a40b4.png)

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
