### PR TITLE
Fix #16021: Removed input text area auto focus in edtor page

### DIFF
--- a/core/templates/components/forms/schema-based-editors/schema-based-unicode-editor.component.ts
+++ b/core/templates/components/forms/schema-based-editors/schema-based-unicode-editor.component.ts
@@ -160,11 +160,6 @@ implements ControlValueAccessor, OnInit, Validator {
           })
       );
     }
-    // So that focus is applied after all the functions in
-    // main thread have executed.
-    setTimeout(() => {
-      this.focusManagerService.setFocusWithoutScroll(this.labelForFocusTarget);
-    }, 5);
   }
 
   onKeypress(evt: KeyboardEvent): void {

--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-answer-group-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-answer-group-modal.component.html
@@ -1,11 +1,11 @@
 <div class="modal-header e2e-test-add-response-modal-header" ngbAutofocus>
-  <h3>Add Response</h3>
-  <i class="fa fa-times" (click)="cancel()"></i>
+  <h3 tabindex="0">Add Response</h3>
+  <i class="fa fa-times" tabindex="0" role="button" (keydown.enter)="cancel()" (click)="cancel()"></i>
 </div>
 
 <div class="modal-body">
   <form name="addAnswerGroupForm.outcomeDetailsForm" class="e2e-test-add-response-details">
-    <div class="oppia-rule-details-header">
+    <div class="oppia-rule-details-header" tabindex="0">
       <strong>If the learner's answer...</strong>
     </div>
 
@@ -23,7 +23,7 @@
       <div class="oppia-rule-details-header oppia-editable-section">
         <div class="oppia-rule-preview oppia-transition-200">
           <div class="oppia-click-to-start-editing" (click)="openFeedbackEditor()">
-            <i class="fa fa-pen oppia-editor-edit-icon e2e-test-open-feedback-editor" (keydown.enter)="openFeedbackEditor()" aria-label="edit button" tabindex="0" title="Edit Feedback">&#xE254;</i>
+            <i class="fa fa-pen oppia-editor-edit-icon e2e-test-open-feedback-editor" (keydown.enter)="openFeedbackEditor()" aria-label="edit feedback button" tabindex="0" title="Edit Feedback">&#xE254;</i>
           </div>
           <strong>Oppia tells the learner...</strong>
           <div class="position-relative">


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #16021
2. This PR removes input text area auto focus in edtor page

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct
Before:
[Screen recording 2022-09-08 4.21.16 PM.webm](https://user-images.githubusercontent.com/101634267/189104364-10436008-88bb-4d01-b597-7c00f9980a8b.webm)

After:
https://github.com/oppia/oppia/assets/96219910/849f5c57-47ae-4748-9264-afc165093ff7


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
