### PR TITLE
Fix issue #19157 : Corrected contributor dashboard admin link in the emails from Contributor Dashboard Team 

### DIFF
--- a/core/domain/email_manager.py
+++ b/core/domain/email_manager.py
@@ -324,7 +324,7 @@ ADMIN_NOTIFICATION_FOR_SUGGESTIONS_NEEDING_REVIEW_EMAIL_DATA: Dict[str, str] = {
         'There are suggestions on the <a href="%s%s">Contributor Dashboard</a> '
         'that have been waiting for more than %s days for review. Please take '
         'a look at the suggestions mentioned below and help them get reviewed '
-        'by going to the <a href="%s%s#/roles">admin roles page</a> and either:'
+        'by going to the <a href="%s%s">admin roles page</a> and either:'
         '<br><br><ul>'
         '<li>Add more reviewers to the suggestion types that have suggestions '
         'waiting too long for a review</li><br>'
@@ -1761,7 +1761,7 @@ def _send_suggestions_waiting_too_long_email(
             curriculum_admin_usernames[index], feconf.OPPIA_SITE_URL,
             feconf.CONTRIBUTOR_DASHBOARD_URL,
             suggestion_models.SUGGESTION_REVIEW_WAIT_TIME_THRESHOLD_IN_DAYS,
-            feconf.OPPIA_SITE_URL, feconf.ADMIN_URL,
+            feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_ADMIN_URL,
             list_of_suggestion_descriptions)
 
         _send_email(

--- a/core/domain/email_manager_test.py
+++ b/core/domain/email_manager_test.py
@@ -4440,7 +4440,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             '<a href="%s%s">Contributor Dashboard</a> that have been waiting '
             'for more than 0 days for review. Please take a look at the '
             'suggestions mentioned below and help them get reviewed by going '
-            'to the <a href="%s%s#/roles">admin roles page</a> and either:'
+            'to the <a href="%s%s">admin roles page</a> and either:'
             '<br><br><ul>'
             '<li>Add more reviewers to the suggestion types that have '
             'suggestions waiting too long for a review</li><br>'
@@ -4459,7 +4459,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             'Best Wishes!<br><br>'
             '- The Oppia Contributor Dashboard Team' % (
                 feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_URL,
-                feconf.OPPIA_SITE_URL, feconf.ADMIN_URL)
+                feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_ADMIN_URL)
         )
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
@@ -4513,7 +4513,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             '<a href="%s%s">Contributor Dashboard</a> that have been waiting '
             'for more than 0 days for review. Please take a look at the '
             'suggestions mentioned below and help them get reviewed by going '
-            'to the <a href="%s%s#/roles">admin roles page</a> and either:'
+            'to the <a href="%s%s">admin roles page</a> and either:'
             '<br><br><ul>'
             '<li>Add more reviewers to the suggestion types that have '
             'suggestions waiting too long for a review</li><br>'
@@ -4535,7 +4535,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             'Best Wishes!<br><br>'
             '- The Oppia Contributor Dashboard Team' % (
                 feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_URL,
-                feconf.OPPIA_SITE_URL, feconf.ADMIN_URL)
+                feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_ADMIN_URL)
         )
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
@@ -4583,7 +4583,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             '<a href="%s%s">Contributor Dashboard</a> that have been waiting '
             'for more than 0 days for review. Please take a look at the '
             'suggestions mentioned below and help them get reviewed by going '
-            'to the <a href="%s%s#/roles">admin roles page</a> and either:'
+            'to the <a href="%s%s">admin roles page</a> and either:'
             '<br><br><ul>'
             '<li>Add more reviewers to the suggestion types that have '
             'suggestions waiting too long for a review</li><br>'
@@ -4602,7 +4602,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             'Best Wishes!<br><br>'
             '- The Oppia Contributor Dashboard Team' % (
                 feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_URL,
-                feconf.OPPIA_SITE_URL, feconf.ADMIN_URL)
+                feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_ADMIN_URL)
         )
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
@@ -4656,7 +4656,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             '<a href="%s%s">Contributor Dashboard</a> that have been waiting '
             'for more than 0 days for review. Please take a look at the '
             'suggestions mentioned below and help them get reviewed by going '
