### PR TITLE
Drop the codeowner review teams for MyPy, data/stability, and learner analytics.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,13 +34,13 @@
 # be superseded by the relevant codeowners mentioned elsewhere in this file.
 # (Reference: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners)
 /core/controllers/ @oppia/lace-backend-reviewers
-/core/domain/ @oppia/data-and-stability-reviewers
+/core/domain/ @oppia/lace-backend-reviewers
 /core/templates/components/ @oppia/lace-frontend-reviewers
 /core/templates/domain/ @oppia/lace-frontend-reviewers
 /core/templates/pages/ @oppia/lace-frontend-reviewers
 /core/templates/services/ @oppia/lace-frontend-reviewers
 /core/templates/utility/ @oppia/lace-frontend-reviewers
-/extensions/ @oppia/data-and-stability-reviewers
+/extensions/ @oppia/lace-backend-reviewers
 /scripts/ @oppia/dev-workflow-reviewers
 
 
@@ -77,9 +77,9 @@
 /src @oppia/lace-frontend-reviewers
 
 # TS typing
-/typings/ @oppia/data-and-stability-reviewers
-/tsconfig*.json @oppia/data-and-stability-reviewers
-/scripts/typescript_checks*.py @oppia/data-and-stability-reviewers
+/typings/ @oppia/dev-workflow-reviewers
+/tsconfig*.json @oppia/dev-workflow-reviewers
+/scripts/typescript_checks*.py @oppia/dev-workflow-reviewers
 
 
 # Answer classification team.
@@ -207,14 +207,14 @@
 # Exploration project.
 /core/controllers/editor*.py @oppia/lace-backend-reviewers
 /core/controllers/reader*.py @oppia/lace-backend-reviewers
-/core/controllers/resources*.py @oppia/data-and-stability-reviewers
+/core/controllers/resources*.py @oppia/lace-backend-reviewers
 /core/domain/exp*.py @oppia/lace-backend-reviewers
 /core/domain/fs*.py @oppia/lace-backend-reviewers
 /core/domain/param_domain*.py @oppia/lace-backend-reviewers
 /core/domain/rating_services*.py @oppia/lace-backend-reviewers
 /core/domain/state_domain*.py @oppia/lace-backend-reviewers
 /core/domain/summary_services*.py @oppia/lace-backend-reviewers
-/core/domain/value_generators_domain*.py @oppia/data-and-stability-reviewers
+/core/domain/value_generators_domain*.py @oppia/lace-backend-reviewers
 /core/templates/components/entity-creation-services/exploration-creation.service*.ts @oppia/lace-frontend-reviewers
 /core/templates/components/entity-creation-services/exploration-creation-backend-api.service*.ts @oppia/lace-frontend-reviewers
 /core/templates/components/button-directives/hint-and-solution-buttons.component*.ts @oppia/lace-frontend-reviewers
@@ -359,37 +359,37 @@
 
 
 # Lesson Analytics team.
