### PR TITLE
Convert timestamp to utc datetime obj

### DIFF
--- a/core/controllers/contributor_dashboard.py
+++ b/core/controllers/contributor_dashboard.py
@@ -1142,7 +1142,7 @@ class ContributorCertificateHandler(
 
         from_datetime = datetime.datetime.strptime(from_date, '%Y-%m-%d')
         to_datetime = datetime.datetime.strptime(to_date, '%Y-%m-%d')
-        if to_datetime.date() > datetime.datetime.now().date():
+        if to_datetime.date() > datetime.datetime.now(datetime.timezone.utc).date():
             raise self.InvalidInputException(
                 'To date should not be a future date.')
 

--- a/core/domain/skill_domain_test.py
+++ b/core/domain/skill_domain_test.py
@@ -71,8 +71,8 @@ class SkillDomainUnitTests(test_utils.GenericTestBase):
             feconf.CURRENT_RUBRIC_SCHEMA_VERSION,
             feconf.CURRENT_SKILL_CONTENTS_SCHEMA_VERSION, 'en', 0, 1,
             None, False, ['skill_id_2'],
-            created_on=datetime.datetime.now(),
-            last_updated=datetime.datetime.now())
+            created_on=datetime.datetime.now(datetime.timezone.utc),
+            last_updated=datetime.datetime.now(datetime.timezone.utc))
 
     # Here we use MyPy ignore because the signature of this method
     # doesn't match with TestBase._assert_validation_error().
@@ -1443,7 +1443,8 @@ class ShortSkillSummaryTests(test_utils.GenericTestBase):
         super().setUp()
         self.skill_summary = skill_domain.SkillSummary(
             'skill_1', 'Description 1', 'en', 1,
-            0, 0, datetime.datetime.now(), datetime.datetime.now())
+            0, 0, datetime.datetime.now(datetime.timezone.utc),
+            datetime.datetime.now(datetime.timezone.utc))
         self.short_skill_summary = skill_domain.ShortSkillSummary(
             'skill_1', 'Description 1')
 

--- a/core/domain/story_domain_test.py
+++ b/core/domain/story_domain_test.py
@@ -715,8 +715,9 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
 
     def test_story_node_update_planned_publication_date(self) -> None:
         self.story.story_contents.nodes[0].planned_publication_date = None
-        current_time = datetime.datetime.now()
-        current_time_msecs = utils.get_time_in_millisecs(current_time)
+        current_time_msecs = utils.get_current_time_in_millisecs()
+        current_time = utils.convert_millisecs_time_to_datetime_object(
+            current_time_msecs)
         self.story.update_node_planned_publication_date(
             'node_1', current_time_msecs)
         self.assertEqual(
@@ -725,16 +726,18 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
 
     def test_story_node_update_last_modified(self) -> None:
         self.story.story_contents.nodes[0].last_modified = None
-        current_time = datetime.datetime.now()
-        current_time_msecs = utils.get_time_in_millisecs(current_time)
+        current_time_msecs = utils.get_current_time_in_millisecs()
+        current_time = utils.convert_millisecs_time_to_datetime_object(
+            current_time_msecs)
         self.story.update_node_last_modified('node_1', current_time_msecs)
         self.assertEqual(
             self.story.story_contents.nodes[0].last_modified, current_time)
 
     def test_story_node_update_first_publication_date(self) -> None:
         self.story.story_contents.nodes[0].first_publication_date = None
-        current_time = datetime.datetime.now()
-        current_time_msecs = utils.get_time_in_millisecs(current_time)
+        current_time_msecs = utils.get_current_time_in_millisecs()
+        current_time = utils.convert_millisecs_time_to_datetime_object(
+            current_time_msecs)
         self.story.update_node_first_publication_date(
             'node_1', current_time_msecs)
         self.assertEqual(
@@ -910,7 +913,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
             'Expected planned publication date to be a datetime, received '
             '10 July')
         self.story.story_contents.nodes[0].planned_publication_date = (
-            datetime.datetime.now())
+            datetime.datetime.now(datetime.timezone.utc))
 
         # TODO(#13059): Here we use MyPy ignore because after we fully type the
         # codebase we plan to get rid of the tests that intentionally test wrong
