### PR TITLE
Fix #16873: Added alt text field to the image click input interaction

### DIFF
--- a/extensions/interactions/ImageClickInput/ImageClickInput.py
+++ b/extensions/interactions/ImageClickInput/ImageClickInput.py
@@ -60,6 +60,17 @@ class ImageClickInput(base.BaseInteraction):
         },
         'default_value': _image_and_regions_default_value,
     }, {
+        'name': 'altText',
+        'description': 'Alt text for this image',
+        'schema': {
+            'type': 'custom',
+            'obj_type': 'SubtitledUnicode'
+        },
+        'default_value': {
+            'content_id': None,
+            'unicode_str': ''
+        }
+    }, {
         'name': 'highlightRegionsOnHover',
         'description': 'Highlight regions when the learner hovers over them',
         'schema': {

--- a/extensions/interactions/ImageClickInput/directives/image-click-input-interaction.component.html
+++ b/extensions/interactions/ImageClickInput/directives/image-click-input-interaction.component.html
@@ -52,6 +52,7 @@
 
   <div class="image-click-container" *ngIf="!isLoadingIndicatorShown && !isTryAgainShown">
     <img [src]="imageUrl"
+         [alt]="altText"
          class="oppia-image-click-img"
          (click)="onClickImage($event)"
          (mousemove)="onMousemoveImage($event)"

--- a/extensions/interactions/ImageClickInput/directives/image-click-input-validation.service.spec.ts
+++ b/extensions/interactions/ImageClickInput/directives/image-click-input-validation.service.spec.ts
@@ -93,6 +93,9 @@ describe('ImageClickInputValidationService', () => {
           }]
         }
       },
+      altTest: {
+        value: 'test'
+      },
       highlightRegionsOnHover: {
         value: true
       }

--- a/extensions/interactions/ImageClickInput/directives/image-click-input-validation.service.spec.ts
+++ b/extensions/interactions/ImageClickInput/directives/image-click-input-validation.service.spec.ts
@@ -93,7 +93,7 @@ describe('ImageClickInputValidationService', () => {
           }]
         }
       },
-      altTest: {
+      altText: {
         value: 'test'
       },
       highlightRegionsOnHover: {

--- a/extensions/interactions/ImageClickInput/directives/oppia-interactive-image-click-input.component.ts
+++ b/extensions/interactions/ImageClickInput/directives/oppia-interactive-image-click-input.component.ts
@@ -55,9 +55,11 @@ interface ImagePoint {
 })
 export class InteractiveImageClickInput implements OnInit, OnDestroy {
   @Input() imageAndRegionsWithValue: string;
+  @Input() altTextWithValue: string;
   @Input() highlightRegionsOnHoverWithValue: string;
   @Input() lastAnswer: ImageClickAnswer;
   imageAndRegions: ImageWithRegions;
+  altText: string;
   highlightRegionsOnHover: boolean = false;
   componentSubscriptions = new Subscription();
   currentlyHoveredRegions: string[] = [];
@@ -91,6 +93,7 @@ export class InteractiveImageClickInput implements OnInit, OnDestroy {
   private _getAttrs() {
     return {
       imageAndRegionsWithValue: this.imageAndRegionsWithValue,
+      altTextWithValue: this.altTextWithValue,
       highlightRegionsOnHoverWithValue: this.highlightRegionsOnHoverWithValue
     };
   }
@@ -107,10 +110,12 @@ export class InteractiveImageClickInput implements OnInit, OnDestroy {
   ngOnInit(): void {
     const {
       imageAndRegions,
+      altText,
       highlightRegionsOnHover
     } = this.interactionAttributesExtractorService.getValuesFromAttributes(
       'ImageClickInput', this._getAttrs()) as ImageClickInputCustomizationArgs;
     this.imageAndRegions = imageAndRegions.value;
+    this.altText = altText.value;
     this.highlightRegionsOnHover = highlightRegionsOnHover.value;
     this.componentSubscriptions.add(
       this.playerPositionService.onNewCardAvailable.subscribe(

--- a/extensions/interactions/customization-args-defs.ts
+++ b/extensions/interactions/customization-args-defs.ts
@@ -218,6 +218,9 @@ export interface ImageClickInputCustomizationArgsBackendDict {
   imageAndRegions: {
     value: ImageWithRegions;
   };
+  altText: {
+    value: string;
+  };
   highlightRegionsOnHover: {
     value: boolean;
   };
@@ -225,6 +228,9 @@ export interface ImageClickInputCustomizationArgsBackendDict {
 export interface ImageClickInputCustomizationArgs {
   imageAndRegions: {
     value: ImageWithRegions;
+  };
+  altText: {
+    value: string;
   };
   highlightRegionsOnHover: {
     value: boolean;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #16873 .
2. This PR does the following: Adds the alt text field and made changes to the tests.

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
