### PR TITLE
Fix 17072 : Make submit question checkbox accessible

### DIFF
--- a/core/templates/components/state-directives/outcome-editor/outcome-editor.component.html
+++ b/core/templates/components/state-directives/outcome-editor/outcome-editor.component.html
@@ -262,12 +262,13 @@
 
   <div class="oppia-outcome-container" *ngIf="isEditable">
     <div *ngIf="outcome">
-      <input class="mr-2 e2e-test-editor-correctness-toggle"
+      <input id="labelledAsCorrect"
+             class="mr-2 e2e-test-editor-correctness-toggle"
              type="checkbox"
              [disabled]="isSelfLoop(savedOutcome)"
              [(ngModel)]="outcome.labelledAsCorrect"
              (change)="onChangeCorrectnessLabel()">
     </div>
-    <strong class="oppia-outcome-heading">The answers in this group are correct</strong>
+    <strong class="oppia-outcome-heading"><label for="labelledAsCorrect">The answers in this group are correct</label></strong>
   </div>
 </div>

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-answer-group-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-answer-group-modal.component.html
@@ -59,10 +59,11 @@
   </form>
 
   <div class="oppia-correctness-label-editor" *ngIf="isCorrectnessFeedbackEnabled() && !isCurrentInteractionLinear()">
-    <input class="e2e-test-editor-correctness-toggle mr-2"
+    <input id="labelledAsCorrect"
+           class="e2e-test-editor-correctness-toggle mr-2"
            type="checkbox"
            [(ngModel)]="tmpOutcome.labelledAsCorrect">
-    <strong>The answers in this group are correct</strong>
+    <strong><label for="labelledAsCorrect">The answers in this group are correct</label></strong>
   </div>
 
   <oppia-question-misconception-editor *ngIf="questionModeEnabled"


### PR DESCRIPTION


## Overview

1. This PR fixes  #17072.
2. This PR does the following: Make the checkbox that marks an answer as correct on the submit question page accessible by a screen reader. This is done by adding a label tag to the existing description and binding it to the check box.The fix is made on 2 pages, the modal dialog and the page behind.


## Essential Checklist

- [x ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct


https://user-images.githubusercontent.com/123914818/231770254-12b8b93b-0565-4094-a3fa-c9d08013e8e7.mp4

[axe dev tools screen prints.odt](https://github.com/oppia/oppia/files/11222542/axe.dev.tools.screen.prints.odt)


@sagangwee PTAL