@@ -919,7 +922,7 @@ class StoryDomainUnitTests(test_utils.GenericTestBase):
         self._assert_validation_error(
             'Expected last modified to be a datetime, received 1')
         self.story.story_contents.nodes[0].last_modified = (
-            datetime.datetime.now())
+            datetime.datetime.now(datetime.timezone.utc))
 
         # TODO(#13059): Here we use MyPy ignore because after we fully type the
         # codebase we plan to get rid of the tests that intentionally test wrong

--- a/core/domain/story_services_test.py
+++ b/core/domain/story_services_test.py
@@ -357,13 +357,16 @@ class StoryServicesUnitTests(test_utils.GenericTestBase):
             constants.STORY_NODE_STATUS_PUBLISHED)
         self.assertEqual(
             story.story_contents.nodes[1].
-            planned_publication_date, datetime.datetime(2023, 1, 2, 0, 0))
+            planned_publication_date,
+            datetime.datetime(2023, 1, 2, 0, 0, tzinfo=datetime.timezone.utc))
         self.assertEqual(
             story.story_contents.nodes[1].
-            first_publication_date, datetime.datetime(2023, 1, 1, 0, 0))
+            first_publication_date,
+            datetime.datetime(2023, 1, 1, 0, 0, tzinfo=datetime.timezone.utc))
         self.assertEqual(
             story.story_contents.nodes[1].
-            last_modified, datetime.datetime(2023, 1, 1, 0, 0))
+            last_modified,
+            datetime.datetime(2023, 1, 1, 0, 0, tzinfo=datetime.timezone.utc))
 
         story_summary = story_fetchers.get_story_summary_by_id(self.STORY_ID)
         self.assertEqual(story_summary.node_titles, ['Title 1', 'Title 2'])

--- a/core/domain/topic_domain_test.py
+++ b/core/domain/topic_domain_test.py
@@ -1374,8 +1374,8 @@ class TopicDomainUnitTests(test_utils.GenericTestBase):
         works as intended by leaving the topic unchanged. Added values
         for self.topic.created_on and last_updated.
         """
-        self.topic.created_on = datetime.datetime.now()
-        self.topic.last_updated = datetime.datetime.now()
+        self.topic.created_on = datetime.datetime.now(datetime.timezone.utc)
+        self.topic.last_updated = datetime.datetime.now(datetime.timezone.utc)
         self.assertEqual(
             self.topic.to_dict(),
             topic_domain.Topic.deserialize(

--- a/core/storage/suggestion/gae_models_test.py
+++ b/core/storage/suggestion/gae_models_test.py
@@ -206,7 +206,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             suggestion_models.STATUS_ACCEPTED, 'test_author',
             'reviewer_1', self.change_cmd, self.score_category,
             'exploration.exp1.thread_6', 'hi')
-        to_date = datetime.datetime.now()
+        to_date = datetime.datetime.now(datetime.timezone.utc)
         from_date = to_date - datetime.timedelta(days=1)
 
         suggestions = (
@@ -226,7 +226,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
             suggestion_models.STATUS_ACCEPTED, 'test_author',
             'reviewer_1', self.change_cmd, self.score_category,
             'exploration.exp1.thread_6', 'hi')
-        to_date = datetime.datetime.now()
+        to_date = datetime.datetime.now(datetime.timezone.utc)
         from_date = to_date - datetime.timedelta(days=1)
 
         suggestions = (

--- a/core/utils.py
+++ b/core/utils.py
@@ -633,7 +633,8 @@ def convert_millisecs_time_to_datetime_object(
         datetime. An object of type datetime.datetime corresponding to
         the given milliseconds.
     """
