### PR TITLE
Revert "Fix part of #18675: Temporarily ignore cert console error assertions"

### DIFF
--- a/.lighthouserc-2.js
+++ b/.lighthouserc-2.js
@@ -87,9 +87,7 @@ module.exports = {
         {
           'matchingUrlPattern': 'http://[^/]+/create/.*$',
           'assertions': {
-            // TODO(18675): Change this back to 1 once the pencilcode.net TLS
-            // cert error is fixed.
-            'errors-in-console': ['error', {'minScore': 0}],
+            'errors-in-console': ['error', {'minScore': 1}],
             // TODO(#13465): Change this maxLength to 0 once images are migrated.
             'modern-image-formats': [
               'error', {'maxLength': 3, 'strategy': 'pessimistic'}


### PR DESCRIPTION
Reverts oppia/oppia#18676 now that the TLS cert is fixed. Fixes #18675.