### PR TITLE
Fix #14937  : Removed python-matplotlib from scripts/install_prerequisites.sh

### DIFF
--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -34,7 +34,6 @@ sudo apt-get install python3-dev
 sudo apt-get install python3-pip
 sudo apt-get install unzip
 sudo apt-get install python3-yaml
-sudo apt-get install python-matplotlib
 sudo apt-get install python3-matplotlib
 pip install --upgrade pip==21.2.3
 


### PR DESCRIPTION
…Removed python-matplotlib from scripts/install_prerequisites.sh as python-matplotlib does not have an installation candidate only the python3-matplotlib is available for download from apt repository

## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #14937 .
2. This PR does the following: This PR fixes the error "Package 'python-matplotlib' has no installation candidate". This is done by removing the python-matplotlib from scripts/install_prerequisites.sh
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

- [ ☑️] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [☑️ ] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [ ☑️] The linter/Karma presubmit checks have passed on my local machine.
- [☑️ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [ ☑️] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ ] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct

No proof of changes is required because this only removes unused module

#### Proof of changes on desktop with slow/throttled network

No proof of changes is required because this wont cause throttle issues

#### Proof of changes on mobile phone

No proof of changes is required 

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
