### PR TITLE
Balkishan

### DIFF
--- a/core/templates/pages/contributor-dashboard-page/services/translate-text.service.ts
+++ b/core/templates/pages/contributor-dashboard-page/services/translate-text.service.ts
@@ -75,7 +75,7 @@ export class TranslateTextService {
   activeContentStatus: Status;
 
   constructor(
-    private translateTextBackedApiService:
+    private translateTextBackendApiService:
       TranslateTextBackendApiService
   ) { }
 


### PR DESCRIPTION
[BUG]: Fix typo in translateTextBackedApiService (should be translateTextBackendApiService) #18917 

Overview
This PR fixes or fixes part of #18917
This PR does the following: Fixes typo in translateTextBackedApiService (should be translateTextBackendApiService)
(For bug-fixing PRs only) The original bug occurred because: It had the typo error in translateTextBackedApiService
"No proof of changes needed because this bug just had a small typo error.