-    return datetime.datetime.fromtimestamp(date_time_msecs / 1000.0)
+    return datetime.datetime.fromtimestamp(
+        date_time_msecs / 1000.0, datetime.timezone.utc)
 
 
 def convert_naive_datetime_to_string(datetime_obj: datetime.datetime) -> str:

--- a/core/utils_test.py
+++ b/core/utils_test.py
@@ -783,7 +783,7 @@ class UtilsTests(test_utils.GenericTestBase):
         msecs = 1690761600000
         dt = utils.convert_millisecs_time_to_datetime_object(
             msecs + 1000.0 * time.timezone)
-        dt2 = datetime.datetime(2023, 7, 31)
+        dt2 = datetime.datetime(2023, 7, 30, 18, 30, tzinfo=datetime.timezone.utc)
         self.assertEqual(dt, dt2)
 
     def test_grouper(self) -> None:

--- a/core/utils_test.py
+++ b/core/utils_test.py
@@ -783,7 +783,8 @@ class UtilsTests(test_utils.GenericTestBase):
         msecs = 1690761600000
         dt = utils.convert_millisecs_time_to_datetime_object(
             msecs + 1000.0 * time.timezone)
-        dt2 = datetime.datetime(2023, 7, 30, 18, 30, tzinfo=datetime.timezone.utc)
+        dt2 = datetime.datetime(
+            2023, 7, 30, 18, 30,tzinfo=datetime.timezone.utc)
         self.assertEqual(dt, dt2)
 
     def test_grouper(self) -> None:

--- a/core/utils_test.py
+++ b/core/utils_test.py
@@ -784,7 +784,7 @@ class UtilsTests(test_utils.GenericTestBase):
         dt = utils.convert_millisecs_time_to_datetime_object(
             msecs + 1000.0 * time.timezone)
         dt2 = datetime.datetime(
-            2023, 7, 30, 18, 30,tzinfo=datetime.timezone.utc)
+            2023, 7, 30, 18, 30, tzinfo=datetime.timezone.utc)
         self.assertEqual(dt, dt2)
 
     def test_grouper(self) -> None:

--- a/core/utils_test.py
+++ b/core/utils_test.py
@@ -780,11 +780,9 @@ class UtilsTests(test_utils.GenericTestBase):
             dt, datetime.datetime.fromtimestamp(msecs / 1000.0))
 
     def test_convert_millisecs_time_to_datetime_object(self) -> None:
-        msecs = 1690761600000
-        dt = utils.convert_millisecs_time_to_datetime_object(
-            msecs + 1000.0 * time.timezone)
+        dt = utils.convert_millisecs_time_to_datetime_object(1690761600000)
         dt2 = datetime.datetime(
-            2023, 7, 30, 18, 30, tzinfo=datetime.timezone.utc)
+            2023, 7, 31, 0, 0, tzinfo=datetime.timezone.utc)
         self.assertEqual(dt, dt2)
 
     def test_grouper(self) -> None:


### PR DESCRIPTION
If we don't specify the timezone, the datetime object in created in the timezone of the local machine.

## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes part of #18795.
2. This PR does the following: Converts timestamp to utc datetime objects.
3. (For bug-fixing PRs only) The original bug occurred because: The function converted utc timestamps to objects without specifying a timezone. This created the datetime objects in the timezone of the local machine. While the original bug should eliminate the use of datetime entirely. This makes the timezones consistent locally until that happens.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Testing doc (for PRs with Beam jobs that modify production server data)

<!--
If this PR affects production server data, please follow
[these instructions](https://github.com/oppia/oppia/wiki/Testing-jobs-and-other-features-on-production#submitting-a-pr-with-a-new-job-or-feature-that-requires-third-party-api)
and link to the job request doc here.

Otherwise, please delete this section.
-->
- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.


## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
