### PR TITLE
Fix the translation-voiceover toggle button not appearing for curated explorations 

### DIFF
--- a/core/templates/pages/exploration-editor-page/translation-tab/translator-overview/translator-overview.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/translator-overview/translator-overview.component.spec.ts
@@ -237,6 +237,27 @@ describe('Translator Overview component', () => {
       });
     });
 
+  describe('when selected language is not exploration language', () => {
+    beforeEach(() => {
+      component.languageCode = 'hi';
+      spyOn(explorationLanguageCodeService, 'displayed').and.returnValue('en');
+    });
+
+    it('should show mode switcher if exploration is linked to story', () => {
+      spyOn(contextService, 'isExplorationLinkedToStory').and.returnValue(true);
+      expect(component.canShowTabModeSwitcher()).toBeTrue;
+    });
+
+    it('should not show mode switcher if exploration is not linked to story',
+      () => {
+        spyOn(contextService, 'isExplorationLinkedToStory').and.returnValue(
+          false
+        );
+        expect(component.canShowTabModeSwitcher()).toBeFalse;
+      }
+    );
+  });
+
   it('should change to voiceover active mode when changing translation tab',
     fakeAsync(() => {
       spyOn(userExplorationPermissionsService, 'getPermissionsAsync').and

--- a/core/templates/pages/exploration-editor-page/translation-tab/translator-overview/translator-overview.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/translator-overview/translator-overview.component.spec.ts
@@ -240,7 +240,7 @@ describe('Translator Overview component', () => {
   describe('when selected language is not exploration language', () => {
     beforeEach(() => {
       component.languageCode = 'hi';
-      spyOn(explorationLanguageCodeService, 'displayed').and.returnValue('en');
+      explorationLanguageCodeService.init('en');;
     });
 
     it('should show mode switcher if exploration is linked to story', () => {

--- a/core/templates/pages/exploration-editor-page/translation-tab/translator-overview/translator-overview.component.spec.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/translator-overview/translator-overview.component.spec.ts
@@ -240,7 +240,7 @@ describe('Translator Overview component', () => {
   describe('when selected language is not exploration language', () => {
     beforeEach(() => {
       component.languageCode = 'hi';
-      explorationLanguageCodeService.init('en');;
+      explorationLanguageCodeService.init('en');
     });
 
     it('should show mode switcher if exploration is linked to story', () => {

--- a/core/templates/pages/exploration-editor-page/translation-tab/translator-overview/translator-overview.component.ts
+++ b/core/templates/pages/exploration-editor-page/translation-tab/translator-overview/translator-overview.component.ts
@@ -83,7 +83,7 @@ export class TranslatorOverviewComponent implements OnInit {
   ) { }
 
   canShowTabModeSwitcher(): boolean {
-    return !this.contextService.isExplorationLinkedToStory() && (
+    return this.contextService.isExplorationLinkedToStory() && (
       this.languageCode !== this.explorationLanguageCodeService.displayed);
   }
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR does the following: Fix the translation-voiceover toggle button not appearing for curated explorations 

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct
![image](https://github.com/oppia/oppia/assets/16653571/5f53557c-e99b-4bb6-93ec-552258685293)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
