### PR TITLE
Added Loader and Loading message for Lesson pages

### DIFF
--- a/core/templates/pages/exploration-player-page/exploration-player-page.component.html
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.component.html
@@ -1,7 +1,6 @@
 <div>
   <div *ngIf="isLoadingExploration" class="loader-container">
-    <p>Loading...</p>
-    <mat-spinner></mat-spinner>
+    <oppia-loading-message [message]="'Loagding...'"></oppia-loading-message>
   </div>
   <background-banner *ngIf="!isLoadingExploration"></background-banner>
   <div class="embedded-body" *ngIf="pageIsIframed">
@@ -12,18 +11,4 @@
   <oppia-on-screen-keyboard></oppia-on-screen-keyboard>
 </div>
 <style>
-  .loader-container {
-    align-items: center;
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    justify-content: center;
-    width: 100%;
-  }
-
-  .loader-container p {
-    font-size: 24px;
-    font-weight: bold;
-    margin: 1em 0;
-  }
 </style>

--- a/core/templates/pages/exploration-player-page/exploration-player-page.component.html
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.component.html
@@ -1,5 +1,9 @@
 <div>
-  <background-banner></background-banner>
+  <div *ngIf="isLoadingExploration" class="loader-container">
+    <p>Loading...</p>
+    <mat-spinner></mat-spinner>
+  </div>
+  <background-banner *ngIf="!isLoadingExploration"></background-banner>
   <div class="embedded-body" *ngIf="pageIsIframed">
     <oppia-conversation-skin></oppia-conversation-skin>
   </div>
@@ -7,3 +11,19 @@
   <attribution-guide></attribution-guide>
   <oppia-on-screen-keyboard></oppia-on-screen-keyboard>
 </div>
+<style>
+  .loader-container {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .loader-container p {
+    font-size: 24px;
+    font-weight: bold;
+    margin: 1em 0;
+  }
+</style>

--- a/core/templates/pages/exploration-player-page/exploration-player-page.component.html
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.component.html
@@ -1,6 +1,6 @@
 <div>
   <div *ngIf="isLoadingExploration" class="loader-container">
-    <oppia-loading-message [message]="'Loagding...'"></oppia-loading-message>
+    <oppia-loading-message [message]="'Loading...'"></oppia-loading-message>
   </div>
   <background-banner *ngIf="!isLoadingExploration"></background-banner>
   <div class="embedded-body" *ngIf="pageIsIframed">

--- a/core/templates/pages/exploration-player-page/exploration-player-page.component.html
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.component.html
@@ -10,5 +10,3 @@
   <attribution-guide></attribution-guide>
   <oppia-on-screen-keyboard></oppia-on-screen-keyboard>
 </div>
-<style>
-</style>

--- a/core/templates/pages/exploration-player-page/exploration-player-page.component.html
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.component.html
@@ -1,6 +1,6 @@
 <div>
   <div *ngIf="isLoadingExploration" class="loader-container">
-    <oppia-loading-message [message]="'Loading...'"></oppia-loading-message>
+    <oppia-loading-message [message]="'Loading'"></oppia-loading-message>
   </div>
   <background-banner *ngIf="!isLoadingExploration"></background-banner>
   <div class="embedded-body" *ngIf="pageIsIframed">

--- a/core/templates/pages/exploration-player-page/exploration-player-page.component.ts
+++ b/core/templates/pages/exploration-player-page/exploration-player-page.component.ts
@@ -38,6 +38,7 @@ export class ExplorationPlayerPageComponent implements OnDestroy {
   directiveSubscriptions = new Subscription();
   pageIsIframed: boolean = false;
   explorationTitle!: string;
+  isLoadingExploration: boolean = true;
 
   constructor(
     private contextService: ContextService,
@@ -84,7 +85,10 @@ export class ExplorationPlayerPageComponent implements OnDestroy {
           content: response.exploration.objective
         }
       ]);
-    });
+    }).finally(() => {
+      this.isLoadingExploration = false;
+    }
+    );
 
     this.pageIsIframed = this.urlService.isIframed();
     this.keyboardShortcutService.bindExplorationPlayerShortcuts();


### PR DESCRIPTION
## Overview
1. This PR fixes #18468.

### This PR does the following

Added loading-spinner with loading message before Lesson page is fully rendered.

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [ ] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct


https://github.com/oppia/oppia/assets/108923011/e524923d-d3a1-4410-a2d8-f8a79a3083b9






