### PR TITLE
Move tempdir generated by test file to core/tests/data so that it does not interfere with backend shard checks.

### DIFF
--- a/scripts/check_backend_associated_test_file_test.py
+++ b/scripts/check_backend_associated_test_file_test.py
@@ -22,6 +22,7 @@ import os
 import sys
 import tempfile
 
+from core import feconf
 from core.tests import test_utils
 from scripts import check_backend_associated_test_file
 
@@ -88,7 +89,8 @@ class CheckBackendAssociatedTestFileTests(test_utils.GenericTestBase):
 
     def test_checks_pass_when_all_backend_files_have_an_associated_test_file(
             self) -> None:
-        tempdir = tempfile.TemporaryDirectory(prefix=os.getcwd() + '/core/')
+        tempdir = tempfile.TemporaryDirectory(
+            prefix=os.path.join(os.getcwd(), feconf.TESTS_DATA_DIR, ''))
         backend_file = os.path.join(tempdir.name, 'backend_file.py')
         backend_test_file = os.path.join(
             tempdir.name, 'backend_file_test.py')


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #N/A
2. This PR does the following: We are seeing several CI failures in the backend tests (e.g. [here](https://github.com/oppia/oppia/actions/runs/6748179225/job/18345974460) and [here](https://github.com/oppia/oppia/actions/runs/6747451633/job/18343638155) along the following lines. This PR aims to fix that.

```
======================================================================
FAIL: test_errors_in_test_suite_throw_error (scripts.run_backend_tests_test.RunBackendTestsTests)
----------------------------------------------------------------------
Exception: Modules {'core.nnmg53t5.backend_file_test'} are present on the filesystem but are not listed in the backend test shards. See https://github.com/oppia/oppia/wiki/Writing-backend-tests#common-errors.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/oppia/oppia/scripts/run_backend_tests_test.py", line 766, in test_errors_in_test_suite_throw_error
    run_backend_tests.main(args=['--test_shard', '1'])
AssertionError: "2 errors, 0 failures" does not match "Modules {'core.nnmg53t5.backend_file_test'} are present on the filesystem but are not listed in the backend test shards. See https://github.com/oppia/oppia/wiki/Writing-backend-tests#common-errors."
```

3. (For bug-fixing PRs only) The original bug occurred because: there is a test test_checks_pass_when_all_backend_files_have_an_associated_test_file which creates a temporary directory and file, then runs a long-running script on it. If this happens at the same time as our backend test shard checks (test_errors_in_test_suite_throw_error (scripts.run_backend_tests_test.RunBackendTestsTests)), the extra directory gets picked up as a file with a missing test. This PR moves that generated temporary dir/file to core/tests/data which is skipped by the shard checks.

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct

I confirm that I've run the tests locally and that the temporary folder now shows up in core/tests/data, rather than in core/ as it did before.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
