### PR TITLE
Fix part of issue #19136: Removed parentScope from oppia-interaction-display

### DIFF
--- a/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-or-update-solution-modal.component.html
+++ b/core/templates/pages/exploration-editor-page/editor-tab/templates/modal-templates/add-or-update-solution-modal.component.html
@@ -17,7 +17,7 @@
       <div>
         <oppia-interaction-display classStr="e2e-test-interaction-html"
                                    [htmlData]="correctAnswerEditorHtml"
-                                   [parentScope]="this">
+                                   >
         </oppia-interaction-display>
       </div>
       <br>


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #19131.
2. This PR does the following: Removes [parentScope]="this" from oppia-interaction-display to enable code-editor functionality when the code editor interaction is selected. 
3. (For bug-fixing PRs only) The original bug occurred because: oppia-interaction-display had [parentScope]="this"

## Proof that changes are correct

https://github.com/oppia/oppia/assets/73959321/6ffa122b-81ef-4248-946c-615e3eeddc32