### PR TITLE
fix Part of #18373: add warning about useless destIfStuck

### DIFF
--- a/extensions/interactions/base-interaction-validation.service.ts
+++ b/extensions/interactions/base-interaction-validation.service.ts
@@ -66,21 +66,33 @@ export class baseInteractionValidationService {
 
     // This does not check the default outcome.
     for (var i = 0; i < answerGroups.length; i++) {
-      if (answerGroups[i].outcome.isConfusing(stateName)) {
+      let answerGroup = answerGroups[i];
+      let groupId = String(i + 1);
+      if (answerGroup.outcome.isConfusing(stateName)) {
         partialWarningsList.push({
           type: AppConstants.WARNING_TYPES.ERROR,
           message: (
             'Please specify what Oppia should do in Oppia response ' +
-            String(i + 1) + '.')
+            `${groupId}.`)
         });
       }
-      if (answerGroups[i].outcome.dest === stateName &&
-          answerGroups[i].outcome.labelledAsCorrect) {
+      if (answerGroup.outcome.dest === stateName &&
+          answerGroup.outcome.labelledAsCorrect) {
         partialWarningsList.push({
           type: AppConstants.WARNING_TYPES.ERROR,
           message: (
-            'In answer group ' + String(i + 1) + ', self-loops should ' +
+            `In answer group ${groupId}, self-loops should ` +
             'not be labelled as correct.')
+        });
+      }
+      if (answerGroup.outcome.labelledAsCorrect &&
+        answerGroup.outcome.destIfReallyStuck !== null) {
+        partialWarningsList.push({
+          type: AppConstants.WARNING_TYPES.ERROR,
+          message: (
+            `In answer group ${groupId}, correct answer should ` +
+            'not have the destination for really stuck learners, ' +
+            'because it is useless')
         });
       }
     }

--- a/extensions/interactions/base-interaction-validation.service.ts
+++ b/extensions/interactions/base-interaction-validation.service.ts
@@ -90,9 +90,9 @@ export class baseInteractionValidationService {
         partialWarningsList.push({
           type: AppConstants.WARNING_TYPES.ERROR,
           message: (
-            `In answer group ${groupId}, correct answer should ` +
-            'not have the destination for really stuck learners, ' +
-            'because it is useless')
+            `The answer group ${groupId} is labelled as 'correct', ` +
+            'but includes a \'destination for really stuck learners\'. ' +
+            'The latter is unnecessary and should be removed.')
         });
       }
     }

