### PR TITLE
Fix part of #17523: Github Team Discussion deprecation

### DIFF
--- a/.github/PENDING_REVIEW_NOTIFICATION_TEMPLATE.md
+++ b/.github/PENDING_REVIEW_NOTIFICATION_TEMPLATE.md
@@ -1,8 +1,0 @@
-Hi {{ username }},
-
-It looks like you're assigned to this PR, but haven't taken any action for at least 2 days:
-{{ pr_list }}
-
-Please review the pending PRs as soon as possible, and reply to this thread once all the PRs are reviewed.
-
-To avoid these messages in the future, please bookmark [this link](https://github.com/pulls/assigned) and check it daily. Thanks!

--- a/.github/workflows/pending-review-notification.yml
+++ b/.github/workflows/pending-review-notification.yml
@@ -22,7 +22,8 @@ jobs:
         with:
           python-version: '3.8.15'
           architecture: 'x64'
-      - uses: oppia/stale-review-request-notifier@develop
+        # SHA1 hash of the develop commit.
+      - uses: oppia/stale-review-request-notifier@5c3267f3f43cdb99827425fc67ceba52442a54b7
         with:
           category-name: Notify\ Reviewers
           discussion-title: Pending\ Reviews

--- a/.github/workflows/pending-review-notification.yml
+++ b/.github/workflows/pending-review-notification.yml
@@ -22,9 +22,10 @@ jobs:
         with:
           python-version: '3.8.15'
           architecture: 'x64'
-      - uses: DubeySandeep/pending-review-notification@v1
+      - uses: oppia/stale-review-request-notifier@develop
         with:
-          team-slug: oppia-codeowners
+          category-name: Reviewer_notifications
+          discussion-title: Pending_Reviews
           repo-token: ${{ secrets.DISCUSSION_NOTIFICATION_TOKEN }}
           review-turnaround-hours: 48
       - name: Report if failed

--- a/.github/workflows/pending-review-notification.yml
+++ b/.github/workflows/pending-review-notification.yml
@@ -24,8 +24,8 @@ jobs:
           architecture: 'x64'
       - uses: oppia/stale-review-request-notifier@develop
         with:
-          category-name: Reviewer_notifications
-          discussion-title: Pending_Reviews
+          category-name: Notify\ Reviewers
+          discussion-title: Pending\ Reviews
           repo-token: ${{ secrets.DISCUSSION_NOTIFICATION_TOKEN }}
           review-turnaround-hours: 48
       - name: Report if failed


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This fixes part of #17523.
2. This PR does the following: This PR updates the workflow file to use `oppia/stale-review-request-notifier`  as a GitHub action and removes the `PENDING_REVIEW_NOTIFICATION_TEMPLATE.md` since we will not be using it anymore.

## Essential Checklist

- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [X] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [X] The linter/Karma presubmit checks have passed on my local machine.
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [X] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->

## Proof that changes are correct

I used the updated workflow file in [this repo](https://github.com/SD-13/test-pending-review-notifier) and there it is working as expected. For more context see the actions and [this discussion](https://github.com/SD-13/test-pending-review-notifier/discussions/1?sort=new) in that repo.
<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface.

Please also include videos/screenshots of the developer tools
browser console, so that we can be sure that there are no console errors.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- Make sure your PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
