### PR TITLE
Remove obsolete rule for mapreduce images.

### DIFF
--- a/app_dev.yaml
+++ b/app_dev.yaml
@@ -26,9 +26,6 @@ handlers:
   static_files: assets/sitemap.xml
   upload: assets/sitemap.xml
   secure: always
-- url: /mapreduce/pipeline/images
-  static_dir: third_party/gae-mapreduce-1.9.22.0/mapreduce/lib/pipeline/ui/images
-  secure: always
 - url: /build
   static_dir: build
   secure: always


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Drops a rule in app_dev.yaml that points to an obsolete filepath (we no longer use mapreduce since it's been superseded by our new Apache Beam pipeline).

## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

No proof of changes needed because this removes an unused handler and there are no calls being made to that handler. 