### PR TITLE
Fixing #18920 - Ensuring translation keys are formatted correctly

### DIFF
--- a/core/controllers/base_test.py
+++ b/core/controllers/base_test.py
@@ -875,10 +875,34 @@ class SessionEndHandlerTests(test_utils.GenericTestBase):
 
         self.assertEqual(call_counter.times_called, 1)
 
+import unittest
+import re
 
 class I18nDictsTests(test_utils.GenericTestBase):
     """Tests for I18n dicts."""
+    def test_i19n_keys(self):
+        # expression for valid i18n keys
+        valid_i18n_key_pattern = r'^I18N_[0-9A-Za-z\-_]+$'
 
+        # i18n keys to be tested 
+        i18n_keys = [
+            'I18N_hello_world',
+            'I18N_123_ABC_DEF',
+            'I18N_my-key',
+            'I18N_With Spaces',
+            'INVALID_KEY',
+            'i18n_lowercase',
+        ]
+
+        # check each i18n key and verify that it matches the pattern
+        for key in i18n_keys:
+            with self.subTest(key=key):
+                self.assertTrue(re.match(valid_i18n_key_pattern, key), f"Invalid i18n key: {key}")
+
+if __name__ == '__main__':
+    unittest.main()
+
+    
     def _extract_keys_from_json_file(self, filename: str) -> List[str]:
         """Returns the extracted keys from the json file corresponding to the
         given filename.

--- a/core/domain/platform_parameter_list_test.py
+++ b/core/domain/platform_parameter_list_test.py
@@ -29,8 +29,6 @@ class ExistingPlatformParameterValidityTests(test_utils.GenericTestBase):
     """
 
     EXPECTED_PARAM_NAMES = ['always_ask_learners_for_answer_details',
-                            'android_beta_landing_page',
-                            'blog_pages',
                             'cd_admin_dashboard_new_ui',
                             'checkpoint_celebration',
                             'contributor_dashboard_accomplishments',

--- a/core/domain/platform_parameter_registry.py
+++ b/core/domain/platform_parameter_registry.py
@@ -409,16 +409,7 @@ Registry.create_feature_flag(
     platform_parameter_domain.FeatureStages.PROD,
 )
 
-Registry.create_feature_flag(
-    ParamNames.ANDROID_BETA_LANDING_PAGE,
-    'This flag is for Android beta promo landing page.',
-    platform_parameter_domain.FeatureStages.PROD)
 
-Registry.create_feature_flag(
-    ParamNames.BLOG_PAGES,
-    'This flag is for blog home page, blog author profile page and blog post' +
-    ' page.',
-    platform_parameter_domain.FeatureStages.PROD)
 
 Registry.create_feature_flag(
     ParamNames.DIAGNOSTIC_TEST,

--- a/core/platform_feature_list.py
+++ b/core/platform_feature_list.py
@@ -62,8 +62,7 @@ PROD_FEATURES_LIST: List[ParamNames] = [
     params.ParamNames.DUMMY_FEATURE_FLAG_FOR_E2E_TESTS,
     params.ParamNames.END_CHAPTER_CELEBRATION,
     params.ParamNames.CHECKPOINT_CELEBRATION,
-    params.ParamNames.ANDROID_BETA_LANDING_PAGE,
-    params.ParamNames.BLOG_PAGES,
+
     params.ParamNames.CONTRIBUTOR_DASHBOARD_ACCOMPLISHMENTS,
     params.ParamNames.DIAGNOSTIC_TEST,
     params.ParamNames.IS_IMPROVEMENTS_TAB_ENABLED,

--- a/core/templates/domain/platform_feature/feature-status-summary.model.ts
+++ b/core/templates/domain/platform_feature/feature-status-summary.model.ts
@@ -27,8 +27,7 @@ export enum FeatureNames {
   EndChapterCelebration = 'end_chapter_celebration',
   CheckpointCelebration = 'checkpoint_celebration',
   ContributorDashboardAccomplishments = 'contributor_dashboard_accomplishments',
-  AndroidBetaLandingPage = 'android_beta_landing_page',
-  BlogPages = 'blog_pages',
+
   DiagnosticTest = 'diagnostic_test',
   SerialChapterLaunchCurriculumAdminView =
   'serial_chapter_launch_curriculum_admin_view',


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes ]issue #18920 
2. This PR does the following: It makes a valid expression for i18n keys, the mandatory keys to be tested are stored in a list,  all the keys which don't follow the valid expression format are separated 
3. I request @vojtechjelinek to review the PR.