### PR TITLE
Color contrast

### DIFF
--- a/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
+++ b/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
@@ -73,7 +73,7 @@
 
 <style>
   .oppia-rule-header {
-    color: rgb(120, 120, 120);
+    color: rgb(110, 110, 110);
     padding-left: 0;
     text-overflow: ellipsis;
   }
@@ -87,11 +87,10 @@
   }
 
   .oppia-add-rule-button {
-    background-color: rgba(165,165,165,0.9);
+    background-color: rgba(115,115,115, 1);
     border: 0;
     border-radius: 0;
     color: white;
-    opacity: 0.9;
     padding: 7px;
     width: 100%;
   }
@@ -102,9 +101,8 @@
   .oppia-modify-training-data-button:active,
   .oppia-modify-training-data-button:focus,
   .oppia-modify-training-data-button:hover {
-    background-color: rgba(165,165,165,1);
+    background-color: rgba(115,115,115,1);
     color: white;
-    opacity: 1;
   }
 
   .oppia-delete-rule-button {

--- a/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
+++ b/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
@@ -90,7 +90,7 @@
     background-color: rgba(115,115,115, 1);
     border: 0;
     border-radius: 0;
-    color: white;
+    color: #fff;
     padding: 7px;
     width: 100%;
   }

--- a/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
+++ b/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
@@ -102,6 +102,7 @@
   .oppia-modify-training-data-button:focus,
   .oppia-modify-training-data-button:hover {
     background-color: rgba(115,115,115,1);
+    opacity: 1;
     color: white;
   }
 

--- a/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
+++ b/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
@@ -102,7 +102,6 @@
   .oppia-modify-training-data-button:focus,
   .oppia-modify-training-data-button:hover {
     background-color: rgba(115,115,115,1);
-    opacity: 1;
     color: white;
   }
 


### PR DESCRIPTION
1. This PR fixes or fixes part of #18008
2. This PR does the following: The PR changes  color contrast of few element of the issues from 3.94 (foreground color: #787878, background color: #f2f2f2, font size: 12.0pt (16px), font weight: normal). To expected contrast ratio of >=4.5:1

## Essential Checklist

- [x] The PR title starts with "Fix #18008 : " It made sure the color contrast of elements are based on WACG norms.
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because it was a minor fix

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