-            'to the <a href="%s%s#/roles">admin roles page</a> and either:'
+            'to the <a href="%s%s">admin roles page</a> and either:'
             '<br><br><ul>'
             '<li>Add more reviewers to the suggestion types that have '
             'suggestions waiting too long for a review</li><br>'
@@ -4678,7 +4678,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             'Best Wishes!<br><br>'
             '- The Oppia Contributor Dashboard Team' % (
                 feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_URL,
-                feconf.OPPIA_SITE_URL, feconf.ADMIN_URL)
+                feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_ADMIN_URL)
         )
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
@@ -4740,7 +4740,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             '<a href="%s%s">Contributor Dashboard</a> that have been waiting '
             'for more than 0 days for review. Please take a look at the '
             'suggestions mentioned below and help them get reviewed by going '
-            'to the <a href="%s%s#/roles">admin roles page</a> and either:'
+            'to the <a href="%s%s">admin roles page</a> and either:'
             '<br><br><ul>'
             '<li>Add more reviewers to the suggestion types that have '
             'suggestions waiting too long for a review</li><br>'
@@ -4762,7 +4762,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             'Best Wishes!<br><br>'
             '- The Oppia Contributor Dashboard Team' % (
                 feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_URL,
-                feconf.OPPIA_SITE_URL, feconf.ADMIN_URL)
+                feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_ADMIN_URL)
         )
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
@@ -4841,7 +4841,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             '<a href="%s%s">Contributor Dashboard</a> that have been waiting '
             'for more than 0 days for review. Please take a look at the '
             'suggestions mentioned below and help them get reviewed by going '
-            'to the <a href="%s%s#/roles">admin roles page</a> and either:'
+            'to the <a href="%s%s">admin roles page</a> and either:'
             '<br><br><ul>'
             '<li>Add more reviewers to the suggestion types that have '
             'suggestions waiting too long for a review</li><br>'
@@ -4860,7 +4860,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             'Best Wishes!<br><br>'
             '- The Oppia Contributor Dashboard Team' % (
                 feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_URL,
-                feconf.OPPIA_SITE_URL, feconf.ADMIN_URL)
+                feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_ADMIN_URL)
         )
         expected_email_html_body_admin_2 = (
             'Hi user2,'
@@ -4869,7 +4869,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             '<a href="%s%s">Contributor Dashboard</a> that have been waiting '
             'for more than 0 days for review. Please take a look at the '
             'suggestions mentioned below and help them get reviewed by going '
-            'to the <a href="%s%s#/roles">admin roles page</a> and either:'
+            'to the <a href="%s%s">admin roles page</a> and either:'
             '<br><br><ul>'
             '<li>Add more reviewers to the suggestion types that have '
             'suggestions waiting too long for a review</li><br>'
@@ -4888,7 +4888,7 @@ class NotifyAdminsSuggestionsWaitingTooLongForReviewEmailTests(
             'Best Wishes!<br><br>'
             '- The Oppia Contributor Dashboard Team' % (
                 feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_URL,
-                feconf.OPPIA_SITE_URL, feconf.ADMIN_URL))
+                feconf.OPPIA_SITE_URL, feconf.CONTRIBUTOR_DASHBOARD_ADMIN_URL))
 
         with self.can_send_emails_ctx, self.log_new_error_ctx:
             with self.swap_get_platform_parameter_value, self.swap(


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes #19157 .
2. This PR does the following: Corrects the wrong link of the 'admin roles page' hyperlink  in the emails sent to notify Contributor Dashboard Admins about 'Suggestions waiting too long'
3. (For bug-fixing PRs only) The original bug occurred because: Wrong URL was passed to the email_body_template in the function which sends the email and there was a mistake in the email_body_template as well.
## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

[oppia-email-bug.webm](https://github.com/oppia/oppia/assets/119884665/a80ce8d9-bd99-4744-a2c5-dba5cc6e6fd6)

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->


## PR Pointers
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.