### PR TITLE
Fix light performance flake: Replaces webp/png image with SVG image 

### DIFF
--- a/assets/images/sidebar/learn-math-logo.svg
+++ b/assets/images/sidebar/learn-math-logo.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 220 250" xmlns="http://www.w3.org/2000/svg">
+  <defs></defs>
+  <rect x="38.456" y="47.014" width="134" height="1.8" style="stroke: rgb(0, 0, 0);"></rect>
+  <rect x="38.456" y="90.518" width="134" height="1.8" style="stroke: rgb(0, 0, 0);"></rect>
+  <rect x="39.456" y="130.881" width="134" height="1.8" style="stroke: rgb(0, 0, 0);"></rect>
+  <rect x="39.456" y="171.881" width="134" height="1.788" style="stroke: rgb(0, 0, 0);"></rect>
+  <ellipse style="fill: rgb(225, 114, 128); stroke: rgb(225, 114, 128);" cx="49.848" cy="49.398" rx="12.515" ry="12.515"></ellipse>
+  <ellipse style="fill: rgb(225, 114, 128); stroke: rgb(225, 114, 128);" cx="159.827" cy="49.994" rx="12.515" ry="12.515"></ellipse>
+  <ellipse style="stroke: rgb(241, 208, 115); fill: rgb(241, 208, 115);" cx="51.19" cy="92.306" rx="12.515" ry="12.515"></ellipse>
+  <ellipse style="stroke: rgb(241, 208, 115); fill: rgb(241, 208, 115);" cx="123.108" cy="91.437" rx="12.515" ry="12.515"></ellipse>
+  <ellipse style="fill: rgb(141, 179, 166); stroke: rgb(141, 179, 166);" cx="76.281" cy="132.831" rx="12.515" ry="12.515"></ellipse>
+  <ellipse style="fill: rgb(141, 179, 166); stroke: rgb(141, 179, 166);" cx="125.07" cy="132.194" rx="12.515" ry="12.515"></ellipse>
+  <ellipse style="stroke: rgb(165, 190, 250); fill: rgb(165, 190, 250);" cx="125.148" cy="173.355" rx="12.515" ry="12.515"></ellipse>
+  <ellipse style="stroke: rgb(165, 190, 250); fill: rgb(165, 190, 250);" cx="162.189" cy="172.759" rx="12.515" ry="12.515"></ellipse>
+  <path style="fill: rgba(216, 216, 216, 0); stroke: rgb(250, 240, 228); stroke-width: 14px;" d="M 30.181 208.516 L 30.761 8.874 L 180.971 8.874 L 181.551 207.359"></path>
+  <rect x="4.171" y="207.496" width="200.834" height="36.353" style="stroke: rgb(250, 240, 228); fill: rgb(250, 240, 228);"></rect>
+</svg>

--- a/core/templates/components/common-layout-directives/navigation-bars/side-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/side-navigation-bar.component.html
@@ -148,15 +148,15 @@
     color: #767676;
     font-family: "Roboto", Arial, sans-serif;
     margin-top: 2px;
-    width: 75%;
+    width: 85%;
   }
   .oppia-sidebar-menu li {
     border-bottom: 1px solid #e3e3e3;
   }
-  .oppia-submenu-image-position {
-    float: right;
-    margin-right: 5%;
-    margin-top: 2.5%;
+  .oppia-submenu {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
   }
   .oppia-submenu-image {
     height: 80px;
@@ -236,23 +236,16 @@
         </span>
       </div>
       <div [hidden]="!learnSubmenuIsShown" class="oppia-sidebar-submenu-upperborder">
-        <div class="oppia-submenu-image-position">
-          <picture>
-            <source type="image/webp"
-                    [srcset]="this.getStaticImageUrl('/sidebar/learn-math-logo.webp')">
-            <source type="image/png"
-                    [srcset]="this.getStaticImageUrl('/sidebar/learn-math-logo.png')">
-            <img [src]="getStaticImageUrl('/sidebar/learn-math-logo.png')"
-                 height="80"
-                 width="64.54"
-                 alt="learn-math-logo">
-          </picture>
+        <div class="oppia-submenu">
+          <!-- We set tabindex to -1 because this should not be focusable while tabbing on desktop -->
+          <a href="/learn/{{DEFAULT_CLASSROOM_URL_FRAGMENT}}" tabindex="-1" smartRouterLink="/learn/{{DEFAULT_CLASSROOM_URL_FRAGMENT}}" class="e2e-mobile-test-mathematics-link mb-1">
+            <span>{{ 'I18N_SIDEBAR_CLASSROOM_BASIC_MATHS' | translate }}</span>
+            <p class="oppia-sidebar-learn-subtext mt-2">{{ 'I18N_SIDEBAR_MATH_FOUNDATIONS_DESCRIPTION' | translate }}</p>
+          </a>
+          <div class="w-50">
+            <img [src]="getStaticImageUrl('/sidebar/learn-math-logo.svg')" class="w-100" alt="learn-math-logo">
+          </div>
         </div>
-        <!-- We set tabindex to -1 because this should not be focusable while tabbing on desktop -->
-        <a href="/learn/{{DEFAULT_CLASSROOM_URL_FRAGMENT}}" tabindex="-1" smartRouterLink="/learn/{{DEFAULT_CLASSROOM_URL_FRAGMENT}}" class="e2e-mobile-test-mathematics-link mb-1">
-          <span>{{ 'I18N_SIDEBAR_CLASSROOM_BASIC_MATHS' | translate }}</span>
-          <p class="oppia-sidebar-learn-subtext mt-2">{{ 'I18N_SIDEBAR_MATH_FOUNDATIONS_DESCRIPTION' | translate }}</p>
-        </a>
         <div *ngIf="classroomData.length > 0">
           <div *ngFor="let topicSummary of classroomData.slice(0, 3); index as idx">
             <div class="submenu-notop-margin">

--- a/core/templates/components/common-layout-directives/navigation-bars/side-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/side-navigation-bar.component.html
@@ -243,7 +243,8 @@
             <source type="image/png"
                     [srcset]="this.getStaticImageUrl('/sidebar/learn-math-logo.png')">
             <img [src]="getStaticImageUrl('/sidebar/learn-math-logo.png')"
-                 class="oppia-submenu-image"
+                 height="80px"
+                 width="64.54px"
                  alt="learn-math-logo">
           </picture>
         </div>

--- a/core/templates/components/common-layout-directives/navigation-bars/side-navigation-bar.component.html
+++ b/core/templates/components/common-layout-directives/navigation-bars/side-navigation-bar.component.html
@@ -243,8 +243,8 @@
             <source type="image/png"
                     [srcset]="this.getStaticImageUrl('/sidebar/learn-math-logo.png')">
             <img [src]="getStaticImageUrl('/sidebar/learn-math-logo.png')"
-                 height="80px"
-                 width="64.54px"
+                 height="80"
+                 width="64.54"
                  alt="learn-math-logo">
           </picture>
         </div>


### PR DESCRIPTION
Created this PR to validate whether this PR introduced an error in the lighthouse-2 workflow:

https://github.com/oppia/oppia/actions/runs/6821969725/job/18598654892?pr=19082#step:12:6092
![image](https://github.com/oppia/oppia/assets/16653571/fbda4ee2-87e9-4d53-a9ad-7458e06d8768)

https://github.com/oppia/oppia/pull/19152/commits/3613957d4f687503841ef70158f2a675733b8cac

## New UI:
![image](https://github.com/oppia/oppia/assets/16653571/30550c4b-9594-41c8-b5a8-d2cbcf9c7ef2)
