### PR TITLE
Fixes #19175  Prevent entering of emojis in the exploration title

### DIFF
--- a/core/templates/pages/exploration-editor-page/exploration-title-editor/exploration-title-editor.component.html
+++ b/core/templates/pages/exploration-editor-page/exploration-title-editor/exploration-title-editor.component.html
@@ -20,6 +20,9 @@
         </span>
       </span>
     </mat-hint>
+    <div *ngIf="isEmojiError" style="color: red; font-size: 12px; margin-top: 5px;">
+      Emojis are not allowed in the title.
+    </div>
   </mat-form-field>
 </div>
 

--- a/core/templates/pages/exploration-editor-page/exploration-title-editor/exploration-title-editor.component.ts
+++ b/core/templates/pages/exploration-editor-page/exploration-title-editor/exploration-title-editor.component.ts
@@ -41,7 +41,9 @@ export class ExplorationTitleEditorComponent implements OnInit, OnDestroy {
   @Output() onInputFieldBlur = new EventEmitter<void>();
 
   MAX_CHARS_IN_EXPLORATION_TITLE!: number;
-
+  // Property to track if an emoji is found in the title
+  isEmojiError: boolean = false;
+  
   constructor(
     public explorationTitleService: ExplorationTitleService,
     private focusManagerService: FocusManagerService,
@@ -49,9 +51,15 @@ export class ExplorationTitleEditorComponent implements OnInit, OnDestroy {
   ) { }
 
   inputFieldBlur(): void {
+    this.isEmojiError = this.containsEmoji(this.explorationTitleService.displayed);
     this.onInputFieldBlur.emit();
   }
-
+  // Function to check if a string contains emojis
+  containsEmoji(text: string): boolean {
+    const emojiPattern = /[\uD800-\uDBFF][\uDC00-\uDFFF]/;
+    return emojiPattern.test(text);
+  }
+  
   ngOnInit(): void {
     this.MAX_CHARS_IN_EXPLORATION_TITLE = (
       AppConstants.MAX_CHARS_IN_EXPLORATION_TITLE);
@@ -68,6 +76,7 @@ export class ExplorationTitleEditorComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.directiveSubscriptions.unsubscribe();
   }
+ 
 }
 
 angular.module('oppia').directive(


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19175 
2. This PR does the following: Whenever creator enters an emoji in the title of an exploration,it gives an error message and prevents entering an emoji.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x]  I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x]  The linter/Karma presubmit checks have passed on my local machine.
- [x]  "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x]  My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x]  I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct
<img width="946" alt="emoji_shriya" src="https://github.com/oppia/oppia/assets/73349138/73ee218e-a26e-4a36-aa0f-4f11d9161982">


## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
