### PR TITLE
Fix GHSA-49jp-pjc3-2532: Strengthen CSRF Protections

### DIFF
--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -743,7 +743,7 @@ class CsrfTokenManagerTests(test_utils.GenericTestBase):
         self.assertFalse(
             base.CsrfTokenManager.is_csrf_token_valid(uid, 'new_token'))
         self.assertFalse(
-            base.CsrfTokenManager.is_csrf_token_valid(uid, 'new/token'))
+            base.CsrfTokenManager.is_csrf_token_valid(uid, 'a/new/token'))
 
     def test_non_default_csrf_secret_is_used(self) -> None:
         base.CsrfTokenManager.create_csrf_token('uid')


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes [GHSA-49jp-pjc3-2532](https://github.com/oppia/oppia/security/advisories/GHSA-49jp-pjc3-2532), an un-disclosed security vulnerability.
2. This PR does the following: Adds the following protections:

   * A nonce to prevent collisions. This is best practice per OWASP.
   * A constant-time comparison of expected and received tokens. This prevents timing attacks.
   * HMAC-SHA256 instead of HMAC-MD5. Even though HMAC-MD5 is not broken yet, attacks against MD5 have been getting better, and there's no reason not to switch to SHA256.
   
   For more details on CSRF and protections, see [OWASP's guidance](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#signed-double-submit-cookie).
4. (For bug-fixing PRs only) The original bug occurred because: See security advisory (once disclosed).

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Proof that changes are correct

https://github.com/oppia/oppia/assets/19878639/a82fb601-7aa5-4b71-b5dc-86cc118267b6

## PR Pointers

- Never force push! If you do, your PR will be closed.
- Make sure your PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide), otherwise this will lead to review delays.
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
