### PR TITLE
Added 1 h1 tag at the at lesson-information-card

### DIFF
--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.css
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.css
@@ -21,7 +21,7 @@
 
 .oppia-lesson-info-card .oppia-exploration-description {
   color: #333;
-  font-size: 15px;
+  font-size: 17px;
   font-weight: normal;
   margin-top: 20px;
   padding-bottom: 10px;
@@ -91,7 +91,7 @@
   margin-right: -50%;
   position: absolute;
   top: 50%;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, -87%);
   width: 120px;
 }
 

--- a/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
+++ b/core/templates/pages/exploration-player-page/templates/lesson-information-card-modal.component.html
@@ -3,13 +3,13 @@
     <img [src]="getStaticImageUrl(infoCardBackgroundImageUrl)"
          class="oppia-info-card-bg-image"
          alt="{{ expCategory }}">
-    <h2 class="oppia-info-card-title break-word" *ngIf="isHackyExpTitleTranslationDisplayed()">
+    <h1 class="oppia-info-card-title break-word" *ngIf="isHackyExpTitleTranslationDisplayed()">
       {{ expTitleTranslationKey | translate }}
-    </h2>
-    <h2 class="oppia-info-card-title break-word"
+    </h1>
+    <h1 class="oppia-info-card-title break-word"
         *ngIf="!isHackyExpTitleTranslationDisplayed()">
       {{ expTitle }}
-    </h2>
+    </h1>
   </div>
   <div class="oppia-lesson-info-content">
     <div class="oppia-lesson-info-content-inner-container">


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #16995
2. This PR does the following: [This PR changes the h2 tag to h1 tag having class .oppia-info-card-title, changes the font size of the h4 tag from 15px to 17px, the icon's position is also changed according to the space given.]

## Essential Checklist

- [x] The PR title starts with "Fix #16995: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #16995: No heading 1 tag is seen when lesson info dialog box opens up ".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
previously looked like 
<img width="1661" alt="Screenshot 2023-05-16 at 7 26 28 PM" src="https://github.com/oppia/oppia/assets/114716075/520d0527-426c-4492-ad20-96c2de6b645d">


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.
<img width="1662" alt="Screenshot 2023-05-16 at 7 26 10 PM" src="https://github.com/oppia/oppia/assets/114716075/2458b48e-8dde-424a-86b6-8b77ac26668d">


after changes
<img width="1662" alt="Screenshot 2023-05-16 at 7 26 10 PM" src="https://github.com/oppia/oppia/assets/114716075/fd1f48bd-e6d6-4fd6-93f2-f1ef30c738d1">






Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
<img width="205" alt="Screenshot 2023-05-16 at 7 34 03 PM" src="https://github.com/oppia/oppia/assets/114716075/8357d9b1-67e7-45d2-bc48-adb05ec25185">


<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->



## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
