### PR TITLE
Fix #18034: Fix axedevtools issues with the publish exploration

### DIFF
--- a/core/templates/pages/exploration-editor-page/editor-tab/state-version-history/state-version-history.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/state-version-history/state-version-history.component.html
@@ -24,6 +24,6 @@
     font-weight: bold;
   }
   .error-message {
-    color: #f00;
+    color: #c70000;
   }
 </style>

--- a/core/templates/pages/exploration-editor-page/modal-templates/exploration-save-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/modal-templates/exploration-save-modal.component.html
@@ -8,8 +8,8 @@
   <div class="modal-body oppia-long-text">
     <p class="e2e-test-exploration-save-modal">
       <span *ngIf="isExplorationPrivate">(Optional)</span>
-      Please enter a brief description of what you have changed:
-      <textarea rows="3" cols="50" [maxlength]="MAX_COMMIT_MESSAGE_LENGTH" [(ngModel)]="commitMessage" class="oppia-commit-message-input e2e-test-commit-message-input" autofocus></textarea>
+      <label for="commitMessage">Please enter a brief description of what you have changed:</label>
+      <textarea id="commitMessage" rows="3" cols="50" [maxlength]="MAX_COMMIT_MESSAGE_LENGTH" [(ngModel)]="commitMessage" class="oppia-commit-message-input e2e-test-commit-message-input" autofocus></textarea>
     </p>
     <button class="btn btn-secondary" (click)="onClickToggleDiffButton()">
       <span *ngIf="!showDiff">Show Changes</span>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #18034
2. This PR fixes axedevtools issues with the publish exploration

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).



## Proof that changes are correct
![Screenshot from 2023-10-29 18-17-31](https://github.com/oppia/oppia/assets/96219910/4ceb75d6-be14-4bdb-a8ec-762e90c30c34)

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
