### PR TITLE
Fix #19163: add a delay to address the flake in the extensions test suite.

### DIFF
--- a/core/tests/webdriverio_desktop/additionalEditorFeaturesModals.js
+++ b/core/tests/webdriverio_desktop/additionalEditorFeaturesModals.js
@@ -118,7 +118,7 @@ describe('Full exploration editor', function() {
 
       // Add a content change and does not save the draft.
       await explorationEditorMainTab.setContent(async function(richTextEditor) {
-        await richTextEditor.appendPlainText('How are you feeling?');
+        await richTextEditor.appendPlainText('How are you feeling today?');
       }, true);
       await action.waitForAutosave();
       await users.logout();
@@ -129,7 +129,7 @@ describe('Full exploration editor', function() {
       await users.login('user14@editor.com');
       await general.openEditor(explorationId, true);
       await explorationEditorMainTab.setContent(async function(richTextEditor) {
-        await richTextEditor.appendPlainText('You must be feeling great?');
+        await richTextEditor.appendPlainText('Are you feeling great?');
       }, true);
       await explorationEditorPage.saveChanges();
       await users.logout();
@@ -146,7 +146,7 @@ describe('Full exploration editor', function() {
       await waitFor.pageToFullyLoad();
       await explorationEditorMainTab.expectContentToMatch(
         async function(richTextChecker) {
-          await richTextChecker.readPlainText('You must be feeling great?');
+          await richTextChecker.readPlainText('Are you feeling great?');
         }
       );
       await users.logout();

--- a/core/tests/webdriverio_utils/ExplorationEditorMainTab.js
+++ b/core/tests/webdriverio_utils/ExplorationEditorMainTab.js
@@ -516,6 +516,8 @@ var ExplorationEditorMainTab = function() {
   // possible to click on them to view their contents, as clicks instead open
   // the rich text editor.
   this.expectContentToMatch = async function(richTextInstructions) {
+    await waitFor.visibilityOf(
+      stateContentDisplay, 'State content display not showing up');
     await forms.expectRichText(stateContentDisplay).toMatch(
       richTextInstructions);
   };

--- a/extensions/rich_text_components/Collapsible/webdriverio.js
+++ b/extensions/rich_text_components/Collapsible/webdriverio.js
@@ -30,13 +30,16 @@ var customizeComponent = async function(modal, heading, contentInstructions) {
 
 var expectComponentDetailsToMatch = async function(
     elem, heading, contentInstructions) {
-  var headerElement = elem.$(
-    '.e2e-test-collapsible-heading');
+  var headerElement = elem.$('.e2e-test-collapsible-heading');
   expect(await headerElement.getText()).toMatch(heading);
   // Open the collapsible block so we can examine it.
   await headerElement.click();
-  const collapsibleElem = elem.$(
-    '.e2e-test-collapsible-content');
+  const collapsibleElem = elem.$('.e2e-test-collapsible-content');
+  // The collapsible element has a built-in animation which takes time to
+  // complete (even though the element exists on the page), so we need to build
+  // in an explicit waiting time here.
+  // eslint-disable-next-line oppia/e2e-practices
+  await browser.pause(1000);
   await forms.expectRichText(collapsibleElem).toMatch(contentInstructions);
 };
 


### PR DESCRIPTION
## Overview
1. This PR fixes #19163.
2. This PR does the following: Adds a delay to address the flake in the extensions test suite, which happens due to the delay caused by animating the collapsible. Also renames some strings to allow tests to be disambiguated more easily, and adds a guard to try and avoid another occasional failing test: https://github.com/oppia/oppia/actions/runs/7013587332/job/19080566932
3. (For bug-fixing PRs only) The original bug occurred because: There is a delay in loading the text in the collapsible due to the animation. (For some reason this seems to have built up over time and doesn't always occur, I'm not sure why that is.)

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Proof that changes are correct

I ran this locally and it failed regularly prior to the fix and passed regularly after the fix, but proof will come when we see what the results of the e2e test run is on this PR.
