### PR TITLE
[GSoC M1.1] : Add feature flag show translation size

### DIFF
--- a/core/domain/platform_parameter_list.py
+++ b/core/domain/platform_parameter_list.py
@@ -97,4 +97,4 @@ Registry.create_feature_flag(
     ParamNames.SHOW_TRANSLATION_SIZE,
     'This flag is to show translation size on translation cards in' +
     'contributor dashboard.',
-    platform_parameter_domain.FeatureStages.PROD)
+    platform_parameter_domain.FeatureStages.DEV)

--- a/core/domain/platform_parameter_list.py
+++ b/core/domain/platform_parameter_list.py
@@ -43,6 +43,7 @@ class ParamNames(enum.Enum):
         'serial_chapter_launch_curriculum_admin_view')
     SHOW_TRANSLATION_SIZE = 'show_translation_size'
 
+
 # Platform parameters should all be defined below.
 
 Registry.create_feature_flag(

--- a/core/domain/platform_parameter_list.py
+++ b/core/domain/platform_parameter_list.py
@@ -95,6 +95,6 @@ Registry.create_feature_flag(
 
 Registry.create_feature_flag(
     ParamNames.SHOW_TRANSLATION_SIZE,
-    'This flag is to show translation size on translation cards in contributor' +
-    ' dashboard.',
+    'This flag is to show translation size on translation cards in' +
+    'contributor dashboard.',
     platform_parameter_domain.FeatureStages.PROD)

--- a/core/domain/platform_parameter_list.py
+++ b/core/domain/platform_parameter_list.py
@@ -93,13 +93,11 @@ Registry.create_feature_flag(
     'This flag is for the diagnostic test functionality.',
     platform_parameter_domain.FeatureStages.PROD)
 
-
 Registry.create_feature_flag(
     ParamNames.SERIAL_CHAPTER_LAUNCH_CURRICULUM_ADMIN_VIEW,
     'This flag is for serial chapter launch feature and making changes only' +
     'in the curriculum admin view.',
     platform_parameter_domain.FeatureStages.DEV)
-
 
 Registry.create_feature_flag(
     ParamNames.SHOW_TRANSLATION_SIZE,

--- a/core/domain/platform_parameter_list.py
+++ b/core/domain/platform_parameter_list.py
@@ -39,6 +39,7 @@ class ParamNames(enum.Enum):
     ANDROID_BETA_LANDING_PAGE = 'android_beta_landing_page'
     BLOG_PAGES = 'blog_pages'
     DIAGNOSTIC_TEST = 'diagnostic_test'
+    SHOW_TRANSLATION_SIZE = 'show_translation_size'
 
 
 # Platform parameters should all be defined below.
@@ -89,4 +90,11 @@ Registry.create_feature_flag(
 Registry.create_feature_flag(
     ParamNames.DIAGNOSTIC_TEST,
     'This flag is for the diagnostic test functionality.',
+    platform_parameter_domain.FeatureStages.PROD)
+
+
+Registry.create_feature_flag(
+    ParamNames.SHOW_TRANSLATION_SIZE,
+    'This flag is to show translation size on translation cards in contributor' +
+    ' dashboard.',
     platform_parameter_domain.FeatureStages.PROD)

--- a/core/domain/platform_parameter_list_test.py
+++ b/core/domain/platform_parameter_list_test.py
@@ -38,7 +38,6 @@ class ExistingPlatformParameterValidityTests(test_utils.GenericTestBase):
                             'serial_chapter_launch_curriculum_admin_view',
                             'show_translation_size']
 
-
     def test_all_defined_parameters_are_valid(self) -> None:
         all_names = params.Registry.get_all_platform_parameter_names()
         for name in all_names:

--- a/core/domain/platform_parameter_list_test.py
+++ b/core/domain/platform_parameter_list_test.py
@@ -34,7 +34,8 @@ class ExistingPlatformParameterValidityTests(test_utils.GenericTestBase):
                             'android_beta_landing_page',
                             'blog_pages',
                             'contributor_dashboard_accomplishments',
-                            'diagnostic_test']
+                            'diagnostic_test',
+                            'show_translation_size']
 
     def test_all_defined_parameters_are_valid(self) -> None:
         all_names = params.Registry.get_all_platform_parameter_names()

--- a/core/platform_feature_list.py
+++ b/core/platform_feature_list.py
@@ -44,6 +44,7 @@ ParamNames = params.ParamNames
 # be in dev stage otherwise it will cause a test error in the backend test.
 DEV_FEATURES_LIST = [
     params.ParamNames.DUMMY_FEATURE,
+    params.ParamNames.SHOW_TRANSLATION_SIZE
 ]
 
 # Names of features in test stage, the corresponding feature flag instances must

--- a/core/templates/domain/platform_feature/feature-status-summary.model.ts
+++ b/core/templates/domain/platform_feature/feature-status-summary.model.ts
@@ -29,7 +29,8 @@ export enum FeatureNames {
   ContributorDashboardAccomplishments = 'contributor_dashboard_accomplishments',
   AndroidBetaLandingPage = 'android_beta_landing_page',
   BlogPages = 'blog_pages',
-  DiagnosticTest = 'diagnostic_test'
+  DiagnosticTest = 'diagnostic_test',
+  ShowTranslationSize = 'show_translation_size'
 }
 
 export interface FeatureStatusSummaryBackendDict {

--- a/core/templates/services/platform-feature.service.spec.ts
+++ b/core/templates/services/platform-feature.service.spec.ts
@@ -165,6 +165,7 @@ describe('PlatformFeatureService', () => {
               [FeatureNames.BlogPages]: true,
               [FeatureNames.ContributorDashboardAccomplishments]: true,
               [FeatureNames.DiagnosticTest]: true,
+              [FeatureNames.ShowTranslationSize]: true,
             }
           })
         });


### PR DESCRIPTION
## Overview

 This PR does the following: Adds feature flag for the Translation Size feature for GSoC project Milestone [1.1]. ([Proposal](https://docs.google.com/document/d/18rFozOzbcDYWa6sS9gTYu4R_VfMevbM5v3xlf7Gy3zQ/edit#bookmark=id.8turutparmoy))



## Essential Checklist

- [ ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".



## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
