### PR TITLE
fixes #19157: Email from the Contributor Dashboard Team contains the wrong link

### DIFF
--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -324,7 +324,7 @@ ADMIN_NOTIFICATION_FOR_SUGGESTIONS_NEEDING_REVIEW_EMAIL_DATA: Dict[str, str] = {
         'There are suggestions on the <a href="%s%s">Contributor Dashboard</a> '
         'that have been waiting for more than %s days for review. Please take '
         'a look at the suggestions mentioned below and help them get reviewed '
-        'by going to the <a href="%s%s#/roles">admin roles page</a> and either:'
+        'by going to the <a href="%s%s">admin roles page</a> and either:'
         '<br><br><ul>'
         '<li>Add more reviewers to the suggestion types that have suggestions '
         'waiting too long for a review</li><br>'
@@ -1761,7 +1761,7 @@ def _send_suggestions_waiting_too_long_email(
             curriculum_admin_usernames[index], feconf.OPPIA_SITE_URL,
             feconf.CONTRIBUTOR_DASHBOARD_URL,
             suggestion_models.SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS,
-            feconf.OPPIA_SITE_URL, feconf.ADMIN_URL,
+            feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_ADMIN_URL,
             list_of_suggestion_descriptions)
 
         _send_email(


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #19157
2. This PR does the following: Changes email template and input given for placeholders
3. (For bug-fixing PRs only) The original bug occurred because: wrong link was used in placeholder of email template.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).