### PR TITLE
Fix - #18145  - #18116  - #18115  - #18120 - #17211  - #17948  - #17212 : Fixed a11y issues with the story player page

### DIFF
--- a/core/templates/components/question-directives/question-player/question-player.component.html
+++ b/core/templates/components/question-directives/question-player/question-player.component.html
@@ -2,9 +2,9 @@
   <!-- Question Player -->
   <div class="oppia-question-player" *ngIf="!resultsLoaded">
 
-    <div class="oppia-practice-session">
+    <h1 class="oppia-practice-session">
       Practice Session
-    </div>
+    </h1>
 
     <div class="oppia-question-player-card">
       <span class="beta-label"
@@ -13,7 +13,7 @@
         Beta
       </span>
       <div tabindex="0" [hidden]="!(totalQuestions > 0)">
-        <h3 class="oppia-question-player-header">Question {{currentQuestion}}/{{totalQuestions}}</h3>
+        <h2 class="oppia-question-player-header">Question {{currentQuestion}}/{{totalQuestions}}</h2>
         <div class="oppia-question-player-progress">
           <div class="current-progress" [ngStyle]="{'width': currentProgress + '%'}"></div>
         </div>

--- a/core/templates/components/summary-tile/story-summary-tile.component.html
+++ b/core/templates/components/summary-tile/story-summary-tile.component.html
@@ -45,7 +45,7 @@
   <div class="story-details">
     <div class="story-thumbnail e2e-test-story-thumbnail"
          [ngStyle]="{background: thumbnailBgColor}">
-      <a [href]="storyLink" aria-label="Link to the story">
+      <a [href]="storyLink" [attr.aria-label]="'Link to the story ' + storyTitle"></a>">
         <img *ngIf="thumbnailUrl !== null"
              [src]="thumbnailUrl"
              alt=""

--- a/core/templates/components/summary-tile/story-summary-tile.component.html
+++ b/core/templates/components/summary-tile/story-summary-tile.component.html
@@ -45,7 +45,7 @@
   <div class="story-details">
     <div class="story-thumbnail e2e-test-story-thumbnail"
          [ngStyle]="{background: thumbnailBgColor}">
-      <a [href]="storyLink" [attr.aria-label]="'Link to the story ' + storyTitle"></a>">
+      <a [href]="storyLink" [attr.aria-label]="'Link to the story ' + storyTitle">
         <img *ngIf="thumbnailUrl !== null"
              [src]="thumbnailUrl"
              alt=""

--- a/core/templates/components/summary-tile/story-summary-tile.component.html
+++ b/core/templates/components/summary-tile/story-summary-tile.component.html
@@ -45,7 +45,7 @@
   <div class="story-details">
     <div class="story-thumbnail e2e-test-story-thumbnail"
          [ngStyle]="{background: thumbnailBgColor}">
-      <a [href]="storyLink">
+      <a [href]="storyLink" aria-label="Link to the story">
         <img *ngIf="thumbnailUrl !== null"
              [src]="thumbnailUrl"
              alt=""

--- a/core/templates/components/summary-tile/subtopic-summary-tile.component.html
+++ b/core/templates/components/summary-tile/subtopic-summary-tile.component.html
@@ -1,6 +1,8 @@
 <div class="subtopic-card e2e-test-subtopic-tile"
      (click)="openSubtopicPage()"
-     [ngClass]="{'disabled-link': !classroomUrlFragment}">
+     (keydown.enter)="openSubtopicPage()"
+     [ngClass]="{'disabled-link': !classroomUrlFragment}"
+     tabindex="0">
   <div class="subtopic-thumbnail e2e-test-subtopic-thumbnail"
        [ngStyle]="{background: thumbnailBgColor}">
     <img [src]="thumbnailUrl"
@@ -26,7 +28,7 @@
   }
 
   .subtopic-card:focus {
-    outline: 0;
+    outline: 2px solid black;
   }
 
   .subtopic-thumbnail {

--- a/core/templates/components/summary-tile/subtopic-summary-tile.component.html
+++ b/core/templates/components/summary-tile/subtopic-summary-tile.component.html
@@ -28,7 +28,7 @@
   }
 
   .subtopic-card:focus {
-    outline: 2px solid black;
+    outline: 2px solid #000;
   }
 
   .subtopic-thumbnail {

--- a/core/templates/components/summary-tile/subtopic-summary-tile.component.ts
+++ b/core/templates/components/summary-tile/subtopic-summary-tile.component.ts
@@ -68,16 +68,9 @@ export class SubtopicSummaryTileComponent implements OnInit {
         }
       ), '_self'
     );
