### PR TITLE
Fix #16895: Fix a11y issues in explore page and made lighthouse score 1

### DIFF
--- a/core/templates/components/checkpoint-celebration-modal/checkpoint-celebration-modal.component.html
+++ b/core/templates/components/checkpoint-celebration-modal/checkpoint-celebration-modal.component.html
@@ -78,10 +78,10 @@
       </div>
     </div>
     <div class="button-row">
-      <button class="progress-info" (click)="openLessonInfoModal()">
+      <button class="progress-info" (click)="openLessonInfoModal()" [attr.tabindex]="(messageModalIsShown || miniMessageTooltipIsShown) ? 1 : -1">
         <i class="material-icons progress-info-icon">&#xE88E;</i>
       </button>
-      <button class="modal-close-button" (click)="dismissMessage()">
+      <button class="modal-close-button" (click)="dismissMessage()" tabindex="-1" [attr.tabindex]="(messageModalIsShown || miniMessageTooltipIsShown) ? 1 : -1">
         <i class="material-icons">&#xE5CD;</i>
       </button>
     </div>

--- a/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.css
+++ b/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.css
@@ -42,7 +42,7 @@ attribution-guide .oppia-cc-icon a.oppia-attribution-link:focus {
 }
 
 .oppia-attribution-guide .oppia-attribution-guide-text {
-  color: #008080;
+  color: #094142;
   font-size: 10px;
   text-decoration: underline;
 }

--- a/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.html
+++ b/core/templates/components/common-layout-directives/common-elements/attribution-guide.component.html
@@ -41,9 +41,9 @@
         </button>
         <div class="container pt-4">
           <div class="font-weight-bold">
-            <span [innerHTML]="'I18N_ATTRIBUTION_TITLE' | translate"></span>
+            <span [innerHTML]="'I18N_ATTRIBUTION_TITLE' | translate" tabindex="0"></span>
           </div>
-          <div class="attribution-html-section">
+          <div class="attribution-html-section" tabindex="0">
             <div class="font-weight-bold">
               <span [innerHTML]="'I18N_ATTRIBUTION_HTML_TITLE' | translate"></span>
             </div>
@@ -61,7 +61,7 @@
             </div>
             <button mat-flat-button class="attribution-copy-button float-right mt-2" (click)="copyAttribution('attribution-html-code')">COPY</button>
           </div>
-          <div class="attribution-print-section">
+          <div class="attribution-print-section" tabindex="0">
             <div class="font-weight-bold"><span [innerHTML]="'I18N_ATTRIBUTION_PRINT_TITLE' | translate"></span></div>
             <ol class="attribute-instructions">
               <li><span [innerHTML]="'I18N_ATTRIBUTION_PRINT_STEP_ONE' | translate"></span></li>

--- a/core/templates/pages/exploration-player-page/layout-directives/learner-local-nav.component.html
+++ b/core/templates/pages/exploration-player-page/layout-directives/learner-local-nav.component.html
@@ -3,16 +3,27 @@
 </ng-template>
 <ul class="nav navbar-nav oppia-navbar-nav float-right mr-0">
   <li class="nav-item">
-    <span tabindex="0" class="nav-link" ngbTooltip="Share"
-          placement="bottom" (click)="toggleAttributionModal()">
+    <span tabindex="0"
+          class="nav-link"
+          ngbTooltip="Share"
+          placement="bottom"
+          (click)="toggleAttributionModal()"
+          (keydown.enter)="toggleAttributionModal()">
       <i class="fas fa-share-alt exploration-player-navbar-icons"></i>
       <span class="oppia-icon-accessibility-label">Share</span>
     </span>
   </li>
-  <li *ngIf="feedbackOptionIsShown" placement="bottom-right"
-      [ngbPopover]="popContent" triggers="manual" (click)="togglePopover()"
-      class="nav-item" #feedbackPopOver="ngbPopover" [autoClose]="false">
-    <div tabindex="0" class="nav-link e2e-test-exploration-feedback-popup-link"
+  <li *ngIf="feedbackOptionIsShown"
+      placement="bottom-right"
+      [ngbPopover]="popContent"
+      triggers="manual"
+      (click)="togglePopover()"
+      (keydown.enter)="togglePopover()"
+      class="nav-item"
+      tabindex="0"
+      #feedbackPopOver="ngbPopover"
+      [autoClose]="false">
+    <div class="nav-link e2e-test-exploration-feedback-popup-link"
        ngbTooltip="{{ 'I18N_PLAYER_FEEDBACK_TOOLTIP' | translate }}" placement="bottom">
       <i class="fas fa-comment-alt exploration-player-navbar-icons"></i>
       <span class="oppia-icon-accessibility-label">{{ 'I18N_PLAYER_FEEDBACK_TOOLTIP' | translate }}</span>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #16895
2. This PR fixes a11y issues in explore page and made lighthouse score 1

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Proof that changes are correct

![Screenshot from 2023-10-30 03-51-26](https://github.com/oppia/oppia/assets/96219910/8d788bcc-ff21-4238-bdbc-bf044041e5cc)
![Screenshot from 2023-10-30 05-34-42](https://github.com/oppia/oppia/assets/96219910/97b497cd-3727-4691-b111-555a7ca49639)

Before:(Screen reader focus jumping into button that is not present on screen)
https://github.com/oppia/oppia/assets/96219910/9a858d8e-297d-440b-84f6-21351c5e2111

After:

https://github.com/oppia/oppia/assets/96219910/0603dbde-a826-4359-bb48-a625ebf5e104






<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
