### PR TITLE
Fix #18887 : TypeError: Cannot read property 'removeItem' of null

### DIFF
--- a/core/templates/services/platform-feature.service.spec.ts
+++ b/core/templates/services/platform-feature.service.spec.ts
@@ -208,6 +208,70 @@ describe('PlatformFeatureService', () => {
     }));
   });
 
+  describe('clearSavedResults', () => {
+    it('should remove sessionStorage item if nativeWindow exists', () => {
+      platformFeatureService = TestBed.inject(PlatformFeatureService);
+
+      const removeItemSpy = spyOn(
+        windowRef.nativeWindow.sessionStorage, 'removeItem'
+      );
+
+      mockSessionStore({
+        // This throws "TS2341". We need to suppress this error because
+        // The 'SESSION_STORAGE_KEY' member is private
+        // and can only be accessed within the class 'PlatformFeatureService'.
+        // @ts-ignore
+        [PlatformFeatureService.SESSION_STORAGE_KEY]: 'someValue',
+      });
+
+      // This throws "TS2341". We need to suppress this error because
+      // The 'clearSavedResults' method is private
+      // and can only be accessed within the class 'PlatformFeatureService'.
+      // @ts-ignore
+      platformFeatureService.clearSavedResults();
+
+      expect(removeItemSpy).toHaveBeenCalledWith(
+        // This throws "TS2341". We need to suppress this error because
+        // The 'SESSION_STORAGE_KEY' member is private
+        // and can only be accessed within the class 'PlatformFeatureService'.
+        // @ts-ignore
+        PlatformFeatureService.SESSION_STORAGE_KEY
+      );
+    });
+
+    it('should handle the case when nativeWindow is null', () => {
+      platformFeatureService = TestBed.inject(PlatformFeatureService);
+      const removeItemSpy = spyOn(
+        windowRef.nativeWindow.sessionStorage, 'removeItem'
+      );
+
+      const mockWindowRef = {
+        nativeWindow: null,
+      };
+
+      // This throws "TS2341". We need to suppress this error because
+      // The 'windowRef' member is private
+      // and can only be accessed within the class 'PlatformFeatureService'.
+      // @ts-ignore
+      platformFeatureService.windowRef = mockWindowRef;
+
+      mockSessionStore({
+        // This throws "TS2341". We need to suppress this error because
+        // The 'SESSION_STORAGE_KEY' member is private
+        // and can only be accessed within the class 'PlatformFeatureService'.
+        // @ts-ignore
+        [PlatformFeatureService.SESSION_STORAGE_KEY]: 'someValue',
+      });
+
+      // This throws "TS2341". We need to suppress this error because
+      // The 'clearSavedResults' method is private
+      // and can only be accessed within the class 'PlatformFeatureService'.
+      // @ts-ignore
+      platformFeatureService.clearSavedResults();
+      expect(removeItemSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('.featureSummary', () => {
     it('should return correct values of feature flags', fakeAsync(() => {
       platformFeatureService = TestBed.inject(PlatformFeatureService);

--- a/core/templates/services/platform-feature.service.spec.ts
+++ b/core/templates/services/platform-feature.service.spec.ts
@@ -218,21 +218,21 @@ describe('PlatformFeatureService', () => {
 
       mockSessionStore({
         // This throws "TS2341". We need to suppress this error because
-        // The 'SESSION_STORAGE_KEY' member is private
+        // the 'SESSION_STORAGE_KEY' member is private
         // and can only be accessed within the class 'PlatformFeatureService'.
         // @ts-ignore
         [PlatformFeatureService.SESSION_STORAGE_KEY]: 'someValue',
       });
 
       // This throws "TS2341". We need to suppress this error because
-      // The 'clearSavedResults' method is private
+      // the 'clearSavedResults' method is private
       // and can only be accessed within the class 'PlatformFeatureService'.
       // @ts-ignore
       platformFeatureService.clearSavedResults();
 
       expect(removeItemSpy).toHaveBeenCalledWith(
         // This throws "TS2341". We need to suppress this error because
-        // The 'SESSION_STORAGE_KEY' member is private
+        // the 'SESSION_STORAGE_KEY' member is private
         // and can only be accessed within the class 'PlatformFeatureService'.
         // @ts-ignore
         PlatformFeatureService.SESSION_STORAGE_KEY
@@ -250,21 +250,21 @@ describe('PlatformFeatureService', () => {
       };
 
       // This throws "TS2341". We need to suppress this error because
-      // The 'windowRef' member is private
+      // the 'windowRef' member is private
       // and can only be accessed within the class 'PlatformFeatureService'.
       // @ts-ignore
       platformFeatureService.windowRef = mockWindowRef;
 
       mockSessionStore({
         // This throws "TS2341". We need to suppress this error because
-        // The 'SESSION_STORAGE_KEY' member is private
+        // the 'SESSION_STORAGE_KEY' member is private
         // and can only be accessed within the class 'PlatformFeatureService'.
         // @ts-ignore
         [PlatformFeatureService.SESSION_STORAGE_KEY]: 'someValue',
       });
 
       // This throws "TS2341". We need to suppress this error because
-      // The 'clearSavedResults' method is private
+      // the 'clearSavedResults' method is private
       // and can only be accessed within the class 'PlatformFeatureService'.
       // @ts-ignore
       platformFeatureService.clearSavedResults();

--- a/core/templates/services/platform-feature.service.ts
+++ b/core/templates/services/platform-feature.service.ts
@@ -165,8 +165,14 @@ export class PlatformFeatureService {
    * Clears results from the sessionStorage, if any.
    */
   private clearSavedResults(): void {
-    this.windowRef.nativeWindow.sessionStorage.removeItem(
-      PlatformFeatureService.SESSION_STORAGE_KEY);
+    if (
+      this.windowRef.nativeWindow &&
+      this.windowRef.nativeWindow.sessionStorage
+    ) {
+      this.windowRef.nativeWindow.sessionStorage.removeItem(
+        PlatformFeatureService.SESSION_STORAGE_KEY
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #18887 #16003 .
2. This PR does the following: Check if we have the right permissions, and only then access the sessionStorage and call any function on it.
3. (For bug-fixing PRs only) The original bug occurred because:  the "Block third-party cookies and site data" checkbox is set in Content Settings.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->
- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.


## Proof that changes are correct

The frontend test has PASSED
![Screenshot from 2023-09-18 22-57-45](https://github.com/oppia/oppia/assets/79896602/8fd86c51-0e07-4a74-83fc-2aba31a0b368)



<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
N/A

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
N/A
<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language
N/A
<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
