### PR TITLE
Fix #18008: Elements must have sufficient color contrast in the exploration editor page with Numeric expression input interaction

### DIFF
--- a/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
+++ b/core/templates/components/state-directives/answer-group-editor/answer-group-editor.component.html
@@ -73,7 +73,7 @@
 
 <style>
   .oppia-rule-header {
-    color: rgb(120, 120, 120);
+    color: rgb(81, 81, 81);
     padding-left: 0;
     text-overflow: ellipsis;
   }
@@ -124,7 +124,7 @@
     background-color: rgba(165,165,165,0.9);
     border: 0;
     border-radius: 0;
-    color: white;
+    color: #504848;
     margin-top: 4%;
     opacity: 0.9;
     padding: 7px;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [18008] below in 1.
-->

1. This PR fixes or fixes part of #18008 
2. 3. This PR does the following: Fixes #18008 Elements must have sufficient color contrast in the exploration editor page with Numeric expression input interaction 

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
before :
![18008](https://github.com/oppia/oppia/assets/79320301/43cee235-e751-4889-9c1a-64877dfb6017)
![18008 1](https://github.com/oppia/oppia/assets/79320301/968db71f-5e57-4489-9d9f-78acdbbb9044)
![18008befoer](https://github.com/oppia/oppia/assets/79320301/de2c91a1-8e5f-4b59-a661-4dde4ac8a0e7)
after:

![18008after1](https://github.com/oppia/oppia/assets/79320301/ee35f9d7-d81e-4472-8d54-c605a0462ada)
![after180008](https://github.com/oppia/oppia/assets/79320301/cb42b84f-d7b5-453e-b3cc-2cdf1e5ca810)
no color contrast issue found after fix proof :
![nocol18008](https://github.com/oppia/oppia/assets/79320301/252e73b9-416a-476f-ba8e-6109ae3980a3)

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
