### PR TITLE
Fix #19157: Update "admin roles page" link in notification email

### DIFF
--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -329,7 +329,7 @@ ADMIN_NOTIFICATION_FOR_SUGGESTIONS_NEEDING_REVIEW_EMAIL_DATA: Dict[str, str] = {
         'There are suggestions on the <a href="%s%s">Contributor Dashboard</a> '
         'that have been waiting for more than %s days for review. Please take '
         'a look at the suggestions mentioned below and help them get reviewed '
-        'by going to the <a href="%s%s#/roles">admin roles page</a> and either:'
+        'by going to the <a href="http://www.oppia.org/contributor-dashboard-admin%s">admin roles page</a> and either:'
         '<br><br><ul>'
         '<li>Add more reviewers to the suggestion types that have suggestions '
         'waiting too long for a review</li><br>'
@@ -347,6 +347,7 @@ ADMIN_NOTIFICATION_FOR_SUGGESTIONS_NEEDING_REVIEW_EMAIL_DATA: Dict[str, str] = {
         'Contributor Dashboard Suggestions Have Been Waiting Too Long for '
         'Review')
 }
+
 
 CONTRIBUTOR_RANK_ACHIEVEMENT_NOTIFICATION: Dict[
     str, Dict[str, Dict[str, str]]] = {


### PR DESCRIPTION
## Overview
1. This PR fixes #19157. 
2. This PR updates the email body template in the `ADMIN_NOTIFICATION_FOR_SUGGESTIONS_NEEDING_REVIEW_EMAIL_DATA` dictionary. The hyperlink labeled "admin roles page" now directs to "http://www.oppia.org/contributor-dashboard-admin" instead of "https://www.oppia.org/admin#/roles".
3. N/A

## Essential Checklist
- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked.
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR.

## Testing doc
- [ ] A testing doc has been written: ... (ADD LINK) ...
- [ ] _(To be confirmed by the server admin)_ All jobs in this PR have been verified on a live server, and the PR is safe to merge.

## Proof that changes are correct
No proof of changes is required because this was a one line fix.
### Proof of changes on desktop with slow/throttled network
- Throttle the network (to 3G) using the browser Developer Tools. There should be no performance or UI issues while the network is slow.

### Proof of changes on mobile phone
- Use the Developer Tools emulator to verify changes.

### Proof of changes in Arabic language
- Add screenshots with the site language set to Arabic.

## PR Pointers
- Never force push!
- To reply to reviewers, follow these instructions: [Address Review Comments](https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve)
- Some e2e tests are flaky, check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
