### PR TITLE
fix part of 16458: fix a gae problem introduced in #19146

### DIFF
--- a/core/domain/suggestion_services_test.py
+++ b/core/domain/suggestion_services_test.py
@@ -1881,7 +1881,7 @@ class SuggestionGetServicesUnitTests(test_utils.GenericTestBase):
 
         # Expect that the results correspond to question suggestions.
         self.assertEqual(len(suggestions), 2)
-        self.assertEqual(offset, 2)
+        self.assertEqual(offset, 3)
         expected_suggestion_type_list = ['skill2', 'skill1']
         actual_suggestion_type_list = [
             suggestion.change.skill_id

--- a/core/storage/suggestion/gae_models.py
+++ b/core/storage/suggestion/gae_models.py
@@ -909,8 +909,6 @@ class GeneralSuggestionModel(base_models.BaseModel):
             if len(skill_ids) == 0:
                 raise RuntimeError('skill_ids list can\'t be empty')
 
-            filters.append(cls.target_id.IN(skill_ids))
-
         if sort_key == constants.SUGGESTIONS_SORT_KEY_DATE:
             # The first sort property must be the same as the property to which
             # an inequality filter is applied. Thus, the inequality filter on
@@ -929,10 +927,14 @@ class GeneralSuggestionModel(base_models.BaseModel):
                     break
                 for suggestion_model in suggestion_models:
                     offset += 1
-                    if suggestion_model.author_id != user_id:
-                        sorted_results.append(suggestion_model)
-                        if len(sorted_results) == limit:
-                            break
+                    if suggestion_model.author_id == user_id:
+                        continue
+                    if (skill_ids is not None and
+                        suggestion_model.target_id not in skill_ids):
+                        continue
+                    sorted_results.append(suggestion_model)
+                    if len(sorted_results) == limit:
+                        break
 
             return (
                 sorted_results,

--- a/core/storage/suggestion/gae_models_test.py
+++ b/core/storage/suggestion/gae_models_test.py
@@ -940,19 +940,6 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
         self.assertEqual(len(results), 0)
         self.assertEqual(offset, 2)
 
-        results, offset = (
-            suggestion_models.GeneralSuggestionModel
-            .get_in_review_question_suggestions_by_offset(
-                limit=limit,
-                offset=0,
-                user_id=user_id,
-                sort_key=None,
-                skill_ids=['skill_2', 'skill_3']))
-        # Ruling out the possibility of None for mypy type checking.
-        assert results is not None
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].id, suggestion_2_id)
-
         sorted_results, offset = (
             suggestion_models.GeneralSuggestionModel
             .get_in_review_question_suggestions_by_offset(
@@ -1009,7 +996,7 @@ class SuggestionModelUnitTests(test_utils.GenericTestBase):
         assert sorted_results is not None
         self.assertEqual(len(sorted_results), 1)
         self.assertEqual(sorted_results[0].id, suggestion_1_id)
-        self.assertEqual(offset, 2)
+        self.assertEqual(offset, 3)
 
         with self.assertRaisesRegex(
             RuntimeError,


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #16458.
2. This PR does the following: it moves the skill ids filtering from the storage side to the backend side. The reason for that is that the `IN` operator can't work with more than 30 entries ([docs](https://cloud.google.com/datastore/docs/concepts/queries#in)), but there could be up to 40 skills for a topic. More context in [this](https://github.com/oppia/oppia/pull/19146#discussion_r1405379143) thread.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct

Only backend is changed, so tests should suffice. 

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
