### PR TITLE
Contributor dashboard -- Fixes axeDev tools + lighthouse error and makes the lighthouse score to 1

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributions-and-review/contributions-and-review.component.html
@@ -46,8 +46,8 @@
     </div>
   </div>
   <div class="oppia-contributions-show-review-side-navbar-container" >
-    <div class="oppia-contributions-side-navbar-part" *ngIf="reviewTabs.length > 0">
-      <div class="oppia-contributions-navbar-items-list" navbar-label="Available Tasks">
+    <div class="oppia-contributions-side-navbar-part" *ngIf="reviewTabs.length > 0" tabindex="0">
+      <div class="oppia-contributions-navbar-items-list" navbar-label="Available Tasks" aria-label="Available tasks">
         <div class="oppia-contributions-navbar-item" *ngFor="let tab of reviewTabs">
           <button class="oppia-contributions-navbar-button"
                   (click)="switchToTab(TAB_TYPE_REVIEWS, tab.tabSubType)"
@@ -56,8 +56,8 @@
         </div>
       </div>
     </div>
-    <div class="oppia-contributions-side-navbar-part" *ngIf="userIsLoggedIn">
-      <div class="oppia-contributions-navbar-items-list" navbar-label="Contributions">
+    <div class="oppia-contributions-side-navbar-part" *ngIf="userIsLoggedIn" tabindex="0">
+      <div class="oppia-contributions-navbar-items-list" navbar-label="Contributions" aria-label="Contributions">
         <div class="oppia-contributions-navbar-item" *ngFor="let tab of contributionTabs">
           <button *ngIf="tab && tab.enabled"
                   class="oppia-contributions-navbar-button"
@@ -66,8 +66,8 @@
           </button>
         </div>
       </div>
-      <div class="oppia-contributions-side-navbar-part" *ngIf="accomplishmentsTabIsEnabled && userIsLoggedIn">
-        <div class="oppia-contributions-navbar-items-list" navbar-label="Accomplishments">
+      <div class="oppia-contributions-side-navbar-part" *ngIf="accomplishmentsTabIsEnabled && userIsLoggedIn" tabindex="0">
+        <div class="oppia-contributions-navbar-items-list" navbar-label="Accomplishments" aria-label="Accomplishments">
           <div class="oppia-contributions-navbar-item" *ngFor="let tab of accomplishmentsTabs">
             <button *ngIf="tab && tab.enabled"
                     class="oppia-contributions-navbar-button"
@@ -96,6 +96,7 @@
           <p class="sort-by-text">Sort By</p>
           <select [(ngModel)]="reviewableQuestionsSortKey"
                   class="sort-options"
+                  aria-label="Sort by"
                   (change)="setReviewableQuestionsSortKey(reviewableQuestionsSortKey)">
             <option *ngFor="let key of REVIEWABLE_QUESTIONS_SORT_KEYS"
                     [value]="key"
@@ -151,7 +152,7 @@
   }
 
   .oppia-contributions-show-review-side-navbar-container {
-    background-color: #009688;
+    background-color: #00645d;
     width: 25%;
   }
 
