### PR TITLE
Merge frontend-test-reviewers into lace-frontend-reviewers. Fix incorrect status badge on README.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -686,10 +686,10 @@
 
 
 # Frontend unit tests
-/core/templates/**/*.spec.ts @oppia/frontend-test-reviewers
-/core/templates/**/*Spec.ts @oppia/frontend-test-reviewers
-/extensions/**/*.spec.ts @oppia/frontend-test-reviewers
-/extensions/**/*Spec.ts @oppia/frontend-test-reviewers
+/core/templates/**/*.spec.ts @oppia/lace-frontend-reviewers
+/core/templates/**/*Spec.ts @oppia/lace-frontend-reviewers
+/extensions/**/*.spec.ts @oppia/lace-frontend-reviewers
+/extensions/**/*Spec.ts @oppia/lace-frontend-reviewers
 
 # Draft version upgrade.
 /core/domain/draft_upgrade_services*.py @oppia/lace-backend-reviewers

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,4 +1,4 @@
-# [Oppia](https://www.oppia.org) [![End-to-End and Lighthouse CI performance tests](https://github.com/oppia/oppia/actions/workflows/e2e_and%20lighthouse_performance_tests.yml/badge.svg)](https://github.com/oppia/oppia/actions/workflows/e2e_and%20lighthouse_performance_tests.yml)
+# [Oppia](https://www.oppia.org) [![End-to-End and Lighthouse CI performance tests](https://github.com/oppia/oppia/actions/workflows/e2e_lighthouse_performance_acceptance_tests.yml/badge.svg)](https://github.com/oppia/oppia/actions/workflows/e2e_lighthouse_performance_acceptance_tests.yml)
 
 Oppia is an online learning tool that enables anyone to easily create and share interactive activities (called 'explorations'). These activities simulate a one-on-one conversation with a tutor, making it possible for students to learn by doing while getting feedback.
 


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: 
- Merges frontend-test-reviewers codeowner group into lace-frontend-reviewers.
- Fixes incorrect status on README.md (it's pointing to an old set of e2e actions that haven't run in 2 months).


## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Proof that changes are correct

The codeowners proof of correctness can be seen from the CI codeowner file check, and it can be verified that there are no remaining instances of frontend-test-reviewers in the file.
The README proof of correctness can be seen by previewing the file / clicking on the link.