### PR TITLE
Fix #12238: Making the question sticky in the question editor modal

### DIFF
--- a/core/templates/components/question-directives/question-editor/question-editor.component.html
+++ b/core/templates/components/question-directives/question-editor/question-editor.component.html
@@ -10,7 +10,8 @@
                       (onSaveInapplicableSkillMisconceptionIds)="saveInapplicableSkillMisconceptionIds($event)"
                       [interactionIsShown]="interactionIsShown"
                       [stateContentPlaceholder]="getStateContentPlaceholder()"
-                      [stateContentSaveButtonPlaceholder]="getStateContentSaveButtonPlaceholder()">
+                      [stateContentSaveButtonPlaceholder]="getStateContentSaveButtonPlaceholder()"
+                      [isSticky]="isSticky">
   </oppia-state-editor>
 </div>
 

--- a/core/templates/components/question-directives/question-editor/question-editor.component.ts
+++ b/core/templates/components/question-directives/question-editor/question-editor.component.ts
@@ -52,12 +52,13 @@ export class QuestionEditorComponent implements OnInit, OnDestroy {
   @Input() question!: Question;
   @Input() questionId!: string;
   @Input() questionStateData!: State;
+  @Input() isSticky: boolean = false;
+
   interactionIsShown!: boolean;
   oppiaBlackImgUrl!: string;
   stateEditorIsInitialized!: boolean;
   nextContentIdIndexMemento!: number;
   nextContentIdIndexDisplayedValue!: number;
-
   componentSubscriptions = new Subscription();
 
   constructor(

--- a/core/templates/components/question-directives/question-editor/question-editor.component.ts
+++ b/core/templates/components/question-directives/question-editor/question-editor.component.ts
@@ -53,7 +53,6 @@ export class QuestionEditorComponent implements OnInit, OnDestroy {
   @Input() questionId!: string;
   @Input() questionStateData!: State;
   @Input() isSticky: boolean = false;
-
   interactionIsShown!: boolean;
   oppiaBlackImgUrl!: string;
   stateEditorIsInitialized!: boolean;

--- a/core/templates/components/state-editor/state-editor.component.html
+++ b/core/templates/components/state-editor/state-editor.component.html
@@ -23,7 +23,7 @@
   </p>
 </ng-template>
 
-<mat-card class="oppia-editor-card-with-avatar">
+<mat-card class="oppia-editor-card-with-avatar oppia-editor-card-with-avatar-sticky">
   <div class="state-content-header-container" (click)="toggleConceptCard()">
     <div class="state-content-header oppia-mobile-collapsible-card-header">
       <h3 class="oppia-exp-content-card-header">Content</h3>
@@ -39,8 +39,8 @@
   </div>
   <div class="oppia-mobile-collapsible-card-content" *ngIf="conceptCardIsShown"  joyrideStep="editorTabTourContentEditorTab" [stepContent]="ContentEditorTab">
     <div class="oppia-editor-card-body oppia-editor-concept-container">
-      <img *ngIf="!windowIsNarrow" [src]="oppiaBlackImgUrl" alt="" class="oppia-editor-card-avatar">
-      <div id="tutorialStateContent" class="oppia-editor-card-section state-content-editor-parent-container">
+      <img *ngIf="!windowIsNarrow" [src]="oppiaBlackImgUrl" alt="" class="oppia-editor-card-avatar" [ngClass]="{'oppia-editor-card-avatar-sticky': isSticky}">
+      <div id="tutorialStateContent" class="oppia-editor-card-section" [ngClass]="{'state-content-editor-parent-container': !isSticky}">
         <oppia-state-content-editor class="e2e-test-state-content-editor"
                                     (saveStateContent)="sendOnSaveStateContent($event)"
                                     [stateContentPlaceholder]="stateContentPlaceholder"
@@ -93,6 +93,16 @@
 </div>
 
 <style>
+  .oppia-editor-card-with-avatar-sticky {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+
+  .oppia-editor-card-avatar-sticky {
+    top: 15px;
+  }
+
   .state-content-header-container {
     display: none;
     padding: 0 30px;

--- a/core/templates/components/state-editor/state-editor.component.html
+++ b/core/templates/components/state-editor/state-editor.component.html
@@ -93,15 +93,18 @@
 </div>
 
 <style>
+
   .oppia-editor-card-with-avatar-sticky {
     position: sticky;
-    top: 0;
     z-index: 1;
+    top: 82px;
   }
 
-  .oppia-editor-card-avatar-sticky {
-    top: 15px;
-  }
+  /*!*doesnt do anything??? so this is maybe because of the function not wroking*!*/
+  /*.oppia-editor-card-avatar-sticky {*/
+  /*  top: 15px;*/
+  /*}*/
+
 
   .state-content-header-container {
     display: none;

--- a/core/templates/components/state-editor/state-editor.component.html
+++ b/core/templates/components/state-editor/state-editor.component.html
@@ -1,15 +1,15 @@
 <ng-template #ContentEditorTab>
-  <h3 class="e2e-test-joyride-title">Content</h3>
-  <p>An Oppia exploration is divided into several 'cards'. The first part of a card is the <b>content</b>. Use the content section to set the scene. Tell the learner a story,
+  <h3 class="e2e-test-joyride-title" tabindex="0">Content</h3>
+  <p tabindex="0">An Oppia exploration is divided into several 'cards'. The first part of a card is the <b>content</b>. Use the content section to set the scene. Tell the learner a story,
   give them some information, and then ask a relevant question.</p>
 </ng-template>
 
 <ng-template #StateInteractionEditorTab>
-  <h3 class="e2e-test-joyride-title">Interaction</h3>
-  <p>After you've written the content of your conversation, choose an <b>interaction type</b>. An interaction is how you want your learner to respond
+  <h3 class="e2e-test-joyride-title" tabindex="0">Interaction</h3>
+  <p tabindex="0">After you've written the content of your conversation, choose an <b>interaction type</b>. An interaction is how you want your learner to respond
     to your question. Oppia has several built-in interactions, including:
   </p>
-  <ul>
+  <ul tabindex="0">
     <li>Multiple Choice</li>
     <li>Text/Number input</li>
     <li>Code snippets</li>
@@ -17,13 +17,13 @@
 </ng-template>
 
 <ng-template #StateResponsesTab>
-  <h3 class="e2e-test-joyride-title">Responses</h3>
-  <p>
+  <h3 class="e2e-test-joyride-title" tabindex="0">Responses</h3>
+  <p tabindex="0">
     After the learner uses the interaction you created, it's your turn again to choose how your exploration will respond to their input. You can send a learner to a new card or have them repeat the same card, depending on how they answer.
   </p>
 </ng-template>
 
-<mat-card class="oppia-editor-card-with-avatar" [ngClass]="{'oppia-editor-card-with-avatar-sticky': isSticky}"> <!-- here is where we want the sticky !!!!!!! oppia-editor-card-with-avatar-sticky -->
+<mat-card class="oppia-editor-card-with-avatar" [ngClass]="{'oppia-editor-card-with-avatar-sticky': isSticky}">
   <div class="state-content-header-container" (click)="toggleConceptCard()">
     <div class="state-content-header oppia-mobile-collapsible-card-header">
       <h3 class="oppia-exp-content-card-header">Content</h3>
@@ -39,8 +39,8 @@
   </div>
   <div class="oppia-mobile-collapsible-card-content" *ngIf="conceptCardIsShown"  joyrideStep="editorTabTourContentEditorTab" [stepContent]="ContentEditorTab">
     <div class="oppia-editor-card-body oppia-editor-concept-container">
-      <img *ngIf="!windowIsNarrow" [src]="oppiaBlackImgUrl" alt="" class="oppia-editor-card-avatar" [ngClass]="{'oppia-editor-card-avatar-sticky': isSticky}"> <!-- add a image next to the question  -->
-      <div id="tutorialStateContent" class="oppia-editor-card-section" [ngClass]="{'state-content-editor-parent-container': !isSticky}"> <!--add some width and height, this and above seems not to be usefull for us -->
+      <img *ngIf="!windowIsNarrow" [src]="oppiaBlackImgUrl" alt="" class="oppia-editor-card-avatar">
+      <div id="tutorialStateContent" class="oppia-editor-card-section state-content-editor-parent-container">
         <oppia-state-content-editor class="e2e-test-state-content-editor"
                                     (saveStateContent)="sendOnSaveStateContent($event)"
                                     [stateContentPlaceholder]="stateContentPlaceholder"
@@ -98,7 +98,6 @@
     top: 82px;
     z-index: 1;
   }
-
 
   .state-content-header-container {
     display: none;
@@ -159,7 +158,6 @@
   @media only screen and (max-width: 500px) {
     .oppia-mobile-collapsible-card-content {
       padding-left: 10px;
-      padding-right: 10px;
     }
   }
 </style>

--- a/core/templates/components/state-editor/state-editor.component.html
+++ b/core/templates/components/state-editor/state-editor.component.html
@@ -93,19 +93,11 @@
 </div>
 
 <style>
-
   .oppia-editor-card-with-avatar-sticky {
     position: sticky;
     z-index: 1;
     top: 82px;
   }
-
-  /*!*doesnt do anything??? so this is maybe because of the function not wroking*!*/
-  /*.oppia-editor-card-avatar-sticky {*/
-  /*  top: 15px;*/
-  /*}*/
-
-
   .state-content-header-container {
     display: none;
     padding: 0 30px;

--- a/core/templates/components/state-editor/state-editor.component.html
+++ b/core/templates/components/state-editor/state-editor.component.html
@@ -23,7 +23,7 @@
   </p>
 </ng-template>
 
-<mat-card class="oppia-editor-card-with-avatar oppia-editor-card-with-avatar-sticky">
+<mat-card class="oppia-editor-card-with-avatar" [ngClass]="{'oppia-editor-card-with-avatar-sticky': isSticky}"> <!-- here is where we want the sticky !!!!!!! oppia-editor-card-with-avatar-sticky -->
   <div class="state-content-header-container" (click)="toggleConceptCard()">
     <div class="state-content-header oppia-mobile-collapsible-card-header">
       <h3 class="oppia-exp-content-card-header">Content</h3>
@@ -39,8 +39,8 @@
   </div>
   <div class="oppia-mobile-collapsible-card-content" *ngIf="conceptCardIsShown"  joyrideStep="editorTabTourContentEditorTab" [stepContent]="ContentEditorTab">
     <div class="oppia-editor-card-body oppia-editor-concept-container">
-      <img *ngIf="!windowIsNarrow" [src]="oppiaBlackImgUrl" alt="" class="oppia-editor-card-avatar" [ngClass]="{'oppia-editor-card-avatar-sticky': isSticky}">
-      <div id="tutorialStateContent" class="oppia-editor-card-section" [ngClass]="{'state-content-editor-parent-container': !isSticky}">
+      <img *ngIf="!windowIsNarrow" [src]="oppiaBlackImgUrl" alt="" class="oppia-editor-card-avatar" [ngClass]="{'oppia-editor-card-avatar-sticky': isSticky}"> <!-- add a image next to the question  -->
+      <div id="tutorialStateContent" class="oppia-editor-card-section" [ngClass]="{'state-content-editor-parent-container': !isSticky}"> <!--add some width and height, this and above seems not to be usefull for us -->
         <oppia-state-content-editor class="e2e-test-state-content-editor"
                                     (saveStateContent)="sendOnSaveStateContent($event)"
                                     [stateContentPlaceholder]="stateContentPlaceholder"
@@ -95,9 +95,11 @@
 <style>
   .oppia-editor-card-with-avatar-sticky {
     position: sticky;
-    z-index: 1;
     top: 82px;
+    z-index: 1;
   }
+
+
   .state-content-header-container {
     display: none;
     padding: 0 30px;

--- a/core/templates/components/state-editor/state-editor.component.html
+++ b/core/templates/components/state-editor/state-editor.component.html
@@ -96,7 +96,11 @@
   </div>
 </div>
 
+
+
+<!--Oppia style editor does not do anyhting? -->
 <style>
+
   .oppia-editor-card-with-avatar-sticky {
     position: sticky;
     z-index: 1;

--- a/core/templates/components/state-editor/state-editor.component.html
+++ b/core/templates/components/state-editor/state-editor.component.html
@@ -23,8 +23,8 @@
   </p>
 </ng-template>
 
-<mat-card class="oppia-editor-card-with-avatar oppia-editor-card-with-avatar-sticky">
-  <div class="state-content-header-container" (click)="toggleConceptCard()">
+<mat-card class="oppia-editor-card-with-avatar" [ngClass]="{'oppia-editor-card-with-avatar-sticky': shouldBeSticky}">
+    <div class="state-content-header-container" (click)="toggleConceptCard()">
     <div class="state-content-header oppia-mobile-collapsible-card-header">
       <h3 class="oppia-exp-content-card-header">Content</h3>
       <i class="fa fa-caret-down"
@@ -39,8 +39,11 @@
   </div>
   <div class="oppia-mobile-collapsible-card-content" *ngIf="conceptCardIsShown"  joyrideStep="editorTabTourContentEditorTab" [stepContent]="ContentEditorTab">
     <div class="oppia-editor-card-body oppia-editor-concept-container">
-      <img *ngIf="!windowIsNarrow" [src]="oppiaBlackImgUrl" alt="" class="oppia-editor-card-avatar" [ngClass]="{'oppia-editor-card-avatar-sticky': isSticky}">
-      <div id="tutorialStateContent" class="oppia-editor-card-section" [ngClass]="{'state-content-editor-parent-container': !isSticky}">
+      <img *ngIf="!windowIsNarrow" [src]="oppiaBlackImgUrl" alt="" class="oppia-editor-card-avatar">
+      <div id="tutorialStateContent" class="oppia-editor-card-section state-content-editor-parent-container">
+<!--        This is "my changes" -->
+<!--      <img *ngIf="!windowIsNarrow" [src]="oppiaBlackImgUrl" alt="" class="oppia-editor-card-avatar" [ngClass]="{'oppia-editor-card-avatar-sticky': isSticky}">-->
+<!--      <div id="tutorialStateContent" class="oppia-editor-card-section" [ngClass]="{'state-content-editor-parent-container': !isSticky}">-->
         <oppia-state-content-editor class="e2e-test-state-content-editor"
                                     (saveStateContent)="sendOnSaveStateContent($event)"
                                     [stateContentPlaceholder]="stateContentPlaceholder"
@@ -49,6 +52,7 @@
       </div>
     </div>
   </div>
+</mat-card>
 </mat-card>
 
 <div joyrideStep="editorTabTourSlideStateInteractionEditorTab" [stepContent]="StateInteractionEditorTab">

--- a/core/templates/components/state-editor/state-editor.component.ts
+++ b/core/templates/components/state-editor/state-editor.component.ts
@@ -90,6 +90,8 @@ export class StateEditorComponent implements OnInit, OnDestroy {
   servicesInitialized: boolean = false;
   currentInteractionCanHaveSolution: boolean = false;
   conceptCardIsShown: boolean = true;
+  isSticky: boolean = false;
+
 
   constructor(
     private stateCardIsCheckpointService: StateCardIsCheckpointService,
@@ -106,6 +108,11 @@ export class StateEditorComponent implements OnInit, OnDestroy {
     private urlInterpolationService: UrlInterpolationService,
     private windowDimensionsService: WindowDimensionsService,
   ) { }
+
+
+  onChildScroll(sticky: boolean): void {
+    this.isSticky = sticky;
+  }
 
   sendRecomputeGraph(): void {
     this.recomputeGraph.emit();

--- a/core/templates/components/state-editor/state-editor.component.ts
+++ b/core/templates/components/state-editor/state-editor.component.ts
@@ -90,7 +90,6 @@ export class StateEditorComponent implements OnInit, OnDestroy {
   servicesInitialized: boolean = false;
   currentInteractionCanHaveSolution: boolean = false;
   conceptCardIsShown: boolean = true;
-  shouldBeSticky: boolean = false;
 
   constructor(
     private stateCardIsCheckpointService: StateCardIsCheckpointService,

--- a/core/templates/components/state-editor/state-editor.component.ts
+++ b/core/templates/components/state-editor/state-editor.component.ts
@@ -76,7 +76,7 @@ export class StateEditorComponent implements OnInit, OnDestroy {
   @Input() interactionIsShown!: boolean;
   @Input() stateContentSaveButtonPlaceholder!: string;
   @Input() stateContentPlaceholder!: string;
-
+  @Input() isSticky: boolean = false;
 
   oppiaBlackImgUrl!: string;
   // State name is null if their is no state selected or have no active state.

--- a/core/templates/components/state-editor/state-editor.component.ts
+++ b/core/templates/components/state-editor/state-editor.component.ts
@@ -90,8 +90,6 @@ export class StateEditorComponent implements OnInit, OnDestroy {
   servicesInitialized: boolean = false;
   currentInteractionCanHaveSolution: boolean = false;
   conceptCardIsShown: boolean = true;
-  isSticky: boolean = false;
-
 
   constructor(
     private stateCardIsCheckpointService: StateCardIsCheckpointService,
@@ -108,11 +106,6 @@ export class StateEditorComponent implements OnInit, OnDestroy {
     private urlInterpolationService: UrlInterpolationService,
     private windowDimensionsService: WindowDimensionsService,
   ) { }
-
-
-  onChildScroll(sticky: boolean): void {
-    this.isSticky = sticky;
-  }
 
   sendRecomputeGraph(): void {
     this.recomputeGraph.emit();

--- a/core/templates/components/state-editor/state-editor.component.ts
+++ b/core/templates/components/state-editor/state-editor.component.ts
@@ -90,6 +90,7 @@ export class StateEditorComponent implements OnInit, OnDestroy {
   servicesInitialized: boolean = false;
   currentInteractionCanHaveSolution: boolean = false;
   conceptCardIsShown: boolean = true;
+  shouldBeSticky: boolean = false;
 
   constructor(
     private stateCardIsCheckpointService: StateCardIsCheckpointService,

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review-modal.component.ts
@@ -100,6 +100,9 @@ export class QuestionSuggestionReviewModalComponent
   @Output() editSuggestionEmitter = (
     new EventEmitter<QuestionSuggestionModalValue>());
 
+  @Output() scrollEvent = new EventEmitter<boolean>();
+
+
   // These properties below are initialized using Angular lifecycle hooks
   // where we need to do non-null assertion. For more information see
   // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
@@ -147,6 +150,16 @@ export class QuestionSuggestionReviewModalComponent
   ) {
     super(ngbActiveModal);
   }
+
+  handleScroll(event: Event): void {
+    const element = event.target as HTMLElement;
+    if (element.scrollTop > 50) {
+      this.scrollEvent.emit(true);
+    } else {
+      this.scrollEvent.emit(false);
+    }
+  }
+
 
   cancel(): void {
     this.suggestionModalService.cancelSuggestion(this.ngbActiveModal);

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review-modal.component.ts
@@ -100,9 +100,6 @@ export class QuestionSuggestionReviewModalComponent
   @Output() editSuggestionEmitter = (
     new EventEmitter<QuestionSuggestionModalValue>());
 
-  @Output() scrollEvent = new EventEmitter<boolean>();
-
-
   // These properties below are initialized using Angular lifecycle hooks
   // where we need to do non-null assertion. For more information see
   // https://github.com/oppia/oppia/wiki/Guide-on-defining-types#ts-7-1
@@ -150,16 +147,6 @@ export class QuestionSuggestionReviewModalComponent
   ) {
     super(ngbActiveModal);
   }
-
-  handleScroll(event: Event): void {
-    const element = event.target as HTMLElement;
-    if (element.scrollTop > 50) {
-      this.scrollEvent.emit(true);
-    } else {
-      this.scrollEvent.emit(false);
-    }
-  }
-
 
   cancel(): void {
     this.suggestionModalService.cancelSuggestion(this.ngbActiveModal);

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review-modal.component.ts
@@ -106,6 +106,7 @@ export class QuestionSuggestionReviewModalComponent
   @Input() reviewable!: boolean;
   @Input() suggestionId!: string;
   @Input() misconceptionsBySkill!: MisconceptionSkillMap;
+  @Input() isInSuggestionReview: boolean = false;
   reviewMessage!: string;
   reviewer!: string;
   questionStateData!: State;
@@ -133,6 +134,7 @@ export class QuestionSuggestionReviewModalComponent
   questionId: string | null = null;
   isFirstItem: boolean = true;
   isLastItem: boolean = true;
+  isSticky: boolean = true;
 
   constructor(
     private contextService: ContextService,

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review-modal.component.ts
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review-modal.component.ts
@@ -133,6 +133,7 @@ export class QuestionSuggestionReviewModalComponent
   questionId: string | null = null;
   isFirstItem: boolean = true;
   isLastItem: boolean = true;
+  shouldBeSticky: boolean = false;
 
   constructor(
     private contextService: ContextService,

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
@@ -20,20 +20,23 @@
 </div>
 
 <div class="modal-body">
+  <section class="oppia-suggestion-review-container">
   <div class="oppia-question-details questionSuggestionDiv" (scroll)="handleScroll($event)" tabindex="0">
-    <strong class="oppia-difficulty-title">
-      Selected Difficulty: {{skillDifficultyLabel}}
-    </strong>
-    <div *ngIf="skillRubricExplanations.length > 0">
-      <strong class="oppia-skill-rubrics"
-              title="Use these notes to make sure your question is at the right difficulty.">
-        Notes from Skill Rubric
+    <div class="oppia-question-suggestion">
+      <strong class="oppia-difficulty-title">
+        Selected Difficulty: {{skillDifficultyLabel}}
       </strong>
-      <ul>
-        <li *ngFor="let explanation of skillRubricExplanations">
-          <span class="oppia-skill-explanation" [innerHtml]="explanation"></span>
-        </li>
-      </ul>
+      <div *ngIf="skillRubricExplanations.length > 0">
+        <strong class="oppia-skill-rubrics"
+                title="Use these notes to make sure your question is at the right difficulty.">
+          Notes from Skill Rubric
+        </strong>
+        <ul>
+          <li *ngFor="let explanation of skillRubricExplanations">
+            <span class="oppia-skill-explanation" [innerHtml]="explanation"></span>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
   <div *ngIf="showQuestion">
@@ -46,6 +49,7 @@
                            tabindex="0">
     </oppia-question-editor>
   </div>
+  </section>
   <section [hidden]="!reviewable"
            class="oppia-reviewer-actions">
     <div class="oppia-suggestion-review-message">
@@ -110,6 +114,36 @@
 </div>
 
 <style>
+
+  /*This one makes it sticky */
+  .modal-header {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    background-color: white; /* To ensure content doesn't show behind the header */
+  }
+
+  .oppia-suggestion-review-container {
+    height: 1300px;
+    padding-bottom: 0;
+    padding-top: 0;
+  }
+
+
+  .oppia-editor-card-with-avatar-sticky {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+  .oppia-editor-card-avatar-sticky {
+    top: 15px;
+  }
+
+  /*Doest not seems to do anything */
+  .modal-header .oppia-question-header {
+    margin-top: 0;
+  }
+
   .oppia-close-button-position {
     font-size: 2.5rem;
     position: absolute;
@@ -181,7 +215,7 @@
   }
   .oppia-question-suggestion {
     height: 100%;
-    overflow: scroll;
+    overflow: auto;
   }
   .oppia-reviewer-actions {
     border-top: 1px solid #e5e5e5;
@@ -213,9 +247,7 @@
       display: block;
       font-size: 20px;
     }
-    .modal-header {
-      padding-bottom: 0;
-    }
+
     .oppia-question-header {
       display: none;
     }

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
@@ -20,7 +20,7 @@
 </div>
 
 <div class="modal-body">
-  <div class="oppia-question-details" tabindex="0">
+  <div class="oppia-question-details questionSuggestionDiv" (scroll)="handleScroll($event)" tabindex="0">
     <strong class="oppia-difficulty-title">
       Selected Difficulty: {{skillDifficultyLabel}}
     </strong>

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
@@ -19,6 +19,8 @@
   </button>
 </div>
 
+<h1>2320</h1>
+
 <div class="modal-body">
   <section class="oppia-suggestion-review-container">
   <div class="oppia-question-details questionSuggestionDiv" (scroll)="handleScroll($event)" tabindex="0">
@@ -115,33 +117,17 @@
 </div>
 
 <style>
-
-  /*This one makes it sticky */
   .modal-header {
     position: sticky;
     top: 0;
     z-index: 1000;
-    background-color: white; /* To ensure content doesn't show behind the header */
+    background-color: white;
   }
-
   .oppia-suggestion-review-container {
     height: 1300px;
     padding-bottom: 0;
     padding-top: 0;
   }
-
-
-  .oppia-editor-card-with-avatar-sticky {
-    position: sticky;
-    top: 82px;
-    z-index: 1;
-  }
-
-  /*Doest not seems to do anything */
-  .modal-header .oppia-question-header {
-    margin-top: 0;
-  }
-
   .oppia-close-button-position {
     font-size: 2.5rem;
     position: absolute;
@@ -245,7 +231,9 @@
       display: block;
       font-size: 20px;
     }
-
+    .modal-header {
+      padding-bottom: 0;
+    }
     .oppia-question-header {
       display: none;
     }

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
@@ -20,35 +20,35 @@
 </div>
 <div class="modal-body">
   <section class="oppia-suggestion-review-container">
-  <div class="oppia-question-details questionSuggestionDiv" tabindex="0">
-    <div class="oppia-question-suggestion">
-      <strong class="oppia-difficulty-title">
-        Selected Difficulty: {{skillDifficultyLabel}}
-      </strong>
-      <div *ngIf="skillRubricExplanations.length > 0">
-        <strong class="oppia-skill-rubrics"
-                title="Use these notes to make sure your question is at the right difficulty.">
-          Notes from Skill Rubric
+    <div class="oppia-question-details questionSuggestionDiv" tabindex="0">
+      <div class="oppia-question-suggestion">
+        <strong class="oppia-difficulty-title">
+          Selected Difficulty: {{skillDifficultyLabel}}
         </strong>
-        <ul>
-          <li *ngFor="let explanation of skillRubricExplanations">
-            <span class="oppia-skill-explanation" [innerHtml]="explanation"></span>
-          </li>
-        </ul>
+        <div *ngIf="skillRubricExplanations.length > 0">
+          <strong class="oppia-skill-rubrics"
+                  title="Use these notes to make sure your question is at the right difficulty.">
+            Notes from Skill Rubric
+          </strong>
+          <ul>
+            <li *ngFor="let explanation of skillRubricExplanations">
+              <span class="oppia-skill-explanation" [innerHtml]="explanation"></span>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
-  </div>
-  <div *ngIf="showQuestion">
-    <oppia-question-editor [questionId]="questionId"
-                           [isSticky] ="isSticky"
-                           [misconceptionsBySkill]="misconceptionsBySkill"
-                           [questionStateData]="questionStateData"
-                           [question]="question"
-                           [userCanEditQuestion]="canEditQuestion"
-                           (questionChange)="questionChanged()"
-                           tabindex="0">
-    </oppia-question-editor>
-  </div>
+    <div *ngIf="showQuestion">
+      <oppia-question-editor [questionId]="questionId"
+                             [isSticky]="isSticky"
+                             [misconceptionsBySkill]="misconceptionsBySkill"
+                             [questionStateData]="questionStateData"
+                             [question]="question"
+                             [userCanEditQuestion]="canEditQuestion"
+                             (questionChange)="questionChanged()"
+                             tabindex="0">
+      </oppia-question-editor>
+    </div>
   </section>
   <section [hidden]="!reviewable"
            class="oppia-reviewer-actions">
@@ -115,10 +115,10 @@
 
 <style>
   .modal-header {
+    background-color: white;
     position: sticky;
     top: 0;
     z-index: 1000;
-    background-color: white;
   }
   .oppia-suggestion-review-container {
     height: 1300px;

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
@@ -21,7 +21,7 @@
 
 <div class="modal-body">
   <section class="oppia-suggestion-review-container">
-  <div class="oppia-question-details questionSuggestionDiv" (scroll)="handleScroll($event)" tabindex="0">
+    <div class="oppia-question-details questionSuggestionDiv" tabindex="0">
     <div class="oppia-question-suggestion">
       <strong class="oppia-difficulty-title">
         Selected Difficulty: {{skillDifficultyLabel}}
@@ -114,7 +114,6 @@
 </div>
 
 <style>
-
   /*This one makes it sticky */
   .modal-header {
     position: sticky;
@@ -122,28 +121,11 @@
     z-index: 1000;
     background-color: white; /* To ensure content doesn't show behind the header */
   }
-
   .oppia-suggestion-review-container {
     height: 1300px;
     padding-bottom: 0;
     padding-top: 0;
   }
-
-
-  .oppia-editor-card-with-avatar-sticky {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-  }
-  .oppia-editor-card-avatar-sticky {
-    top: 15px;
-  }
-
-  /*Doest not seems to do anything */
-  .modal-header .oppia-question-header {
-    margin-top: 0;
-  }
-
   .oppia-close-button-position {
     font-size: 2.5rem;
     position: absolute;
@@ -247,7 +229,6 @@
       display: block;
       font-size: 20px;
     }
-
     .oppia-question-header {
       display: none;
     }

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
@@ -41,6 +41,7 @@
   </div>
   <div *ngIf="showQuestion">
     <oppia-question-editor [questionId]="questionId"
+                           [isSticky] ="isSticky"
                            [misconceptionsBySkill]="misconceptionsBySkill"
                            [questionStateData]="questionStateData"
                            [question]="question"
@@ -132,11 +133,8 @@
 
   .oppia-editor-card-with-avatar-sticky {
     position: sticky;
-    top: 0;
+    top: 82px;
     z-index: 1;
-  }
-  .oppia-editor-card-avatar-sticky {
-    top: 15px;
   }
 
   /*Doest not seems to do anything */

--- a/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
+++ b/core/templates/pages/contributor-dashboard-page/modal-templates/question-suggestion-review.component.html
@@ -18,12 +18,9 @@
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
-
-<h1>2320</h1>
-
 <div class="modal-body">
   <section class="oppia-suggestion-review-container">
-  <div class="oppia-question-details questionSuggestionDiv" (scroll)="handleScroll($event)" tabindex="0">
+  <div class="oppia-question-details questionSuggestionDiv" tabindex="0">
     <div class="oppia-question-suggestion">
       <strong class="oppia-difficulty-title">
         Selected Difficulty: {{skillDifficultyLabel}}


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

## Explanation 
This PR makes the question sticky in the question editor modal, which appears when reviewing questions in the contribution panel.

The question needs to be fixed within the the state-editor.component because it has the tab that is used inside the question editor. Because the state-editor.component is used in multiple places we pass a boolean from the question-suggestion-review-modal.component.html to make sure that its only fixed at the question editor modal.

1. This PR fixes or fixes part of #12238.
2. This PR does the following: It makes the question sticky in the editor modal

## Essential Checklist

- [ X] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...",
followed by a short, clear summary of the changes.
- [X ] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [X ] The linter/Karma presubmit checks have passed on my local machine.
- [X ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [ X] My PR follows the [style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide).
- [ X] I have assigned the correct reviewers to this PR (or will leave a
comment with the phrase "@{{reviewer_username}} PTAL" if I don't have
permissions to assign reviewers directly).

## Proof that changes are correct

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