@@ -314,7 +315,8 @@
 
   .oppia-contributions-active-navbar,
   .oppia-contributions-navbar-button:hover {
-    background-color: #0b6c63;
+    background-color: #fff;
+    color: #00645d;
   }
 
   .oppia-contributions-navbar-items-list::before {

--- a/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
+++ b/core/templates/pages/contributor-dashboard-page/contributor-dashboard-page.component.html
@@ -67,6 +67,7 @@
                   </h1>
                 </div>
                 <div class="oppia-review-right-details-container e2e-test-review-rights"
+                     tabindex="0"
                      *ngIf="userIsReviewer">
                   <strong>Review rights:</strong>
                   <div *ngIf="userCanReviewTranslationSuggestionsInLanguages.length > 0">
@@ -130,14 +131,14 @@
                  *ngIf="showLanguageSelector() || showTopicSelector()">
               <div class="oppia-dashboard-language-container"
                    *ngIf="showLanguageSelector()">
-                <div class="oppia-dashboard-language-container-label">Translate to</div>
+                <div class="oppia-dashboard-language-container-label" tabindex="0">Translate to</div>
                 <translation-language-selector class="oppia-language-selector"
                                                [activeLanguageCode]="languageCode"
                                                (setActiveLanguageCode)="onChangeLanguage($event)">
                 </translation-language-selector>
               </div>
               <div class="oppia-dashboard-topic-container" *ngIf="showTopicSelector()">
-                <div class="oppia-dashboard-topic-container-label">Subject</div>
+                <div class="oppia-dashboard-topic-container-label" tabindex="0">Subject</div>
                 <translation-topic-selector class="oppia-topic-selector"
                                             [activeTopicName]="topicName"
                                             (setActiveTopicName)="onChangeTopic($event)">

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
@@ -1,6 +1,6 @@
 <div class="modal-header e2e-test-question-suggestion-review-modal-header">
   <div>
-    <h3 class="oppia-question-header">
+    <h3 class="oppia-question-header" tabindex="0">
       {{questionHeader}}
     </h3>
     <h3 class="oppia-mobile-question-header" title="{{questionHeader}}">
@@ -20,7 +20,7 @@
 </div>
 
 <div class="modal-body">
-  <div class="oppia-question-details">
+  <div class="oppia-question-details" tabindex="0">
     <strong class="oppia-difficulty-title">
       Selected Difficulty: {{skillDifficultyLabel}}
     </strong>
@@ -42,7 +42,8 @@
                            [questionStateData]="questionStateData"
                            [question]="question"
                            [userCanEditQuestion]="canEditQuestion"
-                           (questionChange)="questionChanged()">
+                           (questionChange)="questionChanged()"
+                           tabindex="0">
     </oppia-question-editor>
   </div>
   <section [hidden]="!reviewable"

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/translation-suggestion-review-modal.component.html
@@ -1,5 +1,5 @@
 <div class="modal-header">
-  <div class="oppia-modal-info">
+  <div class="oppia-modal-info" tabindex="0">
     <h3 title="{{ heading }}"
         class="oppia-modal-info-header">
       {{ heading }}

--- a/core/templates/pages/contributor-dashboard-page/opportunities-list-item/opportunities-list-item.component.html
+++ b/core/templates/pages/contributor-dashboard-page/opportunities-list-item/opportunities-list-item.component.html
@@ -17,6 +17,7 @@
            class="progress">
         <div class="progress-bar bg-success"
              role="progressbar"
+             aria-hidden="true"
              [ngStyle]="translatedProgressStyle"
              ngbTooltip="{{opportunity.translationsCount}}/{{opportunity.totalCount}} cards accepted"
              container="body"
@@ -24,6 +25,7 @@
         </div>
         <div class="progress-bar bg-light-green"
              role="progressbar"
+             aria-hidden="true"
              [ngStyle]="inReviewProgressStyle"
              ngbTooltip="{{opportunity.inReviewCount}}/{{opportunity.totalCount}} cards awaiting review"
              container="body"
@@ -31,6 +33,7 @@
         </div>
         <div class="progress-bar bg-light"
              role="progressbar"
+             aria-label="Progress Bar"
              [ngStyle]="untranslatedProgressStyle"
              ngbTooltip="{{cardsAvailable}}/{{opportunity.totalCount}} cards available for translation"
              container="body"
@@ -118,7 +121,7 @@
 
 <!-- Desktop -->
 <div *ngIf="!onMobile && !opportunityDataIsLoading"
-     class="oppia-opportunities-list-item oppia-desktop-list-item e2e-test-opportunity-list-item">
+     class="oppia-opportunities-list-item oppia-desktop-list-item e2e-test-opportunity-list-item" tabindex="0">
   <ng-template [ngTemplateOutlet]="OpportunitiesDetails"></ng-template>
   <ng-template [ngTemplateOutlet]="ProgressBar"></ng-template>
   <ng-template [ngTemplateOutlet]="OpportunitiesLabel"></ng-template>
@@ -187,7 +190,7 @@
     min-width: 64%;
     text-align: center;
   }
