### PR TITLE
Fix search bar container's alignment

### DIFF
--- a/core/templates/pages/classroom-page/classroom-page.component.css
+++ b/core/templates/pages/classroom-page/classroom-page.component.css
@@ -6,10 +6,7 @@
 .oppia-classroom-search-container {
   background-color: #d7d7d7;
   bottom: 0;
-  margin-left: -12.5vw;
-  margin-right: -12.5vw;
   padding-bottom: 10px;
-  position: absolute;
   width: 100vw;
 }
 
@@ -78,7 +75,6 @@
   margin-bottom: 10vh;
   margin-top: 40px;
   overflow-y: auto;
-  padding-bottom: 30vh;
   row-gap: 24px;
 }
 
@@ -176,9 +172,8 @@ classroom-page .oppia-classroom-page-subheading-text {
   }
   .oppia-classroom-viewer-container .oppia-topic-summary-tiles {
     grid-template-columns: 150px 150px 150px;
-    margin-bottom: 28vh;
+    margin-bottom: 5vh;
     margin-top: 5vh;
-    padding-bottom: 140px;
   }
 }
 
@@ -206,10 +201,6 @@ classroom-page .oppia-classroom-page-subheading-text {
 @media(max-width: 600px) {
   .oppia-classroom-viewer-container {
     width: 85vw;
-  }
-
-  .oppia-classroom-search-container {
-    margin-left: -7.5vw;
   }
 
   .oppia-classroom-search-section {

--- a/core/templates/pages/classroom-page/classroom-page.component.html
+++ b/core/templates/pages/classroom-page/classroom-page.component.html
@@ -1,71 +1,61 @@
 <background-banner></background-banner>
-<div class="oppia-classroom-viewer-container position-relative">
-  <div class="oppia-classroom-header">
-    <div class="classroom-header">{{ 'I18N_CLASSROOM_PAGE_HEADING' | translate }}</div>
-    <h1 class="classroom-name">
-      <span *ngIf="!isHackyClassroomTranslationDisplayed()">
-        {{ classroomDisplayName }}
-      </span>
-      <span *ngIf="isHackyClassroomTranslationDisplayed()">
-        {{ classroomNameTranslationKey | translate }}
-      </span>
-    </h1>
-  </div>
-  <div class="oppia-classroom-banner">
-    <img class="oppia-classroom-banner-img" [src]="bannerImageFileUrl" width="480" height="247" alt="">
-  </div>
-  <div class="oppia-classroom-details" *ngIf="classroomData">
-    <h2>{{ 'I18N_CLASSROOM_PAGE_COURSE_DETAILS' | translate }}</h2>
-    <!-- The course details and topic list intro texts are hardcoded so that they can be translated.
+<div>
+  <div class="oppia-classroom-viewer-container position-relative">
+    <div class="oppia-classroom-header">
+      <div class="classroom-header">{{ 'I18N_CLASSROOM_PAGE_HEADING' | translate }}</div>
+      <h1 class="classroom-name">
+        <span *ngIf="!isHackyClassroomTranslationDisplayed()">
+          {{ classroomDisplayName }}
+        </span>
+        <span *ngIf="isHackyClassroomTranslationDisplayed()">
+          {{ classroomNameTranslationKey | translate }}
+        </span>
+      </h1>
+    </div>
+    <div class="oppia-classroom-banner">
+      <img class="oppia-classroom-banner-img" [src]="bannerImageFileUrl" width="480" height="247" alt="">
+    </div>
+    <div class="oppia-classroom-details" *ngIf="classroomData">
+      <h2>{{ 'I18N_CLASSROOM_PAGE_COURSE_DETAILS' | translate }}</h2>
+      <!-- The course details and topic list intro texts are hardcoded so that they can be translated.
     This method should be changed when more classrooms are added in the future. -->
-    <p class="course-details"> {{ 'I18N_MATH_COURSE_DETAILS' | translate }} </p>
-    <h2>{{ 'I18N_CLASSROOM_PAGE_TOPICS_COVERED' | translate }}</h2>
-    <p>{{ 'I18N_MATH_TOPICS_COVERED' | translate }}</p>
-  </div>
-  <div class="oppia-classroom-page-guidance-tile-container"
-       *ngIf="classroomData && classroomData.getTopicSummaries().length > 0 && isDiagnosticTestFeatureFlagEnabled()">
-    <div class="oppia-classroom-page-guidance-tile">
-      <p>
-        <strong>
-          {{ 'I18N_CLASSROOM_PAGE_NEW_TO_MATH_HEADING' | translate}}
-        </strong>
-      </p>
-      <p>
-        {{ begineWithFirstTopicDescriptionText }}
-      </p>
-      <a [href]="firstTopicUrl">
-        <span class="oppia-classroom-page-tile-button-text">
-          <strong>
-            {{ beginWithFirstTopicButtonText }}
-          </strong>
-        </span>
-      </a>
+      <p class="course-details">{{ 'I18N_MATH_COURSE_DETAILS' | translate }}</p>
+      <h2>{{ 'I18N_CLASSROOM_PAGE_TOPICS_COVERED' | translate }}</h2>
+      <p>{{ 'I18N_MATH_TOPICS_COVERED' | translate }}</p>
     </div>
-    <div class="oppia-classroom-page-guidance-tile">
-      <p>
-        <strong>
-          {{ 'I18N_CLASSROOM_PAGE_ALREADY_KNOW_SOME_MATH_HEADING' | translate}}
-        </strong>
-      </p>
-      <p>
-        {{ 'I18N_CLASSROOM_PAGE_ALREADY_KNOW_SOME_MATH_TEXT' | translate}}
-      </p>
-      <a href="/diagnostic-test-player" class="e2e-test-take-diagnostic-test">
-        <span class="oppia-classroom-page-tile-button-text">
-          <strong>
-            {{ 'I18N_CLASSROOM_PAGE_TAKE_A_TEST_BUTTON' | translate}}
-          </strong>
-        </span>
-      </a>
+    <div class="oppia-classroom-page-guidance-tile-container"
+         *ngIf="classroomData && classroomData.getTopicSummaries().length > 0 && isDiagnosticTestFeatureFlagEnabled()">
+      <div class="oppia-classroom-page-guidance-tile">
+        <p>
+          <strong>{{ 'I18N_CLASSROOM_PAGE_NEW_TO_MATH_HEADING' | translate }}</strong>
+        </p>
+        <p>{{ begineWithFirstTopicDescriptionText }}</p>
+        <a [href]="firstTopicUrl">
+          <span class="oppia-classroom-page-tile-button-text">
+            <strong>{{ beginWithFirstTopicButtonText }}</strong>
+          </span>
+        </a>
+      </div>
+      <div class="oppia-classroom-page-guidance-tile">
+        <p>
+          <strong>{{ 'I18N_CLASSROOM_PAGE_ALREADY_KNOW_SOME_MATH_HEADING' | translate }}</strong>
+        </p>
+        <p>{{ 'I18N_CLASSROOM_PAGE_ALREADY_KNOW_SOME_MATH_TEXT' | translate }}</p>
+        <a href="/diagnostic-test-player" class="e2e-test-take-diagnostic-test">
+          <span class="oppia-classroom-page-tile-button-text">
+            <strong>{{ 'I18N_CLASSROOM_PAGE_TAKE_A_TEST_BUTTON' | translate }}</strong>
+          </span>
+        </a>
+      </div>
     </div>
-  </div>
-  <div class="oppia-topic-summary-tiles" *ngIf="classroomData">
-    <div *ngFor="let topicSummary of classroomData.getTopicSummaries()"
-         class="oppia-topic-summary-tile e2e-test-topic-summary-tile">
-      <oppia-topic-summary-tile [topicSummary]="topicSummary"
-                                [classroomUrlFragment]="classroomUrlFragment"
-                                [isPublished]="topicSummary.isTopicPublished()">
-      </oppia-topic-summary-tile>
+    <div class="oppia-topic-summary-tiles" *ngIf="classroomData">
+      <div *ngFor="let topicSummary of classroomData.getTopicSummaries()"
+           class="oppia-topic-summary-tile e2e-test-topic-summary-tile">
+        <oppia-topic-summary-tile [topicSummary]="topicSummary"
+                                  [classroomUrlFragment]="classroomUrlFragment"
+                                  [isPublished]="topicSummary.isTopicPublished()">
+        </oppia-topic-summary-tile>
+      </div>
     </div>
   </div>
   <div class="oppia-classroom-search-container">


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here].
2. This PR does the following: This PR moves the search container outside of the classroom content's div. That page has a 75vw css so we previously had to apply separate css to increase width of the search container back to 100vw with negative margins and padding to fix alignment.
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->
- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.


## Proof that changes are correct
### Before:

https://github.com/oppia/oppia/assets/31477127/1eb26fa6-6b9c-43dc-bd90-7b67ca7a0714

### After:

https://github.com/oppia/oppia/assets/31477127/2c51dbd9-52c4-47cf-8ddd-28e93b97416c


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
