### PR TITLE
Fix #15986: update three dots to animate properly on exploration question submission

### DIFF
--- a/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.css
+++ b/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.css
@@ -30,43 +30,9 @@ oppia-input-response-pair .oppia-popover {
   overflow-y: scroll;
 }
 
-.conversation-skin-feedback-dot-one,
-.conversation-skin-feedback-dot-two,
-.conversation-skin-feedback-dot-three {
-  background-color: #666;
-  display: inline-block;
-  height: 2px;
-  width: 2px;
-}
-
-.conversation-skin-feedback-dot-one {
-  -webkit-animation: dot 1.0s infinite;
-  -moz-animation: dot 1.0s infinite;
-  animation: dot 1.0s infinite;
-  -webkit-animation-delay: 0.0s;
-  -moz-animation-delay: 0.0s;
-  animation-delay: 0.0s;
-  opacity: 0;
-}
-
-.conversation-skin-feedback-dot-two {
-  -webkit-animation: dot 1.0s infinite;
-  -moz-animation: dot 1.0s infinite;
-  animation: dot 1.0s infinite;
-  -webkit-animation-delay: 0.2s;
-  -moz-animation-delay: 0.2s;
-  animation-delay: 0.2s;
-  opacity: 0;
-}
-
-.conversation-skin-feedback-dot-three {
-  -webkit-animation: dot 1.0s infinite;
-  -moz-animation: dot 1.0s infinite;
-  animation: dot 1.0s infinite;
-  -webkit-animation-delay: 0.4s;
-  -moz-animation-delay: 0.4s;
-  animation-delay: 0.4s;
-  opacity: 0;
+.conversation-skin-feedback-dots {
+  font-size: 24px;
+  font-weight: bold;
 }
 
 .conversation-skin-oppia-feedback.ng-enter {

--- a/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.html
+++ b/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.html
@@ -40,11 +40,8 @@
   <img class="conversation-skin-oppia-avatar rounded-circle"
        [src]="oppiaAvatarImageUrl"
        alt="">
-  <div *ngIf="!data.oppiaResponse && isCurrentCardAtEndOfTranscript()"
-       class="e2e-test-input-response-loading-dots">
-    <div class="conversation-skin-feedback-dot-one"></div>
-    <div class="conversation-skin-feedback-dot-two"></div>
-    <div class="conversation-skin-feedback-dot-three"></div>
+  <div class="conversation-skin-feedback-dots" *ngIf="shouldShowLoadingDots()">
+    <loading-dots></loading-dots>
   </div>
   <span id="getInputResponsePairId()"></span>
   <div dir="auto">

--- a/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.spec.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.spec.ts
@@ -292,4 +292,48 @@ describe('InputResponsePairComponent', () => {
     number = '-12.3';
     expect(component.convertAnswerToLocalFormat(number)).toEqual('-12.3');
   });
+
+  it('should show loading dots when Oppia response null and last card', () => {
+    spyOn(playerTranscriptService, 'isLastCard').and.returnValue(true);
+    component.data = {
+      learnerInput: '',
+      oppiaResponse: null,
+      isHint: true
+    };
+
+    expect(component.shouldShowLoadingDots()).toBeTrue();
+  });
+
+  it('should not show loading dots w/ null response and not last card', () => {
+    spyOn(playerTranscriptService, 'isLastCard').and.returnValue(false);
+    component.data = {
+      learnerInput: '',
+      oppiaResponse: null,
+      isHint: true
+    };
+
+    expect(component.shouldShowLoadingDots()).toBeFalse();
+  });
+
+  it('should not show loading dots w/ response and not last card', () => {
+    spyOn(playerTranscriptService, 'isLastCard').and.returnValue(false);
+    component.data = {
+      learnerInput: '',
+      oppiaResponse: 'response',
+      isHint: true
+    };
+
+    expect(component.shouldShowLoadingDots()).toBeFalse();
+  });
+
+  it('should not show loading dots w/ response and last card', () => {
+    spyOn(playerTranscriptService, 'isLastCard').and.returnValue(true);
+    component.data = {
+      learnerInput: '',
+      oppiaResponse: 'response',
+      isHint: true
+    };
+
+    expect(component.shouldShowLoadingDots()).toBeFalse();
+  });
 });

--- a/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.ts
+++ b/core/templates/pages/exploration-player-page/learner-experience/input-response-pair.component.ts
@@ -152,6 +152,13 @@ export class InputResponsePairComponent {
   togglePopover(): void {
     this.popover.toggle();
   }
+
+  shouldShowLoadingDots(): boolean {
+    if (!this.data.oppiaResponse && this.isCurrentCardAtEndOfTranscript()) {
+      return true;
+    }
+    return false;
+  }
 }
 
 angular.module('oppia').directive('oppiaInputResponsePair',


### PR DESCRIPTION
## Overview

1. This PR fixes #15986.
2. This PR does the following: Replaces the method that displays and animates the loading dots when the feedback for a submitted question in an exploration loads.

## Essential Checklist

- [X] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [X] The linter/Karma presubmit checks have passed locally on your machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [X] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

https://user-images.githubusercontent.com/59969813/233503725-4ac1ee26-b446-4063-980f-fb4431e8f4b4.mov

Front end tests and coverage checks pass:
<img width="566" alt="Screenshot 2023-04-20 at 5 58 36 PM" src="https://user-images.githubusercontent.com/59969813/233503782-47ec4b87-3a85-492a-a66b-f4df5e24669e.png">
Linter:
<img width="479" alt="Screenshot 2023-04-20 at 5 46 43 PM" src="https://user-images.githubusercontent.com/59969813/233503857-dadc3e02-fd3c-430d-955d-41f987d76e10.png">

E2E tests pass under test suite explorationFeedbackTab:
<img width="461" alt="Screenshot 2023-04-20 at 6 32 01 PM" src="https://user-images.githubusercontent.com/59969813/233503959-c3f286a3-fccd-4198-bfae-4a1adc410c7b.png">

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

N/A

#### Proof of changes in Arabic language

N/A

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