-  .oppia-opportunities-button:hover {
+  .oppia-opportunities-button:hover, .oppia-opportunities-button:focus {
     background-color: #6f817f;
     color: #fff;
     -webkit-transition: background-color 200ms ease-out;

--- a/core/templates/pages/contributor-dashboard-page/translation-language-selector/review-translation-language-selector.component.html
+++ b/core/templates/pages/contributor-dashboard-page/translation-language-selector/review-translation-language-selector.component.html
@@ -1,6 +1,6 @@
 <div #dropdown class="oppia-review-translation-language-selector-container e2e-test-language-selector">
 
-  <div class="oppia-review-translation-language-selector-inner-container" (click)="toggleDropdown()">
+  <div class="oppia-review-translation-language-selector-inner-container" (click)="toggleDropdown()" (keydown.enter)="toggleDropdown()" tabindex="0">
     <span class="oppia-language-selector-label e2e-test-language-selector-selected">
       {{languageSelection}}
     </span>
@@ -22,6 +22,8 @@
       <div class="oppia-review-translation-language-selector-dropdown-option e2e-test-language-selector-option"
            *ngFor="let option of filteredOptions"
            (click)="selectOption(option.id)"
+           (keydown.enter)="selectOption(option.id)"
+           tabindex="0"
            [ngClass]="{'oppia-review-translation-language-selector-dropdown-option-selected' : option.id === activeLanguageCode}">
         {{option.description}}
       </div>

--- a/core/templates/pages/contributor-dashboard-page/translation-language-selector/translation-language-selector.component.html
+++ b/core/templates/pages/contributor-dashboard-page/translation-language-selector/translation-language-selector.component.html
@@ -6,7 +6,7 @@
       {{explanationPopupContent}}
     </span>
   </div>
-  <div class="oppia-translation-language-selector-inner-container" (click)="toggleDropdown()">
+  <div class="oppia-translation-language-selector-inner-container" (click)="toggleDropdown()" tabindex="0" (keydown.enter)="toggleDropdown()">
     <span class="oppia-language-selector-label e2e-test-language-selector-selected">
       {{languageSelection}}
     </span>
@@ -30,7 +30,9 @@
         <div *ngFor="let featuredOption of featuredLanguages; index as i">
           <div class="oppia-translation-language-selector-dropdown-option e2e-test-featured-language"
                *ngIf="languageIdToDescription[featuredOption.languageCode]"
+               tabindex="0"
                (click)="selectOption(featuredOption.languageCode)"
+               (keydown.enter)="selectOption(featuredOption.languageCode)"
                [ngClass]="{'oppia-translation-language-selector-dropdown-option-selected' : featuredOption.languageCode === activeLanguageCode}">
             <span class="material-icons oppia-translation-language-selector-info-icon e2e-test-featured-language-tooltip"
                   *ngIf="featuredOption.explanation"
@@ -48,6 +50,8 @@
       <div class="oppia-translation-language-selector-dropdown-option e2e-test-language-selector-option"
            *ngFor="let option of filteredOptions"
            (click)="selectOption(option.id)"
+           (keydown.enter)="selectOption(option.id)"
+           tabindex="0"
            [ngClass]="{'oppia-translation-language-selector-dropdown-option-selected' : option.id === activeLanguageCode}">
         {{option.description}}
       </div>

--- a/core/templates/pages/contributor-dashboard-page/translation-topic-selector/translation-topic-selector.component.html
+++ b/core/templates/pages/contributor-dashboard-page/translation-topic-selector/translation-topic-selector.component.html
@@ -1,5 +1,5 @@
 <div #dropdown class="oppia-translation-topic-selector-container e2e-test-topic-selector">
-  <div class="oppia-translation-topic-selector-inner-container e2e-test-topic-selector-selected" (click)="toggleDropdown()">
+  <div class="oppia-translation-topic-selector-inner-container e2e-test-topic-selector-selected" (click)="toggleDropdown()" (keydown.enter)="toggleDropdown()" tabindex="0">
     {{activeTopicName}}
     <span class="fas fa-caret-down oppia-translation-topic-selector-inner-container-arrow" [ngStyle]="{ 'transform': dropdownShown ? 'scaleY(-1)' : 'scaleY(1)' }">
     </span>
@@ -11,6 +11,8 @@
     <div class="oppia-translation-topic-selector-dropdown-option e2e-test-topic-selector-option"
          *ngFor="let option of options"
          (click)="selectOption(option)"
+         (keydown.enter)="selectOption(option)"
+         tabindex="0"
          [ngClass]="{'oppia-translation-topic-selector-dropdown-option-selected' : option === activeTopicName}">
       {{option}}
     </div>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR is related my GSoC project -- Improve accessibility. This PR solves axe devtools errors and lighthouse errors for contributor dashboard page.
2. This PR does the following:  Adds aria-label and keyboard support, screen reader support and changed the color contrast to follow the [W3 AA contrast guidelines](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

#### Proof of changes on desktop 
Before: 
![Screenshot 2023-06-22 170404](https://github.com/oppia/oppia/assets/96219910/31bab06c-fd1e-4904-8b4b-824c16e050e8)
![Screenshot 2023-06-22 170342](https://github.com/oppia/oppia/assets/96219910/83063171-21b0-4f03-95fa-6f4cd42e0a56)


After:
![Screenshot 2023-06-22 165205](https://github.com/oppia/oppia/assets/96219910/e10bd2e8-4ae0-4147-b15e-5d23a98e8490)
![Screenshot 2023-06-22 165143](https://github.com/oppia/oppia/assets/96219910/3648c85a-9270-4f80-be34-3a8a9aa226f1)
![Screenshot 2023-06-22 165127](https://github.com/oppia/oppia/assets/96219910/c4e73e7d-4f7a-4d7a-b244-5f75d83536a6)
![Screenshot 2023-06-22 165107](https://github.com/oppia/oppia/assets/96219910/8bbaf0d2-9ea8-4913-a2d3-78d52d4dbc02)
![Screenshot 2023-06-22 165048](https://github.com/oppia/oppia/assets/96219910/89629c45-eb09-4a92-ac0d-8c79f4fd06f2)
![Screenshot 2023-06-22 165026](https://github.com/oppia/oppia/assets/96219910/9a18d8db-a3d0-4529-b264-37046274389a)




https://github.com/oppia/oppia/assets/96219910/d2e8af6a-6d4b-4238-ac91-2b87dfa9804e


https://github.com/oppia/oppia/assets/96219910/c451f7d0-cb54-4665-ae33-4b9b1bccf753
https://github.com/oppia/oppia/assets/96219910/9e594978-f047-4176-aa5b-e1f288f7dbba

https://github.com/oppia/oppia/assets/96219910/9a9bb1bf-439b-4fb6-b4dc-45bc30636963







<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->


<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- Make sure your PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
