### PR TITLE
Fix part of #14219: Increased backend test coverage of core.storage.topic.gae_models_test to 97%

### DIFF
--- a/core/storage/topic/gae_models_test.py
+++ b/core/storage/topic/gae_models_test.py
@@ -130,6 +130,48 @@ class TopicModelUnitTests(test_utils.GenericTestBase):
             self.TOPIC_ID
         )
 
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            topic_models.TopicModel.
+                get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER)
+
+    def test_get_export_policy(self) -> None:
+        expected_dict = {
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'version': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'name': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'canonical_name': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'abbreviated_name': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'thumbnail_filename': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'thumbnail_bg_color': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'thumbnail_size_in_bytes': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'description': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'canonical_story_references':
+                base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'additional_story_references':
+                base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'story_reference_schema_version':
+                base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'uncategorized_skill_ids': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'subtopics': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'subtopic_schema_version': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'next_subtopic_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'language_code': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'meta_tag_content': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'page_title_fragment_for_web': (
+                base_models.EXPORT_POLICY.NOT_APPLICABLE),
+            'practice_tab_is_displayed':
+                base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'url_fragment': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'skill_ids_for_diagnostic_test':
+                base_models.EXPORT_POLICY.NOT_APPLICABLE
+        }
+        self.assertEqual(
+            topic_models.TopicModel.get_export_policy(),
+            expected_dict)
 
 class TopicCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
     """Tests the TopicCommitLogEntryModel class."""
@@ -168,6 +210,30 @@ class TopicCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
             'topic-entity_id-1'
         )
 
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            topic_models.TopicCommitLogEntryModel.
+                get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER)
+
+    def test_get_export_policy(self) -> None:
+        expected_dict = {
+            'commit_cmds': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'commit_message': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'commit_type': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'user_id': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'version': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'post_commit_community_owned': base_models.EXPORT_POLICY.NOT_APPLICABLE, # pylint: disable=line-too-long
+            'post_commit_is_private': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'post_commit_status': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'topic_id': base_models.EXPORT_POLICY.NOT_APPLICABLE
+        }
+        self.assertEqual(
+            topic_models.TopicCommitLogEntryModel.get_export_policy(),
+            expected_dict)
 
 class TopicSummaryModelUnitTests(test_utils.GenericTestBase):
     """Tests the TopicSummaryModel class."""
@@ -177,6 +243,40 @@ class TopicSummaryModelUnitTests(test_utils.GenericTestBase):
             topic_models.TopicSummaryModel.get_deletion_policy(),
             base_models.DELETION_POLICY.NOT_APPLICABLE)
 
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            topic_models.TopicSummaryModel.
+                get_model_association_to_user(),
+            base_models.MODEL_ASSOCIATION_TO_USER.NOT_CORRESPONDING_TO_USER)
+
+    def test_get_export_policy(self) -> None:
+        expected_dict = {
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'name': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'canonical_name': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'language_code': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'description': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'topic_model_last_updated':
+                base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'topic_model_created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'canonical_story_count': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'additional_story_count': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'total_skill_count': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'total_published_node_count':
+                base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'uncategorized_skill_count':
+                base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'subtopic_count': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'thumbnail_filename': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'thumbnail_bg_color': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'version': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'url_fragment': base_models.EXPORT_POLICY.NOT_APPLICABLE
+        }
+        self.assertEqual(
+            topic_models.TopicSummaryModel.get_export_policy(),
+            expected_dict)
 
 class TopicRightsRightsSnapshotContentModelTests(test_utils.GenericTestBase):
 
@@ -282,3 +382,35 @@ class TopicRightsModelUnitTests(test_utils.GenericTestBase):
             'managed_topic_ids': []
         }
         self.assertEqual(user_data, expected_data)
+
+    def test_get_by_user(self) -> None:
+        self.assertEqual(len(topic_models.TopicRightsModel.get_by_user(self.MANAGER_1_ID_OLD)), 0) # pylint: disable=line-too-long
+
+    def test_get_model_association_to_user(self) -> None:
+        self.assertEqual(
+            topic_models.TopicRightsModel.
+                get_model_association_to_user(),
+            base_models
+            .MODEL_ASSOCIATION_TO_USER
+            .ONE_INSTANCE_SHARED_ACROSS_USERS)
+
+    def test_get_field_name_mapping_to_takeout_keys(self) -> None:
+        self.assertEqual(
+            topic_models.TopicRightsModel.
+            get_field_name_mapping_to_takeout_keys(),
+            {
+                'manager_ids': 'managed_topic_ids'
+            })
+
+    def test_get_export_policy(self) -> None:
+        expected_dict = {
+            'created_on': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'deleted': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'last_updated': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'version': base_models.EXPORT_POLICY.NOT_APPLICABLE,
+            'manager_ids': base_models.EXPORT_POLICY.EXPORTED,
+            'topic_is_published': base_models.EXPORT_POLICY.NOT_APPLICABLE
+            }
+        self.assertEqual(
+            topic_models.TopicRightsModel.get_export_policy(),
+            expected_dict)

--- a/core/storage/topic/gae_models_test.py
+++ b/core/storage/topic/gae_models_test.py
@@ -173,6 +173,7 @@ class TopicModelUnitTests(test_utils.GenericTestBase):
             topic_models.TopicModel.get_export_policy(),
             expected_dict)
 
+
 class TopicCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
     """Tests the TopicCommitLogEntryModel class."""
 
@@ -235,6 +236,7 @@ class TopicCommitLogEntryModelUnitTest(test_utils.GenericTestBase):
             topic_models.TopicCommitLogEntryModel.get_export_policy(),
             expected_dict)
 
+
 class TopicSummaryModelUnitTests(test_utils.GenericTestBase):
     """Tests the TopicSummaryModel class."""
 
@@ -277,6 +279,7 @@ class TopicSummaryModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(
             topic_models.TopicSummaryModel.get_export_policy(),
             expected_dict)
+
 
 class TopicRightsRightsSnapshotContentModelTests(test_utils.GenericTestBase):
 

--- a/scripts/backend_tests_incomplete_coverage.txt
+++ b/scripts/backend_tests_incomplete_coverage.txt
@@ -88,7 +88,6 @@ core.storage.base_model.gae_models_test
 core.storage.collection.gae_models_test
 core.storage.exploration.gae_models_test
 core.storage.question.gae_models_test
-core.storage.topic.gae_models_test
 core.utils_test
 main_test
 scripts.build_test

--- a/scripts/backend_tests_incomplete_coverage.txt
+++ b/scripts/backend_tests_incomplete_coverage.txt
@@ -88,6 +88,7 @@ core.storage.base_model.gae_models_test
 core.storage.collection.gae_models_test
 core.storage.exploration.gae_models_test
 core.storage.question.gae_models_test
+core.storage.topic.gae_models_test
 core.utils_test
 main_test
 scripts.build_test


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #14219.
2. This PR does the following: Increase the coverage of core.storage.topic.gae_models_test. The current coverage is 97%.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
Before:
<img width="619" alt="ProofForPrevious91%Coverage" src="https://user-images.githubusercontent.com/60730964/232258127-780eafdf-f1f9-4c2d-a778-a8849c73fe30.png">


Current:
<img width="704" alt="ProofFor97%Coverage" src="https://user-images.githubusercontent.com/60730964/232258088-2cc72725-8a0c-405a-85ba-e3d729fccad5.png">


## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
