### PR TITLE
Revert "Fix  #18027:  Elements must be contained on ul or ol tags

### DIFF
--- a/core/templates/pages/exploration-editor-page/exploration-editor-page.component.html
+++ b/core/templates/pages/exploration-editor-page/exploration-editor-page.component.html
@@ -12,23 +12,23 @@
       </span>
     </div>
     <div class="navbar-icons">
-      <ul [ngClass]="{'navbar-tab-active': getActiveTabName() === 'main', 'uib-dropdown': countWarnings()}" (click)="selectMainTab()"
+      <li [ngClass]="{'navbar-tab-active': getActiveTabName() === 'main', 'uib-dropdown': countWarnings()}" (click)="selectMainTab()"
           class="nav-item icon nav-list-item position-relative">
-        <li href="#"
-            class="nav-link navbar-tab e2e-test-main-tab"
-            [ngbTooltip]="'Editor'"
-            placement="{{countWarnings() ? 'left' : 'bottom'}}"
-            aria-label="Exploration Editor Button">
+        <a href="#"
+           class="nav-link navbar-tab e2e-test-main-tab"
+           [ngbTooltip]="'Editor'"
+           placement="{{countWarnings() ? 'left' : 'bottom'}}"
+           aria-label="Exploration Editor Button">
           <i class="fas fa-pen navbar-tab-icon" [ngClass]="{'navbar-tab-active-icon': getActiveTabName() === 'main'}"></i>
-        </li>
-        <li [hidden]="!(countWarnings())" class="oppia-editor-warnings-indicator"
-            (mouseover)="isWarningsAreShown(true)"
-            (mouseleave)="isWarningsAreShown(false)"
-            [ngClass]="{'oppia-editor-warnings-critical-color': hasCriticalWarnings(), 'oppia-editor-warnings-error-color': !hasCriticalWarnings()}">
+        </a>
+        <div [hidden]="!(countWarnings())" class="oppia-editor-warnings-indicator"
+             (mouseover)="isWarningsAreShown(true)"
+             (mouseleave)="isWarningsAreShown(false)"
+             [ngClass]="{'oppia-editor-warnings-critical-color': hasCriticalWarnings(), 'oppia-editor-warnings-error-color': !hasCriticalWarnings()}">
           <span class="oppia-editor-warnings-count">
             {{ countWarnings() }}
           </span>
-          <ng-container class="uib-dropdown-menu oppia-editor-warnings-box dropdown-menu exploration-editor-warning-box" *ngIf="warningsAreShown">
+          <ul class="uib-dropdown-menu oppia-editor-warnings-box dropdown-menu exploration-editor-warning-box" *ngIf="warningsAreShown">
             <span class="oppia-editor-warnings-header">Warnings</span>
             <li class="oppia-editor-warnings-text" *ngFor="let warning of getWarnings(); index as index">
               <hr class="oppia-editor-warnings-separator">
@@ -39,61 +39,57 @@
                 {{ warning.message }}
               </span>
             </li>
-          </ng-container>
-        </li>
-      </ul>
+          </ul>
+        </div>
+      </li>
 
-      <ul [ngClass]="{'navbar-tab-active': getActiveTabName() === 'translation', 'oppia-disabled-tab': !connectedToInternet || editabilityService.isLockedByAdmin()}"
-          id="tutorialTranslationTab"
-          class="nav-item icon nav-list-item e2e-test-translation-tab"
-          (click)="!connectedToInternet || editabilityService.isLockedByAdmin() || selectTranslationTab()" [ngbTooltip]="'Translations does not work when offline.'"
-          [disableTooltip]="connectedToInternet"
-          placement="bottom">
-        <li class="nav-link navbar-tab"
-            [ngbTooltip]="'Translations'"
-            placement="bottom"
-            tabindex="0"
-            aria-label="Exploration Translation Button"
-            (keydown.enter)="!connectedToInternet || editabilityService.isLockedByAdmin() || selectTranslationTab()">
+      <li [ngClass]="{'navbar-tab-active': getActiveTabName() === 'translation', 'oppia-disabled-tab': !connectedToInternet || editabilityService.isLockedByAdmin()}" id="tutorialTranslationTab" class="nav-item icon nav-list-item e2e-test-translation-tab"
+          (click)="!connectedToInternet || editabilityService.isLockedByAdmin() || selectTranslationTab()" [ngbTooltip]="'Translations does not work when offline.'" [disableTooltip]="connectedToInternet" placement="bottom">
+        <a class="nav-link navbar-tab"
+           [ngbTooltip]="'Translations'"
+           placement="bottom"
+           tabindex="0"
+           aria-label="Exploration Translation Button"
+           (keydown.enter)="!connectedToInternet || editabilityService.isLockedByAdmin() || selectTranslationTab()">
           <i class="fas fa-microphone navbar-tab-icon" [ngClass]="{'navbar-tab-active-icon': getActiveTabName() === 'translation'}"></i>