-/core/controllers/features*.py @oppia/learner-analytics-reviewers
-/core/controllers/improvements*.py @oppia/learner-analytics-reviewers
-/core/domain/action_registry*.py @oppia/learner-analytics-reviewers
-/core/domain/calculation_registry*.py @oppia/learner-analytics-reviewers
-/core/domain/event_services*.py @oppia/learner-analytics-reviewers
-/core/domain/improvements_domain*.py @oppia/learner-analytics-reviewers
-/core/domain/improvements_services*.py @oppia/learner-analytics-reviewers
-/core/domain/playthrough_issue_registry*.py @oppia/learner-analytics-reviewers
-/core/domain/stats*.py @oppia/learner-analytics-reviewers
-/core/domain/visualization_registry*.py @oppia/learner-analytics-reviewers
-/core/templates/components/common-layout-directives/common-elements/answer-content-modal.component*.ts @oppia/learner-analytics-reviewers
-/core/templates/components/common-layout-directives/common-elements/answer-content-modal.component.html @oppia/learner-analytics-reviewers
-/core/templates/components/statistics-directives/ @oppia/learner-analytics-reviewers
-/core/templates/domain/statistics/ @oppia/learner-analytics-reviewers
-/core/templates/domain/improvements/ @oppia/learner-analytics-reviewers
-/core/templates/pages/exploration-editor-page/improvements-tab/ @oppia/learner-analytics-reviewers
-/core/templates/pages/exploration-editor-page/statistics-tab/ @oppia/learner-analytics-reviewers
-/core/templates/services/exploration-improvements.service*.ts @oppia/learner-analytics-reviewers
-/core/templates/services/exploration-improvements-backend-api.service*.ts @oppia/learner-analytics-reviewers
-/core/templates/services/exploration-improvements-task-registry.service*.ts @oppia/learner-analytics-reviewers
-/core/templates/services/exploration-stats.service*.ts @oppia/learner-analytics-reviewers
-/core/templates/services/exploration-stats-backend-api.service*.ts @oppia/learner-analytics-reviewers
-/core/templates/services/improvements.service*.ts @oppia/learner-analytics-reviewers
-/core/templates/services/messenger.service.ts @oppia/learner-analytics-reviewers
-/core/templates/services/playthrough*.ts @oppia/learner-analytics-reviewers
-/core/templates/services/state-interaction-stats.service*.ts @oppia/learner-analytics-reviewers
-/core/templates/services/state-top-answers-stats*.ts @oppia/learner-analytics-reviewers
-/extensions/actions/ @oppia/learner-analytics-reviewers
-/extensions/answer_summarizers/ @oppia/learner-analytics-reviewers
-/extensions/issues/ @oppia/learner-analytics-reviewers
-/extensions/visualizations/ @oppia/learner-analytics-reviewers
+/core/controllers/features*.py @oppia/lace-backend-reviewers
+/core/controllers/improvements*.py @oppia/lace-backend-reviewers
+/core/domain/action_registry*.py @oppia/lace-backend-reviewers
+/core/domain/calculation_registry*.py @oppia/lace-backend-reviewers
+/core/domain/event_services*.py @oppia/lace-backend-reviewers
+/core/domain/improvements_domain*.py @oppia/lace-backend-reviewers
+/core/domain/improvements_services*.py @oppia/lace-backend-reviewers
+/core/domain/playthrough_issue_registry*.py @oppia/lace-backend-reviewers
+/core/domain/stats*.py @oppia/lace-backend-reviewers
+/core/domain/visualization_registry*.py @oppia/lace-backend-reviewers
+/core/templates/components/common-layout-directives/common-elements/answer-content-modal.component*.ts @oppia/lace-frontend-reviewers
+/core/templates/components/common-layout-directives/common-elements/answer-content-modal.component.html @oppia/lace-frontend-reviewers
+/core/templates/components/statistics-directives/ @oppia/lace-frontend-reviewers
+/core/templates/domain/statistics/ @oppia/lace-frontend-reviewers
+/core/templates/domain/improvements/ @oppia/lace-frontend-reviewers
+/core/templates/pages/exploration-editor-page/improvements-tab/ @oppia/lace-frontend-reviewers
+/core/templates/pages/exploration-editor-page/statistics-tab/ @oppia/lace-frontend-reviewers
+/core/templates/services/exploration-improvements.service*.ts @oppia/lace-frontend-reviewers
+/core/templates/services/exploration-improvements-backend-api.service*.ts @oppia/lace-frontend-reviewers
+/core/templates/services/exploration-improvements-task-registry.service*.ts @oppia/lace-frontend-reviewers
+/core/templates/services/exploration-stats.service*.ts @oppia/lace-frontend-reviewers
+/core/templates/services/exploration-stats-backend-api.service*.ts @oppia/lace-frontend-reviewers
+/core/templates/services/improvements.service*.ts @oppia/lace-frontend-reviewers
+/core/templates/services/messenger.service.ts @oppia/lace-frontend-reviewers
+/core/templates/services/playthrough*.ts @oppia/lace-frontend-reviewers
+/core/templates/services/state-interaction-stats.service*.ts @oppia/lace-frontend-reviewers
+/core/templates/services/state-top-answers-stats*.ts @oppia/lace-frontend-reviewers
+/extensions/actions/ @oppia/lace-backend-reviewers
+/extensions/answer_summarizers/ @oppia/lace-backend-reviewers
+/extensions/issues/ @oppia/lace-backend-reviewers
+/extensions/visualizations/ @oppia/lace-backend-reviewers
 
 
 # Library page.
