### PR TITLE
Fix #18241: Update format of android handler response to correctly handle multiple items in the request. Also possibly fix e2e flake in navigation.js.

### DIFF
--- a/core/controllers/android.py
+++ b/core/controllers/android.py
@@ -36,7 +36,6 @@ from core.domain import subtopic_page_domain
 from core.domain import subtopic_page_services
 from core.domain import topic_domain
 from core.domain import topic_fetchers
-from core.domain import translation_domain
 from core.domain import translation_fetchers
 
 from typing import Dict, List, Optional, TypedDict, Union
@@ -105,7 +104,7 @@ class _ActivityDataResponseDictRequiredFields(TypedDict):
         subtopic_page_domain.SubtopicPageDict,
         classroom_config_domain.ClassroomDict,
         topic_domain.TopicDict,
-        translation_domain.EntityTranslationDict,
+        Dict[str, feconf.TranslatedContentDict],
         classroom_domain.ClassroomDict,
         None
     ]
@@ -278,7 +277,8 @@ class AndroidActivityHandler(base.BaseHandler[
                     'version': version,
                     'language_code': language_code,
                     'payload': (
-                        translation.to_dict() if translation is not None
+                        translation.to_dict()['translations']
+                        if translation is not None
                         else None)
                 })
         else:

--- a/core/controllers/android.py
+++ b/core/controllers/android.py
@@ -24,8 +24,6 @@ from core.domain import android_services
 from core.domain import classroom_config_domain
 from core.domain import classroom_config_services
 from core.domain import classroom_domain
-from core.domain import classroom_services
-from core.domain import config_domain
 from core.domain import exp_domain
 from core.domain import exp_fetchers
 from core.domain import skill_domain
