### PR TITLE
fixing guppy icons error

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,6 +30,11 @@
                 "glob": "**/*",
                 "input": "./node_modules/midi/examples/soundfont/",
                 "output": "./midi/examples/soundfont/"
+              },
+              {
+                "glob": "**/*",
+                "input": "./node_modules/guppy-dev/build/icons/",
+                "output": "./icons/"
               }
             ],
             "styles": [

--- a/core/templates/third-party-imports/guppy.import.ts
+++ b/core/templates/third-party-imports/guppy.import.ts
@@ -18,3 +18,4 @@
 
 (window as Window).Guppy = require('guppy-dev/build/guppy.min.js');
 import 'guppy-dev/build/guppy-default.min.css';
+import 'guppy-dev/build/icons/help.png';

--- a/webpack.common.config.ts
+++ b/webpack.common.config.ts
@@ -619,6 +619,20 @@ module.exports = {
       ]
     },
     {
+      test: /\.(jpe?g|png|gif|svg)$/i,
+      include: [
+        path.resolve(__dirname, 'assets'),
+        path.resolve(__dirname, 'core/templates'),
+        path.resolve(__dirname, 'extensions'),
+        path.resolve(__dirname, 'typings'),
+        path.resolve(__dirname, 'node_modules'),
+      ],
+      loader: 'file-loader',
+      options: {
+        name: '/guppy-dev/build/icons/help.png'
+      }
+    },
+    {
       test: {
         include: /.html$/,
         exclude: /(directive|component)\.html$/


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here]
2. This PR does the following: the changes contains fixes for the guppy help icon not rendering. Although I need to change some CSS from the guppy repo also, which Oppia has forked which will completely fix the issue. refer [here](https://github.com/oppia/guppy/pull/4)
The PR include changes in the webpack configs (to bundle the icons with webpack), angular configs (for copying the icons to dist folder so that they are present to use from the package CSS files)

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).



## Proof that changes are correct
cannot add screen recording because need to do some changes in the [oppia-guppy](https://github.com/oppia/guppy) repo also which will completely fix the issue, PR [link](https://github.com/oppia/guppy/pull/4)
