### PR TITLE
fix #18917 : typo in "translateTextBackedApiService."

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/services/translate-text.service.ts
+++ b/core/templates/pages/contributor-dashboard-page/services/translate-text.service.ts
@@ -75,7 +75,7 @@ export class TranslateTextService {
   activeContentStatus: Status;
 
   constructor(
-    private translateTextBackedApiService:
+    private translateTextBackendApiService:
       TranslateTextBackendApiService
   ) { }
 


### PR DESCRIPTION
### Overview
1. This PR fixes : #18917 .
2. This PR does the following: fixes the typo "translateTextBackedApiService" to "translateTextBackendApiService"
3. (For bug-fixing PRs only) The original bug occurred because: there is a typo in "translateTextBackedApiService"

### Essential Checklist

- [x] The PR title starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x]  The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [ ] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly)
