### PR TITLE
Try increasing portserver shutdown timeout to avoid 'exited unexpectedly' error.

### DIFF
--- a/scripts/servers.py
+++ b/scripts/servers.py
@@ -647,10 +647,13 @@ def managed_portserver() -> Iterator[psutil.Process]:
                 # Otherwise, give the portserver 10 seconds to shut down after
                 # sending CTRL-C (SIGINT).
                 try:
-                    proc.wait(timeout=10)
+                    proc.wait(timeout=30)
                 except psutil.TimeoutExpired:
                     # If the server fails to shut down, allow proc_context to
                     # end it by calling terminate() and/or kill().
+                    # WARNING: This might result in a failure along the lines
+                    # of "Process Portserver exited unexpectedly with exit code
+                    # 1".
                     pass
 
 


### PR DESCRIPTION
## Overview
1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Increases portserver timeout to give it more time to shut down naturally.
3. (For bug-fixing PRs only) The original bug occurred because: It's unclear what's causing this, but recently portserver has taken more and more time to shut down, resulting in [occasional failures](https://github.com/oppia/oppia/actions/runs/6955893329/job/18951626489#step:13:1141) at the end of an e2e test run with the following stacktrace: 

```
  File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/runner/work/oppia/oppia/scripts/run_e2e_tests.py", line 208, in <module>
    main()
  File "/home/runner/work/oppia/oppia/scripts/run_e2e_tests.py", line 202, in main
    _, return_code = run_tests(parsed_args)
  File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/home/runner/work/oppia/oppia/scripts/servers.py", line 654, in managed_portserver
    pass
  File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/home/runner/work/oppia/oppia/scripts/servers.py", line 138, in managed_process
    raise Exception(
Exception: Process Portserver(pid=5482) exited unexpectedly with exit code 1
```

On analysis of this code, one hypothesis is that the 10-second timeout on line 654 in servers.py is too short. When that timeout expires, the server is killed. I suspect this might be being registered as an exit code with error 1 (there is no other reason for the test to fail since all the e2e checks themselves actually pass).

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct

Since this is a flake, we will need to see whether the e2e tests pass reliably after this change. If they do for this PR, I'll re-run them once after the first time so we can have high confidence that this change fixes the root cause.