@@ -434,10 +434,10 @@
 
 
 # Readme
-/core/README.md @oppia/data-and-stability-reviewers
-/core/templates/css/README.md @oppia/lace-frontend-reviewers
-/extensions/README.md @oppia/data-and-stability-reviewers
-/scripts/README.md @oppia/data-and-stability-reviewers
+/core/README.md @oppia/dev-workflow-reviewers
+/core/templates/css/README.md @oppia/dev-workflow-reviewers
+/extensions/README.md @oppia/dev-workflow-reviewers
+/scripts/README.md @oppia/dev-workflow-reviewers
 
 # Skill project.
 /core/controllers/concept_card_viewer*.py @oppia/lace-backend-reviewers
@@ -492,26 +492,26 @@
 /core/templates/pages/learner-group-pages/ @oppia/lace-frontend-reviewers
 
 # Beam jobs
-/setup*.py @oppia/data-and-stability-reviewers
-/MANIFEST.in @oppia/data-and-stability-reviewers
-/core/jobs/ @oppia/data-and-stability-reviewers
-/core/jobs/transforms @oppia/data-and-stability-reviewers
-/core/jobs/types @oppia/data-and-stability-reviewers
-/core/templates/domain/jobs/ @oppia/data-and-stability-reviewers
-/core/controllers/beam_jobs*.py @oppia/data-and-stability-reviewers
-/core/domain/beam_job*.py @oppia/data-and-stability-reviewers
+/setup*.py @oppia/dev-workflow-reviewers
+/MANIFEST.in @oppia/lace-backend-reviewers
+/core/jobs/ @oppia/lace-backend-reviewers
+/core/jobs/transforms @oppia/lace-backend-reviewers
+/core/jobs/types @oppia/lace-backend-reviewers
+/core/templates/domain/jobs/ @oppia/lace-frontend-reviewers
+/core/controllers/beam_jobs*.py @oppia/lace-backend-reviewers
+/core/domain/beam_job*.py @oppia/lace-backend-reviewers
 
 # Infrastructure.
-/core/controllers/cron*.py @oppia/data-and-stability-reviewers
-/core/domain/cron_services*.py @oppia/data-and-stability-reviewers
-/main*.py @oppia/data-and-stability-reviewers
-/core/feconf*.py @oppia/data-and-stability-reviewers
-/core/constants*.py @oppia/data-and-stability-reviewers
-/assets/constants.ts @oppia/data-and-stability-reviewers
+/core/controllers/cron*.py @oppia/lace-backend-reviewers
+/core/domain/cron_services*.py @oppia/lace-backend-reviewers
+/main*.py @oppia/lace-backend-reviewers
+/core/feconf*.py @oppia/lace-backend-reviewers
+/core/constants*.py @oppia/lace-backend-reviewers
+/assets/constants.ts @oppia/lace-frontend-reviewers
 /core/controllers/tasks*.py @oppia/lace-backend-reviewers
 /core/domain/email*.py @oppia/lace-backend-reviewers
 /core/domain/image_service*.py @oppia/lace-backend-reviewers
-/core/platform/ @oppia/data-and-stability-reviewers
+/core/platform/ @oppia/lace-backend-reviewers
 /core/templates/App*.ts @oppia/lace-frontend-reviewers
 /core/templates/app.constants.ts @oppia/lace-frontend-reviewers
 /core/templates/app.constants.ajs.ts @oppia/lace-frontend-reviewers