-        </li>
-      </ul>
+        </a>
+      </li>
 
-      <ul [ngClass]="{'navbar-tab-active': getActiveTabName() === 'preview', 'oppia-disabled-tab': !connectedToInternet}" id="tutorialPreviewTab" class="nav-item icon nav-list-item e2e-test-preview-tab" joyrideStep="editorTabTourPreviewTab" [stepContent]="EditorTabTourPreviewTab"
+      <li [ngClass]="{'navbar-tab-active': getActiveTabName() === 'preview', 'oppia-disabled-tab': !connectedToInternet}" id="tutorialPreviewTab" class="nav-item icon nav-list-item e2e-test-preview-tab" joyrideStep="editorTabTourPreviewTab" [stepContent]="EditorTabTourPreviewTab"
           (click)="!connectedToInternet || selectPreviewTab()" [ngbTooltip]="'Preview does not work when offline.'" [disableTooltip]="connectedToInternet" placement="bottom">
-        <li class="nav-link  navbar-tab"
-            [ngbTooltip]="'Preview'"
-            placement="bottom"
-            tabindex="0"
-            aria-label="Exploration Preview Button"
-            (keydown.enter)="!connectedToInternet || selectPreviewTab()">
+        <a class="nav-link  navbar-tab"
+           [ngbTooltip]="'Preview'"
+           placement="bottom"
+           tabindex="0"
+           aria-label="Exploration Preview Button"
+           (keydown.enter)="!connectedToInternet || selectPreviewTab()">
           <i class="fas fa-play navbar-tab-icon nav-bar-preview-icon" [ngClass]="{'navbar-tab-active-icon': getActiveTabName() === 'preview'}"></i>
-        </li>
-      </ul>
+        </a>
+      </li>
 
-      <ul [ngClass]="{'navbar-tab-active': getActiveTabName() === 'settings', 'oppia-disabled-tab': !connectedToInternet}" class="nav-item icon nav-list-item e2e-test-settings-tab"
+      <li [ngClass]="{'navbar-tab-active': getActiveTabName() === 'settings', 'oppia-disabled-tab': !connectedToInternet}" class="nav-item icon nav-list-item e2e-test-settings-tab"
           (click)="!connectedToInternet || selectSettingsTab()" [ngbTooltip]="'Settings does not work when offline.'" [disableTooltip]="connectedToInternet" placement="bottom">
-        <li class="nav-link  navbar-tab"
-            [ngbTooltip]="'Settings'"
-            placement="bottom"
-            tabindex="0"
-            aria-label="Exploration Setting Button"
-            (keydown.enter)="!connectedToInternet || selectSettingsTab()">
+        <a class="nav-link  navbar-tab"
+           [ngbTooltip]="'Settings'"
+           placement="bottom"
+           tabindex="0"
+           aria-label="Exploration Setting Button"
+           (keydown.enter)="!connectedToInternet || selectSettingsTab()">
           <i class="fas fa-cog navbar-tab-icon" [ngClass]="{'navbar-tab-active-icon': getActiveTabName() === 'settings'}"></i>
-        </li>
-      </ul>
+        </a>
+      </li>
 
-      <ul [ngClass]="{'navbar-tab-active': getActiveTabName() === 'stats', 'oppia-disabled-tab': !connectedToInternet}" class="nav-item icon nav-list-item e2e-test-stats-tab"
+      <li [ngClass]="{'navbar-tab-active': getActiveTabName() === 'stats', 'oppia-disabled-tab': !connectedToInternet}" class="nav-item icon nav-list-item e2e-test-stats-tab"
           (click)="!connectedToInternet || selectStatsTab()" [ngbTooltip]="'Statistics does not work when offline.'" [disableTooltip]="connectedToInternet" placement="bottom">
-        <li class="nav-link  navbar-tab"
-            [ngbTooltip]="'Statistics'"
-            placement="bottom"
-            tabindex="0"
-            aria-label="Exploration Statistics Button"
-            (keydown.enter)="!connectedToInternet || selectStatsTab()">
+        <a class="nav-link  navbar-tab"
+           [ngbTooltip]="'Statistics'"
+           placement="bottom"
+           tabindex="0"
+           aria-label="Exploration Statistics Button"
+           (keydown.enter)="!connectedToInternet || selectStatsTab()">
           <i class="fas fa-poll navbar-tab-icon" [ngClass]="{'navbar-tab-active-icon': getActiveTabName() === 'stats'}"></i>
-        </li>
-      </ul>
+        </a>
+      </li>
 
       <li *ngIf="isImprovementsTabEnabled() && screenIsLarge" [ngClass]="{'navbar-tab-active': getActiveTabName() === 'improvements', 'oppia-disabled-tab': !connectedToInternet}" class="nav-item icon nav-list-item e2e-test-improvements-tab"
           (click)="!connectedToInternet || selectImprovementsTab()"  [ngbTooltip]="'Improvements does not work when offline.'" [disableTooltip]="connectedToInternet" placement="bottom">
