### PR TITLE
Fix Issue #18403 : Browse Our Lesson button redirect to /learn/math from empty feedback …

### DIFF
--- a/core/templates/pages/feedback-updates-page/feedback-updates-page.component.html
+++ b/core/templates/pages/feedback-updates-page/feedback-updates-page.component.html
@@ -45,9 +45,9 @@
 
               <a class="btn oppia-dashboard-intro-button oppia-transition-200 oppia-feedback-updates-intro-button-link"
                  [innerHTML]="'I18N_ACTION_BROWSE_LESSONS' | translate"
-                 href="/learn/math"
-                 [smartRouterLink]="'/' + PAGES_REGISTERED_WITH_FRONTEND.CLASSROOM.ROUTE">
+                 href="/learn/math" >
               </a>
+              
             </div>
           </mat-card>
 


### PR DESCRIPTION
working solution recording -


https://github.com/oppia/oppia/assets/33974086/c46f0944-39b5-4235-b810-68e542bc51c1