@@ -527,42 +527,42 @@
 /core/templates/services/interaction-rules-registry.service*.ts @oppia/lace-frontend-reviewers
 /core/templates/services/interaction-specs.service*.ts @oppia/lace-frontend-reviewers
 /core/templates/services/translation-file-hash-loader-backend-api.service.ts @oppia/lace-frontend-reviewers
-/redis.conf @oppia/data-and-stability-reviewers
-/redis_docker.conf @oppia/data-and-stability-reviewers
-/.firebase.json @oppia/data-and-stability-reviewers
-/.firebase_docker.json @oppia/data-and-stability-reviewers
+/redis.conf @oppia/dev-workflow-reviewers
+/redis_docker.conf @oppia/dev-workflow-reviewers
+/.firebase.json @oppia/dev-workflow-reviewers
+/.firebase_docker.json @oppia/dev-workflow-reviewers
 
 
 # Miscellaneous.
-/__init__.py @oppia/data-and-stability-reviewers
-/core/__init__.py @oppia/data-and-stability-reviewers
-/core/controllers/__init__.py @oppia/data-and-stability-reviewers
-/core/domain/__init__.py @oppia/data-and-stability-reviewers
+/__init__.py @oppia/dev-workflow-reviewers
+/core/__init__.py @oppia/lace-backend-reviewers
+/core/controllers/__init__.py @oppia/lace-backend-reviewers
+/core/domain/__init__.py @oppia/lace-backend-reviewers
 /core/domain/config*.py @oppia/lace-backend-reviewers
 /core/domain/change_domain*.py @oppia/lace-backend-reviewers
 /core/templates/tests/ @oppia/lace-frontend-reviewers
 /core/templates/domain/utilities/ @oppia/lace-frontend-reviewers
 /core/templates/Polyfills.ts @oppia/lace-frontend-reviewers
 /extensions/extensions.module.ts @oppia/lace-frontend-reviewers
-/core/schema_utils*.py @oppia/data-and-stability-reviewers
+/core/schema_utils*.py @oppia/lace-backend-reviewers
 /core/utils*.py @oppia/lace-backend-reviewers
 /.rtlcssrc @oppia/lace-frontend-reviewers
 
 
 # Python typing
-/mypy.ini @oppia/mypy-reviewers
-/mypy_imports*.py @oppia/mypy-reviewers
-/mypy_requirements.txt @oppia/mypy-reviewers
-/stubs/ @oppia/mypy-reviewers
-/scripts/run_mypy_checks*.py @oppia/mypy-reviewers
+/mypy.ini @oppia/dev-workflow-reviewers
+/mypy_imports*.py @oppia/dev-workflow-reviewers
+/mypy_requirements.txt @oppia/dev-workflow-reviewers
+/stubs/ @oppia/dev-workflow-reviewers
+/scripts/run_mypy_checks*.py @oppia/dev-workflow-reviewers
 
 
 # Restricted pages.
-/core/controllers/admin*.py @oppia/data-and-stability-reviewers
+/core/controllers/admin*.py @oppia/lace-backend-reviewers
 /core/controllers/blog_admin*.py @oppia/lace-backend-reviewers
-/core/controllers/moderator*.py @oppia/data-and-stability-reviewers
-/core/controllers/recent_commits*.py @oppia/data-and-stability-reviewers
-/core/domain/moderator_services*.py @oppia/data-and-stability-reviewers
+/core/controllers/moderator*.py @oppia/lace-backend-reviewers
+/core/controllers/recent_commits*.py @oppia/lace-backend-reviewers
+/core/domain/moderator_services*.py @oppia/lace-backend-reviewers
 /core/templates/domain/admin/ @oppia/lace-frontend-reviewers
 /core/templates/domain/blog-admin/ @oppia/lace-frontend-reviewers
 /core/templates/pages/admin-page/ @oppia/lace-frontend-reviewers
