### PR TITLE
Fix wiki revert action by merging source repo commits before pushing revert

### DIFF
--- a/.github/workflows/revert-web-wiki-updates.yml
+++ b/.github/workflows/revert-web-wiki-updates.yml
@@ -40,8 +40,16 @@ jobs:
           git revert --no-commit source/develop..origin/master
           msg_file=$(mktemp)
           echo "Reverting the following changes made through the web interface:\n" > $msg_file
-          git log soure/develop..origin/master | while read line; do echo "    ${line}"; done >> $msg_file
+          git log source/develop..origin/master | while read line; do echo "    ${line}"; done >> $msg_file
           git commit -F $msg_file
+      - name: Merge in development commits
+        if: ${{ steps.check-diff.outputs.diff != '' }}
+        # If a PR in the source repository was merged around the same time as a
+        # change was made to the wiki through the web interface, its deployment
+        # might fail before this job can revert the change. In that case, we
+        # need to merge in those un-deployed changes to both the source and
+        # deployment repositories.
+        run: git merge source/develop
       - name: Push to deployment repository
         if: ${{ steps.check-diff.outputs.diff != '' }}
         run: git push source master:develop


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following: Fixes a race condition where a revert of a change to the wiki through the web interface could fail if a PR was merged into the source repo around the same time.
3. (For bug-fixing PRs only) The original bug occurred because: This bug has existed since we first set up a separate source repo for the wiki.

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct

I tested these changes locally:

```console
$ git revert --no-commit upstream/develop..deployment/master
$ git status
HEAD detached at deployment/master
You are currently reverting commit c66a790.
  (all conflicts fixed: run "git revert --continue")
  (use "git revert --skip" to skip this patch)
  (use "git revert --abort" to cancel the revert operation)

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
	modified:   Contributor-dashboard.md
$ git commitutc -m tmp
[detached HEAD e70b7a9] tmp
 Date: Sat Jul 15 19:26:01 2023 +0000
 1 file changed, 4 insertions(+), 6 deletions(-)
$ git merge --no-commit upstream/develop
Automatic merge went well; stopped before committing as requested
$ git status
HEAD detached from deployment/master
All conflicts fixed but you are still merging.
  (use "git commit" to conclude merge)

Changes to be committed:
	modified:   Acceptance-Tests.md
	modified:   Coding-style-guide.md
	modified:   Contributing-code-to-Oppia.md
	new file:   How-To-Load-Data.md
	modified:   Installing-Oppia-(Linux;-Python-3).md
	modified:   LaCE-onboarding-guide.md
	modified:   Learning-Resources.md
	modified:   Lighthouse-Tests.md
	new file:   images/LaCEOnboardingGuide/Activity-Tab.png
	new file:   images/LaCEOnboardingGuide/Admin-Page.png
	new file:   images/LaCEOnboardingGuide/Classroom-Page-Detail.png
	new file:   images/LaCEOnboardingGuide/Data-Saved.png
	new file:   images/LaCEOnboardingGuide/Dummy-Exploration.png
	new file:   images/LaCEOnboardingGuide/Dummy-Math-Classroom.png
	new file:   images/LaCEOnboardingGuide/Dummy-New-Structure-Data.png
	new file:   images/LaCEOnboardingGuide/Dummy-Skill-with-question.png
	new file:   images/LaCEOnboardingGuide/Reload-Single-collection.png
	new file:   images/LaCEOnboardingGuide/Save.png
	new file:   images/LaCEOnboardingGuide/config-classroom.png
	new file:   images/LaCEOnboardingGuide/config-save.png
	new file:   images/LaCEOnboardingGuide/config-tab.png
	new file:   images/LaCEOnboardingGuide/creating-a-skill.png
	new file:   images/LaCEOnboardingGuide/question-difficulty.png
	new file:   images/LaCEOnboardingGuide/question-hint.png
	new file:   images/LaCEOnboardingGuide/question-interaction-answers-responses.png
	new file:   images/LaCEOnboardingGuide/question-problem.png
	new file:   images/LaCEOnboardingGuide/question-save-button.png
	new file:   images/LaCEOnboardingGuide/skill-details-section.png
	new file:   images/LaCEOnboardingGuide/skill-misconceptions-section.png
	new file:   images/LaCEOnboardingGuide/skill-pre-requisite-skill-section.png
	new file:   images/LaCEOnboardingGuide/skill-rubrics-section.png
	new file:   images/LaCEOnboardingGuide/skill-worked-examples-section.png
	new file:   images/LaCEOnboardingGuide/topic-canonical-stories-section.png
	new file:   images/LaCEOnboardingGuide/topic-diagnostic-test-section.png
	new file:   images/LaCEOnboardingGuide/topic-editor-warnings.png
	new file:   images/LaCEOnboardingGuide/topic-editor.png
	new file:   images/LaCEOnboardingGuide/topic-modal.png
	new file:   images/LaCEOnboardingGuide/topic-subtopics-section.png
	new file:   images/lighthouse-test-failure.png
	new file:   images/lighthouse-test-report.png
	new file:   images/lighthouse-test-score.png
```

## PR Pointers

- Never force push! If you do, your PR will be closed.
- Make sure your PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
