### PR TITLE
Fix #14107: Fix backend flake by making assertions order-independent

### DIFF
--- a/core/platform/taskqueue/cloud_tasks_emulator_test.py
+++ b/core/platform/taskqueue/cloud_tasks_emulator_test.py
@@ -107,20 +107,20 @@ class CloudTasksEmulatorUnitTests(test_utils.TestBase):
             queue_name=self.queue_name1)
 
         self.assertEqual(
-            self.output,
-            [
+            set(self.output),
+            {
                 'Task Default in queue %s with payload %s is sent to %s.' % (
                     self.queue_name1,
                     str(self.payload1),
                     self.url)
-            ]
+            }
         )
 
         self.assertEqual(self.unit_test_emulator.get_number_of_tasks(), 1)
         self.unit_test_emulator.process_and_flush_tasks()
         self.assertEqual(
-            self.output,
-            [
+            set(self.output),
+            {
                 'Task Default in queue %s with payload %s is sent to %s.' % (
                     self.queue_name1,
                     str(self.payload1),
@@ -129,7 +129,7 @@ class CloudTasksEmulatorUnitTests(test_utils.TestBase):
                     self.queue_name2,
                     str(self.payload2),
                     self.url),
-            ]
+            }
         )
         self.assertEqual(self.unit_test_emulator.get_number_of_tasks(), 0)
 
@@ -144,8 +144,8 @@ class CloudTasksEmulatorUnitTests(test_utils.TestBase):
         time.sleep(1)
 
         self.assertEqual(
-            self.output,
-            [
+            set(self.output),
+            {
                 'Task Default in queue %s with payload %s is sent to %s.' % (
                     self.queue_name1,
                     str(self.payload1),
@@ -154,5 +154,5 @@ class CloudTasksEmulatorUnitTests(test_utils.TestBase):
                     self.queue_name2,
                     str(self.payload2),
                     self.url),
-            ]
+            }
         )


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #14107.
2. This PR does the following: Fix backend test flake
3. (For bug-fixing PRs only) The original bug occurred because: The backend test assumed tasks would be executed in the order in which they were added, which often happens by chance but is not guaranteed.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Proof that changes are correct

Backend test runs on CI will show that this PR doesn't break anything. It's difficult to know for sure that this PR fixes the flake, but the diagnosis is pretty straightforward.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- Make sure your PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
