### PR TITLE
Fix#18215 The number in the warning icon comes out of the box when it is >9 in Topic page fixed

### DIFF
--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -2533,7 +2533,7 @@ div#ng-curtain {
 
 .oppia-editor-warnings-indicator {
   border-style: inset;
-  border-width: 0 9px 14px 9px;
+  border-width: 0 12px 16px 12px;
   bottom: 10px;
   font-size: 0.7em;
   font-weight: bold;
@@ -2551,7 +2551,10 @@ div#ng-curtain {
   color: #fff;
 }
 .oppia-editor-warnings-count {
-  margin-left: -3px;
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  padding-top: 2px;
 }
 
 .uib-dropdown-menu.oppia-editor-warnings-box {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[18215].
2. This PR does the following: [warning count is made display flex, text-align center , align items center and the border width increase slightly so that the number does not go out of the icon]

## Essential Checklist

- [YES] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [YES ] The linter/Karma presubmit checks have passed locally on your machine.
- [YES ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [NO ] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
<img width="1440" alt="Screenshot 2023-05-11 at 11 45 45 PM" src="https://github.com/oppia/oppia/assets/93394632/7d517128-7d96-4b39-bae3-b0e9e1749e74">

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