--- a/extensions/interactions/base-interaction-validation.service.ts
+++ b/extensions/interactions/base-interaction-validation.service.ts
@@ -66,8 +66,8 @@ export class baseInteractionValidationService {
 
     // This does not check the default outcome.
     for (var i = 0; i < answerGroups.length; i++) {
-      let answerGroup = answerGroups[i];
-      let groupId = String(i + 1);
+      const answerGroup = answerGroups[i];
+      const groupId = String(i + 1);
       if (answerGroup.outcome.isConfusing(stateName)) {
         partialWarningsList.push({
           type: AppConstants.WARNING_TYPES.ERROR,

--- a/extensions/interactions/base-validator.spec.ts
+++ b/extensions/interactions/base-validator.spec.ts
@@ -163,8 +163,9 @@ describe('Interaction validator', function() {
         expect(warnings).toEqual([{
           type: WARNING_TYPES.ERROR,
           message:
-              'In answer group 1, correct answer should not have the ' +
-              'destination for really stuck learners, because it is useless'
+              'The answer group 1 is labelled as \'correct\', ' +
+              'but includes a \'destination for really stuck learners\'. ' +
+              'The latter is unnecessary and should be removed.'
         }]);
       }
     );

--- a/extensions/interactions/base-validator.spec.ts
+++ b/extensions/interactions/base-validator.spec.ts
@@ -34,6 +34,7 @@ import { OutcomeObjectFactory } from
   'domain/exploration/OutcomeObjectFactory';
 import { UpgradedServices } from 'services/UpgradedServices';
 // ^^^ This block is to be removed.
+import { AppConstants } from 'app.constants';
 
 describe('Interaction validator', function() {
   var bivs, WARNING_TYPES, agof;
@@ -64,7 +65,7 @@ describe('Interaction validator', function() {
 
   beforeEach(angular.mock.inject(function($injector, $rootScope) {
     bivs = $injector.get('baseInteractionValidationService');
-    WARNING_TYPES = $injector.get('WARNING_TYPES');
+    WARNING_TYPES = AppConstants.WARNING_TYPES;
     agof = $injector.get('AnswerGroupObjectFactory');
     oof = $injector.get('OutcomeObjectFactory');
 
@@ -149,6 +150,23 @@ describe('Interaction validator', function() {
             'In answer group 1, self-loops should not be labelled as correct.'
       }]);
     });
+
+    it('should have a warning for a correct answer group with destIfStuck',
+      function() {
+        goodOutcomeDest.labelledAsCorrect = true;
+        goodOutcomeDest.destIfReallyStuck = 'destIfReallyStuck';
+        var answerGroups = [
+          agof.createNew([], goodOutcomeDest, false, null)
+        ];
+        var warnings = bivs.getAnswerGroupWarnings(answerGroups, currentState);
+        expect(warnings).toEqual([{
+          type: WARNING_TYPES.ERROR,
+          message:
+              'In answer group 1, correct answer should not have the ' +
+              'destination for really stuck users, because it is useless'
+        }]);
+      }
+    );
 
     it('should not have any warnings for a non-confusing default outcome',
       function() {

--- a/extensions/interactions/base-validator.spec.ts
+++ b/extensions/interactions/base-validator.spec.ts
@@ -24,6 +24,7 @@
  * tests to ensure it is working properly.
  */
 
+import { AppConstants } from 'app.constants';
 // TODO(#7222): Remove the following block of unnnecessary imports once
 // interaction validators is upgraded to Angular 8.
 import { AnswerGroupObjectFactory } from
@@ -34,7 +35,6 @@ import { OutcomeObjectFactory } from
   'domain/exploration/OutcomeObjectFactory';
 import { UpgradedServices } from 'services/UpgradedServices';
 // ^^^ This block is to be removed.
-import { AppConstants } from 'app.constants';
 
 describe('Interaction validator', function() {
   var bivs, WARNING_TYPES, agof;
@@ -155,10 +155,10 @@ describe('Interaction validator', function() {
       function() {
         goodOutcomeDest.labelledAsCorrect = true;
         goodOutcomeDest.destIfReallyStuck = 'destIfReallyStuck';
-        var answerGroups = [
+        const answerGroups = [
           agof.createNew([], goodOutcomeDest, false, null)
         ];
-        var warnings = bivs.getAnswerGroupWarnings(answerGroups, currentState);
+        const warnings = bivs.getAnswerGroupWarnings(answerGroups, currentState);
         expect(warnings).toEqual([{
           type: WARNING_TYPES.ERROR,
           message:

--- a/extensions/interactions/base-validator.spec.ts
+++ b/extensions/interactions/base-validator.spec.ts
@@ -163,7 +163,7 @@ describe('Interaction validator', function() {
           type: WARNING_TYPES.ERROR,
           message:
               'In answer group 1, correct answer should not have the ' +
-              'destination for really stuck users, because it is useless'
+              'destination for really stuck learners, because it is useless'
         }]);
       }
     );

--- a/extensions/interactions/base-validator.spec.ts
+++ b/extensions/interactions/base-validator.spec.ts
@@ -158,7 +158,8 @@ describe('Interaction validator', function() {
         const answerGroups = [
           agof.createNew([], goodOutcomeDest, false, null)
         ];
-        const warnings = bivs.getAnswerGroupWarnings(answerGroups, currentState);
+        const warnings = bivs.getAnswerGroupWarnings(
+          answerGroups, currentState);
         expect(warnings).toEqual([{
           type: WARNING_TYPES.ERROR,
           message:


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #18373.
2. This PR does the following: It adds a frontend check, which verifies, that the answer doesn't have set destIfReallyStuck for correct answers.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Proof that changes are correct

[Here's](https://github.com/oppia/oppia/assets/6707908/69987e4f-cea5-4d4a-b912-357fb0146d47) the screencast of this warning showing up.


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