-    console.log("It is called!!!!!")
   }
 
   ngOnInit(): void {
-
-    window.addEventListener('keydown', (event: KeyboardEvent) => {
-      const focusedElement = document.activeElement as HTMLElement;
-      console.log('Focused Element:', focusedElement);
-    });
-
     this.thumbnailBgColor = this.subtopic.getThumbnailBgColor();
     this.subtopicTitle = this.subtopic.getTitle();
     let thumbnailFileName = this.subtopic.getThumbnailFilename();

--- a/core/templates/components/summary-tile/subtopic-summary-tile.component.ts
+++ b/core/templates/components/summary-tile/subtopic-summary-tile.component.ts
@@ -68,9 +68,16 @@ export class SubtopicSummaryTileComponent implements OnInit {
         }
       ), '_self'
     );
+    console.log("It is called!!!!!")
   }
 
   ngOnInit(): void {
+
+    window.addEventListener('keydown', (event: KeyboardEvent) => {
+      const focusedElement = document.activeElement as HTMLElement;
+      console.log('Focused Element:', focusedElement);
+    });
+
     this.thumbnailBgColor = this.subtopic.getThumbnailBgColor();
     this.subtopicTitle = this.subtopic.getTitle();
     let thumbnailFileName = this.subtopic.getThumbnailFilename();

--- a/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.component.html
+++ b/core/templates/pages/subtopic-viewer-page/subtopic-viewer-page.component.html
@@ -36,7 +36,8 @@
       </p>
       <p *ngIf="prevSubtopic"
          class="oppia-subtopic-next-subtopic-label"
-         [innerHTML]="'I18N_SUBTOPIC_VIEWER_PREVIOUS_SKILL' | translate">
+         [innerHTML]="'I18N_SUBTOPIC_VIEWER_PREVIOUS_SKILL' | translate"
+         tabindex="0">
          Previous Skill:
       </p>
       <oppia-subtopic-summary-tile [topicUrlFragment]="topicUrlFragment"

--- a/core/templates/pages/topic-viewer-page/practice-tab/practice-tab.component.html
+++ b/core/templates/pages/topic-viewer-page/practice-tab/practice-tab.component.html
@@ -2,7 +2,7 @@
   <div class="oppia-practice-tab-container e2e-test-practice-tab-container"
        [ngClass]="{'practice-tab-for-learner-dashboard': displayArea === 'progressTab'}">
     <mat-card class="oppia-page-card oppia-long-text">
-      <h2 class="tab-title"
+      <h1 class="tab-title"
           *ngIf="displayArea === 'topicViewer'">
         <span [innerHTML]="'I18N_TOPIC_VIEWER_PRACTICE_SESSION_BETA_TAG' | translate"
               class="beta-label"
@@ -11,7 +11,7 @@
         </span>
         <span [innerHTML]="'I18N_TOPIC_VIEWER_MASTER_SKILLS' | translate: {topicName: translatedTopicName}"></span>
         <span>&nbsp;</span>
-      </h2>
+      </h1>
       <div class="practice-content"
            *ngIf="displayArea === 'topicViewer'">
         <span [innerHTML]="'I18N_TOPIC_VIEWER_SELECT_SKILLS' | translate: {topicName: topicName}"></span>

--- a/core/templates/pages/topic-viewer-page/stories-list/topic-viewer-stories-list.component.html
+++ b/core/templates/pages/topic-viewer-page/stories-list/topic-viewer-stories-list.component.html
@@ -1,14 +1,14 @@
 <div class="stories-list">
   <div class="oppia-stories-list-container">
     <mat-card class="oppia-page-card oppia-long-text">
-      <h2 class="tab-title">
+      <h1 class="tab-title">
         <span *ngIf="!isHackyTopicNameTranslationDisplayed()">
           {{ topicName }}
         </span>
         <span *ngIf="isHackyTopicNameTranslationDisplayed()">
           {{ topicNameTranslationKey | translate }}
         </span>
-      </h2>
+      </h1>
       <div class="topic-description e2e-test-topic-description">
         <span *ngIf="!isHackyTopicNameTranslationDisplayed()">
           {{ topicDescription }}

--- a/core/templates/pages/topic-viewer-page/topic-viewer-page.component.html
+++ b/core/templates/pages/topic-viewer-page/topic-viewer-page.component.html
@@ -2,7 +2,7 @@
   <div class="oppia-topic-viewer-tabs-container position-relative" headroom>
     <div class="topic-viewer-tabs-list">
       <ul class="topic-viewer-tabs" [ngClass]="checkTabletView() ? 'pad-top-mobile': 'pad-top-desktop'">
-        <li [ngClass]="{'topic-viewer-tabs-active': activeTab === 'story'}" tabindex="0">
+        <li [ngClass]="{'topic-viewer-tabs-active': activeTab === 'story'}" tabindex="0" (keydown.enter)="setActiveTab('story')">
           <div class="topic-viewer-tabs-text" (click)="setActiveTab('story')">
             <img *ngIf="!checkTabletView()" alt="play story icon" class="tab-icon" [src]="getStaticImageUrl('/icons/play_icon_24px.svg')">
             <a class="tab-title"
@@ -10,7 +10,7 @@
             </a>
           </div>
         </li>
-        <li [ngClass]="{'topic-viewer-tabs-active': activeTab === 'practice'}" tabindex="0">
+        <li [ngClass]="{'topic-viewer-tabs-active': activeTab === 'practice'}" tabindex="0" (keydown.enter)="setActiveTab('practice')">
           <div class="topic-viewer-tabs-text" (click)="setActiveTab('practice')">
             <img *ngIf="!checkTabletView()" alt="practice icon" class="tab-icon" [src]="getStaticImageUrl('/icons/train_icon_24px.svg')">
             <a class="tab-title e2e-test-practice-tab-link"
@@ -18,9 +18,9 @@
             </a>
           </div>
         </li>
-        <li [ngClass]="{'topic-viewer-tabs-active': activeTab === 'subtopics'}" tabindex="0">
+        <li [ngClass]="{'topic-viewer-tabs-active': activeTab === 'subtopics'}" tabindex="0" (keydown.enter)="setActiveTab('subtopics')">
           <div class="topic-viewer-tabs-text" (click)="setActiveTab('subtopics')">
-            <img *ngIf="!checkTabletView()" alt="practice icon" class="tab-icon" [src]="getStaticImageUrl('/icons/review_icon_24px.svg')">
+            <img *ngIf="!checkTabletView()" alt="revision icon" class="tab-icon" [src]="getStaticImageUrl('/icons/review_icon_24px.svg')">
             <a class="tab-title e2e-test-revision-tab-link"
                [innerHTML]="'I18N_TOPIC_VIEWER_REVISION' | translate">
             </a>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes: 
- #18145 
- #18116 
- #18115 
- #18120
- #17211 
- #17948 
- #17212 

3. This PR does the following: 
- Adds focus to the previous skill and next skill
- Adds focus for lessons, practice and revisions tab
- Changed the alt of the revisions tab icon
- Added h1 tag in story player page, practice tab and practice sessions page
- Fixes In practice session lint not having name

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The linter/Karma presubmit checks have passed locally on your machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [x] The PR is made from a branch that's **not** called "develop".

## Proof that changes are correct
1. For #18145 

https://github.com/oppia/oppia/assets/96219910/103adf40-e7c7-4dfc-96ee-8b65963dd5cd

2. #18116 

https://github.com/oppia/oppia/assets/96219910/15eb272e-dd0b-440a-a3d5-788d6bbb7ac0



3. For #18115  

https://github.com/oppia/oppia/assets/96219910/74ab7425-8129-4509-b7fc-cb61403e98e0

4. For #18120
![Screenshot 2023-06-11 183512](https://github.com/oppia/oppia/assets/96219910/d705874f-f7ae-4f23-815b-d3e29d4018d7)
![Screenshot 2023-06-11 183337](https://github.com/oppia/oppia/assets/96219910/27309a44-6409-4ae2-8687-28c4db698895)
![Screenshot 2023-06-11 183312](https://github.com/oppia/oppia/assets/96219910/45a4c7fc-9270-4dc0-a8ae-f598aaa53698)

5. #17211 
![Screenshot 2023-06-11 183635](https://github.com/oppia/oppia/assets/96219910/4e8c75eb-5317-4630-9bf0-8345c1aedcec)
![Screenshot 2023-06-11 183607](https://github.com/oppia/oppia/assets/96219910/e0bd3724-a3dd-4da0-94ac-13d198f996bc)
![Screenshot 2023-06-11 183556](https://github.com/oppia/oppia/assets/96219910/a83befe7-eeb5-44d9-98d1-56f366c8b822)

6. #17948 
![Screenshot 2023-06-11 184000](https://github.com/oppia/oppia/assets/96219910/0d8341ce-efa1-419f-8bc2-dd41bebbeaf9)

![Screenshot 2023-06-11 183800](https://github.com/oppia/oppia/assets/96219910/45e3a8f7-a740-42de-8a5c-5b2f61db0eb5)
![Screenshot 2023-06-11 183749](https://github.com/oppia/oppia/assets/96219910/19303c65-0e82-40f0-a913-3ed2d61c9f04)

7. For #17212
![Screenshot 2023-06-11 184132](https://github.com/oppia/oppia/assets/96219910/a12e9fcc-174b-47ba-b980-8137168fb13f)


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Make sure to follow the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL". Oppiabot will help assign that person for you.
- For what code owners will expect, see the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers).
- Make sure your PR follows conventions in the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Never force push. If you do, your PR will be closed.
- Some of the e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
