### PR TITLE
Make fields required on issue template. Tidy up PR template a bit.

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report_form.yml
@@ -20,21 +20,21 @@ body:
   - type: input
     attributes:
       label: URL of the page where the issue is observed.
-      description: The URL of the specific page where you are experiencing the issue.
+      description: The URL of the specific page where you are experiencing the issue (or N/A if not applicable).
     validations:
-      required: false 
+      required: true
   - type: textarea
     attributes:
       label: Steps To Reproduce
       description: Steps to reproduce the behavior. **Example:** "1. Go to the library page. 2. Click on the 'Sign in' button. 3. See error."
     validations:
-      required: false
+      required: true
   - type: textarea
     attributes:
       label: Expected Behavior
       description: A clear and concise description of what you expected to happen. **Example:** "I expect to be redirected to the login page."
     validations:
-      required: false
+      required: true
   - type: textarea
     attributes:
       label: Screenshots/Videos
@@ -52,6 +52,8 @@ body:
       options:
         - Desktop
         - Mobile
+    validations:
+      required: true
   - type: dropdown
     attributes:
       label: Operating System
@@ -64,6 +66,8 @@ body:
         - Android
         - IOS
         - Other
+    validations:
+      required: true
   - type: dropdown
     attributes:
       label: What browsers are you seeing the problem on?

--- a/.github/ISSUE_TEMPLATE/3_ci_error_template.yml
+++ b/.github/ISSUE_TEMPLATE/3_ci_error_template.yml
@@ -18,7 +18,7 @@ body:
         - Lighthouse CI accessibility
         - Other
     validations:
-      required: false
+      required: true
   - type: textarea
     id: logs
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Overview
 <!--
 READ ME FIRST:
-Please answer *both* questions below and check off every point from the Essential Checklist!
+Please answer *all* questions below and check off every point from the Essential Checklist!
 If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
 -->
 
@@ -12,15 +12,11 @@ If there is no corresponding issue number, fill in N/A where it says [fill_in_nu
 
 ## Essential Checklist
 
-- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
-followed by a short, clear summary of the changes.
+- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
 - [ ] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
-- [ ] The linter/Karma presubmit checks have passed on my local machine.
+- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
+- [ ] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
 - [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
-- [ ] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
-- [ ] I have assigned the correct reviewers to this PR (or will leave a
-comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
-permissions to assign reviewers directly).
 
 ## Testing doc (for PRs with Beam jobs that modify production server data)
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Sometimes, issue filers leave most of the fields blank, omitting important context. This is probably because those fields aren't marked as required. This PR fixes that (and also makes a few small tidy-ups and simplifications to the PR template).

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] The linter/Karma presubmit checks have passed on my local machine.
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [x] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).
