### PR TITLE
Fix #17805: Added edit icon for mobile screen in exploration editor content section

### DIFF
--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
@@ -122,6 +122,6 @@
     .oppia-editor-edit-icon-position {
       right: -20px;
       top: 20px;
-  }
+    }
   }
 </style>

--- a/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
+++ b/core/templates/components/state-editor/state-content-editor/state-content-editor.component.html
@@ -119,8 +119,9 @@
      display: block;
     }
   @media screen and (max-width: 700px) {
-    .oppia-editor-edit-icon {
-     display: none;
-    }
+    .oppia-editor-edit-icon-position {
+      right: -20px;
+      top: 20px;
+  }
   }
 </style>

--- a/core/templates/components/state-editor/state-editor.component.html
+++ b/core/templates/components/state-editor/state-editor.component.html
@@ -152,7 +152,6 @@
   @media only screen and (max-width: 500px) {
     .oppia-mobile-collapsible-card-content {
       padding-left: 10px;
-      padding-right: 10px;
     }
   }
 </style>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #17805
2. This PR adds edit icon for mobile screen in exploration editor content section

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).



## Proof that changes are correct
![Screenshot from 2023-10-31 12-04-32](https://github.com/oppia/oppia/assets/96219910/932fd869-d158-4229-9cb9-e1174aa43773)
![Screenshot from 2023-10-31 12-04-22](https://github.com/oppia/oppia/assets/96219910/f6a52c8d-a80e-46ad-b8d5-8a83233a5ad5)
![Screenshot from 2023-10-31 12-04-14](https://github.com/oppia/oppia/assets/96219910/666c72e2-218e-42af-bb13-b18876d8368b)
![Screenshot from 2023-10-31 11-34-42](https://github.com/oppia/oppia/assets/96219910/105628f0-b698-410f-8047-685a54dd4d59)

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
