### PR TITLE
Fixes #19040, Changing Twitter Logo

### DIFF
--- a/core/templates/components/button-directives/social-buttons.component.css
+++ b/core/templates/components/button-directives/social-buttons.component.css
@@ -49,7 +49,7 @@
   padding: 5px 10px;
 }
 .oppia-footer-social .oppia-footer-social-icons .oppia-twitter-follow {
-  background: #1da1f2;
+  background: #000;
   margin-right: 6px;
   padding: 5px 6px;
 }

--- a/core/templates/components/button-directives/social-buttons.component.html
+++ b/core/templates/components/button-directives/social-buttons.component.html
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+
 <div class="oppia-footer-social">
   <div class="oppia-follow-us">
     <p>
@@ -22,7 +24,7 @@
 
     <div class="oppia-twitter-follow">
       <a href="https://twitter.com/oppiaorg" target="_blank" rel="noopener">
-        <i class="oppia-follow-icons fab fa-twitter"></i>
+        <i class="oppia-follow-icons fa-brands fa-x-twitter"></i>
         <span class="oppia-icon-accessibility-label">Twitter</span>
       </a>
     </div>

--- a/core/templates/components/common-layout-directives/common-elements/sharing-links.component.html
+++ b/core/templates/components/common-layout-directives/common-elements/sharing-links.component.html
@@ -108,7 +108,7 @@
     font-size: 2.01rem;
   }
 
-  i.oppia-share-icons.fa-brands.fa-square-x-twitter{
+  i.oppia-share-icons.fa-brands.fa-square-x-twitter {
     color: #000;
     font-size: 2.01rem;
   }

--- a/core/templates/components/common-layout-directives/common-elements/sharing-links.component.html
+++ b/core/templates/components/common-layout-directives/common-elements/sharing-links.component.html
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+
 <div class="oppia-sharing-links" [ngClass]="getFontAndFlexClass()">
   <div class="fx-main-center fx-cross-center padding-0-2">
     <a title="Facebook" class="fx-main-center fx-cross-start" [href]="getUrl('facebook')" (click)="registerShareEvent('facebook')" target="_window">
@@ -7,7 +9,7 @@
   </div>
   <div class="fx-main-center fx-cross-center padding-0-2 twitter-icon">
     <a title="Twitter" class="fx-main-center fx-cross-start" [href]="getUrl('twitter')"  (click)="registerShareEvent('twitter')" target="_window">
-      <i class="oppia-share-icons fab fa-twitter-square" [ngClass]="{'blog-post-sharing-link-icon': shareType === 'blog','font-small': smallFont, 'font-big': !smallFont}" ></i>
+      <i class="oppia-share-icons fa-brands fa-square-x-twitter" [ngClass]="{'blog-post-sharing-link-icon': shareType === 'blog','font-small': smallFont, 'font-big': !smallFont}" ></i>
       <span class="oppia-icon-accessibility-label">Share on Twitter</span>
     </a>
   </div>
@@ -106,8 +108,8 @@
     font-size: 2.01rem;
   }
 
-  i.oppia-share-icons.fab.fa-twitter-square {
-    color: #1da1f2;
+  i.oppia-share-icons.fa-brands.fa-square-x-twitter{
+    color: #000;
     font-size: 2.01rem;
   }
 

--- a/core/tests/data/third_party/css/third_party.css
+++ b/core/tests/data/third_party/css/third_party.css
@@ -24787,10 +24787,10 @@ readers do not read off random characters that represent icons */
 .fa-twitch:before {
   content: "\f1e8"; }
 
-.fa-twitter:before {
+.fa-x-twitter:before {
   content: "\f099"; }
 
-.fa-twitter-square:before {
+.fa-square-x-twitter:before {
   content: "\f081"; }
 
 .fa-typo3:before {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19040 .
2. This PR does the following: Changes the Old Twitter Bird logo to its new X logo
3. (For bug-fixing PRs only) The original bug occurred because: N/A

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->
- [ ] A testing doc has been written: ... (ADD LINK) ...
- [x] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.


## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network
![image](https://github.com/oppia/oppia/assets/124715224/033a6d4a-abdc-4ed7-b311-dc3b30aafc7b)

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone
![image](https://github.com/oppia/oppia/assets/124715224/4802c919-7792-4fa4-9379-6b9b86de3515)

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
