### PR TITLE
Fix: #17306: Source: UNESCO' is not aligned properly in The Oppia Foundation page

### DIFF
--- a/core/templates/pages/about-foundation-page/about-foundation-page.component.html
+++ b/core/templates/pages/about-foundation-page/about-foundation-page.component.html
@@ -296,7 +296,7 @@
   }
 
   .oppia-about-foundation-image-with-caption {
-    text-align: end;
+    text-align: center;
   }
 
   .oppia-about-foundation-info-card-gray {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #17306
2. This PR does the following: The source:Unesco was centered so the best solution was to center the image.
Overall the UI looks not affected so much by this small change.

## Essential Checklist

- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [X] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [X] The linter/Karma presubmit checks have passed on my local machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [X] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct
![Screenshot (22)](https://github.com/oppia/oppia/assets/109658545/069c1260-d22f-4e15-aca7-aa71523449b8)


## PR Pointers

- Never force push! If you do, your PR will be closed.
- Make sure your PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
