### PR TITLE
Fix #17918 and fix #17949: adjust position of dropdowns in library page; prevent category dropdown falling behind the selected lessons.

### DIFF
--- a/core/templates/pages/library-page/library-page.component.css
+++ b/core/templates/pages/library-page/library-page.component.css
@@ -121,11 +121,6 @@ oppia-library-page .oppia-library-group-header a,
   color: #04857c;
   text-decoration: none;
 }
-@media (max-width: 720px) {
-  .oppia-library-group-header {
-    font-size: 6vw;
-  }
-}
 .oppia-carousel-box {
   align-items: center;
   display: flex;
@@ -212,7 +207,7 @@ oppia-library-page .oppia-exploration-summary-header {
   max-width: 856px;
 }
 oppia-library-page .oppia-search-bar-container {
-  margin: 0 auto 5vh auto;
+  margin: 0 auto 6vh auto;
   padding-bottom: 60px;
   width: max-content;
 }

--- a/core/templates/pages/library-page/search-bar/search-bar.component.css
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.css
@@ -26,7 +26,10 @@ oppia-search-bar .oppia-same-row-container {
 
 oppia-search-bar .oppia-navbar-button-container {
   border-radius: 0;
-  margin-top: 10px;
+  /* This is needed so that the category and language dropdowns
+  in the library/search page do not fall behind the exploration
+  summary tiles. */
+  z-index: 15;
 }
 
 .search-bar-float-left {
@@ -109,10 +112,6 @@ oppia-search-bar .oppia-input-group {
   max-width: 150px;
 }
 
-oppia-search-bar .oppia-input-group.classroom-page-input-group {
-  width: 20em;
-}
-
 .btn-text {
   color: #257d76;
   margin-left: 8px;
@@ -170,7 +169,7 @@ oppia-search-bar .oppia-input-group.classroom-page-input-group {
     border-top-right-radius: 10px;
     padding: 8px 11px 9px 9px;
   }
-  oppia-search-bar .oppia-input-group.classroom-page-input-group {
+  .oppia-input-group.classroom-page-input-group {
     width: 17em;
   }
   .oppia-search-bar-form .input-group .oppia-search-bar-text-input {
@@ -203,7 +202,6 @@ oppia-search-bar .oppia-input-group.classroom-page-input-group {
     border-radius: 10px;
     color: #fff;
     height: 40px;
-    margin-left: 50px;
     margin-top: -60px;
     max-width: none;
     padding: 8px 7px 0 6px;
@@ -274,7 +272,7 @@ oppia-search-bar .oppia-input-group.classroom-page-input-group {
     display: none;
   }
   .search-button-icon {
-    font-size: 36px;
+    font-size: 24px;
     margin: auto;
   }
 }

--- a/core/templates/pages/library-page/search-bar/search-bar.component.html
+++ b/core/templates/pages/library-page/search-bar/search-bar.component.html
@@ -3,9 +3,9 @@
     <div class="form-group">
       <div class="input-group oppia-input-group" [ngClass]="{'classroom-page-input-group': isSearchButtonActive()}">
         <div class="input-group-addon oppia-search-bar-icon">
-          <i class="fas fa-search material-icons oppia-translate-icon-down md-18" *ngIf="!isSearchInProgress()"></i>
+          <i class="fas fa-search oppia-translate-icon-down md-18" *ngIf="!isSearchInProgress()"></i>
           <span *ngIf="isSearchInProgress()">
-            <i class="fas fa-sync material-icons md-18 oppia-animate-spin"></i>
+            <i class="fas fa-sync oppia-animate-spin"></i>
           </span>
         </div>
         <input type="text"
@@ -30,7 +30,7 @@
             type="button"
             class="btn e2e-test-search-bar-dropdown-toggle oppia-search-bar-dropdown-toggle oppia-search-bar-input oppia-search-bar-category-input dropdown-toggle"
             title="{{ selectionDetails.categories.description | translate }}">
-      <i *ngIf="isMobileViewActive()" class="fas fa-shapes material-icons md-18 category-selector-icon"></i>
+      <i *ngIf="isMobileViewActive()" class="fas fa-shapes category-selector-icon"></i>
       <span class="btn-text">
         {{ categoryButtonText | truncate:14 }}
       </span>
@@ -42,18 +42,18 @@
         <li ngbDropdownItem *ngIf="selectionDetails.categories.selections[item.id]">
           <a (click)="toggleSelection('categories', item.id)" *ngIf="!first && !last" class="dropdown-item">
             <span class="e2e-test-selected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check material-icons md-18 float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
           <a (click)="toggleSelection('categories', item.id)" *ngIf="first" (keydown)="onMenuKeypress($event, 'category', {shiftTab: ACTION_CLOSE})" class="dropdown-item">
             <span class="e2e-test-selected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check material-icons md-18 float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
           <a (click)="toggleSelection('categories', item.id)"
              *ngIf="last"
              (keydown)="onMenuKeypress($event, 'category', {tab: ACTION_CLOSE})"
              class="dropdown-item">
             <span class="e2e-test-selected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check material-icons md-18 float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
         </li>
       </ng-container>
@@ -65,16 +65,16 @@
         <li ngbDropdownItem *ngIf="!selectionDetails.categories.selections[item.id]">
           <a (click)="toggleSelection('categories', item.id)" *ngIf="!first && !last" class="dropdown-item">
             <span class="e2e-test-deselected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check material-icons md-18 float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
           <a (click)="toggleSelection('categories', item.id)" *ngIf="first" (keydown)="onMenuKeypress($event, 'category', {shiftTab: ACTION_CLOSE})" class="dropdown-item">
             <span class="e2e-test-deselected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check material-icons md-18 float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
           <a (click)="toggleSelection('categories', item.id)" *ngIf="last" (keydown)="onMenuKeypress($event, 'category', {tab: ACTION_CLOSE})"
              class="dropdown-item">
             <span class="e2e-test-deselected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check material-icons md-18 float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.categories.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
         </li>
       </ng-container>
@@ -90,7 +90,7 @@
             type="button"
             class="btn e2e-test-search-bar-dropdown-toggle oppia-search-bar-input oppia-search-bar-language-input dropdown-toggle language-dropdown-toggle oppia-search-bar-dropdown-toggle-button"
             title="{{selectionDetails.languageCodes.description | translate}}">
-      <i *ngIf="isMobileViewActive()" class="fas fa-globe material-icons md-18 language-selector-icon"></i>
+      <i *ngIf="isMobileViewActive()" class="fas fa-globe language-selector-icon"></i>
       <span class="btn-text">
         {{ languageButtonText | truncate:14 }}
       </span>
@@ -101,16 +101,16 @@
         <li ngbDropdownItem *ngIf="selectionDetails.languageCodes.selections[item.id]">
           <a (click)="toggleSelection('languageCodes', item.id)" *ngIf="!first && !last" class="dropdown-item">
             <span class="e2e-test-selected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check material-icons md-18 float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
           <a (click)="toggleSelection('languageCodes', item.id)" *ngIf="first" (keydown)="onMenuKeypress($event, 'language', {shiftTab: ACTION_CLOSE})" class="dropdown-item">
             <span class="e2e-test-selected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check material-icons md-18 float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
           <a (click)="toggleSelection('languageCodes', item.id)" *ngIf="last" (keydown)="onMenuKeypress($event, 'language', {tab: ACTION_CLOSE})"
              class="dropdown-item">
             <span class="e2e-test-selected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check material-icons md-18 float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
         </li>
       </ng-container>
@@ -122,16 +122,16 @@
         <li ngbDropdownItem *ngIf="!selectionDetails.languageCodes.selections[item.id]">
           <a (click)="toggleSelection('languageCodes', item.id)" *ngIf="!first && !last" class="dropdown-item">
             <span class="e2e-test-deselected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check material-icons md-18  float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
           <a (click)="toggleSelection('languageCodes', item.id)" *ngIf="first" (keydown)="onMenuKeypress($event, 'language', {shiftTab: ACTION_CLOSE})" class="dropdown-item">
             <span class="e2e-test-deselected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check material-icons md-18  float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
           <a (click)="toggleSelection('languageCodes', item.id)" *ngIf="last" (keydown)="onMenuKeypress($event, 'language', {tab: ACTION_CLOSE})"
              class="dropdown-item">
             <span class="e2e-test-deselected">{{ item.text | translate }}</span>
-            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check material-icons md-18  float-right oppia-search-bar-category-selection-symbol"></i>
+            <i *ngIf="selectionDetails.languageCodes.selections[item.id]" class="fas fa-check float-right oppia-search-bar-category-selection-symbol"></i>
           </a>
         </li>
       </ng-container>
@@ -143,7 +143,7 @@
            class="oppia-search-button e2e-test-search-button"
            (click)="onSearchQueryChangeExec()"
            title="Click here to search">
-        <i class="fas fa-search material-icons md-18 search-button-icon"></i>
+        <i class="fas fa-search search-button-icon"></i>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Overview

1. This PR fixes #17918 and fixes #17949.
2. This PR does the following: Make CSS changes to prevent dropdowns falling behind the lessons and adjust their position so that they look correct in the library page. It also fixes some auxiliary issues: the library group headers were too large in mobile view, the search button icon was displayed too large in the library, and old references to the material-icons class had been left in the codebase from an earlier PR.

One problem that resulted in the poor placement of the buttons (and inconsistent behaviour) was the margin-top in .oppia-navbar-button-container which conflicted with the margin-top property of the category dropdown selector button -- the former was taking priority in the library page, resulting in the button appearing too high on the page. This PR removes that CSS rule.


## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

Library page (widescreen):

![Screenshot from 2023-04-17 13-49-55](https://user-images.githubusercontent.com/10575562/232394292-47f0b3f8-d367-4a8c-af8c-6a5b47be47ba.png)

Library page (narrowscreen):

![Screenshot from 2023-04-17 13-50-03](https://user-images.githubusercontent.com/10575562/232394314-56206b1e-390e-40f0-9a85-48b8c598e734.png)

Lessons page (widescreen):
![Screenshot from 2023-04-17 13-54-30](https://user-images.githubusercontent.com/10575562/232394928-abdcd51a-95ba-4ba1-b823-b4b525a90211.png)


Lessons page (narrowscreen):

![Screenshot from 2023-04-17 13-50-57](https://user-images.githubusercontent.com/10575562/232394877-38e9b887-004e-4f8a-84e6-2079ebecd796.png)

#### Proof of changes in Arabic language

Note: There are existing problems with the Arabic version of the library page (below the search bar). These are not fixed in this PR. There is an issue filed for this here: https://github.com/oppia/oppia/issues/15427

Arabic library page (widescreen):

![Screenshot from 2023-04-17 13-52-11](https://user-images.githubusercontent.com/10575562/232395053-e2166f0d-44c5-4b84-8160-8d679b688a8d.png)


Arabic library page (narrowscreen):

![Screenshot from 2023-04-17 13-52-19](https://user-images.githubusercontent.com/10575562/232395072-41d2a34f-29cb-4d00-9af8-e9bb5137ecbf.png)


Arabic lessons page (widescreen):
![Screenshot from 2023-04-17 13-51-51](https://user-images.githubusercontent.com/10575562/232394970-0f160f73-27cb-4da7-853c-b8c987465358.png)

Arabic lessons page (narrowscreen):

![Screenshot from 2023-04-17 13-51-18](https://user-images.githubusercontent.com/10575562/232394980-b16bd6d7-c2d5-4940-a667-44744316d627.png)