@@ -627,8 +627,8 @@
 
 
 # Simple pages.
-/core/controllers/pages*.py @oppia/data-and-stability-reviewers
-/core/controllers/custom_landing_pages*.py @oppia/data-and-stability-reviewers
+/core/controllers/pages*.py @oppia/lace-backend-reviewers
+/core/controllers/custom_landing_pages*.py @oppia/lace-backend-reviewers
 /core/templates/pages/contact-page/ @oppia/lace-frontend-reviewers
 /core/templates/pages/delete-account-page/ @oppia/lace-frontend-reviewers
 /core/templates/pages/donate-page/ @oppia/lace-frontend-reviewers
@@ -661,11 +661,11 @@
 /.lighthouserc*.js @oppia/dev-workflow-reviewers
 /puppeteer-login-script.js @oppia/dev-workflow-reviewers
 /scripts/run_lighthouse_tests.py @oppia/dev-workflow-reviewers
-/webpack.*.ts @oppia/data-and-stability-reviewers
+/webpack.*.ts @oppia/dev-workflow-reviewers
 
 
 # User’s profile page.
-/core/controllers/profile*.py @oppia/data-and-stability-reviewers
+/core/controllers/profile*.py @oppia/lace-backend-reviewers
 /core/templates/domain/user/ @oppia/lace-frontend-reviewers
 /core/templates/pages/profile-page/ @oppia/lace-frontend-reviewers
 /core/templates/services/user.service*.ts @oppia/lace-frontend-reviewers
@@ -700,16 +700,16 @@
 /core/templates/domain/mailing-list/mailing-list-backend-api.service*.ts @oppia/lace-frontend-reviewers
 
 # Data stability.
-/core/controllers/domain_objects_validator*.py @oppia/data-and-stability-reviewers
-/core/controllers/payload_validator*.py @oppia/data-and-stability-reviewers
-/core/handler_schema_constants*.py @oppia/data-and-stability-reviewers
+/core/controllers/domain_objects_validator*.py @oppia/lace-backend-reviewers
+/core/controllers/payload_validator*.py @oppia/lace-backend-reviewers
+/core/handler_schema_constants*.py @oppia/lace-backend-reviewers
 
 
 # QA team.
 /core/tests/ @oppia/dev-workflow-reviewers
-/assets/ @oppia/data-and-stability-reviewers
-/data/ @oppia/data-and-stability-reviewers
-/core/templates/karma.module.ts @oppia/lace-frontend-reviewers
+/assets/ @oppia/lace-frontend-reviewers
+/data/ @oppia/lace-backend-reviewers
+/core/templates/karma.module.ts @oppia/dev-workflow-reviewers
 /core/tests/webdriverio_utils/ @oppia/dev-workflow-reviewers
 /core/tests/webdriverio_desktop/ @oppia/dev-workflow-reviewers
 /core/tests/webdriverio/ @oppia/dev-workflow-reviewers
@@ -725,11 +725,11 @@
 
 
 # Python 3 Migration project.
-/core/domain/auth*.py @oppia/data-and-stability-reviewers
-/core/domain/caching*.py @oppia/data-and-stability-reviewers
-/core/domain/taskqueue*.py @oppia/data-and-stability-reviewers
-/core/templates/services/auth.service*.ts @oppia/data-and-stability-reviewers
-/core/templates/services/auth-backend-api.service*.ts @oppia/data-and-stability-reviewers
+/core/domain/auth*.py @oppia/lace-backend-reviewers
+/core/domain/caching*.py @oppia/lace-backend-reviewers
+/core/domain/taskqueue*.py @oppia/lace-backend-reviewers
+/core/templates/services/auth.service*.ts @oppia/lace-frontend-reviewers
+/core/templates/services/auth-backend-api.service*.ts @oppia/lace-frontend-reviewers
 
 
 # Critical files.


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Consolidates codeowner teams -- drops the separate teams for MyPy, data/stability and learner analytics so that a PR generally requires fewer reviewers to approve it.

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).
