### PR TITLE
fix-18034: fixed the accessibility issues in publish changes dialogbox

### DIFF
--- a/core/templates/pages/exploration-editor-page/editor-tab/graph-directives/state-graph-visualization.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/graph-directives/state-graph-visualization.component.html
@@ -32,6 +32,7 @@ with the same id on the page. -->
                     [attr.style]="node.style"
                     (click)="sendOnClickFunctionData(node.id)"
                     [attr.aria-label]="'Switch to ' + getNodeTitle(node) + 'Card'">
+                    role="button"
               </rect>
               <title>{{getNodeTitle(node)}}</title>
               <text text-anchor="middle" [attr.x]="node.xLabel" [attr.y]="node.yLabel">
@@ -50,6 +51,7 @@ with the same id on the page. -->
                       [attr.transform]="getHighlightTransform(node.x0, node.y0)"
                       [attr.style]="'fill: yellow; z-index: 10000;'"
                       [attr.aria-label]="getNodeErrorMessage(node.label)">
+                      role="button"
                 </rect>
                 <text fill="firebrick" text-anchor="middle" [attr.x]="node.x0 + 11"
                       [attr.y]="node.y0 + 9"
@@ -65,6 +67,7 @@ with the same id on the page. -->
                       class="clickable oppia-node-delete"
                       (click)="onNodeDeletionClick(node.id)"
                       [attr.aria-label]="'Delete' + getNodeTitle(node) + 'card'">
+                      role="button"
                 </rect>
                 <text [attr.dx]="node.x0 + node.width" [attr.dy]="node.y0" text-anchor="right">
                   x

--- a/core/templates/pages/exploration-editor-page/modal-templates/exploration-save-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/modal-templates/exploration-save-modal.component.html
@@ -9,7 +9,7 @@
     <p class="e2e-test-exploration-save-modal">
       <span *ngIf="isExplorationPrivate">(Optional)</span>
       Please enter a brief description of what you have changed:
-      <textarea rows="3" cols="50" [maxlength]="MAX_COMMIT_MESSAGE_LENGTH" [(ngModel)]="commitMessage" class="oppia-commit-message-input e2e-test-commit-message-input" autofocus></textarea>
+      <textarea rows="3" cols="50" [maxlength]="MAX_COMMIT_MESSAGE_LENGTH" [(ngModel)]="commitMessage" class="oppia-commit-message-input e2e-test-commit-message-input" autofocus title="commit message"></textarea>
     </p>
     <button class="btn btn-secondary" (click)="onClickToggleDiffButton()">
       <span *ngIf="!showDiff">Show Changes</span>


### PR DESCRIPTION
## Overview

1. This PR fixes #18034 .
2. This PR does the following: Fixed all accessibility issues in Publish Changes Dialogbox by adding the role attribute to the anchor tags that were causing problems with the aria-label attribute, and adding a title attribute to the form element.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

![Image 4-23-23 at 11 46 AM](https://user-images.githubusercontent.com/98051270/233854062-eddb124a-1deb-46d6-a57d-0cd97530c0b7.jpg)


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
