### PR TITLE
Fix #18464: Present translated content to learners even if it requires update

### DIFF
--- a/core/templates/domain/state_card/state-card.model.ts
+++ b/core/templates/domain/state_card/state-card.model.ts
@@ -281,7 +281,7 @@ export class StateCard {
   swapContentsWithTranslation(entityTranslation: EntityTranslation): void {
     let writtenTranslation = entityTranslation.getWrittenTranslation(
       this._contentId) as TranslatedContent;
-    if (writtenTranslation && !writtenTranslation.needsUpdate) {
+    if (writtenTranslation) {
       this.contentHtml = writtenTranslation.translation as string;
     }
     this._interaction.swapContentsWithTranslation(entityTranslation);


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #18464.
2. This PR does the following: Removes the check for needsUpdate when presenting translated content to users.

Note: This was (i.e, not presenting needsUpdate translated content to learner)  expected and we had decided to keep it as-is to avoid presenting invalid data to learners. But now we realize that it creates a bad UX for learners to suddenly present an entire card in English and no we also allow editors to remove translations for changes that have significant changes to ruin the translated content because of these reasons we are now presenting the translated content even if it requires an update. 

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct

[scrnli_28_06_2023_05-02-18.webm](https://github.com/oppia/oppia/assets/16653571/2949bc29-aec1-4eb3-b4a1-87589f25f968)

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

If the changes in your PRs are autogenerated via a script and you cannot provide proof
for the changes then please leave a comment "No proof of changes needed because {{Reason}}"
and remove all the sections below.
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- Make sure your PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
