### PR TITLE
#18798 string type used to represent bool type in schema validation dictionary

### DIFF
--- a/core/controllers/learner_group.py
+++ b/core/controllers/learner_group.py
@@ -918,7 +918,7 @@ class LearnerGroupLearnerInvitationHandler(
         assert self.normalized_payload is not None
         learner_username = self.normalized_payload['learner_username']
         is_invitation_accepted = (
-            self.normalized_payload['is_invitation_accepted'] == True)
+            self.normalized_payload['is_invitation_accepted'] is True)
         progress_sharing_permission = (
             self.normalized_payload['progress_sharing_permission'] == 'true')
 

--- a/core/controllers/learner_group.py
+++ b/core/controllers/learner_group.py
@@ -899,7 +899,7 @@ class LearnerGroupLearnerInvitationHandler(
             },
             'is_invitation_accepted': {
                 'schema': {
-                    'type': 'basestring'
+                    'type': 'bool'
                 },
                 'default_value': 'false'
             },
@@ -918,7 +918,7 @@ class LearnerGroupLearnerInvitationHandler(
         assert self.normalized_payload is not None
         learner_username = self.normalized_payload['learner_username']
         is_invitation_accepted = (
-            self.normalized_payload['is_invitation_accepted'] == 'true')
+            self.normalized_payload['is_invitation_accepted'] == True)
         progress_sharing_permission = (
             self.normalized_payload['progress_sharing_permission'] == 'true')
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #18798 .
2. This PR does the following: [In LearnerGroupLearnerInvitationHandler, string type is used to denote the boolean value from the frontend we changed it into boolean and also the values here it was affecting as string for boolean value]

## Essential Checklist

- [x] The **[SCHEMA HANDLER ISSUE]: String type used to represent bool type in schema validation dictionary.** starts with "Fix #18798",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).


## Proof that changes are correct

<!--
<img width="1440" alt="Screenshot 2023-08-23 at 11 10 44 PM" src="https://github.com/oppia/oppia/assets/81969353/22c972f5-72a1-4756-9d70-c11b638bd866">

-->


