### PR TITLE
Fix #17973: Implement Preferred Exploration Language Instant Search

### DIFF
--- a/core/templates/pages/preferences-page/form-fields/preferred-languages.component.html
+++ b/core/templates/pages/preferences-page/form-fields/preferred-languages.component.html
@@ -2,12 +2,12 @@
   <mat-label class="text-capitalize">
     {{ 'I18N_PREFERENCES_PREFERRED_EXPLORATION_LANGUAGE' | translate }}
   </mat-label>
-  <mat-chip-list #chipList aria-label="Preferred Exploration Languages">
+  <mat-chip-list #chipList aria-label="Preferred exploration Languages">
     <mat-chip *ngFor="let language of preferredLanguages"
               [selectable]="selectable"
               [removable]="removable"
               (removed)="remove(language)">
-      <ng-container *ngFor="let choice of choices">
+      <ng-container *ngFor="let choice of choices" >
         <ng-container *ngIf="choice.id === language">
           {{ choice.text }}
         </ng-container>
@@ -15,16 +15,17 @@
       <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
     </mat-chip>
     <input placeholder="{{ 'I18N_PREFERENCES_PREFERRED_EXPLORATION_LANGUAGE_SELECT' | translate }}"
-           #languageInput
-           [formControl]="formCtrl"
-           [matAutocomplete]="auto"
-           [matChipInputFor]="chipList"
-           [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-           (matChipInputTokenEnd)="add($event)">
+            #languageInput
+            [formControl]="formCtrl"
+            [matAutocomplete]="auto"
+            [matChipInputFor]="chipList"
+            [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+            (matChipInputTokenEnd)="add($event)"
+            [(ngModel)]="searchQuery" (ngModelChange)="onSearchInputChange($event)" (click)="onInputBoxClick()">
   </mat-chip-list>
   <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selected($event)">
-    <mat-option *ngFor="let language of choices" [value]="language.id">
-      {{ language.text }}
+    <mat-option *ngFor="let choice of filteredChoices" [value]="choice.id">
+      {{ choice.text }}
     </mat-option>
   </mat-autocomplete>
 </mat-form-field>
@@ -34,3 +35,5 @@
     width: 100%;
   }
 </style>
+
+

--- a/core/templates/pages/preferences-page/form-fields/preferred-languages.component.html
+++ b/core/templates/pages/preferences-page/form-fields/preferred-languages.component.html
@@ -2,7 +2,7 @@
   <mat-label class="text-capitalize">
     {{ 'I18N_PREFERENCES_PREFERRED_EXPLORATION_LANGUAGE' | translate }}
   </mat-label>
-  <mat-chip-list #chipList aria-label="Preferred exploration Languages">
+  <mat-chip-list #chipList aria-label="Preferred Exploration Languages">
     <mat-chip *ngFor="let language of preferredLanguages"
               [selectable]="selectable"
               [removable]="removable"

--- a/core/templates/pages/preferences-page/form-fields/preferred-languages.component.ts
+++ b/core/templates/pages/preferences-page/form-fields/preferred-languages.component.ts
@@ -16,11 +16,12 @@
  * @fileoverview Preferred languages component.
  */
 
-import { ENTER } from '@angular/cdk/keycodes';
 import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { MatChipList } from '@angular/material/chips';
+import { ENTER } from '@angular/cdk/keycodes';
 import { LanguageIdAndText } from 'domain/utilities/language-util.service';
+
 
 @Component({
   selector: 'oppia-preferred-languages',
@@ -42,6 +43,19 @@ export class PreferredLanguagesComponent {
   separatorKeysCodes: number[] = [ENTER];
   formCtrl = new FormControl();
 
+  // Changes Here
+  filteredChoices: LanguageIdAndText[] = [];
+  searchQuery: string = ''; 
+
+  onInputBoxClick(): void {
+    setTimeout(() => {
+      // Reset the search query
+      this.searchQuery = '';
+      // Reset the filteredChoices array
+      this.filteredChoices = this.choices;
+    });
+  }
+  
   ngOnInit(): void {
     this.formCtrl.valueChanges.subscribe((value: string) => {
       if (!this.validInput(value)) {
@@ -51,16 +65,18 @@ export class PreferredLanguagesComponent {
       }
     });
   }
-
+  
+  
   validInput(value: string): boolean {
     let availableLanguage = false;
-    for (let i = 0; i < this.choices.length; i++) {
-      if (this.choices[i].id === value) {
+    // Changes Here, filteredChoices instead of Choices
+    for (let i = 0; i < this.filteredChoices.length; i++) {
+      if (this.filteredChoices[i].id === value) {
         availableLanguage = true;
         break;
       }
     }
-
+  
     return availableLanguage &&
       this.preferredLanguages.indexOf(value) < 0 ? true : false;
   }
@@ -76,6 +92,9 @@ export class PreferredLanguagesComponent {
       this.preferredLanguagesChange.emit(this.preferredLanguages);
       this.languageInput.nativeElement.value = '';
     }
+
+    this.searchQuery = '';
+    this.filteredChoices = this.choices;
   }
 
   remove(fruit: string): void {
@@ -93,5 +112,14 @@ export class PreferredLanguagesComponent {
     } else {
       this.add(event.option);
     }
+  }
+  
+  //Changes Here
+  onSearchInputChange(): void {
+    // Filter the choices array based on the search query
+    this.filteredChoices = this.choices.filter(choice => {
+      return choice.text.toLowerCase().includes(this.searchQuery.toLowerCase()) ||
+             choice.id.toLowerCase().includes(this.searchQuery.toLowerCase());
+    });
   }
 }


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[17973].
2. This PR does the following: [Implement Preferred Exploration Language Instant Search]

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ ] The linter/Karma presubmit checks have passed locally on your machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
[-->]

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
