### PR TITLE
Revert "Set evaluation context for platform params and remove browser_type filter (#18619)"

### DIFF
--- a/assets/constants.ts
+++ b/assets/constants.ts
@@ -6383,6 +6383,8 @@ export default {
   // Maximum allowed length of unique progress url ID.
   "MAX_PROGRESS_URL_ID_LENGTH": 6,
 
+  "PLATFORM_PARAMETER_ALLOWED_BROWSER_TYPES": [
+    "Chrome", "Edge", "Safari", "Firefox", "Others"],
   "PLATFORM_PARAMETER_ALLOWED_PLATFORM_TYPES": ["Web", "Android", "Backend"],
   // The ordering of in ALLOWED_APP_VERSION_FLAVORS implies the ordering
   // of corresponding flavors, which is used in app_version_flavor filter for

--- a/core/controllers/platform_feature.py
+++ b/core/controllers/platform_feature.py
@@ -34,6 +34,7 @@ class PlatformFeaturesEvaluationHandlerNormalizedRequestDict(TypedDict):
     """
 
     platform_type: Optional[str]
+    browser_type: Optional[str]
     app_version: Optional[str]
 
 
@@ -52,6 +53,14 @@ class PlatformFeaturesEvaluationHandler(
             'platform_type': {
                 'schema': {
                     'type': 'basestring'
+                },
+                'default_value': None
+            },
+            'browser_type': {
+                'schema': {
+                    'type': 'basestring',
+                    'choices': (
+                        constants.PLATFORM_PARAMETER_ALLOWED_BROWSER_TYPES)
                 },
                 'default_value': None
             },
@@ -79,6 +88,7 @@ class PlatformFeaturesEvaluationHandler(
         assert self.normalized_request is not None
         context_dict: platform_parameter_domain.ClientSideContextDict = {
             'platform_type': self.normalized_request.get('platform_type'),
+            'browser_type': self.normalized_request.get('browser_type'),
             'app_version': self.normalized_request.get('app_version'),
         }
         context = (

--- a/core/controllers/platform_feature_test.py
+++ b/core/controllers/platform_feature_test.py
@@ -159,6 +159,25 @@ class PlatformFeaturesEvaluationHandlerTest(test_utils.GenericTestBase):
                 '[\'test\', \'alpha\', \'beta\', \'release\'] if specified.'
             )
 
+    def test_get_features_invalid_browser_type_raises_400(
+        self
+    ) -> None:
+        with self.swap(constants, 'DEV_MODE', True):
+            result = self.get_json(
+                '/platform_features_evaluation_handler',
+                params={
+                    'browser_type': 'invalid_browser',
+                },
+                expected_status_int=400
+            )
+
+            error_msg = (
+                'Schema validation for \'browser_type\' failed: Received '
+                'invalid_browser which is not in the allowed range of choices: '
+                '[\'Chrome\', \'Edge\', \'Safari\', \'Firefox\', \'Others\']'
+            )
+            self.assertEqual(result['error'], error_msg)
+
     def test_get_features_invalid_app_version_raises_400(self) -> None:
         with self.swap(constants, 'DEV_MODE', True):
             result = self.get_json(

--- a/core/domain/platform_feature_services.py
+++ b/core/domain/platform_feature_services.py
@@ -32,18 +32,14 @@ docstrings in this file.
 
 from __future__ import annotations
 
-import json
-import os
-
 from core import feconf
 from core import platform_feature_list
-from core import utils
 from core.constants import constants
 from core.domain import platform_parameter_domain
 from core.domain import platform_parameter_list
 from core.domain import platform_parameter_registry as registry
 
-from typing import Dict, Final, List, Set
+from typing import Dict, List, Set
 
 ALL_FEATURE_FLAGS: List[platform_feature_list.ParamNames] = (
     platform_feature_list.DEV_FEATURES_LIST +
@@ -78,8 +74,6 @@ ALL_PLATFORM_PARAMS_EXCEPT_FEATURE_FLAGS: List[
         platform_parameter_list.ParamNames.PROMO_BAR_ENABLED,
         platform_parameter_list.ParamNames.PROMO_BAR_MESSAGE,
     ]
-
-PACKAGE_JSON_FILE_PATH: Final = os.path.join(os.getcwd(), 'package.json')
 
 
 class FeatureFlagNotFoundException(Exception):
@@ -232,29 +226,17 @@ def _create_evaluation_context_for_server() -> (
     Returns:
         EvaluationContext. The context for evaluation.
     """
-    current_app_version = json.load(utils.open_file(
-        PACKAGE_JSON_FILE_PATH, 'r'))['version']
-    # We want to make sure that the branch is the release branch.
-    if not constants.BRANCH_NAME == '' and 'release' in constants.BRANCH_NAME:
-        # We only need current app version so we can drop the 'release' part.
-        current_app_version = constants.BRANCH_NAME.split('release-')[1]
-        # We want to replace the '-' with the '.' for the version name.
-        # If the branch is the hotfix branch then we would require to further
-        # split it up and do the replacement for the version name. In the end,
-        # '3-3-1-hotfix-5' will be '3.3.1-hotfix-5' and '3-3-1' will be '3.3.1'.
-        if 'hotfix' in current_app_version:
-            split_via_hotfix = current_app_version.split('-hotfix')
-            current_app_version = (
-                split_via_hotfix[0].replace('-', '.') +
-                '-hotfix' + split_via_hotfix[1]
-            )
-        else:
-            current_app_version = current_app_version.replace('-', '.')
-
+    # TODO(#11208): Here we use MyPy ignore because due to the missing
+    # `browser_type` key MyPy throwing missing key error. Also, `app_version`
+    # key is set as none which forces us to use `.get()` method while fetching
+    # the values from dictionaries. So, to remove 'type ignore' from here and
+    # '.get()' method from '.from_dict' method, properly set app version and
+    # browser type key below using GAE app version as part of the server &
+    # client context.
     return platform_parameter_domain.EvaluationContext.from_dict(
-        {
-            'platform_type': 'Web',
-            'app_version': current_app_version,
+        {  # type: ignore[typeddict-item]
+            'platform_type': 'Backend',
+            'app_version': None,
         },
         {
             'server_mode': get_server_mode()

--- a/core/domain/platform_feature_services_test.py
+++ b/core/domain/platform_feature_services_test.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import enum
 
 from core import feconf
+from core import utils
 from core.constants import constants
 from core.domain import caching_services
 from core.domain import platform_feature_services as feature_services
@@ -37,7 +38,6 @@ class ParamNames(enum.Enum):
     FEATURE_C = 'feature_c'
     PARAM_A = 'param_a'
     PARAM_B = 'param_b'
-    PARAM_C = 'param_c'
 
 
 ServerMode = platform_parameter_domain.ServerMode
@@ -57,9 +57,8 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
             registry.Registry.parameter_registry.copy())
         registry.Registry.parameter_registry.clear()
         # Parameter names that might be used in following tests.
-        param_names = ['param_a', 'param_b', 'param_c']
-        param_name_enums = [
-            ParamNames.PARAM_A, ParamNames.PARAM_B, ParamNames.PARAM_C]
+        param_names = ['param_a', 'param_b']
+        param_name_enums = [ParamNames.PARAM_A, ParamNames.PARAM_B]
         param_names_features = ['feature_a', 'feature_b', 'feature_c']
         param_name_enums_features = [
             ParamNames.FEATURE_A, ParamNames.FEATURE_B, ParamNames.FEATURE_C]
@@ -87,11 +86,6 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
             ParamNames.PARAM_B,
             'Parameter named b',
             platform_parameter_domain.DataTypes.BOOL)
-        self.param_c = registry.Registry.create_platform_parameter(
-            ParamNames.PARAM_C,
-            'Parameter named c',
-            platform_parameter_domain.DataTypes.BOOL)
-
         registry.Registry.update_platform_parameter(
             self.dev_feature.name, self.user_id, 'edit rules',
             [
@@ -186,7 +180,6 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
         expected_dicts = [
             self.param_a.to_dict(),
             self.param_b.to_dict(),
-            self.param_c.to_dict(),
         ]
         self.assertEqual(
             feature_services.
@@ -212,6 +205,7 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
             context = feature_services.create_evaluation_context_for_client(
                 {
                     'platform_type': 'Android',
+                    'browser_type': None,
                     'app_version': '1.0.0',
                 }
             )
@@ -219,6 +213,7 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
                 context.server_mode,
                 FeatureStages.DEV)
             self.assertEqual(context.platform_type, 'Android')
+            self.assertEqual(context.browser_type, None)
             self.assertEqual(context.app_version, '1.0.0')
 
     def test_get_all_feature_flag_dicts_returns_correct_dicts(self) -> None:
@@ -237,6 +232,7 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
         with self.swap(constants, 'DEV_MODE', True):
             context = feature_services.create_evaluation_context_for_client({
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.0.0',
             })
             self.assertEqual(
@@ -257,6 +253,7 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
         with constants_swap, env_swap:
             context = feature_services.create_evaluation_context_for_client({
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.0.0',
             })
             self.assertEqual(
@@ -276,6 +273,7 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
         with constants_swap, env_swap:
             context = feature_services.create_evaluation_context_for_client({
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.0.0',
             })
             self.assertEqual(
@@ -338,41 +336,7 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
                 self.assertTrue(
                     feature_services.is_feature_enabled(self.prod_feature.name))
 
-    def test_evaluation_context_for_app_version_works_as_expected(self) -> None:
-        self.assertFalse(feature_services.get_platform_parameter_value(
-            self.param_c.name))
-
-        registry.Registry.update_platform_parameter(
-            self.param_c.name, self.user_id, 'edit rules',
-            [
-                platform_parameter_domain.PlatformParameterRule.from_dict({
-                    'filters': [
-                        {
-                            'type': 'app_version',
-                            'conditions': [
-                                ['=', '3.3.1']
-                            ],
-                        }
-                    ],
-                    'value_when_matched': True
-                })
-            ],
-            False
-        )
-
-        with self.swap(constants, 'BRANCH_NAME', ''):
-            self.assertTrue(feature_services.get_platform_parameter_value(
-                self.param_c.name))
-
-        with self.swap(constants, 'BRANCH_NAME', 'release-3-3-1-hotfix-5'):
-            self.assertTrue(feature_services.get_platform_parameter_value(
-                self.param_c.name))
-
-        with self.swap(constants, 'BRANCH_NAME', 'release-3-3-1'):
-            self.assertTrue(feature_services.get_platform_parameter_value(
-                self.param_c.name))
-
-    def test_evaluate_feature_for_prod_server_matches_to_web_filter(
+    def test_evaluate_feature_for_prod_server_matches_to_backend_filter(
         self
     ) -> None:
         registry.Registry.update_platform_parameter(
@@ -381,9 +345,15 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
                 platform_parameter_domain.PlatformParameterRule.from_dict({
                     'filters': [
                         {
+                            'type': 'server_mode',
+                            'conditions': [
+                                ['=', ServerMode.PROD.value]
+                            ],
+                        },
+                        {
                             'type': 'platform_type',
                             'conditions': [
-                                ['=', 'Web']
+                                ['=', 'Backend']
                             ],
                         }
                     ],
@@ -439,6 +409,30 @@ class PlatformFeatureServiceTest(test_utils.GenericTestBase):
                     platform_parameter_domain.PlatformParameterRule.from_dict(
                         {'filters': [], 'value_when_matched': False}
                     ),
+                ],
+                False
+            )
+
+    def test_update_feature_flag_with_invalid_rules_raises_error(
+        self
+    ) -> None:
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'must have a server_mode filter'):
+            feature_services.update_feature_flag(
+                self.dev_feature.name, self.user_id, 'test update',
+                [
+                    platform_parameter_domain.PlatformParameterRule.from_dict({
+                        'filters': [
+                            {
+                                'type': 'app_version',
+                                'conditions': [['=', '1.2.3']]
+                            }
+                        ],
+                        'value_when_matched': True
+                    }),
+                    platform_parameter_domain.PlatformParameterRule.from_dict({
+                        'filters': [], 'value_when_matched': False
+                    })
                 ],
                 False
             )

--- a/core/domain/platform_parameter_domain.py
+++ b/core/domain/platform_parameter_domain.py
@@ -67,6 +67,9 @@ ALLOWED_FEATURE_STAGES: Final = [
 ALLOWED_PLATFORM_TYPES: List[str] = (
     constants.PLATFORM_PARAMETER_ALLOWED_PLATFORM_TYPES
 )
+ALLOWED_BROWSER_TYPES: List[str] = (
+    constants.PLATFORM_PARAMETER_ALLOWED_BROWSER_TYPES
+)
 ALLOWED_APP_VERSION_FLAVORS: List[str] = (
     constants.PLATFORM_PARAMETER_ALLOWED_APP_VERSION_FLAVORS
 )
@@ -109,6 +112,7 @@ class ClientSideContextDict(TypedDict):
     """Dictionary representing the client's side Context object."""
 
     platform_type: Optional[str]
+    browser_type: Optional[str]
     app_version: Optional[str]
 
 
@@ -124,10 +128,12 @@ class EvaluationContext:
     def __init__(
         self,
         platform_type: Optional[str],
+        browser_type: Optional[str],
         app_version: Optional[str],
         server_mode: ServerMode
     ) -> None:
         self._platform_type = platform_type
+        self._browser_type = browser_type
         self._app_version = app_version
         self._server_mode = server_mode
 
@@ -139,6 +145,16 @@ class EvaluationContext:
             str|None. The platform type, e.g. 'Web', 'Android', 'Backend'.
         """
         return self._platform_type
+
+    @property
+    def browser_type(self) -> Optional[str]:
+        """Returns client browser type.
+
+        Returns:
+            str|None. The client browser type, e.g. 'Chrome', 'FireFox',
+            'Edge'. None if the platform type is not Web.
+        """
+        return self._browser_type
 
     @property
     def app_version(self) -> Optional[str]:
@@ -183,6 +199,13 @@ class EvaluationContext:
         """Validates the EvaluationContext domain object, raising an exception
         if the object is in an irrecoverable error state.
         """
+        if (
+                self._browser_type is not None and
+                self._browser_type not in ALLOWED_BROWSER_TYPES):
+            raise utils.ValidationError(
+                'Invalid browser type \'%s\', must be one of %s.' % (
+                    self._browser_type, ALLOWED_BROWSER_TYPES))
+
         if self._app_version is not None:
             match = APP_VERSION_WITH_HASH_REGEXP.match(self._app_version)
             if match is None:
@@ -226,6 +249,7 @@ class EvaluationContext:
         # to fetch dictionary keys.
         return cls(
             client_context_dict['platform_type'],
+            client_context_dict.get('browser_type'),
             client_context_dict.get('app_version'),
             server_context_dict['server_mode'],
         )
@@ -242,13 +266,14 @@ class PlatformParameterFilter:
     """Domain object for filters in platform parameters."""
 
     SUPPORTED_FILTER_TYPES: Final = [
-        'server_mode', 'platform_type', 'app_version',
+        'server_mode', 'platform_type', 'browser_type', 'app_version',
         'app_version_flavor',
     ]
 
     SUPPORTED_OP_FOR_FILTERS: Final = {
         'server_mode': ['='],
         'platform_type': ['='],
+        'browser_type': ['='],
         'app_version_flavor': ['=', '<', '<=', '>', '>='],
         'app_version': ['=', '<', '<=', '>', '>='],
     }
@@ -317,7 +342,7 @@ class PlatformParameterFilter:
             Exception. Given operator is not supported.
         """
         if (
-            self._type in ['server_mode', 'platform_type']
+            self._type in ['server_mode', 'platform_type', 'browser_type']
             and op != '='
         ):
             raise Exception(
@@ -330,6 +355,8 @@ class PlatformParameterFilter:
             matched = context.server_mode.value == value
         elif self._type == 'platform_type' and op == '=':
             matched = context.platform_type == value
+        elif self._type == 'browser_type' and op == '=':
+            matched = context.browser_type == value
         elif self._type == 'app_version_flavor':
             # Ruling out the possibility of None for mypy type checking.
             assert context.app_version is not None
@@ -617,6 +644,16 @@ class PlatformParameterRule:
             filter_domain.evaluate(context)
             for filter_domain in self._filters)
 
+    def has_server_mode_filter(self) -> bool:
+        """Checks if the rule has a filter with type 'server_mode'.
+
+        Returns:
+            bool. True if the rule has a filter with type 'server_mode'.
+        """
+        return any(
+            filter_domain.type == 'server_mode'
+            for filter_domain in self._filters)
+
     def to_dict(self) -> PlatformParameterRuleDict:
         """Returns a dict representation of the PlatformParameterRule domain
         object.
@@ -816,6 +853,9 @@ class PlatformParameter:
                 raise utils.ValidationError(
                     'Expected %s, received \'%s\' in value_when_matched.' % (
                         self._data_type, rule.value_when_matched))
+            if not rule.has_server_mode_filter():
+                raise utils.ValidationError(
+                    'All rules must have a server_mode filter.')
             rule.validate()
 
         if self._is_feature:

--- a/core/domain/platform_parameter_domain_test.py
+++ b/core/domain/platform_parameter_domain_test.py
@@ -106,6 +106,7 @@ class EvaluationContextTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.0.0',
             },
             {
@@ -113,6 +114,7 @@ class EvaluationContextTests(test_utils.GenericTestBase):
             },
         )
         self.assertEqual(context.platform_type, 'Android')
+        self.assertEqual(context.browser_type, None)
         self.assertEqual(context.app_version, '1.0.0')
         self.assertEqual(context.server_mode, ServerMode.DEV)
 
@@ -120,6 +122,7 @@ class EvaluationContextTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'invalid',
+                'browser_type': None,
                 'app_version': '1.0.0',
             },
             {
@@ -132,6 +135,7 @@ class EvaluationContextTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.0.0',
             },
             {
@@ -144,6 +148,7 @@ class EvaluationContextTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Web',
+                'browser_type': 'Chrome',
                 'app_version': None,
             },
             {
@@ -156,6 +161,7 @@ class EvaluationContextTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Backend',
+                'browser_type': None,
                 'app_version': '3.0.0',
             },
             {
@@ -168,6 +174,7 @@ class EvaluationContextTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.0.0',
             },
             {
@@ -182,6 +189,7 @@ class EvaluationContextTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'invalid',
+                'browser_type': None,
                 'app_version': '1.0.0',
             },
             {
@@ -192,10 +200,26 @@ class EvaluationContextTests(test_utils.GenericTestBase):
         # ignored.
         context.validate()
 
+    def test_validate_with_invalid_browser_type_raises_exception(self) -> None:
+        context = parameter_domain.EvaluationContext.from_dict(
+            {
+                'platform_type': 'Web',
+                'browser_type': 'Invalid',
+                'app_version': '1.0.0',
+            },
+            {
+                'server_mode': ServerMode.DEV,
+            },
+        )
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'Invalid browser type \'Invalid\''):
+            context.validate()
+
     def test_validate_with_invalid_app_version_raises_exception(self) -> None:
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': 'a.a.a',
             },
             {
@@ -212,6 +236,7 @@ class EvaluationContextTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.0.0.0',
             },
             {
@@ -228,6 +253,7 @@ class EvaluationContextTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.0.0-abcedef-invalid',
             },
             {
@@ -244,6 +270,7 @@ class EvaluationContextTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.0.0',
             },
             {
@@ -267,6 +294,7 @@ class PlatformParameterFilterTests(test_utils.GenericTestBase):
     def _create_example_context(
         self,
         platform_type: str = 'Android',
+        browser_type: Optional[str] = None,
         app_version: Optional[str] = '1.2.3',
         mode: str = 'DEV'
     ) -> parameter_domain.EvaluationContext:
@@ -276,6 +304,7 @@ class PlatformParameterFilterTests(test_utils.GenericTestBase):
         return parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': platform_type,
+                'browser_type': browser_type,
                 'app_version': app_version,
             },
             {
@@ -413,6 +442,34 @@ class PlatformParameterFilterTests(test_utils.GenericTestBase):
 
         native_context = self._create_example_context(platform_type='Android')
         self.assertFalse(filter_domain.evaluate(native_context))
+
+    def test_evaluate_chrome_browser_filter_with_chrome_returns_true(
+        self
+    ) -> None:
+        filter_dict: parameter_domain.PlatformParameterFilterDict = {
+            'type': 'browser_type',
+            'conditions': [['=', 'Chrome']]
+        }
+        filter_domain = (
+            parameter_domain
+            .PlatformParameterFilter.from_dict(filter_dict))
+
+        chrome_context = self._create_example_context(browser_type='Chrome')
+        self.assertTrue(filter_domain.evaluate(chrome_context))
+
+    def test_evaluate_chrome_browser_filter_with_firefox_returns_false(
+        self
+    ) -> None:
+        filter_dict: parameter_domain.PlatformParameterFilterDict = {
+            'type': 'browser_type',
+            'conditions': [['=', 'Chrome']]
+        }
+        filter_domain = (
+            parameter_domain
+            .PlatformParameterFilter.from_dict(filter_dict))
+
+        firefox_context = self._create_example_context(browser_type='Firefox')
+        self.assertFalse(filter_domain.evaluate(firefox_context))
 
     def test_evaluate_eq_version_filter_with_same_version_returns_true(
         self
@@ -1430,6 +1487,30 @@ class PlatformParameterRuleTests(test_utils.GenericTestBase):
         rule = parameter_domain.PlatformParameterRule.from_dict(rule_dict)
         self.assertEqual(rule.to_dict(), rule_dict)
 
+    def test_has_server_mode_filter_with_mode_filter_returns_true(self) -> None:
+        rule = parameter_domain.PlatformParameterRule.from_dict(
+            {
+                'filters': [
+                    {'type': 'server_mode', 'conditions': [['=', 'dev']]}
+                ],
+                'value_when_matched': False,
+            },
+        )
+        self.assertTrue(rule.has_server_mode_filter())
+
+    def test_has_server_mode_filter_without_mode_filter_returns_false(
+        self
+    ) -> None:
+        rule = parameter_domain.PlatformParameterRule.from_dict(
+            {
+                'filters': [
+                    {'type': 'app_version', 'conditions': [['=', '1.2.3']]}
+                ],
+                'value_when_matched': False,
+            },
+        )
+        self.assertFalse(rule.has_server_mode_filter())
+
     def test_evaluation_with_matching_context_returns_true(self) -> None:
         rule = parameter_domain.PlatformParameterRule.from_dict(
             {
@@ -1443,6 +1524,7 @@ class PlatformParameterRuleTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.2.3',
             },
             {
@@ -1464,6 +1546,7 @@ class PlatformParameterRuleTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.2.3',
             },
             {
@@ -1830,6 +1913,7 @@ class PlatformParameterTests(test_utils.GenericTestBase):
         dev_context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.2.3',
             },
             {
@@ -1864,6 +1948,7 @@ class PlatformParameterTests(test_utils.GenericTestBase):
         prod_context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.2.3',
             },
             {
@@ -1900,6 +1985,7 @@ class PlatformParameterTests(test_utils.GenericTestBase):
         dev_context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'invalid',
+                'browser_type': None,
                 'app_version': '1.2.3',
             },
             {
@@ -1936,6 +2022,7 @@ class PlatformParameterTests(test_utils.GenericTestBase):
         dev_context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': '',
+                'browser_type': None,
                 'app_version': '1.2.3',
             },
             {
@@ -1996,6 +2083,29 @@ class PlatformParameterTests(test_utils.GenericTestBase):
         })
         with self.assertRaisesRegex(
             utils.ValidationError, 'Invalid feature stage, got \'Invalid\''):
+            parameter.validate()
+
+    def test_validate_feature_with_no_mode_filter_raises_exception(
+        self
+    ) -> None:
+        parameter = parameter_domain.PlatformParameter.from_dict({
+            'name': 'parameter_a',
+            'description': 'for test',
+            'data_type': 'bool',
+            'rules': [
+                {
+                    'filters': [],
+                    'value_when_matched': True
+                }
+            ],
+            'rule_schema_version': (
+                feconf.CURRENT_PLATFORM_PARAMETER_RULE_SCHEMA_VERSION),
+            'default_value': False,
+            'is_feature': True,
+            'feature_stage': 'dev',
+        })
+        with self.assertRaisesRegex(
+            utils.ValidationError, 'must have a server_mode filter'):
             parameter.validate()
 
     def test_validate_dev_feature_for_test_env_raises_exception(self) -> None:

--- a/core/domain/platform_parameter_registry_test.py
+++ b/core/domain/platform_parameter_registry_test.py
@@ -448,6 +448,7 @@ class PlatformParameterRegistryTests(test_utils.GenericTestBase):
         context = parameter_domain.EvaluationContext.from_dict(
             {
                 'platform_type': 'Android',
+                'browser_type': None,
                 'app_version': '1.2.3',
             },
             {

--- a/core/templates/domain/platform_feature/client-context.model.spec.ts
+++ b/core/templates/domain/platform_feature/client-context.model.spec.ts
@@ -21,16 +21,18 @@ import { ClientContext } from
 
 describe('Client Context Model', () => {
   it('should create an instance.', () => {
-    const context = ClientContext.create('Web');
+    const context = ClientContext.create('Web', 'Chrome');
 
     expect(context.platformType).toEqual('Web');
+    expect(context.browserType).toEqual('Chrome');
   });
 
   it('should convert an instance to a dict.', () => {
-    const context = ClientContext.create('Web');
+    const context = ClientContext.create('Web', 'Chrome');
 
     expect(context.toBackendDict()).toEqual({
       platform_type: 'Web',
+      browser_type: 'Chrome',
     });
   });
 });

--- a/core/templates/domain/platform_feature/client-context.model.ts
+++ b/core/templates/domain/platform_feature/client-context.model.ts
@@ -18,6 +18,7 @@
 
 export interface ClientContextBackendDict {
   'platform_type': string;
+  'browser_type': string;
 }
 
 /**
@@ -26,13 +27,15 @@ export interface ClientContextBackendDict {
  */
 export class ClientContext {
   readonly platformType: string;
+  readonly browserType: string;
 
-  constructor(platformType: string) {
+  constructor(platformType: string, browserType: string) {
     this.platformType = platformType;
+    this.browserType = browserType;
   }
 
-  static create(platformType: string): ClientContext {
-    return new ClientContext(platformType);
+  static create(platformType: string, browserType: string): ClientContext {
+    return new ClientContext(platformType, browserType);
   }
 
   /**
@@ -44,6 +47,7 @@ export class ClientContext {
   toBackendDict(): ClientContextBackendDict {
     return {
       platform_type: this.platformType,
+      browser_type: this.browserType,
     };
   }
 }

--- a/core/templates/domain/platform_feature/platform-feature-backend-api.service.spec.ts
+++ b/core/templates/domain/platform_feature/platform-feature-backend-api.service.spec.ts
@@ -51,7 +51,7 @@ describe('PlatformFeatureBackendApiService', () => {
         const successHandler = jasmine.createSpy('success');
         const failHandler = jasmine.createSpy('fail');
 
-        const context = ClientContext.create('Web');
+        const context = ClientContext.create('Web', 'Chrome');
         const contextDict = context.toBackendDict();
         const responseDict = {
           feature_a: true,
@@ -81,7 +81,7 @@ describe('PlatformFeatureBackendApiService', () => {
       const successHandler = jasmine.createSpy('success');
       const failHandler = jasmine.createSpy('fail');
 
-      const context = ClientContext.create('Web');
+      const context = ClientContext.create('Web', 'Chrome');
       const contextDict = context.toBackendDict();
 
       platformFeatureBackendApiService.fetchFeatureFlags(context)

--- a/core/templates/domain/platform_feature/platform-parameter-filter.model.ts
+++ b/core/templates/domain/platform_feature/platform-parameter-filter.model.ts
@@ -21,6 +21,7 @@ import cloneDeep from 'lodash/cloneDeep';
 export enum PlatformParameterFilterType {
   ServerMode = 'server_mode',
   PlatformType = 'platform_type',
+  BrowserType = 'browser_type',
   AppVersion = 'app_version',
   AppVersionFlavor = 'app_version_flavor'
 }

--- a/core/templates/domain/platform_feature/platform-parameter-rule.model.spec.ts
+++ b/core/templates/domain/platform_feature/platform-parameter-rule.model.spec.ts
@@ -86,6 +86,10 @@ describe('PlatformParameterRuleModel', () => {
       const instance = PlatformParameterRule.createFromBackendDict({
         filters: [
           {
+            type: PlatformParameterFilterType.BrowserType,
+            conditions: [['=', 'Chrome']]
+          },
+          {
             type: PlatformParameterFilterType.AppVersion,
             conditions: [['>', '1.0.0']]
           }

--- a/core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.ts
+++ b/core/templates/pages/admin-page/platform-parameters-tab/admin-platform-parameters-tab.component.ts
@@ -81,6 +81,11 @@ export class AdminPlatformParametersTabComponent implements OnInit {
         options: AdminFeaturesTabConstants.ALLOWED_PLATFORM_TYPES,
         operators: ['=']
       },
+      [PlatformParameterFilterType.BrowserType]: {
+        displayName: 'Browser Type',
+        options: AdminFeaturesTabConstants.ALLOWED_BROWSER_TYPES,
+        operators: ['=']
+      },
       [PlatformParameterFilterType.AppVersion]: {
         displayName: 'App Version',
         operators: ['=', '<', '>', '<=', '>='],

--- a/core/templates/pages/release-coordinator-page/features-tab/features-tab.component.ts
+++ b/core/templates/pages/release-coordinator-page/features-tab/features-tab.component.ts
@@ -90,6 +90,11 @@ export class FeaturesTabComponent implements OnInit {
         options: AdminFeaturesTabConstants.ALLOWED_PLATFORM_TYPES,
         operators: ['=']
       },
+      [PlatformParameterFilterType.BrowserType]: {
+        displayName: 'Browser Type',
+        options: AdminFeaturesTabConstants.ALLOWED_BROWSER_TYPES,
+        operators: ['=']
+      },
       [PlatformParameterFilterType.AppVersion]: {
         displayName: 'App Version',
         operators: ['=', '<', '>', '<=', '>='],

--- a/core/templates/pages/release-coordinator-page/features-tab/features-tab.constants.ts
+++ b/core/templates/pages/release-coordinator-page/features-tab/features-tab.constants.ts
@@ -29,6 +29,8 @@ export const AdminFeaturesTabConstants = {
   ALLOWED_PLATFORM_TYPES: (
     AppConstants.PLATFORM_PARAMETER_ALLOWED_PLATFORM_TYPES),
 
+  ALLOWED_BROWSER_TYPES: AppConstants.PLATFORM_PARAMETER_ALLOWED_BROWSER_TYPES,
+
   // Matches app version with the numeric part only, hash and flavor are not
   // needed since hash is redundant and there is already app_version_flavor
   // filter.

--- a/core/templates/services/platform-feature.service.ts
+++ b/core/templates/services/platform-feature.service.ts
@@ -178,8 +178,9 @@ export class PlatformFeatureService {
    */
   private generateClientContext(): ClientContext {
     const platformType = 'Web';
+    const browserType = this.browserCheckerService.detectBrowserType();
 
-    return ClientContext.create(platformType);
+    return ClientContext.create(platformType, browserType);
   }
 }
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[n/a].
2. This PR does the following: This reverts commit 9b7fca2eca20fffffe32edf6ffeb6679595acd3b. @lkbhitesh07 the test `test_evaluation_context_for_app_version_works_as_expected()` that you added in #18619 appears to be flaky, as it [failed](https://github.com/oppia/oppia/actions/runs/5678068653/job/15387558231?pr=18691#step:8:2650) in #18691, and when I ran it locally from `develop` (see proof of correctness below)
3. (For bug-fixing PRs only) The original bug occurred because: A flaky backend test was merged into `develop`.

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [ ] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [ ] The linter/Karma presubmit checks have passed on my local machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [ ] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Proof that changes are correct

Local test runs:

```console
$ python -m scripts.run_backend_tests --test_target core.domain.platform_feature_services_test.PlatformFeatureServiceTest.test_evaluation_context_for_app_version_works_as_expected
...
+------------------+
| SUMMARY OF TESTS |
+------------------+

======================================================================
FAIL: test_evaluation_context_for_app_version_works_as_expected (core.domain.platform_feature_services_test.PlatformFeatureServiceTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/cs/Documents/School/Stanford/ExtraCurriculars/oppia/code/oppia/oppia/core/domain/platform_feature_services_test.py", line 364, in test_evaluation_context_for_app_version_works_as_expected
    self.assertTrue(feature_services.get_platform_parameter_value(
AssertionError: False is not true

---------------------------------------------------------------------
FAILED    core.domain.platform_feature_services_test.PlatformFeatureServiceTest.test_evaluation_context_for_app_version_works_as_expected: 0 errors, 1 failures

Ran 1 test in 1 test class.
(0 ERRORS, 1 FAILURES)
Traceback (most recent call last):
  File "/Users/cs/.pyenv/versions/3.8.15/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/cs/.pyenv/versions/3.8.15/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/cs/Documents/School/Stanford/ExtraCurriculars/oppia/code/oppia/oppia/scripts/run_backend_tests.py", line 680, in <module>
    main()
  File "/Users/cs/Documents/School/Stanford/ExtraCurriculars/oppia/code/oppia/oppia/scripts/run_backend_tests.py", line 589, in main
    raise Exception(
Exception: 0 errors, 1 failures

$ git revert -n 9b7fca2eca20fffffe32edf6ffeb6679595acd3b
...
$ python -m scripts.run_backend_tests --test_target core.domain.platform_feature_services_test.PlatformFeatureServiceTest.test_evaluate_feature_for_prod_server_matches_to_backend_filter
...
+------------------+
| SUMMARY OF TESTS |
+------------------+

SUCCESS   core.domain.platform_feature_services_test.PlatformFeatureServiceTest.test_evaluate_feature_for_prod_server_matches_to_backend_filter: 1 tests (0.8 secs)

Ran 1 test in 1 test class.
All tests passed.


Done!
```

## PR Pointers

- Never force push! If you do, your PR will be closed.
- Make sure your PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
