### PR TITLE
Fix #19306 : Added instagram icon & link in footer, changed order of icons

### DIFF
--- a/core/templates/components/button-directives/social-buttons.component.css
+++ b/core/templates/components/button-directives/social-buttons.component.css
@@ -38,6 +38,12 @@
   position: relative;
 }
 
+.oppia-footer-social .oppia-footer-social-icons .oppia-instagram-follow {
+  background: #d6249f;
+  background: radial-gradient(circle at 30% 107%, #fdf497 0%, #fdf497 5%, #fd5949 45%,#d6249f 60%,#285aeb 90%);
+  margin-right: 6px;
+  padding: 5px 6px;
+}
 .oppia-footer-social .oppia-footer-social-icons .oppia-youtube-follow {
   background: #cd201f;
   margin-right: 6px;

--- a/core/templates/components/button-directives/social-buttons.component.html
+++ b/core/templates/components/button-directives/social-buttons.component.html
@@ -8,10 +8,11 @@
   </div>
 
   <div class="oppia-footer-social-icons">
-    <div class="oppia-youtube-follow">
-      <a href="https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw" target="_blank" rel="noopener">
-        <i class="oppia-follow-icons fab fa-youtube"></i>
-        <span class="oppia-icon-accessibility-label">Youtube</span>
+
+    <div class="oppia-instagram-follow">
+      <a href="https://www.instagram.com/oppia.global" target="_blank" rel="noopener">
+        <i class="oppia-follow-icons fa-brands fa-instagram"></i>
+        <span class="oppia-icon-accessibility-label">Instagram</span>
       </a>
     </div>
 
@@ -19,6 +20,13 @@
       <a href="https://www.facebook.com/oppiaorg" target="_blank" rel="noopener">
         <i class="oppia-follow-icons fab fa-facebook-f"></i>
         <span class="oppia-icon-accessibility-label">Facebook</span>
+      </a>
+    </div>
+
+    <div class="oppia-youtube-follow">
+      <a href="https://www.youtube.com/channel/UC5c1G7BNDCfv1rczcBp9FPw" target="_blank" rel="noopener">
+        <i class="oppia-follow-icons fab fa-youtube"></i>
+        <span class="oppia-icon-accessibility-label">Youtube</span>
       </a>
     </div>
 


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->
1. This PR fixes #19306 
2. This PR does the following:
- Adds instagram icon to social icons of Oppia in the footer (The link will open in a new tab).
- Re-orders the social icons in the footer.
## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)

## Proof that changes are correct

[oppia-social-icons.webm](https://github.com/oppia/oppia/assets/119884665/fd06e8a3-9ae6-4e3f-ac46-fe949f33f463)

<!--
Add videos/screenshots of the user-facing interface to demonstrate that the changes
made in this PR work correctly. If this PR is for a developer-facing feature,
provide the videos/screenshots of developer-facing interface. Please also include
videos/screenshots of the developer tools browser console, so that we can be
sure that there are no console errors.

When you make updates to the PR, please update these videos/screenshots as well.
You can drop videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g. a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.
-->

#### Proof of changes on desktop with slow/throttled network

[oppia-insta-throttle.webm](https://github.com/oppia/oppia/assets/119884665/2dc3ef90-929e-454c-9d8b-ac377d68b9d0)


<!--
Make sure to properly verify that everything works correctly, and that there are
no weird UI mistakes or other problems. Also, if there are any newly added fields,
try to fill them out and test that different inputs are correctly accepted/rejected.

Throttle the network (to 3G) using the browser Developer Tools (see references below).
There should be no performance or UI issues while the network is slow.

References:
 - Chrome: https://css-tricks.com/throttling-the-network/
 - Firefox: https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor/Throttling
-->

#### Proof of changes on mobile phone

[oppia-insta-mobile.webm](https://github.com/oppia/oppia/assets/119884665/376e9430-d84f-4990-a8c6-30be6a1c9ff1)

<!--
In some cases this is not needed (e.g. for pages that we do not expect to
support mobile phones, or for backend-only features).

Feel free to use the Developer Tools emulator for this.

References:
 - Chrome: https://developer.chrome.com/docs/devtools/device-mode/
 - Firefox: https://firefox-source-docs.mozilla.org/devtools-user/index.html#responsive-design-mode
-->

#### Proof of changes in Arabic language

[oppia-insta-arabic.webm](https://github.com/oppia/oppia/assets/119884665/ee4ab149-e2a0-4ce7-861d-711e4dc3d257)

<!--
If the PR changes the UI, make sure to add screenshots with the site
language set to Arabic as well (we use Arabic as it is a language written from right to left).
-->

## PR Pointers

- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
