### PR TITLE
added enhancement to css to library group

### DIFF
--- a/core/templates/pages/library-page/library-page.component.css
+++ b/core/templates/pages/library-page/library-page.component.css
@@ -59,20 +59,13 @@ oppia-library-page .oppia-group-page-header {
   padding-bottom: 1em;
 }
 .oppia-library-group {
-  display: block;
-  height: 350px;
-  margin-top: 36px;
-  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }
 .oppia-library-group-header-container {
-  margin: 0 -15px 0 0;
-  max-width: 928px;
-  min-width: 315px;
-  text-align: left;
-  width: calc(100% - 120px);
-  width: -moz-calc(100% - 120px);
-  width: -o-calc(100% - 120px);
-  width: -webkit-calc(100% - 120px);
+  align-self: baseline;
 }
 @media(max-width: 720px) {
   .oppia-library-group-header-container {
@@ -97,14 +90,6 @@ oppia-library-page .oppia-group-page-header {
 .oppia-library-group-header.active {
   color: #04857c;
   font-family: "Capriola", "Roboto", Arial, sans-serif;
-}
-@media(max-width: 720px) {
-  .oppia-library-group-header {
-    width: -webkit-calc(80% - 120px);
-    width: -moz-calc(80% - 120px);
-    width: -o-calc(80% - 120px);
-    width: calc(80% - 120px);
-  }
 }
 @media(max-width: 390px) {
   .oppia-library-group-header {
@@ -275,8 +260,7 @@ oppia-library-page .oppia-search-bar-container {
 @media (max-width: 536px) {
   .oppia-library-group-header {
     font-size: 1.2em;
-    margin-left: 7%;
-    width: 80%;
+    width: fit-content;
   }
   oppia-library-page .oppia-search-bar-container {
     margin-bottom: 90px;
@@ -285,6 +269,7 @@ oppia-library-page .oppia-search-bar-container {
     border-top: 3px solid white;
     height: auto;
     width: 100%;
+    margin-top: 20px;
   }
   .oppia-library-mobile-tile {
     display: flex;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of N/A.
2. This PR does the following: enhance css of library group in community library
3. (For bug-fixing PRs only) The original bug occurred because: The css of community library is not aligned properly

## Essential Checklist
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Testing doc (for PRs with Beam jobs that modify production server data)


## Proof that changes are correct
### Screenshot before the change:
![Oppia_PR_before2](https://github.com/oppia/oppia/assets/77102885/2a8d6308-72b6-4457-aa44-51c4b9d1e1d7)
### Screenshot after the change:
![Oppia_PR_after2](https://github.com/oppia/oppia/assets/77102885/958ec5e5-022e-41fd-958b-8920fc29fc5d)