@@ -107,47 +103,47 @@
         </a>
       </li>
 
-      <ul [ngClass]="{'navbar-tab-active': getActiveTabName() === 'history', 'oppia-disabled-tab': !connectedToInternet}" class="nav-item icon nav-list-item e2e-test-history-tab"
+      <li [ngClass]="{'navbar-tab-active': getActiveTabName() === 'history', 'oppia-disabled-tab': !connectedToInternet}" class="nav-item icon nav-list-item e2e-test-history-tab"
           (click)="!connectedToInternet || selectHistoryTab()"  [ngbTooltip]="'History does not work when offline.'" [disableTooltip]="connectedToInternet" placement="bottom">
-        <li class="nav-link  navbar-tab"
-            [ngbTooltip]="'History'"
-            placement="bottom"
-            tabindex="0"
-            aria-label="Exploration History Button"
-            (keydown.enter)="!connectedToInternet || selectHistoryTab()">
+        <a class="nav-link  navbar-tab"
+           [ngbTooltip]="'History'"
+           placement="bottom"
+           tabindex="0"
+           aria-label="Exploration History Button"
+           (keydown.enter)="!connectedToInternet || selectHistoryTab()">
           <i class="fas fa-clock navbar-tab-icon" [ngClass]="{'navbar-tab-active-icon': getActiveTabName() === 'history'}"></i>
-        </li>
-      </ul>
+        </a>
+      </li>
 
-      <ul [ngClass]="{'navbar-tab-active': getActiveTabName() === 'feedback', 'oppia-disabled-tab': !connectedToInternet}" class="nav-item icon nav-list-item e2e-test-feedback-tab"
+      <li [ngClass]="{'navbar-tab-active': getActiveTabName() === 'feedback', 'oppia-disabled-tab': !connectedToInternet}" class="nav-item icon nav-list-item e2e-test-feedback-tab"
           (click)="!connectedToInternet || selectFeedbackTab()" [ngbTooltip]="'Feedback does not work when offline.'" [disableTooltip]="connectedToInternet" placement="bottom">
-        <li class="nav-link  navbar-tab"
-            [ngbTooltip]="'Feedback'"
-            placement="bottom"
-            tabindex="0"
-            aria-label="Exploration Feedback Button"
-            (keydown.enter)="!connectedToInternet || selectFeedbackTab()">
+        <a class="nav-link  navbar-tab"
+           [ngbTooltip]="'Feedback'"
+           placement="bottom"
+           tabindex="0"
+           aria-label="Exploration Feedback Button"
+           (keydown.enter)="!connectedToInternet || selectFeedbackTab()">
           <i class="fas fa-comment-alt navbar-tab-icon" [ngClass]="{'navbar-tab-active-icon': getActiveTabName() === 'feedback'}"></i>
-        </li>
+        </a>
         <div [hidden]="!(getOpenThreadsCount())" class="oppia-exploration-open-threads-indicator oppia-exploration-open-threads-color">
           <span class="oppia-exploration-open-threads-count">
               {{ getOpenThreadsCount() }}
           </span>
         </div>
-      </ul>
+      </li>
 
-      <ul [ngClass]="{'oppia-disabled-tab': !connectedToInternet}" class="nav-item icon nav-list-item" (click)="!connectedToInternet || showUserHelpModal()"
+      <li [ngClass]="{'oppia-disabled-tab': !connectedToInternet}" class="nav-item icon nav-list-item" (click)="!connectedToInternet || showUserHelpModal()"
           [ngbTooltip]="'Help does not work when offline.'" [disableTooltip]="connectedToInternet" placement="bottom">
-        <li href="#"
-            [ngbTooltip]="'Help'"
-            tabindex="0"
-            (keydown.enter)="!connectedToInternet || showUserHelpModal()"
-            placement="bottom"
-            class="nav-link oppia-editor-navbar-tab-anchor"
-            aria-label="Exploration Help Button">
+        <a href="#"
+           [ngbTooltip]="'Help'"
+           tabindex="0"
+           (keydown.enter)="!connectedToInternet || showUserHelpModal()"
+           placement="bottom"
+           class="nav-link oppia-editor-navbar-tab-anchor"
+           aria-label="Exploration Help Button">
           <i class="fas fa-question-circle navbar-tab-icon"></i>
-        </li>
-      </ul>
+        </a>
+      </li>
     </div>
   </div>
   <div *ngIf="explorationEditorPageHasInitialized && editabilityService.isLockedByAdmin()" class="exploration-locked-for-editing-banner">


### PR DESCRIPTION

This reverts commit 604dc26775f0ab195573b85c5fe40cc4666fe0d7.
This PR fixes #18732 
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

This PR reverts the changes made in the commit 604dc26775f0ab195573b85c5fe40cc4666fe0d7
If you're curious about the reason checkout this discussion thread https://github.com/oppia/oppia/issues/18732#issuecomment-1667190279

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- Make sure your PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
