### PR TITLE
Add mock to fix failing backend test

### DIFF
--- a/core/domain/platform_feature_services_test.py
+++ b/core/domain/platform_feature_services_test.py
@@ -350,7 +350,7 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
                         {
                             'type': 'app_version',
                             'conditions': [
-                                ['=', '3.3.1']
+                                ['>=', '3.3.1']
                             ],
                         }
                     ],

--- a/scripts/servers_test.py
+++ b/scripts/servers_test.py
@@ -28,6 +28,7 @@ import subprocess
 import sys
 import threading
 import time
+from unittest import mock
 
 from core.tests import test_utils
 from scripts import common
@@ -35,7 +36,6 @@ from scripts import scripts_test_utils
 from scripts import servers
 
 import psutil
-
 from typing import Callable, Iterator, List, Optional, Sequence, Tuple
 
 
@@ -48,6 +48,7 @@ class ManagedProcessTests(test_utils.TestBase):
     def setUp(self) -> None:
         super().setUp()
         self.exit_stack = contextlib.ExitStack()
+        self.chrome_version = '104.0.5112.79'.encode('UTF-8')
 
     def tearDown(self) -> None:
         try:
@@ -1011,11 +1012,26 @@ class ManagedProcessTests(test_utils.TestBase):
         self.assertIn('--suite full', program_args)
         self.assertIn('--params.devMode=True', program_args)
 
-    def test_managed_webdriverio_mobile(self) -> None:
+    @mock.patch('urllib.request.urlopen')
+    def test_managed_webdriverio_mobile(
+        self, mock_urlopen: mock.MagicMock
+    ) -> None:
+        mock_response = mock.MagicMock()
+        mock_response.getcode.return_value = 200
+        mock_response.read.return_value = self.chrome_version
+        mock_urlopen.return_value = mock_response
         with servers.managed_webdriverio_server(mobile=True):
             self.assertEqual(os.getenv('MOBILE'), 'true')
 
-    def test_managed_webdriverio_with_explicit_args(self) -> None:
+    @mock.patch('urllib.request.urlopen')
+    def test_managed_webdriverio_with_explicit_args(
+        self, mock_urlopen: mock.MagicMock
+    ) -> None:
+        mock_response = mock.MagicMock()
+        mock_response.getcode.return_value = 200
+        mock_response.read.return_value = self.chrome_version
+        mock_urlopen.return_value = mock_response
+
         popen_calls = self.exit_stack.enter_context(self.swap_popen())
 
         self.exit_stack.enter_context(servers.managed_webdriverio_server(


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

This PR does the following: It fixes the failing backend test on develop by mocking the external request

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [X] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [X] The linter/Karma presubmit checks have passed on my local machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [ ] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

## Proof that changes are correct

These two tests was failing before

![Screenshot_20230727_001926](https://github.com/oppia/oppia/assets/89520981/5d898351-1e57-4d46-9a2d-bb8d1b58958f)
![Screenshot_20230727_002119](https://github.com/oppia/oppia/assets/89520981/8d85daeb-37d5-4708-9547-83e3c16fb6e4)

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- Make sure your PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
