### PR TITLE
Fix #17863: Added help text for RTE accessibility menu

### DIFF
--- a/core/templates/components/forms/schema-based-editors/schema-based-html-editor.component.html
+++ b/core/templates/components/forms/schema-based-editors/schema-based-html-editor.component.html
@@ -1,5 +1,6 @@
 <!-- label-for-focus-target feature is removed since CKEditor has a
 focusManager to manage the focus activity automatically. -->
+<p class="oppia-rte-keyboard-accessibility-text" tabindex="0">Alt+0 for keyboard accessibility</p>
 <ck-editor-4-rte class="e2e-test-ck-editor"
                  *ngIf="!disabled"
                  [value]="localValue"

--- a/core/templates/components/forms/schema-based-editors/schema-based-html-editor.component.html
+++ b/core/templates/components/forms/schema-based-editors/schema-based-html-editor.component.html
@@ -1,6 +1,5 @@
 <!-- label-for-focus-target feature is removed since CKEditor has a
 focusManager to manage the focus activity automatically. -->
-<p class="oppia-rte-keyboard-accessibility-text" tabindex="0">Alt+0 for keyboard accessibility</p>
 <ck-editor-4-rte class="e2e-test-ck-editor"
                  *ngIf="!disabled"
                  [value]="localValue"

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
@@ -53,6 +53,7 @@
 
 <div *ngIf="contentEditorIsOpen" class="e2e-test-state-content-editor">
   <!-- TODO(sll): Find a way to do this without resorting to private properties like _html -->
+  <p class="oppia-rte-keyboard-accessibility-text" tabindex="0">Alt+0 for keyboard accessibility</p>
   <schema-based-editor [schema]="HTML_SCHEMA"
                        [(localValue)]="stateContentService.displayed._html">
   </schema-based-editor>

--- a/core/templates/css/oppia.css
+++ b/core/templates/css/oppia.css
@@ -1795,6 +1795,14 @@ pre.oppia-pre-wrapped-text {
   text-align: left;
 }
 
+.oppia-rte-keyboard-accessibility-text {
+  color: #757575;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  margin-bottom: 0;
+}
+
 .oppia-prevent-selection {
   -moz-user-select: none;
   -ms-user-select: none;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #17863
2. This PR Adds help text for RTE accessibility menu
3. Additional context:
- We use cke editor for the rich text, that already has the keyboard accessiblity shortcuts and fucntionality([see here](https://ckeditor.com/docs/ckeditor4/latest/features/shortcuts.html#accessibility)). 
- The fix for this issue is to add a help text for the users so they can access the accesiblity menu, the solution to this issue is similar to this #18427, here designers had suggested me to add the help text with appropriate stylings, that I have used here.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Proof that changes are correct
![Screenshot from 2023-10-30 05-42-15](https://github.com/oppia/oppia/assets/96219910/2b9deade-83f7-4c7b-9665-231813809418)
![Screenshot from 2023-10-30 05-41-54](https://github.com/oppia/oppia/assets/96219910/08e304e9-ea7c-46e0-9005-607f0f6be33a)

https://github.com/oppia/oppia/assets/96219910/295055d8-ac02-4a06-9a80-b755d68d43ad


<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
