### PR TITLE
fix #17759: use skill id from the new card

### DIFF
--- a/core/templates/pages/exploration-player-page/layout-directives/exploration-footer.component.ts
+++ b/core/templates/pages/exploration-player-page/layout-directives/exploration-footer.component.ts
@@ -187,7 +187,7 @@ export class ExplorationFooterComponent {
     this.directiveSubscriptions.add(
       this.playerPositionService.onNewCardOpened.subscribe(
         (newCard: StateCard) => {
-          this.conceptCardManagerService.reset();
+          this.conceptCardManagerService.reset(newCard);
         }
       )
     );

--- a/core/templates/pages/exploration-player-page/services/concept-card-manager.service.spec.ts
+++ b/core/templates/pages/exploration-player-page/services/concept-card-manager.service.spec.ts
@@ -68,7 +68,7 @@ describe('ConceptCardManager service', () => {
       AudioTranslationLanguageService);
   }));
 
-  beforeEach(fakeAsync(() => {
+  beforeEach(() => {
     stateCard = StateCard.createNewCard(
       'State 2', '<p>Content</p>', '<interaction></interaction>',
       interactionObjectFactory.createFromBackendDict({
@@ -125,7 +125,7 @@ describe('ConceptCardManager service', () => {
       }),
       RecordedVoiceovers.createEmpty(),
       'content', audioTranslationLanguageService);
-  }));
+  });
 
   it('should show concept card icon at the right time', fakeAsync(() => {
     // Case when no hints exist.

--- a/core/templates/pages/exploration-player-page/services/concept-card-manager.service.spec.ts
+++ b/core/templates/pages/exploration-player-page/services/concept-card-manager.service.spec.ts
@@ -39,6 +39,7 @@ describe('ConceptCardManager service', () => {
   let mockNewCardAvailableEmitter = new EventEmitter();
   let interactionObjectFactory: InteractionObjectFactory;
   let audioTranslationLanguageService: AudioTranslationLanguageService;
+  let stateCard: StateCard;
 
   const WAIT_BEFORE_REALLY_STUCK_MSEC: number = 160000;
   const WAIT_FOR_TOOLTIP_TO_BE_SHOWN_MSEC: number = 500;
@@ -67,117 +68,8 @@ describe('ConceptCardManager service', () => {
       AudioTranslationLanguageService);
   }));
 
-  it('should show concept card icon at the right time', fakeAsync(() => {
-    // Case when no hints exist.
-    spyOn(ccms, 'conceptCardForStateExists').and.returnValue(true);
-    ccms.hintsAvailable = 0;
-    expect(ccms.isConceptCardTooltipOpen()).toBe(false);
-    expect(ccms.isConceptCardViewable()).toBe(false);
-    expect(ccms.isConceptCardConsumed()).toBe(false);
-
-    ccms.reset();
-
-    // Time delay before concept card is released.
-    tick(WAIT_FOR_CONCEPT_CARD_MSEC);
-    // Time delay before tooltip for the concept card is shown.
-    tick(WAIT_FOR_TOOLTIP_TO_BE_SHOWN_MSEC);
-
-    expect(ccms.isConceptCardTooltipOpen()).toBe(true);
-    expect(ccms.isConceptCardViewable()).toBe(true);
-    expect(ccms.isConceptCardConsumed()).toBe(false);
-  }));
-
-  it('should not show concept card when hints exist', fakeAsync(() => {
-    // Case when hints exist.
-    ccms.hintsAvailable = 1;
-    spyOn(ccms, 'conceptCardForStateExists').and.returnValue(true);
-    expect(ccms.isConceptCardTooltipOpen()).toBe(false);
-    expect(ccms.isConceptCardViewable()).toBe(false);
-    expect(ccms.isConceptCardConsumed()).toBe(false);
-
-    ccms.reset();
-
-    // Time delay before concept card is released.
-    tick(WAIT_FOR_CONCEPT_CARD_MSEC);
-    // Time delay before tooltip for the concept card is shown.
-    tick(WAIT_FOR_TOOLTIP_TO_BE_SHOWN_MSEC);
-
-    expect(ccms.isConceptCardTooltipOpen()).toBe(false);
-    expect(ccms.isConceptCardViewable()).toBe(false);
-    expect(ccms.isConceptCardConsumed()).toBe(false);
-  }));
-
-  it('should reset the service when timeouts was called before',
-    fakeAsync(() => {
-      // Initialize the service with two hints and a solution.
-      spyOn(ccms, 'conceptCardForStateExists').and.returnValue(true);
-      ccms.reset();
-
-      // Set timeout.
-      tick(WAIT_FOR_CONCEPT_CARD_MSEC);
-      // Set tooltipTimeout.
-      tick(WAIT_FOR_TOOLTIP_TO_BE_SHOWN_MSEC);
-
-      // Reset service to 0 solutions so releaseHint timeout won't be called.
-      ccms.reset();
-
-      // There is no timeout to flush. timeout and tooltipTimeout variables
-      // were cleaned.
-      expect(flush()).toBe(60000);
-    }));
-
-  it('should return if concept card for the state exists', fakeAsync(() => {
-    const endState = {
-      classifier_model_id: null,
-      recorded_voiceovers: {
-        voiceovers_mapping: {
-          content: {}
-        }
-      },
-      solicit_answer_details: false,
-      interaction: {
-        solution: null,
-        confirmed_unclassified_answers: [],
-        id: 'EndExploration',
-        hints: [],
-        customization_args: {
-          recommendedExplorationIds: {
-            value: ['recommendedExplorationId']
-          }
-        },
-        answer_groups: [],
-        default_outcome: null
-      },
-      param_changes: [],
-      next_content_id_index: 0,
-      card_is_checkpoint: false,
-      linked_skill_id: 'Id',
-      content: {
-        content_id: 'content',
-        html: 'Congratulations, you have finished!'
-      }
-    };
-    spyOn(ees, 'getState')
-      .and.returnValue(
-        stateObjectFactory.createFromBackendDict('End', endState));
-
-    ccms.hintsAvailable = 0;
-    ccms.reset();
-
-    // Time delay before concept card is released.
-    tick(WAIT_FOR_CONCEPT_CARD_MSEC);
-    // Time delay before tooltip for the concept card is shown.
-    tick(WAIT_FOR_TOOLTIP_TO_BE_SHOWN_MSEC);
-
-    expect(ccms.isConceptCardTooltipOpen()).toBe(true);
-    expect(ccms.isConceptCardViewable()).toBe(true);
-    expect(ccms.isConceptCardConsumed()).toBe(false);
-  }));
-
-  it('should set the number of hints available', fakeAsync(() => {
-    spyOn(pps.onNewCardOpened, 'subscribe');
-    // A StateCard which supports hints.
-    let newCard = StateCard.createNewCard(
+  beforeEach(fakeAsync(() => {
+    stateCard = StateCard.createNewCard(
       'State 2', '<p>Content</p>', '<interaction></interaction>',
       interactionObjectFactory.createFromBackendDict({
         id: 'TextInput',
@@ -233,8 +125,119 @@ describe('ConceptCardManager service', () => {
       }),
       RecordedVoiceovers.createEmpty(),
       'content', audioTranslationLanguageService);
+  }));
 
-    pps.onNewCardOpened.emit(newCard);
+  it('should show concept card icon at the right time', fakeAsync(() => {
+    // Case when no hints exist.
+    spyOn(ccms, 'conceptCardForStateExists').and.returnValue(true);
+    ccms.hintsAvailable = 0;
+    expect(ccms.isConceptCardTooltipOpen()).toBe(false);
+    expect(ccms.isConceptCardViewable()).toBe(false);
+    expect(ccms.isConceptCardConsumed()).toBe(false);
+
+    ccms.reset(stateCard);
+
+    // Time delay before concept card is released.
+    tick(WAIT_FOR_CONCEPT_CARD_MSEC);
+    // Time delay before tooltip for the concept card is shown.
+    tick(WAIT_FOR_TOOLTIP_TO_BE_SHOWN_MSEC);
+
+    expect(ccms.isConceptCardTooltipOpen()).toBe(true);
+    expect(ccms.isConceptCardViewable()).toBe(true);
+    expect(ccms.isConceptCardConsumed()).toBe(false);
+  }));
+
+  it('should not show concept card when hints exist', fakeAsync(() => {
+    // Case when hints exist.
+    ccms.hintsAvailable = 1;
+    spyOn(ccms, 'conceptCardForStateExists').and.returnValue(true);
+    expect(ccms.isConceptCardTooltipOpen()).toBe(false);
+    expect(ccms.isConceptCardViewable()).toBe(false);
+    expect(ccms.isConceptCardConsumed()).toBe(false);
+
+    ccms.reset(stateCard);
+
+    // Time delay before concept card is released.
+    tick(WAIT_FOR_CONCEPT_CARD_MSEC);
+    // Time delay before tooltip for the concept card is shown.
+    tick(WAIT_FOR_TOOLTIP_TO_BE_SHOWN_MSEC);
+
+    expect(ccms.isConceptCardTooltipOpen()).toBe(false);
+    expect(ccms.isConceptCardViewable()).toBe(false);
+    expect(ccms.isConceptCardConsumed()).toBe(false);
+  }));
+
+  it('should reset the service when timeouts was called before',
+    fakeAsync(() => {
+      // Initialize the service with two hints and a solution.
+      spyOn(ccms, 'conceptCardForStateExists').and.returnValue(true);
+      ccms.reset(stateCard);
+
+      // Set timeout.
+      tick(WAIT_FOR_CONCEPT_CARD_MSEC);
+      // Set tooltipTimeout.
+      tick(WAIT_FOR_TOOLTIP_TO_BE_SHOWN_MSEC);
+
+      // Reset service to 0 solutions so releaseHint timeout won't be called.
+      ccms.reset(stateCard);
+
+      // There is no timeout to flush. timeout and tooltipTimeout variables
+      // were cleaned.
+      expect(flush()).toBe(60000);
+    }));
+
+  it('should return if concept card for the state with the new name exists',
+    fakeAsync(() => {
+      const endState = {
+        classifier_model_id: null,
+        recorded_voiceovers: {
+          voiceovers_mapping: {
+            content: {}
+          }
+        },
+        solicit_answer_details: false,
+        interaction: {
+          solution: null,
+          confirmed_unclassified_answers: [],
+          id: 'EndExploration',
+          hints: [],
+          customization_args: {
+            recommendedExplorationIds: {
+              value: ['recommendedExplorationId']
+            }
+          },
+          answer_groups: [],
+          default_outcome: null
+        },
+        param_changes: [],
+        next_content_id_index: 0,
+        card_is_checkpoint: false,
+        linked_skill_id: 'Id',
+        content: {
+          content_id: 'content',
+          html: 'Congratulations, you have finished!'
+        }
+      };
+      spyOn(ees, 'getStateFromStateName').withArgs('State 2')
+        .and.returnValue(
+          stateObjectFactory.createFromBackendDict('End', endState));
+
+      ccms.hintsAvailable = 0;
+      ccms.reset(stateCard);
+
+      // Time delay before concept card is released.
+      tick(WAIT_FOR_CONCEPT_CARD_MSEC);
+      // Time delay before tooltip for the concept card is shown.
+      tick(WAIT_FOR_TOOLTIP_TO_BE_SHOWN_MSEC);
+
+      expect(ccms.isConceptCardTooltipOpen()).toBe(true);
+      expect(ccms.isConceptCardViewable()).toBe(true);
+      expect(ccms.isConceptCardConsumed()).toBe(false);
+    }));
+
+  it('should set the number of hints available', fakeAsync(() => {
+    spyOn(pps.onNewCardOpened, 'subscribe');
+    pps.onNewCardOpened.emit(stateCard);
     expect(ccms.hintsAvailable).toEqual(0);
   }));
 
@@ -259,7 +262,7 @@ describe('ConceptCardManager service', () => {
   it('should record the wrong answer twice', fakeAsync(() => {
     // Initialize the service with two hints and a solution.
     spyOn(ccms, 'conceptCardForStateExists').and.returnValue(true);
-    ccms.reset();
+    ccms.reset(stateCard);
 
     expect(ccms.isConceptCardTooltipOpen()).toBe(false);
     expect(ccms.isConceptCardViewable()).toBe(false);

--- a/core/templates/pages/exploration-player-page/services/concept-card-manager.service.ts
+++ b/core/templates/pages/exploration-player-page/services/concept-card-manager.service.ts
@@ -23,7 +23,6 @@ import { StateCard } from 'domain/state_card/state-card.model';
 import { ExplorationPlayerConstants } from 'pages/exploration-player-page/exploration-player-page.constants';
 import { PlayerPositionService } from 'pages/exploration-player-page/services/player-position.service';
 import { ExplorationEngineService } from './exploration-engine.service';
-import { HintsAndSolutionManagerService } from './hints-and-solution-manager.service';
 
 @Injectable({
   providedIn: 'root'
@@ -57,8 +56,7 @@ export class ConceptCardManagerService {
   conceptCardDiscovered: boolean = false;
 
   constructor(
-    private playerPositionService: PlayerPositionService,
-    private hintsAndSolutionManagerService: HintsAndSolutionManagerService,
+      playerPositionService: PlayerPositionService,
     private explorationEngineService: ExplorationEngineService
   ) {
     // TODO(#10904): Refactor to move subscriptions into components.
@@ -115,7 +113,7 @@ export class ConceptCardManagerService {
       ExplorationPlayerConstants.WAIT_BEFORE_REALLY_STUCK_MSEC);
   }
 
-  reset(): void {
+  reset(newCard: StateCard): void {
     if (this.hintsAvailable) {
       return;
     }
@@ -131,15 +129,16 @@ export class ConceptCardManagerService {
       this.tooltipTimeout = null;
     }
 
-    if (this.conceptCardForStateExists()) {
+    if (this.conceptCardForStateExists(newCard)) {
       this.enqueueTimeout(
         this.releaseConceptCard,
         ExplorationPlayerConstants.WAIT_FOR_CONCEPT_CARD_MSEC);
     }
   }
 
-  conceptCardForStateExists(): boolean {
-    let state = this.explorationEngineService.getState();
+  conceptCardForStateExists(newCard: StateCard): boolean {
+    let state = this.explorationEngineService.getStateFromStateName(
+      newCard.getStateName());
     return state.linkedSkillId !== null;
   }
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #17759.
2. This PR does the following: it makes the concept-card-manager to check if there is a linked skill for the new card, but not for the previous one. Currently concept-card-manager [uses](https://github.com/oppia/oppia/blob/2a71bf454233229b56043890a82399e7a824fb8b/core/templates/pages/exploration-player-page/services/concept-card-manager.service.ts#L142) `this.explorationEngineService.getState` to get state. And `getState` [uses](https://github.com/oppia/oppia/blob/2a71bf454233229b56043890a82399e7a824fb8b/core/templates/pages/exploration-player-page/services/exploration-engine.service.ts#L425) `this.playerTranscriptService.getLastStateName` function to get current state name. The problem is that the transcript service doesn't have the new card at the point the `conceptCardForStateExists` function is called, so the `getState` function returns state for the *previous* card. 

So if there are two cards, the first has a linked skill, and the second doesn't, when a user transfers to the second card, the code thinks that there is a concept card for it, but only because the first card has a skill. 

That causes the #17759 bug because the concept card is shown if there is a linked skill for that card (check [this](https://github.com/oppia/oppia/blob/2a71bf454233229b56043890a82399e7a824fb8b/core/templates/pages/exploration-player-page/services/concept-card-manager.service.ts#L134) part).

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Proof that changes are correct

I create an exploration with 4 cards. The second has a linked skill, the third doesn't ([screencast](https://github.com/oppia/oppia/assets/6707908/566822a1-db3b-4b47-9d75-c6df7a090a23)). Which means there should be a concept suggestion for the second card and not the third.

With the existing code the opposite happens. Note I reduced the timeout for the concept to appear from 60s to 6s. See the [screencast](https://github.com/oppia/oppia/assets/6707908/644fb7b9-4413-4357-8b51-89e75044b1d2), on which the second card doesn't have a concept suggestion, but the third one does. The concept suggestion cannot be pressed on the third card too.

With the new changes the second card has a concept suggestion, the third one doesn't. [Screencast](https://github.com/oppia/oppia/assets/6707908/6b28d1b7-cf3e-4a7a-8892-4118569d0bc4). You can see that the concept card is pressable as well.

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