@@ -238,18 +236,9 @@ class AndroidActivityHandler(base.BaseHandler[
                 if activity_data.get('version') is not None:
                     raise self.InvalidInputException(
                         'Version cannot be specified for classroom')
-                matching_classroom_fragment = [
-                    classroom['url_fragment']
-                    for classroom in config_domain.CLASSROOM_PAGES_DATA.value
-                    if classroom['name'] == activity_data['id']
-                ][0]
                 classroom = (
                     classroom_config_services.get_classroom_by_url_fragment(
-                        activity_data['id']
-                    ) or classroom_services.get_classroom_by_url_fragment(
-                        matching_classroom_fragment
-                    )
-                )
+                        activity_data['id']))
                 activities.append({
                     'id': activity_data['id'],
                     'payload': (

--- a/core/controllers/android.py
+++ b/core/controllers/android.py
@@ -82,12 +82,41 @@ class InitializeAndroidTestDataHandler(
         })
 
 
-class ActivityDataDict(TypedDict):
-    """Dict representation of items in activites_data."""
+class ActivityDataRequestDict(TypedDict):
+    """Dict representation of items in activities_data."""
 
     id: str
     version: Optional[int]
     language_code: Optional[str]
+
+
+class _ActivityDataResponseDictRequiredFields(TypedDict):
+    """Required fields for items returned in the activities response list.
+
+    Note: See https://stackoverflow.com/a/74843909. NotRequired isn't available
+    yet for us to use here.
+    """
+
+    id: str
+    payload: Union[
+        exp_domain.ExplorationDict,
+        story_domain.StoryDict,
+        skill_domain.SkillDict,
+        subtopic_page_domain.SubtopicPageDict,
+        classroom_config_domain.ClassroomDict,
+        topic_domain.TopicDict,
+        translation_domain.EntityTranslationDict,
+        classroom_domain.ClassroomDict,
+        None
+    ]
+
+
+class ActivityDataResponseDict(
+        _ActivityDataResponseDictRequiredFields, total=False):
+    """Dict representation of items returned in the activities response list."""
+
+    version: Optional[int]
+    language_code: str
 
 
 class AndroidActivityHandlerHandlerNormalizedRequestDict(TypedDict):
@@ -96,7 +125,7 @@ class AndroidActivityHandlerHandlerNormalizedRequestDict(TypedDict):
     """
 
     activity_type: str
-    activities_data: List[ActivityDataDict]
+    activities_data: List[ActivityDataRequestDict]
 
 
 class AndroidActivityHandler(base.BaseHandler[
@@ -142,53 +171,69 @@ class AndroidActivityHandler(base.BaseHandler[
         assert self.normalized_request is not None
         activities_data = self.normalized_request['activities_data']
         activity_type = self.normalized_request['activity_type']
-        activities: Dict[str, Union[
-            exp_domain.Exploration,
-            story_domain.Story,
-            skill_domain.Skill,
-            subtopic_page_domain.SubtopicPage,
-            classroom_config_domain.Classroom,
-            topic_domain.Topic,
-            translation_domain.EntityTranslation,
-            classroom_domain.Classroom,
-            None
-        ]] = {}
+        activities: List[ActivityDataResponseDict] = []
+
+        hashed_activities_data = [
+            tuple(sorted((k, v) for k, v in activity_data.items()))
+            for activity_data in activities_data]
+        if len(set(hashed_activities_data)) != len(hashed_activities_data):
+            raise self.InvalidInputException(
+                'Entries in activities_data should be unique'
+            )
 
         if activity_type == constants.ACTIVITY_TYPE_EXPLORATION:
-            activities = {
-                activity_data['id']: exp_fetchers.get_exploration_by_id(
+            for activity_data in activities_data:
+                exploration = exp_fetchers.get_exploration_by_id(
                     activity_data['id'],
                     strict=False,
-                    version=activity_data.get('version')
-                ) for activity_data in activities_data
-            }
+                    version=activity_data.get('version'))
+                activities.append({
+                    'id': activity_data['id'],
+                    'version': activity_data.get('version'),
+                    'payload': (
+                        exploration.to_dict() if exploration is not None
+                        else None)
+                })
         elif activity_type == constants.ACTIVITY_TYPE_STORY:
-            activities = {
-                activity_data['id']: story_fetchers.get_story_by_id(
+            for activity_data in activities_data:
+                story = story_fetchers.get_story_by_id(
                     activity_data['id'],
                     strict=False,
-                    version=activity_data.get('version')
-                ) for activity_data in activities_data
-            }
+                    version=activity_data.get('version'))
+                activities.append({
+                    'id': activity_data['id'],
+                    'version': activity_data.get('version'),
+                    'payload': (
+                        story.to_dict() if story is not None else None)
+                })
         elif activity_type == constants.ACTIVITY_TYPE_SKILL:
-            activities = {
-                activity_data['id']: skill_fetchers.get_skill_by_id(
+            for activity_data in activities_data:
+                skill = skill_fetchers.get_skill_by_id(
                     activity_data['id'],
                     strict=False,
-                    version=activity_data.get('version')
-                ) for activity_data in activities_data
-            }
+                    version=activity_data.get('version'))
+                activities.append({
+                    'id': activity_data['id'],
+                    'version': activity_data.get('version'),
+                    'payload': (
+                        skill.to_dict() if skill is not None else None)
+                })
         elif activity_type == constants.ACTIVITY_TYPE_SUBTOPIC:
             for activity_data in activities_data:
                 topic_id, subtopic_page_id = activity_data['id'].split('-')
-                activities[activity_data['id']] = (
-                    subtopic_page_services.get_subtopic_page_by_id(
-                        topic_id,
-                        int(subtopic_page_id),
-                        strict=False,
-                        version=activity_data.get('version')
-                    )
+                subtopic_page = subtopic_page_services.get_subtopic_page_by_id(
+                    topic_id,
+                    int(subtopic_page_id),
+                    strict=False,
+                    version=activity_data.get('version')
                 )
+                activities.append({
+                    'id': activity_data['id'],
+                    'version': activity_data.get('version'),
+                    'payload': (
+                        subtopic_page.to_dict() if subtopic_page is not None
+                        else None)
+                })
         elif activity_type == constants.ACTIVITY_TYPE_CLASSROOM:
             for activity_data in activities_data:
                 if activity_data.get('version') is not None:
@@ -199,13 +244,18 @@ class AndroidActivityHandler(base.BaseHandler[
                     for classroom in config_domain.CLASSROOM_PAGES_DATA.value
                     if classroom['name'] == activity_data['id']
                 ][0]
-                activities[activity_data['id']] = (
+                classroom = (
                     classroom_config_services.get_classroom_by_url_fragment(
                         activity_data['id']
                     ) or classroom_services.get_classroom_by_url_fragment(
                         matching_classroom_fragment
                     )
                 )
+                activities.append({
+                    'id': activity_data['id'],
+                    'payload': (
+                        classroom.to_dict() if classroom is not None else None)
+                })
         elif activity_type == constants.ACTIVITY_TYPE_EXPLORATION_TRANSLATIONS:
             entity_type = feconf.TranslatableEntityType(
                 feconf.ENTITY_TYPE_EXPLORATION)
@@ -217,24 +267,31 @@ class AndroidActivityHandler(base.BaseHandler[
                         'Version and language code must be specified '
                         'for translation'
                     )
-                activities[activity_data['id']] = (
-                    translation_fetchers.get_entity_translation(
-                        entity_type,
-                        activity_data['id'],
-                        version,
-                        language_code
-                    )
+                translation = translation_fetchers.get_entity_translation(
+                    entity_type,
+                    activity_data['id'],
+                    version,
+                    language_code
                 )
+                activities.append({
+                    'id': activity_data['id'],
+                    'version': version,
+                    'language_code': language_code,
+                    'payload': (
+                        translation.to_dict() if translation is not None
+                        else None)
+                })
         else:
-            activities = {
-                activity_data['id']: topic_fetchers.get_topic_by_id(
+            for activity_data in activities_data:
+                topic = topic_fetchers.get_topic_by_id(
                     activity_data['id'],
                     strict=False,
-                    version=activity_data.get('version')
-                ) for activity_data in activities_data
-            }
+                    version=activity_data.get('version'))
+                activities.append({
+                    'id': activity_data['id'],
+                    'version': activity_data.get('version'),
+                    'payload': (
+                        topic.to_dict() if topic is not None else None)
+                })
 
-        self.render_json({
-            id: activity.to_dict() if activity is not None else None
-            for id, activity in activities.items()
-        })
+        self.render_json(activities)

--- a/core/controllers/android_test.py
+++ b/core/controllers/android_test.py
@@ -178,7 +178,7 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                 ),
                 [{
                     'id': 'exp_id',
-                    'version': 1,
+                    'version': 2,
                     'payload': new_exploration.to_dict()
                 }]
             )
@@ -435,7 +435,13 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
     def test_get_exploration_translation_returns_correct_json(self) -> None:
         translation_model = (
             translation_models.EntityTranslationsModel.create_new(
-                'exploration', 'translation_id', 1, 'es', {}))
+                'exploration', 'translation_id', 1, 'es', {
+                    'content_id_123': {
+                        'content_value': 'Hello world!',
+                        'needs_update': False,
+                        'content_format': 'html'
+                    }
+                }))
         translation_model.update_timestamps()
         translation_model.put()
         with self.secrets_swap:
@@ -455,7 +461,11 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     'language_code': 'es',
                     'version': 1,
                     'payload': {
-                        'translations': {}
+                        'content_id_123': {
+                            'content_value': 'Hello world!',
+                            'needs_update': False,
+                            'content_format': 'html'
+                        }
                     }
                 }]
             )

--- a/core/controllers/android_test.py
+++ b/core/controllers/android_test.py
@@ -108,7 +108,7 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                 expected_status_int=401
             )
 
-    def test_get_non_existent_activity_returns_error(self) -> None:
+    def test_get_non_existent_activity_returns_null_payload(self) -> None:
         with self.secrets_swap:
             self.assertEqual(
                 self.get_json(
@@ -117,7 +117,7 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     headers={'X-ApiKey': 'secret'},
                     expected_status_int=200
                 ),
-                {'story_id': None}
+                [{'id': 'story_id', 'version': 1, 'payload': None}]
             )
 
     def test_get_exploration_returns_correct_json(self) -> None:
@@ -130,7 +130,11 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     headers={'X-ApiKey': 'secret'},
                     expected_status_int=200
                 ),
-                {'exp_id': exploration.to_dict()}
+                [{
+                    'id': 'exp_id',
+                    'version': 1,
+                    'payload': exploration.to_dict()
+                }]
             )
 
     def test_get_different_versions_of_exploration_returns_correct_json(
@@ -159,7 +163,11 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     headers={'X-ApiKey': 'secret'},
                     expected_status_int=200
                 ),
-                {'exp_id': exploration.to_dict()}
+                [{
+                    'id': 'exp_id',
+                    'version': 1,
+                    'payload': exploration.to_dict()
+                }]
             )
             self.assertEqual(
                 self.get_json(
@@ -168,7 +176,124 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     headers={'X-ApiKey': 'secret'},
                     expected_status_int=200
                 ),
-                {'exp_id': new_exploration.to_dict()}
+                [{
+                    'id': 'exp_id',
+                    'version': 1,
+                    'payload': new_exploration.to_dict()
+                }]
+            )
+
+    def test_get_multiple_versions_at_a_time_returns_correct_json(self) -> None:
+        exploration = self.save_new_default_exploration('exp_id', 'owner_id')
+        exp_services.update_exploration(
+            'owner_id',
+            'exp_id',
+            [
+                exp_domain.ExplorationChange({
+                    'cmd': 'edit_exploration_property',
+                    'property_name': 'objective',
+                    'new_value': 'new objective'
+                })
+            ],
+            'change objective'
+        )
+        new_exploration = exp_fetchers.get_exploration_by_id('exp_id')
+
+        with self.secrets_swap:
+            # Try fetching two versions at once, in either order.
+            self.assertEqual(
+                self.get_json(
+                    '/android_data?activity_type=exploration&'
+                    'activities_data=[{"id": "exp_id", "version": 2}, '
+                    '{"id": "exp_id", "version": 1}]',
+                    headers={'X-ApiKey': 'secret'},
+                    expected_status_int=200
+                ),
+                [{
+                    'id': 'exp_id',
+                    'version': 2,
+                    'payload': new_exploration.to_dict()
+                }, {
+                    'id': 'exp_id',
+                    'version': 1,
+                    'payload': exploration.to_dict()
+                }]
+            )
+
+            self.assertEqual(
+                self.get_json(
+                    '/android_data?activity_type=exploration&'
+                    'activities_data=[{"id": "exp_id", "version": 1}, '
+                    '{"id": "exp_id", "version": 2}]',
+                    headers={'X-ApiKey': 'secret'},
+                    expected_status_int=200
+                ),
+                [{
+                    'id': 'exp_id',
+                    'version': 1,
+                    'payload': exploration.to_dict()
+                }, {
+                    'id': 'exp_id',
+                    'version': 2,
+                    'payload': new_exploration.to_dict()
+                }]
+            )
+
+    def test_get_with_invalid_versions_returns_correct_json(self) -> None:
+        exploration = self.save_new_default_exploration('exp_id', 'owner_id')
+
+        with self.secrets_swap:
+            # Note that version 3 does not exist.
+            self.assertEqual(
+                self.get_json(
+                    '/android_data?activity_type=exploration&'
+                    'activities_data=[{"id": "exp_id", "version": 3}, '
+                    '{"id": "exp_id", "version": 1}]',
+                    headers={'X-ApiKey': 'secret'},
+                    expected_status_int=200
+                ),
+                [{
+                    'id': 'exp_id',
+                    'version': 3,
+                    'payload': None
+                }, {
+                    'id': 'exp_id',
+                    'version': 1,
+                    'payload': exploration.to_dict()
+                }]
+            )
+
+            # For completeness, try the opposite order as well.
+            self.assertEqual(
+                self.get_json(
+                    '/android_data?activity_type=exploration&'
+                    'activities_data=[{"id": "exp_id", "version": 1}, '
+                    '{"id": "exp_id", "version": 3}]',
+                    headers={'X-ApiKey': 'secret'},
+                    expected_status_int=200
+                ),
+                [{
+                    'id': 'exp_id',
+                    'version': 1,
+                    'payload': exploration.to_dict()
+                }, {
+                    'id': 'exp_id',
+                    'version': 3,
+                    'payload': None
+                }]
+            )
+
+    def test_get_with_duplicates_is_rejected(self) -> None:
+        with self.secrets_swap:
+            self.assertEqual(
+                self.get_json(
+                    '/android_data?activity_type=exploration&'
+                    'activities_data=[{"id": "exp_id", "version": 1}, '
+                    '{"id": "exp_id", "version": 1}]',
+                    headers={'X-ApiKey': 'secret'},
+                    expected_status_int=400
+                )['error'],
+                'Entries in activities_data should be unique'
             )
 
     def test_get_story_returns_correct_json(self) -> None:
@@ -181,7 +306,11 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     headers={'X-ApiKey': 'secret'},
                     expected_status_int=200
                 ),
-                {'story_id': story.to_dict()}
+                [{
+                    'id': 'story_id',
+                    'version': 1,
+                    'payload': story.to_dict()
+                }]
             )
 
     def test_get_skill_returns_correct_json(self) -> None:
@@ -194,7 +323,11 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     headers={'X-ApiKey': 'secret'},
                     expected_status_int=200
                 ),
-                {'skill_id': skill.to_dict()}
+                [{
+                    'id': 'skill_id',
+                    'version': 1,
+                    'payload': skill.to_dict()
+                }]
             )
 
     def test_get_subtopic_returns_correct_json(self) -> None:
@@ -207,7 +340,11 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     headers={'X-ApiKey': 'secret'},
                     expected_status_int=200
                 ),
-                {'topic_id-1': subtopic.to_dict()}
+                [{
+                    'id': 'topic_id-1',
+                    'version': 1,
+                    'payload': subtopic.to_dict()
+                }]
             )
 
     def test_get_classroom_returns_correct_json(self) -> None:
@@ -234,7 +371,10 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     headers={'X-ApiKey': 'secret'},
                     expected_status_int=200
                 ),
-                {'math': classroom.to_dict()}
+                [{
+                    'id': 'math',
+                    'payload': classroom.to_dict()
+                }]
             )
 
     def test_get_classroom_with_version_returns_error(self) -> None:
@@ -310,15 +450,14 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     headers={'X-ApiKey': 'secret'},
                     expected_status_int=200
                 ),
-                {
-                    'translation_id': {
-                        'entity_id': 'translation_id',
-                        'entity_type': 'exploration',
-                        'entity_version': 1,
-                        'language_code': 'es',
+                [{
+                    'id': 'translation_id',
+                    'language_code': 'es',
+                    'version': 1,
+                    'payload': {
                         'translations': {}
                     }
-                }
+                }]
             )
 
     def test_get_exploration_translation_with_zero_items_returns_correct_json(
@@ -332,7 +471,7 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     headers={'X-ApiKey': 'secret'},
                     expected_status_int=200
                 ),
-                {}
+                []
             )
 
     def test_get_topic_returns_correct_json(self) -> None:
@@ -345,5 +484,9 @@ class AndroidActivityHandlerTests(test_utils.GenericTestBase):
                     headers={'X-ApiKey': 'secret'},
                     expected_status_int=200
                 ),
-                {'topic_id': topic.to_dict()}
+                [{
+                    'id': 'topic_id',
+                    'version': 1,
+                    'payload': topic.to_dict()
+                }]
             )

--- a/core/tests/webdriverio_utils/PreferencesPage.js
+++ b/core/tests/webdriverio_utils/PreferencesPage.js
@@ -58,6 +58,8 @@ var PreferencesPage = function() {
   this.get = async function() {
     await browser.url(USER_PREFERENCES_URL);
     await waitFor.pageToFullyLoad();
+    // Click on a neutral element.
+    await action.click('Preferences page header', pageHeader);
   };
 
   this.expectUploadError = async function() {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #18241.
2. This PR does the following: Updates the format of the Android data handler response to match the discussion in #18241.

Additionally, this PR attempts to fix #16560 by ensuring the Preferences page loads fully before the rest of the test is executed.

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct

Tests have been added to verify all the cases in #18241, and all those tests pass locally (and should pass in the CI). See android_test.py in this PR.