### PR TITLE
Fix flaky test caused due to PR: [18550]

### DIFF
--- a/extensions/rich_text_components/Image/directives/oppia-noninteractive-image.component.spec.ts
+++ b/extensions/rich_text_components/Image/directives/oppia-noninteractive-image.component.spec.ts
@@ -327,7 +327,8 @@ describe('NoninteractiveImage', () => {
   it('should show alt text images when altTextIsDisplayed property is true',
     () => {
       spyOn(contextService, 'getEntityType').and.returnValue('exploration');
-      spyOn(imagePreloaderService, 'getImageUrlAsync').and.resolveTo(dataUrlSvg);
+      spyOn(imagePreloaderService, 'getImageUrlAsync').and.resolveTo(
+        dataUrlSvg);
       spyOn(contextService, 'getExplorationId').and.returnValue('exp_id');
       spyOn(contextService, 'getEntityId').and.returnValue('expId');
 

--- a/extensions/rich_text_components/Image/directives/oppia-noninteractive-image.component.spec.ts
+++ b/extensions/rich_text_components/Image/directives/oppia-noninteractive-image.component.spec.ts
@@ -326,6 +326,11 @@ describe('NoninteractiveImage', () => {
 
   it('should show alt text images when altTextIsDisplayed property is true',
     () => {
+      spyOn(contextService, 'getEntityType').and.returnValue('exploration');
+      spyOn(imagePreloaderService, 'getImageUrlAsync').and.resolveTo(dataUrlSvg);
+      spyOn(contextService, 'getExplorationId').and.returnValue('exp_id');
+      spyOn(contextService, 'getEntityId').and.returnValue('expId');
+
       component.altTextIsDisplayed = true;
       component.imageAltText = 'This is alt text';
       fixture.detectChanges();
@@ -337,6 +342,11 @@ describe('NoninteractiveImage', () => {
 
   it('should not show alt text images when altTextIsDisplayed property is' +
     'false', () => {
+    spyOn(contextService, 'getEntityType').and.returnValue('exploration');
+    spyOn(imagePreloaderService, 'getImageUrlAsync').and.resolveTo(dataUrlSvg);
+    spyOn(contextService, 'getExplorationId').and.returnValue('exp_id');
+    spyOn(contextService, 'getEntityId').and.returnValue('expId');
+
     component.altTextIsDisplayed = false;
     component.imageAltText = 'This is alt text';
     fixture.detectChanges();


### PR DESCRIPTION
## Overview

1. This PR does the following: This PR adds some spies for services to mock the value returned in order to prevent flaky behaviour of https://github.com/oppia/oppia/blame/525bc952f4afe096fc22fe3f3f7e17f6bd194d1f/extensions/rich_text_components/Image/directives/oppia-noninteractive-image.component.spec.ts#L338 which was introduced in [PR #18550](https://github.com/oppia/oppia/pull/18550) 

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [ ] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [ ] The linter/Karma presubmit checks have passed on my local machine.
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [ ] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

