### PR TITLE
Fix for ‘No collapsible content is present inside the tag’ error

### DIFF
--- a/core/domain/html_cleaner.py
+++ b/core/domain/html_cleaner.py
@@ -591,7 +591,7 @@ def validate_tabs_and_collapsible_rte_tags(html_data: str) -> None:
         )
         collapsible_content = json.loads(
             collapsible_content_json).replace('\\"', '')
-        if is_html_empty(collapsible_content):
+        if not collapsible_content or collapsible_content.isspace():
             raise utils.ValidationError(
                 'No collapsible content is present inside the tag.'
             )


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #19184 .
2. This PR does the following: the PR modifies the validation check to `if not collapsible_content or collapsible_content.isspace():`, which correctly identifies both empty content and content that is only whitespace as invalid.
3. The original bug occurred because: The bug was caused by the function `is_html_empty(collapsible_content)`, which was not correctly identifying cases where the collapsible content was only whitespace.

## Essential Checklist

- [x] The **Fix for ‘No collapsible content is present inside the tag’ error ** starts with Fix #19184 : he PR modifies the validation check to `if not collapsible_content or collapsible_content.isspace():`, which correctly identifies both empty content and content that is only whitespace as invalid.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct


#### Proof of changes on mobile phone

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
