### PR TITLE
Use original dir name when deleting after a dependency is reinstalled.

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -56,9 +56,6 @@ NODE_VERSION = '16.13.0'
 # NB: Please ensure that the version is consistent with the version in .yarnrc.
 YARN_VERSION = '1.22.15'
 
-# Versions of libraries used in backend.
-PILLOW_VERSION = '10.1.0'
-
 # Buf version.
 BUF_VERSION = '0.29.0'
 

--- a/scripts/install_python_prod_dependencies.py
+++ b/scripts/install_python_prod_dependencies.py
@@ -234,13 +234,14 @@ def _remove_metadata(library_name: str, version_string: str) -> None:
     possible_normalized_directory_names = (
         _get_possible_normalized_metadata_directory_names(
             library_name, version_string))
-    normalized_directory_names = [
-        normalize_directory_name(name)
+    normalized_to_original_dirnames = {
+        normalize_directory_name(name): name
         for name in os.listdir(common.THIRD_PARTY_PYTHON_LIBS_DIR)
         if os.path.isdir(
             os.path.join(common.THIRD_PARTY_PYTHON_LIBS_DIR, name))
-    ]
-    for normalized_directory_name in normalized_directory_names:
+    }
+    for (normalized_dirname, original_dirname) in (
+            normalized_to_original_dirnames.items()):
         # Python metadata directory names contain a python library name that
         # does not have uniform case. However, python libraries are equivalent
         # regardless of their case. Therefore, in order to check if a python
@@ -248,9 +249,9 @@ def _remove_metadata(library_name: str, version_string: str) -> None:
         # directory name. Otherwise, we would need to check every permutation of
         # the casing for metadata directories generated with the naming
         # convention: <library_name>-<library-version>.
-        if normalized_directory_name in possible_normalized_directory_names:
+        if normalized_dirname in possible_normalized_directory_names:
             path_to_delete = os.path.join(
-                common.THIRD_PARTY_PYTHON_LIBS_DIR, normalized_directory_name)
+                common.THIRD_PARTY_PYTHON_LIBS_DIR, original_dirname)
             shutil.rmtree(path_to_delete)
 
 


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #N/A.
2. This PR does the following: Fixes an issue where the dependency-management script couldn't figure out which old directory to delete.
3. (For bug-fixing PRs only) The original bug occurred because directory names are normalized before comparison, and we need to un-normalize them again before removing the dependency, otherwise we get a "directory not found" error.

Here is an example of the message received when this error happens (after a contributor upgrades from pillow-9.5.0 to pillow-10.1.0):

```
Checking if pip is installed on the local machine
Collecting pillow==10.1.0
  Using cached Pillow-10.1.0-cp38-cp38-manylinux_2_28_x86_64.whl (3.6 MB)
Installing collected packages: pillow
Successfully installed pillow-10.1.0

Traceback (most recent call last):
  File "/.pyenv/versions/3.8.15/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/.pyenv/versions/3.8.15/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/opensource/oppia/scripts/start.py", line 33, in <module>
    install_third_party_libs.main()
  File "/opensource/oppia/scripts/install_third_party_libs.py", line 180, in main
    install_third_party.main(args=[])
  File "/opensource/oppia/scripts/install_third_party.py", line 472, in main
    install_python_prod_dependencies.main()
  File "/opensource/oppia/scripts/install_python_prod_dependencies.py", line 680, in main
    _rectify_third_party_directory(mismatches)
  File "/opensource/oppia/scripts/install_python_prod_dependencies.py", line 334, in _rectify_third_party_directory
    _remove_metadata(normalized_library_name, str(directory_version))
  File "/opensource/oppia/scripts/install_python_prod_dependencies.py", line 254, in _remove_metadata
    shutil.rmtree(path_to_delete)
  File "/.pyenv/versions/3.8.15/lib/python3.8/shutil.py", line 709, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/.pyenv/versions/3.8.15/lib/python3.8/shutil.py", line 707, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/home/sean/opensource/oppia/third_party/python_libs/pillow-9.5.0.dist-info'
```

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)


## Proof that changes are correct

I have tested this locally and verified that the error above does not occur when starting the server. I have also confirmed that the old Pillow directories are correctly deleted.