### PR TITLE
Fix #16559: Added sort for mis-ordering of exploration states again

### DIFF
--- a/core/domain/exp_domain.py
+++ b/core/domain/exp_domain.py
@@ -2098,8 +2098,8 @@ class Exploration(translation_domain.BaseTranslatableObject):
                             curr_queue.append(dest_if_stuck_state)
 
         if len(self.states) != len(processed_queue):
-            unseen_states = list(
-                set(self.states.keys()) - set(processed_queue))
+            unseen_states = sorted(list(
+                set(self.states.keys()) - set(processed_queue)))
             raise utils.ValidationError(
                 'The following states are not reachable from the initial '
                 'state: %s' % ', '.join(unseen_states))


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #16559.
2. This PR does the following: Added sort for un_seen states
3. (For bug-fixing PRs only) The original bug occurred because: Set does not guarantee order so sorting it to pass test_verify_all_states_reachable

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).


## Proof that changes are correct
<img width="673" alt="Screenshot 2023-12-04 at 11 58 09 PM" src="https://github.com/oppia/oppia/assets/60012959/4e40ef2e-b95a-448b-80c9-d09961cb786d">



