### PR TITLE
Fix #18693: Changed warning message when user inputs equation in textbox.

### DIFF
--- a/core/templates/services/math-interactions.service.spec.ts
+++ b/core/templates/services/math-interactions.service.spec.ts
@@ -181,20 +181,17 @@ describe('MathInteractionsService', () => {
     expect(mathInteractionsService.validateAlgebraicExpression(
       'x-y=0', ['x', 'y'])).toBeFalse();
     expect(mathInteractionsService.getWarningText()).toBe(
-      'It looks like you have entered an equation/inequality.' +
-      ' Please enter an expression instead.');
+      'It looks like you have entered an equals sign which turns your answer into an equation. Please remove the equals sign to make your answer an expression.');
 
     expect(mathInteractionsService.validateAlgebraicExpression(
       'x^2 < 2.5', ['x'])).toBeFalse();
     expect(mathInteractionsService.getWarningText()).toBe(
-      'It looks like you have entered an equation/inequality.' +
-      ' Please enter an expression instead.');
+      'It looks like you have entered an equals sign which turns your answer into an equation. Please remove the equals sign to make your answer an expression.');
 
     expect(mathInteractionsService.validateAlgebraicExpression(
       '5 >= 2*alpha', ['α'])).toBeFalse();
     expect(mathInteractionsService.getWarningText()).toBe(
-      'It looks like you have entered an equation/inequality.' +
-      ' Please enter an expression instead.');
+      'It looks like you have entered an equals sign which turns your answer into an equation. Please remove the equals sign to make your answer an expression.');
 
     expect(mathInteractionsService.validateAlgebraicExpression(
       '(x+y)/0', ['x', 'y'])).toBeFalse();

--- a/core/templates/services/math-interactions.service.ts
+++ b/core/templates/services/math-interactions.service.ts
@@ -164,8 +164,7 @@ export class MathInteractionsService {
       return false;
     } else if (expressionString.indexOf('=') !== -1 || expressionString.indexOf(
       '<') !== -1 || expressionString.indexOf('>') !== -1) {
-      this.warningText = 'It looks like you have entered an ' +
-        'equation/inequality. Please enter an expression instead.';
+      this.warningText = 'It looks like you have entered an equals sign which turns your answer into an equation. Please remove the equals sign to make your answer an expression.';
       return false;
     } else if (expressionString.indexOf('_') !== -1) {
       this.warningText = 'Your answer contains an invalid character: "_".';


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->
Closes #18693 
1. This PR fixes or fixes part of #18693.
2. This PR does the following: Changed warning message when user inputs equation.
3. (For bug-fixing PRs only) The original bug occurred because: Original warning message was confusing for the user.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).



## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
![Screenshot from 2023-08-03 16-14-41](https://github.com/oppia/oppia/assets/63249668/90b30a64-31f2-4a1d-92fe-693f591c755e)

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
![Screenshot from 2023-08-03 22-59-59](https://github.com/oppia/oppia/assets/63249668/27bd2621-6282-4306-b800-3c412759f7c4)


<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- Make sure your PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
