### PR TITLE
Fix #19042: show warning on answer groups duplicates

### DIFF
--- a/extensions/interactions/ItemSelectionInput/directives/item-selection-input-validation.service.spec.ts
+++ b/extensions/interactions/ItemSelectionInput/directives/item-selection-input-validation.service.spec.ts
@@ -412,8 +412,6 @@ describe('ItemSelectionInputValidationService', () => {
   });
 
   it('should not warn user when user selects only one answer choice', () => {
-    // CustomizationArguments.choices.value =
-    // [new SubtitledHtml('Selection 1', 'ca_0')];
     customizationArguments.maxAllowableSelectionCount.value = 1;
     customizationArguments.minAllowableSelectionCount.value = 0;
     let answerGroups = [agof.createNew(
@@ -589,6 +587,35 @@ describe('ItemSelectionInputValidationService', () => {
       message: (
         'Please add something for Oppia to say in the ' +
           '\"All other answers\" response.')
+    }]);
+  });
+
+  it('should warn about duplicated rules', () => {
+    const answerGroups = [agof.createNew(
+      [Rule.createFromBackendDict({
+        rule_type: 'Equals',
+        inputs: {
+          x: ['ca_0']
+        }
+      }, 'ItemSelectionInput'),
+      Rule.createFromBackendDict({
+        rule_type: 'Equals',
+        inputs: {
+          x: ['ca_0']
+        }
+      }, 'ItemSelectionInput')],
+      goodDefaultOutcome,
+      [],
+      null)
+    ];
+    const warnings = validatorService.getAllWarnings(
+      currentState, customizationArguments, answerGroups,
+      goodDefaultOutcome);
+    expect(warnings).toEqual([{
+      type: WARNING_TYPES.ERROR,
+      message: (
+        'The rule 1 of answer group 0 of ItemSelectionInput interaction ' +
+        'is a duplicate.')
     }]);
   });
 });

--- a/extensions/interactions/ItemSelectionInput/directives/item-selection-input-validation.service.ts
+++ b/extensions/interactions/ItemSelectionInput/directives/item-selection-input-validation.service.ts
@@ -194,8 +194,8 @@ export class ItemSelectionInputValidationService {
       choicesContentIds: Set<string | null>,
       ruleIndex: number,
       answerIndex: number) {
-    let warningsList: Warning[] = [];
-    let ruleInputs = rule.inputs.x as string[];
+    const warningsList: Warning[] = [];
+    const ruleInputs = rule.inputs.x as string[];
     ruleInputs.forEach((ruleInput) => {
       if (!choicesContentIds.has(ruleInput)) {
         warningsList.push({
@@ -213,8 +213,8 @@ export class ItemSelectionInputValidationService {
   private getWarningsForRulesDuplicates(
       rules: Rule[],
       answerGroupIndex: number): Warning[] {
-    let warningsList: Warning[] = [];
-    let rulesSet = new Set<string>();
+    const warningsList: Warning[] = [];
+    const rulesSet = new Set<string>();
     rules.forEach((rule, ruleIndex) => {
       const ruleStr = JSON.stringify(rule.toBackendDict());
       if (rulesSet.has(ruleStr)) {
@@ -266,7 +266,7 @@ export class ItemSelectionInputValidationService {
         this.getWarningsForRulesDuplicates(rules, answerIndex));
 
       rules.forEach((rule, ruleIndex) => {
-        let ruleInputs = rule.inputs.x as string[];
+        const ruleInputs = rule.inputs.x as string[];
         warningsList = warningsList.concat(
           this.getWarningsForRulesInputs(
             rule, choicesContentIds, ruleIndex, answerIndex));

--- a/extensions/interactions/ItemSelectionInput/directives/item-selection-input-validation.service.ts
+++ b/extensions/interactions/ItemSelectionInput/directives/item-selection-input-validation.service.ts
@@ -189,6 +189,48 @@ export class ItemSelectionInputValidationService {
     return warningsList;
   }
 
+  private getWarningsForRulesInputs(
+      rule: Rule,
+      choicesContentIds: Set<string | null>,
+      ruleIndex: number,
+      answerIndex: number) {
+    let warningsList: Warning[] = [];
+    let ruleInputs = rule.inputs.x as string[];
+    ruleInputs.forEach((ruleInput) => {
+      if (!choicesContentIds.has(ruleInput)) {
+        warningsList.push({
+          type: AppConstants.WARNING_TYPES.ERROR,
+          message: (
+            `Learner answer ${(ruleIndex + 1)} from Oppia response ` +
+            `${(answerIndex + 1)} options do not match customization ` +
+            'argument choices.')
+        });
+      }
+    });
+    return warningsList;
+  }
+
+  private getWarningsForRulesDuplicates(
+      rules: Rule[],
+      answerGroupIndex: number): Warning[] {
+    let warningsList: Warning[] = [];
+    let rulesSet = new Set<string>();
+    rules.forEach((rule, ruleIndex) => {
+      const ruleStr = JSON.stringify(rule.toBackendDict());
+      if (rulesSet.has(ruleStr)) {
+        warningsList.push({
+          type: AppConstants.WARNING_TYPES.ERROR,
+          message: (
+            `The rule ${ruleIndex} of answer group ` +
+            `${answerGroupIndex} of ItemSelectionInput interaction ` +
+            'is a duplicate.')}
+        );
+      }
+      rulesSet.add(ruleStr);
+    });
+    return warningsList;
+  }
+
   getAllWarnings(
       stateName: string, customizationArgs:
       ItemSelectionInputCustomizationArgs, answerGroups: AnswerGroup[],
@@ -220,19 +262,14 @@ export class ItemSelectionInputValidationService {
 
     answerGroups.forEach((answerGroup, answerIndex) => {
       var rules = answerGroup.rules;
+      warningsList = warningsList.concat(
+        this.getWarningsForRulesDuplicates(rules, answerIndex));
+
       rules.forEach((rule, ruleIndex) => {
-        var ruleInputs = rule.inputs.x as string[];
-        ruleInputs.forEach((ruleInput) => {
-          if (!choicesContentIds.has(ruleInput)) {
-            warningsList.push({
-              type: AppConstants.WARNING_TYPES.ERROR,
-              message: (
-                `Learner answer ${(ruleIndex + 1)} from Oppia response ` +
-                `${(answerIndex + 1)} options do not match customization ` +
-                'argument choices.')
-            });
-          }
-        });
+        let ruleInputs = rule.inputs.x as string[];
+        warningsList = warningsList.concat(
+          this.getWarningsForRulesInputs(
+            rule, choicesContentIds, ruleIndex, answerIndex));
 
         if (rule.type === 'IsProperSubsetOf') {
           if (ruleInputs.length < 2) {


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #19042.
2. This PR does the following: it adds a verification that a user didn't add two identical rules

## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct

[Screencast](https://github.com/oppia/oppia/assets/6707908/bfe698bd-bdaa-44df-89ff-48fb90b818e0)

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
