### PR TITLE
issue #17997 Fixed Misaligned Text in blog-home-page.component.html ( synced pull )

### DIFF
--- a/core/templates/pages/blog-home-page/blog-home-page.component.html
+++ b/core/templates/pages/blog-home-page/blog-home-page.component.html
@@ -88,7 +88,9 @@
           <source type="image/png" [srcset]="getStaticImageUrl('/images/general/no_explorations_found.png')">
           <img [src]="getStaticImageUrl('/general/no_explorations_found.png')">
         </picture>
-        {{ 'I18N_BLOG_HOME_PAGE_NO_RESULTS_FOUND' | translate }}
+        <p class="text-center">
+          {{ 'I18N_BLOG_HOME_PAGE_NO_RESULTS_FOUND' | translate }}
+        </p>
       </div>
       <div *ngIf="showBlogPostCardsLoadingScreen" class="col-8 my-auto">
         <mat-spinner class="mx-auto"></mat-spinner>


### PR DESCRIPTION
Issue #17997 [BUG]: Text misaligned when zoomed out

this is updates and synced pull request for closed pull #18472 

Fixed the misalignment of the text ```"Sorry, there are no blog posts to show."``` in file blog-home-page.component.html

Fixes:
### File: [blog-home-page.component.html](https://github.com/oppia/oppia/blob/develop/core/templates/pages/blog-home-page/blog-home-page.component.html)

- In this file I wrapped the ```{{ 'I18N_BLOG_HOME_PAGE_NO_RESULTS_FOUND' | translate }}``` in "p" tags and added a class ```text-center``` to fixed the alignment.

# Before
     - as you can see ```Sorry``` not aligned with the rest of the sentence.
![oppia before](https://github.com/oppia/oppia/assets/85938434/1b61bd03-0496-4201-8f64-6a3b1b865fb9)

# After
     - misalignment fixed 
     ```
         <p class="text-center">
               {{ 'I18N_BLOG_HOME_PAGE_NO_RESULTS_FOUND' | translate }}
         </p>
     ```
![oppia after](https://github.com/oppia/oppia/assets/85938434/b30c010e-996b-49dc-83ba-ea51fe6cb3d2)


  


