### PR TITLE
fix: the typo of translateTextBackedApiService to translateTextBackendApiService

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/services/translate-text.service.ts
+++ b/core/templates/pages/contributor-dashboard-page/services/translate-text.service.ts
@@ -75,7 +75,7 @@ export class TranslateTextService {
   activeContentStatus: Status;
 
   constructor(
-    private translateTextBackedApiService:
+    private translateTextBackendApiService:
       TranslateTextBackendApiService
   ) { }
 


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #18917.
2. This PR does the following: Fixes #18917
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

- [X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [X] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [X] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [X] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [X] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct

<!--
![Screenshot (73)](https://github.com/oppia/oppia/assets/106751412/47846877-8448-4b94-86dd-c14b66b94075)